### PR TITLE
fix(data): remove broken Elite Blade Squad asset_url

### DIFF
--- a/packages/salvageunion-reference/data/squads.json
+++ b/packages/salvageunion-reference/data/squads.json
@@ -99,7 +99,6 @@
     ],
     "hitPoints": 20,
     "damageType": "HP",
-    "asset_url": "https://assets.salvageunion.io/squads/elite%20blade%20squad.jpg",
     "page": 301,
     "content": [
       {


### PR DESCRIPTION
The Elite Blade Squad `asset_url` pointed at `squads/elite blade squad.jpg`, which **never existed in the source bucket** — it 404'd on Supabase and on the new `assets.salvageunion.io` host alike (a pre-existing dangling reference surfaced during the Supabase→Netlify migration, #298).

`asset_url` is optional, so removing it lets the squad render without art (no broken image). One-line data deletion; `validate:all` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHW9jnT9PCApxpedD8RZNN