### PR TITLE
fix(itun): surface Bio & Nanite tech tiers in mech install filter

### DIFF
--- a/apps/in-the-union-now/src/components/mech/InstallStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/InstallStep.tsx
@@ -8,11 +8,18 @@ import { LoadoutPanel } from './LoadoutPanel'
 type InstallItemLike = {
   id: string
   name: string
-  techLevel: number
+  techLevel: TechLevel
   slotsRequired: number
 }
 
-const ALL_TLS: TechLevel[] = [1, 2, 3, 4, 5, 6]
+// Tech tiers, in display order: numeric 1–6 then Bio (B) then Nanite (N).
+// Bio/Nanite are real equipment tiers in the SRD catalog (Core Book p.244 /
+// Quick Ref "Tech Levels"), so the filter must offer them — otherwise their
+// systems/modules become unreachable the moment any numeric chip is active.
+const ALL_TLS: TechLevel[] = [1, 2, 3, 4, 5, 6, 'B', 'N']
+
+// Sort rank for a tech tier: 1–6 keep their value, then B, then N last.
+const TL_RANK: Record<TechLevel, number> = { 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, B: 7, N: 8 }
 
 type InstallStepProps = {
   /** Which dataset this step installs from. */
@@ -54,13 +61,13 @@ export function InstallStep({
     const accessor =
       kind === 'systems' ? SalvageUnionReference.Systems : SalvageUnionReference.Modules
     const items = accessor.all() as unknown as InstallItemLike[]
-    return [...items].sort((a, b) => a.techLevel - b.techLevel || a.name.localeCompare(b.name))
+    return [...items].sort(
+      (a, b) => TL_RANK[a.techLevel] - TL_RANK[b.techLevel] || a.name.localeCompare(b.name)
+    )
   }, [kind])
 
   const visible =
-    activeTls.length === 0
-      ? allItems
-      : allItems.filter((i) => activeTls.includes(i.techLevel as TechLevel))
+    activeTls.length === 0 ? allItems : allItems.filter((i) => activeTls.includes(i.techLevel))
 
   function toggleTl(tl: TechLevel) {
     setActiveTls((prev) => (prev.includes(tl) ? prev.filter((t) => t !== tl) : [...prev, tl]))
@@ -74,7 +81,7 @@ export function InstallStep({
           {ALL_TLS.map((tl) => (
             <FilterChip
               key={tl}
-              label={`TL${tl}`}
+              label={typeof tl === 'number' ? `TL${tl}` : tl === 'B' ? 'Bio' : 'Nanite'}
               active={activeTls.includes(tl)}
               onClick={() => toggleTl(tl)}
               swatchStyle={`var(--color-tl-${tl})`}

--- a/apps/in-the-union-now/src/lib/rules/scrap.ts
+++ b/apps/in-the-union-now/src/lib/rules/scrap.ts
@@ -14,7 +14,7 @@
  */
 
 import { SalvageUnionReference } from 'salvageunion-reference'
-import type { ScrapableItem, TechLevel } from './types'
+import type { NumericTechLevel, ScrapableItem } from './types'
 
 /**
  * Returns the sell (salvage) value of an item in units of its own tech level's
@@ -55,7 +55,7 @@ export function scrapCostFor(item: ScrapableItem): number {
  * Callers should treat `null` as "cannot determine cost" and surface a
  * manual-review warning rather than blocking.
  */
-export function tierUpgradeCost(fromTL: TechLevel, toTL: TechLevel): number | null {
+export function tierUpgradeCost(fromTL: NumericTechLevel, toTL: NumericTechLevel): number | null {
   if (fromTL === toTL) return 0
   if (fromTL > toTL) return null // downgrade; use a soft warning instead
 

--- a/apps/in-the-union-now/src/lib/rules/types.ts
+++ b/apps/in-the-union-now/src/lib/rules/types.ts
@@ -13,9 +13,20 @@
  */
 
 /**
- * Tech level — 1 through 6 as defined in salvageunion-reference tech-levels.json.
+ * Tech level — matches salvageunion-reference's `TechLevelSchema`: the integer
+ * tiers 1 through 6, plus 'B' (Bio) and 'N' (Nanite). Bio/Nanite are legitimate
+ * equipment tiers (Core Book p.244 / Quick Ref "Tech Levels": "Tech 6 — state
+ * of the art, secret projects that begin with X, bio and nanite tech"), so any
+ * system/module filter that constrains by tech level must recognise them.
  */
-export type TechLevel = 1 | 2 | 3 | 4 | 5 | 6
+export type TechLevel = 1 | 2 | 3 | 4 | 5 | 6 | 'B' | 'N'
+
+/**
+ * The numeric-only subset of {@link TechLevel} (tiers 1–6, no Bio/Nanite).
+ * Crawler tech-level gating and upgrade pricing are inherently sequential and
+ * numeric, so utilities that do tier arithmetic constrain to this subset.
+ */
+export type NumericTechLevel = 1 | 2 | 3 | 4 | 5 | 6
 
 /**
  * A system installed on a mech, identified by a name reference into the

--- a/packages/suref-react/src/styles/theme.css
+++ b/packages/suref-react/src/styles/theme.css
@@ -48,6 +48,9 @@
   --color-tl-4: rgb(48, 107, 128);
   --color-tl-5: rgb(30, 83, 100);
   --color-tl-6: rgb(6, 52, 65);
+  /* Non-numeric tiers (Core Book p.244): Bio reads organic green, Nanite silver. */
+  --color-tl-B: rgb(106, 153, 78);
+  --color-tl-N: rgb(192, 192, 192);
 
   /* Entity colors (semantic) */
   --color-pilot: var(--color-su-orange);


### PR DESCRIPTION
## Feedback

In the mech wizard's **Install Systems / Install Modules** step, the tech-tier filter chip row only offered tiers 1–6. The Salvage Union reference dataset also tags systems and modules with tech level `B` (Bio) and `N` (Nanite) — **7 Bio + 3 Nanite systems** and **3 Bio + 3 Nanite modules** (verified against `systems.json` / `modules.json`). Because `InstallStep` hardcoded `ALL_TLS = [1..6]` and typed `techLevel` as a plain `number`, there was no chip (and no swatch color) for the Bio/Nanite tiers. With no chip active the B/N items rendered, but the moment any numeric TL chip was selected, all 16 B/N entries became permanently unreachable, with no way to isolate just the Bio/Nanite gear.

## UX area changed

Mech wizard custom-loadout flow:
- `apps/in-the-union-now/src/components/mech/InstallStep.tsx` (rendered for both kinds via `LoadoutStep.tsx`)
- `apps/in-the-union-now/src/lib/rules/types.ts` (the `TechLevel` type that constrains it)
- `packages/suref-react/src/styles/theme.css` (TL swatch CSS vars)

The crawler builder's deliberate numeric-only TL gating (`CrawlerBuilder.tsx`) is **left unchanged** — out of scope.

## SURules reference

Salvage Union Core Book Digital Edition 2.0a — Tech Levels (p.244 Conditions/Salvage area; mirrored in **SU_Quick Ref Sheets Digital 2.0**, "Tech Levels" box): *"Tech 6 — state of the art, secret projects that begin with X, bio and nanite tech."* This establishes Bio and Nanite as legitimate equipment tech tiers in the catalog (e.g. Nanite Repair Arm), so the builder must surface them rather than omit them. The canonical source of truth in code is `salvageunion-reference`'s `TechLevelSchema` (`number 1-6 | 'B' | 'N'`).

## Fix

- Widen `TechLevel` to `1|2|3|4|5|6|'B'|'N'` to match `TechLevelSchema`; add a `NumericTechLevel` subset (1–6) for the crawler-only tier arithmetic in `tierUpgradeCost`, which stays numeric.
- `InstallStep`: extend `ALL_TLS` with `'B'`/`'N'`, type `InstallItemLike.techLevel` as `TechLevel`, and replace the numeric `a.techLevel - b.techLevel` sort with a `TL_RANK` map ordering 1–6 then Bio then Nanite. The `activeTls.includes(...)` filter works unchanged. Chips label B/N as "Bio"/"Nanite".
- Add `--color-tl-B` / `--color-tl-N` swatch CSS vars so the new chips render a non-empty swatch.

This restores access to all 16 currently-hidden B/N entries with no schema or store change. The reporter's broader "Add"-button redesign (shared with the stacking-item feedback) is a deliberately-separate, larger UX item and is not bundled here.

## Checks

- `bun run typecheck` — pass
- `bun --filter in-the-union-now test` (891 pass / 0 fail) and `bun --filter suref-react test` (310 pass / 0 fail) — pass. (Root `bun test` shows `indexedDB is not defined` failures, a known preload quirk when run from root instead of per-package; pre-push hook test suite passed.)
- `bun run lint` — pass
- `bun run format` — clean
- Pre-push hooks (typecheck, test, validate:all, knip) — passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)