### PR TITLE
feat(itun): horizontal desktop layout for builder wizards

### DIFF
--- a/apps/in-the-union-now/src/components/crawler/SystemsList.tsx
+++ b/apps/in-the-union-now/src/components/crawler/SystemsList.tsx
@@ -27,9 +27,9 @@ export function SystemsList({ systems, selectedSystemSlugs, onChange }: SystemsL
   }
 
   return (
-    <fieldset className="mx-auto w-full max-w-[1400px]">
+    <fieldset className="w-full">
       <legend className="mb-2 text-sm font-semibold">Systems</legend>
-      <div className="flex flex-col gap-2">
+      <div className="grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-3">
         {systems.map((system) => (
           <EntityChoiceCard
             key={system.id}

--- a/apps/in-the-union-now/src/components/mech/ChassisSelector.tsx
+++ b/apps/in-the-union-now/src/components/mech/ChassisSelector.tsx
@@ -19,9 +19,9 @@ export function ChassisSelector({ selectedChassis, onSelect, className }: Chassi
   const allChassis = SalvageUnionReference.Chassis.all()
 
   return (
-    <fieldset className={cn('mx-auto flex w-full max-w-[1400px] flex-col gap-2', className)}>
+    <fieldset className={cn('flex w-full flex-col gap-2', className)}>
       <legend className="mb-1 text-sm font-medium">Chassis</legend>
-      <div className="flex flex-col gap-2">
+      <div className="grid grid-cols-1 gap-2 xl:grid-cols-2">
         {allChassis.map((chassis) => (
           <EntityChoiceCard
             key={chassis.id}

--- a/apps/in-the-union-now/src/components/mech/SystemModuleGrid.tsx
+++ b/apps/in-the-union-now/src/components/mech/SystemModuleGrid.tsx
@@ -80,7 +80,7 @@ export function SystemModuleGrid({
     onToggle: (name: string, slotsRequired: number) => void
   ) {
     return (
-      <div className="mx-auto flex w-full max-w-[1400px] flex-col gap-2">
+      <div className="grid w-full grid-cols-1 gap-2 xl:grid-cols-2">
         {items.map((item) => {
           const isSelected = selectedRefs.some((s) => s.ref === item.name)
           const wouldExceed = !isSelected && max > 0 && used + item.slotsRequired > max

--- a/apps/in-the-union-now/src/components/pilot/AbilitiesStep.tsx
+++ b/apps/in-the-union-now/src/components/pilot/AbilitiesStep.tsx
@@ -63,7 +63,7 @@ export function AbilitiesStep({ classId, selectedAbilities, onToggle, _sur }: Ab
   const isAtBudget = selectedAbilities.length >= STARTING_ABILITY_BUDGET
 
   return (
-    <div className="mx-auto w-full max-w-[1400px] space-y-4">
+    <div className="w-full space-y-4">
       <p className="text-sm opacity-70">
         Choose up to {STARTING_ABILITY_BUDGET} starting abilities from your class trees.{' '}
         <span className="font-medium">
@@ -80,7 +80,7 @@ export function AbilitiesStep({ classId, selectedAbilities, onToggle, _sur }: Ab
         Order: keep the original coreTrees declaration order so abilities
         from the same tree stay contiguous in the list.
       */}
-      <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
         {coreTrees.flatMap((tree) =>
           availableAbilities
             .filter((a) => a.tree === tree)

--- a/apps/in-the-union-now/src/components/pilot/ClassStep.tsx
+++ b/apps/in-the-union-now/src/components/pilot/ClassStep.tsx
@@ -57,11 +57,11 @@ export function ClassStep({ selectedClassId, onSelect, _sur }: ClassStepProps) {
   const baseClasses = allClasses.filter(isBaseClass)
 
   return (
-    <div className="mx-auto w-full max-w-[1400px] space-y-4">
+    <div className="w-full space-y-4">
       <p className="text-sm opacity-70">
         Choose your pilot class. This determines your ability trees.
       </p>
-      <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         {baseClasses.map((cls) => (
           <EntityChoiceCard
             key={cls.id}

--- a/apps/in-the-union-now/src/components/pilot/EquipmentStep.tsx
+++ b/apps/in-the-union-now/src/components/pilot/EquipmentStep.tsx
@@ -34,14 +34,14 @@ export function EquipmentStep({ selectedEquipment, onToggle, _sur }: EquipmentSt
   const isAtBudget = selectedEquipment.length >= STARTING_EQUIPMENT_BUDGET
 
   return (
-    <div className="mx-auto w-full max-w-[1400px] space-y-4">
+    <div className="w-full space-y-4">
       <p className="text-sm opacity-70">
         Choose up to {STARTING_EQUIPMENT_BUDGET} starting equipment items (Tech Level 1).{' '}
         <span className="font-medium">
           {selectedEquipment.length}/{STARTING_EQUIPMENT_BUDGET} selected
         </span>
       </p>
-      <div className="flex flex-col gap-2">
+      <div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
         {allEquipment.map((item) => {
           const isSelected = selectedEquipment.includes(item.id)
           const isDisabled = !isSelected && isAtBudget

--- a/apps/in-the-union-now/src/components/pilot/PilotWizard.tsx
+++ b/apps/in-the-union-now/src/components/pilot/PilotWizard.tsx
@@ -219,199 +219,210 @@ export function PilotWizard({ onComplete, onCancel, pilotId, _rollDeps, _sur }: 
     : null
 
   return (
-    <div className="mx-auto max-w-5xl space-y-6 p-6">
-      {/* Progress indicator */}
-      <nav aria-label="Wizard steps">
-        <ol className="flex items-center gap-2 text-xs">
-          {STEPS.map((s, i) => (
-            <li
-              key={s}
-              className={[
-                'rounded px-2 py-1',
-                s === step
-                  ? 'bg-primary text-primary-foreground font-semibold'
-                  : i < currentIndex
-                    ? 'opacity-60'
-                    : 'opacity-30',
-              ].join(' ')}
-            >
-              {s}
-            </li>
-          ))}
-        </ol>
-      </nav>
+    <div className="mx-auto max-w-7xl p-6">
+      <div className="lg:grid lg:grid-cols-[12rem_minmax(0,1fr)] lg:gap-8">
+        {/* Progress indicator — vertical rail on desktop, horizontal on mobile */}
+        <nav aria-label="Wizard steps" className="mb-6 lg:mb-0">
+          <ol className="flex items-center gap-2 text-xs lg:sticky lg:top-4 lg:flex-col lg:items-stretch lg:gap-1">
+            {STEPS.map((s, i) => (
+              <li
+                key={s}
+                className={[
+                  'rounded px-2 py-1 lg:px-3 lg:py-2',
+                  s === step
+                    ? 'bg-primary text-primary-foreground font-semibold'
+                    : i < currentIndex
+                      ? 'opacity-60'
+                      : 'opacity-30',
+                ].join(' ')}
+              >
+                {s}
+              </li>
+            ))}
+          </ol>
+        </nav>
 
-      {/* Step heading */}
-      <h2 className="text-xl font-bold">
-        {step === 'Class' && 'Choose Your Class'}
-        {step === 'Abilities' && 'Choose Starting Abilities'}
-        {step === 'Equipment' && 'Choose Starting Equipment'}
-        {step === 'Identity' && 'Your Identity'}
-        {step === 'Background' && 'Your Background'}
-        {step === 'Review' && 'Review & Create'}
-      </h2>
+        {/* Content column */}
+        <div className="min-w-0 space-y-6">
+          {/* Step heading */}
+          <h2 className="text-xl font-bold">
+            {step === 'Class' && 'Choose Your Class'}
+            {step === 'Abilities' && 'Choose Starting Abilities'}
+            {step === 'Equipment' && 'Choose Starting Equipment'}
+            {step === 'Identity' && 'Your Identity'}
+            {step === 'Background' && 'Your Background'}
+            {step === 'Review' && 'Review & Create'}
+          </h2>
 
-      {/* Name field — shown on Identity step */}
-      {step === 'Identity' && (
-        <div className="space-y-1">
-          <label className="block text-sm font-medium" htmlFor="pilot-name">
-            Name <span className="text-destructive">*</span>
-          </label>
-          <input
-            id="pilot-name"
-            type="text"
-            value={form.name}
-            onChange={(e) => updateForm({ name: e.target.value })}
-            placeholder="Your pilot's real name"
-            required
-            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          {/* Name field — shown on Identity step */}
+          {step === 'Identity' && (
+            <div className="space-y-1">
+              <label className="block text-sm font-medium" htmlFor="pilot-name">
+                Name <span className="text-destructive">*</span>
+              </label>
+              <input
+                id="pilot-name"
+                type="text"
+                value={form.name}
+                onChange={(e) => updateForm({ name: e.target.value })}
+                placeholder="Your pilot's real name"
+                required
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </div>
+          )}
+
+          {/* Step content */}
+          {step === 'Class' && (
+            <ClassStep
+              selectedClassId={form.classId}
+              onSelect={(classId) => {
+                // Resetting abilities when class changes since trees differ
+                updateForm({ classId, abilities: [] })
+              }}
+              _sur={sur.Classes}
+            />
+          )}
+          {step === 'Abilities' && (
+            <AbilitiesStep
+              classId={form.classId}
+              selectedAbilities={form.abilities}
+              onToggle={toggleAbility}
+              _sur={{ Classes: sur.Classes, Abilities: sur.Abilities }}
+            />
+          )}
+          {step === 'Equipment' && (
+            <EquipmentStep
+              selectedEquipment={form.equipment}
+              onToggle={toggleEquipment}
+              _sur={{ Equipment: sur.Equipment }}
+            />
+          )}
+          {step === 'Identity' && (
+            <IdentityStep
+              callsign={form.callsign}
+              motto={form.motto}
+              keepsake={form.keepsake}
+              appearance={form.appearance}
+              onChange={(field, value) => updateForm({ [field]: value })}
+              _rollDeps={_rollDeps}
+            />
+          )}
+          {step === 'Background' && (
+            <BackgroundStep
+              background={form.background}
+              onChange={(v) => updateForm({ background: v })}
+              _rollDeps={_rollDeps}
+            />
+          )}
+
+          {/* Review step */}
+          {step === 'Review' && (
+            <div className="space-y-4 rounded-lg border border-border p-4 text-sm">
+              <div>
+                <span className="font-semibold">Name: </span>
+                {form.name || <span className="text-destructive">required</span>}
+              </div>
+              <div>
+                <span className="font-semibold">Callsign: </span>
+                {form.callsign || <span className="text-destructive">required</span>}
+              </div>
+              <div>
+                <span className="font-semibold">Class: </span>
+                {selectedClass ? (
+                  (selectedClass as { name: string }).name
+                ) : (
+                  <span className="text-destructive">required</span>
+                )}
+              </div>
+              <div>
+                <span className="font-semibold">Abilities: </span>
+                {form.abilities.length > 0
+                  ? form.abilities
+                      .map((id) => {
+                        const found = sur.Abilities.findAll(
+                          (a) => (a as { id: string }).id === id
+                        )[0]
+                        return found ? (found as { name: string }).name : id
+                      })
+                      .join(', ')
+                  : 'none'}
+              </div>
+              <div>
+                <span className="font-semibold">Equipment: </span>
+                {form.equipment.length > 0
+                  ? form.equipment
+                      .map((id) => {
+                        const found = sur.Equipment.findAll(
+                          (e) => (e as { id: string }).id === id
+                        )[0]
+                        return found ? (found as { name: string }).name : id
+                      })
+                      .join(', ')
+                  : 'none'}
+              </div>
+              <div>
+                <span className="font-semibold">Motto: </span>
+                {form.motto || '—'}
+              </div>
+              <div>
+                <span className="font-semibold">Keepsake: </span>
+                {form.keepsake || '—'}
+              </div>
+              <div>
+                <span className="font-semibold">Appearance: </span>
+                {form.appearance || '—'}
+              </div>
+              <div>
+                <span className="font-semibold">Background: </span>
+                {form.background || '—'}
+              </div>
+
+              {submitError && (
+                <p role="alert" className="text-sm text-destructive">
+                  {submitError}
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Soft warnings (edit mode only — no-op in create flow) */}
+          <SoftWarningBanner
+            warnings={softWarnings}
+            onSaveAnyway={() => void saveSoftAnyway()}
+            onFixIt={fixSoftWarnings}
           />
-        </div>
-      )}
 
-      {/* Step content */}
-      {step === 'Class' && (
-        <ClassStep
-          selectedClassId={form.classId}
-          onSelect={(classId) => {
-            // Resetting abilities when class changes since trees differ
-            updateForm({ classId, abilities: [] })
-          }}
-          _sur={sur.Classes}
-        />
-      )}
-      {step === 'Abilities' && (
-        <AbilitiesStep
-          classId={form.classId}
-          selectedAbilities={form.abilities}
-          onToggle={toggleAbility}
-          _sur={{ Classes: sur.Classes, Abilities: sur.Abilities }}
-        />
-      )}
-      {step === 'Equipment' && (
-        <EquipmentStep
-          selectedEquipment={form.equipment}
-          onToggle={toggleEquipment}
-          _sur={{ Equipment: sur.Equipment }}
-        />
-      )}
-      {step === 'Identity' && (
-        <IdentityStep
-          callsign={form.callsign}
-          motto={form.motto}
-          keepsake={form.keepsake}
-          appearance={form.appearance}
-          onChange={(field, value) => updateForm({ [field]: value })}
-          _rollDeps={_rollDeps}
-        />
-      )}
-      {step === 'Background' && (
-        <BackgroundStep
-          background={form.background}
-          onChange={(v) => updateForm({ background: v })}
-          _rollDeps={_rollDeps}
-        />
-      )}
+          {/* Navigation */}
+          <div className="flex justify-between pt-2">
+            <div className="flex gap-2">
+              {currentIndex > 0 && (
+                <Button type="button" variant="ghost" onClick={goBack} disabled={isSubmitting}>
+                  Back
+                </Button>
+              )}
+              <Button type="button" variant="ghost" onClick={onCancel} disabled={isSubmitting}>
+                Cancel
+              </Button>
+            </div>
 
-      {/* Review step */}
-      {step === 'Review' && (
-        <div className="space-y-4 rounded-lg border border-border p-4 text-sm">
-          <div>
-            <span className="font-semibold">Name: </span>
-            {form.name || <span className="text-destructive">required</span>}
-          </div>
-          <div>
-            <span className="font-semibold">Callsign: </span>
-            {form.callsign || <span className="text-destructive">required</span>}
-          </div>
-          <div>
-            <span className="font-semibold">Class: </span>
-            {selectedClass ? (
-              (selectedClass as { name: string }).name
+            {step !== 'Review' ? (
+              <Button type="button" onClick={goNext} disabled={!canAdvance()}>
+                Next
+              </Button>
             ) : (
-              <span className="text-destructive">required</span>
+              <Button
+                type="button"
+                onClick={handleSubmit}
+                disabled={
+                  isSubmitting || !form.name.trim() || !form.callsign.trim() || !form.classId
+                }
+              >
+                {isSubmitting ? 'Creating…' : 'Create Pilot'}
+              </Button>
             )}
           </div>
-          <div>
-            <span className="font-semibold">Abilities: </span>
-            {form.abilities.length > 0
-              ? form.abilities
-                  .map((id) => {
-                    const found = sur.Abilities.findAll((a) => (a as { id: string }).id === id)[0]
-                    return found ? (found as { name: string }).name : id
-                  })
-                  .join(', ')
-              : 'none'}
-          </div>
-          <div>
-            <span className="font-semibold">Equipment: </span>
-            {form.equipment.length > 0
-              ? form.equipment
-                  .map((id) => {
-                    const found = sur.Equipment.findAll((e) => (e as { id: string }).id === id)[0]
-                    return found ? (found as { name: string }).name : id
-                  })
-                  .join(', ')
-              : 'none'}
-          </div>
-          <div>
-            <span className="font-semibold">Motto: </span>
-            {form.motto || '—'}
-          </div>
-          <div>
-            <span className="font-semibold">Keepsake: </span>
-            {form.keepsake || '—'}
-          </div>
-          <div>
-            <span className="font-semibold">Appearance: </span>
-            {form.appearance || '—'}
-          </div>
-          <div>
-            <span className="font-semibold">Background: </span>
-            {form.background || '—'}
-          </div>
-
-          {submitError && (
-            <p role="alert" className="text-sm text-destructive">
-              {submitError}
-            </p>
-          )}
         </div>
-      )}
-
-      {/* Soft warnings (edit mode only — no-op in create flow) */}
-      <SoftWarningBanner
-        warnings={softWarnings}
-        onSaveAnyway={() => void saveSoftAnyway()}
-        onFixIt={fixSoftWarnings}
-      />
-
-      {/* Navigation */}
-      <div className="flex justify-between pt-2">
-        <div className="flex gap-2">
-          {currentIndex > 0 && (
-            <Button type="button" variant="ghost" onClick={goBack} disabled={isSubmitting}>
-              Back
-            </Button>
-          )}
-          <Button type="button" variant="ghost" onClick={onCancel} disabled={isSubmitting}>
-            Cancel
-          </Button>
-        </div>
-
-        {step !== 'Review' ? (
-          <Button type="button" onClick={goNext} disabled={!canAdvance()}>
-            Next
-          </Button>
-        ) : (
-          <Button
-            type="button"
-            onClick={handleSubmit}
-            disabled={isSubmitting || !form.name.trim() || !form.callsign.trim() || !form.classId}
-          >
-            {isSubmitting ? 'Creating…' : 'Create Pilot'}
-          </Button>
-        )}
       </div>
     </div>
   )

--- a/apps/in-the-union-now/src/routes/crawlers/new.tsx
+++ b/apps/in-the-union-now/src/routes/crawlers/new.tsx
@@ -18,7 +18,7 @@ function CrawlersNewPage() {
   }
 
   return (
-    <main className="mx-auto max-w-5xl px-4 py-8">
+    <main className="mx-auto max-w-7xl px-4 py-8">
       <h1 className="mb-6 text-2xl font-bold">New Crawler</h1>
       <CrawlerBuilder onCreated={handleCreated} onCancel={handleCancel} />
     </main>

--- a/apps/in-the-union-now/src/routes/mechs/new.tsx
+++ b/apps/in-the-union-now/src/routes/mechs/new.tsx
@@ -9,7 +9,7 @@ function MechNewPage() {
   const navigate = useNavigate()
 
   return (
-    <main className="mx-auto max-w-6xl p-6">
+    <main className="mx-auto max-w-7xl p-6">
       <MechBuilder
         onSuccess={() => {
           void navigate({ to: '/' })


### PR DESCRIPTION
Makes the builder wizards use horizontal desktop space. Pilot wizard → desktop 2-pane (vertical step rail + content), widened max-w-5xl→7xl, collapses to top stepper on mobile. Class/Abilities/Equipment steps + mech chassis/system-module lists + crawler systems → responsive grids. /mechs/new and /crawlers/new widened to max-w-7xl. No behavior change (card role=button, Show-abilities disclosure, condition toggles, click-to-edit stats untouched). Full e2e 32/32 green; check:all green; desktop+mobile screenshots reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)