### PR TITLE
fix(suref-react): swap requires-line segment colors

### DIFF
--- a/packages/suref-react/src/components/referenceEntity/DataValueDisplayView.tsx
+++ b/packages/suref-react/src/components/referenceEntity/DataValueDisplayView.tsx
@@ -78,7 +78,7 @@ export function DataValueDisplayView({
         )}
       >
         <Text
-          variant="pseudoheader"
+          variant="pseudoheaderInverse"
           as="span"
           className={cn('!self-auto uppercase', fontSize, fontWeight)}
         >
@@ -87,7 +87,7 @@ export function DataValueDisplayView({
         {trees.map((tree, i) => (
           <span key={i} className="contents">
             <Text
-              variant="pseudoheaderInverse"
+              variant="pseudoheader"
               as="span"
               className={cn('!self-auto uppercase', fontSize, fontWeight)}
             >
@@ -95,7 +95,7 @@ export function DataValueDisplayView({
             </Text>
             {i < trees.length - 1 && (
               <Text
-                variant="pseudoheader"
+                variant="pseudoheaderInverse"
                 as="span"
                 className={cn('!self-auto uppercase', fontSize, fontWeight)}
               >


### PR DESCRIPTION
## Summary

Recolors the "REQUIRES … TREE" requirement line in `DataValueDisplayView` by swapping the shared `Text` pseudoheader variants:

| Segment | Before | After |
|---|---|---|
| REQUIRES | black bg / white text | **white bg / black text** |
| Tree names (e.g. FORGING, ELECTRONICS) | white bg / black text | **black bg / white text** |
| OR | black bg / white text | **white bg / black text** |
| TREE | white bg / black text | white bg / black text (unchanged) |

Implemented purely by switching `pseudoheader` ↔ `pseudoheaderInverse` on the relevant segments — no changes to the shared `Text` variant definitions, so no other consumers are affected.

## Test plan

- [x] `typecheck` (pre-push)
- [x] `test` (pre-push)
- [x] `validate` / `knip` (pre-push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)