### PR TITLE
docs(itun): document 60 FPS sheet-scroll perf methodology (REQ-NF-03)

### DIFF
--- a/apps/in-the-union-now/e2e/sheet-scroll-perf.e2e.ts
+++ b/apps/in-the-union-now/e2e/sheet-scroll-perf.e2e.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test'
+import { buildMech, openSheetFor, waitForReady } from './_helpers'
+
+/**
+ * Sheet-scroll performance probe (REQ-NF-03).
+ *
+ * Acceptance for REQ-NF-03 is a non-functional perf bar: the live sheet must
+ * keep scrolling at 60 FPS on an iPhone-class device. The methodology, the
+ * pass bar, and how to read this probe are documented in
+ * docs/architecture/sheet-scroll-performance.md — read that first.
+ *
+ * Why this assertion shape: 60 FPS means the browser has a ~16.7 ms budget per
+ * frame. Smooth scrolling on a compositor-driven page is broken by *main-thread
+ * long tasks* (≥ 50 ms blocks, the Long Tasks API definition) landing during
+ * the scroll — they stall the rAF/commit pipeline and drop frames. The ITUN
+ * sheet path is deliberately free of per-frame scroll JS (the condense bar is
+ * an IntersectionObserver single-threshold toggle, not an onScroll handler —
+ * see LiveSheet.tsx `useCondensed`), so a healthy run records ZERO long tasks
+ * across a full programmatic scroll of the sheet. We assert exactly that.
+ *
+ * This is a regression guard, not the primary 60-FPS sign-off: the canonical
+ * frame-rate baseline is captured manually under CPU + device throttling (see
+ * the doc). A long task appearing here means new per-frame scroll work crept
+ * onto the sheet path and the manual baseline should be re-measured.
+ *
+ * Chromium-only: the Long Tasks API (PerformanceObserver 'longtask') is a
+ * Chromium feature, matching the CI project pin. The test self-skips on engines
+ * that lack it rather than failing.
+ */
+test('mech sheet scroll generates no main-thread long tasks (REQ-NF-03)', async ({
+  page,
+  browserName,
+}) => {
+  test.skip(browserName !== 'chromium', 'Long Tasks API is Chromium-only')
+
+  // Arrange: a real mech sheet with body slabs to scroll past the hero.
+  await buildMech(page, 'Perf Probe Mech')
+  await openSheetFor(page, 'Perf Probe Mech')
+  await waitForReady(page)
+
+  // Start observing long tasks BEFORE scrolling so we capture the whole gesture.
+  const longTaskSupported = await page.evaluate(() => {
+    if (typeof PerformanceObserver === 'undefined') return false
+    const supported = PerformanceObserver.supportedEntryTypes
+    if (!supported || !supported.includes('longtask')) return false
+    const w = window as unknown as { __longTasks: number[] }
+    w.__longTasks = []
+    const observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) w.__longTasks.push(entry.duration)
+    })
+    observer.observe({ entryTypes: ['longtask'] })
+    return true
+  })
+
+  test.skip(!longTaskSupported, 'Long Tasks API unavailable in this browser')
+
+  // Act: scroll the document top→bottom in realistic steps, yielding a frame
+  // between each so the scroll/condense path actually runs per step.
+  await page.evaluate(async () => {
+    const raf = () => new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
+    const max = document.documentElement.scrollHeight - window.innerHeight
+    const steps = 24
+    for (let i = 0; i <= steps; i++) {
+      window.scrollTo(0, Math.round((max * i) / steps))
+      await raf()
+      await raf()
+    }
+    // Scroll back up to exercise the condense → un-condense transition too.
+    for (let i = steps; i >= 0; i--) {
+      window.scrollTo(0, Math.round((max * i) / steps))
+      await raf()
+      await raf()
+    }
+  })
+
+  // Assert: zero long tasks during the scroll gesture. The sheet path does no
+  // per-frame main-thread work, so any long task is a real regression.
+  const longTasks = await page.evaluate(
+    () => (window as unknown as { __longTasks: number[] }).__longTasks
+  )
+  expect(
+    longTasks,
+    `expected no main-thread long tasks during sheet scroll, saw ${longTasks.length}: [${longTasks
+      .map((d) => `${Math.round(d)}ms`)
+      .join(', ')}]`
+  ).toHaveLength(0)
+})

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,18 +22,21 @@ conventions, then the relevant architecture doc below.
 
 **I'm shipping SEO/a11y work** → [architecture/seo-accessibility.md](architecture/seo-accessibility.md)
 
+**I'm changing the live sheet / its scroll behaviour** → [architecture/sheet-scroll-performance.md](architecture/sheet-scroll-performance.md)
+
 ## Directory Map
 
 ### [`architecture/`](architecture/) — Cross-cutting architecture
 
-| Doc                                                               | Scope                                                                      |
-| ----------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| [display-system.md](architecture/display-system.md)               | 3-layer render stack: DisplayCard → ReferenceEntityDisplay → consumers     |
-| [data-flow.md](architecture/data-flow.md)                         | Reference data + player data hydration, IndexedDB, Zustand, TanStack Query |
-| [package-contracts.md](architecture/package-contracts.md)         | Package APIs, dependency rules, cross-package change checklist             |
-| [rules-engine-boundary.md](architecture/rules-engine-boundary.md) | What the app enforces vs what the Mediator/player decides                  |
-| [combat-loop.md](architecture/combat-loop.md)                     | Action activation, heat checks, conditions — current local-first flow      |
-| [seo-accessibility.md](architecture/seo-accessibility.md)         | SEO strategy (suref-web) + WCAG 2.1 AA patterns                            |
+| Doc                                                                     | Scope                                                                         |
+| ----------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| [display-system.md](architecture/display-system.md)                     | 3-layer render stack: DisplayCard → ReferenceEntityDisplay → consumers        |
+| [data-flow.md](architecture/data-flow.md)                               | Reference data + player data hydration, IndexedDB, Zustand, TanStack Query    |
+| [package-contracts.md](architecture/package-contracts.md)               | Package APIs, dependency rules, cross-package change checklist                |
+| [rules-engine-boundary.md](architecture/rules-engine-boundary.md)       | What the app enforces vs what the Mediator/player decides                     |
+| [combat-loop.md](architecture/combat-loop.md)                           | Action activation, heat checks, conditions — current local-first flow         |
+| [seo-accessibility.md](architecture/seo-accessibility.md)               | SEO strategy (suref-web) + WCAG 2.1 AA patterns                               |
+| [sheet-scroll-performance.md](architecture/sheet-scroll-performance.md) | ITUN live-sheet 60-FPS scroll bar (REQ-NF-03): why it's fast + how to measure |
 
 ### `docs/rules/` — Agent-readable rules digest (generated, gitignored)
 

--- a/docs/architecture/sheet-scroll-performance.md
+++ b/docs/architecture/sheet-scroll-performance.md
@@ -1,0 +1,117 @@
+# Sheet-Scroll Performance (REQ-NF-03)
+
+**Requirement (REQ-NF-03):** the live sheet must keep scrolling at **60 FPS on
+an iPhone-class device**. This is a non-functional performance bar, not a
+feature — this doc records (1) why the scroll path is already free of the usual
+jank sources, (2) how to measure frame rate to confirm the bar, (3) the pass
+criteria + device/throttle profile, and (4) the committed regression guard.
+
+The sheet path is `apps/in-the-union-now/src/components/sheet/`: the shared
+shell `LiveSheet.tsx` plus the body slabs `MechSheet.tsx` / `PilotSheet.tsx` /
+`CrawlerSheet.tsx`, reached via the route `src/routes/sheet/$kind/$id.tsx`.
+
+---
+
+## Why the scroll path is fast by construction
+
+60 FPS gives the browser a **~16.7 ms budget per frame**. Scroll jank on a
+page like this comes from a small, well-known set of causes — each is absent
+here:
+
+| Common jank source                                                                               | Status on the ITUN sheet path                                                                                                                                                                                                                                                           |
+| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Per-frame JS in an `onScroll` / scroll listener                                                  | **Absent.** The sticky-bar "condense" is driven by an `IntersectionObserver` with a single threshold (`LiveSheet.tsx` → `useCondensed`), which fires only at the hero-out-of-view transition, not per frame. No `onScroll`, no `addEventListener('scroll')` anywhere on the sheet path. |
+| `clamp01` / interpolated scroll math per frame                                                   | **Absent.** The prototype's per-frame clamp01 interpolation was deliberately **not** ported; the only reference to `clamp01` in the sheet code is a comment in `LiveSheet.tsx` explaining the choice.                                                                                   |
+| Compositor-thrashing effects (`backdrop-blur` / `backdrop-filter`, `will-change`, `scroll-snap`) | **Absent on the sheet path.** A repo-wide grep finds the only `backdrop-blur` in `WizShell.tsx` (the build wizard), not the sheet. No `will-change`, no `scroll-snap`.                                                                                                                  |
+| Layout-forcing style change per frame                                                            | **Absent.** The only condense-driven style change is a `box-shadow` toggle on the **already-sticky** header (`LiveSheet.tsx`), applied **once** at the intersection transition. `box-shadow` is a paint-only property and the toggle is not per-frame.                                  |
+| Long / virtualized list re-layout while scrolling                                                | **Not a risk at realistic volumes.** The body renders a bounded, non-virtualized list of slabs sized to **one** entity's loadout (`MechSheet` ~332, `PilotSheet` ~754, `CrawlerSheet` ~622 lines of layout). List length is fixed by a single character's data, not user-scalable.      |
+
+Net: there is **no main-thread work scheduled per scroll frame**. Scrolling is a
+compositor-thread operation; the page just moves.
+
+---
+
+## How to measure (methodology)
+
+Two complementary methods. The **manual DevTools run is the canonical 60-FPS
+sign-off**; the scripted Playwright probe is the committed regression guard.
+
+### 1. Canonical baseline — Chrome DevTools Performance panel (manual)
+
+This is the run that satisfies the "60 FPS on an iPhone-class device" criterion.
+It must be run **interactively** (a headless/sandboxed agent session cannot
+launch a throttled, device-emulated Chrome).
+
+1. `bun run dev:itun` and open the app in Chrome (desktop).
+2. Build any mech, open its sheet (`/sheet/mech/$id`). A mech sheet has the most
+   body slabs, so it is the worst case for scroll cost.
+3. Open DevTools → **Device Toolbar** (Cmd/Ctrl+Shift+M) → pick an
+   **iPhone-class device** (e.g. _iPhone 12 Pro_). This sets the viewport and
+   touch emulation.
+4. DevTools → **Performance** panel → gear icon →
+   - **CPU: 4× slowdown** (entry-level emulation) or **6× slowdown** (a
+     conservative iPhone-class lower bound).
+   - **Network:** not relevant to scroll (the sheet is already loaded); leave
+     default.
+5. Click **Record**, then scroll the full sheet top→bottom→top with the
+   trackpad/mouse-wheel over ~3–4 seconds. Stop the recording.
+6. Read the result:
+   - The **Frames** track / **FPS meter** should sit at/near 60 FPS with **no
+     red "dropped frame" bars** during the scroll.
+   - The **Main** thread track should show **no long tasks** (≥ 50 ms; flagged
+     with a red corner) overlapping the scroll gesture.
+   - Frame times should stay at/under the **~16.7 ms** budget.
+
+**Record the device + CPU-throttle profile used and the observed result in the
+"Baseline runs" section below.**
+
+### 2. Regression guard — scripted Playwright (Long Tasks)
+
+Committed at `apps/in-the-union-now/e2e/sheet-scroll-perf.e2e.ts` and run by the
+existing chromium e2e harness (`bun run e2e:itun`).
+
+It builds a mech, opens its sheet, installs a `PerformanceObserver` for
+`longtask` entries (the [Long Tasks API][longtasks] — Chromium-only; the test
+self-skips elsewhere), then programmatically scrolls the document
+top→bottom→top one frame at a time and **asserts zero long tasks** were recorded
+during the gesture.
+
+Rationale: at 60 FPS the per-frame budget is ~16.7 ms; a main-thread **long
+task** (≥ 50 ms) landing during scroll is exactly what drops frames. Because the
+sheet path schedules no per-frame scroll work, a healthy run sees **zero** long
+tasks — so any long task is a real regression (new per-frame scroll JS, a
+layout-forcing condense change, etc.) and a signal to re-measure the manual
+baseline. This probe does **not** itself emulate an iPhone CPU; it asserts the
+_absence of the failure mode_, which is device-independent.
+
+---
+
+## Pass criteria
+
+- **Manual (canonical):** under iPhone-class device emulation + 4×–6× CPU
+  throttle, a full scroll of `/sheet/mech/$id` sustains ~60 FPS with **no
+  dropped frames** and **no main-thread long tasks** overlapping the scroll;
+  frame times stay at/under ~16.7 ms.
+- **Scripted (regression guard):** `sheet-scroll-perf.e2e.ts` records **zero**
+  `longtask` entries across a programmatic top→bottom→top scroll.
+
+If a measured run shows dropped frames or long tasks, **do not** pre-emptively
+refactor — open a separate item against the evidence. The likely levers (only
+if needed) are memoizing the sheet body, or wrapping the condense `box-shadow`
+in a class toggle that cannot force layout.
+
+---
+
+## Baseline runs
+
+Append one row per measured run (newest first). Capture the manual canonical run
+interactively per method 1 above.
+
+| Date      | Build / commit | Method                                            | Device profile             | CPU throttle | Result                            |
+| --------- | -------------- | ------------------------------------------------- | -------------------------- | ------------ | --------------------------------- |
+| _pending_ | _this PR_      | DevTools Performance (manual) — run interactively | iPhone-class (e.g. 12 Pro) | 4×–6×        | _capture & record (see method 1)_ |
+
+> The scripted guard (`e2e/sheet-scroll-perf.e2e.ts`) runs every CI e2e pass and
+> needs no manual entry — it fails loudly if a long task appears.
+
+[longtasks]: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongTaskTiming


### PR DESCRIPTION
## Feedback

**M3: Verify and document 60 FPS mobile sheet-scroll performance (REQ-NF-03)** — acceptance is a non-functional perf bar: keep the live sheet scrolling at 60 FPS on an iPhone-class device, and document how that was measured. This is a verification + documentation task, not a reported defect. The real gap: no perf measurement methodology was committed anywhere (no perf doc, no perf assertion in the e2e suite).

## UX area changed

`apps/in-the-union-now` live-sheet scroll path: the shared shell `src/components/sheet/LiveSheet.tsx` (+ `useCondensed`) and its body slabs `MechSheet.tsx` / `PilotSheet.tsx` / `CrawlerSheet.tsx`, reached via `src/routes/sheet/$kind/$id.tsx`. No sheet code was changed — only documentation and a new e2e regression guard.

## Rules reference

None. REQ-NF-03 is a non-functional **performance** requirement (frame rate), not a Salvage Union game mechanic — the SURules PDFs (Core Book 2.0a, Quick Ref 2.0, Starter Set 1.0) govern game rules, not rendering performance, so there is no rulebook citation this change depends on.

## What this does

Closes the documentation/verification gap; no fix is warranted because the scroll path is already free of the usual jank sources (verified by reading the code + repo-wide grep):

- No `onScroll` / `addEventListener('scroll')` — the sticky-bar condense is a single-threshold `IntersectionObserver` (`useCondensed`), firing once at the hero-out-of-view transition, not per frame.
- The prototype's per-frame `clamp01` interpolation was deliberately not ported (only a comment remains).
- No `backdrop-blur`/`backdrop-filter`, `will-change`, or `scroll-snap` on the sheet path (the only `backdrop-blur` is in `WizShell.tsx`, the build wizard).
- The only condense-driven style change is a one-shot `box-shadow` toggle on the already-sticky header (paint-only, not per-frame).
- Body is a bounded, non-virtualized list of slabs sized to one entity's loadout — list length is not user-scalable.

Changes:

1. **`docs/architecture/sheet-scroll-performance.md`** — why the path is fast by construction; the canonical measurement method (Chrome DevTools Performance + iPhone-class device emulation + 4×–6× CPU throttle); the pass bar (~16.7 ms frames, no dropped frames / no main-thread long tasks); and a Baseline-runs table.
2. **`apps/in-the-union-now/e2e/sheet-scroll-perf.e2e.ts`** — a chromium regression guard that programmatically scrolls a mech sheet top→bottom→top and asserts **zero** main-thread long tasks (Long Tasks API), the device-independent failure mode for dropped frames. Self-skips on non-chromium engines.
3. **`docs/README.md`** — registers the doc in the intent map + architecture table.

> Note: the manual canonical 60-FPS baseline must be captured **interactively** — a headless/sandboxed agent session cannot launch a throttled, device-emulated Chrome. The doc's Baseline-runs table has a `pending` row to fill in from that run.

## Checks passed

- `bun run typecheck:itun` — pass (ITUN app). Pre-existing errors in `packages/salvageunion-reference/lib` + `tools` (untouched here) surface only on the package's broader `tsconfig.json`.
- `bun --filter in-the-union-now test` — 891 pass / 0 fail.
- `bun run lint` — clean (all packages, incl. the new e2e file).
- `bun run format` — clean.
- Pre-push hooks (typecheck, test, validate:all, knip) — passed on push.
- The new e2e scroll probe itself was not executed here (Chromium cannot launch in this sandboxed session); it runs in the chromium e2e harness / CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)