### PR TITLE
fix(suref-web): resolve hydration mismatch (#418) and RUM CSP violation

### DIFF
--- a/apps/suref-web/netlify.toml
+++ b/apps/suref-web/netlify.toml
@@ -48,7 +48,7 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "geolocation=(), microphone=(), camera=()"
     Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self';"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://ingesteer.services-prod.nsvcs.net;"
     X-DNS-Prefetch-Control = "on"
 
 # Astro hashed assets - immutable cache

--- a/apps/suref-web/src/lib/changelog.ts
+++ b/apps/suref-web/src/lib/changelog.ts
@@ -6,6 +6,13 @@ type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: '2026-06-13',
+    title: 'Smoother loads on catalog & entity pages',
+    items: [
+      'Fixed a hydration mismatch that could make a catalog or entity page throw away the server-rendered HTML and re-render (a brief flicker) once game data finished loading.',
+    ],
+  },
+  {
     date: '2026-06-12',
     title: 'Buy links on source books',
     items: [

--- a/apps/suref-web/src/lib/useGameData.tsx
+++ b/apps/suref-web/src/lib/useGameData.tsx
@@ -5,24 +5,64 @@
  * and wait for `ready` before making any ORM calls. The preload runs once
  * and is shared across all islands via the module-scoped promise.
  */
-import { useState, useEffect, useCallback, type ReactNode } from 'react'
+import { useState, useEffect, useCallback, useSyncExternalStore, type ReactNode } from 'react'
 import { SalvageUnionReference } from 'salvageunion-reference'
 
 let preloadPromise: Promise<void> | null = null
+let preloadDone = false
+const readyListeners = new Set<() => void>()
 
 /**
- * Test-only escape hatch: clears the module-level preload promise so tests
+ * Test-only escape hatch: clears the module-level preload state so tests
  * that mock SalvageUnionReference.preload() don't leak state into each other.
  * Production code must never call this.
  */
 export function resetPreloadForTests(): void {
   preloadPromise = null
+  preloadDone = false
+}
+
+function emitReady(): void {
+  for (const listener of readyListeners) listener()
+}
+
+function subscribeReady(onChange: () => void): () => void {
+  readyListeners.add(onChange)
+  return () => {
+    readyListeners.delete(onChange)
+  }
+}
+
+/**
+ * Client snapshot: ready once the shared preload has resolved (or the data was
+ * already loaded at mount).
+ */
+function getReadySnapshot(): boolean {
+  return preloadDone || SalvageUnionReference.isLoaded('chassis')
+}
+
+/**
+ * Server snapshot: ALWAYS false. SSR has no preloaded data and runs no effects,
+ * so islands must server-render the fallback. React reuses this value for the
+ * first client (hydration) render too, so the initial client tree matches the
+ * SSR HTML — reading the live load state here instead caused a hydration
+ * mismatch (React #418) on islands that hydrate after the shared preload
+ * finished (client:idle / client:visible).
+ */
+function getReadyServerSnapshot(): boolean {
+  return false
 }
 
 function ensurePreloaded(): Promise<void> {
-  if (SalvageUnionReference.isLoaded('chassis')) return Promise.resolve()
+  if (SalvageUnionReference.isLoaded('chassis')) {
+    preloadDone = true
+    return Promise.resolve()
+  }
   if (!preloadPromise) {
-    preloadPromise = SalvageUnionReference.preload('all')
+    preloadPromise = SalvageUnionReference.preload('all').then(() => {
+      preloadDone = true
+      emitReady()
+    })
   }
   return preloadPromise
 }
@@ -45,7 +85,11 @@ export function useGameData(options?: { defer?: boolean }): {
   error: Error | null
   load: () => void
 } {
-  const [ready, setReady] = useState(SalvageUnionReference.isLoaded('chassis'))
+  // `ready` is read through useSyncExternalStore so the server (and the first
+  // hydration render) always sees the fallback while the client tracks the live
+  // preload state — keeping hydration consistent without seeding state from a
+  // client-only value during render.
+  const ready = useSyncExternalStore(subscribeReady, getReadySnapshot, getReadyServerSnapshot)
   const [wanted, setWanted] = useState(!options?.defer)
   const [error, setError] = useState<Error | null>(null)
 
@@ -54,16 +98,12 @@ export function useGameData(options?: { defer?: boolean }): {
     // clearing it re-runs this effect, which retries the (reset) preload.
     if (ready || !wanted || error) return
     let cancelled = false
-    ensurePreloaded()
-      .then(() => {
-        if (!cancelled) setReady(true)
-      })
-      .catch((e: unknown) => {
-        // Reset the module-level promise so a retry issues a fresh request
-        // instead of re-awaiting the same rejection.
-        preloadPromise = null
-        if (!cancelled) setError(e instanceof Error ? e : new Error(String(e)))
-      })
+    ensurePreloaded().catch((e: unknown) => {
+      // Reset the module-level promise so a retry issues a fresh request
+      // instead of re-awaiting the same rejection.
+      preloadPromise = null
+      if (!cancelled) setError(e instanceof Error ? e : new Error(String(e)))
+    })
     return () => {
       cancelled = true
     }


### PR DESCRIPTION
Resolves the two console errors reported on the deployed reference site.

## 1. React #418 — hydration mismatch

```
Uncaught Error: Minified React error #418  (args[]=HTML)
→ "Hydration failed because the server rendered HTML didn't match the client.
   As a result this tree will be regenerated on the client."
```

**Cause.** `useGameData` seeded its initial `ready` from `SalvageUnionReference.isLoaded('chassis')` **synchronously during render**. The server always renders the gate's fallback (effects don't run during SSR and the data corpus isn't preloaded at build), but the data islands hydrate **late** (`client:idle` / `client:visible`). By the time one hydrates, the module-shared preload — kicked off by an earlier consumer — may already have resolved, so `isLoaded()` returns `true` and the **first client render diverges to the real content**, mismatching the SSR fallback. React then discards and regenerates the tree (a flicker).

**Fix.** Read `ready` through `useSyncExternalStore` with a `getServerSnapshot` of `false`, so the server **and the first hydration render** always show the fallback, while the client tracks the live preload state and promotes after mount. No client-only state is read during render.

**Verified.** A `renderToString → hydrateRoot` harness reproduced the exact `onRecoverableError` ("server rendered text didn't match the client") before the fix and reports **0** after. Full suref-web suite: **953 pass**. Lint + typecheck clean.

## 2. CSP blocked Netlify RUM

```
Refused to connect to 'https://ingesteer.services-prod.nsvcs.net/rum_collection'
because it violates "connect-src 'self'".
```

Netlify's Real User Metrics beacon was blocked by the site CSP. Added that origin to `connect-src` in `apps/suref-web/netlify.toml`.

> Alternative: if you'd rather not send RUM telemetry at all, disable **Real User Metrics** for the site in the Netlify dashboard (a site setting, not in-repo) and revert this CSP line. I went with allowing it as the in-repo fix; say the word if you'd prefer it off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)