### PR TITLE
feat(itun): live-sheet in-game play — condition tracking, pilot/crawler stats, read-only snapshots (#240–#245)

### DIFF
--- a/apps/in-the-union-now/src/components/shared/ConditionToggle.tsx
+++ b/apps/in-the-union-now/src/components/shared/ConditionToggle.tsx
@@ -37,6 +37,11 @@ type ConditionToggleProps = {
   className?: string
   /** Optional accessible label prefix, e.g. the item name. */
   ariaLabelPrefix?: string
+  /**
+   * When true, renders as a static badge with no interactive affordance.
+   * Used in read-only contexts like published snapshots.
+   */
+  readOnly?: boolean
 }
 
 export function ConditionToggle({
@@ -44,6 +49,7 @@ export function ConditionToggle({
   onChange,
   className,
   ariaLabelPrefix,
+  readOnly = false,
 }: ConditionToggleProps) {
   function cycle() {
     onChange(CYCLE[value])
@@ -60,6 +66,20 @@ export function ConditionToggle({
     ? `${ariaLabelPrefix} condition: ${LABELS[value]}`
     : `Condition: ${LABELS[value]}`
 
+  const badgeClass = cn(
+    'inline-flex select-none items-center rounded border px-2 py-0.5 text-xs font-semibold',
+    STYLES[value],
+    className
+  )
+
+  if (readOnly) {
+    return (
+      <span aria-label={label} className={badgeClass}>
+        {LABELS[value]}
+      </span>
+    )
+  }
+
   return (
     <span
       role="button"
@@ -69,9 +89,8 @@ export function ConditionToggle({
       onClick={cycle}
       onKeyDown={handleKeyDown}
       className={cn(
-        'inline-flex cursor-pointer select-none items-center rounded border px-2 py-0.5 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
-        STYLES[value],
-        className
+        badgeClass,
+        'cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1'
       )}
     >
       {LABELS[value]}

--- a/apps/in-the-union-now/src/components/shared/MechStandIn.tsx
+++ b/apps/in-the-union-now/src/components/shared/MechStandIn.tsx
@@ -1,0 +1,28 @@
+/**
+ * MechStandIn — placeholder rendered in pilot/view contexts when no mech
+ * SoftLink exists for that pilot.
+ *
+ * Intentionally dumb: no entityStore access. The caller is responsible for
+ * checking whether a SoftLink exists and rendering this component when it
+ * does not.
+ */
+
+import { cn } from '../../lib/utils'
+
+type MechStandInProps = {
+  className?: string
+}
+
+export function MechStandIn({ className }: MechStandInProps) {
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-center rounded border border-dashed border-muted-foreground/40 px-4 py-3',
+        className
+      )}
+      aria-label="No mech assigned"
+    >
+      <span className="text-sm text-muted-foreground">No Mech Assigned</span>
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/sheet/CrawlerSheet.tsx
+++ b/apps/in-the-union-now/src/components/sheet/CrawlerSheet.tsx
@@ -9,7 +9,9 @@
 
 import type { Crawler } from '../../lib/schemas/crawler'
 import type { Pilot } from '../../lib/schemas/pilot'
+import { useEntityStore } from '../../stores/entityStore'
 import { CrawlerPilotsStandIn } from '../shared/CrawlerPilotsStandIn'
+import { EditableStatRow } from './EditableStatRow'
 
 type CrawlerSheetProps = {
   crawler: Crawler
@@ -18,9 +20,24 @@ type CrawlerSheetProps = {
    * When empty, renders the stand-in placeholder.
    */
   pilots?: Pilot[]
+  /**
+   * Injectable store — defaults to useEntityStore.
+   * Pass a stub in tests to avoid Zustand/IndexedDB side effects.
+   */
+  store?: typeof useEntityStore
+  /**
+   * When true, stat cells render as plain text with no click-to-edit affordance.
+   * Use in read-only contexts like published snapshots.
+   */
+  readOnly?: boolean
 }
 
-export function CrawlerSheet({ crawler, pilots = [] }: CrawlerSheetProps) {
+export function CrawlerSheet({
+  crawler,
+  pilots = [],
+  store = useEntityStore,
+  readOnly = false,
+}: CrawlerSheetProps) {
   return (
     <section aria-labelledby="crawler-sheet-heading" className="flex flex-col gap-4">
       {/* Header */}
@@ -29,6 +46,31 @@ export function CrawlerSheet({ crawler, pilots = [] }: CrawlerSheetProps) {
           {crawler.name}
         </h2>
         <p className="text-sm text-muted-foreground">Tech Level: {crawler.techLevel}</p>
+      </div>
+
+      {/* Stats — SP (live-play tracking, #245) */}
+      <div>
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+          Stats
+        </h3>
+        <dl className="grid grid-cols-2 gap-2">
+          <div className="flex flex-col items-center rounded border border-border py-2 text-center">
+            <dt className="text-xs text-muted-foreground">SP</dt>
+            <dd className="text-lg font-semibold">
+              {/* TODO: source base value from rules once crawler tech-level data exposes SP */}
+              <EditableStatRow
+                label=""
+                value={crawler.currentSP ?? 0}
+                entityKind="crawler"
+                entityId={crawler.id}
+                fieldPath="currentSP"
+                min={0}
+                store={store}
+                readOnly={readOnly}
+              />
+            </dd>
+          </div>
+        </dl>
       </div>
 
       {/* Bays */}

--- a/apps/in-the-union-now/src/components/sheet/EditableStatRow.tsx
+++ b/apps/in-the-union-now/src/components/sheet/EditableStatRow.tsx
@@ -31,6 +31,8 @@ type EditableStatRowProps<T extends AssignableType> = {
   fieldPath: keyof EntityForType<T> & string
   min?: number
   max?: number
+  /** When true, renders value as plain text with no click-to-edit affordance. */
+  readOnly?: boolean
   /** Injectable store — defaults to useEntityStore */
   store?: typeof useEntityStore
   /** Injectable evaluator — defaults to evaluateSoftWarnings */
@@ -49,6 +51,7 @@ export function EditableStatRow<T extends AssignableType>({
   fieldPath,
   min,
   max,
+  readOnly = false,
   store = useEntityStore,
   evaluate,
 }: EditableStatRowProps<T>) {
@@ -85,6 +88,7 @@ export function EditableStatRow<T extends AssignableType>({
           min={min}
           max={max}
           ariaLabel={`Edit ${label}`}
+          readOnly={readOnly}
         />
       </div>
 

--- a/apps/in-the-union-now/src/components/sheet/MechSheet.tsx
+++ b/apps/in-the-union-now/src/components/sheet/MechSheet.tsx
@@ -45,6 +45,11 @@ type MechSheetProps = {
    * Pass a stub in tests to avoid Zustand/IndexedDB side effects.
    */
   store?: typeof useEntityStore
+  /**
+   * When true, stat cells render as plain text with no click-to-edit affordance.
+   * Use in read-only contexts like published snapshots.
+   */
+  readOnly?: boolean
 }
 
 function resolveChassis(mech: Mech, override?: ChassisLike | null): ChassisLike | null {
@@ -56,6 +61,7 @@ export function MechSheet({
   mech,
   chassis: chassisOverride,
   store = useEntityStore,
+  readOnly = false,
 }: MechSheetProps) {
   const chassis = resolveChassis(mech, chassisOverride)
 
@@ -97,6 +103,7 @@ export function MechSheet({
                 fieldPath="currentHP"
                 min={0}
                 store={store}
+                readOnly={readOnly}
               />
             </dd>
           </div>
@@ -111,6 +118,7 @@ export function MechSheet({
                 fieldPath="currentAP"
                 min={0}
                 store={store}
+                readOnly={readOnly}
               />
             </dd>
           </div>
@@ -125,6 +133,7 @@ export function MechSheet({
                 fieldPath="currentTP"
                 min={0}
                 store={store}
+                readOnly={readOnly}
               />
             </dd>
           </div>
@@ -139,6 +148,7 @@ export function MechSheet({
                 fieldPath="currentSP"
                 min={0}
                 store={store}
+                readOnly={readOnly}
               />
             </dd>
           </div>
@@ -153,6 +163,7 @@ export function MechSheet({
                 fieldPath="currentEP"
                 min={0}
                 store={store}
+                readOnly={readOnly}
               />
             </dd>
           </div>
@@ -167,6 +178,7 @@ export function MechSheet({
                 fieldPath="currentHeat"
                 min={0}
                 store={store}
+                readOnly={readOnly}
               />
             </dd>
           </div>

--- a/apps/in-the-union-now/src/components/sheet/MechSheet.tsx
+++ b/apps/in-the-union-now/src/components/sheet/MechSheet.tsx
@@ -17,6 +17,7 @@
  */
 
 import { SalvageUnionReference } from 'salvageunion-reference'
+import type { ItemCondition } from '../../lib/schemas/mech'
 import type { Mech } from '../../lib/schemas/mech'
 import { useEntityStore } from '../../stores/entityStore'
 import { ConditionToggle } from '../shared/ConditionToggle'
@@ -64,6 +65,17 @@ export function MechSheet({
   readOnly = false,
 }: MechSheetProps) {
   const chassis = resolveChassis(mech, chassisOverride)
+  const storeState = store()
+
+  async function handleSystemConditionChange(slug: string, next: ItemCondition) {
+    const prev = mech.systemConditions ?? {}
+    await storeState.update('mech', mech.id, { systemConditions: { ...prev, [slug]: next } })
+  }
+
+  async function handleModuleConditionChange(slug: string, next: ItemCondition) {
+    const prev = mech.moduleConditions ?? {}
+    await storeState.update('mech', mech.id, { moduleConditions: { ...prev, [slug]: next } })
+  }
 
   return (
     <section aria-labelledby="mech-sheet-heading" className="flex flex-col gap-4">
@@ -198,7 +210,14 @@ export function MechSheet({
                 className="flex items-center justify-between rounded border border-border px-2 py-1 text-sm"
               >
                 <span>{slug}</span>
-                <ConditionToggle value="intact" onChange={() => undefined} ariaLabelPrefix={slug} />
+                <ConditionToggle
+                  value={mech.systemConditions?.[slug] ?? 'intact'}
+                  onChange={(next) => {
+                    void handleSystemConditionChange(slug, next)
+                  }}
+                  ariaLabelPrefix={slug}
+                  readOnly={readOnly}
+                />
               </li>
             ))}
           </ul>
@@ -218,7 +237,14 @@ export function MechSheet({
                 className="flex items-center justify-between rounded border border-border px-2 py-1 text-sm"
               >
                 <span>{slug}</span>
-                <ConditionToggle value="intact" onChange={() => undefined} ariaLabelPrefix={slug} />
+                <ConditionToggle
+                  value={mech.moduleConditions?.[slug] ?? 'intact'}
+                  onChange={(next) => {
+                    void handleModuleConditionChange(slug, next)
+                  }}
+                  ariaLabelPrefix={slug}
+                  readOnly={readOnly}
+                />
               </li>
             ))}
           </ul>

--- a/apps/in-the-union-now/src/components/sheet/MechSheet.tsx
+++ b/apps/in-the-union-now/src/components/sheet/MechSheet.tsx
@@ -72,99 +72,106 @@ export function MechSheet({
       </div>
 
       {/* Stats — inline-editable via EditableStatRow (AC-1 + AC-2) */}
-      {chassis && (
-        <div>
-          <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-2">
-            Stats
-          </h3>
-          <dl className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-6">
-            <div className="flex flex-col items-center rounded border border-border py-2 text-center">
-              <dt className="text-xs text-muted-foreground">HP</dt>
-              <dd className="text-lg font-semibold">
-                <EditableStatRow
-                  label=""
-                  value={mech.currentHP ?? chassis.structurePoints ?? 0}
-                  entityKind="mech"
-                  entityId={mech.id}
-                  fieldPath="currentHP"
-                  min={0}
-                  store={store}
-                />
-              </dd>
-            </div>
-            <div className="flex flex-col items-center rounded border border-border py-2 text-center">
-              <dt className="text-xs text-muted-foreground">AP</dt>
-              <dd className="text-lg font-semibold">
-                <EditableStatRow
-                  label=""
-                  value={mech.currentAP ?? 0}
-                  entityKind="mech"
-                  entityId={mech.id}
-                  fieldPath="currentAP"
-                  min={0}
-                  store={store}
-                />
-              </dd>
-            </div>
-            <div className="flex flex-col items-center rounded border border-border py-2 text-center">
-              <dt className="text-xs text-muted-foreground">TP</dt>
-              <dd className="text-lg font-semibold">
-                <EditableStatRow
-                  label=""
-                  value={mech.currentTP ?? 0}
-                  entityKind="mech"
-                  entityId={mech.id}
-                  fieldPath="currentTP"
-                  min={0}
-                  store={store}
-                />
-              </dd>
-            </div>
-            <div className="flex flex-col items-center rounded border border-border py-2 text-center">
-              <dt className="text-xs text-muted-foreground">SP</dt>
-              <dd className="text-lg font-semibold">
-                <EditableStatRow
-                  label=""
-                  value={mech.currentSP ?? chassis.structurePoints ?? 0}
-                  entityKind="mech"
-                  entityId={mech.id}
-                  fieldPath="currentSP"
-                  min={0}
-                  store={store}
-                />
-              </dd>
-            </div>
-            <div className="flex flex-col items-center rounded border border-border py-2 text-center">
-              <dt className="text-xs text-muted-foreground">EP</dt>
-              <dd className="text-lg font-semibold">
-                <EditableStatRow
-                  label=""
-                  value={mech.currentEP ?? chassis.energyPoints ?? 0}
-                  entityKind="mech"
-                  entityId={mech.id}
-                  fieldPath="currentEP"
-                  min={0}
-                  store={store}
-                />
-              </dd>
-            </div>
-            <div className="flex flex-col items-center rounded border border-border py-2 text-center">
-              <dt className="text-xs text-muted-foreground">Heat</dt>
-              <dd className="text-lg font-semibold">
-                <EditableStatRow
-                  label=""
-                  value={mech.currentHeat ?? chassis.heatCapacity ?? 0}
-                  entityKind="mech"
-                  entityId={mech.id}
-                  fieldPath="currentHeat"
-                  min={0}
-                  store={store}
-                />
-              </dd>
-            </div>
-          </dl>
-        </div>
-      )}
+      {/* Rendered regardless of chassis resolution; falls back to stored values or 0 when chassis is null */}
+      <div>
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+          Stats
+        </h3>
+        {!chassis && (
+          <p
+            role="alert"
+            className="mb-2 rounded border border-yellow-400 bg-yellow-50 px-3 py-2 text-sm text-yellow-800"
+          >
+            Unknown chassis &ldquo;{mech.chassisRef}&rdquo; — using stored/zero defaults
+          </p>
+        )}
+        <dl className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-6">
+          <div className="flex flex-col items-center rounded border border-border py-2 text-center">
+            <dt className="text-xs text-muted-foreground">HP</dt>
+            <dd className="text-lg font-semibold">
+              <EditableStatRow
+                label=""
+                value={mech.currentHP ?? chassis?.structurePoints ?? 0}
+                entityKind="mech"
+                entityId={mech.id}
+                fieldPath="currentHP"
+                min={0}
+                store={store}
+              />
+            </dd>
+          </div>
+          <div className="flex flex-col items-center rounded border border-border py-2 text-center">
+            <dt className="text-xs text-muted-foreground">AP</dt>
+            <dd className="text-lg font-semibold">
+              <EditableStatRow
+                label=""
+                value={mech.currentAP ?? 0}
+                entityKind="mech"
+                entityId={mech.id}
+                fieldPath="currentAP"
+                min={0}
+                store={store}
+              />
+            </dd>
+          </div>
+          <div className="flex flex-col items-center rounded border border-border py-2 text-center">
+            <dt className="text-xs text-muted-foreground">TP</dt>
+            <dd className="text-lg font-semibold">
+              <EditableStatRow
+                label=""
+                value={mech.currentTP ?? 0}
+                entityKind="mech"
+                entityId={mech.id}
+                fieldPath="currentTP"
+                min={0}
+                store={store}
+              />
+            </dd>
+          </div>
+          <div className="flex flex-col items-center rounded border border-border py-2 text-center">
+            <dt className="text-xs text-muted-foreground">SP</dt>
+            <dd className="text-lg font-semibold">
+              <EditableStatRow
+                label=""
+                value={mech.currentSP ?? chassis?.structurePoints ?? 0}
+                entityKind="mech"
+                entityId={mech.id}
+                fieldPath="currentSP"
+                min={0}
+                store={store}
+              />
+            </dd>
+          </div>
+          <div className="flex flex-col items-center rounded border border-border py-2 text-center">
+            <dt className="text-xs text-muted-foreground">EP</dt>
+            <dd className="text-lg font-semibold">
+              <EditableStatRow
+                label=""
+                value={mech.currentEP ?? chassis?.energyPoints ?? 0}
+                entityKind="mech"
+                entityId={mech.id}
+                fieldPath="currentEP"
+                min={0}
+                store={store}
+              />
+            </dd>
+          </div>
+          <div className="flex flex-col items-center rounded border border-border py-2 text-center">
+            <dt className="text-xs text-muted-foreground">Heat</dt>
+            <dd className="text-lg font-semibold">
+              <EditableStatRow
+                label=""
+                value={mech.currentHeat ?? chassis?.heatCapacity ?? 0}
+                entityKind="mech"
+                entityId={mech.id}
+                fieldPath="currentHeat"
+                min={0}
+                store={store}
+              />
+            </dd>
+          </div>
+        </dl>
+      </div>
 
       {/* Systems */}
       {mech.systems.length > 0 && (

--- a/apps/in-the-union-now/src/components/sheet/MechSheet.tsx
+++ b/apps/in-the-union-now/src/components/sheet/MechSheet.tsx
@@ -68,12 +68,14 @@ export function MechSheet({
   const storeState = store()
 
   async function handleSystemConditionChange(slug: string, next: ItemCondition) {
-    const prev = mech.systemConditions ?? {}
+    // Read the freshest map from the store (not the render-time prop) so rapid
+    // sequential toggles don't stomp each other with a stale-closure overwrite.
+    const prev = storeState.get('mech', mech.id)?.systemConditions ?? mech.systemConditions ?? {}
     await storeState.update('mech', mech.id, { systemConditions: { ...prev, [slug]: next } })
   }
 
   async function handleModuleConditionChange(slug: string, next: ItemCondition) {
-    const prev = mech.moduleConditions ?? {}
+    const prev = storeState.get('mech', mech.id)?.moduleConditions ?? mech.moduleConditions ?? {}
     await storeState.update('mech', mech.id, { moduleConditions: { ...prev, [slug]: next } })
   }
 

--- a/apps/in-the-union-now/src/components/sheet/PilotSheet.tsx
+++ b/apps/in-the-union-now/src/components/sheet/PilotSheet.tsx
@@ -50,7 +50,10 @@ export function PilotSheet({ pilot, store = useEntityStore, readOnly = false }: 
   const storeState = store()
 
   async function handleEquipmentConditionChange(slug: string, next: ItemCondition) {
-    const prev = pilot.equipmentConditions ?? {}
+    // Read the freshest map from the store (not the render-time prop) so rapid
+    // sequential toggles don't stomp each other with a stale-closure overwrite.
+    const prev =
+      storeState.get('pilot', pilot.id)?.equipmentConditions ?? pilot.equipmentConditions ?? {}
     await storeState.update('pilot', pilot.id, { equipmentConditions: { ...prev, [slug]: next } })
   }
 

--- a/apps/in-the-union-now/src/components/sheet/PilotSheet.tsx
+++ b/apps/in-the-union-now/src/components/sheet/PilotSheet.tsx
@@ -16,6 +16,7 @@ import { SalvageUnionReference } from 'salvageunion-reference'
 import type { SURefAbility, SURefEntity, SURefEquipment } from 'salvageunion-reference'
 import { ReferenceEntityDisplay } from 'suref-react'
 
+import type { ItemCondition } from '../../lib/schemas/mech'
 import type { Pilot } from '../../lib/schemas/pilot'
 import { useEntityStore } from '../../stores/entityStore'
 import { ConditionToggle } from '../shared/ConditionToggle'
@@ -46,6 +47,13 @@ type PilotSheetProps = {
 }
 
 export function PilotSheet({ pilot, store = useEntityStore, readOnly = false }: PilotSheetProps) {
+  const storeState = store()
+
+  async function handleEquipmentConditionChange(slug: string, next: ItemCondition) {
+    const prev = pilot.equipmentConditions ?? {}
+    await storeState.update('pilot', pilot.id, { equipmentConditions: { ...prev, [slug]: next } })
+  }
+
   return (
     <section aria-labelledby="pilot-sheet-heading" className="flex flex-col gap-4">
       {/* Header */}
@@ -155,11 +163,13 @@ export function PilotSheet({ pilot, store = useEntityStore, readOnly = false }: 
                       </div>
                     )}
                   </div>
-                  {/* Read-only condition display — onChange is a no-op */}
                   <ConditionToggle
-                    value="intact"
-                    onChange={() => undefined}
+                    value={pilot.equipmentConditions?.[slug] ?? 'intact'}
+                    onChange={(next) => {
+                      void handleEquipmentConditionChange(slug, next)
+                    }}
                     ariaLabelPrefix={slug}
+                    readOnly={readOnly}
                   />
                 </div>
               )

--- a/apps/in-the-union-now/src/components/sheet/PilotSheet.tsx
+++ b/apps/in-the-union-now/src/components/sheet/PilotSheet.tsx
@@ -17,7 +17,9 @@ import type { SURefAbility, SURefEntity, SURefEquipment } from 'salvageunion-ref
 import { ReferenceEntityDisplay } from 'suref-react'
 
 import type { Pilot } from '../../lib/schemas/pilot'
+import { useEntityStore } from '../../stores/entityStore'
 import { ConditionToggle } from '../shared/ConditionToggle'
+import { EditableStatRow } from './EditableStatRow'
 
 function resolveAbility(slug: string): SURefAbility | null {
   const all = SalvageUnionReference.Abilities.all() as ReadonlyArray<SURefAbility>
@@ -31,9 +33,19 @@ function resolveEquipment(slug: string): SURefEquipment | null {
 
 type PilotSheetProps = {
   pilot: Pilot
+  /**
+   * Injectable store — defaults to useEntityStore.
+   * Pass a stub in tests to avoid Zustand/IndexedDB side effects.
+   */
+  store?: typeof useEntityStore
+  /**
+   * When true, stat cells render as plain text with no click-to-edit affordance.
+   * Use in read-only contexts like published snapshots.
+   */
+  readOnly?: boolean
 }
 
-export function PilotSheet({ pilot }: PilotSheetProps) {
+export function PilotSheet({ pilot, store = useEntityStore, readOnly = false }: PilotSheetProps) {
   return (
     <section aria-labelledby="pilot-sheet-heading" className="flex flex-col gap-4">
       {/* Header */}
@@ -43,6 +55,47 @@ export function PilotSheet({ pilot }: PilotSheetProps) {
           {pilot.name}
         </h2>
         <p className="text-sm text-muted-foreground">Class: {pilot.classRef}</p>
+      </div>
+
+      {/* Stats — HP + AP (live-play tracking, #245) */}
+      <div>
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+          Stats
+        </h3>
+        <dl className="grid grid-cols-2 gap-2">
+          <div className="flex flex-col items-center rounded border border-border py-2 text-center">
+            <dt className="text-xs text-muted-foreground">HP</dt>
+            <dd className="text-lg font-semibold">
+              {/* TODO: source base value from rules once pilot class data exposes HP */}
+              <EditableStatRow
+                label=""
+                value={pilot.currentHP ?? 0}
+                entityKind="pilot"
+                entityId={pilot.id}
+                fieldPath="currentHP"
+                min={0}
+                store={store}
+                readOnly={readOnly}
+              />
+            </dd>
+          </div>
+          <div className="flex flex-col items-center rounded border border-border py-2 text-center">
+            <dt className="text-xs text-muted-foreground">AP</dt>
+            <dd className="text-lg font-semibold">
+              {/* TODO: source base value from rules once pilot class data exposes AP */}
+              <EditableStatRow
+                label=""
+                value={pilot.currentAP ?? 0}
+                entityKind="pilot"
+                entityId={pilot.id}
+                fieldPath="currentAP"
+                min={0}
+                store={store}
+                readOnly={readOnly}
+              />
+            </dd>
+          </div>
+        </dl>
       </div>
 
       {/* Abilities */}

--- a/apps/in-the-union-now/src/components/sheet/Sheet.tsx
+++ b/apps/in-the-union-now/src/components/sheet/Sheet.tsx
@@ -35,6 +35,7 @@ import { PilotSheet } from './PilotSheet'
 import { MechSheet } from './MechSheet'
 import { CrawlerSheet } from './CrawlerSheet'
 import { PilotStandIn } from '../shared/PilotStandIn'
+import { MechStandIn } from '../shared/MechStandIn'
 import { PublishButton } from './PublishButton'
 
 // ---------------------------------------------------------------------------
@@ -233,6 +234,9 @@ export function Sheet({
 
         {/* Mech section */}
         {resolved.mech && <MechSheet mech={resolved.mech} />}
+
+        {/* Mech stand-in: shown in pilot-only mode and wired pilot+crawler (no mech) */}
+        {kind === 'pilot' && !resolved.mech && <MechStandIn />}
 
         {/* Crawler section — pilots=[] triggers the stand-in in crawler-only mode */}
         {resolved.crawler && (

--- a/apps/in-the-union-now/src/components/sheet/SnapshotView.tsx
+++ b/apps/in-the-union-now/src/components/sheet/SnapshotView.tsx
@@ -110,9 +110,9 @@ export function SnapshotView({ snapshot }: SnapshotViewProps) {
       <SheetHeader name={name} mode={mode} />
 
       <div className="flex flex-col gap-8">
-        {result.kind === 'pilot' && <PilotSheet pilot={result.entity} />}
+        {result.kind === 'pilot' && <PilotSheet pilot={result.entity} readOnly />}
         {result.kind === 'mech' && <MechSheet mech={result.entity} readOnly />}
-        {result.kind === 'crawler' && <CrawlerSheet crawler={result.entity} pilots={[]} />}
+        {result.kind === 'crawler' && <CrawlerSheet crawler={result.entity} pilots={[]} readOnly />}
       </div>
     </main>
   )

--- a/apps/in-the-union-now/src/components/sheet/SnapshotView.tsx
+++ b/apps/in-the-union-now/src/components/sheet/SnapshotView.tsx
@@ -111,7 +111,7 @@ export function SnapshotView({ snapshot }: SnapshotViewProps) {
 
       <div className="flex flex-col gap-8">
         {result.kind === 'pilot' && <PilotSheet pilot={result.entity} />}
-        {result.kind === 'mech' && <MechSheet mech={result.entity} />}
+        {result.kind === 'mech' && <MechSheet mech={result.entity} readOnly />}
         {result.kind === 'crawler' && <CrawlerSheet crawler={result.entity} pilots={[]} />}
       </div>
     </main>

--- a/apps/in-the-union-now/src/components/sheet/__tests__/CrawlerSheet-editable.test.tsx
+++ b/apps/in-the-union-now/src/components/sheet/__tests__/CrawlerSheet-editable.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * CrawlerSheet — editable SP stat tests (#245)
+ *
+ * Asserts that:
+ *   1. Editing SP calls store.update with { currentSP: <value> }
+ *   2. readOnly suppresses editing (no spinbutton, no store.update)
+ */
+
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { CrawlerSheet } from '../CrawlerSheet'
+import type { Crawler } from '../../../lib/schemas/crawler'
+import type { useEntityStore } from '../../../stores/entityStore'
+
+afterEach(() => {
+  cleanup()
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const fakeCrawler: Crawler = {
+  id: 'crawler-edit-1',
+  schemaVersion: 1,
+  name: 'Iron Tortoise',
+  techLevel: 'tech-2',
+  bays: [],
+  systems: [],
+  currentSP: 20,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}
+
+function makeStubStore(
+  crawler: Crawler,
+  updateSpy?: ReturnType<typeof mock>
+): typeof useEntityStore {
+  const updateMock = updateSpy ?? mock(async () => crawler)
+  const storeState = {
+    pilots: [],
+    mechs: [],
+    crawlers: [crawler],
+    softLinks: [],
+    hydrated: { pilots: false, mechs: false, crawlers: true, softLinks: false },
+    hydrate: mock(async () => {}),
+    list: mock(() => [crawler]),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    get: mock((_type: string, id: string) => (id === crawler.id ? crawler : null)) as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    create: mock(async () => crawler) as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    update: updateMock as any,
+    delete: mock(async () => {}),
+  }
+  return (() => storeState) as unknown as typeof useEntityStore
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CrawlerSheet — SP editing (#245)', () => {
+  test('renders SP stat value', () => {
+    render(<CrawlerSheet crawler={fakeCrawler} store={makeStubStore(fakeCrawler)} />)
+    expect(screen.getByText('20')).toBeTruthy()
+  })
+
+  test('clicking SP value enters edit mode (shows spinbutton)', async () => {
+    render(<CrawlerSheet crawler={fakeCrawler} store={makeStubStore(fakeCrawler)} />)
+    const spValue = screen.getByText('20')
+    await act(async () => {
+      fireEvent.click(spValue)
+    })
+    expect(screen.getByRole('spinbutton')).toBeTruthy()
+  })
+
+  test('saving SP calls store.update with { currentSP }', async () => {
+    const updateSpy = mock(async () => fakeCrawler)
+    render(<CrawlerSheet crawler={fakeCrawler} store={makeStubStore(fakeCrawler, updateSpy)} />)
+
+    const spValue = screen.getByText('20')
+    await act(async () => {
+      fireEvent.click(spValue)
+    })
+
+    const input = screen.getByRole('spinbutton')
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '15' } })
+      fireEvent.blur(input)
+    })
+
+    expect(updateSpy).toHaveBeenCalledWith('crawler', fakeCrawler.id, { currentSP: 15 })
+  })
+})
+
+describe('CrawlerSheet — readOnly (#245)', () => {
+  test('no edit spinbutton when readOnly', async () => {
+    render(<CrawlerSheet crawler={fakeCrawler} store={makeStubStore(fakeCrawler)} readOnly />)
+    const spValue = screen.getByText('20')
+    await act(async () => {
+      fireEvent.click(spValue)
+    })
+    expect(screen.queryByRole('spinbutton')).toBeNull()
+  })
+
+  test('store.update is never called when readOnly', async () => {
+    const updateSpy = mock(async () => fakeCrawler)
+    render(
+      <CrawlerSheet crawler={fakeCrawler} store={makeStubStore(fakeCrawler, updateSpy)} readOnly />
+    )
+
+    const spValue = screen.getByText('20')
+    await act(async () => {
+      fireEvent.click(spValue)
+    })
+
+    expect(updateSpy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/in-the-union-now/src/components/sheet/__tests__/MechSheet-editable.test.tsx
+++ b/apps/in-the-union-now/src/components/sheet/__tests__/MechSheet-editable.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * MechSheet — editable stat tests (#244).
+ *
+ * Verifies that clicking each of the six stat cells (HP, AP, TP, SP, EP, Heat),
+ * typing a new value, and pressing Enter calls store.update with the correct
+ * field patch: { currentXxx: N }.
+ *
+ * HP is covered by sheet-smoke.test.tsx (Scenario 6). All six are tested here
+ * for completeness. Uses dep-injection (no mock.module()).
+ *
+ * Conventions: toBeTruthy() not toBeInTheDocument(), no mock.module().
+ */
+
+import { afterEach, beforeAll, describe, expect, mock, test } from 'bun:test'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import { MechSheet } from '../MechSheet'
+import type { Mech } from '../../../lib/schemas/mech'
+import type { useEntityStore } from '../../../stores/entityStore'
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload(['chassis'])
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+// ---------------------------------------------------------------------------
+// Shared fixture
+// ---------------------------------------------------------------------------
+
+const fakeMech: Mech = {
+  id: 'mech-editable-1',
+  schemaVersion: 1,
+  name: 'Edit Test Mech',
+  chassisRef: 'iron-mongrel',
+  systems: [],
+  modules: [],
+  cargo: [],
+  conditions: [],
+  currentHP: 10,
+  currentAP: 3,
+  currentTP: 2,
+  currentSP: 8,
+  currentEP: 5,
+  currentHeat: 4,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}
+
+const fakeChassis = {
+  name: 'Iron Mongrel',
+  structurePoints: 12,
+  energyPoints: 6,
+  heatCapacity: 8,
+  systemSlots: 3,
+  moduleSlots: 2,
+  cargoCapacity: 4,
+}
+
+type CapturedUpdate = { id: string; patch: Partial<Mech> }
+
+function makeStore(mech: Mech, captured: CapturedUpdate[]): typeof useEntityStore {
+  const updateMock = mock(async (_type: string, id: string, patch: Partial<Mech>) => {
+    captured.push({ id, patch })
+    return { ...mech, ...patch } as Mech
+  })
+
+  const storeState = {
+    pilots: [],
+    mechs: [mech],
+    crawlers: [],
+    softLinks: [],
+    hydrated: { pilots: false, mechs: true, crawlers: false, softLinks: false },
+    hydrate: mock(async () => {}),
+    list: mock(() => [mech]),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    get: mock((_type: string, id: string) => (id === mech.id ? mech : null)) as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    create: mock(async () => mech) as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    update: updateMock as any,
+    delete: mock(async () => {}),
+  }
+
+  return (() => storeState) as unknown as typeof useEntityStore
+}
+
+// ---------------------------------------------------------------------------
+// Helper: click stat button at given index, type value, press Enter
+// ---------------------------------------------------------------------------
+
+async function editStatByIndex(index: number, value: string): Promise<void> {
+  const buttons = screen.getAllByRole('button')
+  await act(async () => {
+    fireEvent.click(buttons[index]!)
+  })
+  const input = screen.getByRole('spinbutton')
+  await act(async () => {
+    fireEvent.change(input, { target: { value } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests — one per stat
+// The MechSheet renders stats in order: HP(0), AP(1), TP(2), SP(3), EP(4), Heat(5)
+// ---------------------------------------------------------------------------
+
+describe('MechSheet — editable stat: HP', () => {
+  test('click HP, type new value, Enter → store.update called with { currentHP: N }', async () => {
+    const captured: CapturedUpdate[] = []
+    render(
+      <MechSheet mech={fakeMech} chassis={fakeChassis} store={makeStore(fakeMech, captured)} />
+    )
+
+    await editStatByIndex(0, '7')
+
+    expect(captured.length).toBe(1)
+    expect(captured[0]!.id).toBe('mech-editable-1')
+    expect(captured[0]!.patch).toMatchObject({ currentHP: 7 })
+  })
+})
+
+describe('MechSheet — editable stat: AP', () => {
+  test('click AP, type new value, Enter → store.update called with { currentAP: N }', async () => {
+    const captured: CapturedUpdate[] = []
+    render(
+      <MechSheet mech={fakeMech} chassis={fakeChassis} store={makeStore(fakeMech, captured)} />
+    )
+
+    await editStatByIndex(1, '5')
+
+    expect(captured.length).toBe(1)
+    expect(captured[0]!.id).toBe('mech-editable-1')
+    expect(captured[0]!.patch).toMatchObject({ currentAP: 5 })
+  })
+})
+
+describe('MechSheet — editable stat: TP', () => {
+  test('click TP, type new value, Enter → store.update called with { currentTP: N }', async () => {
+    const captured: CapturedUpdate[] = []
+    render(
+      <MechSheet mech={fakeMech} chassis={fakeChassis} store={makeStore(fakeMech, captured)} />
+    )
+
+    await editStatByIndex(2, '4')
+
+    expect(captured.length).toBe(1)
+    expect(captured[0]!.id).toBe('mech-editable-1')
+    expect(captured[0]!.patch).toMatchObject({ currentTP: 4 })
+  })
+})
+
+describe('MechSheet — editable stat: SP', () => {
+  test('click SP, type new value, Enter → store.update called with { currentSP: N }', async () => {
+    const captured: CapturedUpdate[] = []
+    render(
+      <MechSheet mech={fakeMech} chassis={fakeChassis} store={makeStore(fakeMech, captured)} />
+    )
+
+    await editStatByIndex(3, '6')
+
+    expect(captured.length).toBe(1)
+    expect(captured[0]!.id).toBe('mech-editable-1')
+    expect(captured[0]!.patch).toMatchObject({ currentSP: 6 })
+  })
+})
+
+describe('MechSheet — editable stat: EP', () => {
+  test('click EP, type new value, Enter → store.update called with { currentEP: N }', async () => {
+    const captured: CapturedUpdate[] = []
+    render(
+      <MechSheet mech={fakeMech} chassis={fakeChassis} store={makeStore(fakeMech, captured)} />
+    )
+
+    await editStatByIndex(4, '3')
+
+    expect(captured.length).toBe(1)
+    expect(captured[0]!.id).toBe('mech-editable-1')
+    expect(captured[0]!.patch).toMatchObject({ currentEP: 3 })
+  })
+})
+
+describe('MechSheet — editable stat: Heat', () => {
+  test('click Heat, type new value, Enter → store.update called with { currentHeat: N }', async () => {
+    const captured: CapturedUpdate[] = []
+    render(
+      <MechSheet mech={fakeMech} chassis={fakeChassis} store={makeStore(fakeMech, captured)} />
+    )
+
+    await editStatByIndex(5, '9')
+
+    expect(captured.length).toBe(1)
+    expect(captured[0]!.id).toBe('mech-editable-1')
+    expect(captured[0]!.patch).toMatchObject({ currentHeat: 9 })
+  })
+})

--- a/apps/in-the-union-now/src/components/sheet/__tests__/MechSheet-readOnly.test.tsx
+++ b/apps/in-the-union-now/src/components/sheet/__tests__/MechSheet-readOnly.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * MechSheet — readOnly prop tests (#242)
+ *
+ * When readOnly is true (e.g. in SnapshotView), stat cells must render as
+ * plain text — no role=button, no click-to-edit, no store.update calls.
+ */
+
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { MechSheet } from '../MechSheet'
+import type { Mech } from '../../../lib/schemas/mech'
+import type { useEntityStore } from '../../../stores/entityStore'
+
+afterEach(() => {
+  cleanup()
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const fakeMech: Mech = {
+  id: 'mech-snapshot-1',
+  schemaVersion: 1,
+  name: 'Snapshot Mech',
+  chassisRef: 'iron-mongrel',
+  systems: [],
+  modules: [],
+  cargo: [],
+  conditions: [],
+  currentHP: 12,
+  currentAP: 3,
+  currentTP: 1,
+  currentSP: 8,
+  currentEP: 5,
+  currentHeat: 2,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}
+
+const fakeChassis = {
+  name: 'Iron Mongrel',
+  structurePoints: 14,
+  energyPoints: 6,
+  heatCapacity: 8,
+  systemSlots: 3,
+  moduleSlots: 2,
+  cargoCapacity: 4,
+}
+
+function makeStubStore(mech: Mech, updateSpy?: ReturnType<typeof mock>): typeof useEntityStore {
+  const updateMock = updateSpy ?? mock(async () => mech)
+  const storeState = {
+    pilots: [],
+    mechs: [mech],
+    crawlers: [],
+    softLinks: [],
+    hydrated: { pilots: false, mechs: true, crawlers: false, softLinks: false },
+    hydrate: mock(async () => {}),
+    list: mock(() => [mech]),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    get: mock((_type: string, id: string) => (id === mech.id ? mech : null)) as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    create: mock(async () => mech) as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    update: updateMock as any,
+    delete: mock(async () => {}),
+  }
+  return (() => storeState) as unknown as typeof useEntityStore
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MechSheet — readOnly', () => {
+  test('stat values render as plain text (no role=button) when readOnly', () => {
+    render(
+      <MechSheet mech={fakeMech} chassis={fakeChassis} store={makeStubStore(fakeMech)} readOnly />
+    )
+
+    // No buttons should be present for stat editing
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  test('clicking a stat cell does not enter edit mode when readOnly', async () => {
+    render(
+      <MechSheet mech={fakeMech} chassis={fakeChassis} store={makeStubStore(fakeMech)} readOnly />
+    )
+
+    // The HP value is rendered as plain text — find it
+    const hpValue = screen.getByText('12')
+    await act(async () => {
+      fireEvent.click(hpValue)
+    })
+
+    // No input/spinbutton should appear
+    expect(screen.queryByRole('spinbutton')).toBeNull()
+  })
+
+  test('store.update is never called when readOnly and stat cells are clicked', async () => {
+    const updateSpy = mock(async () => fakeMech)
+    render(
+      <MechSheet
+        mech={fakeMech}
+        chassis={fakeChassis}
+        store={makeStubStore(fakeMech, updateSpy)}
+        readOnly
+      />
+    )
+
+    // Click on all numeric values visible
+    const hpValue = screen.getByText('12')
+    await act(async () => {
+      fireEvent.click(hpValue)
+    })
+
+    expect(updateSpy).not.toHaveBeenCalled()
+  })
+
+  test('stat values are still visible as text when readOnly', () => {
+    render(
+      <MechSheet mech={fakeMech} chassis={fakeChassis} store={makeStubStore(fakeMech)} readOnly />
+    )
+
+    // All stat values should appear as text
+    expect(screen.getByText('12')).toBeTruthy() // HP
+    expect(screen.getByText('3')).toBeTruthy() // AP
+    expect(screen.getByText('1')).toBeTruthy() // TP
+    expect(screen.getByText('8')).toBeTruthy() // SP
+    expect(screen.getByText('5')).toBeTruthy() // EP
+    expect(screen.getByText('2')).toBeTruthy() // Heat
+  })
+})

--- a/apps/in-the-union-now/src/components/sheet/__tests__/MechSheet-unresolved-chassis.test.tsx
+++ b/apps/in-the-union-now/src/components/sheet/__tests__/MechSheet-unresolved-chassis.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * MechSheet — unresolved chassis tests (#243)
+ *
+ * When chassis cannot be resolved (null), the stat block must still render
+ * with fallback to stored values (or 0), and an accessible notice must appear.
+ */
+
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { MechSheet } from '../MechSheet'
+import type { Mech } from '../../../lib/schemas/mech'
+import type { useEntityStore } from '../../../stores/entityStore'
+
+afterEach(() => {
+  cleanup()
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const fakeMechNoStoredValues: Mech = {
+  id: 'mech-unresolved-1',
+  schemaVersion: 1,
+  name: 'Ghost Frame',
+  chassisRef: 'nonexistent-chassis-xyz',
+  systems: [],
+  modules: [],
+  cargo: [],
+  conditions: [],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}
+
+const fakeMechWithStoredValues: Mech = {
+  id: 'mech-unresolved-2',
+  schemaVersion: 1,
+  name: 'Stored Frame',
+  chassisRef: 'nonexistent-chassis-xyz',
+  systems: [],
+  modules: [],
+  cargo: [],
+  conditions: [],
+  currentHP: 7,
+  currentAP: 3,
+  currentTP: 2,
+  currentSP: 5,
+  currentEP: 4,
+  currentHeat: 6,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}
+
+function makeStubStore(mech: Mech): typeof useEntityStore {
+  const storeState = {
+    pilots: [],
+    mechs: [mech],
+    crawlers: [],
+    softLinks: [],
+    hydrated: { pilots: false, mechs: true, crawlers: false, softLinks: false },
+    hydrate: mock(async () => {}),
+    list: mock(() => [mech]),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    get: mock((_type: string, id: string) => (id === mech.id ? mech : null)) as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    create: mock(async () => mech) as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    update: mock(async () => mech) as any,
+    delete: mock(async () => {}),
+  }
+  return (() => storeState) as unknown as typeof useEntityStore
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MechSheet — unresolved chassis (chassis=null)', () => {
+  test('renders all six stat rows even when chassis is null', () => {
+    render(
+      <MechSheet
+        mech={fakeMechNoStoredValues}
+        chassis={null}
+        store={makeStubStore(fakeMechNoStoredValues)}
+      />
+    )
+
+    // The stats section heading should appear
+    expect(screen.getByText('Stats')).toBeTruthy()
+
+    // Each of the six stat labels must be present
+    expect(screen.getByText('HP')).toBeTruthy()
+    expect(screen.getByText('AP')).toBeTruthy()
+    expect(screen.getByText('TP')).toBeTruthy()
+    expect(screen.getByText('SP')).toBeTruthy()
+    expect(screen.getByText('EP')).toBeTruthy()
+    expect(screen.getByText('Heat')).toBeTruthy()
+  })
+
+  test('stat rows are editable (role=button present) when chassis is null', () => {
+    render(
+      <MechSheet
+        mech={fakeMechNoStoredValues}
+        chassis={null}
+        store={makeStubStore(fakeMechNoStoredValues)}
+      />
+    )
+
+    // EditableStatRow renders a button in display mode
+    const buttons = screen.getAllByRole('button')
+    expect(buttons.length).toBeGreaterThanOrEqual(6)
+  })
+
+  test('shows accessible notice referencing the unresolvable chassisRef', () => {
+    render(
+      <MechSheet
+        mech={fakeMechNoStoredValues}
+        chassis={null}
+        store={makeStubStore(fakeMechNoStoredValues)}
+      />
+    )
+
+    // The notice must mention the bogus chassis ref
+    expect(screen.getByRole('alert')).toBeTruthy()
+    expect(screen.getByRole('alert').textContent).toContain('nonexistent-chassis-xyz')
+  })
+
+  test('stat rows fall back to stored values when chassis is null', () => {
+    render(
+      <MechSheet
+        mech={fakeMechWithStoredValues}
+        chassis={null}
+        store={makeStubStore(fakeMechWithStoredValues)}
+      />
+    )
+
+    // The stored HP value (7) should appear somewhere in the document
+    const allText = document.body.textContent ?? ''
+    expect(allText).toContain('7')
+  })
+
+  test('stat rows default to 0 when chassis is null and no stored values', () => {
+    render(
+      <MechSheet
+        mech={fakeMechNoStoredValues}
+        chassis={null}
+        store={makeStubStore(fakeMechNoStoredValues)}
+      />
+    )
+
+    // With no stored values and no chassis, all stats should show 0
+    // EditableStatRow renders the value as text in the button label
+    const buttons = screen.getAllByRole('button')
+    // At least one button should display "0"
+    const zeroButtons = buttons.filter((btn) => btn.textContent?.trim() === '0')
+    expect(zeroButtons.length).toBeGreaterThanOrEqual(6)
+  })
+})

--- a/apps/in-the-union-now/src/components/sheet/__tests__/PilotSheet-editable.test.tsx
+++ b/apps/in-the-union-now/src/components/sheet/__tests__/PilotSheet-editable.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * PilotSheet — editable HP/AP stat tests (#245)
+ *
+ * Asserts that:
+ *   1. Editing HP calls store.update with { currentHP: <value> }
+ *   2. Editing AP calls store.update with { currentAP: <value> }
+ *   3. readOnly suppresses editing (no spinbutton, no store.update)
+ */
+
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { PilotSheet } from '../PilotSheet'
+import type { Pilot } from '../../../lib/schemas/pilot'
+import type { useEntityStore } from '../../../stores/entityStore'
+
+afterEach(() => {
+  cleanup()
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const fakePilot: Pilot = {
+  id: 'pilot-edit-1',
+  schemaVersion: 1,
+  name: 'Yara Voss',
+  callsign: 'Ghost',
+  classRef: 'scavenger',
+  abilities: [],
+  equipment: [],
+  rollResults: [],
+  motto: '',
+  keepsake: '',
+  appearance: '',
+  conditions: [],
+  currentHP: 10,
+  currentAP: 4,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}
+
+function makeStubStore(pilot: Pilot, updateSpy?: ReturnType<typeof mock>): typeof useEntityStore {
+  const updateMock = updateSpy ?? mock(async () => pilot)
+  const storeState = {
+    pilots: [pilot],
+    mechs: [],
+    crawlers: [],
+    softLinks: [],
+    hydrated: { pilots: true, mechs: false, crawlers: false, softLinks: false },
+    hydrate: mock(async () => {}),
+    list: mock(() => [pilot]),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    get: mock((_type: string, id: string) => (id === pilot.id ? pilot : null)) as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    create: mock(async () => pilot) as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    update: updateMock as any,
+    delete: mock(async () => {}),
+  }
+  return (() => storeState) as unknown as typeof useEntityStore
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PilotSheet — HP editing (#245)', () => {
+  test('renders HP stat value', () => {
+    render(<PilotSheet pilot={fakePilot} store={makeStubStore(fakePilot)} />)
+    expect(screen.getByText('10')).toBeTruthy()
+  })
+
+  test('clicking HP value enters edit mode (shows spinbutton)', async () => {
+    render(<PilotSheet pilot={fakePilot} store={makeStubStore(fakePilot)} />)
+    const hpValue = screen.getByText('10')
+    await act(async () => {
+      fireEvent.click(hpValue)
+    })
+    expect(screen.getByRole('spinbutton')).toBeTruthy()
+  })
+
+  test('saving HP calls store.update with { currentHP }', async () => {
+    const updateSpy = mock(async () => fakePilot)
+    render(<PilotSheet pilot={fakePilot} store={makeStubStore(fakePilot, updateSpy)} />)
+
+    const hpValue = screen.getByText('10')
+    await act(async () => {
+      fireEvent.click(hpValue)
+    })
+
+    const input = screen.getByRole('spinbutton')
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '7' } })
+      fireEvent.blur(input)
+    })
+
+    expect(updateSpy).toHaveBeenCalledWith('pilot', fakePilot.id, { currentHP: 7 })
+  })
+})
+
+describe('PilotSheet — AP editing (#245)', () => {
+  test('renders AP stat value', () => {
+    render(<PilotSheet pilot={fakePilot} store={makeStubStore(fakePilot)} />)
+    expect(screen.getByText('4')).toBeTruthy()
+  })
+
+  test('saving AP calls store.update with { currentAP }', async () => {
+    // Use a pilot where HP and AP are different so we can distinguish them
+    const updateSpy = mock(async () => fakePilot)
+    render(<PilotSheet pilot={fakePilot} store={makeStubStore(fakePilot, updateSpy)} />)
+
+    // Click the AP value (4)
+    const apValue = screen.getByText('4')
+    await act(async () => {
+      fireEvent.click(apValue)
+    })
+
+    const input = screen.getByRole('spinbutton')
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '2' } })
+      fireEvent.blur(input)
+    })
+
+    expect(updateSpy).toHaveBeenCalledWith('pilot', fakePilot.id, { currentAP: 2 })
+  })
+})
+
+describe('PilotSheet — readOnly (#245)', () => {
+  test('no edit buttons (role=button with "Edit" label) when readOnly', () => {
+    render(<PilotSheet pilot={fakePilot} store={makeStubStore(fakePilot)} readOnly />)
+    // No edit buttons should be present — readOnly renders plain text
+    const editButtons = document.querySelectorAll('button[aria-label*="Edit"]')
+    expect(editButtons.length).toBe(0)
+  })
+
+  test('clicking stat value does not show spinbutton when readOnly', async () => {
+    render(<PilotSheet pilot={fakePilot} store={makeStubStore(fakePilot)} readOnly />)
+    const hpValue = screen.getByText('10')
+    await act(async () => {
+      fireEvent.click(hpValue)
+    })
+    expect(screen.queryByRole('spinbutton')).toBeNull()
+  })
+
+  test('store.update is never called when readOnly', async () => {
+    const updateSpy = mock(async () => fakePilot)
+    render(<PilotSheet pilot={fakePilot} store={makeStubStore(fakePilot, updateSpy)} readOnly />)
+
+    const hpValue = screen.getByText('10')
+    await act(async () => {
+      fireEvent.click(hpValue)
+    })
+
+    expect(updateSpy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/in-the-union-now/src/components/sheet/__tests__/Sheet.test.tsx
+++ b/apps/in-the-union-now/src/components/sheet/__tests__/Sheet.test.tsx
@@ -30,7 +30,7 @@ import type { SoftLink } from '../../../lib/schemas/softLink'
 // ---------------------------------------------------------------------------
 
 beforeAll(async () => {
-  await SalvageUnionReference.preload(['chassis'])
+  await SalvageUnionReference.preload('all')
 })
 
 afterEach(() => {
@@ -299,6 +299,91 @@ describe('Sheet — wired (mech WITH pilot link)', () => {
       />
     )
     expect(screen.queryByLabelText('No pilot assigned')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// MechStandIn: pilot-only mode
+// ---------------------------------------------------------------------------
+
+describe('Sheet — MechStandIn in pilot-only mode', () => {
+  test('MechStandIn renders when pilot has no mech wired', () => {
+    render(
+      <Sheet
+        kind="pilot"
+        id="pilot-1"
+        entityStore={makeEntityStore([fakePilot])}
+        softLinkStore={makeSoftLinkStore([])}
+      />
+    )
+    expect(screen.getByLabelText('No mech assigned')).toBeTruthy()
+  })
+
+  test('MechStandIn is ABSENT when a mech is wired', () => {
+    const mechToPilotLink = makeLink(
+      'link-1',
+      'mech',
+      'mech-1',
+      'pilot',
+      'pilot-1',
+      'mech-to-pilot'
+    )
+    render(
+      <Sheet
+        kind="pilot"
+        id="pilot-1"
+        entityStore={makeEntityStore([fakePilot, fakeMech])}
+        softLinkStore={makeSoftLinkStore([mechToPilotLink])}
+      />
+    )
+    expect(screen.queryByLabelText('No mech assigned')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// MechStandIn: wired pilot+crawler (no mech)
+// ---------------------------------------------------------------------------
+
+describe('Sheet — MechStandIn in wired pilot+crawler (no mech)', () => {
+  const pilotToCrawlerLink = makeLink(
+    'link-2',
+    'pilot',
+    'pilot-1',
+    'crawler',
+    'crawler-1',
+    'pilot-to-crawler'
+  )
+
+  test('MechStandIn renders when wired pilot+crawler but no mech', () => {
+    render(
+      <Sheet
+        kind="pilot"
+        id="pilot-1"
+        entityStore={makeEntityStore([fakePilot, fakeCrawler])}
+        softLinkStore={makeSoftLinkStore([pilotToCrawlerLink])}
+      />
+    )
+    expect(screen.getByLabelText('No mech assigned')).toBeTruthy()
+  })
+
+  test('MechStandIn is ABSENT when mech is also wired (full wired)', () => {
+    const mechToPilotLink = makeLink(
+      'link-1',
+      'mech',
+      'mech-1',
+      'pilot',
+      'pilot-1',
+      'mech-to-pilot'
+    )
+    render(
+      <Sheet
+        kind="pilot"
+        id="pilot-1"
+        entityStore={makeEntityStore([fakePilot, fakeMech, fakeCrawler])}
+        softLinkStore={makeSoftLinkStore([mechToPilotLink, pilotToCrawlerLink])}
+      />
+    )
+    expect(screen.queryByLabelText('No mech assigned')).toBeNull()
   })
 })
 

--- a/apps/in-the-union-now/src/components/sheet/__tests__/condition-tracking.test.tsx
+++ b/apps/in-the-union-now/src/components/sheet/__tests__/condition-tracking.test.tsx
@@ -1,0 +1,295 @@
+/**
+ * Condition tracking tests — REQ-011 (#240)
+ *
+ * Asserts that:
+ *   1. Clicking a mech system ConditionToggle calls store.update with the
+ *      correct systemConditions patch.
+ *   2. Clicking a mech module ConditionToggle calls store.update with the
+ *      correct moduleConditions patch.
+ *   3. Clicking a pilot equipment ConditionToggle calls store.update with the
+ *      correct equipmentConditions patch.
+ *   4. The displayed condition value reflects what is stored.
+ *   5. In readOnly mode, toggling is a no-op (store.update not called).
+ */
+
+import { afterEach, beforeAll, describe, expect, mock, test } from 'bun:test'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import { MechSheet } from '../MechSheet'
+import { PilotSheet } from '../PilotSheet'
+import type { Mech } from '../../../lib/schemas/mech'
+import type { Pilot } from '../../../lib/schemas/pilot'
+import type { useEntityStore } from '../../../stores/entityStore'
+
+// PilotSheet resolves equipment/ability slugs via salvageunion-reference at render
+beforeAll(async () => {
+  await SalvageUnionReference.preload(['equipment', 'abilities'])
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+// ---------------------------------------------------------------------------
+// Stub factories
+// ---------------------------------------------------------------------------
+
+function makeMechStubStore(mech: Mech, updateSpy?: ReturnType<typeof mock>): typeof useEntityStore {
+  const updateMock = updateSpy ?? mock(async () => mech)
+  const storeState = {
+    pilots: [],
+    mechs: [mech],
+    crawlers: [],
+    softLinks: [],
+    hydrated: { pilots: false, mechs: true, crawlers: false, softLinks: false },
+    hydrate: mock(async () => {}),
+    list: mock(() => [mech]),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    get: mock((_type: string, id: string) => (id === mech.id ? mech : null)) as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    create: mock(async () => mech) as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    update: updateMock as any,
+    delete: mock(async () => {}),
+  }
+  return (() => storeState) as unknown as typeof useEntityStore
+}
+
+function makePilotStubStore(
+  pilot: Pilot,
+  updateSpy?: ReturnType<typeof mock>
+): typeof useEntityStore {
+  const updateMock = updateSpy ?? mock(async () => pilot)
+  const storeState = {
+    pilots: [pilot],
+    mechs: [],
+    crawlers: [],
+    softLinks: [],
+    hydrated: { pilots: true, mechs: false, crawlers: false, softLinks: false },
+    hydrate: mock(async () => {}),
+    list: mock(() => [pilot]),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    get: mock((_type: string, id: string) => (id === pilot.id ? pilot : null)) as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    create: mock(async () => pilot) as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    update: updateMock as any,
+    delete: mock(async () => {}),
+  }
+  return (() => storeState) as unknown as typeof useEntityStore
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const fakeChassis = {
+  name: 'Iron Mongrel',
+  structurePoints: 14,
+  energyPoints: 6,
+  heatCapacity: 8,
+  systemSlots: 3,
+  moduleSlots: 2,
+  cargoCapacity: 4,
+}
+
+const fakeMech: Mech = {
+  id: 'mech-cond-1',
+  schemaVersion: 1,
+  name: 'Test Mech',
+  chassisRef: 'iron-mongrel',
+  systems: ['plasma-torch'],
+  modules: ['reinforced-hull'],
+  cargo: [],
+  conditions: [],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}
+
+const fakeMechWithConditions: Mech = {
+  ...fakeMech,
+  id: 'mech-cond-stored',
+  systemConditions: { 'plasma-torch': 'damaged' },
+  moduleConditions: { 'reinforced-hull': 'destroyed' },
+}
+
+const fakePilot: Pilot = {
+  id: 'pilot-cond-1',
+  schemaVersion: 1,
+  name: 'Zara Quinn',
+  callsign: 'Hex',
+  classRef: 'scavenger',
+  abilities: [],
+  equipment: ['pistol'],
+  rollResults: [],
+  motto: '',
+  keepsake: '',
+  appearance: '',
+  conditions: [],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}
+
+const fakePilotWithConditions: Pilot = {
+  ...fakePilot,
+  id: 'pilot-cond-stored',
+  equipmentConditions: { pistol: 'damaged' },
+}
+
+// ---------------------------------------------------------------------------
+// Mech system condition tests
+// ---------------------------------------------------------------------------
+
+describe('MechSheet — system condition toggle (REQ-011 #240)', () => {
+  test('clicking a system toggle calls store.update with systemConditions patch', async () => {
+    const updateSpy = mock(async () => fakeMech)
+    render(
+      <MechSheet
+        mech={fakeMech}
+        chassis={fakeChassis}
+        store={makeMechStubStore(fakeMech, updateSpy)}
+      />
+    )
+
+    // The system 'plasma-torch' should show as 'Intact' initially
+    const toggle = screen.getByRole('button', { name: /plasma-torch condition/i })
+    await act(async () => {
+      fireEvent.click(toggle)
+    })
+
+    // Should update systemConditions: { 'plasma-torch': 'damaged' }
+    expect(updateSpy).toHaveBeenCalledWith('mech', fakeMech.id, {
+      systemConditions: { 'plasma-torch': 'damaged' },
+    })
+  })
+
+  test('displayed condition reflects stored systemConditions value', () => {
+    render(
+      <MechSheet
+        mech={fakeMechWithConditions}
+        chassis={fakeChassis}
+        store={makeMechStubStore(fakeMechWithConditions)}
+      />
+    )
+
+    // 'plasma-torch' is stored as 'damaged'
+    const toggle = screen.getByRole('button', { name: /plasma-torch condition: damaged/i })
+    expect(toggle).toBeTruthy()
+  })
+
+  test('readOnly: clicking system toggle does not call store.update', async () => {
+    const updateSpy = mock(async () => fakeMech)
+    render(
+      <MechSheet
+        mech={fakeMech}
+        chassis={fakeChassis}
+        store={makeMechStubStore(fakeMech, updateSpy)}
+        readOnly
+      />
+    )
+
+    // In readOnly mode, no role=button toggles should appear
+    expect(screen.queryByRole('button', { name: /plasma-torch condition/i })).toBeNull()
+    expect(updateSpy).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Mech module condition tests
+// ---------------------------------------------------------------------------
+
+describe('MechSheet — module condition toggle (REQ-011 #240)', () => {
+  test('clicking a module toggle calls store.update with moduleConditions patch', async () => {
+    const updateSpy = mock(async () => fakeMech)
+    render(
+      <MechSheet
+        mech={fakeMech}
+        chassis={fakeChassis}
+        store={makeMechStubStore(fakeMech, updateSpy)}
+      />
+    )
+
+    const toggle = screen.getByRole('button', { name: /reinforced-hull condition/i })
+    await act(async () => {
+      fireEvent.click(toggle)
+    })
+
+    expect(updateSpy).toHaveBeenCalledWith('mech', fakeMech.id, {
+      moduleConditions: { 'reinforced-hull': 'damaged' },
+    })
+  })
+
+  test('displayed condition reflects stored moduleConditions value', () => {
+    render(
+      <MechSheet
+        mech={fakeMechWithConditions}
+        chassis={fakeChassis}
+        store={makeMechStubStore(fakeMechWithConditions)}
+      />
+    )
+
+    // 'reinforced-hull' is stored as 'destroyed'
+    const toggle = screen.getByRole('button', { name: /reinforced-hull condition: destroyed/i })
+    expect(toggle).toBeTruthy()
+  })
+
+  test('readOnly: clicking module toggle does not call store.update', async () => {
+    const updateSpy = mock(async () => fakeMech)
+    render(
+      <MechSheet
+        mech={fakeMech}
+        chassis={fakeChassis}
+        store={makeMechStubStore(fakeMech, updateSpy)}
+        readOnly
+      />
+    )
+
+    expect(screen.queryByRole('button', { name: /reinforced-hull condition/i })).toBeNull()
+    expect(updateSpy).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Pilot equipment condition tests
+// ---------------------------------------------------------------------------
+
+describe('PilotSheet — equipment condition toggle (REQ-011 #240)', () => {
+  test('clicking an equipment toggle calls store.update with equipmentConditions patch', async () => {
+    const updateSpy = mock(async () => fakePilot)
+    render(<PilotSheet pilot={fakePilot} store={makePilotStubStore(fakePilot, updateSpy)} />)
+
+    const toggle = screen.getByRole('button', { name: /pistol condition/i })
+    await act(async () => {
+      fireEvent.click(toggle)
+    })
+
+    expect(updateSpy).toHaveBeenCalledWith('pilot', fakePilot.id, {
+      equipmentConditions: { pistol: 'damaged' },
+    })
+  })
+
+  test('displayed condition reflects stored equipmentConditions value', () => {
+    render(
+      <PilotSheet
+        pilot={fakePilotWithConditions}
+        store={makePilotStubStore(fakePilotWithConditions)}
+      />
+    )
+
+    // 'pistol' is stored as 'damaged'
+    const toggle = screen.getByRole('button', { name: /pistol condition: damaged/i })
+    expect(toggle).toBeTruthy()
+  })
+
+  test('readOnly: clicking equipment toggle does not call store.update', async () => {
+    const updateSpy = mock(async () => fakePilot)
+    render(
+      <PilotSheet pilot={fakePilot} store={makePilotStubStore(fakePilot, updateSpy)} readOnly />
+    )
+
+    // In readOnly mode, no interactive toggle button should appear
+    expect(screen.queryByRole('button', { name: /pistol condition/i })).toBeNull()
+    expect(updateSpy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/in-the-union-now/src/components/sheet/__tests__/condition-tracking.test.tsx
+++ b/apps/in-the-union-now/src/components/sheet/__tests__/condition-tracking.test.tsx
@@ -293,3 +293,52 @@ describe('PilotSheet — equipment condition toggle (REQ-011 #240)', () => {
     expect(updateSpy).not.toHaveBeenCalled()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Stale-closure regression (formal-review fix): the handler must merge from the
+// freshest store state, not the render-time prop, so a condition set by a prior
+// (not-yet-re-rendered) toggle is preserved instead of being stomped.
+// ---------------------------------------------------------------------------
+
+describe('MechSheet — condition merge reads live store, not stale prop (#240 regression)', () => {
+  test('preserves a prior condition that exists in the store but not in the render prop', async () => {
+    const updateSpy = mock(async () => fakeMech)
+    // Prop has NO conditions yet; the store (get) already holds a prior toggle.
+    const propMech: Mech = { ...fakeMech, systemConditions: {} }
+    const freshMech: Mech = {
+      ...fakeMech,
+      systemConditions: { 'prior-system': 'destroyed' },
+    }
+    const storeState = {
+      pilots: [],
+      mechs: [freshMech],
+      crawlers: [],
+      softLinks: [],
+      hydrated: { pilots: false, mechs: true, crawlers: false, softLinks: false },
+      hydrate: mock(async () => {}),
+      list: mock(() => [freshMech]),
+      // get returns the FRESH mech (with the prior condition), unlike the prop
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      get: mock((_type: string, id: string) => (id === fakeMech.id ? freshMech : null)) as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      create: mock(async () => fakeMech) as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      update: updateSpy as any,
+      delete: mock(async () => {}),
+    }
+    const store = (() => storeState) as unknown as typeof useEntityStore
+
+    render(<MechSheet mech={propMech} chassis={fakeChassis} store={store} />)
+
+    const toggle = screen.getByRole('button', { name: /plasma-torch condition/i })
+    await act(async () => {
+      fireEvent.click(toggle)
+    })
+
+    // The patch must include BOTH the prior store condition and the new one —
+    // proving the merge base came from store.get, not the empty prop map.
+    expect(updateSpy).toHaveBeenCalledWith('mech', fakeMech.id, {
+      systemConditions: { 'prior-system': 'destroyed', 'plasma-torch': 'damaged' },
+    })
+  })
+})

--- a/apps/in-the-union-now/src/components/sheet/__tests__/mobile-responsive.test.tsx
+++ b/apps/in-the-union-now/src/components/sheet/__tests__/mobile-responsive.test.tsx
@@ -6,10 +6,12 @@
  *       (verified via class attribute containing min-h-11).
  *
  * Design choices:
- * - scrollWidth / clientWidth check uses a wrapper div styled to 320px. In
- *   happy-dom the layout engine is not full-featured, so both values are 0.
- *   We assert scrollWidth <= clientWidth (never overflows) which holds as long
- *   as the component does not explicitly set a width wider than its container.
+ * - 320px overflow check: happy-dom does not implement a full layout engine, so
+ *   scrollWidth and clientWidth are both 0 regardless of CSS. The overflow
+ *   assertion below is therefore replaced with a render-completeness check
+ *   (entity content appears without throwing). Real 320px overflow verification
+ *   requires a browser engine — this is tracked in the M3 a11y/perf work and
+ *   should be covered by a Playwright / puppeteer visual regression test.
  * - Touch target: we assert the display-state span/button carries `min-h-11`
  *   in its className string, matching the Tailwind class applied in the source.
  *   This is the most reliable assertion in happy-dom (no computed styles).
@@ -121,8 +123,15 @@ function makePublishFn(
 // AC-1: No horizontal overflow at 320px
 // ---------------------------------------------------------------------------
 
-describe('Mobile responsive — no horizontal overflow at 320px', () => {
-  test('pilot-only Sheet does not overflow 320px container', () => {
+describe('Mobile responsive — renders without error at 320px container', () => {
+  // NOTE: happy-dom does not implement a real layout engine — scrollWidth and
+  // clientWidth are both 0 regardless of CSS, making overflow assertions vacuous.
+  // These tests assert instead that each Sheet variant renders its core entity
+  // content correctly inside a 320px container (render-completeness check).
+  // Real 320px horizontal-overflow verification is deferred to M3 a11y/perf work
+  // and should be covered by a Playwright / puppeteer browser-engine test.
+
+  test('pilot-only Sheet renders entity name inside 320px container', () => {
     const wrapper = document.createElement('div')
     wrapper.style.width = '320px'
     document.body.appendChild(wrapper)
@@ -137,14 +146,13 @@ describe('Mobile responsive — no horizontal overflow at 320px', () => {
       { container: wrapper }
     )
 
-    // In happy-dom, both values are 0 — the assertion holds (no overflow)
-    // On a real browser, scrollWidth would match or be less than clientWidth
-    expect(wrapper.scrollWidth <= wrapper.clientWidth).toBeTruthy()
+    // Render-completeness: pilot name visible (would throw if render crashes)
+    expect(screen.getAllByText(/Yara Voss/).length).toBeGreaterThan(0)
 
     document.body.removeChild(wrapper)
   })
 
-  test('mech-only Sheet does not overflow 320px container', () => {
+  test('mech-only Sheet renders entity name inside 320px container', () => {
     const wrapper = document.createElement('div')
     wrapper.style.width = '320px'
     document.body.appendChild(wrapper)
@@ -159,12 +167,12 @@ describe('Mobile responsive — no horizontal overflow at 320px', () => {
       { container: wrapper }
     )
 
-    expect(wrapper.scrollWidth <= wrapper.clientWidth).toBeTruthy()
+    expect(screen.getAllByText(/Iron Fist/).length).toBeGreaterThan(0)
 
     document.body.removeChild(wrapper)
   })
 
-  test('crawler-only Sheet does not overflow 320px container', () => {
+  test('crawler-only Sheet renders entity name inside 320px container', () => {
     const wrapper = document.createElement('div')
     wrapper.style.width = '320px'
     document.body.appendChild(wrapper)
@@ -179,7 +187,7 @@ describe('Mobile responsive — no horizontal overflow at 320px', () => {
       { container: wrapper }
     )
 
-    expect(wrapper.scrollWidth <= wrapper.clientWidth).toBeTruthy()
+    expect(screen.getAllByText(/Iron Tortoise/).length).toBeGreaterThan(0)
 
     document.body.removeChild(wrapper)
   })

--- a/apps/in-the-union-now/src/components/sheet/__tests__/sheet-crawler-composition.test.tsx
+++ b/apps/in-the-union-now/src/components/sheet/__tests__/sheet-crawler-composition.test.tsx
@@ -1,0 +1,370 @@
+/**
+ * Sheet — crawler-wired composition mode rendering (#244).
+ *
+ * Covers three composition scenarios NOT yet asserted by Sheet.test.tsx or
+ * sheet-smoke.test.tsx in terms of sub-sheet content visibility:
+ *
+ *   A. pilot + crawler (no mech) — both PilotSheet and CrawlerSheet render
+ *   B. full wired: mech + pilot + crawler — all three sub-sheets render
+ *   C. crawler + pilots (wired) — CrawlerSheet renders with wired pilot names
+ *
+ * These complement the MechStandIn tests in Sheet.test.tsx (which verify
+ * stand-ins appear/disappear) by asserting entity content is actually rendered.
+ *
+ * Conventions: toBeTruthy() not toBeInTheDocument(), no mock.module().
+ */
+
+import { afterEach, beforeAll, describe, expect, mock, test } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import { Sheet } from '../Sheet'
+import type { EntityLookup } from '../Sheet'
+import type { SoftLinkStore } from '../../wiring/useSoftLinks'
+import type { Pilot } from '../../../lib/schemas/pilot'
+import type { Mech } from '../../../lib/schemas/mech'
+import type { Crawler } from '../../../lib/schemas/crawler'
+import type { SoftLink } from '../../../lib/schemas/softLink'
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload(['chassis'])
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+// ---------------------------------------------------------------------------
+// Shared fake entities
+// ---------------------------------------------------------------------------
+
+const fakePilot: Pilot = {
+  id: 'pilot-comp-1',
+  schemaVersion: 1,
+  name: 'Desta Oryn',
+  callsign: 'Delta',
+  classRef: 'mechanic',
+  abilities: [],
+  equipment: [],
+  rollResults: [],
+  motto: 'One wrench.',
+  keepsake: 'Nothing.',
+  appearance: 'Scarred.',
+  conditions: [],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}
+
+const fakePilot2: Pilot = {
+  id: 'pilot-comp-2',
+  schemaVersion: 1,
+  name: 'Hann Vex',
+  callsign: 'Echo',
+  classRef: 'scavenger',
+  abilities: [],
+  equipment: [],
+  rollResults: [],
+  motto: 'Move fast.',
+  keepsake: 'A token.',
+  appearance: 'Wiry.',
+  conditions: [],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}
+
+const fakeMech: Mech = {
+  id: 'mech-comp-1',
+  schemaVersion: 1,
+  name: 'Dust Hammer',
+  chassisRef: 'iron-mongrel',
+  systems: [],
+  modules: [],
+  cargo: [],
+  conditions: [],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}
+
+const fakeCrawler: Crawler = {
+  id: 'crawler-comp-1',
+  schemaVersion: 1,
+  name: 'The Hive',
+  techLevel: 'tech-2',
+  bays: [],
+  systems: [],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}
+
+// ---------------------------------------------------------------------------
+// Store / link factories
+// ---------------------------------------------------------------------------
+
+type AnyEntity = Pilot | Mech | Crawler
+
+function makeEntityStore(entities: AnyEntity[]): EntityLookup {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    get: (_type, id) => (entities.find((e) => e.id === id) ?? null) as any,
+  }
+}
+
+function makeSoftLinkStore(links: SoftLink[]): SoftLinkStore {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const createMock = mock(async () => links[0]) as any
+  return {
+    softLinks: links,
+    create: createMock,
+    delete: mock(async () => undefined),
+  }
+}
+
+function makeLink(
+  id: string,
+  fromType: 'mech' | 'pilot' | 'crawler',
+  fromId: string,
+  toType: 'mech' | 'pilot' | 'crawler',
+  toId: string,
+  type: SoftLink['type']
+): SoftLink {
+  return {
+    id,
+    from: { type: fromType, id: fromId },
+    to: { type: toType, id: toId },
+    type,
+    createdAt: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario A — pilot + crawler (no mech)
+// kind=pilot with pilot-to-crawler outgoing link, no mech-to-pilot link
+// ---------------------------------------------------------------------------
+
+describe('Sheet — pilot+crawler wired composition (no mech)', () => {
+  const pilotToCrawlerLink = makeLink(
+    'link-pc',
+    'pilot',
+    'pilot-comp-1',
+    'crawler',
+    'crawler-comp-1',
+    'pilot-to-crawler'
+  )
+
+  test('PilotSheet content (pilot name) is visible', () => {
+    render(
+      <Sheet
+        kind="pilot"
+        id="pilot-comp-1"
+        entityStore={makeEntityStore([fakePilot, fakeCrawler])}
+        softLinkStore={makeSoftLinkStore([pilotToCrawlerLink])}
+      />
+    )
+    expect(screen.getAllByText(/Desta Oryn/).length).toBeGreaterThan(0)
+  })
+
+  test('CrawlerSheet content (crawler name) is visible', () => {
+    render(
+      <Sheet
+        kind="pilot"
+        id="pilot-comp-1"
+        entityStore={makeEntityStore([fakePilot, fakeCrawler])}
+        softLinkStore={makeSoftLinkStore([pilotToCrawlerLink])}
+      />
+    )
+    expect(screen.getAllByText(/The Hive/).length).toBeGreaterThan(0)
+  })
+
+  test('composition badge shows "Wired"', () => {
+    render(
+      <Sheet
+        kind="pilot"
+        id="pilot-comp-1"
+        entityStore={makeEntityStore([fakePilot, fakeCrawler])}
+        softLinkStore={makeSoftLinkStore([pilotToCrawlerLink])}
+      />
+    )
+    expect(screen.getByLabelText('Composition mode: Wired')).toBeTruthy()
+  })
+
+  test('MechStandIn renders (no mech is wired)', () => {
+    render(
+      <Sheet
+        kind="pilot"
+        id="pilot-comp-1"
+        entityStore={makeEntityStore([fakePilot, fakeCrawler])}
+        softLinkStore={makeSoftLinkStore([pilotToCrawlerLink])}
+      />
+    )
+    expect(screen.getByLabelText('No mech assigned')).toBeTruthy()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario B — full wired: mech + pilot + crawler
+// kind=pilot with both mech-to-pilot incoming AND pilot-to-crawler outgoing
+// ---------------------------------------------------------------------------
+
+describe('Sheet — full wired (mech+pilot+crawler)', () => {
+  const mechToPilotLink = makeLink(
+    'link-mp',
+    'mech',
+    'mech-comp-1',
+    'pilot',
+    'pilot-comp-1',
+    'mech-to-pilot'
+  )
+  const pilotToCrawlerLink = makeLink(
+    'link-pc',
+    'pilot',
+    'pilot-comp-1',
+    'crawler',
+    'crawler-comp-1',
+    'pilot-to-crawler'
+  )
+
+  test('PilotSheet content (pilot name) is visible', () => {
+    render(
+      <Sheet
+        kind="pilot"
+        id="pilot-comp-1"
+        entityStore={makeEntityStore([fakePilot, fakeMech, fakeCrawler])}
+        softLinkStore={makeSoftLinkStore([mechToPilotLink, pilotToCrawlerLink])}
+      />
+    )
+    expect(screen.getAllByText(/Desta Oryn/).length).toBeGreaterThan(0)
+  })
+
+  test('MechSheet content (mech name) is visible', () => {
+    render(
+      <Sheet
+        kind="pilot"
+        id="pilot-comp-1"
+        entityStore={makeEntityStore([fakePilot, fakeMech, fakeCrawler])}
+        softLinkStore={makeSoftLinkStore([mechToPilotLink, pilotToCrawlerLink])}
+      />
+    )
+    expect(screen.getAllByText(/Dust Hammer/).length).toBeGreaterThan(0)
+  })
+
+  test('CrawlerSheet content (crawler name) is visible', () => {
+    render(
+      <Sheet
+        kind="pilot"
+        id="pilot-comp-1"
+        entityStore={makeEntityStore([fakePilot, fakeMech, fakeCrawler])}
+        softLinkStore={makeSoftLinkStore([mechToPilotLink, pilotToCrawlerLink])}
+      />
+    )
+    expect(screen.getAllByText(/The Hive/).length).toBeGreaterThan(0)
+  })
+
+  test('composition badge shows "Wired"', () => {
+    render(
+      <Sheet
+        kind="pilot"
+        id="pilot-comp-1"
+        entityStore={makeEntityStore([fakePilot, fakeMech, fakeCrawler])}
+        softLinkStore={makeSoftLinkStore([mechToPilotLink, pilotToCrawlerLink])}
+      />
+    )
+    expect(screen.getByLabelText('Composition mode: Wired')).toBeTruthy()
+  })
+
+  test('no stand-ins rendered (all three entities are wired)', () => {
+    render(
+      <Sheet
+        kind="pilot"
+        id="pilot-comp-1"
+        entityStore={makeEntityStore([fakePilot, fakeMech, fakeCrawler])}
+        softLinkStore={makeSoftLinkStore([mechToPilotLink, pilotToCrawlerLink])}
+      />
+    )
+    expect(screen.queryByLabelText('No mech assigned')).toBeNull()
+    expect(screen.queryByLabelText('No pilot assigned')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scenario C — crawler + pilots (wired)
+// kind=crawler with pilot-to-crawler incoming links from multiple pilots
+// ---------------------------------------------------------------------------
+
+describe('Sheet — crawler+pilots wired composition', () => {
+  const pilot1ToCrawlerLink = makeLink(
+    'link-p1c',
+    'pilot',
+    'pilot-comp-1',
+    'crawler',
+    'crawler-comp-1',
+    'pilot-to-crawler'
+  )
+  const pilot2ToCrawlerLink = makeLink(
+    'link-p2c',
+    'pilot',
+    'pilot-comp-2',
+    'crawler',
+    'crawler-comp-1',
+    'pilot-to-crawler'
+  )
+
+  test('CrawlerSheet content (crawler name) is visible', () => {
+    render(
+      <Sheet
+        kind="crawler"
+        id="crawler-comp-1"
+        entityStore={makeEntityStore([fakeCrawler, fakePilot, fakePilot2])}
+        softLinkStore={makeSoftLinkStore([pilot1ToCrawlerLink, pilot2ToCrawlerLink])}
+      />
+    )
+    expect(screen.getAllByText(/The Hive/).length).toBeGreaterThan(0)
+  })
+
+  test('first wired pilot name is visible in CrawlerSheet', () => {
+    render(
+      <Sheet
+        kind="crawler"
+        id="crawler-comp-1"
+        entityStore={makeEntityStore([fakeCrawler, fakePilot, fakePilot2])}
+        softLinkStore={makeSoftLinkStore([pilot1ToCrawlerLink, pilot2ToCrawlerLink])}
+      />
+    )
+    expect(screen.getAllByText(/Desta Oryn/).length).toBeGreaterThan(0)
+  })
+
+  test('second wired pilot name is visible in CrawlerSheet', () => {
+    render(
+      <Sheet
+        kind="crawler"
+        id="crawler-comp-1"
+        entityStore={makeEntityStore([fakeCrawler, fakePilot, fakePilot2])}
+        softLinkStore={makeSoftLinkStore([pilot1ToCrawlerLink, pilot2ToCrawlerLink])}
+      />
+    )
+    expect(screen.getAllByText(/Hann Vex/).length).toBeGreaterThan(0)
+  })
+
+  test('composition badge shows "Wired"', () => {
+    render(
+      <Sheet
+        kind="crawler"
+        id="crawler-comp-1"
+        entityStore={makeEntityStore([fakeCrawler, fakePilot, fakePilot2])}
+        softLinkStore={makeSoftLinkStore([pilot1ToCrawlerLink, pilot2ToCrawlerLink])}
+      />
+    )
+    expect(screen.getByLabelText('Composition mode: Wired')).toBeTruthy()
+  })
+
+  test('CrawlerPilotsStandIn not rendered when pilots are wired', () => {
+    render(
+      <Sheet
+        kind="crawler"
+        id="crawler-comp-1"
+        entityStore={makeEntityStore([fakeCrawler, fakePilot, fakePilot2])}
+        softLinkStore={makeSoftLinkStore([pilot1ToCrawlerLink, pilot2ToCrawlerLink])}
+      />
+    )
+    expect(screen.queryByLabelText('No pilots assigned')).toBeNull()
+  })
+})

--- a/apps/in-the-union-now/src/lib/db/__tests__/crud-mech-crawler.test.ts
+++ b/apps/in-the-union-now/src/lib/db/__tests__/crud-mech-crawler.test.ts
@@ -1,0 +1,269 @@
+/**
+ * DB CRUD round-trips for 'mech' and 'crawler' entity types (#244).
+ *
+ * crud.test.ts covers pilots only. This file extends coverage to mechs and
+ * crawlers — create/get/update/delete round-trips, including a currentXxx
+ * stat-field write-through.
+ *
+ * fake-indexeddb/auto is preloaded via bunfig.toml.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { _clearAllStores, mechs, crawlers } from '../index'
+
+beforeEach(async () => {
+  await _clearAllStores()
+})
+
+afterEach(async () => {
+  await _clearAllStores()
+})
+
+// ---------------------------------------------------------------------------
+// Mech base input
+// ---------------------------------------------------------------------------
+
+const baseMechInput = {
+  schemaVersion: 1 as const,
+  name: 'Test Mech',
+  chassisRef: 'iron-mongrel',
+  systems: [],
+  modules: [],
+  cargo: [],
+  conditions: [],
+}
+
+// ---------------------------------------------------------------------------
+// Crawler base input
+// ---------------------------------------------------------------------------
+
+const baseCrawlerInput = {
+  schemaVersion: 1 as const,
+  name: 'Test Crawler',
+  techLevel: 'tech-2',
+  bays: [],
+  systems: [],
+}
+
+// ===========================================================================
+// Mech CRUD
+// ===========================================================================
+
+describe('mechs CRUD — create/get round-trip', () => {
+  test('create then get returns equivalent record', async () => {
+    const created = await mechs.create(baseMechInput)
+
+    expect(typeof created.id).toBe('string')
+    expect(created.id.length).toBeGreaterThan(0)
+    expect(created.name).toBe('Test Mech')
+    expect(created.chassisRef).toBe('iron-mongrel')
+    expect(created.schemaVersion).toBe(1)
+
+    const fetched = await mechs.get(created.id)
+    expect(fetched).not.toBeNull()
+    expect(fetched!.id).toBe(created.id)
+    expect(fetched!.name).toBe(created.name)
+    expect(fetched!.chassisRef).toBe(created.chassisRef)
+    expect(fetched!.createdAt).toBe(created.createdAt)
+    expect(fetched!.updatedAt).toBe(created.updatedAt)
+  })
+})
+
+describe('mechs CRUD — list ordering', () => {
+  test('list returns mechs newest-first by createdAt', async () => {
+    const m1 = await mechs.create({ ...baseMechInput, name: 'Alpha' })
+    await new Promise((r) => setTimeout(r, 5))
+    const m2 = await mechs.create({ ...baseMechInput, name: 'Beta' })
+    await new Promise((r) => setTimeout(r, 5))
+    const m3 = await mechs.create({ ...baseMechInput, name: 'Gamma' })
+
+    const all = await mechs.list()
+    expect(all.length).toBe(3)
+    expect(all[0]!.id).toBe(m3.id)
+    expect(all[1]!.id).toBe(m2.id)
+    expect(all[2]!.id).toBe(m1.id)
+  })
+})
+
+describe('mechs CRUD — update merge', () => {
+  test('update merges patch and bumps updatedAt', async () => {
+    const created = await mechs.create(baseMechInput)
+    const originalUpdatedAt = created.updatedAt
+
+    await new Promise((r) => setTimeout(r, 5))
+
+    const updated = await mechs.update(created.id, { name: 'Renamed Mech', chassisRef: 'scorpion' })
+
+    expect(updated.id).toBe(created.id)
+    expect(updated.name).toBe('Renamed Mech')
+    expect(updated.chassisRef).toBe('scorpion')
+    // Unchanged fields preserved
+    expect(updated.systems).toEqual([])
+    expect(updated.createdAt).toBe(created.createdAt)
+    // updatedAt bumped
+    expect(updated.updatedAt).not.toBe(originalUpdatedAt)
+  })
+
+  test('update throws when id not found', async () => {
+    await expect(mechs.update('nonexistent-mech', { name: 'X' })).rejects.toThrow(
+      '[itun-db] Cannot update'
+    )
+  })
+})
+
+describe('mechs CRUD — currentHP stat write-through', () => {
+  test('update with currentHP writes to db and is retrievable', async () => {
+    const created = await mechs.create(baseMechInput)
+
+    const updated = await mechs.update(created.id, { currentHP: 7 })
+    expect(updated.currentHP).toBe(7)
+
+    const fetched = await mechs.get(created.id)
+    expect(fetched!.currentHP).toBe(7)
+  })
+
+  test('update with multiple stat fields persists all', async () => {
+    const created = await mechs.create(baseMechInput)
+
+    await mechs.update(created.id, {
+      currentHP: 10,
+      currentAP: 3,
+      currentTP: 2,
+      currentSP: 8,
+      currentEP: 5,
+      currentHeat: 4,
+    })
+
+    const fetched = await mechs.get(created.id)
+    expect(fetched!.currentHP).toBe(10)
+    expect(fetched!.currentAP).toBe(3)
+    expect(fetched!.currentTP).toBe(2)
+    expect(fetched!.currentSP).toBe(8)
+    expect(fetched!.currentEP).toBe(5)
+    expect(fetched!.currentHeat).toBe(4)
+  })
+})
+
+describe('mechs CRUD — delete', () => {
+  test('delete removes record; subsequent get returns null', async () => {
+    const created = await mechs.create(baseMechInput)
+    await mechs.delete(created.id)
+
+    const fetched = await mechs.get(created.id)
+    expect(fetched).toBeNull()
+  })
+
+  test('delete is a silent no-op for unknown id', async () => {
+    await mechs.delete('does-not-exist')
+  })
+})
+
+describe('mechs CRUD — Zod rejection', () => {
+  test('create rejects invalid input: missing required chassisRef', async () => {
+    const bad = { ...baseMechInput } as Record<string, unknown>
+    delete bad['chassisRef']
+    await expect(mechs.create(bad as Parameters<typeof mechs.create>[0])).rejects.toThrow()
+  })
+})
+
+// ===========================================================================
+// Crawler CRUD
+// ===========================================================================
+
+describe('crawlers CRUD — create/get round-trip', () => {
+  test('create then get returns equivalent record', async () => {
+    const created = await crawlers.create(baseCrawlerInput)
+
+    expect(typeof created.id).toBe('string')
+    expect(created.id.length).toBeGreaterThan(0)
+    expect(created.name).toBe('Test Crawler')
+    expect(created.techLevel).toBe('tech-2')
+    expect(created.schemaVersion).toBe(1)
+
+    const fetched = await crawlers.get(created.id)
+    expect(fetched).not.toBeNull()
+    expect(fetched!.id).toBe(created.id)
+    expect(fetched!.name).toBe(created.name)
+    expect(fetched!.techLevel).toBe(created.techLevel)
+    expect(fetched!.createdAt).toBe(created.createdAt)
+    expect(fetched!.updatedAt).toBe(created.updatedAt)
+  })
+})
+
+describe('crawlers CRUD — list ordering', () => {
+  test('list returns crawlers newest-first by createdAt', async () => {
+    const c1 = await crawlers.create({ ...baseCrawlerInput, name: 'Alpha' })
+    await new Promise((r) => setTimeout(r, 5))
+    const c2 = await crawlers.create({ ...baseCrawlerInput, name: 'Beta' })
+    await new Promise((r) => setTimeout(r, 5))
+    const c3 = await crawlers.create({ ...baseCrawlerInput, name: 'Gamma' })
+
+    const all = await crawlers.list()
+    expect(all.length).toBe(3)
+    expect(all[0]!.id).toBe(c3.id)
+    expect(all[1]!.id).toBe(c2.id)
+    expect(all[2]!.id).toBe(c1.id)
+  })
+})
+
+describe('crawlers CRUD — update merge', () => {
+  test('update merges patch and bumps updatedAt', async () => {
+    const created = await crawlers.create(baseCrawlerInput)
+    const originalUpdatedAt = created.updatedAt
+
+    await new Promise((r) => setTimeout(r, 5))
+
+    const updated = await crawlers.update(created.id, {
+      name: 'Renamed Crawler',
+      techLevel: 'tech-3',
+    })
+
+    expect(updated.id).toBe(created.id)
+    expect(updated.name).toBe('Renamed Crawler')
+    expect(updated.techLevel).toBe('tech-3')
+    expect(updated.bays).toEqual([])
+    expect(updated.createdAt).toBe(created.createdAt)
+    expect(updated.updatedAt).not.toBe(originalUpdatedAt)
+  })
+
+  test('update throws when id not found', async () => {
+    await expect(crawlers.update('nonexistent-crawler', { name: 'X' })).rejects.toThrow(
+      '[itun-db] Cannot update'
+    )
+  })
+})
+
+describe('crawlers CRUD — currentSP stat write-through', () => {
+  test('update with currentSP writes to db and is retrievable', async () => {
+    const created = await crawlers.create(baseCrawlerInput)
+
+    const updated = await crawlers.update(created.id, { currentSP: 25 })
+    expect(updated.currentSP).toBe(25)
+
+    const fetched = await crawlers.get(created.id)
+    expect(fetched!.currentSP).toBe(25)
+  })
+})
+
+describe('crawlers CRUD — delete', () => {
+  test('delete removes record; subsequent get returns null', async () => {
+    const created = await crawlers.create(baseCrawlerInput)
+    await crawlers.delete(created.id)
+
+    const fetched = await crawlers.get(created.id)
+    expect(fetched).toBeNull()
+  })
+
+  test('delete is a silent no-op for unknown id', async () => {
+    await crawlers.delete('does-not-exist')
+  })
+})
+
+describe('crawlers CRUD — Zod rejection', () => {
+  test('create rejects invalid input: missing required techLevel', async () => {
+    const bad = { ...baseCrawlerInput } as Record<string, unknown>
+    delete bad['techLevel']
+    await expect(crawlers.create(bad as Parameters<typeof crawlers.create>[0])).rejects.toThrow()
+  })
+})

--- a/apps/in-the-union-now/src/lib/schemas/crawler.ts
+++ b/apps/in-the-union-now/src/lib/schemas/crawler.ts
@@ -16,6 +16,12 @@ export const CrawlerSchema = z
     systems: z.array(z.string()),
     /** Optional: links this crawler to a workspace */
     workspaceId: z.string().optional(),
+    // ---------------------------------------------------------------------------
+    // Live-play current stat tracking (#245).
+    // TODO: source base value from rules once crawler tech-level data exposes SP.
+    // ---------------------------------------------------------------------------
+    /** Current structure points */
+    currentSP: z.number().int().min(0).optional(),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
   })

--- a/apps/in-the-union-now/src/lib/schemas/index.ts
+++ b/apps/in-the-union-now/src/lib/schemas/index.ts
@@ -4,8 +4,8 @@ export type { EntityRef } from './entity'
 export { PilotSchema } from './pilot'
 export type { Pilot } from './pilot'
 
-export { MechSchema } from './mech'
-export type { Mech } from './mech'
+export { MechSchema, ItemConditionSchema, ItemConditionMapSchema } from './mech'
+export type { Mech, ItemCondition, ItemConditionMap } from './mech'
 
 export { CrawlerSchema } from './crawler'
 export type { Crawler } from './crawler'

--- a/apps/in-the-union-now/src/lib/schemas/mech.ts
+++ b/apps/in-the-union-now/src/lib/schemas/mech.ts
@@ -1,6 +1,17 @@
 import { z } from 'zod'
 
 /**
+ * Per-item condition states for mech systems, modules, and pilot equipment.
+ * Keyed by the item slug. When absent defaults to 'intact' at the display layer.
+ */
+export const ItemConditionSchema = z.enum(['intact', 'damaged', 'destroyed'])
+export type ItemCondition = z.infer<typeof ItemConditionSchema>
+
+/** Map from item slug → condition */
+export const ItemConditionMapSchema = z.record(z.string(), ItemConditionSchema)
+export type ItemConditionMap = z.infer<typeof ItemConditionMapSchema>
+
+/**
  * chassisRef: slug reference to a Chassis in salvageunion-reference.
  * Resolution against game data is handled at the presentation/query layer.
  */
@@ -42,6 +53,16 @@ export const MechSchema = z
     currentEP: z.number().int().min(0).optional(),
     /** Current heat level (falls back to chassis heatCapacity) */
     currentHeat: z.number().int().min(0).optional(),
+    /**
+     * Per-system condition map (REQ-011 #240). Keyed by system slug.
+     * When absent or key missing, the display layer defaults to 'intact'.
+     */
+    systemConditions: ItemConditionMapSchema.optional(),
+    /**
+     * Per-module condition map (REQ-011 #240). Keyed by module slug.
+     * When absent or key missing, the display layer defaults to 'intact'.
+     */
+    moduleConditions: ItemConditionMapSchema.optional(),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
   })

--- a/apps/in-the-union-now/src/lib/schemas/mech.ts
+++ b/apps/in-the-union-now/src/lib/schemas/mech.ts
@@ -12,7 +12,9 @@ export const ItemConditionMapSchema = z.record(z.string(), ItemConditionSchema)
 export type ItemConditionMap = z.infer<typeof ItemConditionMapSchema>
 
 /**
- * chassisRef: slug reference to a Chassis in salvageunion-reference.
+ * chassisRef: reference to a Chassis in salvageunion-reference by its `name`
+ * (e.g. "Ghost Chassis"), matching how the builder stores it and how the rules
+ * layer (lib/rules/capacity.ts) resolves it. Not a slug.
  * Resolution against game data is handled at the presentation/query layer.
  */
 export const MechSchema = z

--- a/apps/in-the-union-now/src/lib/schemas/pilot.ts
+++ b/apps/in-the-union-now/src/lib/schemas/pilot.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { ItemConditionMapSchema } from './mech'
 
 /**
  * classRef: slug reference to a class in salvageunion-reference.
@@ -35,6 +36,11 @@ export const PilotSchema = z
     currentHP: z.number().int().min(0).optional(),
     /** Current action points */
     currentAP: z.number().int().min(0).optional(),
+    /**
+     * Per-equipment condition map (REQ-011 #240). Keyed by equipment slug.
+     * When absent or key missing, the display layer defaults to 'intact'.
+     */
+    equipmentConditions: ItemConditionMapSchema.optional(),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
   })

--- a/apps/in-the-union-now/src/lib/schemas/pilot.ts
+++ b/apps/in-the-union-now/src/lib/schemas/pilot.ts
@@ -25,6 +25,16 @@ export const PilotSchema = z
     conditions: z.array(z.string()),
     /** Optional: links this pilot to a workspace */
     workspaceId: z.string().optional(),
+    // ---------------------------------------------------------------------------
+    // Live-play current stat tracking (#245).
+    // These are current values for the active session — separate from any
+    // class/rules defaults. When absent the sheet falls back to 0.
+    // TODO: source base value from rules once pilot class data exposes HP/AP.
+    // ---------------------------------------------------------------------------
+    /** Current hit points */
+    currentHP: z.number().int().min(0).optional(),
+    /** Current action points */
+    currentAP: z.number().int().min(0).optional(),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
   })

--- a/apps/in-the-union-now/src/lib/snapshot/__tests__/client.test.ts
+++ b/apps/in-the-union-now/src/lib/snapshot/__tests__/client.test.ts
@@ -1,0 +1,205 @@
+/**
+ * snapshot/client — publish → retrieve round-trip tests (#244).
+ *
+ * The existing PublishButton tests exercise the UI flow using a mocked
+ * publishFn and hardcoded payloads. This file tests the actual client
+ * functions (publishSnapshot, retrieveSnapshot, SnapshotNotFoundError)
+ * by stubbing the global fetch to avoid real HTTP calls.
+ *
+ * Strategy:
+ *   - Stub global.fetch before each test; restore after.
+ *   - publishSnapshot → stub returns { id, url } → assert return value.
+ *   - retrieveSnapshot → stub returns the same payload → assert round-trip.
+ *   - Error paths: non-OK publish, 404 retrieve, non-OK retrieve.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { publishSnapshot, retrieveSnapshot, SnapshotNotFoundError } from '../client'
+import type { SnapshotPayload, PublishResult } from '../client'
+
+// ---------------------------------------------------------------------------
+// Fetch stub helpers
+// ---------------------------------------------------------------------------
+
+type FetchStubOptions = {
+  ok: boolean
+  status: number
+  body: unknown
+}
+
+/**
+ * Returns a fetch-compatible function that always responds with the given stub.
+ * Keeps track of calls in the `calls` array for assertion.
+ */
+function makeFetchStub(response: FetchStubOptions): {
+  fn: typeof fetch
+  calls: Array<[string, RequestInit | undefined]>
+} {
+  const calls: Array<[string, RequestInit | undefined]> = []
+  const fn = (async (url: string, opts?: RequestInit) => {
+    calls.push([url, opts])
+    return {
+      ok: response.ok,
+      status: response.status,
+      json: async () => response.body,
+    }
+  }) as unknown as typeof fetch
+  return { fn, calls }
+}
+
+let originalFetch: typeof fetch
+
+beforeEach(() => {
+  originalFetch = global.fetch
+})
+
+afterEach(() => {
+  global.fetch = originalFetch
+})
+
+// ---------------------------------------------------------------------------
+// publishSnapshot
+// ---------------------------------------------------------------------------
+
+describe('publishSnapshot — success', () => {
+  test('returns PublishResult from server response', async () => {
+    const serverResult: PublishResult = { id: 'abc123', url: '/api/snapshots/abc123' }
+    const { fn } = makeFetchStub({ ok: true, status: 200, body: serverResult })
+    global.fetch = fn
+
+    const payload: SnapshotPayload = { kind: 'pilot', entity: { id: 'p-1', name: 'Test' } }
+    const result = await publishSnapshot(payload)
+
+    expect(result.id).toBe('abc123')
+    expect(result.url).toBe('/api/snapshots/abc123')
+  })
+
+  test('sends POST to /api/snapshots with correct content-type', async () => {
+    const serverResult: PublishResult = { id: 'xyz', url: '/api/snapshots/xyz' }
+    const { fn, calls } = makeFetchStub({ ok: true, status: 200, body: serverResult })
+    global.fetch = fn
+
+    const payload: SnapshotPayload = { kind: 'mech', entity: { id: 'm-1' } }
+    await publishSnapshot(payload)
+
+    expect(calls.length).toBe(1)
+    const [url, options] = calls[0]!
+    expect(url).toBe('/api/snapshots')
+    expect(options?.method).toBe('POST')
+    expect((options?.headers as Record<string, string>)['content-type']).toBe('application/json')
+    expect(JSON.parse(options?.body as string)).toMatchObject({ kind: 'mech' })
+  })
+})
+
+describe('publishSnapshot — error', () => {
+  test('throws when server returns non-OK status', async () => {
+    const { fn } = makeFetchStub({ ok: false, status: 500, body: null })
+    global.fetch = fn
+
+    await expect(publishSnapshot({ data: 'x' })).rejects.toThrow('publish failed: 500')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// retrieveSnapshot
+// ---------------------------------------------------------------------------
+
+describe('retrieveSnapshot — success', () => {
+  test('returns the payload from server', async () => {
+    const storedPayload: SnapshotPayload = {
+      kind: 'pilot',
+      entity: { id: 'p-1', name: 'Zara Heln' },
+    }
+    const { fn } = makeFetchStub({ ok: true, status: 200, body: storedPayload })
+    global.fetch = fn
+
+    const result = await retrieveSnapshot('abc123')
+
+    expect(result).toMatchObject({ kind: 'pilot' })
+    expect((result as { entity: { name: string } }).entity.name).toBe('Zara Heln')
+  })
+
+  test('sends GET to /api/snapshots/:id', async () => {
+    const { fn, calls } = makeFetchStub({
+      ok: true,
+      status: 200,
+      body: { kind: 'pilot', entity: {} },
+    })
+    global.fetch = fn
+
+    await retrieveSnapshot('my-snap-id')
+
+    expect(calls.length).toBe(1)
+    const [url] = calls[0]!
+    expect(url).toBe('/api/snapshots/my-snap-id')
+  })
+})
+
+describe('retrieveSnapshot — 404', () => {
+  test('throws SnapshotNotFoundError on 404', async () => {
+    const { fn } = makeFetchStub({ ok: false, status: 404, body: null })
+    global.fetch = fn
+
+    await expect(retrieveSnapshot('gone-id')).rejects.toThrow(SnapshotNotFoundError)
+  })
+
+  test('SnapshotNotFoundError carries the snapshot id', async () => {
+    const { fn } = makeFetchStub({ ok: false, status: 404, body: null })
+    global.fetch = fn
+
+    let caught: unknown
+    try {
+      await retrieveSnapshot('gone-id')
+    } catch (e) {
+      caught = e
+    }
+
+    expect(caught instanceof SnapshotNotFoundError).toBe(true)
+    expect((caught as SnapshotNotFoundError).snapshotId).toBe('gone-id')
+  })
+})
+
+describe('retrieveSnapshot — other errors', () => {
+  test('throws generic Error on non-404 non-OK status', async () => {
+    const { fn } = makeFetchStub({ ok: false, status: 503, body: null })
+    global.fetch = fn
+
+    await expect(retrieveSnapshot('any-id')).rejects.toThrow('retrieve failed: 503')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Publish → retrieve round-trip (two stubbed calls)
+// ---------------------------------------------------------------------------
+
+describe('publish → retrieve round-trip', () => {
+  test('a published payload can be retrieved and contains the same data', async () => {
+    const payload: SnapshotPayload = {
+      kind: 'pilot',
+      entity: { id: 'pilot-roundtrip-1', name: 'Roundtrip Pilot', callsign: 'RT' },
+    }
+
+    const publishResult: PublishResult = { id: 'rt-001', url: '/api/snapshots/rt-001' }
+    let callCount = 0
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    global.fetch = (async (_url: string, _opts?: RequestInit) => {
+      callCount++
+      if (callCount === 1) {
+        // POST /api/snapshots
+        return { ok: true, status: 200, json: async () => publishResult }
+      }
+      // GET /api/snapshots/rt-001
+      return { ok: true, status: 200, json: async () => payload }
+    }) as unknown as typeof fetch
+
+    const published = await publishSnapshot(payload)
+    expect(published.id).toBe('rt-001')
+
+    // Retrieve using the id from publish
+    const retrieved = await retrieveSnapshot(published.id)
+    expect(retrieved).toMatchObject({ kind: 'pilot' })
+    expect((retrieved as { entity: { name: string } }).entity.name).toBe('Roundtrip Pilot')
+  })
+})

--- a/apps/in-the-union-now/src/stores/__tests__/entityStore-mech-crawler.test.ts
+++ b/apps/in-the-union-now/src/stores/__tests__/entityStore-mech-crawler.test.ts
@@ -1,0 +1,272 @@
+/**
+ * entityStore — mech and crawler CRUD write-through tests (#244).
+ *
+ * entityStore.test.ts covers pilots only. This file extends coverage to mechs
+ * and crawlers: create/get/update/delete round-trips against the real IndexedDB
+ * (via fake-indexeddb), including a currentXxx stat-field write-through.
+ *
+ * fake-indexeddb/auto is preloaded via bunfig.toml.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import {
+  _clearAllStores,
+  _resetDbSingleton,
+  mechs as dbMechs,
+  crawlers as dbCrawlers,
+} from '../../lib/db/index'
+import { useEntityStore } from '../entityStore'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const baseMechInput = {
+  schemaVersion: 1 as const,
+  name: 'Store Test Mech',
+  chassisRef: 'iron-mongrel',
+  systems: [],
+  modules: [],
+  cargo: [],
+  conditions: [],
+}
+
+const baseCrawlerInput = {
+  schemaVersion: 1 as const,
+  name: 'Store Test Crawler',
+  techLevel: 'tech-1',
+  bays: [],
+  systems: [],
+}
+
+function resetEntityStore(): void {
+  useEntityStore.setState({
+    pilots: [],
+    mechs: [],
+    crawlers: [],
+    softLinks: [],
+    hydrated: { pilots: false, mechs: false, crawlers: false, softLinks: false },
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(async () => {
+  _resetDbSingleton()
+  await _clearAllStores()
+  resetEntityStore()
+})
+
+afterEach(async () => {
+  await _clearAllStores()
+  resetEntityStore()
+})
+
+// ===========================================================================
+// Mech
+// ===========================================================================
+
+describe('entityStore — mech hydration', () => {
+  test('empty db: hydrate then list returns []', async () => {
+    await useEntityStore.getState().hydrate('mech')
+    const result = useEntityStore.getState().list('mech')
+    expect(result).toEqual([])
+  })
+
+  test('pre-seeded db: hydrate populates in-memory state', async () => {
+    await dbMechs.create({ ...baseMechInput, name: 'Alpha' })
+    await dbMechs.create({ ...baseMechInput, name: 'Beta' })
+
+    await useEntityStore.getState().hydrate('mech')
+    const result = useEntityStore.getState().list('mech')
+
+    expect(result.length).toBe(2)
+    const names = result.map((m) => m.name)
+    expect(names).toContain('Alpha')
+    expect(names).toContain('Beta')
+  })
+
+  test('hydrate is idempotent for mechs', async () => {
+    await dbMechs.create(baseMechInput)
+
+    await useEntityStore.getState().hydrate('mech')
+    await useEntityStore.getState().hydrate('mech')
+    const result = useEntityStore.getState().list('mech')
+    expect(result.length).toBe(1)
+  })
+})
+
+describe('entityStore — mech create', () => {
+  test('create writes to db and updates in-memory state', async () => {
+    await useEntityStore.getState().hydrate('mech')
+    const created = await useEntityStore.getState().create('mech', baseMechInput)
+
+    expect(created.id).toBeDefined()
+    expect(created.name).toBe('Store Test Mech')
+
+    const inMemory = useEntityStore.getState().list('mech')
+    expect(inMemory.length).toBe(1)
+    expect(inMemory[0]!.id).toBe(created.id)
+
+    const fromDb = await dbMechs.get(created.id)
+    expect(fromDb).not.toBeNull()
+    expect(fromDb!.name).toBe('Store Test Mech')
+  })
+})
+
+describe('entityStore — mech update', () => {
+  test('update merges patch and writes through to db', async () => {
+    await useEntityStore.getState().hydrate('mech')
+    const created = await useEntityStore.getState().create('mech', baseMechInput)
+
+    await new Promise((r) => setTimeout(r, 5))
+
+    const updated = await useEntityStore.getState().update('mech', created.id, {
+      name: 'Renamed Mech',
+      chassisRef: 'scorpion',
+    })
+
+    expect(updated.name).toBe('Renamed Mech')
+    expect(updated.chassisRef).toBe('scorpion')
+
+    const inMemory = useEntityStore.getState().get('mech', created.id)
+    expect(inMemory?.name).toBe('Renamed Mech')
+
+    const fromDb = await dbMechs.get(created.id)
+    expect(fromDb?.name).toBe('Renamed Mech')
+  })
+
+  test('update with currentHP writes stat through to db', async () => {
+    await useEntityStore.getState().hydrate('mech')
+    const created = await useEntityStore.getState().create('mech', baseMechInput)
+
+    await useEntityStore.getState().update('mech', created.id, { currentHP: 7 })
+
+    const inMemory = useEntityStore.getState().get('mech', created.id)
+    expect(inMemory?.currentHP).toBe(7)
+
+    const fromDb = await dbMechs.get(created.id)
+    expect(fromDb?.currentHP).toBe(7)
+  })
+})
+
+describe('entityStore — mech delete', () => {
+  test('delete removes from db and in-memory state', async () => {
+    await useEntityStore.getState().hydrate('mech')
+    const created = await useEntityStore.getState().create('mech', baseMechInput)
+
+    await useEntityStore.getState().delete('mech', created.id)
+
+    const inMemory = useEntityStore.getState().list('mech')
+    expect(inMemory.length).toBe(0)
+
+    const fromDb = await dbMechs.get(created.id)
+    expect(fromDb).toBeNull()
+  })
+})
+
+// ===========================================================================
+// Crawler
+// ===========================================================================
+
+describe('entityStore — crawler hydration', () => {
+  test('empty db: hydrate then list returns []', async () => {
+    await useEntityStore.getState().hydrate('crawler')
+    const result = useEntityStore.getState().list('crawler')
+    expect(result).toEqual([])
+  })
+
+  test('pre-seeded db: hydrate populates in-memory state', async () => {
+    await dbCrawlers.create({ ...baseCrawlerInput, name: 'Crawler A' })
+    await dbCrawlers.create({ ...baseCrawlerInput, name: 'Crawler B' })
+
+    await useEntityStore.getState().hydrate('crawler')
+    const result = useEntityStore.getState().list('crawler')
+
+    expect(result.length).toBe(2)
+    const names = result.map((c) => c.name)
+    expect(names).toContain('Crawler A')
+    expect(names).toContain('Crawler B')
+  })
+
+  test('hydrate is idempotent for crawlers', async () => {
+    await dbCrawlers.create(baseCrawlerInput)
+
+    await useEntityStore.getState().hydrate('crawler')
+    await useEntityStore.getState().hydrate('crawler')
+    const result = useEntityStore.getState().list('crawler')
+    expect(result.length).toBe(1)
+  })
+})
+
+describe('entityStore — crawler create', () => {
+  test('create writes to db and updates in-memory state', async () => {
+    await useEntityStore.getState().hydrate('crawler')
+    const created = await useEntityStore.getState().create('crawler', baseCrawlerInput)
+
+    expect(created.id).toBeDefined()
+    expect(created.name).toBe('Store Test Crawler')
+
+    const inMemory = useEntityStore.getState().list('crawler')
+    expect(inMemory.length).toBe(1)
+    expect(inMemory[0]!.id).toBe(created.id)
+
+    const fromDb = await dbCrawlers.get(created.id)
+    expect(fromDb).not.toBeNull()
+    expect(fromDb!.name).toBe('Store Test Crawler')
+  })
+})
+
+describe('entityStore — crawler update', () => {
+  test('update merges patch and writes through to db', async () => {
+    await useEntityStore.getState().hydrate('crawler')
+    const created = await useEntityStore.getState().create('crawler', baseCrawlerInput)
+
+    await new Promise((r) => setTimeout(r, 5))
+
+    const updated = await useEntityStore.getState().update('crawler', created.id, {
+      name: 'Renamed Crawler',
+      techLevel: 'tech-4',
+    })
+
+    expect(updated.name).toBe('Renamed Crawler')
+    expect(updated.techLevel).toBe('tech-4')
+
+    const inMemory = useEntityStore.getState().get('crawler', created.id)
+    expect(inMemory?.name).toBe('Renamed Crawler')
+
+    const fromDb = await dbCrawlers.get(created.id)
+    expect(fromDb?.name).toBe('Renamed Crawler')
+  })
+
+  test('update with currentSP writes stat through to db', async () => {
+    await useEntityStore.getState().hydrate('crawler')
+    const created = await useEntityStore.getState().create('crawler', baseCrawlerInput)
+
+    await useEntityStore.getState().update('crawler', created.id, { currentSP: 40 })
+
+    const inMemory = useEntityStore.getState().get('crawler', created.id)
+    expect(inMemory?.currentSP).toBe(40)
+
+    const fromDb = await dbCrawlers.get(created.id)
+    expect(fromDb?.currentSP).toBe(40)
+  })
+})
+
+describe('entityStore — crawler delete', () => {
+  test('delete removes from db and in-memory state', async () => {
+    await useEntityStore.getState().hydrate('crawler')
+    const created = await useEntityStore.getState().create('crawler', baseCrawlerInput)
+
+    await useEntityStore.getState().delete('crawler', created.id)
+
+    const inMemory = useEntityStore.getState().list('crawler')
+    expect(inMemory.length).toBe(0)
+
+    const fromDb = await dbCrawlers.get(created.id)
+    expect(fromDb).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Closes the live-sheet in-game-play gaps surfaced by the deep-dive audit. Three of these were M1/M2 stories that had been **closed against unmet acceptance criteria**; the rest are correctness bugs and test-coverage holes in the shipped live sheet.

Closes #240, #241, #242, #243, #244, #245.

## What changed

| Issue | Fix |
| :--- | :--- |
| **#240** | **Condition tracking made real & persistent.** Added per-item condition maps (`Mech.systemConditions`/`moduleConditions`, `Pilot.equipmentConditions` as `z.record(slug → intact/damaged/destroyed)`); wired every `ConditionToggle` `value`/`onChange` to `entityStore.update` (previously hard-wired `onChange={() => undefined}`). Crawler system conditions left out per PRD scope. |
| **#245** | **Pilot HP/AP + crawler SP trackable.** Added `Pilot.currentHP/currentAP` and `Crawler.currentSP` optional fields; `PilotSheet`/`CrawlerSheet` now render click-to-edit `EditableStatRow`s persisting to IndexedDB, mirroring the mech pattern. |
| **#242** | **Read-only snapshots no longer editable.** Threaded `readOnly` through `EditableStatRow`/`MechSheet`/`PilotSheet`/`CrawlerSheet`; `SnapshotView` passes it so snapshot stat cells render as static text and never call `store.update`. |
| **#243** | **MechSheet renders stats even when chassis is unresolved.** Removed the `{chassis && …}` guard that silently hid the entire stat block; stats now fall back to stored/zero values and an accessible "Unknown chassis" notice renders. |
| **#241** | **`MechStandIn` placeholder** added and rendered in pilot-only and wired-pilot-without-mech compositions. |
| **#244** | **Test-coverage gaps closed:** AP/TP/SP/EP/Heat edit+persist, crawler-wired composition modes, mech/crawler DB + store CRUD, snapshot publish→retrieve round-trip; the vacuous 320px overflow assertion was replaced/annotated. |

## Formal review (post-implementation)

Ran a high-effort multi-angle review over the branch diff. Dispositions:

- **Fixed — condition-map stale-closure race:** the three toggle handlers read the current map from the **live store** at click-time instead of the render-time prop, so rapid sequential toggles can't stomp each other. Added a regression test.
- **Fixed — misleading doc:** `mech.chassisRef` was commented as a "slug"; it is actually a chassis **name** (matches `lib/rules/capacity.ts` resolution and how the builder stores it). This stale comment had caused reviewers to flag a false "every mech shows Unknown chassis" regression — **refuted**: production mechs store the name, so resolution works.
- **Noted (not blocking):** `Sheet`'s pre-existing `readOnly` prop isn't threaded to sub-sheets (no current caller sets it); calling `store()` unconditionally in read-only mode is correct per rules-of-hooks; optional follow-up refactors exist (shared `StatCell`, shared condition-updater helper).

## Open question for maintainer

`Mech.currentHP` and `currentSP` both default to `chassis.structurePoints` when unset (pre-existing for HP; SP mirrors it). Confirm whether mech HP should share the SP default or source a distinct value — left as-is for now to avoid scope creep.

## Verification

`bun run check:all` green: lint (0 errors), format, typecheck, **2,150 tests pass (0 fail)** across all packages, validate, knip. ITUN suite: 514 tests.
