### PR TITLE
feat(suref-react): masonry entity options + floating wizard footer

### DIFF
--- a/packages/suref-react/src/components/referenceEntity/GuideStepsDisplay.tsx
+++ b/packages/suref-react/src/components/referenceEntity/GuideStepsDisplay.tsx
@@ -463,15 +463,18 @@ export function GuideStepsDisplay({
                         )
                         return { ...entity, entityId, isGreyedOut, entityControls }
                       })
-                      // Single column on mobile (natural order, "tree by tree");
-                      // two balanced columns at sm+ via native CSS multi-column.
+                      // Masonry layout via native CSS multi-column: the column
+                      // count auto-scales to the available width (column-width
+                      // 15rem floor), so options pack to fill horizontal space
+                      // instead of squishing into a fixed 2-column grid. One
+                      // column on narrow viewports, more as width grows.
                       // break-inside-avoid keeps each card intact across columns.
                       return (
-                        <div className="mt-2 gap-2 sm:columns-2">
+                        <div className="mt-2 gap-3 columns-[15rem]">
                           {enriched.map((e) => (
                             <div
                               key={`${step.id}-${e.schemaName}-${e.entityId}`}
-                              className="mb-2 break-inside-avoid"
+                              className="mb-3 break-inside-avoid"
                             >
                               {renderEntityListing(
                                 e.data,

--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/components/ReferenceEntityDisplayContent.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/components/ReferenceEntityDisplayContent.tsx
@@ -976,16 +976,14 @@ export function ReferenceEntityDisplayContent({
               the white body box, before the footer — same horizontal inset
               as the body box. */}
           {expand && <div className="mx-3 mt-2 min-w-0 pb-2">{expand}</div>}
-          {/* Footer — full-width accent bar (design itun.css .ec__foot: no
-              margin, accent background spanning the full card width). */}
+          {/* Footer. Interactive wizards (renderFooter present) get a floating
+              action that sticks to the bottom-right of the viewport as the form
+              scrolls — keeping confirm/nav reachable without a full-width bar
+              eating vertical space. Static (suref-web) cards keep the plain
+              full-width accent footer below. The wrapper is click-through
+              (pointer-events-none) so only the action itself is interactive. */}
           {interactive?.renderFooter ? (
-            <div
-              className={cn('w-full py-3', accent.className)}
-              style={{
-                ...spacing.contentPaddingXStyle,
-                ...accent.style,
-              }}
-            >
+            <div className="pointer-events-none sticky bottom-4 z-40 flex justify-end px-4 pb-2 [&>*]:pointer-events-auto [&_button]:shadow-lg">
               {interactive.renderFooter()}
             </div>
           ) : (


### PR DESCRIPTION
## Summary

Salvages the **shared-package** design fixes from #277. That PR's ITUN-specific work (`RollInput.tsx`, `AppNav.tsx`, `AppShell.tsx`, `LabeledInput.tsx`, `SalvageModal.tsx`) was obsoleted by the local-first ITUN rebuild on `main`, which deleted those files — so #277 can't be merged as-is. These two suref-react changes still apply cleanly and are worth keeping.

- **Masonry entity options** (`GuideStepsDisplay.tsx`) — replace the fixed `sm:columns-2` grid with a true masonry layout (`columns-[15rem]`). The column count auto-scales to the viewport with a 15rem column-width floor, so options pack to fill horizontal space instead of squishing into two stretched columns: one column on narrow screens, more as width grows.
- **Floating wizard footer** (`ReferenceEntityDisplayContent.tsx`) — interactive wizards (`renderFooter` present) get a click-through floating action stuck to the bottom-right of the viewport instead of a full-width accent bar, freeing vertical space while staying reachable on scroll. Static suref-web reference cards keep the plain full-width footer unchanged.

## Dropped vs #277

- `ci.yml` schema-verify step — **already on `main`** (added during the ITUN rebuild), so redundant.
- `RollInput.tsx` callsign-roller fix + `AppNav.tsx` BETA badge — target **deleted** ITUN files; tracked separately for rework against the new ITUN (see linked issue). #277 will be closed.

## Testing

- `bun --filter suref-react test` ✅ (303 pass)
- `bun run typecheck` ✅ (all packages, 0 errors)
- `bun run lint` ✅

> Visual confirmation recommended: masonry breakpoints and floating-button placement are best eyeballed in the running ITUN wizards across viewport widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)