### PR TITLE
fix(discord-bot): preload reference data before handling interactions

### DIFF
--- a/apps/discord-bot/src/commands/roll.ts
+++ b/apps/discord-bot/src/commands/roll.ts
@@ -12,9 +12,15 @@ import {
   isColumnsTable,
 } from 'salvageunion-reference'
 
-// Get all roll table names for autocomplete
-const rollTables = SalvageUnionReference.RollTables.all()
-const rollTableNames = rollTables.map((t) => t.name)
+// Roll tables load lazily once SalvageUnionReference.preload() has run at startup.
+// Accessing them at module load would throw before preload completes, so defer to first use.
+let cachedRollTables: ReturnType<typeof SalvageUnionReference.RollTables.all> | null = null
+function getRollTables(): ReturnType<typeof SalvageUnionReference.RollTables.all> {
+  if (cachedRollTables === null) {
+    cachedRollTables = SalvageUnionReference.RollTables.all()
+  }
+  return cachedRollTables
+}
 
 /**
  * Get embed color based on roll result (d20)
@@ -49,7 +55,8 @@ export const rollCommand = {
   async autocomplete(interaction: AutocompleteInteraction): Promise<void> {
     const focusedValue = interaction.options.getFocused().toLowerCase()
 
-    const filtered = rollTableNames
+    const filtered = getRollTables()
+      .map((t) => t.name)
       .filter((name) => name.toLowerCase().includes(focusedValue))
       .slice(0, 25) // Discord limits to 25 choices
 
@@ -60,7 +67,7 @@ export const rollCommand = {
     const tableName = interaction.options.getString('table') ?? 'Core Mechanic'
 
     // Find the table
-    const table = rollTables.find((t) => t.name.toLowerCase() === tableName.toLowerCase())
+    const table = getRollTables().find((t) => t.name.toLowerCase() === tableName.toLowerCase())
 
     if (!table) {
       await interaction.reply({

--- a/apps/discord-bot/src/index.ts
+++ b/apps/discord-bot/src/index.ts
@@ -1,4 +1,5 @@
 import { Client, GatewayIntentBits, Events } from 'discord.js'
+import { SalvageUnionReference } from 'salvageunion-reference'
 import { config } from './config.js'
 import { commands } from './commands/index.js'
 import { handleReady } from './events/ready.js'
@@ -34,4 +35,8 @@ process.on('uncaughtException', (error) => {
 
 // Login
 console.log('Starting Salvage Union Discord Bot...')
-client.login(config.discordToken)
+
+// Load reference data before handling any interactions (models throw until preloaded).
+await SalvageUnionReference.preload('all')
+
+await client.login(config.discordToken)


### PR DESCRIPTION
## Problem

With the Render build now fixed (#276), `suref-discord-bot` builds and starts — and immediately **crash-loops on boot**:

```
Error: Schema "roll-tables" not loaded. Call SalvageUnionReference.preload(['roll-tables']) ... first.
    at apps/discord-bot/dist/commands/roll.js  (LazyModel.all)
```

The `salvageunion-reference` ORM now lazy-loads schemas and throws on any data access until `SalvageUnionReference.preload()` runs. `roll.ts` called `SalvageUnionReference.RollTables.all()` at **module load** — which executes during the static `import { commands }` in `index.ts`, before any startup code runs. This was latent: the Render build had been failing for so long the bot never actually started to hit it.

## Fix

- **`index.ts`** — `await SalvageUnionReference.preload('all')` before `client.login()`.
- **`roll.ts`** — defer roll-table access to a lazy `getRollTables()` getter used inside the command handlers, so module import no longer touches unloaded data.

## Verification

Local smoke test (`node dist/index.js` with a dummy token):

```
Starting Salvage Union Discord Bot...
DiscordjsError [TokenInvalid]: An invalid token was provided.
```

It now boots, preloads all schemas cleanly, and fails only on the dummy token — the `Schema "roll-tables" not loaded` crash is gone. With the real `DISCORD_TOKEN` on Render it will log in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)