### PR TITLE
chore: implement Now-bucket audit remediation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
-# Supabase Configuration
-VITE_SUPABASE_URL=your-project-url
-VITE_SUPABASE_ANON_KEY=your-anon-key
+# Root-level environment variables.
+#
+# ITUN (in-the-union-now) is local-first — it has no Supabase/auth backend and
+# needs no env vars to run. Per-app env (e.g. the Discord bot's DISCORD_TOKEN,
+# an optional SENTRY_DSN) lives in each app's own .env / .env.example.
 
-# Google Analytics Configuration
+# Google Analytics (optional — analytics is disabled when unset)
 VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX # Your Google Analytics 4 Measurement ID

--- a/README.md
+++ b/README.md
@@ -1,187 +1,98 @@
 # SURef Monorepo
 
-A Bun monorepo containing the SURef web application and the Salvage Union Reference package.
+A Bun monorepo of tools for **Salvage Union** (tabletop RPG): a static SRD
+reference site, a local-first character builder & game manager, a Discord dice
+bot, and two shared packages.
 
-> **Note**: For detailed documentation, see [docs/README.md](docs/README.md)
+> **Detailed documentation lives in [docs/README.md](docs/README.md)** — it maps
+> intent → the right doc (architecture, ADRs, per-package guides). Agent/build
+> guidance is in [CLAUDE.md](CLAUDE.md).
 
 ## Quick Start
 
-### First Time Setup
-
 ```bash
-# Install all dependencies (sets up workspace links)
+# Install all workspace dependencies
 bun install
 
-# Build the reference package (required for types)
+# Build the reference package (required before apps can resolve types)
 bun run build:package
-```
 
-### Daily Development
-
-```bash
-# Start development server (builds package and starts app)
-bun run dev
-
-# Or work on a specific package
-cd apps/suref-web
+# Start the reference site dev server (builds package, then serves suref-web)
 bun run dev
 ```
+
+Other dev servers: `bun run dev:itun` (character builder), `bun run dev:bot`
+(Discord bot).
 
 ## Structure
 
 ```
 .
 ├── apps/
-│   └── suref-web/              # Main web application
+│   ├── suref-web/              # Static SRD reference site (Astro 5 + React islands)
+│   ├── in-the-union-now/       # Character builder & game manager (React 19, local-first)
+│   └── discord-bot/            # Discord.js bot for rolling on SU tables
 ├── packages/
-│   └── salvageunion-reference/ # Salvage Union game data package
+│   ├── salvageunion-reference/ # Game-data ORM + schema-validated JSON dataset (built)
+│   └── suref-react/            # Shared React component library (no build step)
+├── docs/                       # Architecture docs, ADRs, audit backlog
 ├── package.json                # Root workspace configuration
 ├── .prettierrc.json            # Shared Prettier config
-├── eslint.config.base.js      # Shared ESLint base config
+├── eslint.config.base.js       # Shared ESLint base config
 └── tsconfig.base.json          # Shared TypeScript base config
 ```
 
+**Dependency graph:** `salvageunion-reference → suref-react → {suref-web,
+in-the-union-now}`; `discord-bot` is standalone. The reference package must be
+built (`bun run build:package`) before the apps can resolve its types.
+
 ## Common Commands
 
-### Development
-
 ```bash
-# Start dev server (builds package + starts app)
-bun run dev
+# Development
+bun run dev          # Reference site (suref-web)
+bun run dev:itun     # Character builder (in-the-union-now)
+bun run dev:bot      # Discord bot
 
-# Build package only (quick, skips tests/lint)
-bun run build:package:quick
+# Build
+bun run build            # Everything (package + all apps)
+bun run build:package    # Reference package only
 
-# Build package (full, includes tests/lint)
-bun run build:package
+# Quality (run across all workspaces)
+bun run lint
+bun run format        # bun run format:check to verify only
+bun run typecheck
+bun test
+bun run validate:all  # Data integrity: IDs, cross-refs, action refs
+bun run check:all     # Full CI suite (lint, format, typecheck, test, validate, knip)
 ```
 
-### Quality Checks
-
-```bash
-# Run all checks on all packages
-bun run lint:all
-bun run format:check:all
-bun run test:all
-bun run sanity:all
-
-# Run checks on specific package
-bun --filter suref-web lint
-bun --filter salvageunion-reference test
-```
-
-### Building
-
-```bash
-# Build everything (package + app)
-bun run build
-
-# Build specific package
-bun --filter salvageunion-reference build
-bun --filter suref-web build
-```
-
-## Workspace Scripts
-
-All root scripts use `bun --filter` to target specific packages. You can also run scripts directly:
-
-```bash
-# Run scripts in suref-web app
-bun --filter suref-web <script>
-
-# Run scripts in salvageunion-reference package
-bun --filter salvageunion-reference <script>
-
-# Run scripts in all packages
-bun --filter "*" <script>
-```
-
-### Available Root Scripts
-
-- `dev` - Start development server
-- `build` - Build package and app
-- `build:package` - Build reference package (full)
-- `build:package:quick` - Build reference package (quick, dev mode)
-- `lint` / `lint:all` - Lint suref-web / all packages
-- `format` / `format:all` - Format suref-web / all packages
-- `format:check` / `format:check:all` - Check formatting
-- `test` / `test:all` - Test suref-web / all packages
-- `typecheck` - Type check suref-web
-- `sanity` / `sanity:all` - Run lint, format, and typecheck
+All root scripts use `bun --filter` to target workspaces; you can also run a
+script in a single workspace directly, e.g. `bun --filter suref-web build` or
+`bun --filter salvageunion-reference test`.
 
 ## Making Changes to salvageunion-reference
 
-1. Edit files in `packages/salvageunion-reference/lib/` or `data/`
-2. Rebuild the package:
-   ```bash
-   bun run build:package:quick  # Quick rebuild (dev)
-   # or
-   bun run build:package        # Full rebuild (includes tests/lint)
-   ```
-3. Changes are immediately available to `suref-web` via workspace linking
+1. Edit Zod schemas in `packages/salvageunion-reference/lib/schemas/` or data
+   files in `data/`.
+2. Rebuild: `bun run build:package` (compiles TypeScript and regenerates
+   `schemas/*.schema.json` from the Zod sources).
+3. Changes are immediately available to consuming apps via workspace linking.
 
-**Note**: The package must be built for TypeScript types to resolve correctly.
+`schemas/*.schema.json` and `dist/` are generated — never edit them by hand.
 
-## Troubleshooting
+## Deployment
 
-### TypeScript can't find salvageunion-reference
+- **suref-web** and **in-the-union-now** → Netlify (config in each app's
+  `netlify.toml`). ITUN also serves the snapshot-sharing backend as Netlify
+  Functions — see [ADR-010](docs/adrs/ADR-010-snapshot-backend.md).
+- **discord-bot** → Render worker (Blueprint in `render.yaml`).
 
-**Solution**: Build the package first:
-```bash
-bun run build:package:quick
-```
+## Monorepo Conventions
 
-### Workspace not linking correctly
-
-**Solution**: Reinstall dependencies:
-```bash
-bun install
-```
-
-### Build fails with lint errors
-
-The package build includes linting. Fix lint errors or run quick build:
-```bash
-bun run build:package:quick  # Skips lint
-```
-
-### Dependencies not found
-
-**Solution**: Ensure you've run `bun install` from the root directory. Workspace dependencies are hoisted to root.
-
-## Apps
-
-### suref-web
-
-The main web application for viewing and exploring Salvage Union game data.
-
-- **Dynamic Schema Loading**: Automatically reads all schemas from the reference package
-- **Search**: Search items by name or description
-- **Filtering**: Filter data by any field with multiple values
-- **Sorting**: Click column headers to sort data
-- **Detail View**: Click "View Details" to see all fields for any item
-
-## Packages
-
-### salvageunion-reference
-
-Comprehensive, schema-validated JSON dataset and TypeScript ORM for the Salvage Union tabletop RPG.
-
-See [packages/salvageunion-reference/README.md](packages/salvageunion-reference/README.md) for details.
-
-## Monorepo Best Practices
-
-- **Shared Configs**: Prettier, ESLint base, and TypeScript base configs are at root
-- **Hoisted Dependencies**: Shared dev dependencies (prettier, eslint, typescript) are in root `package.json`
-- **Workspace Protocol**: Packages use `workspace:*` to reference each other
-- **Filter Commands**: Use `bun --filter` instead of `cd` for better monorepo support
-- **Single Lockfile**: Only `bun.lock` at root (no package-lock.json files)
-
-## Documentation
-
-For more detailed documentation, see:
-- [docs/README.md](docs/README.md) - Full documentation
-- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) - Architecture overview
-- [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) - Development guide
-- [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) - Troubleshooting guide
-
+- **Bun** for all package management (not npm/yarn); single `bun.lock` at root.
+- Workspace packages reference each other via the `workspace:*` protocol.
+- Relative imports only (no `@/` path aliases); `type` over `interface`; named
+  exports. See [CLAUDE.md](CLAUDE.md) and `.claude/rules/` for the full set.
+- Pre-commit (Lefthook): lint --fix + format. Pre-push: typecheck, test,
+  validate:all, knip.

--- a/apps/discord-bot/package.json
+++ b/apps/discord-bot/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@randsum/roller": "^2.0.0",
+    "@sentry/node": "10.57.0",
     "discord.js": "^14.26.4",
     "salvageunion-reference": "workspace:*"
   },

--- a/apps/discord-bot/src/config.ts
+++ b/apps/discord-bot/src/config.ts
@@ -14,4 +14,7 @@ export const config = {
   discordToken: requireEnv('DISCORD_TOKEN'),
   discordClientId: requireEnv('DISCORD_CLIENT_ID'),
   discordGuildId: optionalEnv('DISCORD_GUILD_ID'),
+  // Optional error tracking. When SENTRY_DSN is unset, observability is a no-op.
+  sentryDsn: optionalEnv('SENTRY_DSN'),
+  nodeEnv: optionalEnv('NODE_ENV'),
 } as const

--- a/apps/discord-bot/src/index.ts
+++ b/apps/discord-bot/src/index.ts
@@ -4,6 +4,10 @@ import { config } from './config.js'
 import { commands } from './commands/index.js'
 import { handleReady } from './events/ready.js'
 import { handleInteractionCreate } from './events/interactionCreate.js'
+import { initObservability, captureException } from './observability.js'
+
+// Initialize error tracking as early as possible (no-op without SENTRY_DSN).
+initObservability()
 
 // Create client with minimal intents (only Guilds needed for slash commands)
 const client = new Client({
@@ -22,14 +26,17 @@ client.on(Events.InteractionCreate, (interaction) => {
 // Error handling
 client.on('error', (error) => {
   console.error('Discord client error:', error)
+  captureException(error, { source: 'discord-client' })
 })
 
 process.on('unhandledRejection', (error) => {
   console.error('Unhandled promise rejection:', error)
+  captureException(error, { source: 'unhandledRejection' })
 })
 
 process.on('uncaughtException', (error) => {
   console.error('Uncaught exception:', error)
+  captureException(error, { source: 'uncaughtException' })
   process.exit(1)
 })
 

--- a/apps/discord-bot/src/observability.ts
+++ b/apps/discord-bot/src/observability.ts
@@ -1,0 +1,36 @@
+/**
+ * observability — optional Sentry error tracking for the Discord bot.
+ *
+ * Entirely env-gated: when SENTRY_DSN is unset (local dev, tests), every
+ * function here is a no-op and no Sentry network calls are made. No DSN is
+ * ever committed — it is supplied via the Render worker's environment.
+ */
+
+import * as Sentry from '@sentry/node'
+import { config } from './config.js'
+
+let enabled = false
+
+/**
+ * Initializes Sentry if SENTRY_DSN is configured. Idempotent and safe to call
+ * once at startup. No-op (and logs nothing) when the DSN is absent.
+ */
+export function initObservability(): void {
+  if (enabled || !config.sentryDsn) return
+  Sentry.init({
+    dsn: config.sentryDsn,
+    environment: config.nodeEnv ?? 'production',
+  })
+  enabled = true
+  console.log('[observability] Sentry error tracking enabled')
+}
+
+/**
+ * Reports an error to Sentry when enabled. Always returns immediately; the
+ * caller is still responsible for any local logging it wants.
+ */
+export function captureException(error: unknown, context?: Record<string, unknown>): void {
+  if (enabled) {
+    Sentry.captureException(error, context ? { extra: context } : undefined)
+  }
+}

--- a/apps/in-the-union-now/netlify.toml
+++ b/apps/in-the-union-now/netlify.toml
@@ -60,6 +60,11 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "geolocation=(), microphone=(), camera=()"
     Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
+    # Mirrors suref-web's proven CSP. connect-src allows the same-origin snapshot
+    # API ('self') plus the Netlify RUM endpoint; no 'unsafe-eval'. If a future
+    # feature needs another origin, widen the relevant directive here.
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://ingesteer.services-prod.nsvcs.net;"
+    X-DNS-Prefetch-Control = "on"
 
 [[headers]]
   for = "/assets/*"

--- a/apps/in-the-union-now/netlify/functions/__tests__/snapshot.test.ts
+++ b/apps/in-the-union-now/netlify/functions/__tests__/snapshot.test.ts
@@ -223,10 +223,19 @@ describe('snapshot-retrieve', () => {
     expect(body).toEqual(payload)
   })
 
-  it('GET with unknown id → 404', async () => {
-    const req = makeRequest('GET', 'http://localhost/api/snapshots/NOTEXIST')
+  it('GET with unknown (but well-formed) id → 404', async () => {
+    // ZZZZZZZZ is a valid 8-char Crockford-base32 id that was never stored.
+    const req = makeRequest('GET', 'http://localhost/api/snapshots/ZZZZZZZZ')
     const res = await handler(req)
     expect(res.status).toBe(404)
+  })
+
+  it('GET with malformed id → 400 (before any store lookup)', async () => {
+    // Contains I and O (excluded from Crockford base32) and is rejected by the
+    // format guard without touching the blob store.
+    const req = makeRequest('GET', 'http://localhost/api/snapshots/NOTEXIST')
+    const res = await handler(req)
+    expect(res.status).toBe(400)
   })
 
   it('POST → 405 Method Not Allowed', async () => {

--- a/apps/in-the-union-now/netlify/functions/_observability.ts
+++ b/apps/in-the-union-now/netlify/functions/_observability.ts
@@ -1,0 +1,31 @@
+/**
+ * _observability — optional Sentry error tracking for the snapshot Netlify
+ * Functions.
+ *
+ * Env-gated: when SENTRY_DSN is unset, every export here is a no-op and no
+ * Sentry network calls are made. No DSN is committed — it is supplied via the
+ * Netlify site environment. The leading underscore keeps this out of the
+ * deployed function routes (Netlify ignores `_`-prefixed files as endpoints).
+ */
+
+import * as Sentry from '@sentry/node'
+
+let initialized = false
+let enabled = false
+
+/** Initializes Sentry once per cold start, if SENTRY_DSN is configured. */
+export function initObservability(): void {
+  if (initialized) return
+  initialized = true
+  const dsn = process.env.SENTRY_DSN
+  if (!dsn) return
+  Sentry.init({ dsn, environment: process.env.NODE_ENV ?? 'production' })
+  enabled = true
+}
+
+/** Reports an error to Sentry when enabled; otherwise a no-op. */
+export function captureException(error: unknown, context?: Record<string, unknown>): void {
+  if (enabled) {
+    Sentry.captureException(error, context ? { extra: context } : undefined)
+  }
+}

--- a/apps/in-the-union-now/netlify/functions/snapshot-publish.ts
+++ b/apps/in-the-union-now/netlify/functions/snapshot-publish.ts
@@ -15,6 +15,7 @@ import { generateUniqueId } from '../../src/lib/snapshot/id'
 import { RateLimiter, getClientIp } from '../../src/lib/snapshot/rateLimit'
 import { createNetlifyBlobsStorage } from '../../src/lib/snapshot/storage'
 import type { SnapshotStorage } from '../../src/lib/snapshot/storage'
+import { captureException, initObservability } from './_observability'
 
 // ---------------------------------------------------------------------------
 // Module-level rate limiter — persists across invocations within one instance
@@ -91,8 +92,15 @@ export function makePublishHandler(storage: SnapshotStorage) {
 
     // Persist — onlyIfNew is belt-and-suspenders; uniqueness is already
     // checked above, but this prevents a race between two concurrent publishes
-    // that happen to collide after the check.
-    const result = await storage.put(id, payload, { onlyIfNew: true })
+    // that happen to collide after the check. A Blobs outage must surface as a
+    // controlled 503, not an unhandled 500.
+    let result: Awaited<ReturnType<SnapshotStorage['put']>>
+    try {
+      result = await storage.put(id, payload, { onlyIfNew: true })
+    } catch (error) {
+      captureException(error, { fn: 'snapshot-publish', op: 'storage.put' })
+      return new Response('Snapshot storage unavailable', { status: 503 })
+    }
     if (!result.modified) {
       // Collision race — extremely unlikely; caller can retry
       return new Response('ID collision — please retry', { status: 409 })
@@ -108,6 +116,12 @@ export function makePublishHandler(storage: SnapshotStorage) {
 // ---------------------------------------------------------------------------
 
 export default async function (req: Request): Promise<Response> {
-  const storage = await createNetlifyBlobsStorage()
-  return makePublishHandler(storage)(req)
+  initObservability()
+  try {
+    const storage = await createNetlifyBlobsStorage()
+    return await makePublishHandler(storage)(req)
+  } catch (error) {
+    captureException(error, { fn: 'snapshot-publish' })
+    return new Response('Internal Server Error', { status: 500 })
+  }
 }

--- a/apps/in-the-union-now/netlify/functions/snapshot-retrieve.ts
+++ b/apps/in-the-union-now/netlify/functions/snapshot-retrieve.ts
@@ -10,8 +10,10 @@
  * See ADR-010-snapshot-backend.md for full rationale.
  */
 
+import { isValidSnapshotId } from '../../src/lib/snapshot/id'
 import { createNetlifyBlobsStorage } from '../../src/lib/snapshot/storage'
 import type { SnapshotStorage } from '../../src/lib/snapshot/storage'
+import { captureException, initObservability } from './_observability'
 
 // ---------------------------------------------------------------------------
 // Handler factory — accepts injected storage for testability
@@ -33,7 +35,21 @@ export function makeRetrieveHandler(storage: SnapshotStorage) {
       return new Response('Missing snapshot ID', { status: 400 })
     }
 
-    const payload = await storage.get(id)
+    // Reject malformed IDs before touching the blob store. A valid snapshot ID
+    // is always 8 Crockford-base32 chars; anything else cannot exist and skips
+    // a pointless store lookup (input validation, CWE-20).
+    if (!isValidSnapshotId(id)) {
+      return new Response('Invalid snapshot ID', { status: 400 })
+    }
+
+    // A Blobs outage must surface as a controlled 503, not an unhandled 500.
+    let payload: unknown
+    try {
+      payload = await storage.get(id)
+    } catch (error) {
+      captureException(error, { fn: 'snapshot-retrieve', op: 'storage.get', id })
+      return new Response('Snapshot storage unavailable', { status: 503 })
+    }
 
     if (payload === null) {
       return new Response('Not found', { status: 404 })
@@ -48,6 +64,12 @@ export function makeRetrieveHandler(storage: SnapshotStorage) {
 // ---------------------------------------------------------------------------
 
 export default async function (req: Request): Promise<Response> {
-  const storage = await createNetlifyBlobsStorage()
-  return makeRetrieveHandler(storage)(req)
+  initObservability()
+  try {
+    const storage = await createNetlifyBlobsStorage()
+    return await makeRetrieveHandler(storage)(req)
+  } catch (error) {
+    captureException(error, { fn: 'snapshot-retrieve' })
+    return new Response('Internal Server Error', { status: 500 })
+  }
 }

--- a/apps/in-the-union-now/package.json
+++ b/apps/in-the-union-now/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@netlify/blobs": "^10.7.9",
     "@randsum/roller": "^2.0.0",
+    "@sentry/node": "10.57.0",
     "@tanstack/react-query": "^5.101.0",
     "@tanstack/react-router": "^1.170.15",
     "@tanstack/router-plugin": "^1.168.18",

--- a/apps/in-the-union-now/src/lib/snapshot/client.ts
+++ b/apps/in-the-union-now/src/lib/snapshot/client.ts
@@ -26,6 +26,31 @@ export class SnapshotNotFoundError extends Error {
   }
 }
 
+/** Default per-request timeout for snapshot fetches (ms). */
+const REQUEST_TIMEOUT_MS = 10_000
+
+/**
+ * fetch with an AbortController timeout so the share UI can never hang on a
+ * stalled connection. Throws an Error tagged `SnapshotTimeoutError` on timeout;
+ * other network failures propagate as-is.
+ */
+async function fetchWithTimeout(input: string, init?: RequestInit): Promise<Response> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  try {
+    return await fetch(input, { ...init, signal: controller.signal })
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      const timeout = new Error(`snapshot request timed out after ${REQUEST_TIMEOUT_MS}ms`)
+      timeout.name = 'SnapshotTimeoutError'
+      throw timeout
+    }
+    throw err
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 /**
  * Publishes a snapshot payload to the backend.
  *
@@ -33,7 +58,7 @@ export class SnapshotNotFoundError extends Error {
  * @returns PublishResult with the snapshot id and share URL path.
  */
 export async function publishSnapshot(payload: SnapshotPayload): Promise<PublishResult> {
-  const res = await fetch('/api/snapshots', {
+  const res = await fetchWithTimeout('/api/snapshots', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(payload),
@@ -70,7 +95,7 @@ export async function probeSnapshotService(): Promise<boolean> {
  * @throws Error for other non-OK statuses.
  */
 export async function retrieveSnapshot(id: string): Promise<SnapshotPayload> {
-  const res = await fetch(`/api/snapshots/${id}`)
+  const res = await fetchWithTimeout(`/api/snapshots/${id}`)
   if (res.status === 404) {
     throw new SnapshotNotFoundError(id)
   }

--- a/apps/in-the-union-now/src/lib/snapshot/id.ts
+++ b/apps/in-the-union-now/src/lib/snapshot/id.ts
@@ -11,6 +11,18 @@ const ID_LENGTH = 8
 const MAX_RETRIES = 5
 
 /**
+ * Matches a well-formed snapshot ID: exactly 8 uppercase Crockford-base32
+ * characters (0-9, A-Z minus I, L, O, U). Used to reject malformed IDs before
+ * they reach the blob store — a cheap input-validation guard (CWE-20).
+ */
+export const SNAPSHOT_ID_PATTERN = /^[0-9A-HJKMNP-TV-Z]{8}$/
+
+/** True when `id` is a syntactically valid snapshot ID. */
+export function isValidSnapshotId(id: string): boolean {
+  return SNAPSHOT_ID_PATTERN.test(id)
+}
+
+/**
  * Generates a random 8-character base32 ID.
  * Uses crypto.getRandomValues for cryptographic randomness.
  */

--- a/apps/in-the-union-now/src/routes/__root.tsx
+++ b/apps/in-the-union-now/src/routes/__root.tsx
@@ -1,4 +1,5 @@
 import { createRootRoute, Outlet } from '@tanstack/react-router'
+import type { ErrorComponentProps } from '@tanstack/react-router'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { EntityHrefProvider, Toaster } from 'suref-react'
 import { queryClient } from '../lib/queryClient'
@@ -9,7 +10,40 @@ import '../index.css'
 
 export const Route = createRootRoute({
   component: RootComponent,
+  errorComponent: RootErrorComponent,
 })
+
+/**
+ * Top-level error boundary. Without this, a render-time exception anywhere in
+ * the tree (e.g. a rejected game-data preload behind the root Suspense gate)
+ * blanks the whole app. TanStack Router renders this component instead and
+ * offers a recovery affordance. Mirrors suref-web's IslandErrorBoundary UX.
+ */
+function RootErrorComponent({ error }: ErrorComponentProps) {
+  return (
+    <div
+      role="alert"
+      className="mx-auto flex min-h-dvh w-full max-w-2xl flex-col items-center justify-center gap-4 p-6 text-center"
+    >
+      <h1 className="text-lg font-bold">Something went wrong</h1>
+      <p className="text-sm text-muted-foreground">
+        The app hit an unexpected error. Your saved data is stored locally and is not affected.
+      </p>
+      {import.meta.env.DEV && (
+        <pre className="max-w-full overflow-auto rounded bg-muted p-3 text-left text-xs">
+          {error.message}
+        </pre>
+      )}
+      <button
+        type="button"
+        className="rounded bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground"
+        onClick={() => window.location.reload()}
+      >
+        Reload app
+      </button>
+    </div>
+  )
+}
 
 function RootComponent() {
   return (

--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@randsum/roller": "^2.0.0",
+        "@sentry/node": "10.57.0",
         "discord.js": "^14.26.4",
         "salvageunion-reference": "workspace:*",
       },
@@ -47,6 +48,7 @@
       "dependencies": {
         "@netlify/blobs": "^10.7.9",
         "@randsum/roller": "^2.0.0",
+        "@sentry/node": "10.57.0",
         "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-router": "^1.170.15",
         "@tanstack/router-plugin": "^1.168.18",
@@ -591,15 +593,15 @@
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
-    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
-    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.217.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Cdq0jW2lknrNfrAm92MyEAvpe2cRsKjdnQLHUL6xRA4IVUnsWx6P65E7NcUO0Y+L4w1Aee5iV8FvjSwd+lrs9A=="],
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.214.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA=="],
 
     "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.7.1", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ=="],
 
     "@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
 
-    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.217.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.217.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-24ucQMjz7Y34Kw3trbxL2ZrssbtgWnR+Clpaa+YdeWuuyH3Cvk23Q03PcQvqiZrDvt8AmQmjgg9v6Y9PHoxG7w=="],
+    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.214.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.214.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w=="],
 
     "@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
 
@@ -722,6 +724,16 @@
     "@sapphire/shapeshift": ["@sapphire/shapeshift@4.0.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "lodash": "^4.17.21" } }, "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg=="],
 
     "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
+
+    "@sentry-internal/server-utils": ["@sentry-internal/server-utils@10.57.0", "", { "dependencies": { "@sentry/core": "10.57.0" } }, "sha512-Qu8ETmX/ITzteG7Im46b9HOxKKzeaIeqNvftaIlFURu1RUQdHbtGerS7QOmXzwnhuqNGNeiCQYkduB798IfRqA=="],
+
+    "@sentry/core": ["@sentry/core@10.57.0", "", {}, "sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg=="],
+
+    "@sentry/node": ["@sentry/node@10.57.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.6.1", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/sdk-trace-base": "^2.6.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@sentry-internal/server-utils": "10.57.0", "@sentry/core": "10.57.0", "@sentry/node-core": "10.57.0", "@sentry/opentelemetry": "10.57.0", "import-in-the-middle": "^3.0.0" } }, "sha512-7KEStrJ97wPf1fA5nU5ONeTTcIIlh7oT8OMffEVA1PXmlhFoXhcQZVzr4rM+zj9tfMWT01og5Ng/Grgh3dN+FA=="],
+
+    "@sentry/node-core": ["@sentry/node-core@10.57.0", "", { "dependencies": { "@sentry/core": "10.57.0", "@sentry/opentelemetry": "10.57.0", "import-in-the-middle": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1", "@opentelemetry/instrumentation": ">=0.57.1 <1", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/core", "@opentelemetry/exporter-trace-otlp-http", "@opentelemetry/instrumentation", "@opentelemetry/sdk-trace-base", "@opentelemetry/semantic-conventions"] }, "sha512-2v2IF6MfTiu7pimWEq2rYhZsmlwyNbs3bHUsrYFPeP/Rpa6ObDuUWPdVEzJjfyK+AqqYZYxZdV0l3+B13kTEmQ=="],
+
+    "@sentry/opentelemetry": ["@sentry/opentelemetry@10.57.0", "", { "dependencies": { "@sentry/core": "10.57.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-iwRz8cEK0GOISG34aJRO8GdYOk3nfpuT6dT2GDQrxw8f7JjkJKx9LPU8MaenOFa4MhY+Z02hI6NNcrbsoI3cXg=="],
 
     "@shikijs/core": ["@shikijs/core@4.2.0", "", { "dependencies": { "@shikijs/primitive": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ=="],
 
@@ -2551,6 +2563,10 @@
 
     "@netlify/dev-utils/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
+    "@netlify/otel/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@netlify/otel/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.217.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.217.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-24ucQMjz7Y34Kw3trbxL2ZrssbtgWnR+Clpaa+YdeWuuyH3Cvk23Q03PcQvqiZrDvt8AmQmjgg9v6Y9PHoxG7w=="],
+
     "@puppeteer/browsers/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
@@ -2680,6 +2696,8 @@
     "@ladle/react/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "@netlify/dev-utils/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "@netlify/otel/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.217.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Cdq0jW2lknrNfrAm92MyEAvpe2cRsKjdnQLHUL6xRA4IVUnsWx6P65E7NcUO0Y+L4w1Aee5iV8FvjSwd+lrs9A=="],
 
     "@puppeteer/browsers/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 

--- a/docs/adrs/ADR-001-self-service-combat-model.md
+++ b/docs/adrs/ADR-001-self-service-combat-model.md
@@ -2,7 +2,17 @@
 
 ## Status
 
-Accepted
+Accepted — **mechanics partially superseded by the local-first rebuild.**
+
+> The _decision_ still holds: the app is a self-service shared character sheet
+> that never crosses player write boundaries or enforces turn order. The
+> _mechanism_ described below (Supabase RLS policies scoped to `user_id`,
+> realtime subscriptions) no longer exists — ITUN is now local-first
+> (IndexedDB, no auth, no backend; see [ADR-010](ADR-010-snapshot-backend.md)
+> and [data-flow.md](../architecture/data-flow.md)). Read the references to
+> "RLS", "`user_id`", and "realtime sync" below as historical context for why
+> the self-service model was chosen, not as a description of the current
+> implementation.
 
 ## Context
 

--- a/docs/architecture/combat-loop.md
+++ b/docs/architecture/combat-loop.md
@@ -1,5 +1,16 @@
 # Combat Loop Architecture
 
+> **Architecture note (local-first rebuild):** this design doc predates ITUN's
+> move to local-first. The self-service mutation model and the pure-function
+> combat logic in `combatUtils.ts` still hold, but the **persistence mechanics**
+> described below — Supabase RLS policies, realtime subscriptions, and any
+> "Supabase Postgres function / RPC" — no longer exist. Player state now lives
+> in IndexedDB (no auth, no backend; see
+> [data-flow.md](data-flow.md) and [ADR-010](../adrs/ADR-010-snapshot-backend.md)).
+> Multi-client "realtime" is limited to same-device cross-tab broadcast. Read
+> the RLS/realtime/RPC references as historical context for the design decision,
+> not the current implementation.
+
 The combat loop gives players a structured way to spend resources, track heat, apply damage, and record conditions during a Salvage Union session. The system is built around a self-service model: each player manages their own mech and pilot state. The app is a shared living character sheet, not a game engine.
 
 ## Core Design Principles
@@ -8,9 +19,9 @@ The combat loop gives players a structured way to spend resources, track heat, a
 
 **No turn enforcement.** All users can always act. The app does not gate mutations behind a "your turn" check. This removes significant server-side complexity and matches how Salvage Union is actually played at the table.
 
-**No cross-player mutations.** Current RLS policies (owner-only writes) are correct and sufficient for the combat loop. No security-definer RPCs are required. The Mediator sees changes live via realtime sync but does not initiate them remotely.
+**No cross-player mutations.** Each player owns their own records; the app never writes another player's state. (Historically this was enforced by owner-only RLS policies; under the local-first model the data simply never leaves the player's device.)
 
-**Realtime visibility.** All state changes sync to other clients via the existing Supabase realtime subscriptions already wired in `usePilotSheet`. No new channels are needed.
+**Local persistence.** State changes are written to the player's own IndexedDB and reflected in their other open tabs via cross-tab broadcast. There is no cross-device realtime sync.
 
 **Data-first.** Game logic lives in `salvageunion-reference` as pure functions. The ITUN app calls these functions from mutation handlers — it does not reimplement game rules.
 
@@ -33,10 +44,10 @@ Pure functions with no side effects and no Supabase dependency. All combat math 
 function getHeatGenerated(entity: SURefEntity): number | 'variable'
 function applyHeat(currentHeat: number, heatGenerated: number, heatCap: number): number
 function canActivateAction(currentHeat: number, heatCost: number, heatCap: number): boolean
-function shouldTriggerHeatCheck(newHeat: number): boolean  // d20 <= newHeat
+function shouldTriggerHeatCheck(newHeat: number): boolean // d20 <= newHeat
 
 // Pushing
-function canPush(currentHeat: number, heatCap: number): boolean  // pushing adds 2 heat
+function canPush(currentHeat: number, heatCap: number): boolean // pushing adds 2 heat
 
 // Conditions
 function nextCondition(current: ItemCondition): ItemCondition
@@ -72,10 +83,10 @@ The name `useActivateAction` is chosen deliberately. `useActionAction` would be 
 
 **API function naming:** Mechanical names are used, not game concepts.
 
-| Function | Meaning |
-|----------|---------|
-| `spendMechEP(mechId, amount)` | Decrements `current_ep` on the mech row |
-| `spendPilotAP(pilotId, amount)` | Decrements `ap` on the pilot row |
+| Function                        | Meaning                                 |
+| ------------------------------- | --------------------------------------- |
+| `spendMechEP(mechId, amount)`   | Decrements `current_ep` on the mech row |
+| `spendPilotAP(pilotId, amount)` | Decrements `ap` on the pilot row        |
 
 This avoids collision with the `Action` entity type from the reference package.
 
@@ -87,12 +98,12 @@ This avoids collision with the `Action` entity type from the reference package.
 
 **Visual feedback for heat state:**
 
-| Heat range | `StatDisplay` appearance |
-|------------|--------------------------|
-| 0 — 49% of cap | Default (no color change) |
-| 50 — 79% of cap | Warning color |
-| 80 — 99% of cap | Danger color |
-| At cap | Max/critical color |
+| Heat range      | `StatDisplay` appearance  |
+| --------------- | ------------------------- |
+| 0 — 49% of cap  | Default (no color change) |
+| 50 — 79% of cap | Warning color             |
+| 80 — 99% of cap | Danger color              |
+| At cap          | Max/critical color        |
 
 Heat thresholds are calculated as percentages of the mech's heat cap at render time.
 
@@ -197,12 +208,12 @@ The function runs as the calling user's role (not `SECURITY DEFINER`) so RLS sti
 
 Combat events are logged with reversibility set by event type. See ADR-004 for the full rationale.
 
-| Event | `reversible` |
-|-------|-------------|
-| AP spent | `true` |
-| EP spent | `true` |
-| Heat applied | `true` |
-| Condition changed (damaged/destroyed) | `false` |
+| Event                                 | `reversible` |
+| ------------------------------------- | ------------ |
+| AP spent                              | `true`       |
+| EP spent                              | `true`       |
+| Heat applied                          | `true`       |
+| Condition changed (damaged/destroyed) | `false`      |
 
 ---
 
@@ -289,10 +300,7 @@ type ModalPhase =
 The `resolveRollTable(tableSlug, roll)` function is the canonical helper for all roll-table lookups that accept a pre-rolled value. It differs from `rollOnTable` in `pilotUtils.ts`, which rolls internally and returns `{ text, roll }`.
 
 ```typescript
-function resolveRollTable(
-  tableSlug: string,
-  roll: number
-): { label?: string; value: string } | null
+function resolveRollTable(tableSlug: string, roll: number): { label?: string; value: string } | null
 ```
 
 Returns `null` if the table does not exist or no entry matches the roll. All future roll-table resolution with a caller-supplied roll value should use this function, not implement lookup inline.

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -1,6 +1,18 @@
 # Data Flow Architecture
 
-Two data domains meet at render time: **static reference data** (game rules from `salvageunion-reference`) and **dynamic player data** (Supabase). The ITUN app hydrates player records by resolving schema references against the bundled game data.
+Two data domains meet at render time: **static reference data** (game rules from
+`salvageunion-reference`) and **dynamic player data**. The ITUN app is
+**local-first** — player records live in the browser's IndexedDB, never on a
+server — and hydrates those records by resolving schema references against the
+bundled game data.
+
+> **Architecture note (local-first rebuild):** ITUN previously used a Supabase
+> Postgres backend with auth, RLS, and realtime subscriptions. That was removed
+> in favour of a local-first IndexedDB model with no auth and no backend. The
+> only server-side surface that remains is the stateless snapshot-sharing
+> service (Netlify Functions + Blobs); see
+> [ADR-010](../adrs/ADR-010-snapshot-backend.md). This document describes the
+> current local-first design.
 
 ## Static Reference Data
 
@@ -8,339 +20,175 @@ Two data domains meet at render time: **static reference data** (game rules from
 
 ### How It Works
 
-All game data is bundled as JSON and loaded synchronously at import time. Zod schemas validate data at model construction. Each entity type gets a `BaseModel<T>` instance with O(1) ID lookups via an internal `Map`.
+Game data ships as JSON and is loaded via `preload()` (dynamic `import()`, so
+the corpus can be code-split). Zod schemas validate data at model construction.
+Each entity type gets a `BaseModel<T>` with O(1) ID lookups via an internal
+`Map`. See [package-contracts.md](package-contracts.md) for the `preload()` API
+and the module-scope-call hazard.
 
 ### Access Patterns
 
 ```typescript
 import { SalvageUnionReference } from 'salvageunion-reference'
 
-// Direct model access (27 models)
-SalvageUnionReference.Chassis.getById('iron-mongrel')     // O(1) lookup
-SalvageUnionReference.Chassis.all()                        // All entities
-SalvageUnionReference.Chassis.find(c => c.techLevel === 2) // Predicate search
-SalvageUnionReference.Chassis.findAll(c => c.source === 'Core Rules')
+await SalvageUnionReference.preload('all') // load before access
 
-// Generic schema access (cross-schema queries)
-SalvageUnionReference.get('chassis', 'iron-mongrel')       // By schema name + ID
-SalvageUnionReference.exists('abilities', 'bionic-senses')
-SalvageUnionReference.getMany([{ schemaName: 'abilities', id: 'id1' }, ...])
-
-// Reference strings (double-colon format: "schemaName::id")
-SalvageUnionReference.composeRef('abilities', 'bionic-senses')  // -> 'abilities::bionic-senses'
-SalvageUnionReference.parseRef('abilities::bionic-senses')      // -> { schemaName, id }
-SalvageUnionReference.getByRef('abilities::bionic-senses')
-SalvageUnionReference.getManyByRef(['abilities::bionic-senses', 'systems::laser'])
-
-// Metadata extraction
-SalvageUnionReference.getTechLevel(entity)      // number | 'B' | 'N' | undefined
-SalvageUnionReference.getTechLevelNumber(entity) // number | undefined (normalizes B/N to 1)
-SalvageUnionReference.getSalvageValue(entity)
-
-// Search
-SalvageUnionReference.search({ query: 'laser', limit: 10 })
-SalvageUnionReference.searchIn('equipment', 'laser')
-SalvageUnionReference.getSuggestions('las')
+SalvageUnionReference.Chassis.getById('iron-mongrel') // O(1) lookup
+SalvageUnionReference.get('chassis', 'iron-mongrel') // by schema name + ID
+SalvageUnionReference.getByRef('chassis::iron-mongrel') // by reference string
+SalvageUnionReference.search({ query: 'laser', limit: 10 }) // in-memory search
 ```
 
-### Type System
-
-Entity types follow the pattern `SURef{EntityName}` (e.g., `SURefChassis`, `SURefAbility`). The `SchemaToEntityMap` maps schema name strings to their TypeScript types for type-safe generic access.
-
-```typescript
-type SchemaToEntityMap = {
-  abilities: SURefAbility
-  chassis: SURefChassis
-  classes: SURefClass
-  // ... 27 total schema mappings
-}
-
-type SURefEntity = SURefAbility | SURefChassis | SURefClass | ... // Union of all
-type SURefEnumSchemaName = keyof SchemaToEntityMap                // String union
-```
+ITUN preloads the full dataset once at the root via `GameDataReady`
+(`src/components/shared/GameDataReady.tsx`) so every route can render any
+cross-referenced entity without per-route preload lists.
 
 ---
 
-## Dynamic Player Data (Supabase)
+## Dynamic Player Data (IndexedDB, local-first)
 
-**Project:** `dshtuchbleipwqacyokz` (us-east-2)
+**Location:** `apps/in-the-union-now/src/lib/db/`
 
-### Core Tables
+Player data is persisted to a single IndexedDB database via the [`idb`](https://github.com/jakearchibald/idb)
+wrapper (chosen over Dexie for size + Zod-as-schema-of-record — see the ADR
+comment at the top of `src/lib/db/index.ts`).
 
-| Table | Purpose | Key columns |
-|-------|---------|-------------|
-| `pilots` | Player characters | `callsign`, `class_ref`, `hp/ap/tp`, `mech_id`, `crawler_id`, `is_boarded`, `in_downtime` |
-| `mechs` | Player mechs | `chassis_ref`, `pattern_name`, `current_hp/sp`, `pattern_items` (JSON) |
-| `crawlers` | Player crawlers | `crawler_ref`, `name`, `tech_level`, `current_sp`, `scrap_tl1`-`scrap_tl6`, `bay_npcs` (JSON) |
-| `entity_refs` | Bridge: player data -> game data | `parent_id`, `parent_type`, `schema_name`, `schema_ref_id`, `condition`, `sort_order` |
-| `player_choices` | User selections (class, comrade name, etc.) | `parent_id`, `parent_type`, `choice_key`, `choice_value` |
-| `cargo` | Inventory items | `parent_id`, `parent_type`, `name`, `amount`, `schema_name`, `schema_ref_id` |
-| `change_log` | Audit trail | `target_id`, `target_type`, `action`, `field`, `old_value`, `new_value`, `description` |
-| `campaigns` | Multiplayer games | `name`, `owner_id`, `invite_code` |
-| `campaign_members` | Player-campaign links | `campaign_id`, `pilot_id`, `role` |
-| `mech_patterns` | Saved mech builds | `chassis_ref`, `pattern_name`, `pattern_items` |
+- **Database:** `itun-v1`, current `DB_VERSION = 4`.
+- **Object stores** (all keyed on `id`):
 
-### The entity_refs Hydration Pattern
+  | Store          | Holds                                                             |
+  | -------------- | ----------------------------------------------------------------- |
+  | `pilots`       | Player pilots (callsign, class ref, HP/AP/TP, embedded choices)   |
+  | `mechs`        | Player mechs (chassis ref, pattern, current HP/SP, pattern items) |
+  | `crawlers`     | Player crawler instances (crawler ref, tech level, bays, scrap)   |
+  | `mechPatterns` | Saved mech builds (immutable after creation)                      |
+  | `workspaces`   | Grouping container for a player's entities                        |
+  | `softLinks`    | Typed relationships between pilots/mechs/crawlers                 |
 
-Player data stores only references to game data, not copies. The `entity_refs` table bridges the two domains:
+Player records store **slug references** into reference entities (e.g.
+`class_ref: 'hybrid-wolf'`), never copies of game data — the same
+reference-by-slug pattern the dataset uses internally. There is no `entity_refs`
+bridge table and no Postgres; references are plain fields on the record,
+resolved against `SalvageUnionReference` at render time.
 
-```sql
--- Example: pilot "Nova" has the ability "Bionic Senses"
--- pilots table
-id: 'p1', callsign: 'Nova', class_ref: 'hybrid-wolf'
+### CRUD layer (`src/lib/db/crud.ts`)
 
--- entity_refs table
-parent_id: 'p1', parent_type: 'pilot',
-schema_name: 'abilities', schema_ref_id: 'bionic-senses',
-condition: 'intact', sort_order: 0
-```
+`makeStore(getDb, schema, storeName, opts)` builds a typed per-store accessor.
+Key behaviours:
 
-At render time, ITUN hydrates by calling `SalvageUnionReference.get(ref.schema_name, ref.schema_ref_id)` to get the full entity data:
+- **Validation on write:** records are parsed against their Zod schema before
+  persisting.
+- **Salvage path on read:** reads use `schema.strip()` so a drifted record
+  (e.g. after a PWA auto-update version skew) has unknown fields stripped with a
+  console warning instead of bricking hydration.
+- **`hasUpdatedAt`:** Pilot/Mech/Crawler stamp `updatedAt` on write; Workspace,
+  SoftLink, and MechPattern carry `createdAt` only.
 
-```typescript
-// In usePilotSheet hook
-const pilotClass = useMemo(
-  () => pilot ? SalvageUnionReference.get('classes', pilot.class_ref) : undefined,
-  [pilot]
-)
+### Migrations (`src/lib/db/migrations/`)
 
-// For entity_refs
-const entity = SalvageUnionReference.get(
-  ref.schema_name as EntitySchemaName,
-  ref.schema_ref_id
-)
-```
+- Object-store **creation** lives in the `openDB` `upgrade` callback (v1 created
+  the core stores; v2 added `mechPatterns`).
+- Record **rewrites** are one file per version under `migrations/`, registered
+  in `migrations/index.ts` and run by `runMigrations()` inside the
+  `versionchange` transaction.
+- **Atomicity:** if any migration throws, the upgrade transaction is aborted —
+  rolling back the version bump and rejecting the open, so callers never receive
+  a half-migrated database.
 
-### Enums
+### Referential integrity
 
-```typescript
-parent_type: 'pilot' | 'mech' | 'crawler'
-item_condition: 'intact' | 'damaged' | 'destroyed'
-```
-
-All tables have RLS policies scoped to `user_id` (owned data) or via campaign membership (shared data).
+`deleteEntityWithSoftLinks()` removes an entity and every SoftLink referencing
+it (`from.id`/`to.id`) in a single readwrite transaction spanning both stores —
+either all are removed together, or nothing changes (no orphaned links).
 
 ---
 
-## Full Data Flow Trace: Loading a Pilot Sheet
+## State Management (Zustand, write-through)
 
-### Route -> Hook -> Queries -> Hydration -> Render
+**Location:** `apps/in-the-union-now/src/stores/`
 
-**1. Route** (`src/routes/pilots/$pilotId.tsx`): Extracts `pilotId` from URL params.
+ITUN uses Zustand stores layered over the db/ CRUD layer (no React Context for
+shared state):
 
-**2. Orchestration Hook** (`usePilotSheet`): Coordinates ~10 queries and all mutations for the pilot view.
+- **`entityStore`** — pilots, mechs, crawlers, softLinks.
+  - **Lazy auto-hydration:** `list(type)` hydrates that type from IndexedDB on
+    first call (returning a Promise); later reads return the in-memory array
+    synchronously.
+  - **Write-through:** create/update/delete persist to IndexedDB _first_; only
+    on success is in-memory state updated via `set()`. On failure the db error
+    propagates and in-memory state is untouched.
+  - **Multi-tab:** every successful write publishes the affected store via
+    `lib/db/broadcast`; writes from other tabs invalidate this tab's cache so
+    already-hydrated stores re-read from IndexedDB.
+- **`workspaceStore`** — the active workspace and workspace membership.
 
-**3. Core Queries** (TanStack Query):
-```typescript
-const { data: pilot } = usePilot(pilotId)               // pilots table
-const { data: pilotRefs } = usePilotEntityRefs(pilotId)  // entity_refs where parent_id = pilotId
-const { data: mech } = useMech(pilot?.mech_id)           // mechs table (if boarded)
-const { data: mechRefs } = useMechEntityRefs(mech?.id)   // entity_refs for mech
-```
-
-**4. Realtime Subscriptions** (4 channels):
-```typescript
-useRealtimeSubscription('pilots', `id=eq.${pilotId}`, [pilotKeys.detail(pilotId)])
-useRealtimeSubscription('entity_refs', `parent_id=eq.${pilotId}`, [pilotKeys.entityRefs(pilotId)])
-useRealtimeSubscription('mechs', mechFilter, [mechKeys.detail(mechId)])
-useRealtimeSubscription('entity_refs', mechRefsFilter, [mechKeys.entityRefs(mechId)])
-```
-
-**5. Hydration** (useMemo, synchronous):
-```typescript
-const pilotClass = SalvageUnionReference.get('classes', pilot.class_ref)
-const mechChassis = findChassisById(mech.chassis_ref)
-const comrades = extractComrades(pilotRefs, mechRefs, mechChassis)
-```
-
-**6. Mutation Handlers**: Each handler calls the mutation, logs to `changeLogApi`, and shows a toast.
-
-**7. Return**: `{ pilot, pilotRefs, mech, mechRefs, mechChassis, pilotClass, comrades, editConfig }` — consumed by `PlayerPilotDisplay`.
+Writes also call `recordDataWrite()` (`lib/backupNudge`), which periodically
+nudges the user to export a backup — the local-first analogue of durability.
 
 ---
 
-## TanStack Query Patterns
+## TanStack Query
 
-### Configuration
+**File:** `apps/in-the-union-now/src/lib/queryClient.ts`
 
-```typescript
-// src/lib/queryClient.ts
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 1000 * 60 * 5,     // 5 minutes
-      gcTime: 1000 * 60 * 10,       // 10 minutes
-      retry: 1,
-      refetchOnWindowFocus: false,
-    },
-    mutations: { retry: 0 },
-  },
-})
-```
-
-### Query Key Factories
-
-Hierarchical key structure enables targeted invalidation:
+TanStack Query coordinates async/derived data (e.g. snapshot retrieval, derived
+sheet views). Default options:
 
 ```typescript
-export const pilotKeys = {
-  all: ['pilots'] as const,
-  lists: () => [...pilotKeys.all, 'list'] as const,
-  list: (userId: string) => [...pilotKeys.lists(), userId] as const,
-  details: () => [...pilotKeys.all, 'detail'] as const,
-  detail: (id: string) => [...pilotKeys.details(), id] as const,
-  entityRefs: (pilotId: string) => [...pilotKeys.all, 'entityRefs', pilotId] as const,
-}
+queries:   { staleTime: 5 min, gcTime: 10 min, retry: 1, refetchOnWindowFocus: false }
+mutations: { retry: 0 }
 ```
 
-Each resource (`mechs`, `crawlers`, `campaigns`, etc.) follows the same factory pattern.
-
-### Optimistic Updates
-
-```typescript
-export function useUpdatePilot() {
-  return useMutation({
-    mutationFn: ({ pilotId, input }) => updatePilot(pilotId, input),
-
-    // 1. Optimistic update (immediate UI feedback)
-    onMutate: async ({ pilotId, input }) => {
-      await queryClient.cancelQueries({ queryKey: pilotKeys.detail(pilotId) })
-      const previous = queryClient.getQueryData(pilotKeys.detail(pilotId))
-      queryClient.setQueryData(pilotKeys.detail(pilotId), { ...previous, ...input })
-      return { previous }
-    },
-
-    // 2. Rollback on error
-    onError: (_err, { pilotId }, context) => {
-      queryClient.setQueryData(pilotKeys.detail(pilotId), context?.previous)
-    },
-
-    // 3. Canonical update on success
-    onSuccess: (data, { userId }) => {
-      queryClient.invalidateQueries({ queryKey: pilotKeys.list(userId) })
-      queryClient.setQueryData(pilotKeys.detail(data.id), data)
-    },
-  })
-}
-```
+Persistent entity state lives in Zustand/IndexedDB, not in the Query cache.
 
 ---
 
-## API Layer
+## Snapshot Sharing (the only backend)
 
-**Location:** `apps/in-the-union-now/src/lib/api/`
+Read-only share links are the one server-touching feature. See
+[ADR-010](../adrs/ADR-010-snapshot-backend.md).
 
-One file per resource: `pilotApi.ts`, `mechApi.ts`, `crawlerApi.ts`, `entityRefApi.ts`, `playerChoiceApi.ts`, `cargoApi.ts`, `changeLogApi.ts`, `campaignMemberApi.ts`, `gameApi.ts`, `patternApi.ts`.
-
-All functions are async/await, use the typed Supabase client, and throw via `handleSupabaseError(error)` on failure. TanStack Query's `onError` callback handles the thrown error.
-
-```typescript
-export async function getPilotById(pilotId: string): Promise<PilotRow> {
-  const { data, error } = await supabase.from('pilots').select('*').eq('id', pilotId).single()
-  if (error) handleSupabaseError(error)
-  return data!
-}
-```
-
----
-
-## Realtime Subscriptions
-
-**File:** `apps/in-the-union-now/src/hooks/useRealtimeSubscription.ts`
-
-Subscribes to Postgres changes and invalidates TanStack Query caches. No API changes required.
-
-```typescript
-function useRealtimeSubscription(table: string, filter: string | undefined, queryKeys: QueryKey[]) {
-  // Subscribes to INSERT/UPDATE/DELETE on table with filter
-  // On any change: invalidates all provided query keys
-  // Cleanup: removes channel on unmount
-}
-```
-
-This is additive: the existing query/mutation flow works without realtime. Realtime just ensures multi-client consistency by triggering cache invalidation.
+- **Client:** `src/lib/snapshot/client.ts` — `publishSnapshot(payload)` POSTs to
+  `/api/snapshots` and returns `{ id, url }`; `retrieveSnapshot(id)` GETs
+  `/api/snapshots/:id`; `probeSnapshotService()` feature-detects the backend.
+- **Backend:** two Netlify Functions (`netlify/functions/snapshot-publish.ts`,
+  `snapshot-retrieve.ts`) backed by **Netlify Blobs**. The store is
+  unauthenticated and anonymous: no PII, a 256 KB payload cap, per-IP rate
+  limiting, and crypto-random 8-char Crockford-base32 IDs.
+- **Trust boundary:** retrieved payloads are re-validated with Zod
+  (`safeParse`) on the client before rendering, so a tampered blob cannot inject
+  unexpected shapes.
 
 ---
 
-## State Management
-
-### Zustand: Auth Only
-
-**File:** `apps/in-the-union-now/src/stores/authStore.ts`
-
-Zustand manages only auth state (user identity/session). Uses `supabase.auth.onAuthStateChange()` to stay in sync.
-
-```typescript
-type AuthState = {
-  user: User | null
-  loading: boolean
-  initialize: () => () => void   // Returns unsubscribe function
-  signIn, signUp, resetPassword, signOut
-}
-```
-
-All entity data lives in TanStack Query caches, not Zustand.
-
-### Change Log: Fire-and-Forget Audit Trail
-
-**File:** `apps/in-the-union-now/src/lib/api/changeLogApi.ts`
-
-```typescript
-changeLogApi.log(userId, {
-  targetId: pilot.id,
-  targetType: 'pilot',
-  action: 'update',
-  field: 'hp',
-  oldValue: 10, newValue: 8,
-  description: 'Nova HP 10 -> 8',
-})
-```
-
-Called from mutation handlers. Does not block the mutation flow.
-
----
-
-## Complete Data Flow Diagram
+## Full Data Flow Trace: Editing a Pilot's HP
 
 ```
-User Action (click +/- on HP stat)
-    |
-    v
-Mutation Hook (useUpdatePilot)
-    |
-    v
-onMutate: Optimistic update in TanStack Query cache -> UI updates immediately
-    |
-    v
-mutationFn: pilotApi.updatePilot(pilotId, { hp: newValue })
-    |
-    v
-Supabase: UPDATE pilots SET hp = newValue WHERE id = pilotId
-    |
-    +---> change_log INSERT (fire-and-forget audit)
-    |
-    v
-Realtime: Postgres notifies subscribed clients
-    |
-    v
-useRealtimeSubscription: Invalidates pilotKeys.detail(pilotId)
-    |
-    v
-TanStack Query: Refetches pilot data from Supabase
-    |
-    v
-onSuccess: Sets canonical cache data, shows toast
-    |
-    v
-Components: Re-render with confirmed data
+User clicks +/- on the HP stat
+    │
+    ▼
+Component handler → entityStore.update('pilots', id, { hp: next })
+    │
+    ▼
+db.pilots.put(record)  ──►  Zod validate ──►  IndexedDB write (itun-v1 / pilots)
+    │  (on success)
+    ▼
+Zustand set(): in-memory pilots array updated   ──►  React re-renders
+    │
+    ├──►  broadcast: publishStoreChange('pilots')  ──►  other tabs re-hydrate
+    └──►  recordDataWrite(): maybe show backup nudge
+
+Reference data (class, abilities, traits) is resolved synchronously in a
+useMemo via SalvageUnionReference.get(...) using the slug refs on the record.
 ```
 
-**Error path:** `onError` -> rollback optimistic update -> show error toast.
+**Error path:** a failed IndexedDB write rejects out of `entityStore.update`;
+in-memory state is not mutated and the caller surfaces a toast.
 
 ---
 
 ## Cross-References
 
-- `.claude/rules/tanstack-query-hooks.md` — Query key factory conventions, hook naming, mutation patterns
-- `.claude/rules/supabase-api.md` — Client setup, typed queries, RLS, error handling
-- `.claude/rules/entity-data-resolution.md` — Quick-reference rule for editing hooks/API layer
+- `.claude/rules/tanstack-query-hooks.md` — Query key factory conventions, hook patterns
+- `.claude/rules/entity-data-resolution.md` — Resolving player refs against reference data
+- [ADR-010](../adrs/ADR-010-snapshot-backend.md) — Snapshot backend rationale

--- a/docs/architecture/package-contracts.md
+++ b/docs/architecture/package-contracts.md
@@ -189,7 +189,7 @@ Consuming apps' Vite/Astro bundlers compile `.ts/.tsx` files directly. No interm
 ### Dependencies
 
 - **Peer dependencies** (must be provided by consuming apps): `react`, `react-dom`, `@radix-ui/react-dialog`, `@radix-ui/react-hover-card`, `@radix-ui/react-tooltip`, `salvageunion-reference`, `lucide-react`, `sonner`, `class-variance-authority`, `clsx`, `tailwind-merge`, `@randsum/roller`
-- **No Supabase dependency** — data-source agnostic
+- **No backend/data-source dependency** — fully data-source agnostic
 
 ### Design Principles
 
@@ -206,20 +206,20 @@ Consuming apps' Vite/Astro bundlers compile `.ts/.tsx` files directly. No interm
 
 ### Consumes
 
-- `salvageunion-reference` (workspace:*) — game data
-- `suref-react` (workspace:*) — shared components + theme
+- `salvageunion-reference` (workspace:\*) — game data
+- `suref-react` (workspace:\*) — shared components + theme
 - `@radix-ui/react-dialog` — search modal
 
 ### Does Not Use
 
-- Supabase, auth, user data, TanStack Query/Router, Zustand
+- Auth, user data, persistence, TanStack Query/Router, Zustand (pure static site)
 
 ### Tailwind Source Path
 
 ```css
 /* apps/suref-web/src/styles/global.css */
 @source "../../../../packages/suref-react/src";
-@import "suref-react/styles/theme.css";
+@import 'suref-react/styles/theme.css';
 ```
 
 ---
@@ -231,20 +231,24 @@ Consuming apps' Vite/Astro bundlers compile `.ts/.tsx` files directly. No interm
 
 ### Consumes
 
-- `salvageunion-reference` (workspace:*) — game data
-- `suref-react` (workspace:*) — shared components + theme
-- `@supabase/supabase-js` — database + auth
-- `@tanstack/react-router`, `@tanstack/react-query` — routing + data fetching
-- `zustand` — auth state
-- `zod` — input validation
+- `salvageunion-reference` (workspace:\*) — game data
+- `suref-react` (workspace:\*) — shared components + theme
+- `idb` — IndexedDB wrapper for local-first persistence (`src/lib/db/`)
+- `@tanstack/react-router`, `@tanstack/react-query` — routing + async/derived data
+- `zustand` — write-through entity/workspace stores (`src/stores/`)
+- `zod` — schema validation for player records + input
 - Radix UI (dialog, dropdown-menu, separator, slot, tabs, tooltip)
+
+Local-first: there is no auth, no Supabase, and no backend other than the
+stateless snapshot-sharing Netlify Functions (see
+[ADR-010](../adrs/ADR-010-snapshot-backend.md)). Player data lives in IndexedDB.
 
 ### Tailwind Source Path
 
 ```css
 /* apps/in-the-union-now/src/index.css */
 @source "../../../packages/suref-react/src";
-@import "suref-react/styles/theme.css";
+@import 'suref-react/styles/theme.css';
 ```
 
 ---
@@ -256,7 +260,7 @@ Consuming apps' Vite/Astro bundlers compile `.ts/.tsx` files directly. No interm
 
 ### Consumes
 
-- `salvageunion-reference` (workspace:*) — game data for table rolling
+- `salvageunion-reference` (workspace:\*) — game data for table rolling
 
 ### Does Not Use
 
@@ -297,16 +301,21 @@ function buildOptions() {
 
 If you need a module-level constant derived from reference data, compute it lazily (e.g. via a getter function) or call it from a hook/effect that runs after the app's preload bootstrap.
 
-### Circular Dependency: Package vs. HTTP API
+### One-Way Dependency: Reference Package → Apps
 
-`salvageunion-reference` generates the data model that the ITUN app uses to build its HTTP API layer (Supabase RPCs, TanStack Query keys, Zod validation schemas). The dependency flows one way:
+`salvageunion-reference` provides the game-data model that ITUN's local-first
+layer builds on (IndexedDB store shapes, slug references, Zod validation, and
+TanStack Query keys all derive from the reference schema). The dependency flows
+one way:
 
 ```
 salvageunion-reference (game data schema)
-  --> in-the-union-now (derives DB schema, API layer, validation from game data)
+  --> in-the-union-now (derives store shapes, validation, and refs from game data)
 ```
 
-The reference package must never import from the apps. If you find yourself wanting to add app-specific logic (e.g. Supabase row types, player state) to `salvageunion-reference`, that logic belongs in the consuming app instead.
+The reference package must never import from the apps. If you find yourself
+wanting to add app-specific logic (e.g. IndexedDB record types or player state)
+to `salvageunion-reference`, that logic belongs in the consuming app instead.
 
 ### Test Preload Setup
 


### PR DESCRIPTION
Acts on the highest-leverage findings from the codebase audit. Five items, scoped tightly to the audit's "Now" bucket.

## Changes

### 1. Delete Supabase doc/config drift (audit N1/N4)
The Supabase backend was removed in the local-first rebuild, but several docs still described it as current.
- **`docs/architecture/data-flow.md`** — rewritten to the real local-first model (IndexedDB `itun-v1` via `idb`, write-through Zustand stores, the six object stores, migrations + salvage path, snapshot backend).
- **`docs/architecture/package-contracts.md`** — ITUN's stale `@supabase/supabase-js` dependency replaced with `idb`; the "Supabase RPC" circular-dependency section rewritten.
- **`docs/adrs/ADR-001`** and **`docs/architecture/combat-loop.md`** — added labelled supersession banners (ADRs/design docs are historical records, so annotated rather than rewritten) and fixed present-tense RLS/realtime claims.
- **Root `README.md`** — real five-workspace layout, real `package.json` scripts (old `lint:all`/`sanity:all`/`build:package:quick` didn't exist), fixed three broken doc links.
- **Root `.env.example`** — removed Supabase keys. Legitimate Supabase references (game data, the `create-migration` skill) left untouched.

### 2. Env-gated Sentry error tracking (audit N3)
- `@sentry/node` wired into `apps/discord-bot` and both ITUN snapshot Netlify Functions via small `observability` helpers. **No-op unless `SENTRY_DSN` is set**; no DSN committed.

### 3. Harden the snapshot backend + ITUN (audit X4/X5/X6)
- Wrap Blobs `put`/`get` in try/catch → controlled **503** instead of an unhandled 500.
- Validate the snapshot `:id` (Crockford-base32) **before** the store lookup → **400** on malformed input.
- Add a 10s `AbortController` timeout to the client fetch wrappers.
- Add a **CSP** to ITUN's `netlify.toml` (mirrors suref-web's proven policy).
- Add a top-level `errorComponent` to ITUN's `__root.tsx` so a render-time error shows a recovery UI instead of a blank page.

### 4. Remove `apps/itun-legacy`
Empty deprecated stub (was untracked cruft, only `node_modules`); flagged by five audit dimensions.

### 5. Branch protection on `main` (audit N2)
Applied directly via the GitHub API (not a code change): requires the `quality-checks` status check, blocks force-push/deletion, no review requirement, `enforce_admins: false`.

## Verification
`bun run lint`, `knip`, `validate:all`, and `typecheck` all clean; **2,733 tests pass, 0 fail** (added a malformed-id test; fixed one retrieve test that used a non-base32 id).

## Note for review
The **ITUN CSP is unverified against the built bundle** — it mirrors suref-web's known-good policy, but ITUN may differ. The `e2e-itun-preview` job runs Playwright against the live Netlify deploy preview, so it will surface any CSP breakage on this PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)