### PR TITLE
feat(itun): add manual d20 / stat-check reference roller (REQ-027)

### DIFF
--- a/apps/in-the-union-now/src/components/shared/DiceRoller.tsx
+++ b/apps/in-the-union-now/src/components/shared/DiceRoller.tsx
@@ -1,0 +1,104 @@
+/**
+ * DiceRoller — manual d20 / stat-check reference roller (REQ-027).
+ *
+ * A purely ephemeral utility surface: a floating launcher button opens a modal
+ * that rolls a d20, optionally adds a flat stat/situational modifier, and shows
+ * the Salvage Union Core Mechanic outcome band (Core Rulebook p.232). All state
+ * is local `useState` — this component NEVER writes through entityStore /
+ * workspaceStore and touches no IndexedDB record. It is a manual reference tool
+ * with no game-state mutation, mounted globally from __root.tsx so it is
+ * reachable on every route.
+ *
+ * Band labels/values come from the reference dataset's Core Mechanic table via
+ * the pure rollCoreMechanic helper, not hardcoded UI strings.
+ */
+
+import { useState } from 'react'
+import { Dices } from 'lucide-react'
+import { ModalShell } from 'suref-react'
+
+import { Button } from '../ui/button'
+import { rollCoreMechanic } from './diceRollerHelpers'
+import type { CoreMechanicRoll } from './diceRollerHelpers'
+
+export function DiceRoller() {
+  const [open, setOpen] = useState(false)
+  const [modifier, setModifier] = useState(0)
+  const [result, setResult] = useState<CoreMechanicRoll | null>(null)
+
+  function handleRoll() {
+    setResult(rollCoreMechanic(modifier))
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="default"
+        size="icon"
+        aria-label="Open dice roller"
+        title="Dice roller"
+        className="fixed right-4 bottom-4 z-40 rounded-full shadow-lg"
+        onClick={() => setOpen(true)}
+      >
+        <Dices aria-hidden="true" />
+      </Button>
+
+      <ModalShell
+        open={open}
+        onOpenChange={setOpen}
+        title="Dice Roller"
+        subtitle="Core Mechanic (d20)"
+        description="Roll a d20 and read the Salvage Union Core Mechanic outcome. Reference only — nothing is saved."
+        maxWidth="max-w-md"
+        align="center"
+      >
+        <div className="flex flex-col gap-4 p-4">
+          <p className="text-sm text-muted-foreground">
+            Manual reference roller — rolls a d20 and reads the Core Mechanic outcome band. Nothing
+            is saved to your pilots, mechs, or crawlers.
+          </p>
+
+          <label className="flex items-center justify-between gap-3 text-sm font-medium">
+            <span>Modifier (stat check)</span>
+            <input
+              type="number"
+              value={modifier}
+              onChange={(e) => setModifier(Number(e.target.value) || 0)}
+              className="w-20 rounded border border-[var(--color-su-black)] bg-transparent px-2 py-1 text-right text-sm"
+              aria-label="Stat or situational modifier added to the d20"
+            />
+          </label>
+
+          <Button type="button" variant="default" onClick={handleRoll} className="self-start">
+            Roll d20
+          </Button>
+
+          {result && (
+            <div
+              role="status"
+              aria-live="polite"
+              className="flex flex-col gap-2 rounded border border-[var(--color-su-black)] p-3"
+            >
+              <div className="flex items-baseline gap-2 text-sm">
+                <span className="font-medium">Roll:</span>
+                <span>{result.roll}</span>
+                {result.modifier !== 0 && (
+                  <span className="text-muted-foreground">
+                    {result.modifier > 0
+                      ? `+ ${result.modifier}`
+                      : `- ${Math.abs(result.modifier)}`}
+                    {' = '}
+                    <span className="font-medium text-foreground">{result.total}</span>
+                  </span>
+                )}
+              </div>
+              {result.label && <p className="text-base font-bold">{result.label}</p>}
+              <p className="text-sm">{result.value}</p>
+            </div>
+          )}
+        </div>
+      </ModalShell>
+    </>
+  )
+}

--- a/apps/in-the-union-now/src/components/shared/__tests__/diceRollerHelpers.test.ts
+++ b/apps/in-the-union-now/src/components/shared/__tests__/diceRollerHelpers.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for diceRollerHelpers — pure logic, dep-injection only.
+ *
+ * Mirrors components/pilot/__tests__/rollTableHelpers.test.ts: avoids
+ * `mock.module()` (which leaks globally across Bun test files) by passing a
+ * stubbed DiceRollerDeps directly per test.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { rollCoreMechanic } from '../diceRollerHelpers'
+import type { DiceRollerDeps } from '../diceRollerHelpers'
+
+type StubTable = {
+  id: string
+  name: string
+  schemaName: 'roll-tables'
+  table: Record<string, { value: string; label?: string }>
+}
+
+/** Core Mechanic bands per Core Rulebook p.232. */
+const CORE_MECHANIC_TABLE: StubTable = {
+  id: 'rt-core',
+  name: 'Core Mechanic',
+  schemaName: 'roll-tables',
+  table: {
+    '1': { label: 'Cascade Failure', value: 'Something has gone terribly wrong.' },
+    '2-5': { label: 'Failure', value: 'You have failed.' },
+    '6-10': { label: 'Tough Choice', value: 'You succeed, but at a cost.' },
+    '11-19': { label: 'Success', value: 'You have achieved your goal.' },
+    '20': { label: 'Nailed it', value: 'An outstanding success.' },
+  },
+}
+
+function makeDeps(roll: number, table: StubTable = CORE_MECHANIC_TABLE): DiceRollerDeps {
+  return {
+    findTable: () => table as never,
+    rollD20: () => roll,
+  }
+}
+
+describe('rollCoreMechanic', () => {
+  test('returns null when the Core Mechanic table is not found', () => {
+    const noTableDeps: DiceRollerDeps = { findTable: () => undefined, rollD20: () => 10 }
+    expect(rollCoreMechanic(0, noTableDeps)).toBeNull()
+  })
+
+  test('maps a plain d20 of 20 to Nailed it', () => {
+    const result = rollCoreMechanic(0, makeDeps(20))
+    expect(result).toEqual({
+      roll: 20,
+      modifier: 0,
+      total: 20,
+      label: 'Nailed it',
+      value: 'An outstanding success.',
+    })
+  })
+
+  test('maps a mid-range roll to Success', () => {
+    expect(rollCoreMechanic(0, makeDeps(15))?.label).toBe('Success')
+  })
+
+  test('maps a roll of 1 to Cascade Failure', () => {
+    expect(rollCoreMechanic(0, makeDeps(1))?.label).toBe('Cascade Failure')
+  })
+
+  test('adds a positive modifier before resolving the band', () => {
+    // roll 4 + modifier 4 = 8 → Tough Choice band
+    const result = rollCoreMechanic(4, makeDeps(4))
+    expect(result?.total).toBe(8)
+    expect(result?.label).toBe('Tough Choice')
+  })
+
+  test('applies a negative modifier', () => {
+    // roll 8 - 5 = 3 → Failure band
+    const result = rollCoreMechanic(-5, makeDeps(8))
+    expect(result?.total).toBe(3)
+    expect(result?.label).toBe('Failure')
+  })
+
+  test('clamps a total above 20 to 20 (Nailed it)', () => {
+    const result = rollCoreMechanic(10, makeDeps(18))
+    expect(result?.total).toBe(20)
+    expect(result?.label).toBe('Nailed it')
+  })
+
+  test('clamps a total below 1 to 1 (Cascade Failure)', () => {
+    const result = rollCoreMechanic(-10, makeDeps(3))
+    expect(result?.total).toBe(1)
+    expect(result?.label).toBe('Cascade Failure')
+  })
+
+  test('preserves the raw roll separately from the modified total', () => {
+    const result = rollCoreMechanic(2, makeDeps(5))
+    expect(result?.roll).toBe(5)
+    expect(result?.modifier).toBe(2)
+    expect(result?.total).toBe(7)
+  })
+})

--- a/apps/in-the-union-now/src/components/shared/diceRollerHelpers.ts
+++ b/apps/in-the-union-now/src/components/shared/diceRollerHelpers.ts
@@ -1,0 +1,87 @@
+/**
+ * Pure helpers for the manual d20 / stat-check reference roller (REQ-027).
+ *
+ * Isolated from React so they can be tested without a DOM, mirroring
+ * components/pilot/rollTableHelpers.ts. These helpers are READ-ONLY: they roll a
+ * die and resolve the Core Mechanic outcome band from the reference data. They
+ * never touch entityStore / workspaceStore — the roller is a manual reference
+ * tool and must not mutate any game state.
+ */
+
+import { roll } from '@randsum/roller'
+import { SalvageUnionReference, resultForTable } from 'salvageunion-reference'
+import type { SURefRollTable } from 'salvageunion-reference'
+
+/** Name of the Core Mechanic roll table in the reference dataset. */
+const CORE_MECHANIC_TABLE_NAME = 'Core Mechanic'
+
+/**
+ * Outcome of a Core Mechanic resolution.
+ * - `roll` is the raw d20 (1-20).
+ * - `modifier` is the flat stat/situational modifier added for a stat check.
+ * - `total` is `roll + modifier`, clamped to 1-20 for band lookup (the Core
+ *   Mechanic table only has bands for 1-20).
+ * - `label` / `value` come from the reference data, never hardcoded UI strings.
+ */
+export type CoreMechanicRoll = {
+  roll: number
+  modifier: number
+  total: number
+  label: string
+  value: string
+}
+
+/**
+ * Dependency interface for the roller — injectable for testing.
+ */
+export type DiceRollerDeps = {
+  findTable: (name: string) => (SURefRollTable & { schemaName: string }) | undefined
+  rollD20: () => number
+}
+
+/**
+ * Default production deps — read from SalvageUnionReference.
+ */
+const defaultDiceRollerDeps: DiceRollerDeps = {
+  findTable: (name) => SalvageUnionReference.RollTables.find((t) => t.name === name),
+  rollD20: () => roll('1d20').total,
+}
+
+/** Clamps a value to the inclusive 1-20 range the Core Mechanic table covers. */
+function clampToD20(value: number): number {
+  if (value < 1) return 1
+  if (value > 20) return 20
+  return value
+}
+
+/**
+ * Rolls a d20, adds a flat modifier, and resolves the Core Mechanic outcome
+ * band against the reference data. Returns null if the table cannot be found or
+ * the roll fails to resolve (defensive — the Core Mechanic table always exists).
+ *
+ * Per Core Rulebook p.232 the bands are: 20 = Nailed it, 11-19 = Success,
+ * 6-10 = Tough Choice, 2-5 = Failure, 1 = Cascade Failure. The modifier (0 by
+ * default for a plain d20) is added to the roll, then the total is clamped to
+ * 1-20 for band lookup.
+ */
+export function rollCoreMechanic(
+  modifier = 0,
+  deps: DiceRollerDeps = defaultDiceRollerDeps
+): CoreMechanicRoll | null {
+  const table = deps.findTable(CORE_MECHANIC_TABLE_NAME)
+  if (!table) return null
+
+  const rolled = deps.rollD20()
+  const total = clampToD20(rolled + modifier)
+
+  const result = resultForTable(table.table, total)
+  if (!result.success) return null
+
+  return {
+    roll: rolled,
+    modifier,
+    total,
+    label: result.result.label ?? '',
+    value: result.result.value,
+  }
+}

--- a/apps/in-the-union-now/src/routes/__root.tsx
+++ b/apps/in-the-union-now/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import { queryClient } from '../lib/queryClient'
 import { itunEntityHref } from '../lib/entityHref'
 import { GameDataReady } from '../components/shared/GameDataReady'
 import { BackupNudgeToast } from '../components/shared/BackupNudgeToast'
+import { DiceRoller } from '../components/shared/DiceRoller'
 import '../index.css'
 
 export const Route = createRootRoute({
@@ -54,6 +55,7 @@ function RootComponent() {
         </GameDataReady>
         <Toaster />
         <BackupNudgeToast />
+        <DiceRoller />
       </EntityHrefProvider>
     </QueryClientProvider>
   )


### PR DESCRIPTION
## Feedback

**REQ-027 (M4, Could-Have):** Add a generic in-UI dice roller helper to ITUN — a basic d20 / stat-check roller that is purely a manual reference tool and must NOT mutate any game state. ITUN had no general-purpose roller (the only dice usage was the pilot-wizard roll-table helper). The ask: a small, self-contained roller surface that rolls a d20, optionally adds a flat modifier for a stat check, and shows the Salvage Union Core Mechanic outcome band, without touching any pilot/mech/crawler record in IndexedDB.

## UX area changed

- **New shared component:** `apps/in-the-union-now/src/components/shared/DiceRoller.tsx` — a floating launcher button (bottom-right, `lucide-react` Dices icon) that opens a `ModalShell` (reused from `suref-react`). The modal rolls a d20, takes an optional numeric stat/situational modifier, and renders roll + total + the Core Mechanic band label/value.
- **Global mount:** `apps/in-the-union-now/src/routes/__root.tsx` — mounted alongside `Toaster` / `BackupNudgeToast` so it is reachable on every route (dashboard, pilots, mechs, crawlers, sheets).
- **Pure helper:** `apps/in-the-union-now/src/components/shared/diceRollerHelpers.ts` — `rollCoreMechanic(modifier, deps)`, mirroring `components/pilot/rollTableHelpers.ts` (dependency-injected for testing), with unit tests in `__tests__/diceRollerHelpers.test.ts`.

All roller state is local `useState`. It never writes through `entityStore` / `workspaceStore` and touches no IndexedDB record — satisfying the "no game-state mutation (manual reference roller)" acceptance criterion and ITUN's local-first constraints.

## Salvage Union reference

- **Core Rulebook p.232, "The Core Mechanic"** (also `SU_Quick Ref Sheets Digital 2.0.pdf`, Core Resolution) — d20 outcome bands: **20 = Nailed it**, **11-19 = Success**, **6-10 = Tough Choice**, **2-5 = Failure**, **1 = Cascade Failure**. The roller resolves the total against `SalvageUnionReference.RollTables` `'Core Mechanic'` via the reference package's pure `resultForTable` — the same path the Discord bot's `commands/roll.ts` uses — so band labels/values come from the dataset, never hardcoded UI strings. (p.232 notes the die "should not be numerically modified in play"; the modifier input defaults to 0, keeping the default a plain d20, and is provided for the explicitly-requested stat-check case. Totals are clamped to 1-20 for band lookup.)

## Fix summary

Reuses existing building blocks rather than adding new logic: `@randsum/roller` (already an ITUN dependency, already used in `rollTableHelpers.ts`) for the die, the reference package's pure `resultForTable` for resolution, and `ModalShell` + the ITUN `Button` for UI. No new data, no store, no schema/IndexedDB change, no backend.

## Checks

- `bun run build:package` — passed (fresh worktree)
- `bun run typecheck` — passed
- `bun --filter in-the-union-now test` — 900 pass / 0 fail (9 new helper tests)
- `bun run lint` — passed
- `bun run format` — applied
- pre-push hook (typecheck, test, validate:all, knip) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)