### PR TITLE
feat(itun): wizard design pass — callsign roll fix, auto-fill grids, floating footer, BETA badge

### DIFF
--- a/apps/in-the-union-now/src/components/crawler/SystemsList.tsx
+++ b/apps/in-the-union-now/src/components/crawler/SystemsList.tsx
@@ -27,7 +27,7 @@ export function SystemsList({ systems, selectedSystemSlugs, onChange }: SystemsL
   }
 
   return (
-    <div className="grid grid-cols-1 gap-3.5 md:grid-cols-2 xl:grid-cols-3">
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3.5">
       {systems.map((system) => (
         <SelCard
           key={system.id}

--- a/apps/in-the-union-now/src/components/dashboard/Dashboard.tsx
+++ b/apps/in-the-union-now/src/components/dashboard/Dashboard.tsx
@@ -169,7 +169,11 @@ export function Dashboard() {
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
             <h1 className="font-cond text-xl font-bold uppercase leading-none tracking-[.02em] text-ink md:text-[31px]">
-              ITUN <span className="text-rust">—</span> Saved Builds
+              ITUN
+              <span className="ml-1.5 inline-block rounded bg-rust px-1.5 py-0.5 align-[0.35em] font-cond text-[10px] font-bold uppercase leading-none tracking-[0.12em] text-wk-bg md:text-[11px]">
+                Beta
+              </span>{' '}
+              <span className="text-rust">—</span> Saved Builds
             </h1>
             <div className="mt-3 flex flex-wrap items-start gap-2.5">
               <ExportAllButton />

--- a/apps/in-the-union-now/src/components/mech/InstallStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/InstallStep.tsx
@@ -82,7 +82,7 @@ export function InstallStep({
           ))}
         </div>
 
-        <div className="mt-[25px] grid grid-cols-1 gap-3.5 md:grid-cols-2">
+        <div className="mt-[25px] grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3.5">
           {visible.map((item) => (
             <SelCard
               key={item.id}

--- a/apps/in-the-union-now/src/components/mech/Pattern/PatternList.tsx
+++ b/apps/in-the-union-now/src/components/mech/Pattern/PatternList.tsx
@@ -83,7 +83,7 @@ export function PatternList({ onInstantiated }: PatternListProps) {
 
   return (
     <ul
-      className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3"
+      className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3"
       aria-label="Saved mech patterns"
     >
       {patterns.map((pattern) => (

--- a/apps/in-the-union-now/src/components/pilot/AbilitiesStep.tsx
+++ b/apps/in-the-union-now/src/components/pilot/AbilitiesStep.tsx
@@ -135,7 +135,7 @@ export function AbilitiesStep({
           return (
             <section key={tree} className="space-y-3">
               <TreeSep name={tree} />
-              <div className="grid grid-cols-1 gap-3.5 md:grid-cols-2 xl:grid-cols-3">
+              <div className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3.5">
                 {treeAbilities.map(renderCard)}
               </div>
             </section>
@@ -143,7 +143,7 @@ export function AbilitiesStep({
         })
       ) : (
         // Create mode — flat 3-col grid, tree label on the card frame.
-        <div className="grid grid-cols-1 gap-3.5 md:grid-cols-2 xl:grid-cols-3">
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3.5">
           {trees.flatMap((tree) => abilitiesIn(tree).map(renderCard))}
         </div>
       )}

--- a/apps/in-the-union-now/src/components/pilot/EquipmentStep.tsx
+++ b/apps/in-the-union-now/src/components/pilot/EquipmentStep.tsx
@@ -38,7 +38,7 @@ export function EquipmentStep({ selectedEquipment, onToggle, budget, _sur }: Equ
 
   return (
     <div className="w-full">
-      <div className="grid grid-cols-1 gap-3.5 md:grid-cols-2 xl:grid-cols-3">
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3.5">
         {allEquipment.map((item) => {
           const isSelected = selectedEquipment.includes(item.id)
           const isDisabled = !isSelected && isAtBudget

--- a/apps/in-the-union-now/src/components/pilot/__tests__/rollTableHelpers.test.ts
+++ b/apps/in-the-union-now/src/components/pilot/__tests__/rollTableHelpers.test.ts
@@ -89,4 +89,24 @@ describe('rollForPilotField', () => {
     )
     expect(result).toBe('A tarnished medal')
   })
+
+  test('navigates a columns-type table (Callsign Table) via two rolls', () => {
+    // The real Callsign Table is `type: columns`, keyed 1-4 / 5-8 / … A flat
+    // resultForTable can't walk it and returns failure → the roll button no-ops.
+    // Both d20 rolls stub to 5: column roll 5 → the "5-8" column, entry roll 5 → "5".
+    const columnsTable = {
+      id: 'rt-callsign',
+      name: 'Callsign Table',
+      schemaName: 'roll-tables' as const,
+      table: {
+        type: 'columns',
+        '5-8': { '5': { value: 'Candyman' } },
+      },
+    }
+    const result = rollForPilotField('callsign', {
+      findTable: () => columnsTable as never,
+      rollD20: () => 5,
+    })
+    expect(result).toBe('Candyman')
+  })
 })

--- a/apps/in-the-union-now/src/components/pilot/rollTableHelpers.ts
+++ b/apps/in-the-union-now/src/components/pilot/rollTableHelpers.ts
@@ -4,7 +4,12 @@
  */
 
 import { roll } from '@randsum/roller'
-import { SalvageUnionReference, resultForTable } from 'salvageunion-reference'
+import {
+  SalvageUnionReference,
+  resultForTable,
+  resultForColumnsTable,
+  isColumnsTable,
+} from 'salvageunion-reference'
 import type { SURefRollTable } from 'salvageunion-reference'
 
 /** Roll IDs for pilot wizard identity fields. */
@@ -46,8 +51,13 @@ export function rollForPilotField(
   const table = deps.findTable(tableName)
   if (!table) return null
 
-  const roll = deps.rollD20()
-  const result = resultForTable(table.table, roll)
+  // Columns-type tables (e.g. the Callsign Table, keyed 1-4 / 5-8) need two d20
+  // rolls — one to pick the column, one for the entry. resultForTable only walks
+  // flat d20 tables and reports failure on columns tables, silently no-op'ing the
+  // roll button, so delegate those to the columns-aware helper.
+  const result = isColumnsTable(table.table)
+    ? resultForColumnsTable(table.table, deps.rollD20(), deps.rollD20())
+    : resultForTable(table.table, deps.rollD20())
   if (!result.success) return null
 
   const { label, value } = result.result

--- a/apps/in-the-union-now/src/components/wizard/WizShell.tsx
+++ b/apps/in-the-union-now/src/components/wizard/WizShell.tsx
@@ -110,24 +110,19 @@ export function WizShell({
 
         {notice && <div className="mt-6">{notice}</div>}
 
-        <footer
-          className={cn(
-            'mt-6 border-t-[1.5px] border-wk-faint pt-4',
-            ctaFullWidth ? 'flex flex-col gap-3' : 'flex items-center justify-between gap-3'
-          )}
-        >
-          {ctaFullWidth && (
-            <Btn
-              variant="primary"
-              size="lg"
-              className="w-full"
-              onClick={onNext}
-              disabled={nextDisabled || busy}
-            >
-              {busy ? 'Saving…' : ctaLabel}
-            </Btn>
-          )}
-          <div className="flex gap-2">
+        {/* Footer — floats sticky at the bottom-right of the viewport as the
+            content scrolls, so confirm/nav stays reachable without a full-width
+            bar eating vertical space. The footer itself is click-through
+            (pointer-events-none); only the action pill is interactive. On mech
+            install steps (ctaFullWidth) the pill stacks full-width on mobile to
+            emphasise the primary CTA. */}
+        <footer className="pointer-events-none sticky bottom-4 z-40 mt-6 flex justify-end">
+          <div
+            className={cn(
+              'pointer-events-auto flex items-center gap-2 rounded-xl border-[1.5px] border-wk-faint bg-wk-bg/95 p-2 shadow-lg backdrop-blur',
+              ctaFullWidth && 'w-full flex-col items-stretch sm:w-auto sm:flex-row sm:items-center'
+            )}
+          >
             {onBack && (
               <Btn variant="ghost" onClick={onBack} disabled={busy}>
                 Back
@@ -136,12 +131,16 @@ export function WizShell({
             <Btn variant="ghost" onClick={onCancel} disabled={busy}>
               Cancel
             </Btn>
-          </div>
-          {!ctaFullWidth && (
-            <Btn variant="primary" size="lg" onClick={onNext} disabled={nextDisabled || busy}>
+            <Btn
+              variant="primary"
+              size="lg"
+              className={cn(ctaFullWidth && 'w-full sm:w-auto')}
+              onClick={onNext}
+              disabled={nextDisabled || busy}
+            >
               {busy ? 'Saving…' : ctaLabel}
             </Btn>
-          )}
+          </div>
         </footer>
       </main>
     </div>


### PR DESCRIPTION
Re-applies #277's design pass against the **rebuilt local-first ITUN** (the originals targeted files that the rebuild deleted, so #277 itself was unmergeable — closed; shared-package bits live in #279). Closes #280.

## Changes

### 1. Callsign roller bug (functional)
`rollForPilotField` (`pilot/rollTableHelpers.ts`) used `resultForTable` for every identity field, but the **Callsign Table is a `type: columns` table** (keyed 1-4 / 5-8). `resultForTable` can't navigate it → returns failure → `rollForPilotField` returns null → the ⚄ Roll button silently did nothing. Now branches on `isColumnsTable` and uses `resultForColumnsTable` (two d20 rolls). Added a columns-table regression test. *(The other pilot fields — Motto, Keepsake, Appearance, Background — are flat, so callsign was the only broken one. The shared `RollTable.tsx` already handled columns correctly.)*

### 2. Auto-fill option grids (layout)
The selectable entity-card grids moved from a fixed `md:grid-cols-2 xl:grid-cols-3` to `grid-cols-[repeat(auto-fill,minmax(15rem,1fr))]` — the column count auto-scales to viewport width with a 15rem floor while keeping aligned rows, instead of squishing into two stretched columns. Applied to: pilot abilities, pilot equipment, crawler systems, mech patterns, mech install.

### 3. Floating wizard footer
`WizShell` footer now floats sticky at the **bottom-right of the viewport** (click-through wrapper, only the action pill is interactive) instead of an inline bar — frees vertical space, stays reachable on scroll. `ctaFullWidth` still stacks the pill full-width on mobile install steps.

### 4. BETA badge
Small `BETA` badge beside the `ITUN` wordmark on the dashboard header. *(No persistent global nav exists in the rebuild, so it's dashboard-only by design choice.)*

## Testing
- `bun run typecheck` ✅ (all packages) · `bun --filter in-the-union-now test` ✅ (858 pass) · `bun run lint` ✅

> **Visual review:** the grid breakpoints, the floating-footer placement, and the BETA badge alignment are best eyeballed on the Netlify deploy-preview across a few viewport widths — flag anything off and I'll adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)