### PR TITLE
feat(itun): pattern/custom mech wizard flow + masonry selectors

### DIFF
--- a/apps/in-the-union-now/e2e/_helpers.ts
+++ b/apps/in-the-union-now/e2e/_helpers.ts
@@ -85,14 +85,16 @@ export async function buildPilot(page: Page, name: string, callsign: string): Pr
   await page.waitForURL((url) => url.pathname === '/', { timeout: 15_000 })
 }
 
-/** Build a mech (Chassis → Systems → Modules → Identity → Review). */
+/** Build a mech (Chassis → Pattern → Loadout → Identity → Review). */
 export async function buildMech(page: Page, name: string): Promise<void> {
   await page.goto('/mechs/new')
   await waitForReady(page)
   await pickByName(page, 'Mule')
-  await clickNext(page) // -> Systems
-  await clickNext(page) // -> Modules
-  await clickNext(page) // -> Identity
+  await clickNext(page) // -> Pattern
+  await pickByName(page, 'Custom Pattern')
+  await page.getByLabel(/Pattern name/i).fill('Custom')
+  await clickNext(page) // -> Loadout
+  await clickNext(page) // -> Identity (loadout optional)
   await page.getByLabel(/Mech name/i).fill(name)
   await clickNext(page) // -> Review
   await page.getByRole('button', { name: /Create Mech/i }).click()

--- a/apps/in-the-union-now/e2e/mech-build.e2e.ts
+++ b/apps/in-the-union-now/e2e/mech-build.e2e.ts
@@ -3,9 +3,10 @@ import { clickNext, pickByName, waitForReady } from './_helpers'
 
 /**
  * Mech-only build — steps through the chassis-first WizShell wizard
- * (Chassis -> Systems -> Modules -> Identity -> Review) and submits.
- * Verifies the OptRow master-detail chassis step + install steps work in a
- * real browser and that submit lands on the dashboard with the mech visible.
+ * (Chassis -> Pattern -> Loadout -> Identity -> Review) and submits.
+ * Verifies the OptRow master-detail chassis + pattern steps and the combined
+ * Loadout step work in a real browser and that submit lands on the dashboard
+ * with the mech visible.
  */
 test('build a mech from scratch', async ({ page }) => {
   await page.goto('/mechs/new')
@@ -13,13 +14,15 @@ test('build a mech from scratch', async ({ page }) => {
 
   // Step 1 — Chassis. Mule is a guaranteed SU starter chassis.
   await pickByName(page, 'Mule')
-  await clickNext(page) // -> Systems
+  await clickNext(page) // -> Pattern
 
-  // Step 2 — Install Systems (optional; soft budget)
+  // Step 2 — Pattern. Build a custom, named loadout.
+  await pickByName(page, 'Custom Pattern')
+  await page.getByLabel(/Pattern name/i).fill('Field Rig')
+  await clickNext(page) // -> Loadout
+
+  // Step 3 — Loadout (Systems tab by default; optional, soft budget)
   await pickByName(page, 'Cargo Pod')
-  await clickNext(page) // -> Modules
-
-  // Step 3 — Install Modules (optional)
   await clickNext(page) // -> Identity
 
   // Step 4 — Identity
@@ -45,8 +48,10 @@ test('edit a mech loadout via /mechs/$id/edit', async ({ page }) => {
   await page.goto('/mechs/new')
   await waitForReady(page)
   await pickByName(page, 'Mule')
-  await clickNext(page) // -> Systems
-  await clickNext(page) // -> Modules
+  await clickNext(page) // -> Pattern
+  await pickByName(page, 'Custom Pattern')
+  await page.getByLabel(/Pattern name/i).fill('Field Rig')
+  await clickNext(page) // -> Loadout
   await clickNext(page) // -> Identity
   await page.getByLabel(/Mech name/i).fill('Iron Fist')
   await clickNext(page) // -> Review
@@ -63,11 +68,12 @@ test('edit a mech loadout via /mechs/$id/edit', async ({ page }) => {
   await page.waitForURL(/\/mechs\/.+\/edit/, { timeout: 15_000 })
   await waitForReady(page)
 
-  // Wizard is prefilled (chassis chosen), eyebrow flips to edit mode.
+  // Wizard is prefilled (chassis chosen), eyebrow flips to edit mode. Edit
+  // lands on the custom-loadout path, so the Loadout step is present.
   await expect(page.getByText('Edit Mech')).toBeVisible()
-  await clickNext(page) // -> Systems
+  await clickNext(page) // -> Pattern
+  await clickNext(page) // -> Loadout
   await pickByName(page, 'Cargo Pod') // install a system in edit mode
-  await clickNext(page) // -> Modules
   await clickNext(page) // -> Identity
   await clickNext(page) // -> Review
   await page.getByRole('button', { name: /Save Mech/i }).click()

--- a/apps/in-the-union-now/e2e/mech-corner-cases.e2e.ts
+++ b/apps/in-the-union-now/e2e/mech-corner-cases.e2e.ts
@@ -4,16 +4,17 @@ import { clickNext, pickByName, waitForReady } from './_helpers'
 /**
  * MechWizard corner cases (chassis-first WizShell wizard):
  *  - The stepper gates progress: Next is disabled until a chassis is chosen,
- *    then disabled again on Identity until a name is entered, and Create is
- *    enabled on Review.
- *  - The install steps render the 1fr/300px grid: TL filter chips on the
- *    left, the 'Loadout · {name}' panel with budget tracks on the right.
+ *    then the Pattern step requires a pattern (a custom build needs a name),
+ *    then Identity requires a mech name before Create is enabled on Review.
+ *  - The combined Loadout step renders the 1fr/300px grid: TL filter chips on
+ *    the left, the 'Loadout · {name}' panel with budget tracks on the right,
+ *    split by Systems / Modules tabs.
  *
- * The primary CTA is labeled from the steps array ('Next · Systems →'), so
+ * The primary CTA is labeled from the steps array ('Next · Pattern →'), so
  * the shared clickNext/^Next ·/ matcher is used throughout.
  */
 
-test('wizard gates progress until chassis + name are set', async ({ page }) => {
+test('wizard gates progress until chassis + pattern + name are set', async ({ page }) => {
   await page.goto('/mechs/new')
   await waitForReady(page)
 
@@ -23,40 +24,48 @@ test('wizard gates progress until chassis + name are set', async ({ page }) => {
   await expect(next).toBeDisabled()
   await pickByName(page, 'Mule')
   await expect(next).toBeEnabled()
+  await clickNext(page) // -> Pattern
 
-  // Chassis -> Systems -> Modules -> Identity
-  await clickNext(page)
-  await clickNext(page)
-  await clickNext(page)
+  // Pattern step — Custom build requires a name before advancing.
+  await expect(next).toBeDisabled()
+  await pickByName(page, 'Custom Pattern')
+  await expect(next).toBeDisabled()
+  await page.getByLabel(/Pattern name/i).fill('Field Rig')
+  await expect(next).toBeEnabled()
+  await clickNext(page) // -> Loadout
+  await clickNext(page) // -> Identity (loadout optional)
 
   // Identity step — Next disabled until a name is entered.
-  await expect(page.getByRole('button', { name: /^Next ·/ })).toBeDisabled()
+  await expect(next).toBeDisabled()
   await page.getByLabel(/Mech name/i).fill('Iron Fist')
-  await expect(page.getByRole('button', { name: /^Next ·/ })).toBeEnabled()
+  await expect(next).toBeEnabled()
 
   // Identity -> Review — Create is enabled.
   await clickNext(page)
   await expect(page.getByRole('button', { name: /Create Mech/i })).toBeEnabled()
 })
 
-test('install steps show TL filter chips and the Loadout budget panel', async ({ page }) => {
+test('loadout step shows TL filter chips and the Loadout budget panel', async ({ page }) => {
   await page.goto('/mechs/new')
   await waitForReady(page)
 
-  // Chassis step -> pick -> advance to Install Systems.
+  // Chassis -> Pattern (custom) -> Loadout.
   await pickByName(page, 'Mule')
-  await clickNext(page)
+  await clickNext(page) // -> Pattern
+  await pickByName(page, 'Custom Pattern')
+  await page.getByLabel(/Pattern name/i).fill('Field Rig')
+  await clickNext(page) // -> Loadout
 
   // Left column — TL filter chips.
   await expect(page.getByRole('button', { name: 'TL1' })).toBeVisible()
   await expect(page.getByRole('button', { name: 'TL6' })).toBeVisible()
 
-  // Right column — Loadout panel with the pip budget tracks.
+  // Right column — Loadout panel with the pip budget tracks (Systems tab).
   await expect(page.getByText(/Loadout ·/)).toBeVisible()
   await expect(page.getByText(/System Slots ·/i)).toBeVisible()
   await expect(page.getByText(/Energy ·/i).first()).toBeVisible()
 
-  // Modules step shows its own budget track.
-  await clickNext(page)
+  // The Modules tab shows its own budget track.
+  await page.getByRole('tab', { name: 'Modules' }).click()
   await expect(page.getByText(/Module Slots ·/i)).toBeVisible()
 })

--- a/apps/in-the-union-now/src/components/crawler/SystemsList.tsx
+++ b/apps/in-the-union-now/src/components/crawler/SystemsList.tsx
@@ -27,7 +27,7 @@ export function SystemsList({ systems, selectedSystemSlugs, onChange }: SystemsL
   }
 
   return (
-    <div className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3.5">
+    <div className="columns-1 gap-3.5 sm:columns-2 [&>*]:mb-3.5 [&>*]:break-inside-avoid">
       {systems.map((system) => (
         <SelCard
           key={system.id}

--- a/apps/in-the-union-now/src/components/mech/ChassisStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/ChassisStep.tsx
@@ -1,26 +1,10 @@
 import { SalvageUnionReference } from 'salvageunion-reference'
 import type { SURefEntity } from 'salvageunion-reference'
-import { OptRow, ReferenceEntityDisplay, SectionSeparator } from 'suref-react'
+import { OptRow, ReferenceEntityDisplay } from 'suref-react'
 
 type ChassisLike = {
   id: string
   name: string
-  content?: unknown
-  patterns?: {
-    name: string
-    systems?: { name: string }[]
-    modules?: { name: string }[]
-  }[]
-}
-
-/** First paragraph block — used as the OptRow description line. */
-function chassisDescription(chassis: ChassisLike): string | undefined {
-  if (!Array.isArray(chassis.content)) return undefined
-  const firstText = chassis.content.find(
-    (b) =>
-      typeof b === 'object' && b !== null && typeof (b as { value?: unknown }).value === 'string'
-  ) as { value: string } | undefined
-  return firstText?.value
 }
 
 type ChassisOptionListProps = {
@@ -40,7 +24,6 @@ export function ChassisOptionList({ selectedChassis, onSelect }: ChassisOptionLi
         <OptRow
           key={chassis.id}
           name={chassis.name}
-          desc={chassisDescription(chassis)}
           active={chassis.name === selectedChassis}
           onClick={() => onSelect(chassis.name)}
         />
@@ -56,9 +39,8 @@ type ChassisDetailProps = {
 /**
  * Detail pane for the Chassis step (design §3.2c): the selected chassis's
  * full entity card with its chassis-ability compact card (built into the
- * chassis display) and an integrated-systems head grid expanded inside the
- * card — the stock (first) pattern's systems/modules as head-mode cards in a
- * 2-col grid. The bulky patterns section is hidden in favour of that grid.
+ * chassis display). Patterns/loadout live in the next (Pattern) step — the
+ * chassis card shows the bare chassis only.
  */
 export function ChassisDetail({ chassisName }: ChassisDetailProps) {
   const chassis = chassisName
@@ -70,63 +52,15 @@ export function ChassisDetail({ chassisName }: ChassisDetailProps) {
   if (!chassis) {
     return (
       <div className="flex h-full min-h-40 items-center justify-center rounded-[3px] border-[1.5px] border-dashed border-wk-faint p-6 text-center text-sm text-wk-muted">
-        Select a chassis to preview its stats and systems.
+        Select a chassis to preview its stats.
       </div>
     )
   }
-
-  const stockPattern = chassis.patterns?.[0]
-  const integrated = stockPattern
-    ? [
-        ...(stockPattern.systems ?? []).flatMap((s) => {
-          const found = SalvageUnionReference.Systems.find((x) => x.name === s.name)
-          return found
-            ? [
-                {
-                  key: `sys-${s.name}`,
-                  entity: found as unknown as SURefEntity,
-                },
-              ]
-            : []
-        }),
-        ...(stockPattern.modules ?? []).flatMap((m) => {
-          const found = SalvageUnionReference.Modules.find((x) => x.name === m.name)
-          return found
-            ? [
-                {
-                  key: `mod-${m.name}`,
-                  entity: found as unknown as SURefEntity,
-                },
-              ]
-            : []
-        }),
-      ]
-    : []
 
   return (
     <ReferenceEntityDisplay
       data={chassis as unknown as SURefEntity}
       hide={{ patterns: true, choices: true }}
-      afterExtraContent={
-        integrated.length > 0 ? (
-          <div className="mt-4 space-y-3">
-            <SectionSeparator
-              label={`Integrated Systems · ${stockPattern!.name}`}
-              fontSize="text-xs"
-            />
-            <div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
-              {integrated.map(({ key, entity }) => (
-                <ReferenceEntityDisplay
-                  key={key}
-                  data={entity}
-                  mode="head"
-                  hide={{ actions: true, choices: true }}
-                />
-              ))}
-            </div>
-          </div>
-        ) : undefined
-      }
     />
   )
 }

--- a/apps/in-the-union-now/src/components/mech/InstallStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/InstallStep.tsx
@@ -82,7 +82,7 @@ export function InstallStep({
           ))}
         </div>
 
-        <div className="mt-[25px] grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3.5">
+        <div className="mt-[25px] columns-1 gap-3.5 sm:columns-2 [&>*]:mb-3.5 [&>*]:break-inside-avoid">
           {visible.map((item) => (
             <SelCard
               key={item.id}

--- a/apps/in-the-union-now/src/components/mech/LoadoutStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/LoadoutStep.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react'
+import { cn } from '../../lib/utils'
+import { InstallStep } from './InstallStep'
+
+type LoadoutTab = 'systems' | 'modules'
+
+type LoadoutStepProps = {
+  systems: string[]
+  modules: string[]
+  onToggleSystem: (name: string) => void
+  onToggleModule: (name: string) => void
+  loadoutName: string
+  systemSlotsUsed: number
+  systemSlotsMax: number
+  moduleSlotsUsed: number
+  moduleSlotsMax: number
+  energyValue: number
+  energyMax: number
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: string
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        '-mb-[1.5px] border-b-[3px] px-3 pb-2 pt-1 font-cond text-[15px] font-bold uppercase tracking-[0.06em] transition-colors',
+        active
+          ? 'border-rust text-ink'
+          : 'border-transparent text-wk-muted hover:text-ink focus-visible:text-ink'
+      )}
+    >
+      {children}
+    </button>
+  )
+}
+
+/**
+ * Custom-loadout step: systems and modules combined onto one screen, split by
+ * a Systems / Modules tab bar. Each tab renders the existing InstallStep (the
+ * TL-filtered Sel grid + Loadout panel) for its dataset.
+ */
+export function LoadoutStep({
+  systems,
+  modules,
+  onToggleSystem,
+  onToggleModule,
+  loadoutName,
+  systemSlotsUsed,
+  systemSlotsMax,
+  moduleSlotsUsed,
+  moduleSlotsMax,
+  energyValue,
+  energyMax,
+}: LoadoutStepProps) {
+  const [tab, setTab] = useState<LoadoutTab>('systems')
+
+  return (
+    <div className="w-full">
+      <div
+        role="tablist"
+        aria-label="Loadout"
+        className="mb-5 flex gap-1 border-b-[1.5px] border-wk-faint"
+      >
+        <TabButton active={tab === 'systems'} onClick={() => setTab('systems')}>
+          Systems
+        </TabButton>
+        <TabButton active={tab === 'modules'} onClick={() => setTab('modules')}>
+          Modules
+        </TabButton>
+      </div>
+
+      {tab === 'systems' ? (
+        <InstallStep
+          kind="systems"
+          selected={systems}
+          onToggle={onToggleSystem}
+          loadoutName={loadoutName}
+          slotsUsed={systemSlotsUsed}
+          slotsMax={systemSlotsMax}
+          energyValue={energyValue}
+          energyMax={energyMax}
+        />
+      ) : (
+        <InstallStep
+          kind="modules"
+          selected={modules}
+          onToggle={onToggleModule}
+          loadoutName={loadoutName}
+          slotsUsed={moduleSlotsUsed}
+          slotsMax={moduleSlotsMax}
+          energyValue={energyValue}
+          energyMax={energyMax}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/mech/MechReviewStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/MechReviewStep.tsx
@@ -44,6 +44,7 @@ export function MechReviewStep({ form, isEdit, submitError }: MechReviewStepProp
   const rows: [string, string | null][] = [
     ['Name', form.name.trim() || null],
     ['Chassis', form.chassisName || null],
+    ['Pattern', form.patternName.trim() || 'none'],
     ['Systems', form.systems.length > 0 ? form.systems.join(', ') : 'none'],
     ['Modules', form.modules.length > 0 ? form.modules.join(', ') : 'none'],
     [

--- a/apps/in-the-union-now/src/components/mech/MechWizard.tsx
+++ b/apps/in-the-union-now/src/components/mech/MechWizard.tsx
@@ -16,18 +16,19 @@ import { useEntityStore } from '../../stores/entityStore'
 import { SoftWarningBanner } from '../shared/SoftWarningBanner'
 import { WizShell } from '../wizard/WizShell'
 import { ChassisDetail, ChassisOptionList } from './ChassisStep'
-import { InstallStep } from './InstallStep'
+import { LoadoutStep } from './LoadoutStep'
 import { MechIdentityStep } from './MechIdentityStep'
 import { MechReviewStep } from './MechReviewStep'
+import { PatternDetail, PatternOptionList } from './PatternStep'
+import type { PatternLike } from './patternData'
 
-const STEPS = ['Chassis', 'Systems', 'Modules', 'Identity', 'Review'] as const
-type Step = (typeof STEPS)[number]
+type Step = 'Chassis' | 'Pattern' | 'Loadout' | 'Identity' | 'Review'
 
-/** Step heading copy (design §3.2). */
+/** Step heading copy. */
 const STEP_TITLES: Record<Step, string> = {
   Chassis: 'Choose Your Chassis',
-  Systems: 'Install Systems',
-  Modules: 'Install Modules',
+  Pattern: 'Choose a Pattern',
+  Loadout: 'Customize Loadout',
   Identity: 'Name Your Mech',
   Review: 'Review',
 }
@@ -55,9 +56,11 @@ type MechWizardProps = {
  * entity→form mapping lives in lib/wizard/mechFormState.ts, the upsert
  * branch lives in handleSubmit, and step components carry NO edit logic.
  *
- * Capacity is SOFT everywhere (plan 3.4): over-slot/over-cargo selections
- * surface as advisory warnings (budget tracks + banner) and never block
- * navigation or saving.
+ * Pattern step: pick a canonical chassis pattern (auto-fills systems/modules
+ * and skips the Loadout step) or "Custom Pattern" (a named, manual loadout on
+ * the combined Systems/Modules Loadout step). Capacity is SOFT everywhere
+ * (plan 3.4): over-slot/over-cargo selections surface as advisory warnings and
+ * never block navigation or saving.
  */
 export function MechWizard({ onComplete, onCancel, mechId, initialState }: MechWizardProps) {
   const isEdit = mechId !== undefined
@@ -67,10 +70,22 @@ export function MechWizard({ onComplete, onCancel, mechId, initialState }: MechW
 
   const [step, setStep] = useState<Step>('Chassis')
   const [form, setForm] = useState<MechWizardFormState>(initialState ?? EMPTY_MECH_FORM_STATE)
+  // Custom (manual) vs canonical-pattern loadout. Not persisted — editing an
+  // existing mech always lands in the manual loadout path so its install can
+  // be tweaked.
+  const [isCustomPattern, setIsCustomPattern] = useState(isEdit)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
-  const currentIndex = STEPS.indexOf(step)
+  // Loadout step only exists on the custom path; a chosen pattern skips it.
+  const steps = useMemo<Step[]>(
+    () =>
+      isCustomPattern
+        ? ['Chassis', 'Pattern', 'Loadout', 'Identity', 'Review']
+        : ['Chassis', 'Pattern', 'Identity', 'Review'],
+    [isCustomPattern]
+  )
+  const currentIndex = steps.indexOf(step)
 
   function updateForm(patch: Partial<MechWizardFormState>) {
     setForm((prev) => ({ ...prev, ...patch }))
@@ -78,6 +93,31 @@ export function MechWizard({ onComplete, onCancel, mechId, initialState }: MechW
 
   function toggleIn(list: string[], name: string): string[] {
     return list.includes(name) ? list.filter((x) => x !== name) : [...list, name]
+  }
+
+  // Changing the chassis invalidates any chosen pattern/loadout.
+  function selectChassis(chassisName: string) {
+    if (chassisName === form.chassisName) return
+    setIsCustomPattern(false)
+    updateForm({ chassisName, patternName: '', systems: [], modules: [] })
+  }
+
+  // Canonical pattern: fill systems/modules from it and skip the Loadout step.
+  function selectPattern(pattern: PatternLike) {
+    setIsCustomPattern(false)
+    updateForm({
+      patternName: pattern.name,
+      systems: (pattern.systems ?? []).map((s) => s.name),
+      modules: (pattern.modules ?? []).map((m) => m.name),
+    })
+  }
+
+  // Custom pattern: clear the loadout for a manual build (idempotent — never
+  // wipes an in-progress custom loadout if already on the custom path).
+  function selectCustom() {
+    if (isCustomPattern) return
+    setIsCustomPattern(true)
+    updateForm({ patternName: '', systems: [], modules: [] })
   }
 
   // ---------------------------------------------------------------------------
@@ -139,10 +179,12 @@ export function MechWizard({ onComplete, onCancel, mechId, initialState }: MechW
     switch (step) {
       case 'Chassis':
         return form.chassisName !== ''
-      case 'Systems':
+      case 'Pattern':
+        // Canonical pattern chosen, or a custom build with a name (edit mode
+        // relaxes the name requirement so legacy mechs aren't blocked).
+        return isCustomPattern ? isEdit || form.patternName.trim() !== '' : form.patternName !== ''
+      case 'Loadout':
         return true // installs are optional; capacity is soft
-      case 'Modules':
-        return true
       case 'Identity':
         return form.name.trim() !== ''
       case 'Review':
@@ -151,16 +193,16 @@ export function MechWizard({ onComplete, onCancel, mechId, initialState }: MechW
   }
 
   function goNext() {
-    if (step === 'Review') {
+    if (currentIndex >= steps.length - 1) {
       void handleSubmit()
       return
     }
-    setStep(STEPS[currentIndex + 1]!)
+    setStep(steps[currentIndex + 1]!)
   }
 
   function goBack() {
     if (currentIndex > 0) {
-      setStep(STEPS[currentIndex - 1]!)
+      setStep(steps[currentIndex - 1]!)
     }
   }
 
@@ -208,23 +250,25 @@ export function MechWizard({ onComplete, onCancel, mechId, initialState }: MechW
   }
 
   const loadoutName = form.name.trim() || form.chassisName || 'Mech'
+  const selectedPatternName = isCustomPattern ? null : form.patternName || null
 
   const subtitle = (() => {
     switch (step) {
       case 'Chassis':
         return 'Choose your chassis. This sets slots, stats, and cargo capacity.'
-      case 'Systems':
+      case 'Pattern':
+        return 'Pick a ready-made pattern, or build a custom loadout.'
+      case 'Loadout':
         return (
-          <span data-testid="system-slot-count">
-            {capacity.systemSlotsUsed} / {capacity.systemSlotsMax} system slots used · over-capacity
-            warns, never blocks
-          </span>
-        )
-      case 'Modules':
-        return (
-          <span data-testid="module-slot-count">
-            {capacity.moduleSlotsUsed} / {capacity.moduleSlotsMax} module slots used · over-capacity
-            warns, never blocks
+          <span>
+            <span data-testid="system-slot-count">
+              {capacity.systemSlotsUsed} / {capacity.systemSlotsMax} system
+            </span>{' '}
+            ·{' '}
+            <span data-testid="module-slot-count">
+              {capacity.moduleSlotsUsed} / {capacity.moduleSlotsMax} module
+            </span>{' '}
+            slots used · over-capacity warns, never blocks
           </span>
         )
       case 'Identity':
@@ -237,16 +281,21 @@ export function MechWizard({ onComplete, onCancel, mechId, initialState }: MechW
   return (
     <WizShell
       eyebrow={isEdit ? 'Edit Mech' : 'New Mech'}
-      steps={STEPS}
+      steps={steps}
       active={currentIndex}
-      onStepClick={(i) => setStep(STEPS[i]!)}
+      onStepClick={(i) => setStep(steps[i]!)}
       title={STEP_TITLES[step]}
       subtitle={subtitle}
       optionPane={
         step === 'Chassis' ? (
-          <ChassisOptionList
-            selectedChassis={form.chassisName}
-            onSelect={(chassisName) => updateForm({ chassisName })}
+          <ChassisOptionList selectedChassis={form.chassisName} onSelect={selectChassis} />
+        ) : step === 'Pattern' ? (
+          <PatternOptionList
+            chassisName={form.chassisName}
+            selectedPatternName={selectedPatternName}
+            isCustom={isCustomPattern}
+            onSelectPattern={selectPattern}
+            onSelectCustom={selectCustom}
           />
         ) : undefined
       }
@@ -259,29 +308,29 @@ export function MechWizard({ onComplete, onCancel, mechId, initialState }: MechW
       nextDisabled={!canAdvance()}
       busy={isSubmitting}
       submitLabel={isEdit ? 'Save Mech' : 'Create Mech ✦'}
-      ctaFullWidth={step === 'Systems' || step === 'Modules'}
+      ctaFullWidth={step === 'Loadout'}
     >
       {step === 'Chassis' && <ChassisDetail chassisName={form.chassisName} />}
-      {step === 'Systems' && (
-        <InstallStep
-          kind="systems"
-          selected={form.systems}
-          onToggle={(name) => updateForm({ systems: toggleIn(form.systems, name) })}
-          loadoutName={loadoutName}
-          slotsUsed={capacity.systemSlotsUsed}
-          slotsMax={capacity.systemSlotsMax}
-          energyValue={energyValue}
-          energyMax={energyMax}
+      {step === 'Pattern' && (
+        <PatternDetail
+          chassisName={form.chassisName}
+          isCustom={isCustomPattern}
+          selectedPatternName={selectedPatternName}
+          customName={form.patternName}
+          onCustomNameChange={(patternName) => updateForm({ patternName })}
         />
       )}
-      {step === 'Modules' && (
-        <InstallStep
-          kind="modules"
-          selected={form.modules}
-          onToggle={(name) => updateForm({ modules: toggleIn(form.modules, name) })}
+      {step === 'Loadout' && (
+        <LoadoutStep
+          systems={form.systems}
+          modules={form.modules}
+          onToggleSystem={(name) => updateForm({ systems: toggleIn(form.systems, name) })}
+          onToggleModule={(name) => updateForm({ modules: toggleIn(form.modules, name) })}
           loadoutName={loadoutName}
-          slotsUsed={capacity.moduleSlotsUsed}
-          slotsMax={capacity.moduleSlotsMax}
+          systemSlotsUsed={capacity.systemSlotsUsed}
+          systemSlotsMax={capacity.systemSlotsMax}
+          moduleSlotsUsed={capacity.moduleSlotsUsed}
+          moduleSlotsMax={capacity.moduleSlotsMax}
           energyValue={energyValue}
           energyMax={energyMax}
         />

--- a/apps/in-the-union-now/src/components/mech/PatternStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/PatternStep.tsx
@@ -1,0 +1,136 @@
+import { SalvageUnionReference } from 'salvageunion-reference'
+import type { SURefEntity } from 'salvageunion-reference'
+import { Field, Input, OptRow, ReferenceEntityDisplay, SectionSeparator } from 'suref-react'
+import { patternsForChassis } from './patternData'
+import type { PatternLike } from './patternData'
+
+/** Resolve a pattern's system/module name refs to display entities. */
+function resolvePatternEntities(pattern: PatternLike): { key: string; entity: SURefEntity }[] {
+  return [
+    ...(pattern.systems ?? []).flatMap((s) => {
+      const found = SalvageUnionReference.Systems.find((x) => x.name === s.name)
+      return found ? [{ key: `sys-${s.name}`, entity: found as unknown as SURefEntity }] : []
+    }),
+    ...(pattern.modules ?? []).flatMap((m) => {
+      const found = SalvageUnionReference.Modules.find((x) => x.name === m.name)
+      return found ? [{ key: `mod-${m.name}`, entity: found as unknown as SURefEntity }] : []
+    }),
+  ]
+}
+
+type PatternOptionListProps = {
+  chassisName: string
+  /** Selected canonical pattern name; null when custom or nothing chosen. */
+  selectedPatternName: string | null
+  /** True when the "Custom Pattern" option is active. */
+  isCustom: boolean
+  onSelectPattern: (pattern: PatternLike) => void
+  onSelectCustom: () => void
+}
+
+/**
+ * Master pane for the Pattern step (mirrors the Chassis step): an OptRow per
+ * canonical chassis pattern, plus a "Custom Pattern" row that drops into the
+ * manual loadout step.
+ */
+export function PatternOptionList({
+  chassisName,
+  selectedPatternName,
+  isCustom,
+  onSelectPattern,
+  onSelectCustom,
+}: PatternOptionListProps) {
+  const patterns = patternsForChassis(chassisName)
+  return (
+    <div>
+      {patterns.map((pattern) => (
+        <OptRow
+          key={pattern.name}
+          name={pattern.name}
+          active={!isCustom && pattern.name === selectedPatternName}
+          onClick={() => onSelectPattern(pattern)}
+        />
+      ))}
+      <p className="mb-2 mt-5 font-cond text-xs font-bold uppercase tracking-[0.1em] text-wk-muted">
+        Or build your own
+      </p>
+      <OptRow name="Custom Pattern" active={isCustom} onClick={onSelectCustom} />
+    </div>
+  )
+}
+
+type PatternDetailProps = {
+  chassisName: string
+  isCustom: boolean
+  selectedPatternName: string | null
+  /** Current custom pattern name (custom mode only). */
+  customName: string
+  onCustomNameChange: (name: string) => void
+}
+
+/**
+ * Detail pane for the Pattern step: previews the selected canonical pattern's
+ * systems/modules as head-mode cards, or — in custom mode — a required name
+ * field (the manual systems/modules selection happens on the next step).
+ */
+export function PatternDetail({
+  chassisName,
+  isCustom,
+  selectedPatternName,
+  customName,
+  onCustomNameChange,
+}: PatternDetailProps) {
+  if (isCustom) {
+    return (
+      <div className="max-w-[760px] space-y-3">
+        <Field label="Pattern name" required htmlFor="custom-pattern-name">
+          <Input
+            id="custom-pattern-name"
+            type="text"
+            value={customName}
+            onChange={(e) => onCustomNameChange(e.target.value)}
+            placeholder="e.g. My Custom Build"
+            required
+          />
+        </Field>
+        <p className="font-body text-[13px] text-wk-muted">
+          Name your custom pattern. You&rsquo;ll choose its systems and modules next.
+        </p>
+      </div>
+    )
+  }
+
+  const pattern = selectedPatternName
+    ? patternsForChassis(chassisName).find((p) => p.name === selectedPatternName)
+    : undefined
+
+  if (!pattern) {
+    return (
+      <div className="flex h-full min-h-40 items-center justify-center rounded-[3px] border-[1.5px] border-dashed border-wk-faint p-6 text-center text-sm text-wk-muted">
+        Select a pattern to preview its loadout, or choose Custom Pattern to build your own.
+      </div>
+    )
+  }
+
+  const entities = resolvePatternEntities(pattern)
+
+  return (
+    <div className="space-y-3">
+      <SectionSeparator label={`${pattern.name} · Loadout`} fontSize="text-xs" />
+      {entities.length > 0 ? (
+        <div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
+          {entities.map(({ key, entity }) => (
+            <ReferenceEntityDisplay
+              key={key}
+              data={entity}
+              mode="head"
+              hide={{ actions: true, choices: true }}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-wk-muted">This pattern installs no systems or modules.</p>
+      )}
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/mech/__tests__/MechWizard.test.tsx
+++ b/apps/in-the-union-now/src/components/mech/__tests__/MechWizard.test.tsx
@@ -1,9 +1,9 @@
 /**
  * Integration tests for MechWizard (create + edit on the WizShell skeleton).
  *
- * Exercises Chassis → Systems → Modules → Identity → Review → submit using
- * the real wizard, real SalvageUnionReference data, real Zod validation, and
- * a fake-indexeddb-backed entityStore.
+ * Exercises the flow Chassis → Pattern → (Loadout, custom only) → Identity →
+ * Review → submit using the real wizard, real SalvageUnionReference data, real
+ * Zod validation, and a fake-indexeddb-backed entityStore.
  *
  * fake-indexeddb/auto is preloaded via bunfig.toml.
  * SalvageUnionReference is preloaded in beforeAll.
@@ -16,6 +16,7 @@ import { useEntityStore } from '../../../stores/entityStore'
 import { _clearAllStores, _resetDbSingleton } from '../../../lib/db/index'
 import { mechFormToCreateInput, mechToFormState } from '../../../lib/wizard/mechFormState'
 import { MechWizard } from '../MechWizard'
+import { patternsForChassis } from '../patternData'
 
 // ---------------------------------------------------------------------------
 // Pre-load reference data
@@ -66,9 +67,9 @@ afterEach(async () => {
 // ---------------------------------------------------------------------------
 
 /**
- * Chassis rows are OptRow <button>s whose accessible text contains the
- * chassis name; system/module cards are Sel wrappers — div[role="button"]
- * with aria-label set to the entity name.
+ * Chassis/pattern rows are OptRow <button>s whose accessible text contains the
+ * name; system/module cards are Sel wrappers — div[role="button"] with
+ * aria-label set to the entity name.
  */
 function getPickByName(name: string): HTMLElement {
   const candidates = screen.getAllByRole('button')
@@ -85,6 +86,20 @@ async function pick(name: string): Promise<void> {
   })
 }
 
+/** Loadout Systems/Modules tab buttons are role="tab". */
+async function clickTab(name: 'Systems' | 'Modules'): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('tab', { name }))
+  })
+}
+
+async function typeInto(label: RegExp, value: string): Promise<void> {
+  const input = screen.getByLabelText(label) as HTMLInputElement
+  await act(async () => {
+    fireEvent.change(input, { target: { value } })
+  })
+}
+
 /** The primary CTA is labeled from the steps array: 'Next · {step} →'. */
 function getNextButton(): HTMLButtonElement {
   return screen.getByRole('button', { name: /^Next ·/ }) as HTMLButtonElement
@@ -97,11 +112,11 @@ async function clickNext(): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// Happy path: full mech creation
+// Happy path: custom-pattern mech creation
 // ---------------------------------------------------------------------------
 
-describe('MechWizard — happy path', () => {
-  it('walks through every step and creates a valid mech', async () => {
+describe('MechWizard — custom pattern happy path', () => {
+  it('walks Chassis → Pattern(custom) → Loadout → Identity → Review and creates a mech', async () => {
     const onComplete = mock(() => {})
     render(<MechWizard onComplete={onComplete} onCancel={() => {}} />)
 
@@ -109,28 +124,30 @@ describe('MechWizard — happy path', () => {
     await pick('Mule')
     await clickNext()
 
-    // --- Step 2: Install Systems (1fr/300px grid, Sel cards, soft budget) ---
+    // --- Step 2: Pattern — Custom requires a name before advancing ---
+    expect(getNextButton().disabled).toBe(true)
+    await pick('Custom Pattern')
+    expect(getNextButton().disabled).toBe(true)
+    await typeInto(/Pattern name/i, 'Field Rig')
+    expect(getNextButton().disabled).toBe(false)
+    await clickNext()
+
+    // --- Step 3: Loadout — combined Systems / Modules tabs ---
     expect(screen.getByTestId('system-slot-count').textContent).toContain('0 /')
     await pick('Cargo Pod')
     expect(screen.getByTestId('system-slot-count').textContent).toContain('1 /')
-    await clickNext()
-
-    // --- Step 3: Install Modules ---
+    await clickTab('Modules')
     await pick('Comms Module')
     expect(screen.getByTestId('module-slot-count').textContent).toContain('1 /')
     await clickNext()
 
     // --- Step 4: Identity (name required) ---
-    const nameInput = screen.getByLabelText(/Mech name/i) as HTMLInputElement
-    await act(async () => {
-      fireEvent.change(nameInput, { target: { value: 'Iron Fist' } })
-    })
+    await typeInto(/Mech name/i, 'Iron Fist')
     await clickNext()
 
     // --- Step 5: Review → submit ('Create Mech ✦') ---
-    const submit = screen.getByRole('button', { name: /Create Mech/i })
     await act(async () => {
-      fireEvent.click(submit)
+      fireEvent.click(screen.getByRole('button', { name: /Create Mech/i }))
     })
 
     await waitFor(() => {
@@ -139,10 +156,10 @@ describe('MechWizard — happy path', () => {
       const m = mechs[0]!
       expect(m.name).toBe('Iron Fist')
       expect(m.chassisRef).toBe('Mule')
+      expect(m.patternName).toBe('Field Rig')
       expect(m.systems).toEqual(['Cargo Pod'])
       expect(m.modules).toEqual(['Comms Module'])
       expect(m.cargoLots).toEqual([])
-      expect(m.conditions).toEqual([])
       expect(m.currentHeat).toBe(0)
       expect(m.schemaVersion).toBe(1)
     })
@@ -152,41 +169,83 @@ describe('MechWizard — happy path', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Gating: chassis and name are required; capacity never blocks
+// Canonical pattern: fills the loadout and skips the Loadout step
+// ---------------------------------------------------------------------------
+
+describe('MechWizard — canonical pattern', () => {
+  it('fills systems/modules from the chosen pattern and skips the Loadout step', async () => {
+    const pattern = patternsForChassis('Mule')[0]
+    expect(pattern).toBeDefined()
+
+    render(<MechWizard onComplete={() => {}} onCancel={() => {}} />)
+
+    await pick('Mule')
+    await clickNext()
+
+    // Pick a ready-made pattern, then Next jumps straight to Identity.
+    await pick(pattern!.name)
+    await clickNext()
+
+    // Loadout was skipped — its slot-count subtitle is absent; the Identity
+    // name field is present.
+    expect(screen.queryByTestId('system-slot-count')).toBeNull()
+    await typeInto(/Mech name/i, 'Workhorse')
+    await clickNext()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Create Mech/i }))
+    })
+
+    await waitFor(() => {
+      const m = useEntityStore.getState().list('mech')[0]!
+      expect(m.patternName).toBe(pattern!.name)
+      expect(m.systems).toEqual((pattern!.systems ?? []).map((s) => s.name))
+      expect(m.modules).toEqual((pattern!.modules ?? []).map((mod) => mod.name))
+    })
+  }, 30000)
+})
+
+// ---------------------------------------------------------------------------
+// Gating: chassis, pattern, and name are required; capacity never blocks
 // ---------------------------------------------------------------------------
 
 describe('MechWizard — gates', () => {
-  it('keeps Next disabled until a chassis is chosen, and on Identity until named', async () => {
+  it('gates chassis, pattern (custom needs a name), and the mech name', async () => {
     render(<MechWizard onComplete={() => {}} onCancel={() => {}} />)
 
-    // Chassis step — Next disabled until a chassis is chosen.
+    // Chassis required.
     expect(getNextButton().disabled).toBe(true)
     await pick('Mule')
     expect(getNextButton().disabled).toBe(false)
+    await clickNext()
 
-    // Systems and Modules are optional — straight through.
-    await clickNext()
-    await clickNext()
-    await clickNext()
+    // Pattern required — Custom blocks until a name is typed.
+    expect(getNextButton().disabled).toBe(true)
+    await pick('Custom Pattern')
+    expect(getNextButton().disabled).toBe(true)
+    await typeInto(/Pattern name/i, 'Rig')
+    expect(getNextButton().disabled).toBe(false)
+    await clickNext() // Loadout
+    await clickNext() // Identity (loadout optional)
 
     // Identity — Next disabled with the name empty; no mech persisted.
     expect(getNextButton().disabled).toBe(true)
     expect(useEntityStore.getState().list('mech').length).toBe(0)
-
-    const nameInput = screen.getByLabelText(/Mech name/i) as HTMLInputElement
-    await act(async () => {
-      fireEvent.change(nameInput, { target: { value: 'Iron Fist' } })
-    })
+    await typeInto(/Mech name/i, 'Iron Fist')
     expect(getNextButton().disabled).toBe(false)
   }, 30000)
 
   it('over-slot module selection warns but never blocks navigation', async () => {
     render(<MechWizard onComplete={() => {}} onCancel={() => {}} />)
 
-    // Mule has 2 module slots — install three 1-slot modules to breach it.
     await pick('Mule')
-    await clickNext() // Systems
-    await clickNext() // Modules
+    await clickNext() // Pattern
+    await pick('Custom Pattern')
+    await typeInto(/Pattern name/i, 'Rig')
+    await clickNext() // Loadout
+
+    // Mule has 2 module slots — install three 1-slot modules to breach it.
+    await clickTab('Modules')
     await pick('Comms Module')
     await pick('Equipment Locker')
     await pick('Firewall')
@@ -207,6 +266,7 @@ async function seedMuleMech() {
   const input = mechFormToCreateInput({
     name: 'Iron Fist',
     chassisName: 'Mule',
+    patternName: '',
     systems: ['Cargo Pod'],
     modules: [],
     cargoLots: [],
@@ -237,12 +297,14 @@ describe('MechWizard — edit mode', () => {
     // Eyebrow flips to edit mode; chassis is prefilled so Next is enabled.
     expect(screen.getByText('Edit Mech')).toBeTruthy()
     expect(getNextButton().disabled).toBe(false)
-    await clickNext() // Systems
+    await clickNext() // Pattern (edit lands on the custom path; name optional)
+    expect(getNextButton().disabled).toBe(false)
+    await clickNext() // Loadout
 
     // Loadout panel shows the prefilled install (no empty-state message).
     expect(screen.queryByText(/Nothing installed yet/i)).toBeNull()
     await pick('Armour Plating') // add a second system
-    await clickNext() // Modules
+    await clickTab('Modules')
     await pick('Comms Module')
     await clickNext() // Identity (name prefilled)
     await clickNext() // Review
@@ -280,9 +342,9 @@ describe('MechWizard — edit mode', () => {
       />
     )
 
-    await clickNext() // Systems
+    await clickNext() // Pattern
+    await clickNext() // Loadout
     await pick('Cargo Pod') // toggle OFF the only system
-    await clickNext() // Modules
     await clickNext() // Identity
     await clickNext() // Review
 
@@ -300,17 +362,15 @@ describe('MechWizard — edit mode', () => {
 
 describe('MechWizard — cargo lots', () => {
   it('adds a SCRAP lot with a tech level and persists it on create', async () => {
+    const pattern = patternsForChassis('Mule')[0]
     render(<MechWizard onComplete={() => {}} onCancel={() => {}} />)
 
     await pick('Mule')
-    await clickNext() // Systems
-    await clickNext() // Modules
+    await clickNext() // Pattern
+    await pick(pattern!.name) // canonical pattern — skips the Loadout step
     await clickNext() // Identity
 
-    const nameInput = screen.getByLabelText(/Mech name/i) as HTMLInputElement
-    await act(async () => {
-      fireEvent.change(nameInput, { target: { value: 'Iron Fist' } })
-    })
+    await typeInto(/Mech name/i, 'Iron Fist')
 
     // Switch the lot category to SCRAP (TL select appears), add 3 scrap at TL2.
     const catSelect = screen.getByLabelText(/Category/i) as HTMLSelectElement

--- a/apps/in-the-union-now/src/components/mech/patternData.ts
+++ b/apps/in-the-union-now/src/components/mech/patternData.ts
@@ -1,0 +1,22 @@
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+/** A chassis pattern as stored in salvageunion-reference (canonical data). */
+export type PatternLike = {
+  name: string
+  systems?: { name: string }[]
+  modules?: { name: string }[]
+}
+
+type ChassisWithPatterns = {
+  name: string
+  patterns?: PatternLike[]
+}
+
+/** Canonical patterns for the given chassis (empty when none / unchosen). */
+export function patternsForChassis(chassisName: string): PatternLike[] {
+  if (!chassisName) return []
+  const chassis = SalvageUnionReference.Chassis.find((c) => c.name === chassisName) as unknown as
+    | ChassisWithPatterns
+    | undefined
+  return chassis?.patterns ?? []
+}

--- a/apps/in-the-union-now/src/components/pilot/AbilitiesStep.tsx
+++ b/apps/in-the-union-now/src/components/pilot/AbilitiesStep.tsx
@@ -135,7 +135,7 @@ export function AbilitiesStep({
           return (
             <section key={tree} className="space-y-3">
               <TreeSep name={tree} />
-              <div className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3.5">
+              <div className="columns-1 gap-3.5 sm:columns-2 [&>*]:mb-3.5 [&>*]:break-inside-avoid">
                 {treeAbilities.map(renderCard)}
               </div>
             </section>

--- a/apps/in-the-union-now/src/components/pilot/EquipmentStep.tsx
+++ b/apps/in-the-union-now/src/components/pilot/EquipmentStep.tsx
@@ -38,7 +38,7 @@ export function EquipmentStep({ selectedEquipment, onToggle, budget, _sur }: Equ
 
   return (
     <div className="w-full">
-      <div className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3.5">
+      <div className="columns-1 gap-3.5 sm:columns-2 [&>*]:mb-3.5 [&>*]:break-inside-avoid">
         {allEquipment.map((item) => {
           const isSelected = selectedEquipment.includes(item.id)
           const isDisabled = !isSelected && isAtBudget

--- a/apps/in-the-union-now/src/lib/wizard/__tests__/mechFormState.test.ts
+++ b/apps/in-the-union-now/src/lib/wizard/__tests__/mechFormState.test.ts
@@ -57,6 +57,7 @@ describe('mechToFormState', () => {
     expect(form).toEqual({
       name: 'Iron Fist',
       chassisName: 'Mule',
+      patternName: '',
       systems: ['Cargo Pod', 'Armour Plating'],
       modules: ['Comms Module'],
       cargoLots: storedMech.cargoLots,
@@ -80,6 +81,7 @@ describe('mechFormToUpdatePatch', () => {
       'chassisRef',
       'modules',
       'name',
+      'patternName',
       'systems',
     ])
   })
@@ -91,6 +93,20 @@ describe('mechFormToUpdatePatch', () => {
       chassisName: 'Mule',
     })
     expect(patch.name).toBe('Iron Fist')
+  })
+
+  it('carries the pattern name (canonical or custom), undefined when blank', () => {
+    expect(
+      mechFormToUpdatePatch({ ...EMPTY_MECH_FORM_STATE, patternName: 'Hauler Pattern' }).patternName
+    ).toBe('Hauler Pattern')
+    expect(
+      mechFormToUpdatePatch({ ...EMPTY_MECH_FORM_STATE, patternName: '   ' }).patternName
+    ).toBeUndefined()
+  })
+
+  it('round-trips patternName off a stored mech', () => {
+    const form = mechToFormState({ ...storedMech, patternName: 'Hauler Pattern' })
+    expect(form.patternName).toBe('Hauler Pattern')
   })
 })
 

--- a/apps/in-the-union-now/src/lib/wizard/mechFormState.ts
+++ b/apps/in-the-union-now/src/lib/wizard/mechFormState.ts
@@ -24,6 +24,12 @@ export type MechWizardFormState = {
   name: string
   /** Chassis NAME ref (matching Mech.chassisRef); '' while unchosen. */
   chassisName: string
+  /**
+   * Loadout pattern name (maps to Mech.patternName): the chosen chassis
+   * pattern's name, or the user-supplied name for a custom build. '' while
+   * unchosen.
+   */
+  patternName: string
   /** Installed system name refs. */
   systems: string[]
   /** Installed module name refs. */
@@ -34,6 +40,7 @@ export type MechWizardFormState = {
 export const EMPTY_MECH_FORM_STATE: MechWizardFormState = {
   name: '',
   chassisName: '',
+  patternName: '',
   systems: [],
   modules: [],
   cargoLots: [],
@@ -44,6 +51,7 @@ export function mechToFormState(mech: Mech): MechWizardFormState {
   return {
     name: mech.name,
     chassisName: mech.chassisRef,
+    patternName: mech.patternName ?? '',
     systems: [...mech.systems],
     modules: [...mech.modules],
     cargoLots: mech.cargoLots.map((lot) => ({ ...lot })),
@@ -51,12 +59,16 @@ export function mechToFormState(mech: Mech): MechWizardFormState {
 }
 
 /** Wizard-owned mech fields — the only fields an edit save may touch. */
-type MechWizardPatch = Pick<Mech, 'name' | 'chassisRef' | 'systems' | 'modules' | 'cargoLots'>
+type MechWizardPatch = Pick<
+  Mech,
+  'name' | 'chassisRef' | 'patternName' | 'systems' | 'modules' | 'cargoLots'
+>
 
 export function mechFormToUpdatePatch(form: MechWizardFormState): MechWizardPatch {
   return {
     name: form.name.trim(),
     chassisRef: form.chassisName,
+    patternName: form.patternName.trim() || undefined,
     systems: form.systems,
     modules: form.modules,
     cargoLots: form.cargoLots,


### PR DESCRIPTION
## Summary

Reworks the ITUN mech-creation wizard and the full-page selector grids, from a session of incremental UX direction.

### 1. Mech wizard flow — pattern vs. custom

Old flow: **Chassis → Systems → Modules → Identity → Review**
New flow: **Chassis → Pattern → [Loadout — custom only] → Identity → Review**

- **Chassis step** now shows just the chassis card. The old **"Integrated Systems"** preview (it rendered the stock pattern's loadout as if it were intrinsic to the chassis — which it isn't) is **removed**, and the chassis picker is name-only.
- **New Pattern step** (master-detail, mirroring Chassis): a list of the chassis's canonical patterns plus a **"Custom Pattern"** row.
  - Pick a canonical pattern → fills `systems`/`modules` from it, records the name, and **skips** the Loadout step.
  - Pick "Custom Pattern" → a required name, then a manual build.
- **New combined Loadout step** (custom path only): systems and modules on **one screen, Systems / Modules tab-separated**, each tab reusing the existing `InstallStep`.

### 2. Selector layout

- Full-page entity grids (pilot abilities/equipment, crawler systems, mech install) switch from a ragged row-based grid to **2-column CSS-column masonry** (1 column on mobile) so cards absorb whitespace.
- Class/chassis pickers are **name-only** `OptRow`s.

## Persistence

The loadout pattern name maps to the **existing optional `Mech.patternName`** (already surfaced as "Pattern" on the mech sheet) — **no schema migration**. The custom-vs-pattern mode is wizard-local state (not persisted); edit mode lands on the custom path so an existing mech's loadout stays editable.

## Testing

- `bun run check:all` green (lint, format, typecheck, test, validate, knip).
- **891 ITUN unit tests pass.** Rewrote `MechWizard.test.tsx` for the new flow (custom path, canonical-pattern-skips-Loadout, gating, over-slot soft-warn, edit upsert, cargo) and updated `mechFormState.test.ts`.
- **e2e (Playwright) specs updated** to the new flow (`mech-build`, `mech-corner-cases`, `_helpers.buildMech`). ⚠️ These were **not executed** — Playwright needs a real browser, unavailable in the authoring sandbox. Please run `bun run e2e:itun` locally before merge.

## Commits

1. `refactor(itun): masonry 2-column wizard selector grids`
2. `feat(itun): pattern/custom mech wizard flow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pkmi13yiSnxBC7M1xeZoh2