### PR TITLE
fix(reference): align Adv. Epoxy Applicator self-action name for bubble-up

### DIFF
--- a/packages/salvageunion-reference/data/actions.json
+++ b/packages/salvageunion-reference/data/actions.json
@@ -193,7 +193,7 @@
   },
   {
     "id": "97731aa7-b6fa-48cb-94c7-776c3f6216db",
-    "name": "Advanced Epoxy Applicator",
+    "name": "Adv. Epoxy Applicator",
     "content": [
       {
         "type": "paragraph",

--- a/packages/salvageunion-reference/data/equipment.json
+++ b/packages/salvageunion-reference/data/equipment.json
@@ -489,7 +489,7 @@
       "Patch (Adv. Epoxy Applicator)",
       "System Repair",
       "Chassis Repair",
-      "Advanced Epoxy Applicator"
+      "Adv. Epoxy Applicator"
     ],
     "page": 84
   },


### PR DESCRIPTION
## Problem

The user reported a discrepancy between "ADV" entities and "Advanced" actions breaking the action **bubble-up** logic — actions named "Advanced …" belonging to "Adv." entities that should be descriptions of the main entity, not standalone actions.

There was exactly one such case in the dataset:

- The **`Adv. Epoxy Applicator`** equipment entity (`equipment.json`) listed a self-description action named **`Advanced Epoxy Applicator`** (full word).
- The bubble-up logic `findMatchingAction()` in `lib/utilities.ts` keys on an exact `action.name === entity.name` match to pull a self-named action's stats/content into the entity header (`activationCost`, `actionType`, `range`, `damage`, `traits`, `table`, `options`, `choices`).
- Because `"Advanced Epoxy Applicator"` ≠ `"Adv. Epoxy Applicator"`, the match failed, and the action — a pure flavor-text description of the equipment, with no independent stats — leaked out as a spurious standalone action instead of bubbling into the header.

Every other "Adv. repair-arm" entity already follows the correct pattern (e.g. `Adv. Fabrication Arm`'s self-action is named exactly `Adv. Fabrication Arm`).

## Fix

Pure data rename to match the established pattern — the action is genuinely a description of the main entity, not an independent action:

- `actions.json`: action `Advanced Epoxy Applicator` → `Adv. Epoxy Applicator` (ID unchanged)
- `equipment.json`: the entity's `actions` reference updated to match

## Verification

- `bun run validate:all` — IDs, references, action refs, orphans, traits, schemas all ✅
- `bun --filter salvageunion-reference test` — 589 pass, 0 fail
- Confirmed no `Advanced Epoxy Applicator` strings remain in `data/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)