### PR TITLE
fix(suref-react): surface matching-action stats in resolved data row

### DIFF
--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/ReferenceEntityResolvedDataRow.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/ReferenceEntityResolvedDataRow.tsx
@@ -1,5 +1,15 @@
-import type { SURefEntity, SURefObjectDataValue } from 'salvageunion-reference'
-import { getChoices, resolveChoiceView } from 'salvageunion-reference'
+import type {
+  SURefEntity,
+  SURefObjectContentBlock,
+  SURefObjectDataValue,
+} from 'salvageunion-reference'
+import {
+  getChoices,
+  getDamage,
+  getRange,
+  getTraits,
+  resolveChoiceView,
+} from 'salvageunion-reference'
 import { DataValueDisplayView } from '../DataValueDisplayView'
 import type { ChoiceSelections } from '../choiceCard/choiceSelectionHelpers'
 
@@ -8,6 +18,46 @@ type ReferenceEntityResolvedDataRowProps = {
   /** Current choice selections — the row recomputes live as these change. */
   selections: ChoiceSelections
   compact?: boolean
+}
+
+/**
+ * Systems/modules carry their stats (Range/Damage/Traits) and their choice on a
+ * same-named action, not as a root `datavalues` content block or root `choices`
+ * — e.g. the Mech Melee Armament System, whose action holds the stats plus a
+ * freeform "describe the weapon" choice. `resolveChoiceView` only reads the root
+ * datavalues/traits/choices shape (the granted-equipment shape, e.g. the Custom
+ * Sniper Rifle), so for these entities it would resolve an empty data row and
+ * drop the stats. When the entity has no root datavalues block and no root
+ * choices, seed a synthetic resolvable from the matching action's resolved
+ * Range/Damage/Traits so the data row matches the static (non-choice) path.
+ *
+ * Entities carrying their own datavalues block or root choices (granted
+ * equipment) pass through unchanged.
+ */
+function toResolvable(data: SURefEntity): SURefEntity | { content: SURefObjectContentBlock[] } {
+  const content = 'content' in data && Array.isArray(data.content) ? data.content : undefined
+  const hasOwnDataValues = content?.some((block) => block.type === 'datavalues') ?? false
+  const hasRootChoices = 'choices' in data && Array.isArray(data.choices)
+  if (hasOwnDataValues || hasRootChoices) {
+    return data
+  }
+
+  const datavalues: SURefObjectDataValue[] = []
+  const damage = getDamage(data)
+  if (damage) {
+    datavalues.push({
+      label: 'Damage',
+      type: 'keyword',
+      value: damage.amount,
+      unit: damage.damageType,
+    })
+  }
+  const range = getRange(data)
+  if (range) {
+    range.forEach((r) => datavalues.push({ label: 'Range', type: 'keyword', value: r }))
+  }
+  const block: SURefObjectContentBlock = { type: 'datavalues', value: datavalues }
+  return { content: [block], traits: getTraits(data) ?? [] }
 }
 
 /**
@@ -27,7 +77,7 @@ export function ReferenceEntityResolvedDataRow({
   selections,
   compact,
 }: ReferenceEntityResolvedDataRowProps) {
-  const view = resolveChoiceView(data, selections)
+  const view = resolveChoiceView(toResolvable(data), selections)
   const choices = getChoices(data) ?? []
 
   // Resolved traits render with the same chrome as the base datavalues.

--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/__tests__/mechMeleeArmamentStats.test.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/__tests__/mechMeleeArmamentStats.test.tsx
@@ -1,0 +1,51 @@
+import { describe, test, expect, afterEach } from 'bun:test'
+import { render, screen, cleanup } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+import { ReferenceEntityDisplay } from '../index'
+
+/**
+ * Regression: the Mech Melee Armament System carries its stats (Range/Damage/
+ * Traits) and a freeform "describe the weapon" choice on a same-named action,
+ * not as a root `datavalues` block. The choice flips the display into the
+ * resolved-data-row path (used by granted equipment like the Custom Sniper
+ * Rifle), which only reads root datavalues/traits — so the stats used to vanish,
+ * leaving an empty data block (seen on e.g. the Brawler "Gladiator Pattern").
+ * The resolved data row now seeds its base stats from the matching action.
+ */
+const meleeArmament = SalvageUnionReference.Systems.find((s) => s.name === 'Mech Melee Armament')
+// A sibling matching-action-choice System with no Range/Damage/Traits — guards
+// against the fix surfacing spurious stats where there are none.
+const bodyKit = SalvageUnionReference.Systems.find((s) => s.name === 'Industrial Body Kit')
+
+afterEach(() => cleanup())
+
+describe('Mech Melee Armament resolved data row', () => {
+  test('fixtures resolve', () => {
+    expect(meleeArmament).toBeDefined()
+    expect(bodyKit).toBeDefined()
+  })
+
+  test('renders Damage 5 SP from the matching action', () => {
+    render(<ReferenceEntityDisplay data={meleeArmament} compact />)
+    expect(screen.getByText('Damage')).toBeTruthy()
+    expect(screen.getByText('SP')).toBeTruthy()
+  })
+
+  test('renders Range Close from the matching action', () => {
+    render(<ReferenceEntityDisplay data={meleeArmament} compact />)
+    expect(screen.getByText('Range')).toBeTruthy()
+    expect(screen.getByText('Close')).toBeTruthy()
+  })
+
+  test('renders the Melee and Wield traits from the matching action', () => {
+    render(<ReferenceEntityDisplay data={meleeArmament} compact />)
+    expect(screen.getByText(/^melee$/i)).toBeTruthy()
+    expect(screen.getByText(/^wield$/i)).toBeTruthy()
+  })
+
+  test('a sibling matching-action-choice System with no stats shows no Damage/Range', () => {
+    render(<ReferenceEntityDisplay data={bodyKit} compact />)
+    expect(screen.queryByText('Damage')).toBeNull()
+    expect(screen.queryByText('Range')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Symptom

On the Brawler "Gladiator Pattern" chassis, the **Mech Melee Armament** System rendered an **empty data block** — no Range, Damage, or Traits.

## Root cause

That System carries its stats (Range/Damage/Traits) and its freeform "describe the weapon" choice on a **same-named action** (resolved via the action map), not as a root `datavalues` content block or root `choices`. The freeform choice routes the display through `ReferenceEntityResolvedDataRow` → `resolveChoiceView`, which only reads the **root** datavalues/traits/choices shape (the granted-equipment shape, e.g. the Custom Sniper Rifle). For matching-action systems it therefore resolved an empty row and dropped the action-sourced stats. The data and ORM are correct — this is purely a display-layer bug.

## Fix

In `ReferenceEntityResolvedDataRow`, when the entity has **no root `datavalues` block and no root `choices`**, seed the resolved data row's base stats from the matching action's resolved Range/Damage/Traits (via `getDamage`/`getRange`/`getTraits`) before handing off to `resolveChoiceView`. Granted equipment (own `datavalues` block or root `choices`, e.g. the Custom Sniper Rifle) passes through unchanged.

## Testing

- New regression test `mechMeleeArmamentStats.test.tsx`: asserts Mech Melee Armament renders Damage (SP), Range (Close), and the Melee/Wield traits; and a sibling stat-less matching-action System (Industrial Body Kit) shows **no** spurious Damage/Range.
- `bun --filter suref-react test` — **308 pass, 0 fail** (new test passes; existing `grantedEquipmentDisplay.test.tsx` Custom Sniper Rifle still passes — no regression).
- `bun run typecheck` — pass (all packages, 0 errors).
- `bun run lint` — pass (exit 0).
- `bun run format` — pass (formatting applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)