### PR TITLE
feat(itun): crawler wizard selects a type, adds a Crew step, editable tech level

### DIFF
--- a/apps/in-the-union-now/e2e/_helpers.ts
+++ b/apps/in-the-union-now/e2e/_helpers.ts
@@ -99,12 +99,13 @@ export async function buildMech(page: Page, name: string): Promise<void> {
   await page.waitForURL((url) => url.pathname === '/', { timeout: 15_000 })
 }
 
-/** Build a crawler (Crawler → Systems → Identity → Review). */
+/** Build a crawler (Crawler type → Systems → Crew → Identity → Review). */
 export async function buildCrawler(page: Page, name: string): Promise<void> {
   await page.goto('/crawlers/new')
   await waitForReady(page)
-  await pickByName(page, 'Hamlet Crawler')
+  await pickByName(page, 'Battle')
   await clickNext(page) // -> Systems
+  await clickNext(page) // -> Crew
   await clickNext(page) // -> Identity
   await page.getByLabel(/Crawler Name/i).fill(name)
   await clickNext(page) // -> Review

--- a/apps/in-the-union-now/e2e/crawler-build.e2e.ts
+++ b/apps/in-the-union-now/e2e/crawler-build.e2e.ts
@@ -3,26 +3,30 @@ import { clickNext, pickByName, waitForReady } from './_helpers'
 
 /**
  * Crawler build + edit on the WizShell skeleton (plan 3.2/3.6):
- * Crawler (OptRow tech-level master list) -> Systems (Sel grid) ->
- * Identity -> Review -> 'Create Crawler ✦'. Bays are not chosen — every
- * crawler seeds the full SRD bay set on creation.
+ * Crawler (OptRow crawler-type master list) -> Systems (Sel grid) ->
+ * Crew (bay-NPC details) -> Identity -> Review -> 'Create Crawler ✦'.
+ * Tech level is fixed at TL1 on create; bays are not chosen — every crawler
+ * seeds the full SRD bay set on creation.
  */
 test('build a crawler from scratch', async ({ page }) => {
   await page.goto('/crawlers/new')
   await waitForReady(page)
 
-  // Step 1 — Crawler. OptRow per tech level; Hamlet Crawler is TL 1.
-  await pickByName(page, 'Hamlet Crawler')
+  // Step 1 — Crawler. OptRow per crawler type; pick Battle.
+  await pickByName(page, 'Battle')
   await clickNext(page) // -> Systems
 
   // Step 2 — Systems (optional; capacity is soft)
+  await clickNext(page) // -> Crew
+
+  // Step 3 — Crew (bay-NPC details all optional)
   await clickNext(page) // -> Identity
 
-  // Step 3 — Identity
+  // Step 4 — Identity
   await page.getByLabel(/Crawler Name/i).fill('Iron Wagon')
   await clickNext(page) // -> Review
 
-  // Step 4 — Review -> create
+  // Step 5 — Review -> create
   await page.getByRole('button', { name: /Create Crawler/i }).click()
 
   await page.waitForURL((url) => url.pathname === '/', { timeout: 15_000 })
@@ -40,8 +44,9 @@ test('edit a crawler via /crawlers/$id/edit', async ({ page }) => {
   // Build first.
   await page.goto('/crawlers/new')
   await waitForReady(page)
-  await pickByName(page, 'Hamlet Crawler')
+  await pickByName(page, 'Battle')
   await clickNext(page) // -> Systems
+  await clickNext(page) // -> Crew
   await clickNext(page) // -> Identity
   await page.getByLabel(/Crawler Name/i).fill('Iron Wagon')
   await clickNext(page) // -> Review
@@ -58,11 +63,12 @@ test('edit a crawler via /crawlers/$id/edit', async ({ page }) => {
   await page.waitForURL(/\/crawlers\/.+\/edit/, { timeout: 15_000 })
   await waitForReady(page)
 
-  // Wizard is prefilled (TL chosen), eyebrow flips to edit mode.
+  // Wizard is prefilled (type chosen), eyebrow flips to edit mode.
   await expect(page.getByText('Edit Crawler')).toBeVisible()
   await clickNext(page) // -> Systems
   // Install a system in edit mode — pick the first Sel card in the grid.
   await page.locator('div[role="button"]').first().click()
+  await clickNext(page) // -> Crew
   await clickNext(page) // -> Identity (prefilled)
   await clickNext(page) // -> Review
   await page.getByRole('button', { name: /Save Crawler/i }).click()

--- a/apps/in-the-union-now/e2e/crawler-corner-cases.e2e.ts
+++ b/apps/in-the-union-now/e2e/crawler-corner-cases.e2e.ts
@@ -2,33 +2,35 @@ import { test, expect } from '@playwright/test'
 import { clickNext, pickByName, waitForReady } from './_helpers'
 
 /**
- * CrawlerBuilder corner cases (WizShell flow: Crawler -> Systems -> Identity
- * -> Review):
- *  - The CTA is gated: disabled on the Crawler step until a tech level OptRow
+ * CrawlerBuilder corner cases (WizShell flow: Crawler -> Systems -> Crew ->
+ * Identity -> Review):
+ *  - The CTA is gated: disabled on the Crawler step until a crawler type OptRow
  *    is picked, disabled again on Identity until a name is entered.
- *  - The Systems step reveals the Sel grid for the chosen TL.
- *  - Raising the TL (via Back) exposes more systems.
+ *  - The Systems step reveals the Sel grid (new crawlers are fixed at TL1, so
+ *    the offer is the TL1-and-below systems; tech level is raised later on the
+ *    live sheet, not in the wizard).
  *
- * Tech levels render as native OptRow <button>s in the 320px master pane —
- * accessible name includes the TL name ('Hamlet Crawler' … 'Megacity
- * Crawler'). Systems render as Sel-wrapped `<div role="button">` cards, so
+ * Crawler types render as native OptRow <button>s in the 320px master pane —
+ * accessible name includes the type name ('Augmented' … 'Trade Caravan').
+ * Systems render as Sel-wrapped `<div role="button">` cards, so
  * `div[role="button"]` counts only system cards, never the nav buttons. The
  * primary CTA is labelled from the steps array ('Next · Systems →' etc.) and
  * matched via the /^Next ·/ prefix.
  */
 
-test('wizard gates progress until TL + name are set', async ({ page }) => {
+test('wizard gates progress until type + name are set', async ({ page }) => {
   await page.goto('/crawlers/new')
   await waitForReady(page)
 
   const next = page.getByRole('button', { name: /^Next ·/ })
 
-  // Crawler step — CTA disabled until a tech level is chosen.
+  // Crawler step — CTA disabled until a crawler type is chosen.
   await expect(next).toBeDisabled()
-  await pickByName(page, 'Hamlet Crawler')
+  await pickByName(page, 'Battle')
   await expect(next).toBeEnabled()
 
-  // Crawler -> Systems -> Identity
+  // Crawler -> Systems -> Crew -> Identity
+  await clickNext(page)
   await clickNext(page)
   await clickNext(page)
 
@@ -42,34 +44,14 @@ test('wizard gates progress until TL + name are set', async ({ page }) => {
   await expect(page.getByRole('button', { name: /Create Crawler/i })).toBeEnabled()
 })
 
-test('Systems step reveals the Sel grid for the chosen TL', async ({ page }) => {
+test('Systems step reveals the Sel grid for a new (TL1) crawler', async ({ page }) => {
   await page.goto('/crawlers/new')
   await waitForReady(page)
 
-  // Crawler step -> pick TL 1 -> advance to Systems.
-  await pickByName(page, 'Hamlet Crawler')
+  // Crawler step -> pick a type -> advance to Systems.
+  await pickByName(page, 'Battle')
   await clickNext(page)
 
   // At least one system Sel card (div[role="button"]) should be visible.
   await expect(page.locator('div[role="button"]').first()).toBeVisible()
-})
-
-test('raising TL adds more systems to the list', async ({ page }) => {
-  await page.goto('/crawlers/new')
-  await waitForReady(page)
-
-  // TL 1 -> Systems, count system cards.
-  await pickByName(page, 'Hamlet Crawler')
-  await clickNext(page)
-  await expect(page.locator('div[role="button"]').first()).toBeVisible()
-  const tl1Count = await page.locator('div[role="button"]').count()
-
-  // Back to the Crawler step, raise to TL 6 (Megacity), return to Systems.
-  await page.getByRole('button', { name: /^Back$/ }).click()
-  await pickByName(page, 'Megacity Crawler')
-  await clickNext(page)
-  await expect(page.locator('div[role="button"]').nth(tl1Count)).toBeVisible()
-  const tl6Count = await page.locator('div[role="button"]').count()
-
-  expect(tl6Count).toBeGreaterThan(tl1Count)
 })

--- a/apps/in-the-union-now/src/components/crawler/CrawlerBuilder.tsx
+++ b/apps/in-the-union-now/src/components/crawler/CrawlerBuilder.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useMemo, useState } from 'react'
 
 import { SalvageUnionReference } from 'salvageunion-reference'
-import type { SURefEntity, SURefMetaCrawlerTechLevel, SURefSystem } from 'salvageunion-reference'
+import type {
+  SURefCrawler,
+  SURefEntity,
+  SURefMetaCrawlerTechLevel,
+  SURefSystem,
+} from 'salvageunion-reference'
 import { toast } from 'suref-react'
 
 import { useEntityStore } from '../../stores/entityStore'
@@ -9,24 +14,28 @@ import { CrawlerSchema } from '../../lib/schemas/crawler'
 import { computeCrawlerCapacity } from '../../lib/rules/crawlerCapacity'
 import {
   EMPTY_CRAWLER_FORM_STATE,
+  crawlerFormCrewToPatches,
   crawlerFormToCreateInput,
   crawlerFormToUpdatePatch,
+  defaultTypeNpcState,
   seedDefaultCrawlerBays,
 } from '../../lib/wizard/crawlerFormState'
 import type { CrawlerWizardFormState } from '../../lib/wizard/crawlerFormState'
 import { WizShell } from '../wizard/WizShell'
+import { CrawlerCrewStep } from './CrawlerCrewStep'
 import { CrawlerIdentityStep } from './CrawlerIdentityStep'
 import { CrawlerReviewStep } from './CrawlerReviewStep'
 import { CrawlerTypeOptionList, CrawlerTypeDetail } from './CrawlerTypeStep'
 import { SystemsList } from './SystemsList'
 
-const STEPS = ['Crawler', 'Systems', 'Identity', 'Review'] as const
+const STEPS = ['Crawler', 'Systems', 'Crew', 'Identity', 'Review'] as const
 type Step = (typeof STEPS)[number]
 
 /** Step heading copy (design §3.2). */
 const STEP_TITLES: Record<Step, string> = {
   Crawler: 'Choose Your Crawler',
   Systems: 'Install Systems',
+  Crew: 'Meet Your Crew',
   Identity: 'Name Your Crawler',
   Review: 'Review',
 }
@@ -83,6 +92,7 @@ export function CrawlerBuilder({
   const [techLevels, setTechLevels] = useState<SURefMetaCrawlerTechLevel[]>([])
   const [allSystems, setAllSystems] = useState<SURefSystem[]>([])
   const [allBays, setAllBays] = useState<SURefEntity[]>([])
+  const [types, setTypes] = useState<SURefCrawler[]>([])
   const [form, setForm] = useState<CrawlerWizardFormState>(initialState ?? EMPTY_CRAWLER_FORM_STATE)
   const [step, setStep] = useState<Step>('Crawler')
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -91,32 +101,54 @@ export function CrawlerBuilder({
   const currentIndex = STEPS.indexOf(step)
 
   useEffect(() => {
-    // crawler-bays is preloaded so the bay preview grid and the default-bay
-    // seeding at submit time can read the SRD catalog synchronously.
-    void SalvageUnionReference.preload(['crawler-tech-levels', 'systems', 'crawler-bays']).then(
-      () => {
-        const tls = SalvageUnionReference.CrawlerTechLevels.all()
-        setTechLevels([...tls].sort((a, b) => a.techLevel - b.techLevel))
-        setAllSystems(SalvageUnionReference.Systems.all())
-        setAllBays(SalvageUnionReference.CrawlerBays.all() as unknown as SURefEntity[])
-      }
-    )
+    // crawlers drives the type selection; crawler-bays seeds the default bays
+    // + the Crew step; crawler-tech-levels stays for the SP/capacity lookup.
+    void SalvageUnionReference.preload([
+      'crawlers',
+      'crawler-tech-levels',
+      'systems',
+      'crawler-bays',
+    ]).then(() => {
+      const tls = SalvageUnionReference.CrawlerTechLevels.all()
+      setTechLevels([...tls].sort((a, b) => a.techLevel - b.techLevel))
+      setAllSystems(SalvageUnionReference.Systems.all())
+      setAllBays(SalvageUnionReference.CrawlerBays.all() as unknown as SURefEntity[])
+      setTypes(SalvageUnionReference.Crawlers.all())
+    })
   }, [])
 
   function updateForm(patch: Partial<CrawlerWizardFormState>) {
     setForm((prev) => ({ ...prev, ...patch }))
   }
 
+  /**
+   * Choose a crawler type. When switching away from a previously-chosen type,
+   * drop that old type's crew entry (keyed by the old type id) so it can never
+   * be persisted as a phantom bay / stale type NPC on save.
+   */
+  function selectType(type: string) {
+    setForm((prev) => {
+      if (prev.type === type) return { ...prev, type }
+      const nextCrew = { ...prev.crew }
+      if (prev.type !== null) delete nextCrew[prev.type]
+      return { ...prev, type, crew: nextCrew }
+    })
+  }
+
   function canAdvance(): boolean {
     switch (step) {
       case 'Crawler':
-        return form.techLevel !== null
+        // New crawlers must choose a type; editing a legacy (untyped) crawler
+        // can advance without one (type stays absent, TL is preserved).
+        return isEdit || form.type !== null
       case 'Systems':
         return true // systems are optional
+      case 'Crew':
+        return true // crew details are all optional
       case 'Identity':
         return form.name.trim() !== ''
       case 'Review':
-        return form.techLevel !== null && form.name.trim() !== ''
+        return (isEdit || form.type !== null) && form.name.trim() !== ''
     }
   }
 
@@ -142,7 +174,51 @@ export function CrawlerBuilder({
       // Upsert branch (plan 3.1): update when editing — NEVER a second create.
       // The patch touches only wizard-owned fields; bays/NPC live state stays.
       if (crawlerId) {
+        // Read the stored record BEFORE the wizard patch so we know the old
+        // type (the patch overwrites `type`).
+        const stored = store.get('crawler', crawlerId)
+        const oldType = stored?.type ?? null
+        const typeChanged = oldType !== form.type
+
         await store.update('crawler', crawlerId, crawlerFormToUpdatePatch(form))
+
+        // Crew/NPC edits route through targeted updateCrawlerBay calls + a
+        // single bayChoices merge + a typeNpc patch (mirroring how the sheet
+        // writes), so live HP/condition on bays + the type NPC survive an edit.
+        const crewPatches = crawlerFormCrewToPatches(form)
+        for (const [bayRef, patch] of Object.entries(crewPatches.bayPatches)) {
+          if (Object.keys(patch).length === 0) continue
+          await store.updateCrawlerBay(crawlerId, bayRef, patch)
+        }
+
+        // Merge the crew's Keepsake/Motto selections. When the type changed,
+        // also drop the orphaned old type's bayChoices key so a stale NPC's
+        // selections don't bleed onto the new type.
+        if (typeChanged || Object.keys(crewPatches.bayChoices).length > 0) {
+          const fresh = store.get('crawler', crawlerId)
+          const nextBayChoices = { ...(fresh?.bayChoices ?? {}) }
+          if (typeChanged && oldType !== null) delete nextBayChoices[oldType]
+          Object.assign(nextBayChoices, crewPatches.bayChoices)
+          await store.update('crawler', crawlerId, { bayChoices: nextBayChoices })
+        }
+
+        // The type NPC. When the type changed, RESET it to the new type's
+        // default (HP from the new type's npc.hitPoints, if any) plus the
+        // wizard's edits — never merge onto the old type's NPC. When the type
+        // is unchanged, merge so live HP/condition survive an edit pass.
+        if (typeChanged) {
+          const baseNpc = form.type ? defaultTypeNpcState(types, form.type) : undefined
+          const nextTypeNpc = { ...(baseNpc ?? {}), ...(crewPatches.typeNpc ?? {}) }
+          await store.update('crawler', crawlerId, {
+            typeNpc: Object.keys(nextTypeNpc).length > 0 ? nextTypeNpc : undefined,
+          })
+        } else if (crewPatches.typeNpc) {
+          const fresh = store.get('crawler', crawlerId)
+          await store.update('crawler', crawlerId, {
+            typeNpc: { ...(fresh?.typeNpc ?? {}), ...crewPatches.typeNpc },
+          })
+        }
+
         toast.success(`Saved ${form.name.trim() || 'crawler'}.`)
         onComplete(crawlerId)
         return
@@ -182,6 +258,15 @@ export function CrawlerBuilder({
   }
 
   const selectedTechLevel = techLevels.find((t) => t.techLevel === form.techLevel)
+  const selectedType = types.find((t) => t.id === form.type)
+  // Bays with an embedded crew NPC (the 10 base bays) — the Crew step's roster.
+  const crewBays = allBays.filter(
+    (b): b is SURefEntity & { npc: object } => (b as { npc?: unknown }).npc != null
+  ) as unknown as Array<{
+    id: string
+    name: string
+    npc?: { position?: string; choices?: ReadonlyArray<{ id: string; name: string }> }
+  }>
   const filteredSystems = filterSystemsByTL(allSystems, form.techLevel)
   const chosenSystems = form.systems
     .map((id) => allSystems.find((s) => s.id === id))
@@ -217,7 +302,7 @@ export function CrawlerBuilder({
   const subtitle = (() => {
     switch (step) {
       case 'Crawler':
-        return 'Pick a tech level. It sets Structure Points and which systems you can install — every crawler ships with the full bay set.'
+        return 'Pick a crawler type. It grants a special action and a special NPC — every crawler ships with the full bay set and starts at Tech Level 1.'
       case 'Systems':
         return (
           <>
@@ -228,6 +313,8 @@ export function CrawlerBuilder({
             · Tech Level {form.techLevel ?? '—'} and below. Capacity warns, never blocks.
           </>
         )
+      case 'Crew':
+        return 'Name and detail each bay’s crew lead and your crawler type’s special NPC. All optional.'
       case 'Identity':
         return 'Name your crawler and set its starting resources.'
       case 'Review':
@@ -245,15 +332,7 @@ export function CrawlerBuilder({
       subtitle={subtitle}
       optionPane={
         step === 'Crawler' ? (
-          <CrawlerTypeOptionList
-            techLevels={techLevels}
-            selectedTechLevel={form.techLevel}
-            onSelect={(techLevel) => {
-              // Creation resets systems on TL change (the offer changes);
-              // edit keeps them — an upgraded crawler retains its loadout.
-              updateForm(isEdit ? { techLevel } : { techLevel, systems: [] })
-            }}
-          />
+          <CrawlerTypeOptionList types={types} selectedType={form.type} onSelect={selectType} />
         ) : undefined
       }
       notice={capacityNotice}
@@ -264,12 +343,20 @@ export function CrawlerBuilder({
       busy={isSubmitting}
       submitLabel={isEdit ? 'Save Crawler' : 'Create Crawler ✦'}
     >
-      {step === 'Crawler' && <CrawlerTypeDetail selected={selectedTechLevel} bays={allBays} />}
+      {step === 'Crawler' && <CrawlerTypeDetail selected={selectedType} />}
       {step === 'Systems' && (
         <SystemsList
           systems={filteredSystems}
           selectedSystemSlugs={form.systems}
           onChange={(systems) => updateForm({ systems })}
+        />
+      )}
+      {step === 'Crew' && (
+        <CrawlerCrewStep
+          bays={crewBays}
+          selectedType={selectedType}
+          crew={form.crew}
+          onChange={updateForm}
         />
       )}
       {step === 'Identity' && (

--- a/apps/in-the-union-now/src/components/crawler/CrawlerCrewStep.tsx
+++ b/apps/in-the-union-now/src/components/crawler/CrawlerCrewStep.tsx
@@ -1,0 +1,126 @@
+import type { SURefCrawler } from 'salvageunion-reference'
+import { Field, Input } from 'suref-react'
+
+import { findNpcChoiceByName } from '../../lib/crawlerRefs'
+import type { ResolvedNpc } from '../../lib/crawlerRefs'
+import type { CrawlerWizardFormState, CrewNpcForm } from '../../lib/wizard/crawlerFormState'
+
+type NpcSource = {
+  /** Stable key — the bay ref or the type ref. */
+  ref: string
+  /** Heading label (bay name or 'Crawler Type'). */
+  label: string
+  npc: ResolvedNpc
+}
+
+type CrawlerCrewStepProps = {
+  /** Base bays that carry an NPC (the 10 crewed bays). */
+  bays: ReadonlyArray<{ id: string; name: string; npc?: ResolvedNpc }>
+  /** The selected crawler type (its special NPC joins the crew), if any. */
+  selectedType: SURefCrawler | undefined
+  /** Crew form state keyed by bay/type ref. */
+  crew: Record<string, CrewNpcForm>
+  onChange: (patch: Partial<CrawlerWizardFormState>) => void
+}
+
+/**
+ * Crew step (plan §3): name and detail each base bay's crew lead plus the
+ * crawler-type's special NPC. Every field is optional — the step always
+ * advances. Augmented's A.I. NPC only carries Name/Description (no
+ * Keepsake/Motto), so those fields are guarded off the NPC's own choice set.
+ */
+export function CrawlerCrewStep({ bays, selectedType, crew, onChange }: CrawlerCrewStepProps) {
+  const sources: NpcSource[] = []
+
+  if (selectedType?.npc) {
+    sources.push({
+      ref: selectedType.id,
+      label: `${selectedType.name} Crawler`,
+      npc: selectedType.npc as ResolvedNpc,
+    })
+  }
+
+  for (const bay of bays) {
+    if (!bay.npc) continue
+    sources.push({ ref: bay.id, label: bay.name, npc: bay.npc })
+  }
+
+  function updateNpc(ref: string, patch: Partial<CrewNpcForm>) {
+    onChange({ crew: { ...crew, [ref]: { ...crew[ref], ...patch } } })
+  }
+
+  return (
+    <div className="max-w-[760px] space-y-5">
+      <p className="font-body text-xs text-wk-muted">
+        Each crewed bay is run by its own lead, and your crawler type brings a special NPC. Name and
+        detail them now, or leave them blank and fill them in during play.
+      </p>
+
+      {sources.map((source) => {
+        const value = crew[source.ref] ?? {}
+        const showKeepsake = findNpcChoiceByName(source.npc, 'Keepsake') !== undefined
+        const showMotto = findNpcChoiceByName(source.npc, 'Motto') !== undefined
+        const idBase = `crew-${source.ref}`
+        return (
+          <section
+            key={source.ref}
+            className="space-y-3 rounded-[3px] border-[1.5px] border-wk-faint p-4"
+          >
+            <header>
+              <h3 className="font-cond text-[13px] font-bold uppercase tracking-[0.1em] text-ink">
+                {source.label}
+              </h3>
+              {source.npc.position && (
+                <p className="mt-0.5 font-body text-xs text-wk-muted">{source.npc.position}</p>
+              )}
+            </header>
+
+            <Field label="Name" htmlFor={`${idBase}-name`}>
+              <Input
+                id={`${idBase}-name`}
+                type="text"
+                value={value.name ?? ''}
+                onChange={(e) => updateNpc(source.ref, { name: e.target.value })}
+                placeholder="Name this crew lead"
+              />
+            </Field>
+
+            <Field label="Description" htmlFor={`${idBase}-description`}>
+              <Input
+                id={`${idBase}-description`}
+                type="text"
+                value={value.description ?? ''}
+                onChange={(e) => updateNpc(source.ref, { description: e.target.value })}
+                placeholder="Appearance and personality"
+              />
+            </Field>
+
+            {showKeepsake && (
+              <Field label="Keepsake" htmlFor={`${idBase}-keepsake`}>
+                <Input
+                  id={`${idBase}-keepsake`}
+                  type="text"
+                  value={value.keepsake ?? ''}
+                  onChange={(e) => updateNpc(source.ref, { keepsake: e.target.value })}
+                  placeholder="A personal item"
+                />
+              </Field>
+            )}
+
+            {showMotto && (
+              <Field label="Motto" htmlFor={`${idBase}-motto`}>
+                <Input
+                  id={`${idBase}-motto`}
+                  type="text"
+                  value={value.motto ?? ''}
+                  onChange={(e) => updateNpc(source.ref, { motto: e.target.value })}
+                  placeholder="A personal saying"
+                />
+              </Field>
+            )}
+          </section>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/crawler/CrawlerTypeStep.tsx
+++ b/apps/in-the-union-now/src/components/crawler/CrawlerTypeStep.tsx
@@ -1,30 +1,37 @@
-import type { SURefEntity, SURefMetaCrawlerTechLevel } from 'salvageunion-reference'
+import type { SURefCrawler, SURefEntity } from 'salvageunion-reference'
 import { OptRow, ReferenceEntityDisplay } from 'suref-react'
 
 type CrawlerTypeOptionListProps = {
-  techLevels: SURefMetaCrawlerTechLevel[]
-  selectedTechLevel: number | null
-  onSelect: (techLevel: number) => void
+  types: SURefCrawler[]
+  selectedType: string | null
+  onSelect: (id: string) => void
+}
+
+/** First paragraph of an entity's `content`, if any. */
+function firstParagraph(entity: SURefCrawler): string {
+  const first = entity.content?.[0]
+  return typeof first?.value === 'string' ? first.value : ''
 }
 
 /**
- * Master pane for the Crawler step (design §3.2b): one OptRow per crawler
- * tech level (Hamlet → Megalopolis), the active row driving the detail pane.
+ * Master pane for the Crawler step: one OptRow per crawler type
+ * (Augmented / Battle / Engineering / Exploratory / Trade Caravan), the active
+ * row driving the detail pane.
  */
 export function CrawlerTypeOptionList({
-  techLevels,
-  selectedTechLevel,
+  types,
+  selectedType,
   onSelect,
 }: CrawlerTypeOptionListProps) {
   return (
     <div>
-      {techLevels.map((tl) => (
+      {types.map((type) => (
         <OptRow
-          key={tl.id}
-          name={tl.name}
-          desc={`Tech Level ${tl.techLevel} · ${tl.structurePoints} SP`}
-          active={tl.techLevel === selectedTechLevel}
-          onClick={() => onSelect(tl.techLevel)}
+          key={type.id}
+          name={type.name}
+          desc={type.npc?.position ?? firstParagraph(type)}
+          active={type.id === selectedType}
+          onClick={() => onSelect(type.id)}
         />
       ))}
     </div>
@@ -32,45 +39,20 @@ export function CrawlerTypeOptionList({
 }
 
 type CrawlerTypeDetailProps = {
-  selected: SURefMetaCrawlerTechLevel | undefined
-  /** SRD crawler bays — every crawler installs the full set on creation. */
-  bays: SURefEntity[]
+  selected: SURefCrawler | undefined
 }
 
 /**
- * Detail pane for the Crawler step (design §3.2c): the selected tech level's
- * entity card with the crawler's bay complement expanded inside it as a
- * 2-col grid of head-mode bay cards.
+ * Detail pane for the Crawler step: the selected crawler type's entity card —
+ * its description, special action(s) and special NPC.
  */
-export function CrawlerTypeDetail({ selected, bays }: CrawlerTypeDetailProps) {
+export function CrawlerTypeDetail({ selected }: CrawlerTypeDetailProps) {
   if (!selected) {
     return (
       <div className="flex h-full min-h-40 items-center justify-center rounded-[3px] border-[1.5px] border-dashed border-wk-faint p-6 text-center text-sm text-wk-muted">
-        Select a crawler tech level to preview its bays.
+        Select a crawler type to preview its features.
       </div>
     )
   }
-  return (
-    <ReferenceEntityDisplay
-      data={selected as unknown as SURefEntity}
-      afterExtraContent={
-        <div className="mt-4">
-          <p className="mb-2 font-cond text-xs font-bold uppercase tracking-[0.1em] text-wk-muted">
-            Structure Points · {selected.structurePoints} — Bays · {bays.length} (installed on every
-            crawler)
-          </p>
-          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-            {bays.map((bay) => (
-              <ReferenceEntityDisplay
-                key={bay.id}
-                data={bay}
-                mode="head"
-                hide={{ actions: true, choices: true }}
-              />
-            ))}
-          </div>
-        </div>
-      }
-    />
-  )
+  return <ReferenceEntityDisplay data={selected as unknown as SURefEntity} />
 }

--- a/apps/in-the-union-now/src/components/crawler/__tests__/CrawlerBuilder-responsive.test.tsx
+++ b/apps/in-the-union-now/src/components/crawler/__tests__/CrawlerBuilder-responsive.test.tsx
@@ -20,7 +20,12 @@ import { CrawlerBuilder } from '../CrawlerBuilder'
 beforeAll(async () => {
   // The builder preloads these on mount; warming the cache here lets the
   // act() flush below absorb the resulting state update.
-  await SalvageUnionReference.preload(['crawler-tech-levels', 'systems', 'crawler-bays'])
+  await SalvageUnionReference.preload([
+    'crawlers',
+    'crawler-tech-levels',
+    'systems',
+    'crawler-bays',
+  ])
 })
 
 async function renderBuilder() {
@@ -37,9 +42,12 @@ describe('CrawlerBuilder — responsive wizard layout', () => {
     expect(shell).toBeTruthy()
   })
 
-  test('renders a stepper navigation rail', async () => {
+  test('renders a stepper navigation rail with all five steps', async () => {
     const { container } = await renderBuilder()
     const stepper = container.querySelector('nav[aria-label="Steps"]')
     expect(stepper).toBeTruthy()
+    for (const label of ['Crawler', 'Systems', 'Crew', 'Identity', 'Review']) {
+      expect(stepper?.textContent).toContain(label)
+    }
   })
 })

--- a/apps/in-the-union-now/src/components/crawler/__tests__/CrawlerBuilder.test.tsx
+++ b/apps/in-the-union-now/src/components/crawler/__tests__/CrawlerBuilder.test.tsx
@@ -2,10 +2,11 @@
  * Integration tests for CrawlerBuilder (create + edit on the WizShell
  * skeleton).
  *
- * Exercises Crawler (master-detail tech-level pick with bay preview) →
- * Systems (TL-filtered Sel grid) → Identity (name + starting resources) →
- * Review → submit using the real wizard, real SalvageUnionReference data,
- * real Zod validation, and a fake-indexeddb-backed entityStore.
+ * Exercises Crawler (master-detail TYPE pick with feature preview) →
+ * Systems (TL-filtered Sel grid) → Crew (NPC details) → Identity (name +
+ * starting resources) → Review → submit using the real wizard, real
+ * SalvageUnionReference data, real Zod validation, and a fake-indexeddb-backed
+ * entityStore.
  *
  * fake-indexeddb/auto is preloaded via bunfig.toml.
  * SalvageUnionReference is preloaded in beforeAll.
@@ -115,32 +116,34 @@ function systemAtTL(tl: number): { id: string; name: string } {
 // ---------------------------------------------------------------------------
 
 describe('CrawlerBuilder — create mode', () => {
-  it('renders the master-detail Crawler step with tech-level rows and bay preview', async () => {
+  it('renders the master-detail Crawler step with TYPE rows and a feature preview', async () => {
     render(<CrawlerBuilder onComplete={() => {}} onCancel={() => {}} />)
 
     expect(screen.getByText('Choose Your Crawler')).toBeTruthy()
     await waitFor(() => {
-      expect(getPickByName('Hamlet Crawler')).toBeTruthy()
+      expect(getPickByName('Battle')).toBeTruthy()
     })
 
     // No selection yet — Next is disabled, detail pane shows the empty hint.
     expect(getNextButton().disabled).toBe(true)
-    expect(screen.getByText(/Select a crawler tech level/i)).toBeTruthy()
+    expect(screen.getByText(/Select a crawler type to preview/i)).toBeTruthy()
 
-    // Selecting a level expands its detail card with the 2-col bay head grid.
-    await pick('Village Crawler')
+    // Selecting a type shows its feature card (special action + NPC), NOT a bay grid.
+    await pick('Battle')
     await waitFor(() => {
-      expect(screen.getByText('Command Bay')).toBeTruthy()
-      expect(screen.getByText('Mech Bay')).toBeTruthy()
+      // The special action is unique to the detail card.
+      expect(screen.getByText('Improved Armour and Armaments')).toBeTruthy()
+      // The special NPC's position surfaces (also in the OptRow desc → multiple).
+      expect(screen.getAllByText('Grizzled Veteran').length).toBeGreaterThan(0)
     })
     expect(getNextButton().disabled).toBe(false)
   }, 30000)
 
-  it('TL-filters the Systems step to the crawler tech level and below', async () => {
+  it('TL-filters the Systems step to Tech Level 1 (fixed for new crawlers)', async () => {
     render(<CrawlerBuilder onComplete={() => {}} onCancel={() => {}} />)
 
-    await waitFor(() => getPickByName('Hamlet Crawler'))
-    await pick('Hamlet Crawler')
+    await waitFor(() => getPickByName('Battle'))
+    await pick('Battle')
     await clickNext()
 
     const tl1 = systemAtTL(1)
@@ -151,13 +154,16 @@ describe('CrawlerBuilder — create mode', () => {
     expect(screen.queryByRole('button', { name: tl2.name })).toBeNull()
   }, 30000)
 
-  it('walks through every step and creates a valid crawler with seeded bays + resources', async () => {
+  it('walks through every step and creates a TL1 typed crawler with seeded bays, crew + resources', async () => {
     const onComplete = mock(() => {})
     render(<CrawlerBuilder onComplete={onComplete} onCancel={() => {}} />)
 
-    // --- Step 1: Crawler (master-detail OptRow list) ---
-    await waitFor(() => getPickByName('Hamlet Crawler'))
-    await pick('Hamlet Crawler')
+    const battle = SalvageUnionReference.Crawlers.find((c) => c.name === 'Battle')!
+    const commandBay = SalvageUnionReference.CrawlerBays.find((b) => b.name === 'Command Bay')!
+
+    // --- Step 1: Crawler — pick a TYPE ---
+    await waitFor(() => getPickByName('Battle'))
+    await pick('Battle')
     await clickNext()
 
     // --- Step 2: Systems — live count in subtitle ---
@@ -166,7 +172,28 @@ describe('CrawlerBuilder — create mode', () => {
     expect(screen.getByTestId('system-count').textContent).toContain('1 /')
     await clickNext()
 
-    // --- Step 3: Identity — name + starting resources ---
+    // --- Step 3: Crew — fill the Command Bay lead + the type NPC ---
+    const byId = (id: string): HTMLElement => {
+      const el = document.getElementById(id)
+      if (!el) throw new Error(`No element #${id}`)
+      return el
+    }
+    await waitFor(() => byId(`crew-${commandBay.id}-name`))
+    fireEvent.change(byId(`crew-${commandBay.id}-name`), {
+      target: { value: 'Maddox' },
+    })
+    fireEvent.change(byId(`crew-${commandBay.id}-keepsake`), {
+      target: { value: 'A medal' },
+    })
+    fireEvent.change(byId(`crew-${battle.id}-name`), {
+      target: { value: 'Vex' },
+    })
+    fireEvent.change(byId(`crew-${battle.id}-motto`), {
+      target: { value: 'No retreat' },
+    })
+    await clickNext()
+
+    // --- Step 4: Identity — name + starting resources ---
     fireEvent.change(screen.getByLabelText(/Crawler Name/i), {
       target: { value: 'Bay Wagon' },
     })
@@ -178,8 +205,7 @@ describe('CrawlerBuilder — create mode', () => {
     })
     await clickNext()
 
-    // --- Step 4: Review → submit ('Create Crawler ✦') ---
-    expect(screen.getByText(/seeded automatically/i)).toBeTruthy()
+    // --- Step 5: Review → submit ('Create Crawler ✦') ---
     const submit = screen.getByRole('button', { name: /Create Crawler/i })
     await act(async () => {
       fireEvent.click(submit)
@@ -191,6 +217,7 @@ describe('CrawlerBuilder — create mode', () => {
       const c = crawlers[0]!
       expect(c.name).toBe('Bay Wagon')
       expect(c.techLevel).toBe('tech-1')
+      expect(c.type).toBe(battle.id)
       expect(c.schemaVersion).toBe(1)
       expect(c.systems).toEqual([tl1.id])
       expect(c.scrapPool).toEqual({ tl2: 3 })
@@ -199,11 +226,18 @@ describe('CrawlerBuilder — create mode', () => {
       // Full SRD bay set seeded, NPCs at max HP (4) where the bay has one.
       const srdBays = SalvageUnionReference.CrawlerBays.all()
       expect(c.crawlerBays?.length).toBe(srdBays.length)
-      const commandBay = srdBays.find((b) => b.name === 'Command Bay')!
       const seeded = c.crawlerBays?.find((e) => e.bayRef === commandBay.id)
       expect(seeded?.npcCurrentHP).toBe(4)
+      expect(seeded?.npcName).toBe('Maddox')
 
-      // Fresh crawlers start at full SP for their tech level.
+      // Crew Keepsake routed to bayChoices; type NPC persisted to typeNpc.
+      const keepsakeId = commandBay.npc!.choices!.find((ch) => ch.name === 'Keepsake')!.id
+      expect(c.bayChoices?.[commandBay.id]?.[keepsakeId]).toEqual(['A medal'])
+      expect(c.typeNpc?.npcName).toBe('Vex')
+      const mottoId = battle.npc!.choices!.find((ch) => ch.name === 'Motto')!.id
+      expect(c.bayChoices?.[battle.id]?.[mottoId]).toEqual(['No retreat'])
+
+      // Fresh crawlers start at full SP for Tech Level 1.
       const tl = SalvageUnionReference.CrawlerTechLevels.find((t) => t.techLevel === 1)!
       expect(c.currentSP).toBe(tl.structurePoints)
     })
@@ -213,9 +247,10 @@ describe('CrawlerBuilder — create mode', () => {
   it('name gate: cannot reach Create with an empty name', async () => {
     render(<CrawlerBuilder onComplete={() => {}} onCancel={() => {}} />)
 
-    await waitFor(() => getPickByName('Hamlet Crawler'))
-    await pick('Hamlet Crawler')
+    await waitFor(() => getPickByName('Battle'))
+    await pick('Battle')
     await clickNext() // Systems
+    await clickNext() // Crew
     await clickNext() // Identity
 
     // Name left empty — Next stays disabled, Review/Create is unreachable.
@@ -233,13 +268,13 @@ describe('CrawlerBuilder — create mode', () => {
     expect(onCancel).toHaveBeenCalledTimes(1)
   })
 
-  it('offers no bay catalog or free-text crew editor — bays are seeded, not chosen', async () => {
+  it('offers no bay catalog in the Crawler step — bays are seeded, not chosen', async () => {
     render(<CrawlerBuilder onComplete={() => {}} onCancel={() => {}} />)
 
-    await waitFor(() => getPickByName('Hamlet Crawler'))
-    await pick('Hamlet Crawler')
-    await clickNext()
+    await waitFor(() => getPickByName('Battle'))
+    await pick('Battle')
 
+    // The type detail card shows features, not a 2-col bay head grid.
     expect(screen.queryByLabelText('Bay entity slug')).toBeNull()
     expect(screen.queryByRole('button', { name: /Add Bay/i })).toBeNull()
   }, 30000)
@@ -249,12 +284,14 @@ describe('CrawlerBuilder — create mode', () => {
 // Edit mode: upsert branch — live-play state never clobbered
 // ---------------------------------------------------------------------------
 
-async function seedCrawler() {
+async function seedCrawler(overrides?: { techLevel?: number; type?: string }) {
   const input = crawlerFormToCreateInput(
     {
       name: 'The Wandering Kettle',
-      techLevel: 1,
+      techLevel: overrides?.techLevel ?? 1,
+      type: overrides?.type ?? null,
       systems: [],
+      crew: {},
       scrapPool: { ...EMPTY_SCRAP_POOL },
       upgradePool: 0,
     },
@@ -296,6 +333,7 @@ describe('CrawlerBuilder — edit mode', () => {
     const tl1 = systemAtTL(1)
     await waitFor(() => screen.getByRole('button', { name: tl1.name }))
     await pick(tl1.name)
+    await clickNext() // Crew (all optional)
     await clickNext() // Identity (name prefilled)
     await clickNext() // Review
 
@@ -321,5 +359,113 @@ describe('CrawlerBuilder — edit mode', () => {
       expect(c.crawlerBays?.length).toBe(crawler.crawlerBays!.length)
     })
     expect(onComplete).toHaveBeenCalledWith(crawler.id)
+  }, 30000)
+
+  it('preserves a higher stored tech level on save (only create fixes TL1)', async () => {
+    // A pre-feature crawler at Tech 3 with no chosen type.
+    const crawler = await seedCrawler({ techLevel: 3 })
+    expect(crawler.techLevel).toBe('tech-3')
+    const played = useEntityStore.getState().get('crawler', crawler.id)!
+
+    render(
+      <CrawlerBuilder
+        crawlerId={crawler.id}
+        initialState={crawlerToFormState(played)}
+        onComplete={() => {}}
+        onCancel={() => {}}
+      />
+    )
+
+    // Type-unselected (legacy crawler), but TL is preserved so Next gates on name.
+    await waitFor(() => {
+      expect(getNextButton().disabled).toBe(false)
+    })
+    await clickNext() // Systems
+    await clickNext() // Crew
+    await clickNext() // Identity
+    await clickNext() // Review
+
+    const save = screen.getByRole('button', { name: /Save Crawler/i })
+    await act(async () => {
+      fireEvent.click(save)
+    })
+
+    await waitFor(() => {
+      const c = useEntityStore.getState().get('crawler', crawler.id)!
+      expect(c.techLevel).toBe('tech-3')
+    })
+  }, 30000)
+
+  it('changing the crawler TYPE on edit drops the old type NPC + bayChoices (no phantom bay)', async () => {
+    const battle = SalvageUnionReference.Crawlers.find((c) => c.name === 'Battle')!
+    const engineering = SalvageUnionReference.Crawlers.find((c) => c.name === 'Engineering')!
+
+    // Seed a Battle crawler with a named Grizzled Veteran (type NPC) and a
+    // Keepsake persisted in bayChoices keyed by the Battle type id.
+    const input = crawlerFormToCreateInput(
+      {
+        name: 'War Wagon',
+        techLevel: 1,
+        type: battle.id,
+        systems: [],
+        crew: { [battle.id]: { name: 'Old Vex', keepsake: 'A dog tag' } },
+        scrapPool: { ...EMPTY_SCRAP_POOL },
+        upgradePool: 0,
+      },
+      { maxSP: 20, crawlerBays: seedDefaultCrawlerBays() }
+    )
+    const crawler = await useEntityStore.getState().create('crawler', input)
+    expect(crawler.typeNpc?.npcName).toBe('Old Vex')
+    expect(crawler.bayChoices?.[battle.id]).toBeTruthy()
+
+    // Wound a real bay's NPC so we can prove live HP is preserved on save.
+    const playedBayRef = crawler.crawlerBays![0]!.bayRef
+    await useEntityStore.getState().updateCrawlerBay(crawler.id, playedBayRef, { npcCurrentHP: 1 })
+
+    const played = useEntityStore.getState().get('crawler', crawler.id)!
+    render(
+      <CrawlerBuilder
+        crawlerId={crawler.id}
+        initialState={crawlerToFormState(played)}
+        onComplete={() => {}}
+        onCancel={() => {}}
+      />
+    )
+
+    // Switch the type: Battle → Engineering on the Crawler step.
+    await waitFor(() => getPickByName('Engineering'))
+    await pick('Engineering')
+    await clickNext() // Systems
+    await clickNext() // Crew
+    await clickNext() // Identity
+    await clickNext() // Review
+
+    const save = screen.getByRole('button', { name: /Save Crawler/i })
+    await act(async () => {
+      fireEvent.click(save)
+    })
+
+    await waitFor(() => {
+      const c = useEntityStore.getState().get('crawler', crawler.id)!
+      expect(c.type).toBe(engineering.id)
+
+      // No phantom bay keyed by a type id (neither old nor new type).
+      const srdBayIds = new Set(SalvageUnionReference.CrawlerBays.all().map((b) => b.id))
+      for (const entry of c.crawlerBays ?? []) {
+        expect(srdBayIds.has(entry.bayRef)).toBe(true)
+      }
+      expect(c.crawlerBays?.some((e) => e.bayRef === battle.id)).toBe(false)
+      expect(c.crawlerBays?.some((e) => e.bayRef === engineering.id)).toBe(false)
+
+      // The old type's NPC name does NOT carry over to the new type.
+      expect(c.typeNpc?.npcName).not.toBe('Old Vex')
+
+      // The orphaned old-type bayChoices key is cleared.
+      expect(c.bayChoices?.[battle.id]).toBeUndefined()
+
+      // Live bay HP is preserved through the type switch.
+      const bay = c.crawlerBays?.find((e) => e.bayRef === playedBayRef)
+      expect(bay?.npcCurrentHP).toBe(1)
+    })
   }, 30000)
 })

--- a/apps/in-the-union-now/src/components/crawler/__tests__/CrawlerCrewStep.test.tsx
+++ b/apps/in-the-union-now/src/components/crawler/__tests__/CrawlerCrewStep.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for CrawlerCrewStep — the wizard's crew/NPC details step.
+ *
+ * Renders the 10 crewed base bays (the 4 expansion bays carry no NPC →
+ * excluded) plus the selected crawler type's special NPC. Each NPC exposes the
+ * SRD freeform set Name/Description/Keepsake/Motto, guarded off the NPC's own
+ * choices: the Augmented type's A.I. has only Name/Description.
+ *
+ * Uses real SalvageUnionReference data. NO mock.module().
+ */
+
+import { afterEach, beforeAll, describe, expect, it, mock } from 'bun:test'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+import type { SURefCrawler } from 'salvageunion-reference'
+
+import { CrawlerCrewStep } from '../CrawlerCrewStep'
+import type { CrewNpcForm } from '../../../lib/wizard/crawlerFormState'
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+function crewedBays() {
+  return (
+    SalvageUnionReference.CrawlerBays.all() as Array<{ id: string; name: string; npc?: unknown }>
+  ).filter((b) => b.npc != null) as Array<{
+    id: string
+    name: string
+    npc?: { position?: string; choices?: ReadonlyArray<{ id: string; name: string }> }
+  }>
+}
+
+function byId(container: HTMLElement, id: string): HTMLElement {
+  const el = container.querySelector(`#${id}`)
+  if (!el) throw new Error(`No element #${id}`)
+  return el as HTMLElement
+}
+
+describe('CrawlerCrewStep', () => {
+  it('renders exactly the 10 crewed base bays (expansion bays excluded)', () => {
+    const bays = crewedBays()
+    expect(bays.length).toBe(10)
+    const { container } = render(
+      <CrawlerCrewStep bays={bays} selectedType={undefined} crew={{}} onChange={() => {}} />
+    )
+    for (const bay of bays) {
+      expect(byId(container, `crew-${bay.id}-name`)).toBeTruthy()
+    }
+    // No expansion bay (e.g. VR Tubes) has a crew section.
+    expect(container.textContent).not.toContain('VR Tubes')
+  })
+
+  it('renders Name/Description/Keepsake/Motto for a standard bay NPC', () => {
+    const bays = crewedBays()
+    const command = bays.find((b) => b.name === 'Command Bay')!
+    const { container } = render(
+      <CrawlerCrewStep bays={bays} selectedType={undefined} crew={{}} onChange={() => {}} />
+    )
+    expect(byId(container, `crew-${command.id}-name`)).toBeTruthy()
+    expect(byId(container, `crew-${command.id}-description`)).toBeTruthy()
+    expect(byId(container, `crew-${command.id}-keepsake`)).toBeTruthy()
+    expect(byId(container, `crew-${command.id}-motto`)).toBeTruthy()
+  })
+
+  it('includes the selected type’s special NPC with its full field set', () => {
+    const battle = SalvageUnionReference.Crawlers.find((c) => c.name === 'Battle')!
+    const { container } = render(
+      <CrawlerCrewStep bays={crewedBays()} selectedType={battle} crew={{}} onChange={() => {}} />
+    )
+    expect(byId(container, `crew-${battle.id}-name`)).toBeTruthy()
+    expect(byId(container, `crew-${battle.id}-keepsake`)).toBeTruthy()
+    expect(byId(container, `crew-${battle.id}-motto`)).toBeTruthy()
+  })
+
+  it('Augmented edge: A.I. NPC shows Name/Description only (no Keepsake/Motto)', () => {
+    const augmented = SalvageUnionReference.Crawlers.find((c) => c.name === 'Augmented')!
+    const { container } = render(
+      <CrawlerCrewStep bays={crewedBays()} selectedType={augmented} crew={{}} onChange={() => {}} />
+    )
+    expect(byId(container, `crew-${augmented.id}-name`)).toBeTruthy()
+    expect(byId(container, `crew-${augmented.id}-description`)).toBeTruthy()
+    expect(container.querySelector(`#crew-${augmented.id}-keepsake`)).toBeNull()
+    expect(container.querySelector(`#crew-${augmented.id}-motto`)).toBeNull()
+  })
+
+  it('edits a bay NPC field through onChange (merging crew state)', () => {
+    const bays = crewedBays()
+    const command = bays.find((b) => b.name === 'Command Bay')!
+    const onChange = mock((patch: { crew?: Record<string, CrewNpcForm> }) => patch)
+    const { container } = render(
+      <CrawlerCrewStep bays={bays} selectedType={undefined} crew={{}} onChange={onChange} />
+    )
+    fireEvent.change(byId(container, `crew-${command.id}-name`), {
+      target: { value: 'Maddox' },
+    })
+    expect(onChange).toHaveBeenCalledWith({
+      crew: { [command.id]: { name: 'Maddox' } },
+    })
+  })
+
+  it('renders existing crew values', () => {
+    const bays = crewedBays()
+    const command = bays.find((b) => b.name === 'Command Bay')!
+    const crew: Record<string, CrewNpcForm> = {
+      [command.id]: { name: 'Maddox', motto: 'Hold the line' },
+    }
+    const { container } = render(
+      <CrawlerCrewStep
+        bays={bays}
+        selectedType={undefined as unknown as SURefCrawler | undefined}
+        crew={crew}
+        onChange={() => {}}
+      />
+    )
+    expect((byId(container, `crew-${command.id}-name`) as HTMLInputElement).value).toBe('Maddox')
+    expect((byId(container, `crew-${command.id}-motto`) as HTMLInputElement).value).toBe(
+      'Hold the line'
+    )
+  })
+})

--- a/apps/in-the-union-now/src/components/sheet/CrawlerSheet.tsx
+++ b/apps/in-the-union-now/src/components/sheet/CrawlerSheet.tsx
@@ -24,9 +24,11 @@ import type { SURefEntity } from 'salvageunion-reference'
 import { Btn, ReferenceEntityDisplay, Slab, StepBtn, useDetailModal } from 'suref-react'
 import type { CardFootMeta, ChoiceSelections } from 'suref-react'
 
+import { cn } from '../../lib/utils'
 import { addToScrapPool, scrapPoolBucket } from '../../lib/cargo/cargoTransfer'
 import { useCargo } from '../../lib/cargo/useCargo'
 import { parseCrawlerTechLevel } from '../../lib/crawlerLevel'
+import { findNpcChoiceByName, resolveCrawlerBay, resolveCrawlerType } from '../../lib/crawlerRefs'
 import type { Crawler, ScrapPool } from '../../lib/schemas/crawler'
 import type { Mech } from '../../lib/schemas/mech'
 import { useEntityStore } from '../../stores/entityStore'
@@ -36,24 +38,6 @@ import { NpcInset } from './NpcInset'
 import { StorageManifest } from './StorageManifest'
 
 type CrawlerBayEntry = NonNullable<Crawler['crawlerBays']>[number]
-
-type ResolvedBayNpc = {
-  position?: string
-  hitPoints?: number
-  choices?: ReadonlyArray<{ id: string; name: string }>
-}
-
-type ResolvedBay = { id: string; name: string; npc?: ResolvedBayNpc }
-
-/** Resolve a stored crawler-bay ref (id or name) to its SRD entity. */
-function resolveCrawlerBay(ref: string): ResolvedBay | null {
-  try {
-    const all = SalvageUnionReference.CrawlerBays.all() as ReadonlyArray<ResolvedBay>
-    return all.find((b) => b.id === ref || b.name === ref) ?? null
-  } catch {
-    return null
-  }
-}
 
 /** Resolve a stored crawler-system ref (id or name) to its SRD entity [gap 20]. */
 function resolveCrawlerSystem(ref: string): SURefEntity | null {
@@ -164,15 +148,24 @@ function CrawlerBayCard({
     patchEntry({ condition: damaged ? 'intact' : 'damaged' })
   }
 
-  // Keepsake persists through the bay NPC's SRD freeform 'Keepsake' choice —
-  // same bayChoices map as the bay's own choices, no extra schema field.
-  const keepsakeChoice = npc?.choices?.find((c) => c.name === 'Keepsake')
+  // Keepsake/Motto persist through the bay NPC's SRD freeform choices — same
+  // bayChoices map as the bay's own choices, no extra schema field.
+  const keepsakeChoice = findNpcChoiceByName(npc, 'Keepsake')
   const keepsake = keepsakeChoice ? (selections[keepsakeChoice.id]?.[0] ?? '') : ''
   function setKeepsake(next: string) {
     if (!keepsakeChoice) return
     setSelections({
       ...selections,
       [keepsakeChoice.id]: next.trim().length > 0 ? [next] : [],
+    })
+  }
+  const mottoChoice = findNpcChoiceByName(npc, 'Motto')
+  const motto = mottoChoice ? (selections[mottoChoice.id]?.[0] ?? '') : ''
+  function setMotto(next: string) {
+    if (!mottoChoice) return
+    setSelections({
+      ...selections,
+      [mottoChoice.id]: next.trim().length > 0 ? [next] : [],
     })
   }
 
@@ -184,11 +177,13 @@ function CrawlerBayCard({
       hp={entry.npcCurrentHP ?? maxHP}
       maxHp={maxHP}
       keepsake={keepsake}
+      motto={motto}
       detail={entry.npcDescription ?? ''}
       facts={entry.npcFacts ?? []}
       onNameChange={readOnly ? undefined : (next) => patchEntry({ npcName: next })}
       onHpChange={readOnly ? undefined : (next) => patchEntry({ npcCurrentHP: next })}
       onKeepsakeChange={readOnly || !keepsakeChoice ? undefined : setKeepsake}
+      onMottoChange={readOnly || !mottoChoice ? undefined : setMotto}
       onDetailChange={readOnly ? undefined : (next) => patchEntry({ npcDescription: next })}
       onFactsChange={readOnly ? undefined : (next) => patchEntry({ npcFacts: next })}
       readOnly={readOnly}
@@ -257,6 +252,111 @@ function CrawlerBayCard({
       />
       {detail.modal}
     </>
+  )
+}
+
+type CrawlerNpcState = NonNullable<Crawler['typeNpc']>
+
+type CrawlerTypeCardProps = {
+  crawlerId: string
+  /** The crawler-type ref (SRD id) — also the bayChoices key for its NPC. */
+  typeRef: string
+  /** Live state for the type's special NPC. */
+  typeNpc: CrawlerNpcState | undefined
+  /** Persisted Keepsake/Motto selections for the type NPC (from the crawler prop). */
+  seedSelections: ChoiceSelections | undefined
+  store: typeof useEntityStore
+  readOnly: boolean
+}
+
+/**
+ * CrawlerTypeCard — the chosen crawler type as an entity card (description +
+ * special action(s)), with its special NPC rendered as an NpcInset in the
+ * expand slot. Mirrors CrawlerBayCard: the SRD npc block is stripped from the
+ * card (it lives in the inset); Keepsake/Motto persist through the NPC's
+ * freeform choices into the crawler's bayChoices map keyed by the type ref;
+ * structured name/HP/description/facts persist into the `typeNpc` field.
+ */
+function CrawlerTypeCard({
+  crawlerId,
+  typeRef,
+  typeNpc,
+  seedSelections,
+  store,
+  readOnly,
+}: CrawlerTypeCardProps) {
+  const storeState = store()
+  const { selections, setSelections } = useEntityChoices(
+    'crawler',
+    crawlerId,
+    typeRef,
+    'bayChoices',
+    seedSelections,
+    store
+  )
+  const type = resolveCrawlerType(typeRef)
+  if (!type) return null
+
+  const npc = type.npc
+  const maxHP = npc?.hitPoints ?? 0
+
+  function patchNpc(patch: Partial<CrawlerNpcState>) {
+    const fresh = storeState.get('crawler', crawlerId)
+    void storeState.update('crawler', crawlerId, {
+      typeNpc: { ...(fresh?.typeNpc ?? {}), ...patch },
+    })
+  }
+
+  const keepsakeChoice = findNpcChoiceByName(npc, 'Keepsake')
+  const keepsake = keepsakeChoice ? (selections[keepsakeChoice.id]?.[0] ?? '') : ''
+  function setKeepsake(next: string) {
+    if (!keepsakeChoice) return
+    setSelections({
+      ...selections,
+      [keepsakeChoice.id]: next.trim().length > 0 ? [next] : [],
+    })
+  }
+  const mottoChoice = findNpcChoiceByName(npc, 'Motto')
+  const motto = mottoChoice ? (selections[mottoChoice.id]?.[0] ?? '') : ''
+  function setMotto(next: string) {
+    if (!mottoChoice) return
+    setSelections({
+      ...selections,
+      [mottoChoice.id]: next.trim().length > 0 ? [next] : [],
+    })
+  }
+
+  const crew = npc ? (
+    <NpcInset
+      bayName={type.name}
+      title={npc.position}
+      name={typeNpc?.npcName ?? ''}
+      hp={typeNpc?.npcCurrentHP ?? maxHP}
+      maxHp={maxHP}
+      keepsake={keepsake}
+      motto={motto}
+      detail={typeNpc?.npcDescription ?? ''}
+      facts={typeNpc?.npcFacts ?? []}
+      onNameChange={readOnly ? undefined : (next) => patchNpc({ npcName: next })}
+      onHpChange={readOnly ? undefined : (next) => patchNpc({ npcCurrentHP: next })}
+      onKeepsakeChange={readOnly || !keepsakeChoice ? undefined : setKeepsake}
+      onMottoChange={readOnly || !mottoChoice ? undefined : setMotto}
+      onDetailChange={readOnly ? undefined : (next) => patchNpc({ npcDescription: next })}
+      onFactsChange={readOnly ? undefined : (next) => patchNpc({ npcFacts: next })}
+      readOnly={readOnly}
+    />
+  ) : undefined
+
+  // Card renders WITHOUT the SRD npc block — the special NPC lives in the inset.
+  const cardData = { ...type, npc: undefined } as unknown as SURefEntity
+
+  return (
+    <ReferenceEntityDisplay
+      data={cardData}
+      selections={selections}
+      onSelectionChange={readOnly ? undefined : setSelections}
+      expand={crew}
+    />
   )
 }
 
@@ -383,8 +483,66 @@ export function CrawlerSheet({
     })
   }
 
+  /** Set the crawler's tech level (1–6), recomputing SP/capacity downstream. */
+  function setTechLevel(next: number) {
+    if (readOnly) return
+    if (next < 1 || next > 6 || next === tl) return
+    void storeState.update('crawler', crawler.id, { techLevel: `tech-${next}` })
+  }
+
+  const TECH_LEVELS = [1, 2, 3, 4, 5, 6] as const
+
   return (
     <section aria-label={`${crawler.name} crawler sheet`} className="flex flex-col gap-7">
+      {/* Crawler Type — only when a type was chosen (legacy crawlers have none) */}
+      {crawler.type && (
+        <div>
+          <Slab label="Crawler Type" count="special action + special NPC" />
+          <Ecflow>
+            <Erow>
+              <CrawlerTypeCard
+                crawlerId={crawler.id}
+                typeRef={crawler.type}
+                typeNpc={crawler.typeNpc}
+                seedSelections={crawler.bayChoices?.[crawler.type]}
+                store={store}
+                readOnly={readOnly}
+              />
+            </Erow>
+          </Ecflow>
+        </div>
+      )}
+
+      {/* Tech Level — editable stepper (rules: upgraded on the live sheet) */}
+      <div>
+        <Slab label="Tech Level" count={`Tech ${tl} crawler`} />
+        {readOnly ? (
+          <p className="font-body text-sm text-ink">Tech Level {tl}</p>
+        ) : (
+          <div
+            role="group"
+            aria-label="Crawler tech level"
+            className="inline-flex items-stretch overflow-hidden rounded-[2px] border-[1.5px] border-ink bg-paper"
+          >
+            {TECH_LEVELS.map((n) => (
+              <button
+                key={n}
+                type="button"
+                aria-label={`Set tech level ${n}`}
+                aria-pressed={n === tl}
+                onClick={() => setTechLevel(n)}
+                className={cn(
+                  'min-w-9 px-2 py-1 font-cond text-sm font-bold leading-none',
+                  n === tl ? 'bg-ink text-su-white' : 'text-ink hover:bg-su-paper'
+                )}
+              >
+                {n}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
       {/* Crawler Bays */}
       {bays.length > 0 && (
         <div>

--- a/apps/in-the-union-now/src/components/sheet/NpcInset.tsx
+++ b/apps/in-the-union-now/src/components/sheet/NpcInset.tsx
@@ -28,11 +28,13 @@ type NpcInsetProps = {
   hp: number
   maxHp: number
   keepsake: string
+  motto: string
   detail: string
   facts: ReadonlyArray<string>
   onNameChange?: (next: string) => void
   onHpChange?: (next: number) => void
   onKeepsakeChange?: (next: string) => void
+  onMottoChange?: (next: string) => void
   onDetailChange?: (next: string) => void
   onFactsChange?: (next: string[]) => void
   readOnly?: boolean
@@ -45,11 +47,13 @@ export function NpcInset({
   hp,
   maxHp,
   keepsake,
+  motto,
   detail,
   facts,
   onNameChange,
   onHpChange,
   onKeepsakeChange,
+  onMottoChange,
   onDetailChange,
   onFactsChange,
   readOnly = false,
@@ -115,6 +119,23 @@ export function NpcInset({
                 />
               ) : (
                 keepsake || '—'
+              )}
+            </dd>
+          </div>
+          <div className="flex items-baseline gap-1.5">
+            <dt className="shrink-0 font-cond text-[9px] font-bold uppercase leading-none tracking-[0.1em] text-ink">
+              Motto
+            </dt>
+            <dd className="m-0 min-w-0 font-body text-[11.5px] leading-snug text-ink-2">
+              {editable && onMottoChange ? (
+                <InlineEditField
+                  value={motto}
+                  onSave={(next) => onMottoChange(String(next))}
+                  type="text"
+                  ariaLabel={`Edit ${bayName} crew motto`}
+                />
+              ) : (
+                motto || '—'
               )}
             </dd>
           </div>

--- a/apps/in-the-union-now/src/components/sheet/__tests__/CrawlerSheet-bay-npc.test.tsx
+++ b/apps/in-the-union-now/src/components/sheet/__tests__/CrawlerSheet-bay-npc.test.tsx
@@ -34,6 +34,7 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 const KEEPSAKE_CHOICE_ID = 'command-bay-keepsake-1'
+const MOTTO_CHOICE_ID = 'command-bay-motto-1'
 
 const MOCK_BAYS = [
   {
@@ -46,6 +47,7 @@ const MOCK_BAYS = [
       choices: [
         { id: 'command-bay-name-1', name: 'Name', choiceType: 'freeform' },
         { id: KEEPSAKE_CHOICE_ID, name: 'Keepsake', choiceType: 'freeform' },
+        { id: MOTTO_CHOICE_ID, name: 'Motto', choiceType: 'freeform' },
       ],
     },
   },
@@ -287,6 +289,55 @@ describe('CrawlerSheet — crew keepsake via bayChoices', () => {
     render(<CrawlerSheet crawler={baseCrawler} store={makeStubStore(baseCrawler)} />)
     // Mech Bay's mock npc carries no choices — keepsake cannot persist.
     expect(screen.queryByLabelText('Edit Mech Bay crew keepsake')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Motto — persists through the SRD freeform 'Motto' choice (bayChoices)
+// ---------------------------------------------------------------------------
+
+describe('CrawlerSheet — crew motto via bayChoices', () => {
+  let restore: () => void
+  afterEach(() => {
+    restore?.()
+  })
+
+  test('renders the persisted motto from bayChoices', async () => {
+    restore = await patchCrawlerBays()
+    const withMotto: Crawler = {
+      ...baseCrawler,
+      bayChoices: { 'command-bay': { [MOTTO_CHOICE_ID]: ['No retreat'] } },
+    }
+    render(<CrawlerSheet crawler={withMotto} store={makeStubStore(withMotto)} />)
+    const inset = screen.getByLabelText('Command Bay crew lead')
+    expect(within(inset).getByText('No retreat')).toBeTruthy()
+  })
+
+  test('editing the motto persists into bayChoices via store.update', async () => {
+    restore = await patchCrawlerBays()
+    const update = mock(async () => baseCrawler)
+    render(<CrawlerSheet crawler={baseCrawler} store={makeStubStore(baseCrawler, { update })} />)
+
+    const field = screen.getByLabelText('Edit Command Bay crew motto')
+    await act(async () => {
+      fireEvent.click(field)
+    })
+    const input = screen.getByLabelText('Edit Command Bay crew motto')
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'No retreat' } })
+      fireEvent.blur(input)
+    })
+
+    expect(update).toHaveBeenCalledWith('crawler', baseCrawler.id, {
+      bayChoices: { 'command-bay': { [MOTTO_CHOICE_ID]: ['No retreat'] } },
+    })
+  })
+
+  test('a bay whose NPC has no Motto choice renders a read-only dash', async () => {
+    restore = await patchCrawlerBays()
+    render(<CrawlerSheet crawler={baseCrawler} store={makeStubStore(baseCrawler)} />)
+    // Mech Bay's mock npc carries no choices — motto cannot persist.
+    expect(screen.queryByLabelText('Edit Mech Bay crew motto')).toBeNull()
   })
 })
 

--- a/apps/in-the-union-now/src/components/sheet/__tests__/CrawlerSheet-type.test.tsx
+++ b/apps/in-the-union-now/src/components/sheet/__tests__/CrawlerSheet-type.test.tsx
@@ -1,0 +1,258 @@
+/**
+ * CrawlerSheet — Crawler Type slab + special NPC tests.
+ *
+ * When `crawler.type` is set, the sheet renders a "Crawler Type" slab: the
+ * type's entity card (description + special action) with its special NPC as an
+ * NpcInset in the expand slot. Keepsake/Motto persist through the type NPC's
+ * SRD freeform choices into bayChoices keyed by the type ref; structured
+ * name/HP/description persist into the `typeNpc` field.
+ *
+ * Covers: type slab presence, the special NPC, the Augmented edge
+ * (hitPoints:0 → no HP block), and untyped legacy crawlers (no slab, no crash).
+ *
+ * Uses a patched Crawlers.all + the store-injection seam. NO mock.module().
+ */
+
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+
+import { CrawlerSheet } from '../CrawlerSheet'
+import type { Crawler } from '../../../lib/schemas/crawler'
+import type { useEntityStore } from '../../../stores/entityStore'
+
+afterEach(() => {
+  cleanup()
+})
+
+// ---------------------------------------------------------------------------
+// Patched crawler-type catalog
+// ---------------------------------------------------------------------------
+
+const BATTLE_REF = 'battle-type'
+const BATTLE_KEEPSAKE_ID = 'battle-keepsake-1'
+const BATTLE_MOTTO_ID = 'battle-motto-1'
+
+const AUGMENTED_REF = 'augmented-type'
+
+const MOCK_TYPES = [
+  {
+    id: BATTLE_REF,
+    name: 'Battle',
+    schemaName: 'crawlers',
+    actions: ['Improved Armour and Armaments'],
+    content: [{ type: 'paragraph', value: 'Bristles with armour and armaments.' }],
+    npc: {
+      position: 'Grizzled Veteran',
+      hitPoints: 10,
+      choices: [
+        { id: 'battle-name-1', name: 'Name', choiceType: 'freeform' },
+        { id: BATTLE_KEEPSAKE_ID, name: 'Keepsake', choiceType: 'freeform' },
+        { id: BATTLE_MOTTO_ID, name: 'Motto', choiceType: 'freeform' },
+      ],
+    },
+  },
+  {
+    id: AUGMENTED_REF,
+    name: 'Augmented',
+    schemaName: 'crawlers',
+    actions: ['Crawler Wide Augments'],
+    content: [{ type: 'paragraph', value: 'Nearly everyone is augmented.' }],
+    npc: {
+      position: 'Union Crawler A.I.',
+      hitPoints: 0,
+      choices: [
+        { id: 'aug-name-1', name: 'Name', choiceType: 'freeform' },
+        { id: 'aug-desc-1', name: 'Description', choiceType: 'freeform' },
+      ],
+    },
+  },
+]
+
+async function patchCrawlers(): Promise<() => void> {
+  const { SalvageUnionReference } = await import('salvageunion-reference')
+  const original = SalvageUnionReference.Crawlers.all.bind(SalvageUnionReference.Crawlers)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  SalvageUnionReference.Crawlers.all = mock(() => MOCK_TYPES as any)
+  return () => {
+    SalvageUnionReference.Crawlers.all = original
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Store stub
+// ---------------------------------------------------------------------------
+
+function makeStubStore(crawler: Crawler, update?: ReturnType<typeof mock>): typeof useEntityStore {
+  const updateMock = update ?? mock(async () => crawler)
+  const storeState = {
+    pilots: [],
+    mechs: [],
+    crawlers: [crawler],
+    softLinks: [],
+    hydrated: { pilots: false, mechs: false, crawlers: true, softLinks: false },
+    hydrate: mock(async () => {}),
+    list: mock(() => [crawler]),
+    get: mock((_t: string, id: string) => (id === crawler.id ? crawler : null)),
+    create: mock(async () => crawler),
+    update: updateMock,
+    updateCrawlerBay: mock(async () => crawler),
+    delete: mock(async () => {}),
+  }
+  return (() => storeState) as unknown as typeof useEntityStore
+}
+
+function makeCrawler(overrides?: Partial<Crawler>): Crawler {
+  return {
+    id: 'crawler-type-1',
+    schemaVersion: 1,
+    name: 'War Wagon',
+    techLevel: 'tech-2',
+    systems: [],
+    currentSP: 20,
+    crawlerBays: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CrawlerSheet — Crawler Type slab', () => {
+  let restore: () => void
+  afterEach(() => {
+    restore?.()
+  })
+
+  test('renders the type card (description + special action) and its special NPC', async () => {
+    restore = await patchCrawlers()
+    const crawler = makeCrawler({ type: BATTLE_REF, typeNpc: { npcName: 'Vex', npcCurrentHP: 8 } })
+    render(<CrawlerSheet crawler={crawler} store={makeStubStore(crawler)} />)
+
+    expect(screen.getByText('Crawler Type')).toBeTruthy()
+    expect(screen.getByText('Improved Armour and Armaments')).toBeTruthy()
+
+    const inset = screen.getByLabelText('Battle crew lead')
+    expect(within(inset).getByText('Vex')).toBeTruthy()
+    expect(within(inset).getByText('Grizzled Veteran')).toBeTruthy()
+  })
+
+  test('renders the type NPC Keepsake/Motto from bayChoices keyed by the type ref', async () => {
+    restore = await patchCrawlers()
+    const crawler = makeCrawler({
+      type: BATTLE_REF,
+      typeNpc: { npcName: 'Vex' },
+      bayChoices: {
+        [BATTLE_REF]: { [BATTLE_KEEPSAKE_ID]: ['A dog tag'], [BATTLE_MOTTO_ID]: ['No retreat'] },
+      },
+    })
+    render(<CrawlerSheet crawler={crawler} store={makeStubStore(crawler)} />)
+
+    const inset = screen.getByLabelText('Battle crew lead')
+    expect(within(inset).getByText('A dog tag')).toBeTruthy()
+    expect(within(inset).getByText('No retreat')).toBeTruthy()
+  })
+
+  test('editing the type NPC motto persists into bayChoices via store.update', async () => {
+    restore = await patchCrawlers()
+    const update = mock(async () => makeCrawler())
+    const crawler = makeCrawler({ type: BATTLE_REF, typeNpc: { npcName: 'Vex' } })
+    render(<CrawlerSheet crawler={crawler} store={makeStubStore(crawler, update)} />)
+
+    const field = screen.getByLabelText('Edit Battle crew motto')
+    await act(async () => {
+      fireEvent.click(field)
+    })
+    const input = screen.getByLabelText('Edit Battle crew motto')
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'No retreat' } })
+      fireEvent.blur(input)
+    })
+
+    expect(update).toHaveBeenCalledWith('crawler', crawler.id, {
+      bayChoices: { [BATTLE_REF]: { [BATTLE_MOTTO_ID]: ['No retreat'] } },
+    })
+  })
+
+  test('Augmented edge: hitPoints:0 NPC renders no HP block', async () => {
+    restore = await patchCrawlers()
+    const crawler = makeCrawler({ type: AUGMENTED_REF, typeNpc: { npcName: 'Oracle' } })
+    render(<CrawlerSheet crawler={crawler} store={makeStubStore(crawler)} />)
+
+    const inset = screen.getByLabelText('Augmented crew lead')
+    expect(within(inset).getByText('Oracle')).toBeTruthy()
+    // No HP pips when maxHp is 0.
+    expect(inset.querySelectorAll('[data-pip]').length).toBe(0)
+    // Augmented's A.I. carries no Keepsake/Motto choice.
+    expect(screen.queryByLabelText('Edit Augmented crew keepsake')).toBeNull()
+    expect(screen.queryByLabelText('Edit Augmented crew motto')).toBeNull()
+  })
+
+  test('untyped legacy crawler: no Crawler Type slab, no crash', async () => {
+    restore = await patchCrawlers()
+    const crawler = makeCrawler() // no `type`
+    render(<CrawlerSheet crawler={crawler} store={makeStubStore(crawler)} />)
+
+    expect(screen.queryByText('Crawler Type')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Editable tech level
+// ---------------------------------------------------------------------------
+
+describe('CrawlerSheet — editable tech level', () => {
+  test('clicking a tech-level button writes techLevel via store.update', async () => {
+    const update = mock(async () => makeCrawler())
+    const crawler = makeCrawler({ techLevel: 'tech-2' })
+    render(<CrawlerSheet crawler={crawler} store={makeStubStore(crawler, update)} />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Set tech level 4'))
+    })
+    expect(update).toHaveBeenCalledWith('crawler', crawler.id, { techLevel: 'tech-4' })
+  })
+
+  test('readOnly renders static tech-level text, no buttons', async () => {
+    const update = mock(async () => makeCrawler())
+    const crawler = makeCrawler({ techLevel: 'tech-3' })
+    render(<CrawlerSheet crawler={crawler} store={makeStubStore(crawler, update)} readOnly />)
+
+    expect(screen.getByText('Tech Level 3')).toBeTruthy()
+    expect(screen.queryByLabelText('Set tech level 4')).toBeNull()
+    expect(update).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Schema legacy tolerance
+// ---------------------------------------------------------------------------
+
+describe('CrawlerSchema — type/typeNpc legacy tolerance', () => {
+  test('a legacy crawler (no type/typeNpc) still validates', async () => {
+    const { CrawlerSchema } = await import('../../../lib/schemas/crawler')
+    const legacy = makeCrawler({ techLevel: 'tech-3' })
+    const result = CrawlerSchema.safeParse(legacy)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.type).toBeUndefined()
+      expect(result.data.typeNpc).toBeUndefined()
+    }
+  })
+
+  test('round-trips type + typeNpc when present', async () => {
+    const { CrawlerSchema } = await import('../../../lib/schemas/crawler')
+    const typed = makeCrawler({
+      type: BATTLE_REF,
+      typeNpc: { npcName: 'Vex', npcCurrentHP: 8, condition: 'intact' },
+    })
+    const result = CrawlerSchema.safeParse(typed)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.type).toBe(BATTLE_REF)
+      expect(result.data.typeNpc).toEqual({ npcName: 'Vex', npcCurrentHP: 8, condition: 'intact' })
+    }
+  })
+})

--- a/apps/in-the-union-now/src/lib/crawlerRefs.ts
+++ b/apps/in-the-union-now/src/lib/crawlerRefs.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared crawler reference-data lookups.
+ *
+ * The crawler wizard (lib/wizard/crawlerFormState.ts) and the live sheet
+ * (components/sheet/CrawlerSheet.tsx) both need to resolve a stored crawler
+ * type / bay ref (id OR name) to its SRD entity, and to find an NPC's freeform
+ * choice by name (Keepsake / Motto). These helpers are the single source of
+ * truth so both surfaces stay in lockstep.
+ *
+ * All lookups are id-or-name and salvage-tolerant: a missing catalog (e.g.
+ * reference data not yet preloaded) resolves to null rather than throwing.
+ */
+
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+/** A freeform/permanent NPC choice (its id + display name). */
+export type ResolvedNpcChoice = { id: string; name: string }
+
+/** The embedded NPC of a crawler type or bay. */
+export type ResolvedNpc = {
+  position?: string
+  hitPoints?: number
+  choices?: ReadonlyArray<ResolvedNpcChoice>
+}
+
+/** A resolved crawler type or bay entity. */
+type ResolvedCrawlerEntity = { id: string; name: string; npc?: ResolvedNpc }
+
+/** Resolve a stored crawler-type ref (id or name) to its SRD entity. */
+export function resolveCrawlerType(ref: string): ResolvedCrawlerEntity | null {
+  try {
+    const all =
+      SalvageUnionReference.Crawlers.all() as unknown as ReadonlyArray<ResolvedCrawlerEntity>
+    return all.find((c) => c.id === ref || c.name === ref) ?? null
+  } catch {
+    return null
+  }
+}
+
+/** Resolve a stored crawler-bay ref (id or name) to its SRD entity. */
+export function resolveCrawlerBay(ref: string): ResolvedCrawlerEntity | null {
+  try {
+    const all =
+      SalvageUnionReference.CrawlerBays.all() as unknown as ReadonlyArray<ResolvedCrawlerEntity>
+    return all.find((b) => b.id === ref || b.name === ref) ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Find an NPC's freeform choice by its SRD name (e.g. 'Keepsake', 'Motto').
+ * Returns the choice (id + name) or undefined when the NPC has no such choice
+ * — Augmented's A.I. NPC, for instance, carries neither Keepsake nor Motto.
+ */
+export function findNpcChoiceByName(
+  npc: ResolvedNpc | undefined,
+  name: string
+): ResolvedNpcChoice | undefined {
+  return npc?.choices?.find((c) => c.name === name)
+}

--- a/apps/in-the-union-now/src/lib/schemas/__tests__/crawler.test.ts
+++ b/apps/in-the-union-now/src/lib/schemas/__tests__/crawler.test.ts
@@ -69,6 +69,46 @@ describe('CrawlerSchema', () => {
     })
   })
 
+  test('happy path: type + typeNpc are optional (legacy records load)', () => {
+    const result = CrawlerSchema.parse(validCrawler)
+    expect(result.type).toBeUndefined()
+    expect(result.typeNpc).toBeUndefined()
+  })
+
+  test('happy path: round-trips a chosen type + its special NPC state', () => {
+    const result = CrawlerSchema.parse({
+      ...validCrawler,
+      type: 'battle-type-id',
+      typeNpc: {
+        npcName: 'Vex',
+        npcCurrentHP: 8,
+        npcDescription: 'A scarred veteran.',
+        npcFacts: ['Owes a debt'],
+        condition: 'damaged',
+      },
+    })
+    expect(result.type).toBe('battle-type-id')
+    expect(result.typeNpc).toEqual({
+      npcName: 'Vex',
+      npcCurrentHP: 8,
+      npcDescription: 'A scarred veteran.',
+      npcFacts: ['Owes a debt'],
+      condition: 'damaged',
+    })
+  })
+
+  test('happy path: legacy crawler with no type and a high tech level validates', () => {
+    const result = CrawlerSchema.parse({ ...validCrawler, techLevel: 'tech-5' })
+    expect(result.techLevel).toBe('tech-5')
+    expect(result.type).toBeUndefined()
+  })
+
+  test('rejects unknown fields inside typeNpc (strict)', () => {
+    expect(() =>
+      CrawlerSchema.parse({ ...validCrawler, typeNpc: { npcName: 'Vex', bogus: 'nope' } })
+    ).toThrow()
+  })
+
   test('rejects missing required field: name', () => {
     expect(() => CrawlerSchema.parse(omit(validCrawler, 'name'))).toThrow()
   })

--- a/apps/in-the-union-now/src/lib/schemas/crawler.ts
+++ b/apps/in-the-union-now/src/lib/schemas/crawler.ts
@@ -21,6 +21,40 @@ export const ScrapPoolSchema = z
 export type ScrapPool = z.infer<typeof ScrapPoolSchema>
 
 /**
+ * Per-NPC live state shared by crawler-bay crew leads and the crawler-type's
+ * special NPC (rules C11). Extracted from the inline `crawlerBays` entry so the
+ * type NPC (`typeNpc`) reuses the same shape. The NPC's freeform identity
+ * fields (Keepsake/Motto) persist in the crawler's `bayChoices` map, NOT here —
+ * this schema holds only the structured live-play state.
+ */
+export const CrawlerNpcStateSchema = z
+  .object({
+    /** Freeform name the player gave this NPC. */
+    npcName: z.string().optional(),
+    /** NPC's current HP (max from the SRD entity's `npc.hitPoints`). */
+    npcCurrentHP: z.number().int().min(0).optional(),
+    /**
+     * Player-editable freeform description of the NPC (appearance, personality,
+     * etc.). Distinct from the SRD entity's own rules text (`content`), which is
+     * read-only and resolved from the reference entity.
+     */
+    npcDescription: z.string().optional(),
+    /**
+     * Player-decided facts about the NPC — a freeform list of short strings the
+     * table has established in play (add/remove). Read sites treat a missing
+     * value as an empty list.
+     */
+    npcFacts: z.array(z.string()).optional(),
+    /**
+     * NPC condition (rules C8). Intact/Damaged ONLY — never Destroyed. Absent
+     * reads as 'intact'.
+     */
+    condition: z.enum(['intact', 'damaged']).optional(),
+  })
+  .strict()
+export type CrawlerNpcState = z.infer<typeof CrawlerNpcStateSchema>
+
+/**
  * Crawler tech levels are I–VI per the Salvage Union ruleset.
  */
 export const CrawlerSchema = z
@@ -30,6 +64,23 @@ export const CrawlerSchema = z
     name: z.string().min(1),
     /** Tech level (I–VI) expressed as a string slug, e.g. "tech-1" */
     techLevel: z.string(),
+    /**
+     * Chosen crawler-type ref (SRD `id` of the Augmented/Battle/Engineering/
+     * Exploratory/Trade Caravan type; resolve by id-or-name like the bay refs).
+     *
+     * Additive-optional — no DB migration, no `schemaVersion` bump. Legacy
+     * crawlers persisted before this feature (no `type`, any techLevel) validate
+     * unchanged; a missing value reads as an untyped crawler.
+     */
+    type: z.string().optional(),
+    /**
+     * Live state for the crawler-type's special NPC (the Battle type's Grizzled
+     * Veteran, etc.). Same shape as a bay's embedded NPC state. The freeform
+     * Keepsake/Motto persist in `bayChoices` keyed by the type ref.
+     *
+     * Additive-optional — absent on legacy / untyped crawlers.
+     */
+    typeNpc: CrawlerNpcStateSchema.optional(),
     /**
      * Installed SRD crawler bays (Command Bay, Mech Bay, Storage Bay, …). The
      * official crawler sheets pre-print all bays as fixed sections, so every
@@ -47,33 +98,9 @@ export const CrawlerSchema = z
      */
     crawlerBays: z
       .array(
-        z.object({
+        CrawlerNpcStateSchema.extend({
           /** SRD crawler-bay id (or name) this entry installs. */
           bayRef: z.string(),
-          /** Freeform name the player gave the bay's embedded NPC. */
-          npcName: z.string().optional(),
-          /** NPC's current HP (max from the SRD bay's `npc.hitPoints`, 4). */
-          npcCurrentHP: z.number().int().min(0).optional(),
-          /**
-           * Player-editable freeform description of the bay's embedded NPC
-           * (appearance, personality, etc.). Distinct from the SRD bay's own
-           * rules text (`content`), which is read-only and resolved from the
-           * reference entity. Optional — additive field, no DB migration needed.
-           */
-          npcDescription: z.string().optional(),
-          /**
-           * Player-decided facts about the bay's NPC — a freeform list of short
-           * strings the table has established in play (add/remove). Optional;
-           * read sites treat a missing value as an empty list.
-           */
-          npcFacts: z.array(z.string()).optional(),
-          /**
-           * Bay condition (rules C8). Bays are Intact/Damaged ONLY — never
-           * Destroyed (unlike mech items). Damaged disables the bay's
-           * function; repair costs 5 Scrap of crawler TL or higher. Absent
-           * reads as 'intact'.
-           */
-          condition: z.enum(['intact', 'damaged']).optional(),
         })
       )
       .optional(),

--- a/apps/in-the-union-now/src/lib/wizard/__tests__/crawlerFormState.test.ts
+++ b/apps/in-the-union-now/src/lib/wizard/__tests__/crawlerFormState.test.ts
@@ -5,17 +5,29 @@
  * fields — an edit save must never clobber live-play state (bays + NPC HP,
  * bayChoices, currentSP, cargoLots, maxSpModifier, workspaceId).
  */
-import { describe, expect, it } from 'bun:test'
+import { beforeAll, describe, expect, it } from 'bun:test'
+import { SalvageUnionReference } from 'salvageunion-reference'
 import type { Crawler } from '../../schemas/crawler'
 import { CrawlerSchema } from '../../schemas/crawler'
 import {
   EMPTY_CRAWLER_FORM_STATE,
   EMPTY_SCRAP_POOL,
+  crawlerFormCrewToPatches,
   crawlerFormToCreateInput,
   crawlerFormToUpdatePatch,
   crawlerToFormState,
+  seedDefaultCrawlerBays,
   toScrapPoolPatch,
 } from '../crawlerFormState'
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+// Real Battle crawler type + its special NPC's freeform choice ids.
+const BATTLE_TYPE_ID = '3d1d9f79-9c56-43fa-a4c9-6dfe10b9aac9'
+const BATTLE_KEEPSAKE_ID = '94e8204d-652c-47f4-93ca-271cebb16459'
+const BATTLE_MOTTO_ID = 'b103d074-5b3c-40af-99ee-805c92814199'
 
 const storedCrawler: Crawler = {
   id: 'c-1',
@@ -49,10 +61,17 @@ describe('crawlerToFormState', () => {
     expect(form).toEqual({
       name: 'The Wandering Kettle',
       techLevel: 3,
+      type: null,
       systems: ['system-drill'],
+      crew: {},
       scrapPool: { ...EMPTY_SCRAP_POOL, tl3: 5 },
       upgradePool: 18,
     })
+  })
+
+  it('preserves a higher stored tech level (edit does NOT force 1)', () => {
+    const form = crawlerToFormState(storedCrawler)
+    expect(form.techLevel).toBe(3)
   })
 
   it('defaults absent scrapPool/upgradePool to zeros', () => {
@@ -88,6 +107,7 @@ describe('toScrapPoolPatch', () => {
 describe('crawlerFormToUpdatePatch', () => {
   it('contains ONLY wizard-owned fields — live-play state is never clobbered', () => {
     const patch = crawlerFormToUpdatePatch(crawlerToFormState(storedCrawler))
+    // No type chosen on this fixture → patch omits `type`.
     expect(Object.keys(patch).sort()).toEqual([
       'name',
       'scrapPool',
@@ -99,8 +119,29 @@ describe('crawlerFormToUpdatePatch', () => {
     expect(patch.scrapPool).toEqual({ tl3: 5 })
   })
 
+  it('adds the chosen type to the patch (and nothing else from crew/NPC state)', () => {
+    const patch = crawlerFormToUpdatePatch({
+      ...EMPTY_CRAWLER_FORM_STATE,
+      name: 'Bay Wagon',
+      techLevel: 1,
+      type: 'battle-type-id',
+      crew: { 'some-bay': { name: 'Vex', keepsake: 'A cog' } },
+    })
+    expect(Object.keys(patch).sort()).toEqual([
+      'name',
+      'scrapPool',
+      'systems',
+      'techLevel',
+      'type',
+      'upgradePool',
+    ])
+    expect(patch.type).toBe('battle-type-id')
+  })
+
   it('throws when no tech level is chosen', () => {
-    expect(() => crawlerFormToUpdatePatch(EMPTY_CRAWLER_FORM_STATE)).toThrow(/tech level/i)
+    expect(() =>
+      crawlerFormToUpdatePatch({ ...EMPTY_CRAWLER_FORM_STATE, techLevel: null })
+    ).toThrow(/tech level/i)
   })
 
   it('trims the name', () => {
@@ -117,9 +158,9 @@ describe('crawlerFormToCreateInput', () => {
   it('builds a CrawlerSchema-valid payload with seeded bays and full SP', () => {
     const input = crawlerFormToCreateInput(
       {
+        ...EMPTY_CRAWLER_FORM_STATE,
         name: 'Bay Wagon',
         techLevel: 1,
-        systems: [],
         scrapPool: { ...EMPTY_SCRAP_POOL, tl1: 3 },
         upgradePool: 12,
       },
@@ -150,5 +191,109 @@ describe('crawlerFormToCreateInput', () => {
       { crawlerBays: [] }
     )
     expect('currentSP' in input).toBe(false)
+  })
+
+  it('folds the crew + type NPC into bays, bayChoices and typeNpc', () => {
+    const commandBay = SalvageUnionReference.CrawlerBays.find((b) => b.name === 'Command Bay')!
+    const battle = SalvageUnionReference.Crawlers.find((c) => c.id === BATTLE_TYPE_ID)!
+    const input = crawlerFormToCreateInput(
+      {
+        ...EMPTY_CRAWLER_FORM_STATE,
+        name: 'War Wagon',
+        techLevel: 1,
+        type: BATTLE_TYPE_ID,
+        crew: {
+          [commandBay.id]: { name: 'Maddox', description: 'Stern', keepsake: 'A medal' },
+          [BATTLE_TYPE_ID]: { name: 'Vex', keepsake: 'A dog tag', motto: 'No retreat' },
+        },
+      },
+      { maxSP: 20, crawlerBays: seedDefaultCrawlerBays() }
+    )
+
+    // Bay structured state folded in; Keepsake routed to bayChoices.
+    const seededCommand = input.crawlerBays.find((e) => e.bayRef === commandBay.id)
+    expect(seededCommand?.npcName).toBe('Maddox')
+    expect(seededCommand?.npcDescription).toBe('Stern')
+    const commandKeepsakeId = commandBay.npc!.choices!.find((c) => c.name === 'Keepsake')!.id
+    expect(input.bayChoices?.[commandBay.id]?.[commandKeepsakeId]).toEqual(['A medal'])
+
+    // Type NPC: structured name + HP from the SRD npc, Keepsake/Motto in bayChoices.
+    expect(input.typeNpc?.npcName).toBe('Vex')
+    expect(input.typeNpc?.npcCurrentHP).toBe(battle.npc!.hitPoints)
+    expect(input.bayChoices?.[BATTLE_TYPE_ID]?.[BATTLE_KEEPSAKE_ID]).toEqual(['A dog tag'])
+    expect(input.bayChoices?.[BATTLE_TYPE_ID]?.[BATTLE_MOTTO_ID]).toEqual(['No retreat'])
+
+    const parsed = CrawlerSchema.safeParse({
+      ...input,
+      id: 'temp',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    })
+    expect(parsed.success).toBe(true)
+  })
+})
+
+describe('crawlerToFormState — type + crew hydration (edit mode)', () => {
+  it('hydrates type, crew name/desc and Keepsake/Motto from storage', () => {
+    const commandBay = SalvageUnionReference.CrawlerBays.find((b) => b.name === 'Command Bay')!
+    const commandKeepsakeId = commandBay.npc!.choices!.find((c) => c.name === 'Keepsake')!.id
+    const crawler: Crawler = {
+      id: 'c-edit',
+      schemaVersion: 1,
+      name: 'War Wagon',
+      techLevel: 'tech-3',
+      type: BATTLE_TYPE_ID,
+      systems: [],
+      crawlerBays: [{ bayRef: commandBay.id, npcName: 'Maddox', npcDescription: 'Stern' }],
+      typeNpc: { npcName: 'Vex', npcCurrentHP: 8 },
+      bayChoices: {
+        [commandBay.id]: { [commandKeepsakeId]: ['A medal'] },
+        [BATTLE_TYPE_ID]: {
+          [BATTLE_KEEPSAKE_ID]: ['A dog tag'],
+          [BATTLE_MOTTO_ID]: ['No retreat'],
+        },
+      },
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    }
+    const form = crawlerToFormState(crawler)
+    expect(form.type).toBe(BATTLE_TYPE_ID)
+    expect(form.techLevel).toBe(3)
+    expect(form.crew[commandBay.id]).toEqual({
+      name: 'Maddox',
+      description: 'Stern',
+      keepsake: 'A medal',
+      motto: undefined,
+    })
+    expect(form.crew[BATTLE_TYPE_ID]).toEqual({
+      name: 'Vex',
+      description: undefined,
+      keepsake: 'A dog tag',
+      motto: 'No retreat',
+    })
+  })
+})
+
+describe('crawlerFormCrewToPatches', () => {
+  it('splits crew into bay patches, bayChoices and a typeNpc patch', () => {
+    const commandBay = SalvageUnionReference.CrawlerBays.find((b) => b.name === 'Command Bay')!
+    const commandKeepsakeId = commandBay.npc!.choices!.find((c) => c.name === 'Keepsake')!.id
+    const patches = crawlerFormCrewToPatches({
+      ...EMPTY_CRAWLER_FORM_STATE,
+      name: 'War Wagon',
+      techLevel: 1,
+      type: BATTLE_TYPE_ID,
+      crew: {
+        [commandBay.id]: { name: 'Maddox', keepsake: 'A medal' },
+        [BATTLE_TYPE_ID]: { name: 'Vex', motto: 'No retreat' },
+      },
+    })
+    // Bay patch carries structured state only; Keepsake goes to bayChoices.
+    expect(patches.bayPatches[commandBay.id]).toEqual({ npcName: 'Maddox' })
+    expect(patches.bayChoices[commandBay.id]?.[commandKeepsakeId]).toEqual(['A medal'])
+    // The type ref produces a typeNpc patch (NOT a bay patch) + bayChoices.
+    expect(patches.bayPatches[BATTLE_TYPE_ID]).toBeUndefined()
+    expect(patches.typeNpc).toEqual({ npcName: 'Vex' })
+    expect(patches.bayChoices[BATTLE_TYPE_ID]?.[BATTLE_MOTTO_ID]).toEqual(['No retreat'])
   })
 })

--- a/apps/in-the-union-now/src/lib/wizard/crawlerFormState.ts
+++ b/apps/in-the-union-now/src/lib/wizard/crawlerFormState.ts
@@ -17,10 +17,46 @@
  */
 
 import { SalvageUnionReference } from 'salvageunion-reference'
-import type { Crawler, ScrapPool } from '../schemas/crawler'
+import type { SURefCrawler } from 'salvageunion-reference'
+import type { Crawler, CrawlerNpcState, ScrapPool } from '../schemas/crawler'
 import { parseCrawlerTechLevel } from '../crawlerLevel'
+import { findNpcChoiceByName, resolveCrawlerBay, resolveCrawlerType } from '../crawlerRefs'
+import type { ResolvedNpc } from '../crawlerRefs'
+import type { ChoiceSelections } from 'suref-react'
 
 type CrawlerBayEntry = NonNullable<Crawler['crawlerBays']>[number]
+
+/** Freeform crew/NPC details captured per NPC in the wizard's Crew step. */
+export type CrewNpcForm = {
+  name?: string
+  description?: string
+  keepsake?: string
+  motto?: string
+}
+
+/** First value of a single-element choice-selection array, or undefined. */
+function firstSelection(
+  selections: ChoiceSelections | undefined,
+  choiceId: string | undefined
+): string | undefined {
+  if (!selections || !choiceId) return undefined
+  const v = selections[choiceId]?.[0]
+  return v && v.length > 0 ? v : undefined
+}
+
+/** Read a crew form's structured Name/Description + Keepsake/Motto from storage. */
+function crewFormFromStorage(
+  npc: ResolvedNpc | undefined,
+  npcState: CrawlerNpcState | undefined,
+  selections: ChoiceSelections | undefined
+): CrewNpcForm {
+  return {
+    name: npcState?.npcName,
+    description: npcState?.npcDescription,
+    keepsake: firstSelection(selections, findNpcChoiceByName(npc, 'Keepsake')?.id),
+    motto: firstSelection(selections, findNpcChoiceByName(npc, 'Motto')?.id),
+  }
+}
 
 /** Scrap-pool form shape: every TL bucket present (zeros allowed). */
 export type ScrapPoolForm = Required<ScrapPool>
@@ -37,10 +73,17 @@ export const EMPTY_SCRAP_POOL: ScrapPoolForm = {
 /** Shape of form state carried through the crawler wizard. */
 export type CrawlerWizardFormState = {
   name: string
-  /** Numeric tech level 1–6; null until chosen. */
+  /** Numeric tech level 1–6; new crawlers fix this at 1, edit preserves stored. */
   techLevel: number | null
+  /** Chosen crawler-type ref (SRD id); null until chosen. */
+  type: string | null
   /** Installed system ids. */
   systems: string[]
+  /**
+   * Freeform crew/NPC details, keyed by the bay ref (and the type ref for the
+   * crawler-type's special NPC). Captured in the wizard's Crew step.
+   */
+  crew: Record<string, CrewNpcForm>
   /** Shared party scrap pool, TL-bucketed (rules C5). */
   scrapPool: ScrapPoolForm
   /** Upgrade Pool progress (rules C4). */
@@ -49,18 +92,45 @@ export type CrawlerWizardFormState = {
 
 export const EMPTY_CRAWLER_FORM_STATE: CrawlerWizardFormState = {
   name: '',
-  techLevel: null,
+  // New crawlers always start at Tech Level 1 (Hamlet); upgraded on the sheet.
+  techLevel: 1,
+  type: null,
   systems: [],
+  crew: {},
   scrapPool: { ...EMPTY_SCRAP_POOL },
   upgradePool: 0,
 }
 
 /** Maps a stored crawler onto wizard initial state (edit-mode prefill). */
 export function crawlerToFormState(crawler: Crawler): CrawlerWizardFormState {
+  const crew: Record<string, CrewNpcForm> = {}
+
+  // Hydrate each base bay's crew form (structured name/desc + Keepsake/Motto).
+  for (const entry of crawler.crawlerBays ?? []) {
+    const bay = resolveCrawlerBay(entry.bayRef)
+    if (!bay?.npc) continue
+    crew[entry.bayRef] = crewFormFromStorage(bay.npc, entry, crawler.bayChoices?.[entry.bayRef])
+  }
+
+  // Hydrate the crawler-type's special NPC, keyed by the type ref.
+  if (crawler.type) {
+    const typeEntity = resolveCrawlerType(crawler.type)
+    if (typeEntity?.npc) {
+      crew[crawler.type] = crewFormFromStorage(
+        typeEntity.npc,
+        crawler.typeNpc,
+        crawler.bayChoices?.[crawler.type]
+      )
+    }
+  }
+
   return {
     name: crawler.name,
+    // Keep the stored tech level on edit — only create fixes it at 1.
     techLevel: parseCrawlerTechLevel(crawler.techLevel) ?? null,
+    type: crawler.type ?? null,
     systems: [...crawler.systems],
+    crew,
     scrapPool: { ...EMPTY_SCRAP_POOL, ...(crawler.scrapPool ?? {}) },
     upgradePool: crawler.upgradePool ?? 0,
   }
@@ -81,7 +151,7 @@ export function toScrapPoolPatch(pool: ScrapPoolForm): ScrapPool {
 /** Wizard-owned crawler fields — the only fields an edit save may touch. */
 type CrawlerWizardPatch = Pick<
   Crawler,
-  'name' | 'techLevel' | 'systems' | 'scrapPool' | 'upgradePool'
+  'name' | 'techLevel' | 'type' | 'systems' | 'scrapPool' | 'upgradePool'
 >
 
 export function crawlerFormToUpdatePatch(form: CrawlerWizardFormState): CrawlerWizardPatch {
@@ -91,6 +161,10 @@ export function crawlerFormToUpdatePatch(form: CrawlerWizardFormState): CrawlerW
   return {
     name: form.name.trim(),
     techLevel: `tech-${form.techLevel}`,
+    // The chosen crawler type — additive wizard-owned field. Crew/NPC edits do
+    // NOT go through this patch (they route through crawlerFormCrewToPatches so
+    // live HP/condition survive an edit save).
+    ...(form.type !== null ? { type: form.type } : {}),
     systems: form.systems,
     // Always present in the patch so buckets can be zeroed out on edit.
     scrapPool: toScrapPoolPatch(form.scrapPool),
@@ -123,9 +197,50 @@ export function seedDefaultCrawlerBays(): CrawlerBayEntry[] {
   })
 }
 
+/** Structured npcName/npcDescription patch from a crew form (only set keys). */
+function npcStatePatch(crew: CrewNpcForm | undefined): CrawlerNpcState {
+  const out: CrawlerNpcState = {}
+  if (crew?.name && crew.name.trim().length > 0) out.npcName = crew.name.trim()
+  if (crew?.description && crew.description.trim().length > 0) {
+    out.npcDescription = crew.description.trim()
+  }
+  return out
+}
+
+/** Build the `bayChoices` entry (Keepsake/Motto) for one NPC's crew form. */
+function npcChoiceSelections(
+  npc: ResolvedNpc | undefined,
+  crew: CrewNpcForm | undefined
+): ChoiceSelections | undefined {
+  const keepsakeId = findNpcChoiceByName(npc, 'Keepsake')?.id
+  const mottoId = findNpcChoiceByName(npc, 'Motto')?.id
+  const out: ChoiceSelections = {}
+  if (keepsakeId && crew?.keepsake && crew.keepsake.trim().length > 0) {
+    out[keepsakeId] = [crew.keepsake.trim()]
+  }
+  if (mottoId && crew?.motto && crew.motto.trim().length > 0) {
+    out[mottoId] = [crew.motto.trim()]
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
+/**
+ * Default structured state for a crawler-type's special NPC: its max HP from
+ * the SRD `npc.hitPoints` (when present; Augmented's A.I. is 0 → absent). Used
+ * to RESET the type NPC when the wizard switches a crawler to a different type.
+ */
+export function defaultTypeNpcState(types: SURefCrawler[], typeRef: string): CrawlerNpcState {
+  const type = types.find((t) => t.id === typeRef || t.name === typeRef)
+  const maxHP = type?.npc?.hitPoints
+  // Mirror the create path: seed npcCurrentHP from the SRD hitPoints when the
+  // field is present (Augmented's A.I. is 0 → seeds 0, renders no HP block).
+  return typeof maxHP === 'number' ? { npcCurrentHP: maxHP } : {}
+}
+
 /**
  * Create payload for a fresh crawler: seeded SRD bay set, full SP for the
- * tech level, and the starting resources from the Identity step.
+ * tech level, the chosen type + its special NPC, the crew's structured/choice
+ * NPC details, and the starting resources from the Identity step.
  */
 export function crawlerFormToCreateInput(
   form: CrawlerWizardFormState,
@@ -136,10 +251,95 @@ export function crawlerFormToCreateInput(
     crawlerBays: CrawlerBayEntry[]
   }
 ) {
+  const bayChoices: Record<string, ChoiceSelections> = {}
+
+  // Fold each bay's crew form into the seeded entry's structured NPC state
+  // (name/description) plus a Keepsake/Motto bayChoices entry. Only fold for
+  // entries that resolve to a REAL bay — a stale/unknown ref is never written.
+  const crawlerBays = opts.crawlerBays.map((entry) => {
+    const crew = form.crew[entry.bayRef]
+    if (!crew) return entry
+    const bay = resolveCrawlerBay(entry.bayRef)
+    if (!bay) return entry
+    const selections = npcChoiceSelections(bay.npc, crew)
+    if (selections) bayChoices[entry.bayRef] = selections
+    return { ...entry, ...npcStatePatch(crew) }
+  })
+
+  // The crawler-type's special NPC: structured state in `typeNpc`, Keepsake/
+  // Motto in `bayChoices` keyed by the type ref.
+  let typeNpc: CrawlerNpcState | undefined
+  if (form.type) {
+    const typeEntity = resolveCrawlerType(form.type)
+    const crew = form.crew[form.type]
+    const npc = typeEntity?.npc
+    const state = npcStatePatch(crew)
+    const maxHP = npc?.hitPoints
+    typeNpc = {
+      ...state,
+      ...(typeof maxHP === 'number' ? { npcCurrentHP: maxHP } : {}),
+    }
+    if (Object.keys(typeNpc).length === 0) typeNpc = undefined
+    const selections = npcChoiceSelections(npc, crew)
+    if (selections) bayChoices[form.type] = selections
+  }
+
   return {
     schemaVersion: 1 as const,
     ...crawlerFormToUpdatePatch(form),
-    crawlerBays: opts.crawlerBays,
+    crawlerBays,
+    ...(typeNpc ? { typeNpc } : {}),
+    ...(Object.keys(bayChoices).length > 0 ? { bayChoices } : {}),
     ...(opts.maxSP !== undefined ? { currentSP: opts.maxSP } : {}),
   }
+}
+
+/**
+ * Crew edits applied on an edit-mode save. The returned patches route through
+ * targeted `updateCrawlerBay` calls + a single `bayChoices` merge + a `typeNpc`
+ * patch (mirroring how the sheet persists) so live HP/condition on bays and the
+ * type NPC are never clobbered by an edit pass.
+ */
+type CrawlerFormCrewPatches = {
+  /** Per-bay structured NPC state patches, keyed by bay ref. */
+  bayPatches: Record<string, CrawlerNpcState>
+  /** Merged Keepsake/Motto selections, keyed by bay ref (or type ref). */
+  bayChoices: Record<string, ChoiceSelections>
+  /** Structured state patch for the crawler-type's special NPC, if any. */
+  typeNpc?: CrawlerNpcState
+}
+
+export function crawlerFormCrewToPatches(form: CrawlerWizardFormState): CrawlerFormCrewPatches {
+  const bayPatches: Record<string, CrawlerNpcState> = {}
+  const bayChoices: Record<string, ChoiceSelections> = {}
+
+  for (const [ref, crew] of Object.entries(form.crew)) {
+    const isType = form.type !== null && ref === form.type
+    if (isType) {
+      // The type NPC's structured state is handled below (typeNpc); only its
+      // Keepsake/Motto selections route through bayChoices keyed by the type ref.
+      const selections = npcChoiceSelections(resolveCrawlerType(ref)?.npc, crew)
+      if (selections) bayChoices[ref] = selections
+      continue
+    }
+
+    // Guard: a non-type ref must resolve to a REAL bay before we write a bay
+    // patch or selections for it. A stale ref (e.g. a previously-chosen type id
+    // left in form.crew after switching type) is dropped, never written as a
+    // phantom bay entry.
+    const bay = resolveCrawlerBay(ref)
+    if (!bay) continue
+
+    const selections = npcChoiceSelections(bay.npc, crew)
+    if (selections) bayChoices[ref] = selections
+
+    bayPatches[ref] = npcStatePatch(crew)
+  }
+
+  let typeNpc: CrawlerNpcState | undefined
+  if (form.type && form.crew[form.type]) {
+    typeNpc = npcStatePatch(form.crew[form.type])
+  }
+
+  return { bayPatches, bayChoices, ...(typeNpc ? { typeNpc } : {}) }
 }


### PR DESCRIPTION
Reworks ITUN crawler creation around the crawler **type** and captures the crew up front.

## Changes

### Crawler step → select a TYPE (not tech level)
The step now lists the 5 crawler types (**Augmented, Battle, Engineering, Exploratory, Trade Caravan**) and the detail pane shows the selected type's entity — its description + special features (its action + special NPC) — **instead of listing every bay**. New crawlers fix tech level at **TL1 (Hamlet)**; it's upgraded later on the sheet.

### New "Crew" step
`Crawler → Systems → Crew → Identity → Review`. Lists the **10 base-bay NPCs** (Princeps, Greaser, Doc, Ace, …) plus the type's special NPC, each capturing the full SRD freeform set — **Name, Description, Keepsake, Motto**. The 4 expansion bays have no NPC and are excluded. (Augmented's NPC edge — `hitPoints: 0`, Name/Description only — is guarded.)

### Sheet
- Persisted **Crawler Type** slab: the type entity + its special NPC inset.
- Bay NPCs gain a **Motto** field (paralleling Keepsake).
- **Tech level is now editable on the live sheet** (1–6 stepper), recomputing SP/capacity. Read-only/snapshot renders static.

## Data model
Additive-optional schema: new `type` + `typeNpc` sharing a new `CrawlerNpcStateSchema` — **no `DB_VERSION` bump, no migration**. Legacy crawlers (no type, any tech level) validate unchanged and **keep their stored tech level on edit** (only create fixes TL1). Crew/NPC edits on save route through targeted `updateCrawlerBay` + a `bayChoices` merge + `typeNpc`, so live HP/condition are never clobbered.

## Testing
- `bun --filter in-the-union-now test` ✅ **886 pass**
- `bun run typecheck` ✅ (all packages) · `bun run lint` ✅ · `bun run knip` ✅
- New tests: `CrawlerCrewStep.test.tsx`, `CrawlerSheet-type.test.tsx`, schema legacy-tolerance; updated CrawlerBuilder/formState/bay-npc tests.

> **Visual review:** best eyeballed on the Netlify ITUN deploy-preview — create a crawler (pick Battle → see its features + Grizzled Veteran, no bay grid), fill some crew Mottos, create, and confirm the Crawler Type slab + editable TL on the sheet. Flag anything off and I'll adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)