### PR TITLE
refactor(suref-react): keep editable inputs out of the SRD reference

### DIFF
--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/ReferenceEntityNpcDisplay.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/ReferenceEntityNpcDisplay.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect, useRef } from 'react'
 import type { ReactNode } from 'react'
 import { getNpc } from 'salvageunion-reference'
 import type { SURefMetaEntity } from 'salvageunion-reference'
@@ -36,79 +35,14 @@ type ReferenceEntityNpcDisplayProps = {
   headerBg?: string
   /** Parent raw CSS color (for content-block border color) */
   headerBgColor?: string
-  /** NPC name value (for inline editing in embedded mode) */
+  /** NPC name value (rendered as static text) */
   npcName?: string
-  /** Callback when NPC name changes */
-  onNpcNameChange?: (name: string) => void
-  /** Callback when NPC name input loses focus */
-  onNpcNameBlur?: () => void
   /** Whether the NPC fields are read-only */
   readOnly?: boolean
   /** Show an "NPC" section separator above the NPC name/HP block */
   showSeparator?: boolean
   /** Hide the header row (name, position, HP) in embedded mode */
   hideHeader?: boolean
-}
-
-function NpcNameInput({
-  value,
-  onChange,
-  onBlur,
-  compact,
-}: {
-  value: string
-  onChange: (value: string) => void
-  onBlur?: () => void
-  compact?: boolean
-}) {
-  const measureRef = useRef<HTMLSpanElement>(null)
-  const [inputWidth, setInputWidth] = useState(0)
-  const fontClass = compact ? 'text-base' : 'text-[1.75rem]'
-  const placeholder = 'Name...'
-
-  useEffect(() => {
-    if (measureRef.current) {
-      setInputWidth(measureRef.current.scrollWidth)
-    }
-  }, [value])
-
-  return (
-    <span className="relative inline-flex items-baseline">
-      <span
-        ref={measureRef}
-        aria-hidden
-        className={`pointer-events-none invisible absolute whitespace-pre font-cond ${fontClass} font-bold uppercase leading-none`}
-      >
-        {value || placeholder}
-      </span>
-      <Text
-        variant="pseudoheader"
-        as="span"
-        className={cn(
-          'inline-flex items-center box-decoration-clone bg-su-black px-1 text-su-white',
-          fontClass,
-          compact ? 'py-[3px]' : 'py-1'
-        )}
-        style={compact ? { lineHeight: 1 } : undefined}
-      >
-        <input
-          type="text"
-          size={1}
-          placeholder={placeholder}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          onBlur={onBlur}
-          className={cn(
-            'border-none bg-transparent p-0 outline-none',
-            'font-cond font-bold uppercase leading-none tracking-tight',
-            'text-su-white placeholder:normal-case placeholder:text-su-white/50',
-            fontClass
-          )}
-          style={{ width: inputWidth || undefined, lineHeight: compact ? 1 : undefined }}
-        />
-      </Text>
-    </span>
-  )
 }
 
 export function ReferenceEntityNpcDisplay({
@@ -124,8 +58,6 @@ export function ReferenceEntityNpcDisplay({
   headerBg,
   headerBgColor,
   npcName,
-  onNpcNameChange,
-  onNpcNameBlur,
   readOnly = false,
   showSeparator,
   hideHeader = false,
@@ -134,8 +66,8 @@ export function ReferenceEntityNpcDisplay({
   if (!npc) return null
 
   const hasContent = !hideContent && npc.content && npc.content.length > 0
-  // Static when explicitly readOnly OR when no interactive props are provided
-  const isStatic = readOnly || (!npcChildren && !onNpcNameChange && !hpSlot)
+  // Static when explicitly readOnly OR when no interactive slots are provided
+  const isStatic = readOnly || (!npcChildren && !hpSlot)
   // showSeparator: explicit true/false overrides, undefined defaults to isStatic
   const renderSeparator = showSeparator ?? isStatic
 
@@ -153,26 +85,17 @@ export function ReferenceEntityNpcDisplay({
             <div className="min-w-0">
               {hasName && (
                 <div>
-                  {readOnly || !onNpcNameChange ? (
-                    <Text
-                      variant="pseudoheader"
-                      as="span"
-                      className={cn(
-                        'box-decoration-clone bg-su-black px-1 text-su-white uppercase tracking-[-0.02em]',
-                        compact ? 'py-[3px] text-base' : 'py-1 text-[1.75rem]'
-                      )}
-                      style={compact ? { lineHeight: 1 } : undefined}
-                    >
-                      {npcName || '\u2014'}
-                    </Text>
-                  ) : (
-                    <NpcNameInput
-                      value={npcName}
-                      onChange={onNpcNameChange}
-                      onBlur={onNpcNameBlur}
-                      compact={compact}
-                    />
-                  )}
+                  <Text
+                    variant="pseudoheader"
+                    as="span"
+                    className={cn(
+                      'box-decoration-clone bg-su-black px-1 text-su-white uppercase tracking-[-0.02em]',
+                      compact ? 'py-[3px] text-base' : 'py-1 text-[1.75rem]'
+                    )}
+                    style={compact ? { lineHeight: 1 } : undefined}
+                  >
+                    {npcName || '\u2014'}
+                  </Text>
                 </div>
               )}
               {npc.position && (
@@ -210,19 +133,8 @@ export function ReferenceEntityNpcDisplay({
   // Full card framing for standalone NPC display
   const hasName = npcName !== undefined
 
-  // Build title: editable input or static name (falls back to position)
-  const titleContent = hasName
-    ? readOnly || !onNpcNameChange
-      ? npcName || '\u2014'
-      : ((
-          <NpcNameInput
-            value={npcName}
-            onChange={onNpcNameChange}
-            onBlur={onNpcNameBlur}
-            compact={compact}
-          />
-        ) as React.ReactNode)
-    : (npc.position ?? '')
+  // Build title: static name (falls back to position)
+  const titleContent = hasName ? npcName || '\u2014' : (npc.position ?? '')
 
   // HP as stats on DisplayCard (when no custom hpSlot), or as rightContent (when hpSlot)
   const npcStats: StatItem[] | undefined =

--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/ReferenceEntityResolvedChoices.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/ReferenceEntityResolvedChoices.tsx
@@ -18,6 +18,12 @@ type ReferenceEntityResolvedChoicesProps = {
   selections: ChoiceSelections
   onSelectionChange: (selections: ChoiceSelections) => void
   /**
+   * Render free-text choices (Name / Appearance / A.I. Personality) as static
+   * text rather than editable inputs. The SRD reference has no persistence, so
+   * it reads-only; ITUN's live builder leaves this false to allow editing.
+   */
+  readOnly?: boolean
+  /**
    * Optional scaling parent for `constraints.scalesWithField` caps (e.g. the
    * Modification choice scaling with `techLevel`). A consumer with a play/build
    * context (ITUN) passes e.g. `{ techLevel: effectiveCrawlerLevel }` so the cap
@@ -46,6 +52,7 @@ export function ReferenceEntityResolvedChoices({
   parentHeaderBgColor,
   selections,
   onSelectionChange,
+  readOnly,
   scalingParent,
 }: ReferenceEntityResolvedChoicesProps) {
   const choices = getChoices(data) ?? []
@@ -66,6 +73,7 @@ export function ReferenceEntityResolvedChoices({
       parent={scalingParent}
       selections={selections}
       onSelectionChange={onSelectionChange}
+      readOnly={readOnly}
       compact={compact}
       parentHeaderBg={parentHeaderBg}
       parentHeaderBgColor={parentHeaderBgColor}

--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/components/ReferenceEntityDisplayContent.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/components/ReferenceEntityDisplayContent.tsx
@@ -824,6 +824,7 @@ export function ReferenceEntityDisplayContent({
                 parentHeaderBgColor={headerBgColor}
                 selections={choiceSelections}
                 onSelectionChange={setChoiceSelections}
+                readOnly={onSelectionChange === undefined}
                 scalingParent={scalingParent}
               />
               <ReferenceEntityIntegratedSystems data={data} compact={compact} />
@@ -879,8 +880,6 @@ export function ReferenceEntityDisplayContent({
                       headerBg={headerBg}
                       headerBgColor={headerBgColor}
                       npcName={npcConfig?.name}
-                      onNpcNameChange={npcConfig?.onNameChange}
-                      onNpcNameBlur={npcConfig?.onNameBlur}
                       readOnly={npcConfig?.readOnly}
                       showSeparator={npcConfig?.showNpcSeparator}
                       hideHeader={npcConfig?.hideNpcHeader}

--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/referenceEntityDisplayTypes.ts
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/referenceEntityDisplayTypes.ts
@@ -71,8 +71,6 @@ export type NpcConfig = {
   afterContent?: ReactNode
   damaged?: boolean
   name?: string
-  onNameChange?: (name: string) => void
-  onNameBlur?: () => void
   readOnly?: boolean
   /** Show an "NPC" section separator above the NPC name/HP block */
   showNpcSeparator?: boolean

--- a/packages/suref-react/src/components/referenceEntity/choiceCard/ChoiceCard.tsx
+++ b/packages/suref-react/src/components/referenceEntity/choiceCard/ChoiceCard.tsx
@@ -182,12 +182,20 @@ type FreeTextChoiceCardProps = ChoiceCardShellProps & {
   multiline?: boolean
   /** Placeholder text for the field. */
   placeholder?: string
+  /**
+   * Render as a static, non-editable card (no input). The SRD reference (and
+   * read-only snapshots) have no persistence, so they show the prompt — or the
+   * saved value — as plain text instead of an editable field. Editable surfaces
+   * (ITUN's live builder) leave this false.
+   */
+  readOnly?: boolean
 }
 
 /**
- * ChoiceCard (free-text variant) — the same coloured header + white inset body,
- * wrapping an editable field (Name / Appearance / A.I. Personality). Always
- * renders fully active (full accent fill + full title); no Chosen/Not-Chosen
+ * ChoiceCard (free-text variant) — the same coloured header + white inset body.
+ * When editable it wraps an input field (Name / Appearance / A.I. Personality);
+ * when `readOnly` it renders the saved value (or the prompt) as static text.
+ * Always renders fully active (full accent fill + full title); no Chosen/Not-Chosen
  * status, and the prompt becomes the field placeholder.
  */
 export function FreeTextChoiceCard({
@@ -200,11 +208,16 @@ export function FreeTextChoiceCard({
   compact = false,
   parentHeaderBg,
   parentHeaderBgColor,
+  readOnly = false,
 }: FreeTextChoiceCardProps) {
   const accent = choiceAccent(parentHeaderBg, parentHeaderBgColor)
   // The prompt becomes the field's placeholder — these are inputs, not text
   // description fields.
   const effectivePlaceholder = placeholder ?? description
+  const fontSize = compact ? 'text-xs' : 'text-sm'
+  // Static view shows the saved value, falling back to the prompt (muted).
+  const staticText = value || effectivePlaceholder || '—'
+  const parsedStaticText = useParseTraitReferences(staticText)
 
   const handleChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     onValueChange?.(event.target.value)
@@ -225,7 +238,11 @@ export function FreeTextChoiceCard({
     >
       <ChoiceCardHeader label={label} chosen compact={compact} />
       <ChoiceCardBody accent={accent} compact={compact}>
-        {multiline ? (
+        {readOnly ? (
+          <Text as="span" className={cn('block text-su-black', fontSize, !value && 'opacity-70')}>
+            {parsedStaticText}
+          </Text>
+        ) : multiline ? (
           <textarea
             aria-label={label}
             className={fieldClasses}

--- a/packages/suref-react/src/components/referenceEntity/choiceCard/ChoiceGroup.tsx
+++ b/packages/suref-react/src/components/referenceEntity/choiceCard/ChoiceGroup.tsx
@@ -19,6 +19,8 @@ type ChoiceGroupProps = {
   onFreeTextChange: (value: string) => void
   /** Resolved multi-select cap, when one applies. */
   cap?: number
+  /** Render free-text choices as static text (no input) — the SRD reference. */
+  readOnly?: boolean
   compact?: boolean
   parentHeaderBg?: string
   parentHeaderBgColor?: string
@@ -39,6 +41,7 @@ export function ChoiceGroup({
   onToggleOption,
   onFreeTextChange,
   cap,
+  readOnly,
   compact,
   parentHeaderBg,
   parentHeaderBgColor,
@@ -60,6 +63,7 @@ export function ChoiceGroup({
         value={currentValue}
         onValueChange={onFreeTextChange}
         multiline={choice.name.toLowerCase() !== 'name'}
+        readOnly={readOnly}
         compact={compact}
         parentHeaderBg={parentHeaderBg}
         parentHeaderBgColor={parentHeaderBgColor}

--- a/packages/suref-react/src/components/referenceEntity/choiceCard/ChoiceGroups.tsx
+++ b/packages/suref-react/src/components/referenceEntity/choiceCard/ChoiceGroups.tsx
@@ -25,6 +25,12 @@ type ChoiceGroupsProps = {
   selections?: ChoiceSelections
   /** Called with the next selections map whenever a selection changes. */
   onSelectionChange?: (selections: ChoiceSelections) => void
+  /**
+   * Render free-text choices as static text instead of editable inputs. The SRD
+   * reference (and read-only snapshots) have no persistence, so their Name /
+   * Appearance / A.I. Personality fields show as plain text, not inputs.
+   */
+  readOnly?: boolean
   compact?: boolean
   parentHeaderBg?: string
   parentHeaderBgColor?: string
@@ -49,6 +55,7 @@ export function ChoiceGroups({
   parent,
   selections: controlledSelections,
   onSelectionChange,
+  readOnly,
   compact,
   parentHeaderBg,
   parentHeaderBgColor,
@@ -102,6 +109,7 @@ export function ChoiceGroups({
           cap={resolveMultiSelectCap(choice, parent)}
           onToggleOption={(value) => handleToggleOption(choice, value)}
           onFreeTextChange={(value) => handleFreeTextChange(choice, value)}
+          readOnly={readOnly}
           compact={compact}
           parentHeaderBg={parentHeaderBg}
           parentHeaderBgColor={parentHeaderBgColor}


### PR DESCRIPTION
## Problem

The static SRD reference site (`apps/suref-web`) was rendering live, editable text inputs that belong only in the character builder (ITUN). The most visible case: free-text choice fields like the **Sestra Drone's "A.I. Personality"** rendered as an editable `<input>`/`<textarea>` on the reference site, where there's no persistence — keystrokes were ephemeral and lost on refresh.

## Changes

**1. Free-text choice cards render as static text on the SRD (still editable in ITUN).**
`FreeTextChoiceCard` (Name / Appearance / A.I. Personality) now takes a `readOnly` flag, threaded through `ReferenceEntityResolvedChoices → ChoiceGroups → ChoiceGroup`. The flag is derived from the absence of a real consumer change handler (`onSelectionChange === undefined`):
- **SRD reference** → renders the prompt (or saved value) as plain text, no input.
- **ITUN live builder** → unchanged, fully editable.
- **Bonus:** ITUN read-only snapshots also go static — they previously showed inputs that silently dropped keystrokes.

**2. Removed the dead shared NPC-name input.**
`NpcNameInput` plus its `onNpcNameChange` / `onNpcNameBlur` props (and the `NpcConfig.onNameChange` / `onNameBlur` fields) were unused: ITUN edits NPC names through its own `InlineEditField` / `NpcInset`, and no consumer passed `npcConfig`'s name-edit callbacks. NPC names now render as static text.

## Out of scope (intentionally left alone)

- Choice **option toggle** cards (buttons, not text inputs).
- `GuideStepsDisplay`'s interactive text inputs — gated behind an `interactive` config that no app ever passes, so they never appear in the SRD. Removing that whole config surface is a separate dead-code cleanup.

## Validation

- `bun run typecheck` — clean across all packages
- `bun --filter suref-react test` — 303 pass
- `bun --filter in-the-union-now test` — 888 pass
- `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)