### PR TITLE
feat(itun): gate crawler tech-level upgrade behind scrap spend + soft warnings

### DIFF
--- a/apps/in-the-union-now/src/components/sheet/CrawlerSheet.tsx
+++ b/apps/in-the-union-now/src/components/sheet/CrawlerSheet.tsx
@@ -19,6 +19,8 @@
  * readOnly suppresses every edit affordance (snapshot contexts).
  */
 
+import { useState } from 'react'
+
 import { SalvageUnionReference } from 'salvageunion-reference'
 import type { SURefEntity } from 'salvageunion-reference'
 import { Btn, ReferenceEntityDisplay, Slab, StepBtn, useDetailModal } from 'suref-react'
@@ -29,9 +31,13 @@ import { addToScrapPool, scrapPoolBucket } from '../../lib/cargo/cargoTransfer'
 import { useCargo } from '../../lib/cargo/useCargo'
 import { parseCrawlerTechLevel } from '../../lib/crawlerLevel'
 import { findNpcChoiceByName, resolveCrawlerBay, resolveCrawlerType } from '../../lib/crawlerRefs'
+import { evaluateCrawlerWarnings } from '../../lib/rules/softWarnings'
+import { tierUpgradeCost } from '../../lib/rules/scrap'
+import type { TechLevel } from '../../lib/rules/types'
 import type { Crawler, ScrapPool } from '../../lib/schemas/crawler'
 import type { Mech } from '../../lib/schemas/mech'
 import { useEntityStore } from '../../stores/entityStore'
+import { SoftWarningBanner } from '../shared/SoftWarningBanner'
 import { useEntityChoices } from '../shared/useEntityChoices'
 import { Ecflow, Erow } from './Erow'
 import { NpcInset } from './NpcInset'
@@ -483,11 +489,92 @@ export function CrawlerSheet({
     })
   }
 
-  /** Set the crawler's tech level (1–6), recomputing SP/capacity downstream. */
+  // Scrap available toward an upgrade: the Upgrade Pool plus every TL+ bucket
+  // (TL or higher scrap may be spent, mirroring repairBay's spill — S12).
+  const upgradePool = crawler.upgradePool ?? 0
+  const upgradeAvailable = upgradePool + repairable
+
+  /**
+   * A pending tech-level UPGRADE awaiting confirmation. Downgrades and no-ops
+   * commit immediately; only an upward step opens the advisory confirm panel
+   * (SRD p.218 — upgrading is a deliberate scrap spend).
+   */
+  const [pendingUpgrade, setPendingUpgrade] = useState<TechLevel | null>(null)
+
+  // Cost + advisory warnings for the pending upgrade (pure rule layer).
+  const upgradeCost =
+    pendingUpgrade !== null ? tierUpgradeCost(tl as TechLevel, pendingUpgrade) : null
+  const damagedBayCount = bays.filter((b) => (b.condition ?? 'intact') === 'damaged').length
+  const upgradeWarnings =
+    pendingUpgrade !== null
+      ? evaluateCrawlerWarnings({
+          entityType: 'crawler',
+          crawlerUpgrade: {
+            fromTL: tl as TechLevel,
+            toTL: pendingUpgrade,
+            cost: upgradeCost,
+            available: upgradeAvailable,
+            damagedBayCount,
+          },
+        })
+      : []
+
+  /**
+   * Set the crawler's tech level (1–6). Downgrades and no-ops commit straight
+   * away (downgrade warnings live in the shared TECH_LEVEL_DOWNGRADE path);
+   * an upward step stages a confirm panel instead of writing immediately.
+   */
   function setTechLevel(next: number) {
     if (readOnly) return
     if (next < 1 || next > 6 || next === tl) return
+    if (next > tl) {
+      setPendingUpgrade(next as TechLevel)
+      return
+    }
     void storeState.update('crawler', crawler.id, { techLevel: `tech-${next}` })
+  }
+
+  /**
+   * Confirm the staged upgrade (SRD p.218). One write-through:
+   *   - set techLevel to the target,
+   *   - debit the cost from the Upgrade Pool first, then spill into scrap-pool
+   *     buckets at the current TL or higher (mirrors repairBay; advisory — a
+   *     short pool still upgrades, S12 / ADR-007),
+   *   - then flip every damaged bay to Intact (SRD p.219).
+   */
+  function confirmUpgrade() {
+    if (readOnly || pendingUpgrade === null) return
+    const target = pendingUpgrade
+    const fresh = storeState.get('crawler', crawler.id) ?? crawler
+    const cost = tierUpgradeCost(tl as TechLevel, target) ?? 0
+
+    let remaining = cost
+    const fromPool = Math.min(fresh.upgradePool ?? 0, remaining)
+    remaining -= fromPool
+    let nextPool: ScrapPool = { ...(fresh.scrapPool ?? {}) }
+    for (let t = tl; t <= 6 && remaining > 0; t++) {
+      const take = Math.min(scrapPoolBucket(nextPool, t), remaining)
+      if (take > 0) {
+        nextPool = addToScrapPool(nextPool, t, -take)
+        remaining -= take
+      }
+    }
+
+    void storeState.update('crawler', crawler.id, {
+      techLevel: `tech-${target}`,
+      upgradePool: (fresh.upgradePool ?? 0) - fromPool,
+      scrapPool: nextPool,
+    })
+
+    // Damaged bays are repaired during the upgrade (SRD p.219).
+    const freshBays = fresh.crawlerBays ?? []
+    freshBays.forEach((bay, i) => {
+      if ((bay.condition ?? 'intact') === 'damaged') {
+        void storeState.updateCrawlerBay(crawler.id, bay.bayRef, { condition: 'intact' }, i)
+      }
+    })
+
+    setPendingUpgrade(null)
   }
 
   const TECH_LEVELS = [1, 2, 3, 4, 5, 6] as const
@@ -513,32 +600,61 @@ export function CrawlerSheet({
         </div>
       )}
 
-      {/* Tech Level — editable stepper (rules: upgraded on the live sheet) */}
+      {/* Tech Level — editable stepper; upgrades route through a confirm flow
+          that spends scrap and repairs bays (SRD p.218–219). */}
       <div>
         <Slab label="Tech Level" count={`Tech ${tl} crawler`} />
         {readOnly ? (
           <p className="font-body text-sm text-ink">Tech Level {tl}</p>
         ) : (
-          <div
-            role="group"
-            aria-label="Crawler tech level"
-            className="inline-flex items-stretch overflow-hidden rounded-[2px] border-[1.5px] border-ink bg-paper"
-          >
-            {TECH_LEVELS.map((n) => (
-              <button
-                key={n}
-                type="button"
-                aria-label={`Set tech level ${n}`}
-                aria-pressed={n === tl}
-                onClick={() => setTechLevel(n)}
-                className={cn(
-                  'min-w-9 px-2 py-1 font-cond text-sm font-bold leading-none',
-                  n === tl ? 'bg-ink text-su-white' : 'text-ink hover:bg-su-paper'
-                )}
+          <div className="flex flex-col gap-3">
+            <div
+              role="group"
+              aria-label="Crawler tech level"
+              className="inline-flex w-fit items-stretch overflow-hidden rounded-[2px] border-[1.5px] border-ink bg-paper"
+            >
+              {TECH_LEVELS.map((n) => (
+                <button
+                  key={n}
+                  type="button"
+                  aria-label={`Set tech level ${n}`}
+                  aria-pressed={n === tl}
+                  onClick={() => setTechLevel(n)}
+                  className={cn(
+                    'min-w-9 px-2 py-1 font-cond text-sm font-bold leading-none',
+                    n === tl ? 'bg-ink text-su-white' : 'text-ink hover:bg-su-paper'
+                  )}
+                >
+                  {n}
+                </button>
+              ))}
+            </div>
+
+            {pendingUpgrade !== null && (
+              <div
+                role="group"
+                aria-label="Confirm tech level upgrade"
+                className="flex max-w-prose flex-col gap-3 rounded border border-ink/30 bg-su-paper p-3"
               >
-                {n}
-              </button>
-            ))}
+                <p className="font-body text-sm font-bold text-ink">
+                  {upgradeCost !== null
+                    ? `Upgrade to Tech ${pendingUpgrade} — costs ${upgradeCost} Tech-${tl} Scrap`
+                    : `Upgrade to Tech ${pendingUpgrade}`}
+                </p>
+                <p className="font-body text-xs text-ink/70">
+                  {`Available: ${upgradeAvailable} Scrap (Upgrade Pool ${upgradePool} + Tech ${tl}+ buckets ${repairable}).`}
+                </p>
+                <SoftWarningBanner warnings={upgradeWarnings} />
+                <div className="flex gap-2">
+                  <Btn size="sm" variant="primary" onClick={confirmUpgrade}>
+                    Confirm upgrade
+                  </Btn>
+                  <Btn size="sm" variant="ghost" onClick={() => setPendingUpgrade(null)}>
+                    Cancel
+                  </Btn>
+                </div>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/apps/in-the-union-now/src/components/sheet/__tests__/CrawlerSheet-type.test.tsx
+++ b/apps/in-the-union-now/src/components/sheet/__tests__/CrawlerSheet-type.test.tsx
@@ -204,15 +204,28 @@ describe('CrawlerSheet — Crawler Type slab', () => {
 // ---------------------------------------------------------------------------
 
 describe('CrawlerSheet — editable tech level', () => {
-  test('clicking a tech-level button writes techLevel via store.update', async () => {
+  test('upgrading via the confirm flow writes techLevel + scrap debit via store.update', async () => {
+    const { SalvageUnionReference } = await import('salvageunion-reference')
+    await SalvageUnionReference.preload(['crawler-tech-levels'])
     const update = mock(async () => makeCrawler())
-    const crawler = makeCrawler({ techLevel: 'tech-2' })
+    // tech-2 → tech-4: 30 (T2) + 30 (T3) = 60 cost; fund it from the Upgrade Pool.
+    const crawler = makeCrawler({ techLevel: 'tech-2', upgradePool: 60 })
     render(<CrawlerSheet crawler={crawler} store={makeStubStore(crawler, update)} />)
 
+    // Stepping up stages the confirm panel — no write yet.
     await act(async () => {
       fireEvent.click(screen.getByLabelText('Set tech level 4'))
     })
-    expect(update).toHaveBeenCalledWith('crawler', crawler.id, { techLevel: 'tech-4' })
+    expect(update).not.toHaveBeenCalled()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm upgrade' }))
+    })
+    expect(update).toHaveBeenCalledWith('crawler', crawler.id, {
+      techLevel: 'tech-4',
+      upgradePool: 0,
+      scrapPool: {},
+    })
   })
 
   test('readOnly renders static tech-level text, no buttons', async () => {

--- a/apps/in-the-union-now/src/components/sheet/__tests__/CrawlerSheet-upgrade.test.tsx
+++ b/apps/in-the-union-now/src/components/sheet/__tests__/CrawlerSheet-upgrade.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * CrawlerSheet — tech-level upgrade flow (REQ-022, SRD p.218–219).
+ *
+ * Stepping the tech level UP opens an advisory confirm panel (cost preview +
+ * soft warnings); confirming spends scrap (Upgrade Pool first, spilling into
+ * current-TL+ buckets) and repairs damaged bays in one write-through. A short
+ * pool is advisory, never a block (ADR-007). Downgrades commit immediately.
+ *
+ * Uses the store-injection seam + a patched CrawlerBays.all. NO mock.module().
+ */
+
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { CrawlerSheet } from '../CrawlerSheet'
+import type { Crawler } from '../../../lib/schemas/crawler'
+import type { useEntityStore } from '../../../stores/entityStore'
+
+afterEach(() => {
+  cleanup()
+})
+
+const MOCK_BAYS = [
+  {
+    id: 'command-bay',
+    name: 'Command Bay',
+    schemaName: 'crawler-bays',
+    npc: { position: 'Princeps', hitPoints: 4 },
+  },
+  {
+    id: 'mech-bay',
+    name: 'Mech Bay',
+    schemaName: 'crawler-bays',
+    npc: { position: 'Greaser', hitPoints: 4 },
+  },
+]
+
+async function patchCrawlerBays(): Promise<() => void> {
+  const { SalvageUnionReference } = await import('salvageunion-reference')
+  await SalvageUnionReference.preload(['crawler-tech-levels'])
+  const original = SalvageUnionReference.CrawlerBays.all.bind(SalvageUnionReference.CrawlerBays)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  SalvageUnionReference.CrawlerBays.all = mock(() => MOCK_BAYS as any)
+  return () => {
+    SalvageUnionReference.CrawlerBays.all = original
+  }
+}
+
+const fakeCrawler: Crawler = {
+  id: 'crawler-upg-1',
+  schemaVersion: 1,
+  name: 'Iron Tortoise',
+  techLevel: 'tech-1',
+  systems: [],
+  currentSP: 20,
+  upgradePool: 20,
+  scrapPool: { tl1: 5, tl2: 10 },
+  crawlerBays: [
+    { bayRef: 'command-bay', npcCurrentHP: 4, condition: 'damaged' },
+    { bayRef: 'mech-bay', npcCurrentHP: 4 },
+  ],
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}
+
+type Spies = {
+  update: ReturnType<typeof mock>
+  updateCrawlerBay: ReturnType<typeof mock>
+}
+
+function makeStubStore(crawler: Crawler, spies?: Partial<Spies>): typeof useEntityStore {
+  const update = spies?.update ?? mock(async () => crawler)
+  const updateCrawlerBay = spies?.updateCrawlerBay ?? mock(async () => crawler)
+  const storeState = {
+    pilots: [],
+    mechs: [],
+    crawlers: [crawler],
+    softLinks: [],
+    hydrated: { pilots: false, mechs: false, crawlers: true, softLinks: false },
+    hydrate: mock(async () => {}),
+    list: mock(() => [crawler]),
+    get: mock((_type: string, id: string) => (id === crawler.id ? crawler : null)),
+    create: mock(async () => crawler),
+    update,
+    updateCrawlerBay,
+    delete: mock(async () => {}),
+  }
+  return (() => storeState) as unknown as typeof useEntityStore
+}
+
+describe('CrawlerSheet — tech-level upgrade flow (SRD p.218–219)', () => {
+  let restore: () => void
+  afterEach(() => {
+    restore?.()
+  })
+
+  test('stepping UP stages a confirm panel with the cost preview (does not write yet)', async () => {
+    restore = await patchCrawlerBays()
+    const update = mock(async () => fakeCrawler)
+    render(<CrawlerSheet crawler={fakeCrawler} store={makeStubStore(fakeCrawler, { update })} />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Set tech level 2' }))
+    })
+
+    // Tech-1 crawler: 30 Tech-1 Scrap to reach Tech 2.
+    expect(screen.getByText('Upgrade to Tech 2 — costs 30 Tech-1 Scrap')).toBeTruthy()
+    // No write until confirmed.
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  test('a short pool surfaces an advisory warning but still allows confirming', async () => {
+    restore = await patchCrawlerBays()
+    // Upgrade Pool 5 + tl1 3 = 8 available, well short of the 30 cost.
+    const broke: Crawler = { ...fakeCrawler, upgradePool: 5, scrapPool: { tl1: 3 } }
+    render(<CrawlerSheet crawler={broke} store={makeStubStore(broke)} />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Set tech level 2' }))
+    })
+
+    // Advisory short-pool warning is shown…
+    expect(screen.getByText(/short/i)).toBeTruthy()
+    // …but the confirm button is still enabled (advisory, never a block).
+    const confirm = screen.getByRole('button', { name: 'Confirm upgrade' }) as HTMLButtonElement
+    expect(confirm.disabled).toBe(false)
+  })
+
+  test('confirm spends Upgrade Pool first then current-TL+ buckets, and repairs damaged bays', async () => {
+    restore = await patchCrawlerBays()
+    const update = mock(async () => fakeCrawler)
+    const updateCrawlerBay = mock(async () => fakeCrawler)
+    render(
+      <CrawlerSheet
+        crawler={fakeCrawler}
+        store={makeStubStore(fakeCrawler, { update, updateCrawlerBay })}
+      />
+    )
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Set tech level 2' }))
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm upgrade' }))
+    })
+
+    // Cost 30: 20 from Upgrade Pool, remaining 10 from tl1 (5) then tl2 (5).
+    expect(update).toHaveBeenCalledWith('crawler', fakeCrawler.id, {
+      techLevel: 'tech-2',
+      upgradePool: 0,
+      scrapPool: { tl1: 0, tl2: 5 },
+    })
+    // The damaged Command Bay (index 0) is repaired to Intact.
+    expect(updateCrawlerBay).toHaveBeenCalledWith(
+      fakeCrawler.id,
+      'command-bay',
+      { condition: 'intact' },
+      0
+    )
+    // The intact Mech Bay is NOT touched.
+    expect(updateCrawlerBay).toHaveBeenCalledTimes(1)
+  })
+
+  test('cancel dismisses the panel without writing', async () => {
+    restore = await patchCrawlerBays()
+    const update = mock(async () => fakeCrawler)
+    render(<CrawlerSheet crawler={fakeCrawler} store={makeStubStore(fakeCrawler, { update })} />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Set tech level 2' }))
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    })
+
+    expect(screen.queryByRole('group', { name: 'Confirm tech level upgrade' })).toBeNull()
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  test('stepping DOWN commits immediately with no confirm panel', async () => {
+    restore = await patchCrawlerBays()
+    const downCrawler: Crawler = { ...fakeCrawler, techLevel: 'tech-3' }
+    const update = mock(async () => downCrawler)
+    render(<CrawlerSheet crawler={downCrawler} store={makeStubStore(downCrawler, { update })} />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Set tech level 2' }))
+    })
+
+    expect(screen.queryByRole('group', { name: 'Confirm tech level upgrade' })).toBeNull()
+    expect(update).toHaveBeenCalledWith('crawler', downCrawler.id, { techLevel: 'tech-2' })
+  })
+})

--- a/apps/in-the-union-now/src/lib/rules/__tests__/softWarnings.test.ts
+++ b/apps/in-the-union-now/src/lib/rules/__tests__/softWarnings.test.ts
@@ -11,6 +11,7 @@ import {
   evaluateSoftWarnings,
   evaluatePilotWarnings,
   evaluateMechWarnings,
+  evaluateCrawlerWarnings,
   PILOT_ABILITY_CAP,
   SALVAGER_ABILITY_CAP,
 } from '../softWarnings'
@@ -373,6 +374,69 @@ describe('evaluateSoftWarnings — tech-level downgrade', () => {
     const warnings = evaluateSoftWarnings(fakeCrawler, fakeCrawler, ctx)
 
     expect(warnings.some((w) => w.code === 'TECH_LEVEL_DOWNGRADE')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Crawler upgrade warnings (SRD p.218–219)
+// ---------------------------------------------------------------------------
+
+describe('evaluateCrawlerWarnings — tech-level upgrade', () => {
+  it('returns no warnings for a covered upgrade with no damaged bays', () => {
+    const warnings = evaluateCrawlerWarnings({
+      entityType: 'crawler',
+      crawlerUpgrade: { fromTL: 1, toTL: 2, cost: 30, available: 30, damagedBayCount: 0 },
+    })
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('warns when the available scrap is short of the upgrade cost', () => {
+    const warnings = evaluateCrawlerWarnings({
+      entityType: 'crawler',
+      crawlerUpgrade: { fromTL: 1, toTL: 2, cost: 30, available: 18, damagedBayCount: 0 },
+    })
+    const warning = warnings.find((w) => w.code === 'CRAWLER_UPGRADE_POOL_SHORT')
+    expect(warning).toBeDefined()
+    expect(warning?.severity).toBe('warn')
+    expect(warning?.message).toContain('30 Tech-1 Scrap')
+    expect(warning?.message).toContain('12 short')
+  })
+
+  it('warns that TL6 is the cap and cannot be upgraded', () => {
+    const warnings = evaluateCrawlerWarnings({
+      entityType: 'crawler',
+      crawlerUpgrade: { fromTL: 6, toTL: 6, cost: null, available: 999, damagedBayCount: 0 },
+    })
+    // toTL <= fromTL routes to no upgrade check; force an upward step at the cap.
+    const cap = evaluateCrawlerWarnings({
+      entityType: 'crawler',
+      crawlerUpgrade: { fromTL: 6, toTL: 7 as 6, cost: null, available: 999, damagedBayCount: 0 },
+    })
+    expect(warnings.some((w) => w.code === 'CRAWLER_TL_MAX')).toBe(false)
+    expect(cap.some((w) => w.code === 'CRAWLER_TL_MAX')).toBe(true)
+  })
+
+  it('adds an info note when damaged bays will be repaired by the upgrade', () => {
+    const warnings = evaluateCrawlerWarnings({
+      entityType: 'crawler',
+      crawlerUpgrade: { fromTL: 2, toTL: 3, cost: 30, available: 99, damagedBayCount: 2 },
+    })
+    const note = warnings.find((w) => w.code === 'CRAWLER_BAYS_REPAIRED')
+    expect(note).toBeDefined()
+    expect(note?.severity).toBe('info')
+    expect(note?.message).toContain('2 damaged bays')
+  })
+
+  it('returns no upgrade warnings when no upgrade is pending', () => {
+    expect(evaluateCrawlerWarnings({ entityType: 'crawler' })).toHaveLength(0)
+  })
+
+  it('does not emit upgrade warnings for a downgrade (handled by TECH_LEVEL_DOWNGRADE)', () => {
+    const warnings = evaluateCrawlerWarnings({
+      entityType: 'crawler',
+      crawlerUpgrade: { fromTL: 3, toTL: 2, cost: null, available: 0, damagedBayCount: 3 },
+    })
+    expect(warnings.some((w) => w.code.startsWith('CRAWLER_'))).toBe(false)
   })
 })
 

--- a/apps/in-the-union-now/src/lib/rules/softWarnings.ts
+++ b/apps/in-the-union-now/src/lib/rules/softWarnings.ts
@@ -29,6 +29,10 @@ function warn(code: string, message: string): SoftWarning {
   return { code, message, severity: 'warn' }
 }
 
+function info(code: string, message: string): SoftWarning {
+  return { code, message, severity: 'info' }
+}
+
 // ---------------------------------------------------------------------------
 // Pilot warning checks (advancement prerequisites, plan S5 / 3.3–3.4)
 //
@@ -247,6 +251,62 @@ function checkTechLevelDowngrade(context: SoftWarningContext): SoftWarning[] {
 }
 
 // ---------------------------------------------------------------------------
+// Crawler upgrade checks (SRD p.218, M4)
+//
+// Upgrading a Union Crawler costs 30× the crawler's CURRENT Tech Level in Scrap,
+// paid out of the Upgrade Pool (which voluntary scrap may top up). All checks
+// are advisory — the player always confirms and proceeds (ADR-007):
+//   - TL6 (Megacity) is the cap and cannot be upgraded further.
+//   - The Upgrade Pool / scrap may be short of the cost.
+//   - Damaged bays are repaired by the upgrade (informational, SRD p.219).
+// Downgrades are handled by the shared TECH_LEVEL_DOWNGRADE check.
+// ---------------------------------------------------------------------------
+
+function checkCrawlerUpgrade(context: SoftWarningContext): SoftWarning[] {
+  const upgrade = context.crawlerUpgrade
+  if (!upgrade) return []
+  // Downgrades route to checkTechLevelDowngrade, not here.
+  if (upgrade.toTL <= upgrade.fromTL) return []
+
+  const warnings: SoftWarning[] = []
+
+  // TL6 is the cap — cost is null because there is no next level.
+  if (upgrade.fromTL >= 6 || upgrade.cost === null) {
+    warnings.push(
+      warn(
+        'CRAWLER_TL_MAX',
+        'Tech 6 (Megacity) is the highest Union Crawler Tech Level and cannot be upgraded further.'
+      )
+    )
+    return warnings
+  }
+
+  if (upgrade.available < upgrade.cost) {
+    warnings.push(
+      warn(
+        'CRAWLER_UPGRADE_POOL_SHORT',
+        `Upgrading to Tech ${upgrade.toTL} costs ${upgrade.cost} Tech-${upgrade.fromTL} Scrap, ` +
+          `but only ${upgrade.available} Scrap (Upgrade Pool + Tech ${upgrade.fromTL}+ buckets) ` +
+          `is available — ${upgrade.cost - upgrade.available} short. Upgrading anyway is the table's call.`
+      )
+    )
+  }
+
+  if (upgrade.damagedBayCount > 0) {
+    warnings.push(
+      info(
+        'CRAWLER_BAYS_REPAIRED',
+        `${upgrade.damagedBayCount} damaged ${
+          upgrade.damagedBayCount === 1 ? 'bay' : 'bays'
+        } will be repaired to Intact during the upgrade (SRD p.219).`
+      )
+    )
+  }
+
+  return warnings
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -296,15 +356,34 @@ export function evaluateMechWarnings(
 }
 
 /**
+ * Evaluate soft warnings for a crawler edit (SRD p.218–219).
+ *
+ * Documented cases (all advisory, never blocking — ADR-007):
+ * - Tech level is being downgraded (shared TECH_LEVEL_DOWNGRADE check)
+ * - A pending tech-level upgrade hits the TL6 cap
+ * - A pending upgrade's cost exceeds the available Upgrade Pool / scrap
+ * - Informational: damaged bays will be repaired by the upgrade
+ *
+ * Returns an empty array when no warnings apply.
+ */
+export function evaluateCrawlerWarnings(context: SoftWarningContext): SoftWarning[] {
+  const warnings: SoftWarning[] = []
+  warnings.push(...checkTechLevelDowngrade(context))
+  warnings.push(...checkCrawlerUpgrade(context))
+  return warnings
+}
+
+/**
  * Unified entry point for soft-warning evaluation.
  *
  * Dispatches to the appropriate entity-specific evaluator based on
  * `context.entityType`. For 'pilot', `before`/`after` must be `PilotSnapshot`.
- * For 'mech', they must be `MechSnapshot`. For 'crawler', only the
- * tech-level downgrade check applies (crawler-specific rules are M4).
+ * For 'mech', they must be `MechSnapshot`. For 'crawler', the tech-level
+ * downgrade check and the pending-upgrade checks apply (SRD p.218–219); pass
+ * the upgrade details in `context.crawlerUpgrade`.
  *
  * When `entityType` is 'crawler', pass any object satisfying `MechSnapshot`
- * (only the `techLevel` field is read; `systems` can be an empty array).
+ * (the snapshots are unused — crawler warnings derive from `context`).
  *
  * Returns an empty array when no warnings apply.
  */
@@ -321,8 +400,7 @@ export function evaluateSoftWarnings(
     case 'mech':
       return evaluateMechWarnings(snapshot as EditSnapshot<MechSnapshot>, context)
     case 'crawler':
-      // Crawler-specific rules beyond tech-level downgrade are deferred to M4.
-      return checkTechLevelDowngrade(context)
+      return evaluateCrawlerWarnings(context)
     default: {
       // Exhaustiveness guard — TypeScript will catch this at compile time if
       // a new entityType is added without a corresponding case.

--- a/apps/in-the-union-now/src/lib/rules/types.ts
+++ b/apps/in-the-union-now/src/lib/rules/types.ts
@@ -226,6 +226,30 @@ export type MechSnapshot = {
 }
 
 /**
+ * Crawler tech-level upgrade context (SRD p.218). Describes a pending
+ * upgrade so the rule layer can surface advisory warnings before the player
+ * confirms the spend. All checks are non-blocking (ADR-007).
+ */
+export type CrawlerUpgradeContext = {
+  /** Crawler's current tech level (before the upgrade). */
+  fromTL: TechLevel
+  /** Tech level the player is stepping to. */
+  toTL: TechLevel
+  /**
+   * Cost in scrap to perform the upgrade (30× the current TL's scrap per the
+   * SRD), or null when the cost cannot be determined (e.g. already at TL6).
+   */
+  cost: number | null
+  /**
+   * Scrap currently available to cover the cost — the Upgrade Pool plus any
+   * scrap-pool buckets at the current TL or higher (TL+ scrap is allowed).
+   */
+  available: number
+  /** Number of damaged crawler bays that will be repaired by the upgrade. */
+  damagedBayCount: number
+}
+
+/**
  * Context object passed to `evaluateSoftWarnings`.
  * Describes what was changed and who is being saved.
  */
@@ -239,6 +263,12 @@ export type SoftWarningContext = {
    * Set to true when the edit skips the refund step.
    */
   scrapRefundSkipped?: boolean
+  /**
+   * Pending crawler tech-level upgrade (SRD p.218). When present, the crawler
+   * evaluator surfaces advisory upgrade warnings (TL cap, short pool) and an
+   * informational note that damaged bays are repaired by the upgrade.
+   */
+  crawlerUpgrade?: CrawlerUpgradeContext
 }
 
 /**


### PR DESCRIPTION
## Feedback

**Crawler TL upgrade flow: gate the tech-level stepper behind a scrap/Upgrade-Pool spend with soft warnings** (REQ-022, M4)

The CrawlerSheet's Tech Level stepper flipped the stored `techLevel` with no economy interaction, no cost preview, and no warnings. The plumbing existed but was disconnected: the schema already stores `upgradePool`/`scrapPool`, `tierUpgradeCost` (lib/rules/scrap.ts) was fully implemented but unused, the SoftWarningBanner + evaluateSoftWarnings stack existed but its crawler branch explicitly deferred crawler rules to M4. This PR wires those pieces into one real upgrade flow.

## UX area changed

`apps/in-the-union-now/src/components/sheet/CrawlerSheet.tsx` — the "Tech Level" stepper section. Supported by `lib/rules/softWarnings.ts` (new pure crawler upgrade checks), `lib/rules/types.ts` (new `CrawlerUpgradeContext`), and reusing the shared `SoftWarningBanner`.

## SURules references

- **Core Book 2.0a, Workshop Manual p.218** ("Upgrading your Union Crawler"): upgrade is gated on the Upgrade Pool reaching the Upgrade Value = 30× Scrap of the crawler's **current** Tech Level; players may also spend extra Scrap into the pool. TL6 (Megacity) is the cap and cannot be upgraded further (`upgradeCost: null` in crawler-tech-levels.json).
- **Core Book 2.0a, Workshop Manual p.219**: "Any damaged bays are repaired during the upgrade process."

## The fix

Stepping the Tech Level **UP** now routes through an advisory confirm panel instead of a bare `store.update`:

1. **Cost preview** — computed with the existing `tierUpgradeCost(currentTL, nextTL)`, shown as "Upgrade to Tech N — costs 30 Tech-{TL} Scrap", plus an Available line (Upgrade Pool + current-TL+ scrap buckets).
2. **Soft warnings** (reusing `SoftWarningBanner`, never blocking — per ADR-007): insufficient Upgrade Pool/scrap to cover the cost (`CRAWLER_UPGRADE_POOL_SHORT`), the TL6 cap (`CRAWLER_TL_MAX`), and an informational note that damaged bays will be repaired (`CRAWLER_BAYS_REPAIRED`). Downgrades still commit immediately via the existing `TECH_LEVEL_DOWNGRADE` path.
3. **On confirm** — one write-through sets `techLevel`, debits the spend from `upgradePool` first then spills into current-TL+ scrap buckets (mirroring `repairBay`), and flips damaged bays to intact (p.219).
4. **Pure rule layer** — the crawler branch of `evaluateSoftWarnings` (previously TODO-deferred to M4) now delegates to a new pure, testable `evaluateCrawlerWarnings` / `checkCrawlerUpgrade`.

Local-first only (entityStore -> IndexedDB), no backend, no new wizard step or route.

## Checks passed

- `bun run typecheck` — all packages clean
- `bun --filter in-the-union-now test` — 902 pass, 0 fail (includes 6 new rule-check tests + a new 5-case CrawlerSheet upgrade-flow interaction test)
- `bun run lint` — clean (also via pre-commit lint --fix + format)
- `bun run format` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
