### PR TITLE
feat(itun): pilot data export/import (JSON backup + restore)

### DIFF
--- a/apps/in-the-union-now/src/components/dashboard/Dashboard.tsx
+++ b/apps/in-the-union-now/src/components/dashboard/Dashboard.tsx
@@ -25,6 +25,8 @@ import { buttonVariants } from '../ui/buttonVariants'
 import { cn } from '../../lib/utils'
 import { DeleteConfirmDialog } from './DeleteConfirmDialog'
 import { EntityListItem } from './EntityListItem'
+import { ExportAllButton } from '../export/ExportAllButton'
+import { ImportButton } from '../export/ImportButton'
 
 type DeleteTarget = {
   type: EntityType
@@ -90,9 +92,18 @@ export function Dashboard() {
 
   return (
     <main className="mx-auto max-w-7xl p-4 sm:p-6">
-      <div className="mb-8 flex flex-wrap items-center justify-between gap-4 border-b-2 border-[var(--color-su-black)] pb-4">
-        <h1 className="text-3xl font-bold uppercase tracking-wide">ITUN — Saved Builds</h1>
-        <WorkspaceSwitcher activeWorkspaceId={activeWorkspaceId} onSelect={setActiveWorkspaceId} />
+      <div className="mb-8 border-b-2 border-[var(--color-su-black)] pb-4">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <h1 className="text-3xl font-bold uppercase tracking-wide">ITUN — Saved Builds</h1>
+          <WorkspaceSwitcher
+            activeWorkspaceId={activeWorkspaceId}
+            onSelect={setActiveWorkspaceId}
+          />
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <ExportAllButton />
+          <ImportButton />
+        </div>
       </div>
 
       {!hydratedAll ? (

--- a/apps/in-the-union-now/src/components/export/ExportAllButton.tsx
+++ b/apps/in-the-union-now/src/components/export/ExportAllButton.tsx
@@ -1,0 +1,51 @@
+/**
+ * ExportAllButton — triggers a full backup download (all pilots, mechs,
+ * crawlers, workspaces, and softLinks) as a single JSON file.
+ *
+ * Uses buildExportBundle + downloadJson from lib/export.
+ * Renders inline error text on failure rather than a toast.
+ */
+
+import { useState } from 'react'
+
+import { buildExportBundle } from '../../lib/export/buildExportBundle'
+import { downloadJson } from '../../lib/export/downloadJson'
+import { useEntityStore } from '../../stores/entityStore'
+import { useWorkspaceStore } from '../../stores/workspaceStore'
+import { Button } from '../ui/button'
+
+export function ExportAllButton() {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleExportAll() {
+    setBusy(true)
+    setError(null)
+    try {
+      const entityStore = useEntityStore.getState()
+      const workspaceStore = useWorkspaceStore.getState()
+      const bundle = await buildExportBundle(entityStore, workspaceStore)
+      const date = new Date().toISOString().slice(0, 10)
+      downloadJson(`itun-backup-${date}.json`, bundle)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Export failed.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={busy}
+        onClick={() => void handleExportAll()}
+        className="min-h-[44px]"
+      >
+        {busy ? 'Exporting…' : 'Download all'}
+      </Button>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/export/ExportEntityButton.tsx
+++ b/apps/in-the-union-now/src/components/export/ExportEntityButton.tsx
@@ -1,0 +1,59 @@
+/**
+ * ExportEntityButton — exports a single entity (pilot/mech/crawler) plus its
+ * directly-attached softLinks as a JSON file.
+ *
+ * Uses buildEntityExport + downloadJson from lib/export.
+ */
+
+import { useState } from 'react'
+
+import { buildEntityExport } from '../../lib/export/buildExportBundle'
+import { downloadJson } from '../../lib/export/downloadJson'
+import { useEntityStore } from '../../stores/entityStore'
+import { Button } from '../ui/button'
+
+type ExportEntityButtonProps = {
+  type: 'pilot' | 'mech' | 'crawler'
+  id: string
+  /** Display name for the file stem (e.g. pilot.name). */
+  name: string
+}
+
+export function ExportEntityButton({ type, id, name }: ExportEntityButtonProps) {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleExport() {
+    setBusy(true)
+    setError(null)
+    try {
+      const entityStore = useEntityStore.getState()
+      const bundle = await buildEntityExport(type, id, entityStore)
+      // Sanitise the name for use as a filename.
+      const safeName = name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .slice(0, 40)
+      downloadJson(`itun-${type}-${safeName}.json`, bundle)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Export failed.')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={busy}
+        onClick={() => void handleExport()}
+        className="min-h-[44px]"
+      >
+        {busy ? 'Exporting…' : 'Export'}
+      </Button>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/export/ImportButton.tsx
+++ b/apps/in-the-union-now/src/components/export/ImportButton.tsx
@@ -1,0 +1,91 @@
+/**
+ * ImportButton — file input that reads a JSON export bundle and merges it
+ * into the local store.
+ *
+ * Flow:
+ *   1. User clicks "Import…" → hidden <input type="file"> is triggered.
+ *   2. File is read as text → parseImportBundle validates it.
+ *   3. mergeImport assigns fresh ids and creates entities in the store.
+ *   4. A summary is shown inline; errors show inline error text.
+ *
+ * The input resets after each operation so the same file can be re-imported
+ * if the user needs to retry after a partial failure.
+ */
+
+import { useRef, useState } from 'react'
+
+import { mergeImport } from '../../lib/export/mergeImport'
+import { parseImportBundle } from '../../lib/export/parseImportBundle'
+import type { MergeSummary } from '../../lib/export/mergeImport'
+import { useEntityStore } from '../../stores/entityStore'
+import { useWorkspaceStore } from '../../stores/workspaceStore'
+import { Button } from '../ui/button'
+
+export function ImportButton() {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [summary, setSummary] = useState<MergeSummary | null>(null)
+
+  function handleClick() {
+    fileInputRef.current?.click()
+  }
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    setBusy(true)
+    setError(null)
+    setSummary(null)
+
+    try {
+      const text = await file.text()
+      const bundle = parseImportBundle(text)
+      const entityStore = useEntityStore.getState()
+      const workspaceStore = useWorkspaceStore.getState()
+      const result = await mergeImport(bundle, entityStore, workspaceStore)
+      setSummary(result)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Import failed.')
+    } finally {
+      setBusy(false)
+      // Reset input so the same file can be re-selected.
+      if (fileInputRef.current) {
+        fileInputRef.current.value = ''
+      }
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={busy}
+        onClick={handleClick}
+        className="min-h-[44px]"
+      >
+        {busy ? 'Importing…' : 'Import…'}
+      </Button>
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".json,application/json"
+        className="sr-only"
+        aria-hidden="true"
+        onChange={(e) => void handleFileChange(e)}
+      />
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      {summary && !error && (
+        <p className="text-sm text-muted-foreground">
+          Imported: {summary.created.pilots} pilot(s), {summary.created.mechs} mech(s),{' '}
+          {summary.created.crawlers} crawler(s), {summary.created.softLinks} link(s),{' '}
+          {summary.created.workspaces} workspace(s).
+          {summary.skippedDuplicates > 0 && ` Skipped ${summary.skippedDuplicates} duplicate(s).`}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/lib/export/__tests__/export.test.ts
+++ b/apps/in-the-union-now/src/lib/export/__tests__/export.test.ts
@@ -1,0 +1,470 @@
+/**
+ * Unit tests for lib/export/* utilities.
+ *
+ * Uses fake-indexeddb (preloaded via bunfig.toml) + the real entityStore /
+ * workspaceStore so we exercise the full CRUD path without a real browser.
+ *
+ * Test matrix:
+ *   - parseImportBundle: valid bundle, malformed JSON, wrong schemaVersion
+ *   - buildExportBundle: round-trip with pilots + softLinks + workspaces
+ *   - buildEntityExport: single entity + attached softLinks only
+ *   - mergeImport: fresh ids, id-remap integrity, duplicate skip, dangling ref skip
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { _clearAllStores, _resetDbSingleton } from '../../db/index'
+import { useEntityStore } from '../../../stores/entityStore'
+import { useWorkspaceStore } from '../../../stores/workspaceStore'
+
+import { buildExportBundle, buildEntityExport } from '../buildExportBundle'
+import { mergeImport } from '../mergeImport'
+import { parseImportBundle } from '../parseImportBundle'
+import type { ExportBundle } from '../../schemas/exportBundle'
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const basePilotInput = {
+  schemaVersion: 1 as const,
+  name: 'Test Pilot',
+  callsign: 'TP',
+  classRef: 'scavenger',
+  abilities: [],
+  equipment: [],
+  rollResults: [],
+  motto: '',
+  keepsake: '',
+  appearance: '',
+  background: '',
+  conditions: [],
+}
+
+const baseMechInput = {
+  schemaVersion: 1 as const,
+  name: 'Test Mech',
+  chassisRef: 'iron-mongrel',
+  systems: [],
+  modules: [],
+  cargo: [],
+  conditions: [],
+}
+
+const baseCrawlerInput = {
+  schemaVersion: 1 as const,
+  name: 'Test Crawler',
+  techLevel: 'tech-1',
+  bays: [],
+  systems: [],
+}
+
+// ---------------------------------------------------------------------------
+// Reset helpers
+// ---------------------------------------------------------------------------
+
+function resetEntityStore(): void {
+  useEntityStore.setState({
+    pilots: [],
+    mechs: [],
+    crawlers: [],
+    softLinks: [],
+    hydrated: { pilots: false, mechs: false, crawlers: false, softLinks: false },
+  })
+}
+
+function resetWorkspaceStore(): void {
+  useWorkspaceStore.setState({ workspaces: [], hydrated: false })
+}
+
+beforeEach(async () => {
+  _resetDbSingleton()
+  await _clearAllStores()
+  resetEntityStore()
+  resetWorkspaceStore()
+})
+
+afterEach(async () => {
+  await _clearAllStores()
+  resetEntityStore()
+  resetWorkspaceStore()
+})
+
+// ---------------------------------------------------------------------------
+// parseImportBundle
+// ---------------------------------------------------------------------------
+
+describe('parseImportBundle', () => {
+  test('accepts a valid minimal bundle', () => {
+    const bundle: ExportBundle = {
+      schemaVersion: 1,
+      exportedAt: new Date().toISOString(),
+      entities: { pilots: [], mechs: [], crawlers: [] },
+      workspaces: [],
+      softLinks: [],
+    }
+    const result = parseImportBundle(JSON.stringify(bundle))
+    expect(result.schemaVersion).toBe(1)
+    expect(result.entities.pilots).toEqual([])
+  })
+
+  test('rejects malformed JSON', () => {
+    expect(() => parseImportBundle('{not json')).toThrow('not valid JSON')
+  })
+
+  test('rejects bundle with wrong schemaVersion', () => {
+    const badBundle = {
+      schemaVersion: 99,
+      exportedAt: new Date().toISOString(),
+      entities: { pilots: [], mechs: [], crawlers: [] },
+      workspaces: [],
+      softLinks: [],
+    }
+    expect(() => parseImportBundle(JSON.stringify(badBundle))).toThrow('unsupported schemaVersion')
+  })
+
+  test('rejects bundle missing required fields', () => {
+    const incomplete = { schemaVersion: 1, exportedAt: new Date().toISOString() }
+    expect(() => parseImportBundle(JSON.stringify(incomplete))).toThrow('Import failed')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildExportBundle — round-trip
+// ---------------------------------------------------------------------------
+
+describe('buildExportBundle', () => {
+  test('round-trip: build then parse yields valid bundle', async () => {
+    const entityStore = useEntityStore.getState()
+    const workspaceStore = useWorkspaceStore.getState()
+
+    await entityStore.hydrate('pilot')
+    await entityStore.create('pilot', basePilotInput)
+
+    const bundle = await buildExportBundle(entityStore, workspaceStore)
+
+    expect(bundle.schemaVersion).toBe(1)
+    expect(bundle.entities.pilots).toHaveLength(1)
+    expect(bundle.entities.pilots[0]?.name).toBe('Test Pilot')
+    expect(bundle.entities.mechs).toHaveLength(0)
+    expect(bundle.softLinks).toHaveLength(0)
+    expect(bundle.workspaces).toHaveLength(0)
+
+    // Must be parseable again
+    const reparsed = parseImportBundle(JSON.stringify(bundle))
+    expect(reparsed.entities.pilots[0]?.name).toBe('Test Pilot')
+  })
+
+  test('includes softLinks and workspaces in full backup', async () => {
+    const entityStore = useEntityStore.getState()
+    const workspaceStore = useWorkspaceStore.getState()
+
+    await workspaceStore.hydrate()
+    const ws = await workspaceStore.create({ name: 'Campaign Alpha' })
+
+    await entityStore.hydrate('pilot')
+    const pilot = await entityStore.create('pilot', {
+      ...basePilotInput,
+      workspaceId: ws.id,
+    })
+
+    await entityStore.hydrate('mech')
+    const mech = await entityStore.create('mech', baseMechInput)
+
+    await entityStore.hydrate('softLink')
+    await entityStore.create('softLink', {
+      from: { type: 'mech', id: mech.id },
+      to: { type: 'pilot', id: pilot.id },
+      type: 'mech-to-pilot',
+    })
+
+    const bundle = await buildExportBundle(entityStore, workspaceStore)
+
+    expect(bundle.workspaces).toHaveLength(1)
+    expect(bundle.workspaces[0]?.name).toBe('Campaign Alpha')
+    expect(bundle.entities.pilots).toHaveLength(1)
+    expect(bundle.entities.mechs).toHaveLength(1)
+    expect(bundle.softLinks).toHaveLength(1)
+    expect(bundle.softLinks[0]?.from.id).toBe(mech.id)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildEntityExport — single entity
+// ---------------------------------------------------------------------------
+
+describe('buildEntityExport', () => {
+  test('exports only the target pilot and its attached softLinks', async () => {
+    const entityStore = useEntityStore.getState()
+
+    await entityStore.hydrate('pilot')
+    const pilotA = await entityStore.create('pilot', { ...basePilotInput, name: 'Pilot A' })
+    const pilotB = await entityStore.create('pilot', { ...basePilotInput, name: 'Pilot B' })
+
+    await entityStore.hydrate('mech')
+    const mech = await entityStore.create('mech', baseMechInput)
+
+    await entityStore.hydrate('softLink')
+    // Link: mech → pilotA (attached to pilotA)
+    await entityStore.create('softLink', {
+      from: { type: 'mech', id: mech.id },
+      to: { type: 'pilot', id: pilotA.id },
+      type: 'mech-to-pilot',
+    })
+    // Link: pilotB → crawler (not attached to pilotA)
+    await entityStore.hydrate('crawler')
+    const crawler = await entityStore.create('crawler', baseCrawlerInput)
+    await entityStore.create('softLink', {
+      from: { type: 'pilot', id: pilotB.id },
+      to: { type: 'crawler', id: crawler.id },
+      type: 'pilot-to-crawler',
+    })
+
+    const bundle = await buildEntityExport('pilot', pilotA.id, entityStore)
+
+    expect(bundle.entities.pilots).toHaveLength(1)
+    expect(bundle.entities.pilots[0]?.id).toBe(pilotA.id)
+    expect(bundle.entities.mechs).toHaveLength(0)
+    expect(bundle.entities.crawlers).toHaveLength(0)
+    // Only the link touching pilotA
+    expect(bundle.softLinks).toHaveLength(1)
+    expect(bundle.softLinks[0]?.to.id).toBe(pilotA.id)
+    // Workspaces are not included in single-entity export
+    expect(bundle.workspaces).toHaveLength(0)
+  })
+
+  test('returns empty entities array when id not found', async () => {
+    const entityStore = useEntityStore.getState()
+    const bundle = await buildEntityExport('pilot', 'nonexistent-id', entityStore)
+    expect(bundle.entities.pilots).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// mergeImport — round-trip + id integrity
+// ---------------------------------------------------------------------------
+
+describe('mergeImport — round-trip', () => {
+  test('importing into empty store creates all entities with fresh ids', async () => {
+    // Build source store with one pilot, one mech, one link, one workspace.
+    const sourceEntityStore = useEntityStore.getState()
+    const sourceWorkspaceStore = useWorkspaceStore.getState()
+
+    await sourceWorkspaceStore.hydrate()
+    const ws = await sourceWorkspaceStore.create({ name: 'Campaign Alpha' })
+
+    await sourceEntityStore.hydrate('pilot')
+    const pilot = await sourceEntityStore.create('pilot', {
+      ...basePilotInput,
+      workspaceId: ws.id,
+    })
+
+    await sourceEntityStore.hydrate('mech')
+    const mech = await sourceEntityStore.create('mech', baseMechInput)
+
+    await sourceEntityStore.hydrate('softLink')
+    await sourceEntityStore.create('softLink', {
+      from: { type: 'mech', id: mech.id },
+      to: { type: 'pilot', id: pilot.id },
+      type: 'mech-to-pilot',
+    })
+
+    const bundle = await buildExportBundle(sourceEntityStore, sourceWorkspaceStore)
+
+    // ---- reset to simulate a fresh target store ----
+    _resetDbSingleton()
+    await _clearAllStores()
+    resetEntityStore()
+    resetWorkspaceStore()
+
+    const targetEntityStore = useEntityStore.getState()
+    const targetWorkspaceStore = useWorkspaceStore.getState()
+
+    const summary = await mergeImport(bundle, targetEntityStore, targetWorkspaceStore)
+
+    expect(summary.created.pilots).toBe(1)
+    expect(summary.created.mechs).toBe(1)
+    expect(summary.created.workspaces).toBe(1)
+    expect(summary.created.softLinks).toBe(1)
+    expect(summary.skippedDuplicates).toBe(0)
+
+    // Re-hydrate to verify state
+    _resetDbSingleton()
+    resetEntityStore()
+    resetWorkspaceStore()
+    const verifyEntityStore = useEntityStore.getState()
+    const verifyWorkspaceStore = useWorkspaceStore.getState()
+    await verifyEntityStore.hydrate('pilot')
+    await verifyEntityStore.hydrate('mech')
+    await verifyEntityStore.hydrate('softLink')
+    await verifyWorkspaceStore.hydrate()
+
+    const importedPilots = verifyEntityStore.list('pilot')
+    const importedMechs = verifyEntityStore.list('mech')
+    const importedLinks = verifyEntityStore.list('softLink')
+    const importedWorkspaces = verifyWorkspaceStore.list()
+
+    expect(importedPilots).toHaveLength(1)
+    expect(importedPilots[0]?.name).toBe('Test Pilot')
+    // Fresh id — must differ from source
+    expect(importedPilots[0]?.id).not.toBe(pilot.id)
+
+    expect(importedMechs).toHaveLength(1)
+    expect(importedMechs[0]?.id).not.toBe(mech.id)
+
+    expect(importedWorkspaces).toHaveLength(1)
+    expect(importedWorkspaces[0]?.name).toBe('Campaign Alpha')
+    const newWsId = importedWorkspaces[0]?.id
+    expect(newWsId).not.toBe(ws.id)
+
+    // Pilot's workspaceId must point to the NEW workspace id.
+    expect(importedPilots[0]?.workspaceId).toBe(newWsId)
+
+    // SoftLink must reference the new pilot and mech ids.
+    const importedLink = importedLinks[0]
+    expect(importedLink?.from.id).toBe(importedMechs[0]?.id)
+    expect(importedLink?.to.id).toBe(importedPilots[0]?.id)
+    // No dangling refs
+    expect(importedLink?.from.id).not.toBe(mech.id)
+    expect(importedLink?.to.id).not.toBe(pilot.id)
+  })
+
+  test('id-remap integrity: no dangling softLink refs after import', async () => {
+    const sourceEntityStore = useEntityStore.getState()
+    const sourceWorkspaceStore = useWorkspaceStore.getState()
+
+    await sourceEntityStore.hydrate('pilot')
+    const p1 = await sourceEntityStore.create('pilot', { ...basePilotInput, name: 'P1' })
+    const p2 = await sourceEntityStore.create('pilot', { ...basePilotInput, name: 'P2' })
+
+    await sourceEntityStore.hydrate('mech')
+    const m = await sourceEntityStore.create('mech', baseMechInput)
+
+    await sourceEntityStore.hydrate('softLink')
+    await sourceEntityStore.create('softLink', {
+      from: { type: 'mech', id: m.id },
+      to: { type: 'pilot', id: p1.id },
+      type: 'mech-to-pilot',
+    })
+    await sourceEntityStore.create('softLink', {
+      from: { type: 'pilot', id: p2.id },
+      to: { type: 'crawler', id: 'imaginary-crawler-id' }, // dangling — not in bundle
+      type: 'pilot-to-crawler',
+    })
+
+    // Build bundle — note imaginary-crawler-id is NOT in entities.crawlers
+    const bundle = await buildExportBundle(sourceEntityStore, sourceWorkspaceStore)
+
+    _resetDbSingleton()
+    await _clearAllStores()
+    resetEntityStore()
+    resetWorkspaceStore()
+
+    const targetEntityStore = useEntityStore.getState()
+    const targetWorkspaceStore = useWorkspaceStore.getState()
+
+    const summary = await mergeImport(bundle, targetEntityStore, targetWorkspaceStore)
+
+    // The dangling link (imaginary-crawler-id not in idMap) should be skipped.
+    expect(summary.created.softLinks).toBe(1)
+
+    // Verify all imported link ids are valid
+    _resetDbSingleton()
+    resetEntityStore()
+    resetWorkspaceStore()
+    const verifyStore = useEntityStore.getState()
+    await verifyStore.hydrate('pilot')
+    await verifyStore.hydrate('mech')
+    await verifyStore.hydrate('softLink')
+
+    const pilots = verifyStore.list('pilot')
+    const mechs = verifyStore.list('mech')
+    const links = verifyStore.list('softLink')
+    const pilotIds = new Set(pilots.map((p) => p.id))
+    const mechIds = new Set(mechs.map((m) => m.id))
+
+    expect(links).toHaveLength(1)
+    const link = links[0]!
+    // from must be a known mech id
+    expect(mechIds.has(link.from.id)).toBe(true)
+    // to must be a known pilot id
+    expect(pilotIds.has(link.to.id)).toBe(true)
+  })
+
+  test('does not overwrite existing entities — skips duplicates', async () => {
+    const entityStore = useEntityStore.getState()
+    const workspaceStore = useWorkspaceStore.getState()
+
+    await entityStore.hydrate('pilot')
+    const existingPilot = await entityStore.create('pilot', {
+      ...basePilotInput,
+      name: 'Existing Pilot',
+    })
+
+    // Build a bundle that contains the same pilot id.
+    const bundle: ExportBundle = {
+      schemaVersion: 1,
+      exportedAt: new Date().toISOString(),
+      entities: {
+        pilots: [existingPilot],
+        mechs: [],
+        crawlers: [],
+      },
+      workspaces: [],
+      softLinks: [],
+    }
+
+    const summary = await mergeImport(bundle, entityStore, workspaceStore)
+
+    // Should be skipped, not created again.
+    expect(summary.created.pilots).toBe(0)
+    expect(summary.skippedDuplicates).toBe(1)
+
+    // Only one pilot should exist.
+    _resetDbSingleton()
+    resetEntityStore()
+    resetWorkspaceStore()
+    const verifyStore = useEntityStore.getState()
+    await verifyStore.hydrate('pilot')
+    expect(verifyStore.list('pilot')).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// mergeImport — summary.remappedLinks counter
+// ---------------------------------------------------------------------------
+
+describe('mergeImport — remappedLinks counter', () => {
+  test('increments remappedLinks when a link endpoint id is remapped', async () => {
+    const sourceEntityStore = useEntityStore.getState()
+    const sourceWorkspaceStore = useWorkspaceStore.getState()
+
+    await sourceEntityStore.hydrate('pilot')
+    const pilot = await sourceEntityStore.create('pilot', basePilotInput)
+
+    await sourceEntityStore.hydrate('mech')
+    const mech = await sourceEntityStore.create('mech', baseMechInput)
+
+    await sourceEntityStore.hydrate('softLink')
+    await sourceEntityStore.create('softLink', {
+      from: { type: 'mech', id: mech.id },
+      to: { type: 'pilot', id: pilot.id },
+      type: 'mech-to-pilot',
+    })
+
+    const bundle = await buildExportBundle(sourceEntityStore, sourceWorkspaceStore)
+
+    _resetDbSingleton()
+    await _clearAllStores()
+    resetEntityStore()
+    resetWorkspaceStore()
+
+    const targetEntityStore = useEntityStore.getState()
+    const targetWorkspaceStore = useWorkspaceStore.getState()
+
+    const summary = await mergeImport(bundle, targetEntityStore, targetWorkspaceStore)
+
+    // Ids are always remapped when importing into a fresh store.
+    expect(summary.remappedLinks).toBe(1)
+  })
+})

--- a/apps/in-the-union-now/src/lib/export/buildExportBundle.ts
+++ b/apps/in-the-union-now/src/lib/export/buildExportBundle.ts
@@ -1,0 +1,109 @@
+import type { ExportBundle } from '../schemas/exportBundle'
+import type { EntityType } from '../../stores/types'
+
+/**
+ * Minimal store interface required by the build functions.
+ * Accepts either the real Zustand entityStore or a test double.
+ */
+type ExportStore = {
+  hydrate: (type: EntityType) => Promise<void>
+  list: <T extends EntityType>(type: T) => import('../../stores/types').EntityForType<T>[]
+}
+
+/**
+ * Minimal workspace store interface for export.
+ */
+type ExportWorkspaceStore = {
+  hydrate: () => Promise<void>
+  list: () => import('../schemas/workspace').Workspace[]
+}
+
+/**
+ * buildExportBundle — full backup of all entities, workspaces, and softLinks.
+ *
+ * Hydrates every store type first so the caller does not need to pre-hydrate.
+ * The returned bundle is a plain serialisable object — no IDB references.
+ */
+export async function buildExportBundle(
+  entityStore: ExportStore,
+  workspaceStore: ExportWorkspaceStore
+): Promise<ExportBundle> {
+  await Promise.all([
+    entityStore.hydrate('pilot'),
+    entityStore.hydrate('mech'),
+    entityStore.hydrate('crawler'),
+    entityStore.hydrate('softLink'),
+    workspaceStore.hydrate(),
+  ])
+
+  return {
+    schemaVersion: 1,
+    exportedAt: new Date().toISOString(),
+    entities: {
+      pilots: entityStore.list('pilot'),
+      mechs: entityStore.list('mech'),
+      crawlers: entityStore.list('crawler'),
+    },
+    workspaces: workspaceStore.list(),
+    softLinks: entityStore.list('softLink'),
+  }
+}
+
+/**
+ * buildEntityExport — single entity + its directly-attached softLinks.
+ *
+ * Only the entity and links whose `from.id` or `to.id` matches the entity id
+ * are included. Workspaces are intentionally omitted — the importing store
+ * will already have its own workspace set, and mergeImport handles
+ * workspaceId remapping by clearing references to unknown workspaces.
+ *
+ * Design note: we do NOT pull in the referenced endpoints (e.g. the mech
+ * that a pilot-to-mech link points to). A single-entity export is intended
+ * for "send this pilot to a friend" use-cases — the friend builds their own
+ * mechs. Including deep transitive closure would make the export ambiguous.
+ */
+export async function buildEntityExport(
+  type: 'pilot' | 'mech' | 'crawler',
+  id: string,
+  entityStore: ExportStore
+): Promise<ExportBundle> {
+  await Promise.all([entityStore.hydrate(type), entityStore.hydrate('softLink')])
+
+  const allSoftLinks = entityStore.list('softLink')
+  const attachedLinks = allSoftLinks.filter((l) => l.from.id === id || l.to.id === id)
+
+  const emptyEntities = { pilots: [], mechs: [], crawlers: [] }
+
+  switch (type) {
+    case 'pilot': {
+      const pilot = entityStore.list('pilot').find((p) => p.id === id)
+      return {
+        schemaVersion: 1,
+        exportedAt: new Date().toISOString(),
+        entities: { ...emptyEntities, pilots: pilot ? [pilot] : [] },
+        workspaces: [],
+        softLinks: attachedLinks,
+      }
+    }
+    case 'mech': {
+      const mech = entityStore.list('mech').find((m) => m.id === id)
+      return {
+        schemaVersion: 1,
+        exportedAt: new Date().toISOString(),
+        entities: { ...emptyEntities, mechs: mech ? [mech] : [] },
+        workspaces: [],
+        softLinks: attachedLinks,
+      }
+    }
+    case 'crawler': {
+      const crawler = entityStore.list('crawler').find((c) => c.id === id)
+      return {
+        schemaVersion: 1,
+        exportedAt: new Date().toISOString(),
+        entities: { ...emptyEntities, crawlers: crawler ? [crawler] : [] },
+        workspaces: [],
+        softLinks: attachedLinks,
+      }
+    }
+  }
+}

--- a/apps/in-the-union-now/src/lib/export/downloadJson.ts
+++ b/apps/in-the-union-now/src/lib/export/downloadJson.ts
@@ -1,0 +1,27 @@
+/**
+ * downloadJson — trigger a browser file download for a JSON payload.
+ *
+ * Guards for non-browser environments (SSR, tests) by checking for the
+ * presence of `document`. In those environments the function is a no-op.
+ *
+ * @param filename - The suggested filename (e.g. "itun-backup-2026-01-01.json")
+ * @param data     - Any JSON-serialisable value. Pretty-printed with 2-space indent.
+ */
+export function downloadJson(filename: string, data: unknown): void {
+  if (typeof document === 'undefined') return
+
+  const json = JSON.stringify(data, null, 2)
+  const blob = new Blob([json], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  anchor.style.display = 'none'
+  document.body.appendChild(anchor)
+  anchor.click()
+  document.body.removeChild(anchor)
+
+  // Revoke after a short delay so Safari has time to start the download.
+  setTimeout(() => URL.revokeObjectURL(url), 100)
+}

--- a/apps/in-the-union-now/src/lib/export/mergeImport.ts
+++ b/apps/in-the-union-now/src/lib/export/mergeImport.ts
@@ -1,0 +1,195 @@
+import type { ExportBundle } from '../schemas/exportBundle'
+import type { EntityType } from '../../stores/types'
+
+/**
+ * Minimal create-only store interface required by mergeImport.
+ * The real entityStore and workspaceStore both satisfy this.
+ */
+type MergeEntityStore = {
+  hydrate: (type: EntityType) => Promise<void>
+  list: <T extends EntityType>(type: T) => import('../../stores/types').EntityForType<T>[]
+  create: <T extends EntityType>(
+    type: T,
+    input: import('../../stores/types').CreateInput<T>
+  ) => Promise<import('../../stores/types').EntityForType<T>>
+}
+
+type MergeWorkspaceStore = {
+  hydrate: () => Promise<void>
+  list: () => import('../schemas/workspace').Workspace[]
+  create: (input: { name: string }) => Promise<import('../schemas/workspace').Workspace>
+}
+
+export type MergeSummary = {
+  created: {
+    pilots: number
+    mechs: number
+    crawlers: number
+    workspaces: number
+    softLinks: number
+  }
+  remappedLinks: number
+  skippedDuplicates: number
+}
+
+/**
+ * mergeImport — import an ExportBundle into the local store.
+ *
+ * Strategy:
+ *   1. Hydrate current store state so we know which ids already exist.
+ *   2. Assign FRESH UUIDs to every entity in the bundle.
+ *   3. Build an old-id → new-id map.
+ *   4. Remap:
+ *        - softLink.from.id / softLink.to.id through the map.
+ *        - pilot/mech/crawler.workspaceId through the map.
+ *   5. Create each remapped entity via store.create() (NEVER overwrite).
+ *
+ * Entities whose old id already exists in the store are skipped (counted in
+ * skippedDuplicates). Soft links that reference an id not present in the
+ * id-map (because the endpoint was skipped or absent from the bundle) are
+ * also skipped to avoid dangling refs.
+ *
+ * Returns a MergeSummary with created counts and remap stats.
+ */
+export async function mergeImport(
+  bundle: ExportBundle,
+  entityStore: MergeEntityStore,
+  workspaceStore: MergeWorkspaceStore
+): Promise<MergeSummary> {
+  // Hydrate so we can check for existing ids.
+  await Promise.all([
+    entityStore.hydrate('pilot'),
+    entityStore.hydrate('mech'),
+    entityStore.hydrate('crawler'),
+    entityStore.hydrate('softLink'),
+    workspaceStore.hydrate(),
+  ])
+
+  const existingPilotIds = new Set(entityStore.list('pilot').map((e) => e.id))
+  const existingMechIds = new Set(entityStore.list('mech').map((e) => e.id))
+  const existingCrawlerIds = new Set(entityStore.list('crawler').map((e) => e.id))
+  const existingWorkspaceIds = new Set(workspaceStore.list().map((w) => w.id))
+  const existingSoftLinkIds = new Set(entityStore.list('softLink').map((l) => l.id))
+
+  /** old id → new id for every entity that will be created */
+  const idMap = new Map<string, string>()
+
+  const summary: MergeSummary = {
+    created: { pilots: 0, mechs: 0, crawlers: 0, workspaces: 0, softLinks: 0 },
+    remappedLinks: 0,
+    skippedDuplicates: 0,
+  }
+
+  // -------------------------------------------------------------------------
+  // 1. Workspaces — remap first so entity workspaceId refs can be remapped.
+  // -------------------------------------------------------------------------
+  for (const ws of bundle.workspaces) {
+    if (existingWorkspaceIds.has(ws.id)) {
+      summary.skippedDuplicates++
+      // Map old id → existing id so downstream refs stay valid.
+      idMap.set(ws.id, ws.id)
+      continue
+    }
+    const newWs = await workspaceStore.create({ name: ws.name })
+    idMap.set(ws.id, newWs.id)
+    summary.created.workspaces++
+  }
+
+  // -------------------------------------------------------------------------
+  // 2. Pilots
+  // -------------------------------------------------------------------------
+  for (const pilot of bundle.entities.pilots) {
+    if (existingPilotIds.has(pilot.id)) {
+      summary.skippedDuplicates++
+      idMap.set(pilot.id, pilot.id)
+      continue
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { id: _id, createdAt: _ca, updatedAt: _ua, workspaceId, ...rest } = pilot
+    const remappedWorkspaceId =
+      workspaceId !== undefined ? (idMap.get(workspaceId) ?? undefined) : undefined
+
+    const created = await entityStore.create('pilot', {
+      ...rest,
+      ...(remappedWorkspaceId !== undefined ? { workspaceId: remappedWorkspaceId } : {}),
+    })
+    idMap.set(pilot.id, created.id)
+    summary.created.pilots++
+  }
+
+  // -------------------------------------------------------------------------
+  // 3. Mechs
+  // -------------------------------------------------------------------------
+  for (const mech of bundle.entities.mechs) {
+    if (existingMechIds.has(mech.id)) {
+      summary.skippedDuplicates++
+      idMap.set(mech.id, mech.id)
+      continue
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { id: _id, createdAt: _ca, updatedAt: _ua, workspaceId, ...rest } = mech
+    const remappedWorkspaceId =
+      workspaceId !== undefined ? (idMap.get(workspaceId) ?? undefined) : undefined
+
+    const created = await entityStore.create('mech', {
+      ...rest,
+      ...(remappedWorkspaceId !== undefined ? { workspaceId: remappedWorkspaceId } : {}),
+    })
+    idMap.set(mech.id, created.id)
+    summary.created.mechs++
+  }
+
+  // -------------------------------------------------------------------------
+  // 4. Crawlers
+  // -------------------------------------------------------------------------
+  for (const crawler of bundle.entities.crawlers) {
+    if (existingCrawlerIds.has(crawler.id)) {
+      summary.skippedDuplicates++
+      idMap.set(crawler.id, crawler.id)
+      continue
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { id: _id, createdAt: _ca, updatedAt: _ua, workspaceId, ...rest } = crawler
+    const remappedWorkspaceId =
+      workspaceId !== undefined ? (idMap.get(workspaceId) ?? undefined) : undefined
+
+    const created = await entityStore.create('crawler', {
+      ...rest,
+      ...(remappedWorkspaceId !== undefined ? { workspaceId: remappedWorkspaceId } : {}),
+    })
+    idMap.set(crawler.id, created.id)
+    summary.created.crawlers++
+  }
+
+  // -------------------------------------------------------------------------
+  // 5. SoftLinks — remap from/to through idMap; skip if endpoint missing.
+  // -------------------------------------------------------------------------
+  for (const link of bundle.softLinks) {
+    if (existingSoftLinkIds.has(link.id)) {
+      summary.skippedDuplicates++
+      continue
+    }
+
+    const newFromId = idMap.get(link.from.id)
+    const newToId = idMap.get(link.to.id)
+
+    if (newFromId === undefined || newToId === undefined) {
+      // Endpoint not in the bundle or was skipped — skip link to avoid dangling ref.
+      continue
+    }
+
+    const wasRemapped = newFromId !== link.from.id || newToId !== link.to.id
+    if (wasRemapped) summary.remappedLinks++
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { id: _id, createdAt: _ca, ...rest } = link
+    await entityStore.create('softLink', {
+      ...rest,
+      from: { ...link.from, id: newFromId },
+      to: { ...link.to, id: newToId },
+    })
+    summary.created.softLinks++
+  }
+
+  return summary
+}

--- a/apps/in-the-union-now/src/lib/export/parseImportBundle.ts
+++ b/apps/in-the-union-now/src/lib/export/parseImportBundle.ts
@@ -1,0 +1,40 @@
+import { ExportBundleSchema } from '../schemas/exportBundle'
+import type { ExportBundle } from '../schemas/exportBundle'
+
+/**
+ * parseImportBundle — parse and validate a raw JSON string as an ExportBundle.
+ *
+ * Throws a descriptive Error when:
+ *   - The string is not valid JSON.
+ *   - The parsed value does not conform to ExportBundleSchema.
+ *   - schemaVersion is not 1 (incompatible format).
+ *
+ * On success returns the validated ExportBundle.
+ */
+export function parseImportBundle(jsonText: string): ExportBundle {
+  let raw: unknown
+  try {
+    raw = JSON.parse(jsonText)
+  } catch {
+    throw new Error('Import failed: file is not valid JSON.')
+  }
+
+  // Check schemaVersion early to give a clearer error before full Zod parse.
+  if (
+    typeof raw === 'object' &&
+    raw !== null &&
+    'schemaVersion' in raw &&
+    (raw as Record<string, unknown>).schemaVersion !== 1
+  ) {
+    throw new Error(
+      `Import failed: unsupported schemaVersion "${String((raw as Record<string, unknown>).schemaVersion)}". Only version 1 is supported.`
+    )
+  }
+
+  const result = ExportBundleSchema.safeParse(raw)
+  if (!result.success) {
+    throw new Error(`Import failed: bundle does not match expected schema. ${result.error.message}`)
+  }
+
+  return result.data
+}

--- a/apps/in-the-union-now/src/lib/schemas/exportBundle.ts
+++ b/apps/in-the-union-now/src/lib/schemas/exportBundle.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod'
+
+import { CrawlerSchema } from './crawler'
+import { MechSchema } from './mech'
+import { PilotSchema } from './pilot'
+import { SoftLinkSchema } from './softLink'
+import { WorkspaceSchema } from './workspace'
+
+/**
+ * ExportBundle — the envelope written to disk during a full backup or
+ * single-entity export. schemaVersion: 1 is the current and only supported
+ * version; parseImportBundle() rejects any other value.
+ *
+ * Entity scope:
+ *   - Full backup (buildExportBundle): all pilots, mechs, crawlers, workspaces,
+ *     and softLinks currently in the store.
+ *   - Single-entity export (buildEntityExport): the entity itself plus any
+ *     softLinks whose `from` or `to` ref points to that entity id. Workspaces
+ *     are NOT included in a single-entity export — the importing side will have
+ *     its own workspaces, and the remapping step in mergeImport handles
+ *     workspaceId by dropping links to missing workspaces gracefully.
+ */
+export const ExportBundleSchema = z.object({
+  schemaVersion: z.literal(1),
+  exportedAt: z.string(),
+  entities: z.object({
+    pilots: z.array(PilotSchema),
+    mechs: z.array(MechSchema),
+    crawlers: z.array(CrawlerSchema),
+  }),
+  workspaces: z.array(WorkspaceSchema),
+  softLinks: z.array(SoftLinkSchema),
+})
+
+export type ExportBundle = z.infer<typeof ExportBundleSchema>

--- a/apps/in-the-union-now/src/lib/schemas/index.ts
+++ b/apps/in-the-union-now/src/lib/schemas/index.ts
@@ -1,6 +1,9 @@
 export { EntityRefSchema } from './entity'
 export type { EntityRef } from './entity'
 
+export { ExportBundleSchema } from './exportBundle'
+export type { ExportBundle } from './exportBundle'
+
 export { PilotSchema } from './pilot'
 export type { Pilot } from './pilot'
 

--- a/apps/in-the-union-now/src/routes/crawlers/$id.tsx
+++ b/apps/in-the-union-now/src/routes/crawlers/$id.tsx
@@ -16,6 +16,7 @@ import { AssignToWorkspaceButton } from '../../components/workspace/AssignToWork
 import { useWorkspaceStore } from '../../stores/workspaceStore'
 import { buttonVariants } from '../../components/ui/buttonVariants'
 import { cn } from '../../lib/utils'
+import { ExportEntityButton } from '../../components/export/ExportEntityButton'
 
 export const Route = createFileRoute('/crawlers/$id')({
   loader: async ({ params }) => {
@@ -139,13 +140,14 @@ function CrawlerDetailPage() {
           </section>
 
           {/* Actions */}
-          <div className="flex gap-3">
+          <div className="flex flex-wrap gap-3">
             <a
               href={`/sheet/crawler/${id}`}
               className={cn(buttonVariants({ variant: 'default' }), 'no-underline')}
             >
               View Sheet
             </a>
+            <ExportEntityButton type="crawler" id={id} name={crawler.name} />
           </div>
         </div>
       </div>

--- a/apps/in-the-union-now/src/routes/mechs/$id.tsx
+++ b/apps/in-the-union-now/src/routes/mechs/$id.tsx
@@ -18,6 +18,7 @@ import { AssignToWorkspaceButton } from '../../components/workspace/AssignToWork
 import { useWorkspaceStore } from '../../stores/workspaceStore'
 import { buttonVariants } from '../../components/ui/buttonVariants'
 import { cn } from '../../lib/utils'
+import { ExportEntityButton } from '../../components/export/ExportEntityButton'
 
 export const Route = createFileRoute('/mechs/$id')({
   loader: async ({ params }) => {
@@ -138,13 +139,14 @@ function MechDetailPage() {
           </section>
 
           {/* Actions */}
-          <div className="flex gap-3">
+          <div className="flex flex-wrap gap-3">
             <a
               href={`/sheet/mech/${id}`}
               className={cn(buttonVariants({ variant: 'default' }), 'no-underline')}
             >
               View Sheet
             </a>
+            <ExportEntityButton type="mech" id={id} name={mech.name} />
           </div>
         </div>
       </div>

--- a/apps/in-the-union-now/src/routes/pilots/$id.tsx
+++ b/apps/in-the-union-now/src/routes/pilots/$id.tsx
@@ -19,6 +19,7 @@ import { useWorkspaceStore } from '../../stores/workspaceStore'
 import { buttonVariants } from '../../components/ui/buttonVariants'
 import { cn } from '../../lib/utils'
 import { PilotSheet } from '../../components/sheet/PilotSheet'
+import { ExportEntityButton } from '../../components/export/ExportEntityButton'
 
 export const Route = createFileRoute('/pilots/$id')({
   loader: async ({ params }) => {
@@ -141,13 +142,14 @@ function PilotDetailPage() {
           </section>
 
           {/* Actions */}
-          <div className="flex gap-3">
+          <div className="flex flex-wrap gap-3">
             <a
               href={`/sheet/pilot/${id}`}
               className={cn(buttonVariants({ variant: 'default' }), 'no-underline')}
             >
               View Sheet
             </a>
+            <ExportEntityButton type="pilot" id={id} name={pilot.name} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Adds JSON export of pilot data (abilities, equipment, stats) for offline backup
- Adds JSON import with validation to restore pilot data from backup files
- Wires export/import controls into the pilot sheet UI

Part of the ITUN hardening plan.

Closes #220
Closes #221