### PR TITLE
fix(reference): remove spurious 2 AP cost from First Aid Kit

### DIFF
--- a/packages/salvageunion-reference/data/actions.json
+++ b/packages/salvageunion-reference/data/actions.json
@@ -3230,7 +3230,6 @@
   {
     "id": "907d2ca2-f355-458f-9852-8923f19ab1af",
     "actionType": "Turn",
-    "activationCost": 2,
     "traits": [
       {
         "type": "uses",


### PR DESCRIPTION
## Problem

A user reported that the **First Aid Kit** pilot equipment renders a **"2 AP"** activation cost, but the core book lists no AP cost for it.

## Verification against source

Core Book (Digital Edition 2.0a) **p80** — also Starter Set Player Handbook **p38** — lists it as:

> **First Aid Kit** — *Turn Action // Range: Close // Uses (3)*

No AP cost. The `First Aid Kit` action (`id 907d2ca2…`) in `actions.json` carried a stray `"activationCost": 2`, which the renderer turns into a "2 AP" badge (equipment-source `activationCost` → AP).

It almost certainly inherited the value by being templated alongside the **"2AP Patch" / "2AP System Repair"** repair-tool entries that share page 80.

## Scope check — is it anywhere else?

Audited all **16** equipment-source actions carrying `activationCost` against their cited source pages. The other 15 are **correct** — the source encodes pilot-equipment AP as a prefix on the action name and they all have it:

- Repair tools: `2AP Patch`, `2AP System Repair`, `4AP Chassis Repair` (Riveting Gun, Arc Welder, Epoxy Canister, Adv. Epoxy, Repair Arm, Nanite Injector)
- `1AP` Night Vision Goggles, `2AP` Portable Multi-Phase Shield

**First Aid Kit was the only error.**

> One item, `Bio-Scanner` (from *We Were Here First!* p63), could not be verified — no source PDF on hand. Left untouched.

## Fix

Remove the single `activationCost: 2` line from the First Aid Kit action. `activationCost` is an optional field and the renderer omits the badge when it's undefined — data-only change, no code touched.

Verified locally: `build:package` regenerates schemas cleanly; `validate:all` passes (IDs, cross-refs, action-refs, traits); package tests 589/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)