### PR TITLE
fix: render mech action/ability costs as EP by source (Auto-Doctor + chassis)

### DIFF
--- a/packages/salvageunion-reference/lib/helpers.ts
+++ b/packages/salvageunion-reference/lib/helpers.ts
@@ -496,14 +496,15 @@ export const UPKEEP_RULES = {
 
 /**
  * Resolve the activation currency for a given schema/entity category.
- * Systems and modules cost EP; variable-cost abilities cost XP; everything else costs AP.
+ * Mech-level sources (chassis, systems, modules) cost EP; variable-cost abilities
+ * cost XP; everything else costs AP.
  */
 export function resolveActivationCurrency(
   schemaName: SURefEnumSchemaName | 'actions' | undefined,
   variable: boolean = false
 ): 'AP' | 'EP' | 'XP' {
   if (variable) return 'XP'
-  if (schemaName === 'systems' || schemaName === 'modules') return 'EP'
+  if (schemaName === 'chassis' || schemaName === 'systems' || schemaName === 'modules') return 'EP'
   return 'AP'
 }
 

--- a/packages/suref-react/src/components/referenceEntity/ActionCard.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ActionCard.tsx
@@ -3,6 +3,7 @@ import type { SURefMetaAction, SURefObjectTable } from 'salvageunion-reference'
 import {
   getReferenceEntityName,
   getRequiredTraits,
+  resolveActivationCurrency,
   SalvageUnionReference,
   parseContentBlockString,
 } from 'salvageunion-reference'
@@ -73,7 +74,12 @@ export function ActionCard({
 
   // The action type (e.g. "TURN ACTION") stays in the data-value row alongside
   // range/damage/traits — it is NOT lifted into a callout.
-  const details = extractReferenceEntityDetails(data, undefined, 'AP')
+  // Currency follows the action's source: systems/modules cost EP, everything else AP.
+  const details = extractReferenceEntityDetails(
+    data,
+    undefined,
+    resolveActivationCurrency(data.actionSource)
+  )
 
   const fontSize = compact ? 'text-xs' : 'text-sm'
 

--- a/packages/suref-react/src/components/referenceEntity/NestedActionDisplay.tsx
+++ b/packages/suref-react/src/components/referenceEntity/NestedActionDisplay.tsx
@@ -2,6 +2,7 @@ import type { SURefMetaAction, SURefObjectTable } from 'salvageunion-reference'
 import {
   getReferenceEntityName,
   getRequiredTraits,
+  resolveActivationCurrency,
   SalvageUnionReference,
 } from 'salvageunion-reference'
 import { BlockContentRendererView } from './BlockContentRendererView'
@@ -57,8 +58,12 @@ export function NestedActionDisplay({
   }
 
   // Legacy path: SectionSeparator title + left-border content block.
-  // Regular actions use AP currency
-  const details = extractReferenceEntityDetails(data, undefined, 'AP')
+  // Currency follows the action's source: systems/modules cost EP, everything else AP.
+  const details = extractReferenceEntityDetails(
+    data,
+    undefined,
+    resolveActivationCurrency(data.actionSource)
+  )
 
   // Match ReferenceEntityDisplay fontSize.sm: compact ? 'xs' : 'sm'
   const fontSize = compact ? 'text-xs' : 'text-sm'

--- a/packages/suref-react/src/components/referenceEntity/NestedChassisAbility.tsx
+++ b/packages/suref-react/src/components/referenceEntity/NestedChassisAbility.tsx
@@ -1,5 +1,5 @@
 import type { SURefMetaAction, SURefObjectChoice } from 'salvageunion-reference'
-import { getTable } from 'salvageunion-reference'
+import { getTable, resolveActivationCurrency } from 'salvageunion-reference'
 import { Text } from '../base/Text'
 import { BlockContentRendererView } from './BlockContentRendererView'
 import { ReferenceEntityChoice } from './ReferenceEntityDisplay/ReferenceEntityChoice'
@@ -41,8 +41,12 @@ export function NestedChassisAbility({
   hideChoices = false,
   chassisName,
 }: NestedChassisAbilityProps) {
-  // Chassis abilities use EP currency
-  const details = extractReferenceEntityDetails(data, undefined, 'EP')
+  // Currency follows the action's source; chassis abilities are mech-level (EP).
+  const details = extractReferenceEntityDetails(
+    data,
+    undefined,
+    resolveActivationCurrency(data.actionSource ?? 'chassis')
+  )
 
   const fontSize = compact ? 'text-xs' : 'text-sm'
   const titleFontSize = compact ? 'text-sm' : 'text-base'


### PR DESCRIPTION
## Problem

The Auto-Doctor (a mech module) listed its ability costs as **AP** instead of **EP** in the systems database. Root cause: the nested-action renderers hardcoded the activation-cost currency instead of deriving it from the action's source.

## Fix

Every nested-action renderer now resolves currency from the action's `actionSource` via the shared `resolveActivationCurrency` helper:

- **`ActionCard`** / **`NestedActionDisplay`** — were hardcoded `'AP'`; now `resolveActivationCurrency(data.actionSource)` (systems/modules → EP, otherwise AP).
- **`NestedChassisAbility`** — was hardcoded `'EP'`; now `resolveActivationCurrency(data.actionSource ?? 'chassis')`.
- **`resolveActivationCurrency`** — now maps `'chassis'` → EP (alongside systems/modules), since chassis abilities are mech-level. This also fixes ITUN's `pilotActionUtils.deriveActionCurrency`, which already routed through the helper and was mislabeling chassis ability costs as AP.

Chassis entities carry no top-level `activationCost`, so schema-name callers are unaffected. `undefined` source falls back to AP, preserving prior behavior for all non-mech actions.

## Verification

- `bun run typecheck` — clean across all packages
- Tests: suref-react 207, salvageunion-reference 589, ITUN 997 — all pass
- lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)