### PR TITLE
feat(salvageunion-reference): add expansion crawler bays

### DIFF
--- a/apps/suref-web/src/lib/changelog.ts
+++ b/apps/suref-web/src/lib/changelog.ts
@@ -6,6 +6,14 @@ type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: '2026-06-09',
+    title: 'Expansion crawler bays added',
+    items: [
+      'Four expansion / found Crawler bays now appear in the reference: the Bio-Mech Bay and Bio-Crafting Bay (We Were Here First!), the Nanite Processing Bay (False Flag), and the VR Tubes (Rainmaker).',
+      'Unlike the core fixed facilities, these are player-addable upgrade bays — each shows its build cost (Scrap and/or Bio-Salvage), tech level, or salvage value instead of a crew member and damaged effect.',
+    ],
+  },
+  {
     date: '2026-06-04',
     title: 'Bio-Titans restored; Iron Lady reclassified',
     items: [

--- a/packages/salvageunion-reference/data/crawler-bays.json
+++ b/packages/salvageunion-reference/data/crawler-bays.json
@@ -1031,5 +1031,69 @@
         "page": 62
       }
     ]
+  },
+  {
+    "id": "9ed4cb34-718a-4515-a1a5-b718c2cbe23d",
+    "name": "Bio-Mech Bay",
+    "source": "We Were Here First!",
+    "cost": {
+      "scrap": 5,
+      "scrapTechLevel": 1,
+      "bioSalvage": 10
+    },
+    "page": 61,
+    "content": [
+      {
+        "type": "paragraph",
+        "value": "Pilots may upgrade their Union Crawler with a Bio-Mech Bay at a cost of 10 Bio-Salvage and 5 Tech 1 Scrap. The Bio-Mech Bay fully restores Bio-Tech during downtime. Other Bio-Crafting Bays may be found whilst playing."
+      }
+    ]
+  },
+  {
+    "id": "fb183632-8b3e-4962-82a8-df28e2d9479e",
+    "name": "Bio-Crafting Bay",
+    "source": "We Were Here First!",
+    "cost": {
+      "scrap": 5,
+      "scrapTechLevel": 1,
+      "bioSalvage": 10
+    },
+    "page": 61,
+    "content": [
+      {
+        "type": "paragraph",
+        "value": "Pilots may upgrade their Union Crawler with a Bio-Crafting Bay at a cost of 10 Bio-Salvage and 5 Tech 1 Scrap. The Bio-Crafting Bay allows them to craft Bio-Tech. Other Bio-Crafting Bays may be found whilst playing."
+      }
+    ]
+  },
+  {
+    "id": "3d0b6a77-6213-4596-bc90-00eb1c7eb6ee",
+    "name": "Nanite Processing Bay",
+    "source": "False Flag",
+    "cost": {
+      "scrap": 5,
+      "scrapTechLevel": 6
+    },
+    "page": 66,
+    "content": [
+      {
+        "type": "paragraph",
+        "value": "A Nanite Processing Bay can be added to the Union Crawler at the cost of 5 Tech 6 Scrap. This allows you to safely process Inert Meld Nanites, safely store an unlimited amount of Active Meld Nanites on the Union Crawler, and Craft Nanite Tech."
+      }
+    ]
+  },
+  {
+    "id": "f9fe912f-5a92-4c00-8648-18432ea2988b",
+    "name": "VR Tubes",
+    "source": "Rainmaker",
+    "techLevel": 5,
+    "salvageValue": 1,
+    "page": 57,
+    "content": [
+      {
+        "type": "paragraph",
+        "value": "Eight large cylinders, protruding cables, are set in a circle. Each is large enough to contain a human being. They are Mech simulators, used to rapidly train Pilots without expenditure in resources and material. This area counts as a Tech 5 Training Bay. Any Mech configuration up to Tech 5 may also be tested in combat simulation. Each cylinder can be salvaged for 1 Tech 5 Scrap."
+      }
+    ]
   }
 ]

--- a/packages/salvageunion-reference/lib/schemas/entities.ts
+++ b/packages/salvageunion-reference/lib/schemas/entities.ts
@@ -148,11 +148,43 @@ export const ClassSchema = z
   .describe('Pilot Classes (Base and Hybrid)')
 
 /**
- * Bays and facilities on Union Crawlers
+ * Resource cost to build or add an upgrade bay to a Union Crawler.
+ * Expansion "upgrade" bays (e.g. Bio-Mech Bay, Nanite Processing Bay) are
+ * bought with a mix of Scrap (at a given Tech level) and/or Bio-Salvage.
+ */
+export const CrawlerBayCostSchema = z
+  .object({
+    scrap: NonNegativeIntegerSchema.describe(
+      'Amount of Scrap required to build this bay'
+    ).optional(),
+    scrapTechLevel: TechLevelSchema.describe('Tech level of the Scrap required').optional(),
+    bioSalvage: NonNegativeIntegerSchema.describe(
+      'Amount of Bio-Salvage required to build this bay'
+    ).optional(),
+  })
+  .strict()
+  .describe('Resource cost to build or add this bay to a Union Crawler')
+
+/**
+ * Bays and facilities on Union Crawlers.
+ *
+ * Two shapes are supported:
+ * - Core fixed facilities (Workshop Manual / Starter Set) have a crew `npc`
+ *   and a `damagedEffect`.
+ * - Expansion "upgrade" / found bays (e.g. Bio-Mech Bay, Nanite Processing Bay,
+ *   Training Bay) are player-addable or scenario facilities with a build `cost`
+ *   and/or `techLevel`, and typically no crew NPC or damaged effect.
  */
 export const CrawlerBaySchema = BaseEntitySchema.extend({
-  damagedEffect: z.string().describe('Effect when this bay is damaged'),
-  npc: NpcSchema.describe('NPC crew member who operates this bay'),
+  damagedEffect: z.string().describe('Effect when this bay is damaged').optional(),
+  npc: NpcSchema.describe('NPC crew member who operates this bay').optional(),
+  techLevel: TechLevelSchema.describe('Tech level of this bay').optional(),
+  salvageValue: NonNegativeIntegerSchema.describe(
+    'Scrap value when this bay is salvaged'
+  ).optional(),
+  cost: CrawlerBayCostSchema.describe(
+    'Resource cost to build or add this bay to a Union Crawler'
+  ).optional(),
   choices: ChoicesSchema.describe(
     'Choices available to the player when interacting with the NPC'
   ).optional(),

--- a/packages/salvageunion-reference/schemas/crawler-bays.schema.json
+++ b/packages/salvageunion-reference/schemas/crawler-bays.schema.json
@@ -715,6 +715,47 @@
         "required": ["position", "hitPoints"],
         "additionalProperties": false
       },
+      "techLevel": {
+        "anyOf": [
+          { "type": "integer", "minimum": 0, "maximum": 9007199254740991 },
+          { "type": "string", "const": "B" },
+          { "type": "string", "const": "N" }
+        ],
+        "description": "Tech level of this bay"
+      },
+      "salvageValue": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 9007199254740991,
+        "description": "Scrap value when this bay is salvaged"
+      },
+      "cost": {
+        "type": "object",
+        "properties": {
+          "scrap": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991,
+            "description": "Amount of Scrap required to build this bay"
+          },
+          "scrapTechLevel": {
+            "anyOf": [
+              { "type": "integer", "minimum": 0, "maximum": 9007199254740991 },
+              { "type": "string", "const": "B" },
+              { "type": "string", "const": "N" }
+            ],
+            "description": "Tech level of the Scrap required"
+          },
+          "bioSalvage": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 9007199254740991,
+            "description": "Amount of Bio-Salvage required to build this bay"
+          }
+        },
+        "additionalProperties": false,
+        "description": "Resource cost to build or add this bay to a Union Crawler"
+      },
       "choices": {
         "type": "array",
         "items": {
@@ -3814,16 +3855,7 @@
       },
       "tableName": { "type": "string", "description": "Reference to a roll table name" }
     },
-    "required": [
-      "id",
-      "indexable",
-      "blackMarket",
-      "name",
-      "source",
-      "page",
-      "damagedEffect",
-      "npc"
-    ],
+    "required": ["id", "indexable", "blackMarket", "name", "source", "page"],
     "additionalProperties": false,
     "description": "Bays and facilities on Union Crawlers"
   }


### PR DESCRIPTION
## What

Adds the four expansion / found crawler bays and teaches the schema to model them:

| Bay | Source | Cost / salvage | Function |
|---|---|---|---|
| Bio-Mech Bay | We Were Here First\! p.61 | 10 Bio-Salvage + 5 T1 Scrap | Fully restores Bio-Tech during downtime |
| Bio-Crafting Bay | We Were Here First\! p.61 | 10 Bio-Salvage + 5 T1 Scrap | Craft Bio-Tech |
| Nanite Processing Bay | False Flag p.66 | 5 T6 Scrap | Process Inert Meld Nanites, store unlimited Active Nanites, craft Nanite-Tech |
| VR Tubes | Rainmaker p.57 | salvage 1 T5 Scrap each | Counts as a Tech 5 Training Bay; test Mech configs in sim |

## Why a schema change

The core 10 bays are **fixed crawler facilities** — each has a crew `npc` and a `damagedEffect` (both previously required). These four are a **second category**: player-addable / found *upgrade* bays with a build cost and/or tech level but **no crew NPC and no damaged effect**.

## Schema changes (`lib/schemas/entities.ts`)

- `npc` and `damagedEffect` → **optional** on `CrawlerBaySchema`
- Added optional `techLevel`, `salvageValue`
- Added optional `cost` via new `CrawlerBayCostSchema` (`{ scrap?, scrapTechLevel?, bioSalvage? }`)

These reuse existing precedent: `TechLevelSchema` (already Bio/Nanite-aware), `salvageValue`/`bioSalvage` concepts already exist elsewhere. `Rainmaker` / `False Flag` / `We Were Here First\!` are already valid `source` enum values.

The display layer already tolerates a bay with no NPC (`getNpc → if (\!npc) return null`) and gates `damagedEffect`, so no consumer code changes were needed.

## Verification

- `bun run build:package` ✅ (JSON schema regenerated; `npc`/`damagedEffect` no longer in `required`)
- `bun run typecheck` ✅ 0 errors across all consumers
- `bun run validate:all` ✅
- `bun --filter salvageunion-reference test` ✅ 602/602 (validates all 14 bays against the schema)

> Note: the full monorepo `bun test` could not be run locally (workspace package isn't symlinked in the sandboxed worktree — the unmodified `main` checkout fails identically). CI runs it on a clean install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)