### PR TITLE
fix(suref-react): drive Legal Starting Pattern badge from data tag

### DIFF
--- a/packages/salvageunion-reference/data/chassis.json
+++ b/packages/salvageunion-reference/data/chassis.json
@@ -6178,7 +6178,6 @@
     "patterns": [
       {
         "name": "10 Finger Pattern",
-        "legalStarting": true,
         "systems": [
           {
             "name": "Rigging Arm"
@@ -6271,7 +6270,6 @@
     "patterns": [
       {
         "name": "DronTek Pattern",
-        "legalStarting": true,
         "systems": [
           {
             "name": "K4 Rifle"
@@ -6348,7 +6346,6 @@
     "patterns": [
       {
         "name": "Deerstalker Pattern",
-        "legalStarting": true,
         "systems": [
           {
             "name": "Mech Melee Armament"
@@ -6420,7 +6417,6 @@
     "patterns": [
       {
         "name": "Stefanus Pattern",
-        "legalStarting": true,
         "systems": [
           {
             "name": "Needle Missile Pod",
@@ -6802,7 +6798,6 @@
     "patterns": [
       {
         "name": "Hunchback Pattern",
-        "legalStarting": false,
         "systems": [
           {
             "name": "Long Barrelled Green Laser"
@@ -7132,7 +7127,6 @@
       },
       {
         "name": "Warrior Pattern",
-        "legalStarting": true,
         "systems": [
           {
             "name": "Armoured Shield"
@@ -7235,7 +7229,6 @@
     "patterns": [
       {
         "name": "Moth Pattern",
-        "legalStarting": true,
         "systems": [
           {
             "name": ".50 Cal Machine Gun"

--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/__tests__/legalStartingBadge.test.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/__tests__/legalStartingBadge.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, afterEach } from 'bun:test'
+import { render, screen, cleanup, renderHook } from '@testing-library/react'
+import type { SURefEntity } from 'salvageunion-reference'
+import { useChassisPatternConfig } from '../useChassisPatternConfig'
+import type { PatternOverrideData } from '../referenceEntityDisplayTypes'
+
+/**
+ * "Legal Starting Pattern" is an explicit data tag on a pattern (`legalStarting`),
+ * set only where the source book calls it out. The badge must be driven purely by
+ * that field — never computed from tech level or salvage value. Previously it was
+ * derived from an SV-budget check, so untagged patterns (e.g. every Gopher pattern)
+ * were wrongly badged.
+ */
+describe('useChassisPatternConfig legal starting badge', () => {
+  afterEach(cleanup)
+
+  // Synthetic chassis: one pattern explicitly tagged, one not. Resolution is by
+  // pattern name against this chassis's own patterns, so the dataset is irrelevant.
+  const chassis = {
+    id: 'test-chassis',
+    name: 'Testudo',
+    techLevel: 1,
+    salvageValue: 4,
+    patterns: [
+      { name: 'Tagged Pattern', legalStarting: true, systems: [], modules: [] },
+      { name: 'Untagged Pattern', systems: [], modules: [] },
+    ],
+  } as unknown as SURefEntity
+
+  const override = (name: string): PatternOverrideData => ({ name, systems: [], modules: [] })
+
+  const badgePresent = (patternName: string): boolean => {
+    const { result } = renderHook(() =>
+      useChassisPatternConfig(chassis, override(patternName), false)
+    )
+    render(<>{result.current?.subtitleExtra}</>)
+    return screen.queryByText('Legal Starting Pattern') !== null
+  }
+
+  it('shows the badge when the resolved pattern is tagged legalStarting', () => {
+    expect(badgePresent('Tagged Pattern')).toBe(true)
+  })
+
+  it('hides the badge when the pattern carries no legalStarting tag', () => {
+    expect(badgePresent('Untagged Pattern')).toBe(false)
+  })
+})

--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/patternOverrideUtils.ts
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/patternOverrideUtils.ts
@@ -24,26 +24,6 @@ export function resolvePatternOverride(
   return patterns.find((p) => normalizePatternName(p.name) === normalizedOverride)
 }
 
-/**
- * Check whether a pattern override qualifies as a legal starting mech (total SV <= 20).
- */
-export function checkLegalStartingMech(
-  data: SURefEntity,
-  patternOverride: PatternOverrideData
-): boolean {
-  const STARTING_MECH_BUDGET = 20
-  let total = getSalvageValue(data) ?? 0
-  for (const sys of patternOverride.systems) {
-    const entity = SalvageUnionReference.Systems.find((s) => s.name === sys.name)
-    if (entity) total += getSalvageValue(entity) ?? 0
-  }
-  for (const mod of patternOverride.modules) {
-    const entity = SalvageUnionReference.Modules.find((m) => m.name === mod.name)
-    if (entity) total += getSalvageValue(entity) ?? 0
-  }
-  return total <= STARTING_MECH_BUDGET
-}
-
 /** Sum SV * TL for a list of pattern items (systems or modules). */
 function sumItemTL1(
   items: PatternItem[],

--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/useChassisPatternConfig.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/useChassisPatternConfig.tsx
@@ -10,11 +10,7 @@ import { cn } from '../../../utils/cn'
 import { Text } from '../../base/Text'
 import { BlockContentRendererView } from '../BlockContentRendererView'
 import { ReferenceEntityChassisAbilitiesContent } from './ReferenceEntityChassisAbilitiesContent'
-import {
-  resolvePatternOverride,
-  checkLegalStartingMech,
-  computeSvOverride,
-} from './patternOverrideUtils'
+import { resolvePatternOverride, computeSvOverride } from './patternOverrideUtils'
 import {
   getReferenceEntityFontSizes,
   getReferenceEntitySpacing,
@@ -59,10 +55,10 @@ export function useChassisPatternConfig(
     () => (patternOverride ? resolvePatternOverride(data, patternOverride) : undefined),
     [data, patternOverride]
   )
-  const isLegalStartingMech = useMemo(
-    () => (patternOverride ? checkLegalStartingMech(data, patternOverride) : false),
-    [data, patternOverride]
-  )
+  // "Legal Starting Pattern" is an explicit data tag on the pattern (set only
+  // where the source book calls it out), not a value computed from tech level or
+  // salvage value. The badge shows iff the resolved pattern record carries it.
+  const isLegalStartingMech = overridePatternData?.legalStarting === true
   const svOverride = useMemo(
     () => (patternOverride ? computeSvOverride(data, patternOverride) : undefined),
     [data, patternOverride]


### PR DESCRIPTION
## Problem

A lot of patterns were badged as **Legal Starting Pattern** that shouldn't be — e.g. every Gopher pattern (a T2 chassis). Two distinct issues:

1. The badge was **computed** at display time instead of reading the data tag.
2. The underlying `legalStarting` data tags didn't match the source books.

## "Legal Starting" is a source-book data tag

The designation comes verbatim from the Workshop Manual (Core Book): *"This Pattern is a legal Tech 1 build for a starting Mech if you are new to the game."* It is an explicit per-pattern tag, set only where the source book prints that text — never derived from a tech-level/SV rule.

Verified across every source book the chassis data draws from (Core Book / Workshop Manual, Starter Set + all its booklets, False Flag, Rainmaker, We Were Here First, asset-pack booklets): the text appears **only** in the Core Book, marking exactly 5 patterns — Hauler (Mule), Buzzard (Mazona), Leaky (Scrapper), Settler (Spectrum), Shepherd (Thresher).

## Changes

**1. Drive the badge from the data tag** (`suref-react`)
- `isLegalStartingMech` now reads `legalStarting` off the resolved pattern record in `useChassisPatternConfig`.
- Removed the computed `checkLegalStartingMech` helper (wrong mechanism).
- Regression test `legalStartingBadge.test.tsx`: badge shows for a tagged pattern, hidden for an untagged one.

**2. Correct the data** (`salvageunion-reference`)
- Removed 7 `legalStarting` tags with no "Legal Starting Mech" text in their source book: Warrior (Bobcat), Moth (Gatecrasher), 10 Finger (Kelpie), Deerstalker (Pioneer), DronTek (Trooper), Stefanus (Parasite) — all `true` — and Hunchback (Ravager) `false`.
- The 5 Workshop Manual tags remain. Text-level edit; prettier confirms `chassis.json` formatting unchanged.

## Checks

`bun --filter suref-react test` (305 pass), typecheck, lint, knip, and `validate:all` (27 files) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)