### PR TITLE
feat(itun): publish a mech pattern as a cloneable snapshot (REQ-026/M4)

### DIFF
--- a/apps/in-the-union-now/src/components/mech/Pattern/PatternList.tsx
+++ b/apps/in-the-union-now/src/components/mech/Pattern/PatternList.tsx
@@ -16,6 +16,7 @@ import { useEffect, useState } from 'react'
 import * as db from '../../../lib/db/index'
 import type { MechPattern } from '../../../lib/schemas/pattern'
 import { InstantiateFromPattern } from './InstantiateFromPattern'
+import { PublishPatternButton } from './PublishPatternButton'
 
 type PatternListProps = {
   /** Called with the new mech id when a pattern is instantiated. */
@@ -100,7 +101,10 @@ export function PatternList({ onInstantiated }: PatternListProps) {
               {pattern.modules.length !== 1 ? 's' : ''}, {pattern.cargoLots.length} cargo
             </span>
           </div>
-          <InstantiateFromPattern pattern={pattern} onSuccess={handleInstantiated} />
+          <div className="flex flex-col items-end gap-2 shrink-0">
+            <InstantiateFromPattern pattern={pattern} onSuccess={handleInstantiated} />
+            <PublishPatternButton pattern={pattern} />
+          </div>
         </li>
       ))}
     </ul>

--- a/apps/in-the-union-now/src/components/mech/Pattern/PublishPatternButton.tsx
+++ b/apps/in-the-union-now/src/components/mech/Pattern/PublishPatternButton.tsx
@@ -1,0 +1,150 @@
+/**
+ * PublishPatternButton — publishes a MechPattern as a cloneable anonymous
+ * snapshot (REQ-026 / M4).
+ *
+ * Patterns are not a sheet kind, so they don't route through the sheet Share
+ * Snapshot screen. This inline control reuses the existing kind-agnostic
+ * snapshot backend directly: it probes the service (S6 feature-detect),
+ * publishes a `{ kind: 'pattern', entity: <MechPattern> }` payload via
+ * publishSnapshot, and surfaces the resulting `/s/:id` link with a copy
+ * affordance. The snapshot backend stores arbitrary JSON, so no backend
+ * change is needed.
+ *
+ * Dep-injection: publishFn / probeFn / clipboardWriter are overridable for
+ * testing, mirroring ShareSnapshotScreen.
+ */
+
+import { useEffect, useState } from 'react'
+
+import type { MechPattern } from '../../../lib/schemas/pattern'
+import { probeSnapshotService, publishSnapshot } from '../../../lib/snapshot/client'
+import type { PublishResult, SnapshotPayload } from '../../../lib/snapshot/client'
+import { Button } from '../../ui/button'
+
+type PublishPatternButtonProps = {
+  pattern: MechPattern
+  /** Injectable publish function for testing. */
+  publishFn?: (payload: SnapshotPayload) => Promise<PublishResult>
+  /** Injectable backend feature-detect for testing (S6). */
+  probeFn?: () => Promise<boolean>
+  /** Injectable clipboard writer for testing. */
+  clipboardWriter?: (text: string) => Promise<void>
+}
+
+type ServiceState = 'checking' | 'available' | 'unavailable'
+
+type PublishState =
+  | { status: 'idle' }
+  | { status: 'publishing' }
+  | { status: 'published'; shareUrl: string }
+  | { status: 'error'; message: string }
+
+export function PublishPatternButton({
+  pattern,
+  publishFn = publishSnapshot,
+  probeFn = probeSnapshotService,
+  clipboardWriter = (text) => navigator.clipboard.writeText(text),
+}: PublishPatternButtonProps) {
+  const [service, setService] = useState<ServiceState>('checking')
+  const [publishState, setPublishState] = useState<PublishState>({ status: 'idle' })
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    void probeFn().then((available) => {
+      if (!cancelled) setService(available ? 'available' : 'unavailable')
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [probeFn])
+
+  const shareUrl = publishState.status === 'published' ? publishState.shareUrl : null
+
+  async function handlePublish() {
+    setPublishState({ status: 'publishing' })
+    setCopied(false)
+
+    const payload: SnapshotPayload = {
+      kind: 'pattern',
+      entity: pattern as unknown as Record<string, unknown>,
+    }
+
+    try {
+      const result = await publishFn(payload)
+      setPublishState({
+        status: 'published',
+        shareUrl: `${window.location.origin}/s/${result.id}`,
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      setPublishState({ status: 'error', message: `Failed to publish: ${message}` })
+    }
+  }
+
+  async function handleCopy() {
+    if (!shareUrl) return
+    try {
+      await clipboardWriter(shareUrl)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Leave the link visible; the user can select and copy it manually.
+    }
+  }
+
+  if (service === 'unavailable') {
+    return (
+      <p
+        role="note"
+        title="The snapshot service could not be reached — publishing needs the deployed /api/snapshots endpoint."
+        className="text-xs text-muted-foreground"
+      >
+        Sharing unavailable
+      </p>
+    )
+  }
+
+  if (shareUrl) {
+    return (
+      <div className="flex flex-col items-end gap-1">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => void handleCopy()}
+          aria-label={`Copy share link for pattern ${pattern.name}`}
+        >
+          {copied ? 'Copied ✓' : 'Copy link'}
+        </Button>
+        <a
+          href={shareUrl}
+          className="max-w-[12rem] truncate text-xs text-muted-foreground underline"
+          title={shareUrl}
+        >
+          {shareUrl}
+        </a>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => void handlePublish()}
+        disabled={service === 'checking' || publishState.status === 'publishing'}
+        aria-label={`Share pattern ${pattern.name} as a snapshot`}
+      >
+        {publishState.status === 'publishing' ? 'Sharing…' : 'Share'}
+      </Button>
+      {publishState.status === 'error' && (
+        <p className="text-xs text-destructive" role="alert">
+          {publishState.message}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/sheet/PatternSnapshotView.tsx
+++ b/apps/in-the-union-now/src/components/sheet/PatternSnapshotView.tsx
@@ -1,0 +1,136 @@
+/**
+ * PatternSnapshotView — read-only view of a published Mech Pattern snapshot,
+ * with a "Clone to my builds" action (REQ-026 / M4).
+ *
+ * Patterns aren't a sheet kind, so a published pattern doesn't render through
+ * the Sheet shell. Instead we show a compact read-only summary of the template
+ * (chassis · systems · modules · cargo) and offer a single action that
+ * instantiates the pattern into the visitor's own IndexedDB as a fresh Mech —
+ * reusing the exact instantiate path the local PatternList uses
+ * (entityStore.create('mech') seeded with full SP/EP and currentHeat 0). On
+ * success the visitor is navigated to the new build.
+ *
+ * The clone writes only to the visitor's local store; the snapshot itself is
+ * never mutated.
+ */
+
+import { useState } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import { findChassisByRef } from '../../lib/rules/derivedStats'
+import { totalLotUnits } from '../../lib/schemas/cargoLot'
+import type { MechPattern } from '../../lib/schemas/pattern'
+import { useEntityStore } from '../../stores/entityStore'
+import { Button } from '../ui/button'
+import { AppLink } from '../shared/AppLink'
+
+type PatternSnapshotViewProps = {
+  pattern: MechPattern
+}
+
+export function PatternSnapshotView({ pattern }: PatternSnapshotViewProps) {
+  const navigate = useNavigate()
+  const [isCloning, setIsCloning] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const chassis = SalvageUnionReference.Chassis.find((c) => c.name === pattern.chassisRef) ?? null
+
+  async function handleClone() {
+    setIsCloning(true)
+    setError(null)
+    try {
+      // Mirror InstantiateFromPattern: fresh id/timestamps from the db layer,
+      // fresh cargo-lot ids, full SP/EP from the chassis, Heat at 0.
+      const chassisStats = findChassisByRef(pattern.chassisRef)
+      const mech = await useEntityStore.getState().create('mech', {
+        schemaVersion: 1,
+        name: `${pattern.name} (from pattern)`,
+        chassisRef: pattern.chassisRef,
+        systems: [...pattern.systems],
+        modules: [...pattern.modules],
+        cargoLots: pattern.cargoLots.map((lot) => ({ ...lot, id: crypto.randomUUID() })),
+        conditions: [],
+        currentSP: chassisStats?.structurePoints,
+        currentEP: chassisStats?.energyPoints,
+        currentHeat: 0,
+      })
+      void navigate({ to: '/mechs/$id', params: { id: mech.id } })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to clone pattern to your builds.')
+      setIsCloning(false)
+    }
+  }
+
+  return (
+    <div>
+      {/* Snapshot banner — makes read-only context clear */}
+      <div
+        role="note"
+        aria-label="Read-only snapshot"
+        className="border-b-2 border-ink bg-su-sickly-yellow px-4 py-2 font-body text-sm font-semibold text-ink sm:px-[30px]"
+      >
+        This is a read-only mech pattern snapshot. Clone it to make an editable build of your own.
+      </div>
+
+      <main className="mx-auto flex max-w-3xl flex-col gap-6 p-6">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Mech Pattern
+          </p>
+          <h1 className="text-2xl font-bold">{pattern.name}</h1>
+        </div>
+
+        <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Chassis
+            </dt>
+            <dd className="text-sm">{chassis?.name ?? pattern.chassisRef}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Cargo
+            </dt>
+            <dd className="text-sm">{totalLotUnits(pattern.cargoLots)} units</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Systems
+            </dt>
+            <dd className="text-sm">
+              {pattern.systems.length > 0 ? pattern.systems.join(', ') : 'None'}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Modules
+            </dt>
+            <dd className="text-sm">
+              {pattern.modules.length > 0 ? pattern.modules.join(', ') : 'None'}
+            </dd>
+          </div>
+        </dl>
+
+        <div className="flex flex-col items-start gap-2">
+          <Button
+            type="button"
+            onClick={() => void handleClone()}
+            disabled={isCloning}
+            aria-label={`Clone pattern ${pattern.name} to my builds`}
+          >
+            {isCloning ? 'Cloning…' : 'Clone to my builds'}
+          </Button>
+          {error && (
+            <p className="text-xs text-destructive" role="alert">
+              {error}
+            </p>
+          )}
+          <AppLink href="/" className="text-sm underline">
+            &larr; Back to dashboard
+          </AppLink>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/sheet/SnapshotView.tsx
+++ b/apps/in-the-union-now/src/components/sheet/SnapshotView.tsx
@@ -13,6 +13,12 @@
  * Snapshot payload shape (as published by PublishButton v1):
  *   { kind: 'pilot' | 'mech' | 'crawler', entity: <entity object> }
  *
+ * Mech *patterns* (REQ-026 / M4) are also publishable as snapshots
+ * ({ kind: 'pattern', entity: <MechPattern> }); they don't render through the
+ * Sheet shell (patterns aren't a sheet kind) but as a read-only preview with a
+ * "Clone to my builds" action that instantiates the pattern into the visitor's
+ * local IndexedDB — see PatternSnapshotView.
+ *
  * Payloads are Zod-validated; a graceful error state renders on mismatch.
  */
 
@@ -22,14 +28,17 @@ import { create } from 'zustand'
 import type { Crawler } from '../../lib/schemas/crawler'
 import type { Mech } from '../../lib/schemas/mech'
 import type { Pilot } from '../../lib/schemas/pilot'
+import type { MechPattern } from '../../lib/schemas/pattern'
 import { CrawlerSchema } from '../../lib/schemas/crawler'
 import { MechSchema } from '../../lib/schemas/mech'
+import { MechPatternSchema } from '../../lib/schemas/pattern'
 import { PilotSchema, normalizeLegacyPilotRecord } from '../../lib/schemas/pilot'
 import { normalizeLegacyCargoRecord } from '../../lib/schemas/cargoLot'
 import { useEntityStore } from '../../stores/entityStore'
 import type { EntityType } from '../../stores/entityStore'
 import { AppLink } from '../shared/AppLink'
 
+import { PatternSnapshotView } from './PatternSnapshotView'
 import { Sheet } from './Sheet'
 
 type SnapshotViewProps = {
@@ -41,7 +50,11 @@ type ParseResult =
   | { ok: true; kind: 'pilot'; entity: Pilot }
   | { ok: true; kind: 'mech'; entity: Mech }
   | { ok: true; kind: 'crawler'; entity: Crawler }
+  | { ok: true; kind: 'pattern'; entity: MechPattern }
   | { ok: false; reason: string }
+
+/** Sheet-renderable kinds — pattern is rendered via its own preview, not Sheet. */
+type SheetParseResult = Exclude<Extract<ParseResult, { ok: true }>, { kind: 'pattern' }>
 
 function parseSnapshot(snapshot: Record<string, unknown>): ParseResult {
   const kind = snapshot['kind']
@@ -92,6 +105,21 @@ function parseSnapshot(snapshot: Record<string, unknown>): ParseResult {
     return { ok: true, kind: 'crawler', entity: parsed.data }
   }
 
+  if (kind === 'pattern') {
+    // Mech pattern snapshots (REQ-026 / M4) carry the MechPattern template.
+    // Legacy `cargo` → `cargoLots` rewrite mirrors the mech path above.
+    const parsed = MechPatternSchema.safeParse(
+      normalizeLegacyCargoRecord(entity as Record<string, unknown>)
+    )
+    if (!parsed.success) {
+      return {
+        ok: false,
+        reason: `Invalid pattern data: ${parsed.error.message}`,
+      }
+    }
+    return { ok: true, kind: 'pattern', entity: parsed.data }
+  }
+
   return { ok: false, reason: `Unknown entity kind: ${String(kind)}` }
 }
 
@@ -101,7 +129,7 @@ type EntityState = ReturnType<typeof useEntityStore.getState>
  * A read-only entity store containing ONLY the snapshot entity. Reads serve
  * the frozen record; writes throw (unreachable behind `readOnly`).
  */
-function makeSnapshotStore(parsed: Extract<ParseResult, { ok: true }>): typeof useEntityStore {
+function makeSnapshotStore(parsed: SheetParseResult): typeof useEntityStore {
   const readOnlyWrite = async (): Promise<never> => {
     throw new Error('Snapshots are read-only.')
   }
@@ -133,7 +161,17 @@ function makeSnapshotStore(parsed: Extract<ParseResult, { ok: true }>): typeof u
 
 export function SnapshotView({ snapshot }: SnapshotViewProps) {
   const result = useMemo(() => parseSnapshot(snapshot), [snapshot])
-  const store = useMemo(() => (result.ok ? makeSnapshotStore(result) : null), [result])
+  // Patterns render via their own preview (PatternSnapshotView), not the Sheet
+  // shell, so they never get a read-only entity store.
+  const store = useMemo(
+    () => (result.ok && result.kind !== 'pattern' ? makeSnapshotStore(result) : null),
+    [result]
+  )
+
+  // Mech pattern snapshots (REQ-026 / M4): read-only preview + clone action.
+  if (result.ok && result.kind === 'pattern') {
+    return <PatternSnapshotView pattern={result.entity} />
+  }
 
   if (!result.ok || !store) {
     // Styled validation-failure state (plan 5.2) — invalid payloads land


### PR DESCRIPTION
## Feedback (REQ-026 / M4)

> Publish a named mech **pattern** (the reusable template stored in the `mechPatterns` IndexedDB store) as an anonymous snapshot, re-using the existing M2 snapshot backend. Opening the resulting snapshot URL must offer a **"Clone to my builds"** action that instantiates the pattern into the visitor's local store.

Before this change the snapshot plumbing only handled `pilot | mech | crawler`, and the read-only `/s/$id` view rendered a frozen sheet with no import/clone affordance.

## UX area changed

- **Publish:** `apps/in-the-union-now/src/components/mech/Pattern/PatternList.tsx` — each pattern row now carries an inline Share control, the new `PublishPatternButton.tsx`. It probes the existing kind-agnostic snapshot backend (S6 feature-detect), publishes `{ kind: 'pattern', entity: <MechPattern> }` via `publishSnapshot`, and surfaces the `/s/:id` link with a copy affordance. (Patterns aren't a sheet kind, so they don't route through the sheet `ShareSnapshotScreen`; an inline control is the smallest reuse.)
- **View / clone:** `apps/in-the-union-now/src/components/sheet/SnapshotView.tsx` — `parseSnapshot` now validates `kind === 'pattern'` against `MechPatternSchema` (with the same legacy `cargo → cargoLots` normalization the mech path uses) and renders the new `PatternSnapshotView.tsx`: a read-only template preview (chassis · systems · modules · cargo) plus a **"Clone to my builds"** button that reuses the exact `InstantiateFromPattern` path — `entityStore.create('mech')` with fresh ids/timestamps, fresh cargo-lot ids, full SP/EP from the chassis, and `currentHeat: 0` — then navigates to the new build.

**No backend change:** `snapshot-publish` stores arbitrary JSON and is kind-agnostic; the `MAX_PAYLOAD_BYTES` cap easily covers a pattern.

## SURules reference

A "Mech pattern" is the player's named, reusable Mech build — chassis plus Systems and Modules given a unique pattern name (*Salvage Union Core Book Digital Edition 2.0a*, "Pattern Names Table" / Mech Creation, p. 208: "Finally give your Mech a unique pattern name that marks it as your own creation… if you built a Mule with Zoom Optics and a Red Laser, you might call it a 'Bullseye Pattern Mule'"). Sharing such a build template and cloning it into a fresh Mech is squarely within that concept; the clone seeds a live Mech at full Structure/Energy and Heat 0 per the existing instantiate rules.

## Checks

- `bun run typecheck` — pass (all packages)
- `bun --filter in-the-union-now test` — pass (891 tests)
- `bun run lint` — pass
- `bun run format` — clean
- `bun run knip` — clean
- pre-push hooks (knip, typecheck, test) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)