### PR TITLE
fix(suref-web): eliminate Zod JIT eval to satisfy strict CSP

### DIFF
--- a/apps/suref-web/src/components/islands/SchemaViewerIsland.tsx
+++ b/apps/suref-web/src/components/islands/SchemaViewerIsland.tsx
@@ -124,6 +124,7 @@ export function SchemaViewerIsland({
                 <FilterRow label="Name">
                   <input
                     type="search"
+                    name="name-filter"
                     value={nameFilter}
                     onChange={(e) => setNameFilter(e.target.value)}
                     placeholder="Filter by name…"

--- a/apps/suref-web/src/components/islands/SearchIsland.tsx
+++ b/apps/suref-web/src/components/islands/SearchIsland.tsx
@@ -211,6 +211,7 @@ export function SearchIsland({ navigate }: SearchIslandProps = {}) {
           <input
             ref={inputRef}
             type="text"
+            name="srd-search"
             placeholder="Search…"
             value={query}
             onChange={(e) => handleInput(e.target.value)}

--- a/packages/salvageunion-reference/lib/ModelFactory.ts
+++ b/packages/salvageunion-reference/lib/ModelFactory.ts
@@ -8,7 +8,7 @@
  */
 import { BaseModel } from './BaseModel.js'
 import schemaIndex from '../schemas/index.json' with { type: 'json' }
-import { z } from 'zod'
+import { z } from './zod.js'
 import {
   AbilitySchema,
   AbilityTreeRequirementSchema,

--- a/packages/salvageunion-reference/lib/schemas/common.ts
+++ b/packages/salvageunion-reference/lib/schemas/common.ts
@@ -2,7 +2,7 @@
  * Zod common primitive schemas from common.schema.json
  */
 
-import { z } from 'zod'
+import { z } from '../zod.js'
 
 /**
  * Unique identifier for the entry

--- a/packages/salvageunion-reference/lib/schemas/entities.ts
+++ b/packages/salvageunion-reference/lib/schemas/entities.ts
@@ -2,7 +2,7 @@
  * Zod entity schemas - all 24 entity types
  */
 
-import { z } from 'zod'
+import { z } from '../zod.js'
 import {
   BaseEntitySchema,
   ContentSchema,

--- a/packages/salvageunion-reference/lib/schemas/enums.ts
+++ b/packages/salvageunion-reference/lib/schemas/enums.ts
@@ -2,7 +2,7 @@
  * Zod enum schemas from enums.schema.json
  */
 
-import { z } from 'zod'
+import { z } from '../zod.js'
 
 /**
  * The source book or expansion for this content

--- a/packages/salvageunion-reference/lib/schemas/index.ts
+++ b/packages/salvageunion-reference/lib/schemas/index.ts
@@ -2,7 +2,7 @@
  * Schema index - exports all Zod schemas and inferred TypeScript types
  */
 
-import { z } from 'zod'
+import { z } from '../zod.js'
 
 // Re-export all schemas
 export * from './enums.js'

--- a/packages/salvageunion-reference/lib/schemas/objects.ts
+++ b/packages/salvageunion-reference/lib/schemas/objects.ts
@@ -2,7 +2,7 @@
  * Zod object schemas from objects.schema.json
  */
 
-import { z } from 'zod'
+import { z } from '../zod.js'
 import {
   NonNegativeIntegerSchema,
   PositiveIntegerSchema,

--- a/packages/salvageunion-reference/lib/schemas/schema-descriptions.test.ts
+++ b/packages/salvageunion-reference/lib/schemas/schema-descriptions.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, it } from 'bun:test'
-import { z } from 'zod'
+import { z } from '../zod.js'
 
 import {
   AbilitySchema,

--- a/packages/salvageunion-reference/lib/zod.ts
+++ b/packages/salvageunion-reference/lib/zod.ts
@@ -1,0 +1,18 @@
+/**
+ * Pre-configured Zod instance.
+ *
+ * Disables Zod v4's JIT object parser. The JIT path compiles validators with
+ * `new Function`, and a `new Function("")` eval feature-detect (`allowsEval`)
+ * runs at schema *construction* time. Both trip a strict `script-src`
+ * Content-Security-Policy with no `unsafe-eval` (see apps/suref-web/netlify.toml),
+ * surfacing as console CSP violations in the browser. The jitless interpreted
+ * parser produces identical results, just slightly slower.
+ *
+ * Import `z` from this module (never directly from `zod`) anywhere schemas are
+ * constructed or parsed, so `z.config` runs before the first `z.object()` call.
+ */
+import { z } from 'zod'
+
+z.config({ jitless: true })
+
+export { z }

--- a/packages/salvageunion-reference/package.json
+++ b/packages/salvageunion-reference/package.json
@@ -32,7 +32,10 @@
     },
     "./package.json": "./package.json"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/zod.js",
+    "./lib/zod.ts"
+  ],
   "files": [
     "dist",
     "lib",


### PR DESCRIPTION
## Problem

suref-web's console reports **CSP `script-src` eval violations** pointing at the bundled ORM chunk (`IslandErrorBoundary.*.js`):

> Content Security Policy of your site blocks the use of 'eval' in JavaScript

The site's CSP (`apps/suref-web/netlify.toml`) is intentionally strict — `script-src 'self' 'unsafe-inline'`, **no `unsafe-eval`**. The same report also flagged a minor form-field a11y item.

## Root cause (CSP)

**Zod v4's JIT object parser.** Two eval-family calls in the bundled `salvageunion-reference` ORM:

1. **`allowsEval` feature-detect** — runs `new Function("")` at schema *construction* time (`zod/v4/core/util`).
2. **JIT fastpass** — compiles object validators with `new Function(...)` on parse (`zod/v4/core/schemas`, `doc.compile()`).

Both run in the browser when the ORM chunk loads/parses, tripping CSP.

## Fix (CSP)

Route all Zod usage in `salvageunion-reference` through a side-effect wrapper (`lib/zod.ts`) that calls `z.config({ jitless: true })` **before any schema is constructed**. Zod's jitless interpreted parser is functionally identical, just slightly slower — immeasurable for a static reference dataset.

Because the package is `sideEffects: false`, the bundler tree-shook the bare `z.config()` call away on the first attempt. Added the wrapper to the `sideEffects` allowlist so the config call is preserved while everything else stays tree-shakeable.

No CSP relaxation — the eval is removed at the source, keeping the policy strict.

### Verification (CSP)

Trapped the global `Function` constructor and exercised construction + parsing of all 74 object schemas:

| | construction | + parse |
|---|---|---|
| **JIT on** (negative control) | `new Function("")` | + `new Function("shape","payload",…)` → **2 calls** |
| **jitless (this PR)** | 0 | **0 calls** |

## Fix (form-field a11y)

Chrome's "Improvements" audit also flagged *"A form field element should have an id or name attribute"*. Added a `name` to suref-web's two inputs — the global search box (`name="srd-search"`) and the schema name-filter (`name="name-filter"`). Both already had `aria-label`s; used `name` rather than `id` to avoid duplicate-id risk if an island mounts more than once. The shared `suref-react` editable inputs serve ITUN's builder flows (not suref-web's read-only pages), so they're out of scope here.

## Checks

`typecheck`, `lint`, `knip`, `validate:all`, and the full test suite (589 reference + 953 suref-web) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)