### PR TITLE
feat(reference): model vehicle loadouts as actions, not installable systems

### DIFF
--- a/apps/suref-web/src/lib/changelog.ts
+++ b/apps/suref-web/src/lib/changelog.ts
@@ -6,6 +6,14 @@ type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: '2026-06-11',
+    title: 'Vehicles read as actions, not installable systems',
+    items: [
+      'Conventional vehicles now list their loadout — weapons and locomotion — as actions, the way their statblocks read, rather than as installable Mech Systems.',
+      "The Power Loader's rigging arm now shows its own melee profile (Close, 1 SP), distinct from the mech utility arm, and two placeholder systems (Integrated Amphibious Locomotion System and Shanty Home) were folded into the vehicles that use them.",
+    ],
+  },
+  {
     date: '2026-06-09',
     title: 'Expansion crawler bays added',
     items: [

--- a/packages/salvageunion-reference/data/actions.json
+++ b/packages/salvageunion-reference/data/actions.json
@@ -8216,6 +8216,34 @@
     "actionType": "Turn"
   },
   {
+    "name": "Rigging Arm (Vehicle)",
+    "displayName": "Rigging Arm",
+    "range": ["Close"],
+    "damage": {
+      "amount": 1,
+      "damageType": "SP"
+    },
+    "traits": [
+      {
+        "type": "melee"
+      },
+      {
+        "type": "rigging"
+      }
+    ],
+    "id": "ddff4e0a-542d-4187-a22f-721502ceddb1",
+    "actionSource": "vehicles",
+    "actionType": "Turn",
+    "source": "Salvage Union Workshop Manual",
+    "page": 292,
+    "content": [
+      {
+        "type": "paragraph",
+        "value": "A heavy rigging arm mounted on a vehicle, swung as an improvised melee weapon for 1 SP. Its Rigging Trait also lets it perform the 'Load' Action to pick up and carry Scrap and salvage."
+      }
+    ]
+  },
+  {
     "id": "34d4a7d5-8911-4a8d-bf68-42d93768286d",
     "traits": [
       {
@@ -13172,12 +13200,6 @@
       }
     ],
     "actionSource": "equipment"
-  },
-  {
-    "id": "900c83b0-bf02-4a24-b7f5-5e7346cc18ed",
-    "name": "Integrated Amphibious Locomotion System",
-    "actionType": "Passive",
-    "actionSource": "systems"
   },
   {
     "id": "4ea8fc40-6ee7-4905-8d64-1fbfac7de27e",

--- a/packages/salvageunion-reference/data/systems.json
+++ b/packages/salvageunion-reference/data/systems.json
@@ -1546,32 +1546,6 @@
     ]
   },
   {
-    "id": "05bc4e29-9487-4559-9cbf-1244b4b06ea4",
-    "source": "Reclamation of the Wastes",
-    "name": "Integrated Amphibious Locomotion System",
-    "techLevel": 1,
-    "slotsRequired": 2,
-    "salvageValue": 2,
-    "page": 102,
-    "actions": ["Integrated Amphibious Locomotion System"]
-  },
-  {
-    "id": "4b79a534-38c0-4beb-b43c-c222007fad51",
-    "source": "Reclamation of the Wastes",
-    "name": "Shanty Home",
-    "techLevel": 1,
-    "slotsRequired": 2,
-    "salvageValue": 1,
-    "page": 102,
-    "actions": ["Shanty Home"],
-    "content": [
-      {
-        "type": "paragraph",
-        "value": "Can safely transport a family of people across the wastes."
-      }
-    ]
-  },
-  {
     "id": "2745be06-5961-49e0-acfa-177b87210dea",
     "source": "Salvage Union Starter Set",
     "booklet": "PC",

--- a/packages/salvageunion-reference/data/vehicles.json
+++ b/packages/salvageunion-reference/data/vehicles.json
@@ -3,7 +3,7 @@
     "id": "c1d53d2d-9abd-4a72-8e78-2674eb7d7329",
     "source": "Salvage Union Workshop Manual",
     "name": "Power Loader",
-    "systems": ["Locomotion System", "Rigging Arm", "Rigging Arm"],
+    "actions": ["Locomotion System", "Rigging Arm (Vehicle)", "Rigging Arm (Vehicle)"],
     "techLevel": 1,
     "salvageValue": 1,
     "structurePoints": 1,
@@ -20,7 +20,7 @@
     "id": "cc95bd31-30c2-4f47-b1b3-a881eb228c0d",
     "source": "Salvage Union Workshop Manual",
     "name": "Box Wheel",
-    "systems": ["Locomotion System"],
+    "actions": ["Locomotion System"],
     "traits": [
       {
         "type": "personnel capacity",
@@ -46,7 +46,7 @@
     "id": "b31e45ef-412a-46ae-bf21-83ef01477199",
     "source": "Salvage Union Workshop Manual",
     "name": "Fighting Box Wheel",
-    "systems": ["Locomotion System", ".50 Cal Machine Gun"],
+    "actions": ["Locomotion System", ".50 Cal Machine Gun"],
     "traits": [
       {
         "type": "personnel capacity",
@@ -71,7 +71,7 @@
     "id": "92f28dba-4b4b-4e4d-81f8-bc9e279d92f5",
     "source": "Salvage Union Workshop Manual",
     "name": "Armoured Box Wheel",
-    "systems": ["Locomotion System", "30mm Autocannon"],
+    "actions": ["Locomotion System", "30mm Autocannon"],
     "traits": [
       {
         "type": "personnel capacity",
@@ -98,7 +98,7 @@
     "id": "2ee55c7e-c8fb-406f-93f9-93a5b2a9ba37",
     "source": "Salvage Union Workshop Manual",
     "name": "Tank",
-    "systems": ["Locomotion System", "120mm Cannon"],
+    "actions": ["Locomotion System", "120mm Cannon"],
     "techLevel": 3,
     "salvageValue": 4,
     "structurePoints": 6,
@@ -115,7 +115,7 @@
     "id": "1e582dbd-3d2c-4408-a43c-d961ba63fb37",
     "source": "Salvage Union Workshop Manual",
     "name": "Rotorcraft",
-    "systems": ["Hover Locomotion System", "Rotary Minigun"],
+    "actions": ["Hover Locomotion System", "Rotary Minigun"],
     "traits": [
       {
         "type": "personnel capacity",
@@ -142,7 +142,7 @@
     "source": "Reclamation of the Wastes",
     "page": 102,
     "name": "E-Boat",
-    "systems": ["Integrated Amphibious Locomotion System"],
+    "actions": ["Integrated Amphibious Locomotion System"],
     "traits": [
       {
         "type": "personnel capacity",
@@ -164,7 +164,7 @@
     "source": "Reclamation of the Wastes",
     "page": 102,
     "name": "Tombstone Trackbox",
-    "systems": ["Locomotion System", "Shanty Home"],
+    "actions": ["Locomotion System", "Shanty Home"],
     "traits": [
       {
         "type": "personnel capacity",
@@ -185,7 +185,7 @@
     "id": "79640c87-2166-44fa-a9e5-396de3fe865a",
     "source": "Salvage Union Workshop Manual",
     "name": "Machine Gun Turret",
-    "systems": [".50 Cal Machine Gun"],
+    "actions": [".50 Cal Machine Gun"],
     "traits": [
       {
         "type": "immobile"
@@ -208,7 +208,7 @@
     "source": "Reclamation of the Wastes",
     "page": 103,
     "name": "Green Laser Turret",
-    "systems": ["Green Laser"],
+    "actions": ["Green Laser"],
     "traits": [
       {
         "type": "immobile"
@@ -223,7 +223,7 @@
     "source": "Reclamation of the Wastes",
     "page": 103,
     "name": "Missile Pod Turret",
-    "systems": ["Missile Pod"],
+    "actions": ["Missile Pod"],
     "traits": [
       {
         "type": "immobile"

--- a/packages/salvageunion-reference/lib/schemas/entities.ts
+++ b/packages/salvageunion-reference/lib/schemas/entities.ts
@@ -409,9 +409,18 @@ export const TraitEntitySchema = BaseEntitySchema.extend({
   .describe('Traits and special properties')
 
 /**
- * Conventional vehicles
+ * Conventional vehicles.
+ *
+ * Unlike mechs, vehicles are not built from the system/module install economy:
+ * their capabilities are expressed directly as named `actions`. The `systems`
+ * field inherited from MechanicalEntitySchema is omitted here, and there is no
+ * `modules` field — a vehicle carries neither (the schema is strict).
  */
 export const VehicleSchema = BaseEntitySchema.extend({ ...MechanicalEntitySchema.shape })
+  .omit({ systems: true })
+  .extend({
+    actions: z.array(z.string()).describe('Action names this vehicle can perform').optional(),
+  })
   .strict()
   .describe('Conventional vehicles')
 

--- a/packages/salvageunion-reference/schemas/vehicles.schema.json
+++ b/packages/salvageunion-reference/schemas/vehicles.schema.json
@@ -232,11 +232,6 @@
         "maximum": 9007199254740991,
         "description": "Scrap value when salvaged"
       },
-      "systems": {
-        "type": "array",
-        "items": { "type": "string" },
-        "description": "Installed system names"
-      },
       "traits": {
         "type": "array",
         "items": {
@@ -291,6 +286,11 @@
         "minimum": 0,
         "maximum": 9007199254740991,
         "description": "Cargo carrying capacity"
+      },
+      "actions": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Action names this vehicle can perform"
       }
     },
     "required": ["id", "indexable", "blackMarket", "name", "source", "page"],

--- a/packages/salvageunion-reference/tools/validateActionReferences.ts
+++ b/packages/salvageunion-reference/tools/validateActionReferences.ts
@@ -61,6 +61,7 @@ const dataFiles = [
   'npcs.json',
   'squads.json',
   'chassis.json',
+  'vehicles.json',
 ]
 
 function findSimilarAction(referencedName: string): string | undefined {

--- a/packages/salvageunion-reference/tools/validateOrphans.ts
+++ b/packages/salvageunion-reference/tools/validateOrphans.ts
@@ -105,6 +105,7 @@ const referencedActionNames = collectReferencedActionNames({
     ...squads,
     ...traits,
     ...keywords,
+    ...vehicles,
   ],
 })
 

--- a/packages/salvageunion-reference/tools/validateReferences.ts
+++ b/packages/salvageunion-reference/tools/validateReferences.ts
@@ -37,7 +37,6 @@ function loadData(filename: string): Record<string, unknown>[] {
 const systems = loadData('systems.json')
 const modules = loadData('modules.json')
 const chassis = loadData('chassis.json')
-const vehicles = loadData('vehicles.json')
 const drones = loadData('drones.json')
 const actions = loadData('actions.json')
 const equipment = loadData('equipment.json')
@@ -134,26 +133,6 @@ for (const chassisItem of chassis) {
           }
         }
       }
-    }
-  }
-}
-
-// Validate vehicle systems
-console.log('Validating vehicle systems...')
-for (const vehicle of vehicles) {
-  const systems = vehicle.systems
-  if (!systems || !Array.isArray(systems)) continue
-
-  for (const systemName of systems) {
-    if (typeof systemName !== 'string') continue
-    if (!systemNames.has(systemName)) {
-      errors.push({
-        file: 'vehicles.json',
-        entityName: String(vehicle.name ?? 'unknown'),
-        field: 'systems',
-        referencedName: systemName,
-        message: `System "${systemName}" not found in systems.json`,
-      })
     }
   }
 }


### PR DESCRIPTION
## Summary

Vehicles in Salvage Union run no slot/install economy — their statblocks just list a fixed set of capabilities. This models that directly with `actions` instead of `systems`.

### Changes
- **Schema:** `VehicleSchema` now `.omit({ systems: true })` — vehicles strict-reject `systems` (and never had `modules`). Drones and bio-titans keep `systems` via the shared `MechanicalEntitySchema`. Convention documented in the schema JSDoc.
- **Data:** all 11 vehicles converted from `systems` → `actions`.
- **Cleanup:** removed two vehicle-only "empty" systems (`Integrated Amphibious Locomotion System`, `Shanty Home`) and a duplicate content-less `Integrated Amphibious Locomotion System` action that was shadowing the real chassis-sourced one (this also fixed the **Kraken** chassis ability resolving to empty content).
- **Rigging Arm:** added a distinct `Rigging Arm (Vehicle)` action (`Close / 1 SP / melee + rigging`, per the Power Loader statblock, p.292) so the vehicle melee profile no longer collides with the mech utility `Rigging Arm`. The mech action is untouched.
- **Validators:** validate vehicle `actions`; count vehicle action refs in orphan detection; removed the now-dead vehicle-systems reference check.

### Source note
RAW (Core Book p.245 "Salvaging a Non-Mech" + p.291–292 statblocks) actually calls these loadout items *Systems* and says non-Mechs *can* carry Systems/Modules. Modeling vehicles as actions-only is therefore a deliberate abstraction (vehicles have no slot economy), chosen intentionally — not a transcription of a "vehicles can't have systems" rule.

### Verification
- `validate:all` exit 0 (unique IDs, no dangling refs, orphan count unchanged at 49)
- typecheck 4/4 workspaces · **2,738 tests pass / 0 fail** · lint 0 errors (2 pre-existing warnings, unrelated) · prettier clean
- Behavioral: every vehicle resolves its actions with full range/damage/traits; Power Loader shows `Rigging Arm` ×2 at `Close / 1 SP`; mech `Rigging Arm` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)