### PR TITLE
fix(mcp): drop ${VAR} secret headers from tracked .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,20 +3,6 @@
     "netlify": {
       "command": "npx",
       "args": ["-y", "@netlify/mcp"]
-    },
-    "render": {
-      "type": "http",
-      "url": "https://mcp.render.com/mcp",
-      "headers": {
-        "Authorization": "Bearer ${RENDER_API_KEY}"
-      }
-    },
-    "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/",
-      "headers": {
-        "Authorization": "Bearer ${GITHUB_PAT}"
-      }
     }
   }
 }


### PR DESCRIPTION
## What

Removes the `render` and `github` HTTP MCP server entries from the tracked `.mcp.json`, leaving only the no-auth `netlify` server.

## Why

Those two entries carried `Bearer ${RENDER_API_KEY}` / `Bearer ${GITHUB_PAT}` headers in a **git-tracked** file. That is the Claude Code [#18692](https://github.com/anthropics/claude-code/issues/18692) re-expansion hazard: a later `claude mcp add` run in this repo can expand the `${VAR}` placeholder and write the **resolved token back into this tracked file**.

This was a hazard surface, not an active leak — no resolved token was ever committed (verified across the full history of the file).

Both servers are already configured correctly for this project in the off-git `~/.claude.json` via a `headersHelper → op read` hook (1Password, resolved in-process, never on disk), so the committed entries were a redundant, inferior duplicate. HTTP MCP secret resolution is inherently per-machine and belongs in `~/.claude.json`, not a shared tracked file.

## Effect

- The `${VAR}` re-expansion surface is gone from git.
- `render` + `github` keep working locally via the existing headersHelper config — no behavior change.
- No machine-specific path baked into the shared file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)