### PR TITLE
feat(suref-react): hoist flavor content block into header-right slot (A1)

### DIFF
--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/ReferenceEntityRightHeaderContent.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/ReferenceEntityRightHeaderContent.tsx
@@ -10,17 +10,31 @@ type ReferenceEntityRightHeaderContentProps = {
   /** Accent text colour — a lighter variant of the card's base/header colour.
    *  Falls back to white when not provided. */
   accentColor?: string
+  /**
+   * Flavor string for non-ability entities, hoisted out of the body `content`
+   * array (the first `type: 'flavor'` block) by the orchestrator so it renders
+   * in the header-right slot instead of the body. Abilities ignore this and use
+   * their top-level `description` field as before.
+   */
+  flavor?: string
 }
 
 export function ReferenceEntityRightHeaderContent({
   data,
   fontSize,
   accentColor,
+  flavor,
 }: ReferenceEntityRightHeaderContentProps) {
-  const description = 'description' in data ? data.description : undefined
+  // Abilities surface their top-level `description`; all other entities surface
+  // the hoisted `flavor` content block passed down by the orchestrator.
+  const description = isAbility(data)
+    ? 'description' in data
+      ? data.description
+      : undefined
+    : flavor
   const parsedDescription = useParseTraitReferences(description)
 
-  if (!description || !isAbility(data)) return null
+  if (!description) return null
 
   return (
     <div

--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/components/ReferenceEntityDisplayContent.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/components/ReferenceEntityDisplayContent.tsx
@@ -293,6 +293,21 @@ export function ReferenceEntityDisplayContent({
     contentBlocks = contentBlocks.filter((block) => block.lead !== true)
   }
 
+  // Hoist a non-ability entity's first `type: 'flavor'` content block out of the
+  // body into the header-right italic flavor slot (mirroring how abilities render
+  // their top-level `description` there). Abilities keep using `description`, so
+  // their flavor blocks (if any) stay in the body. The hoisted block is filtered
+  // out of `contentBlocks` below so it isn't shown twice.
+  const hoistedFlavor =
+    !isAbility(data) && contentBlocks
+      ? contentBlocks.find((block) => block.type === 'flavor' && typeof block.value === 'string')
+      : undefined
+  const hoistedFlavorText =
+    hoistedFlavor && typeof hoistedFlavor.value === 'string' ? hoistedFlavor.value : undefined
+  if (contentBlocks && hoistedFlavor) {
+    contentBlocks = contentBlocks.filter((block) => block !== hoistedFlavor)
+  }
+
   // In compact list view (hide.actions), only show content before the first heading
   if (contentBlocks && compact && hide.actions) {
     const firstHeadingIndex = contentBlocks.findIndex((block) => block.type === 'heading')
@@ -360,8 +375,11 @@ export function ReferenceEntityDisplayContent({
   // membership check is needed; this mirrors ReferenceEntityRightHeaderContent's
   // own early-return guard so we never pass a truthy-but-empty node to CardHeader.
   // Granting abilities still show their description in the header-right flavor
-  // slot (the Grants block lives in the body — they don't conflict).
-  const hasHeaderFlavor = isAbilityEntity && !!data.description
+  // slot (the Grants block lives in the body — they don't conflict). Non-ability
+  // entities qualify when they carry a hoisted `flavor` content block.
+  const hasHeaderFlavor = isAbilityEntity
+    ? !!data.description
+    : hoistedFlavorText != null && hoistedFlavorText.length > 0
 
   // Consolidate chassis abilities logic — data-shape driven
   const chassisName = 'name' in data ? data.name : undefined
@@ -575,15 +593,18 @@ export function ReferenceEntityDisplayContent({
         />
       }
       rightContent={
-        // The ability description always renders in the header-right flavor slot
-        // (nothing suppresses it). `hasHeaderFlavor` already means "ability with a
-        // description", so the node is never truthy-but-empty — only abilities
-        // reach this branch; systems/modules render their stats via `stats`.
+        // The flavor quip renders in the header-right slot. Abilities source it
+        // from their top-level `description`; non-ability entities source it from
+        // their hoisted first `type: 'flavor'` content block (passed as `flavor`).
+        // `hasHeaderFlavor` already guarantees a non-empty value, so the node is
+        // never truthy-but-empty. Systems/modules without a flavor block fall
+        // through to `undefined` and render their stats via `stats`.
         hasHeaderFlavor ? (
           <ReferenceEntityRightHeaderContent
             data={data}
             fontSize={fontSize}
             accentColor={accentText}
+            flavor={hoistedFlavorText}
           />
         ) : undefined
       }


### PR DESCRIPTION
## Feedback

> **Hoist `flavor` content block into header-right italic slot for non-ability entities (A1)**
>
> The shared entity card renders an italic, right-aligned "flavor" quip in the header-right slot only for abilities, where the quip is the ability's top-level `description` field (`ReferenceEntityRightHeaderContent` guarded on `isAbility(data)`). The revamp design wants that flavor slot populated for all entity types. The blocker was a content-model mismatch: non-ability entities have no top-level flavor field — flavor lives as a `type: 'flavor'` content block inside the `content` array and renders in the body. So this is not a guard removal; it is a *hoist* of the flavor content block out of the body into the header-right slot (and suppression in the body so it isn't shown twice), implemented visual-only without touching any suref-web/suref-react test.

Data reality check confirmed: flavor content blocks are rare — 6 entities carry one (5 in `actions.json`: Experimental Particle Beam Cannon, First Aid Kit, Navigation Module, Personal Recreation Device, Remote Mine; 1 chassis: Gopher; 1 in `guides.json`). Systems/equipment/modules carry none. The feedback's "Mining Laser system" example does not exist in the data — there is no such flavor block — so the visible impact is limited to those ~6 entities.

## UX area changed

Shared card in `packages/suref-react` (not ITUN-app-specific). ITUN consumes it unchanged via `ContextualEntityDisplay` and wizard `SelCard`, so the change surfaces in ITUN's entity displays automatically — no ITUN route/store/component edit. Files:

- `packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/components/ReferenceEntityDisplayContent.tsx` — orchestration: compute the first non-ability `type: 'flavor'` block, set `hasHeaderFlavor` from it, and filter it out of `contentBlocks` (mirroring the existing `hideLeadContent`/`datavalues` filter pattern) so it isn't duplicated in the body; pass the hoisted value into the header-right slot.
- `packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/ReferenceEntityRightHeaderContent.tsx` — accept an optional `flavor` string for non-abilities; abilities keep sourcing from their top-level `description`. The early-return guard now keys off whichever value resolves.

`BlockContentRendererView`'s `case 'flavor':` arm is left intact (still used wherever a flavor block is NOT hoisted, e.g. abilities or body-only contexts).

## SURules reference

The hoist matches the canonical Core Book layout: in chassis/equipment entries the italic descriptive ("flavor") line sits in the upper-right beside the title and above the stat block — see the Forge chassis entry, **Salvage Union Core Book Digital Edition 2.0a, p.110**, where the italic flavor paragraph occupies the top-right next to the art and stats. No game mechanic depends on the placement; this is a presentation/layout decision faithful to the book.

## Fix summary

Smallest in-scope change: hoist the first `type: 'flavor'` content block of a non-ability entity into the existing header-right flavor slot and remove it from the body so it renders once. Additive optional prop on the right-header component; no schema change, no new UI, no backend.

## Checks

- `bun run typecheck` — pass (all packages)
- `bun --filter suref-react test` — 310 pass, 0 fail (no test file modified)
- `bun --filter suref-web test` — 953 pass, 0 fail (no test file modified)
- `bun run lint` — pass
- `bun run format` — applied
- pre-commit (lint-fix, format) and pre-push (typecheck, test, validate:all, knip) hooks — pass

## Note for reviewers

The feedback flagged a content-model sign-off as a prerequisite ("confirm with the content owner that only the ~6 entities warrant a header flavor"). This was run headless with no content owner to consult. The change is intentionally conservative — it only relocates flavor text that already exists in the data, applies to exactly those ~6 entities, and is fully visual-only (zero test changes). If the content owner decides a particular entity's flavor should stay in the body, that is a per-entity data decision and does not require reverting this presentation change. The referenced `docs/yitun-revamp-gap-closeout.md` (Phase A/A1) was **not found** on the `yitun-revamp` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
