### PR TITLE
fix(suref-react): clear float so entity actions render full-width below image

### DIFF
--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/ReferenceEntityActions.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/ReferenceEntityActions.tsx
@@ -15,14 +15,6 @@ type ReferenceEntityActionsProps = {
   suppressActions?: boolean
   /** When true, renders action titles as SectionSeparators instead of action-cards */
   sectionHeaders?: boolean
-  /**
-   * When true, the entity's image is rendered as a left-float, so actions flow
-   * around it like the body text: each card is its own block-formatting-context
-   * box in plain block flow, narrow beside the image and full-width once below
-   * it. (The default multi-column masonry establishes a formatting context that
-   * stays shrunk beside the float, so it is only used when there is no float.)
-   */
-  wrapImageFloat?: boolean
 }
 
 export function ReferenceEntityActions({
@@ -32,7 +24,6 @@ export function ReferenceEntityActions({
   headerBg,
   suppressActions,
   sectionHeaders = false,
-  wrapImageFloat = false,
 }: ReferenceEntityActionsProps) {
   if (suppressActions) return null
 
@@ -62,55 +53,6 @@ export function ReferenceEntityActions({
   const regularActions = actionsToDisplay.filter(
     (a) => getReferenceEntityName(a) !== 'Titanic Actions'
   )
-
-  // Float-wrap layout: plain block flow (NO flex / grid / multi-column /
-  // container-query wrapper between the float and the cards — each of those
-  // establishes a formatting context that shrinks beside the float and never
-  // re-expands below it). Each card is its own flow-root, so it sits narrow
-  // beside the floated image and takes full width once it clears the image,
-  // exactly like the body text wraps. The titanic action clears the float so
-  // its wide reminder + option list always span the full card width.
-  if (wrapImageFloat) {
-    return (
-      <div className={spacing.smallSpaceYClass}>
-        {regularActions.length > 0 && (
-          <>
-            <SectionSeparator
-              label="Actions"
-              compact={compact}
-              fontSize={compact ? 'text-xs' : 'text-sm'}
-            />
-            <div className="mt-2">
-              {regularActions.map((action) => (
-                <div key={action.id} className="mb-3 [display:flow-root]">
-                  <ActionCard data={action} compact parentHeaderBg={headerBg} />
-                </div>
-              ))}
-            </div>
-          </>
-        )}
-
-        {regularActions.length === 0 && titanicAction && (
-          <SectionSeparator
-            label="Actions"
-            compact={compact}
-            fontSize={compact ? 'text-xs' : 'text-sm'}
-          />
-        )}
-
-        {titanicAction && (
-          <div className={cn('clear-both', regularActions.length > 0 ? 'mt-4' : 'mt-2')}>
-            <ActionCard
-              data={titanicAction}
-              compact={compact}
-              parentHeaderBg={headerBg}
-              titanicMode
-            />
-          </div>
-        )}
-      </div>
-    )
-  }
 
   return (
     <div className={cn('flex flex-col', spacing.smallSpaceYClass)}>

--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/ReferenceEntityIntegratedSystems.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/ReferenceEntityIntegratedSystems.tsx
@@ -8,18 +8,11 @@ import { cn } from '../../../utils/cn'
 type ReferenceEntityIntegratedSystemsProps = {
   data: SURefEntity
   compact: boolean
-  /**
-   * When true, the entity's image floats, so each listing renders as its own
-   * flow-root box in plain block flow — narrow beside the image, full-width once
-   * below it — matching how the body text and actions wrap around the image.
-   */
-  wrapImageFloat?: boolean
 }
 
 export function ReferenceEntityIntegratedSystems({
   data,
   compact,
-  wrapImageFloat = false,
 }: ReferenceEntityIntegratedSystemsProps) {
   if (!('systems' in data) || !Array.isArray(data.systems)) return null
 
@@ -39,27 +32,17 @@ export function ReferenceEntityIntegratedSystems({
         // Index-suffixed: an entity may legitimately integrate the same system
         // more than once (e.g. the Power Loader's two Rigging Arms), so the id
         // alone is not a unique key.
-        <IntegratedSystemListing
-          key={`${system.id}-${idx}`}
-          entity={system}
-          wrapImageFloat={wrapImageFloat}
-        />
+        <IntegratedSystemListing key={`${system.id}-${idx}`} entity={system} />
       ))}
     </div>
   )
 }
 
-function IntegratedSystemListing({
-  entity,
-  wrapImageFloat,
-}: {
-  entity: SURefEntity
-  wrapImageFloat: boolean
-}) {
+function IntegratedSystemListing({ entity }: { entity: SURefEntity }) {
   const detailModal = useDetailModal(entity)
 
   return (
-    <div className={cn(wrapImageFloat && '[display:flow-root]')}>
+    <>
       <ReferenceEntityDisplay
         hide={{ actions: true }}
         data={entity}
@@ -68,6 +51,6 @@ function IntegratedSystemListing({
         controls={[{ ...detailModal.control, hidden: false, cardClick: false }]}
       />
       {detailModal.modal}
-    </div>
+    </>
   )
 }

--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/components/ReferenceEntityDisplayContent.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/components/ReferenceEntityDisplayContent.tsx
@@ -324,10 +324,11 @@ export function ReferenceEntityDisplayContent({
 
   // The image renders as a left-float (CardImage `md:float-left`) on every path
   // EXCEPT the two grid layouts (chassis abilities, afterExtraContent), which
-  // place it in a grid cell. When it floats, actions should wrap around it like
-  // the body text — narrow beside the image, full-width once below it — rather
-  // than render in a multi-column block that stays shrunk beside the float.
-  const wrapImageFloat =
+  // place it in a grid cell. When it floats, only the body prose wraps around it;
+  // the structured sections below (actions, systems, integrated systems, etc.)
+  // are boxy and would be squeezed into the narrow column beside the float, so we
+  // clear the float after the prose and render them full-width below the image.
+  const imageFloats =
     !!assetUrl && !(!compact && ((hasChassisAbilities && !hide.actions) || !!afterExtraContent))
 
   // Resolve drone entity from chassis abilities (rendered below the fold)
@@ -623,6 +624,11 @@ export function ReferenceEntityDisplayContent({
                       {children}
                     </>
                   )}
+                  {/* Only the body prose wraps the floated image; clear the float
+                      here so the structured sections below render full-width
+                      beneath the image instead of squeezed into the narrow column
+                      beside it. */}
+                  {imageFloats && <div className="clear-both" />}
                   <ReferenceEntityFactionData
                     data={data}
                     compact={compact}
@@ -671,7 +677,6 @@ export function ReferenceEntityDisplayContent({
                   actionsToDisplay={visibleActions}
                   headerBg={headerBg}
                   sectionHeaders={schemaName === 'crawlers'}
-                  wrapImageFloat={wrapImageFloat}
                 />
               )}
               {/* Granting ability: a `Grants` block — the nested compact equipment
@@ -681,23 +686,13 @@ export function ReferenceEntityDisplayContent({
                 <ReferenceEntityGrants data={data} spacing={spacing} compact={compact} />
               )}
               {/* Titan-equipped systems/modules render as compact listings under
-                  actions. When the image floats, use plain block flow with each
-                  listing as its own flow-root so they wrap around the image like
-                  the body text (a flex container would stay shrunk beside the
-                  float); otherwise keep the flex column. */}
+                  actions, full-width below the (cleared) image float. */}
               {statblockSystems && statblockSystems.length > 0 && (
                 <>
                   <SectionSeparator label="Mech Systems" compact={compact} />
-                  <div
-                    className={cn(!wrapImageFloat && 'flex flex-col', spacing.sectionSpaceYClass)}
-                  >
+                  <div className={cn('flex flex-col', spacing.sectionSpaceYClass)}>
                     {statblockSystems.map((system) => (
-                      <div
-                        key={`statblock-system-${system.id}`}
-                        className={cn(wrapImageFloat && '[display:flow-root]')}
-                      >
-                        <PatternEquipmentItem data={system} />
-                      </div>
+                      <PatternEquipmentItem key={`statblock-system-${system.id}`} data={system} />
                     ))}
                   </div>
                 </>
@@ -705,16 +700,9 @@ export function ReferenceEntityDisplayContent({
               {statblockModules && statblockModules.length > 0 && (
                 <>
                   <SectionSeparator label="Mech Modules" compact={compact} />
-                  <div
-                    className={cn(!wrapImageFloat && 'flex flex-col', spacing.sectionSpaceYClass)}
-                  >
+                  <div className={cn('flex flex-col', spacing.sectionSpaceYClass)}>
                     {statblockModules.map((mod) => (
-                      <div
-                        key={`statblock-module-${mod.id}`}
-                        className={cn(wrapImageFloat && '[display:flow-root]')}
-                      >
-                        <PatternEquipmentItem data={mod} />
-                      </div>
+                      <PatternEquipmentItem key={`statblock-module-${mod.id}`} data={mod} />
                     ))}
                   </div>
                 </>
@@ -730,11 +718,7 @@ export function ReferenceEntityDisplayContent({
                 selections={choiceSelections}
                 onSelectionChange={setChoiceSelections}
               />
-              <ReferenceEntityIntegratedSystems
-                data={data}
-                compact={compact}
-                wrapImageFloat={wrapImageFloat}
-              />
+              <ReferenceEntityIntegratedSystems data={data} compact={compact} />
 
               <ReferenceEntityBonusPerTechLevel
                 bonusPerTechLevel={'bonusPerTechLevel' in data ? data.bonusPerTechLevel : undefined}


### PR DESCRIPTION
## Problem

On entities with an illustration (e.g. the **Armoured Box Wheel** vehicle), the Actions section was squeezed into a narrow column beside the floated image instead of using the full card width.

\![squeeze](before)

#262 tried to wrap actions around the floated image by giving each action card `[display:flow-root]`. But a flow-root box shrinks to clear the float and **keeps that narrow width for its entire height** — so a single tall action card beside a tall image stays squeezed the whole way down and never expands once it passes the image.

## Fix

Only the body **prose** should wrap the image. This clears the float immediately after the prose, so every boxy structured section (actions, titan systems/modules, integrated systems, faction data) renders **full-width below the image** — where the action masonry can use the full container width.

- Adds a single `clear-both` spacer after the prose (the same pattern already used elsewhere in `ReferenceEntityDisplayContent`).
- Reverts #262's per-card `[display:flow-root]` hacks and the now-unused `wrapImageFloat` props on `ReferenceEntityActions` / `ReferenceEntityIntegratedSystems` / titan systems.

Net −91 lines.

## Verification

- `bun run typecheck` — clean
- `bun --filter suref-react test` — 200 pass
- `bun run lint` — 0 errors (2 pre-existing warnings in unrelated ITUN files)

Please confirm the layout on the deploy preview (Armoured Box Wheel and other illustrated statblocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)