### PR TITLE
fix(reference): add missing Fabrication Bay options

### DIFF
--- a/apps/suref-web/src/lib/changelog.ts
+++ b/apps/suref-web/src/lib/changelog.ts
@@ -6,6 +6,13 @@ type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: '2026-06-15',
+    title: 'Fabrication Bay options restored',
+    items: [
+      'The Fabrication Bay system now lists its four activation options — restore up to 15 SP, restore up to 2 EP, repair damaged Systems/Modules, or repair damaged Chassis/Vehicles. Previously the text promised "choose one of the following options" but showed none.',
+    ],
+  },
+  {
     date: '2026-06-13',
     title: 'Filters above the catalog, smoother window resizing',
     items: [

--- a/packages/salvageunion-reference/data/actions.json
+++ b/packages/salvageunion-reference/data/actions.json
@@ -3156,6 +3156,22 @@
       {
         "type": "paragraph",
         "value": "When activated, choose one of the following options. You may not use these Abilities on your own Mech."
+      },
+      {
+        "type": "list-item",
+        "value": "Restore up to 15 SP to a target Mech within the Fabrication Bay with at least 1 SP."
+      },
+      {
+        "type": "list-item",
+        "value": "Restore up to 2 EP to a target Mech within the Fabrication Bay."
+      },
+      {
+        "type": "list-item",
+        "value": "Repair up to 3 damaged Systems or Modules of Tech 1-5 within the Fabrication Bay to Intact Condition."
+      },
+      {
+        "type": "list-item",
+        "value": "Repair up to 2 damaged Mech Chassis or Vehicles of Tech 1-5 within the Fabrication Bay to Intact Condition."
       }
     ],
     "actionSource": "systems"


### PR DESCRIPTION
## Problem

The **Fabrication Bay** system (`/schema/systems/item/fabrication-bay`) displayed text ending with *"When activated, choose one of the following options. You may not use these Abilities on your own Mech."* — but no options rendered. (Reported via self-report: "Missing options!")

The action's `content` promised options but enumerated none, so the display layer (`getChoices` → `ReferenceEntityResolvedChoices`) had nothing to render.

## Fix

Added the four options verbatim from the Core Book p.183 (the "Workshop Manual" systems chapter) as `list-item` content blocks on the Fabrication Bay action, matching the established Auto-Repair Droid pattern:

- Restore up to 15 SP to a target Mech within the Fabrication Bay (with ≥1 SP)
- Restore up to 2 EP to a target Mech within the Fabrication Bay
- Repair up to 3 damaged Systems or Modules (Tech 1–5) to Intact Condition
- Repair up to 2 damaged Mech Chassis or Vehicles (Tech 1–5) to Intact Condition

## Scope check

Swept **all 686 actions** plus every other data file (systems, equipment, modules, abilities, chassis, npcs, meld, squads, bio-titans, vehicles, roll-tables, etc.) for "promise without enumeration" across all six enumeration forms (list-items, `choices`, `customSystemOptions`, roll-table refs, follow-up paragraphs, linked entities). **Fabrication Bay was the only entity in the dataset genuinely missing its options.**

## Verification

- `build:package` (tsc + JSON-schema regen) ✓ (no schema diff)
- `validate:all` (27 files vs Zod schemas) ✓
- `typecheck` ✓ · `salvageunion-reference test` 589 pass / 0 fail ✓
- Prettier ✓ · pre-push hooks (validate, knip, typecheck, test) ✓

Includes a user-facing changelog entry on the SRD site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)