### PR TITLE
feat(itun): stack duplicate Systems/Modules in mech custom Loadout

### DIFF
--- a/apps/in-the-union-now/src/components/mech/InstallStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/InstallStep.tsx
@@ -24,9 +24,12 @@ const TL_RANK: Record<TechLevel, number> = { 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6,
 type InstallStepProps = {
   /** Which dataset this step installs from. */
   kind: 'systems' | 'modules'
-  /** Name refs currently installed. */
+  /** Name refs currently installed (duplicates allowed — stacking). */
   selected: string[]
-  onToggle: (name: string) => void
+  /** Append a copy of `name` to the installed list. */
+  onAdd: (name: string) => void
+  /** Remove the single installed copy at `index` (not all matches). */
+  onRemoveAt: (index: number) => void
   /** Loadout panel header name (mech name, falling back to chassis). */
   loadoutName: string
   /** 'SYSTEM SLOTS' / 'MODULE SLOTS' budget figures (soft — never blocks). */
@@ -48,7 +51,8 @@ type InstallStepProps = {
 export function InstallStep({
   kind,
   selected,
-  onToggle,
+  onAdd,
+  onRemoveAt,
   loadoutName,
   slotsUsed,
   slotsMax,
@@ -56,6 +60,14 @@ export function InstallStep({
   energyMax,
 }: InstallStepProps) {
   const [activeTls, setActiveTls] = useState<TechLevel[]>([])
+
+  // Per-name installed count drives each card's "× N" badge. The installed
+  // list is a multiset (duplicates allowed) so an item can stack.
+  const countByName = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const ref of selected) counts.set(ref, (counts.get(ref) ?? 0) + 1)
+    return counts
+  }, [selected])
 
   const allItems = useMemo(() => {
     const accessor =
@@ -95,8 +107,9 @@ export function InstallStep({
               key={item.id}
               entity={item}
               name={item.name}
-              selected={selected.includes(item.name)}
-              onToggle={() => onToggle(item.name)}
+              selected={false}
+              count={countByName.get(item.name) ?? 0}
+              onToggle={() => onAdd(item.name)}
             />
           ))}
         </div>
@@ -114,6 +127,7 @@ export function InstallStep({
         energyValue={energyValue}
         energyMax={energyMax}
         chosen={selected}
+        onRemoveAt={onRemoveAt}
         kind={kind}
         className="lg:sticky lg:top-4"
       />

--- a/apps/in-the-union-now/src/components/mech/LoadoutPanel.tsx
+++ b/apps/in-the-union-now/src/components/mech/LoadoutPanel.tsx
@@ -76,8 +76,14 @@ type LoadoutPanelProps = {
   /** Current/max Energy Points — informational is-ap track. */
   energyValue: number
   energyMax: number
-  /** Name refs of the chosen systems or modules (head-mode cards). */
+  /**
+   * Name refs of the chosen systems or modules (head-mode cards). A multiset:
+   * duplicates are allowed and rendered as separate, individually-removable
+   * entries so the same item can be stacked.
+   */
   chosen: string[]
+  /** Remove the single chosen entry at `index` (not all matching names). */
+  onRemoveAt?: (index: number) => void
   /** Which dataset resolves the chosen refs. */
   kind: 'systems' | 'modules'
   className?: string
@@ -86,7 +92,9 @@ type LoadoutPanelProps = {
 /**
  * Right-hand Loadout panel for the install steps (design §3.2 mech wizard):
  * 'Loadout · {name}' header, pip budget tracks (slots default-ink, energy
- * is-ap rust), then the chosen items as head-mode entity cards.
+ * is-ap rust), then the chosen items as head-mode entity cards. Each entry —
+ * including repeated copies of the same item — gets its own remove control so
+ * a single occurrence can be dropped without clearing the rest of a stack.
  */
 export function LoadoutPanel({
   name,
@@ -96,15 +104,19 @@ export function LoadoutPanel({
   energyValue,
   energyMax,
   chosen,
+  onRemoveAt,
   kind,
   className,
 }: LoadoutPanelProps) {
   const accessor =
     kind === 'systems' ? SalvageUnionReference.Systems : SalvageUnionReference.Modules
-  const chosenEntities = chosen.flatMap((ref) => {
-    const found = accessor.find((x) => x.name === ref)
-    return found ? [found as unknown as SURefEntity] : []
-  })
+  // Map over `chosen` by index (NOT flatMap) so each rendered entry's index
+  // lines up with onRemoveAt — removing by index drops exactly one copy.
+  const chosenEntries = chosen.map((ref, index) => ({
+    index,
+    ref,
+    entity: (accessor.find((x) => x.name === ref) as unknown as SURefEntity | undefined) ?? null,
+  }))
 
   return (
     <Panel className={cn('self-start px-4 py-4', className)}>
@@ -118,15 +130,30 @@ export function LoadoutPanel({
       </div>
 
       <div className="mt-4 space-y-2">
-        {chosenEntities.map((entity, i) => (
-          <ReferenceEntityDisplay
-            key={`${(entity as { id?: string }).id ?? i}`}
-            data={entity}
-            mode="head"
-            hide={{ actions: true, choices: true }}
-          />
+        {chosenEntries.map(({ index, ref, entity }) => (
+          <div key={`${ref}-${index}`} className="relative">
+            {entity ? (
+              <ReferenceEntityDisplay
+                data={entity}
+                mode="head"
+                hide={{ actions: true, choices: true }}
+              />
+            ) : (
+              <p className="font-body text-xs text-wk-muted">{ref}</p>
+            )}
+            {onRemoveAt && (
+              <button
+                type="button"
+                aria-label={`Remove ${ref}`}
+                onClick={() => onRemoveAt(index)}
+                className="absolute -right-1.5 -top-1.5 z-10 inline-flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] border-ink bg-paper font-cond text-xs font-bold leading-none text-ink transition-colors hover:border-rust hover:text-rust focus-visible:outline-none focus-visible:ring-[2px] focus-visible:ring-rust/30"
+              >
+                ×
+              </button>
+            )}
+          </div>
         ))}
-        {chosenEntities.length === 0 && (
+        {chosenEntries.length === 0 && (
           <p className="font-body text-xs text-wk-muted">Nothing installed yet.</p>
         )}
       </div>

--- a/apps/in-the-union-now/src/components/mech/LoadoutStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/LoadoutStep.tsx
@@ -7,8 +7,10 @@ type LoadoutTab = 'systems' | 'modules'
 type LoadoutStepProps = {
   systems: string[]
   modules: string[]
-  onToggleSystem: (name: string) => void
-  onToggleModule: (name: string) => void
+  onAddSystem: (name: string) => void
+  onRemoveSystemAt: (index: number) => void
+  onAddModule: (name: string) => void
+  onRemoveModuleAt: (index: number) => void
   loadoutName: string
   systemSlotsUsed: number
   systemSlotsMax: number
@@ -53,8 +55,10 @@ function TabButton({
 export function LoadoutStep({
   systems,
   modules,
-  onToggleSystem,
-  onToggleModule,
+  onAddSystem,
+  onRemoveSystemAt,
+  onAddModule,
+  onRemoveModuleAt,
   loadoutName,
   systemSlotsUsed,
   systemSlotsMax,
@@ -84,7 +88,8 @@ export function LoadoutStep({
         <InstallStep
           kind="systems"
           selected={systems}
-          onToggle={onToggleSystem}
+          onAdd={onAddSystem}
+          onRemoveAt={onRemoveSystemAt}
           loadoutName={loadoutName}
           slotsUsed={systemSlotsUsed}
           slotsMax={systemSlotsMax}
@@ -95,7 +100,8 @@ export function LoadoutStep({
         <InstallStep
           kind="modules"
           selected={modules}
-          onToggle={onToggleModule}
+          onAdd={onAddModule}
+          onRemoveAt={onRemoveModuleAt}
           loadoutName={loadoutName}
           slotsUsed={moduleSlotsUsed}
           slotsMax={moduleSlotsMax}

--- a/apps/in-the-union-now/src/components/mech/MechWizard.tsx
+++ b/apps/in-the-union-now/src/components/mech/MechWizard.tsx
@@ -91,8 +91,18 @@ export function MechWizard({ onComplete, onCancel, mechId, initialState }: MechW
     setForm((prev) => ({ ...prev, ...patch }))
   }
 
-  function toggleIn(list: string[], name: string): string[] {
-    return list.includes(name) ? list.filter((x) => x !== name) : [...list, name]
+  // Loadout installs are a multiset (add-and-stack): the same System/Module
+  // can be installed more than once. `addItem` always appends a copy;
+  // `removeAt` drops exactly the one occurrence at `index` (NOT every match),
+  // so removing one copy of a stacked item leaves the rest intact. Duplicates
+  // are rules-legal — the only limit is slot capacity, which stays a soft
+  // warning (Core Book p.96, "Mech Stats Explained: System Slots").
+  function addItem(list: string[], name: string): string[] {
+    return [...list, name]
+  }
+
+  function removeAt(list: string[], index: number): string[] {
+    return list.filter((_, i) => i !== index)
   }
 
   // Changing the chassis invalidates any chosen pattern/loadout.
@@ -324,8 +334,10 @@ export function MechWizard({ onComplete, onCancel, mechId, initialState }: MechW
         <LoadoutStep
           systems={form.systems}
           modules={form.modules}
-          onToggleSystem={(name) => updateForm({ systems: toggleIn(form.systems, name) })}
-          onToggleModule={(name) => updateForm({ modules: toggleIn(form.modules, name) })}
+          onAddSystem={(name) => updateForm({ systems: addItem(form.systems, name) })}
+          onRemoveSystemAt={(index) => updateForm({ systems: removeAt(form.systems, index) })}
+          onAddModule={(name) => updateForm({ modules: addItem(form.modules, name) })}
+          onRemoveModuleAt={(index) => updateForm({ modules: removeAt(form.modules, index) })}
           loadoutName={loadoutName}
           systemSlotsUsed={capacity.systemSlotsUsed}
           systemSlotsMax={capacity.systemSlotsMax}

--- a/apps/in-the-union-now/src/components/mech/__tests__/MechWizard.test.tsx
+++ b/apps/in-the-union-now/src/components/mech/__tests__/MechWizard.test.tsx
@@ -68,13 +68,20 @@ afterEach(async () => {
 
 /**
  * Chassis/pattern rows are OptRow <button>s whose accessible text contains the
- * name; system/module cards are Sel wrappers — div[role="button"] with
- * aria-label set to the entity name.
+ * name; system/module install cards are Sel wrappers — div[role="button"] —
+ * which in the add-and-stack model carry an aria-label of `Add {name}` (or
+ * `Add {name} ({n} installed)`). Match the exact name first, then the
+ * stack-mode `Add {name}` prefix, then fall back to text content.
  */
 function getPickByName(name: string): HTMLElement {
   const candidates = screen.getAllByRole('button')
   const exact = candidates.find((b) => b.getAttribute('aria-label') === name)
   if (exact) return exact
+  const add = candidates.find((b) => {
+    const al = b.getAttribute('aria-label') ?? ''
+    return al === `Add ${name}` || al.startsWith(`Add ${name} (`)
+  })
+  if (add) return add
   const row = candidates.find((b) => (b.textContent ?? '').includes(name))
   if (!row) throw new Error(`No role=button pick for "${name}"`)
   return row
@@ -83,6 +90,17 @@ function getPickByName(name: string): HTMLElement {
 async function pick(name: string): Promise<void> {
   await act(async () => {
     fireEvent.click(getPickByName(name))
+  })
+}
+
+/**
+ * Remove a single installed copy via the loadout panel's `Remove {name}` ×
+ * control. When the item is stacked there is one such control per copy; this
+ * clicks the first, dropping exactly one occurrence.
+ */
+async function removeFromLoadout(name: string): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getAllByRole('button', { name: `Remove ${name}` })[0]!)
   })
 }
 
@@ -165,6 +183,48 @@ describe('MechWizard — custom pattern happy path', () => {
     })
 
     expect(onComplete).toHaveBeenCalledTimes(1)
+  }, 30000)
+})
+
+// ---------------------------------------------------------------------------
+// Add-and-stack: the same System/Module can be installed multiple times
+// ---------------------------------------------------------------------------
+
+describe('MechWizard — loadout stacking', () => {
+  it('stacks duplicate systems on repeated add and removes a single copy', async () => {
+    render(<MechWizard onComplete={() => {}} onCancel={() => {}} />)
+
+    await pick('Mule')
+    await clickNext() // Pattern
+    await pick('Custom Pattern')
+    await typeInto(/Pattern name/i, 'Stacker')
+    await clickNext() // Loadout
+
+    // Add the same system three times — slot count tracks the multiset.
+    await pick('Cargo Pod')
+    await pick('Cargo Pod')
+    await pick('Cargo Pod')
+    expect(screen.getByTestId('system-slot-count').textContent).toContain('3 /')
+    // Three individually-removable entries are listed in the loadout panel.
+    expect(screen.getAllByRole('button', { name: 'Remove Cargo Pod' }).length).toBe(3)
+
+    // Remove one copy → two remain (a single occurrence dropped, not all).
+    await removeFromLoadout('Cargo Pod')
+    expect(screen.getByTestId('system-slot-count').textContent).toContain('2 /')
+    expect(screen.getAllByRole('button', { name: 'Remove Cargo Pod' }).length).toBe(2)
+
+    await clickNext() // Identity
+    await typeInto(/Mech name/i, 'Double Cargo')
+    await clickNext() // Review
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Create Mech/i }))
+    })
+
+    await waitFor(() => {
+      const m = useEntityStore.getState().list('mech')[0]!
+      // Duplicates round-trip through persistence unchanged (z.array(z.string)).
+      expect(m.systems).toEqual(['Cargo Pod', 'Cargo Pod'])
+    })
   }, 30000)
 })
 
@@ -344,7 +404,7 @@ describe('MechWizard — edit mode', () => {
 
     await clickNext() // Pattern
     await clickNext() // Loadout
-    await pick('Cargo Pod') // toggle OFF the only system
+    await removeFromLoadout('Cargo Pod') // remove the only system via the × control
     await clickNext() // Identity
     await clickNext() // Review
 

--- a/apps/in-the-union-now/src/components/wizard/SelCard.tsx
+++ b/apps/in-the-union-now/src/components/wizard/SelCard.tsx
@@ -15,6 +15,15 @@ type SelCardProps = {
   disabledReason?: string
   /** Optional pseudo-header label on the card frame (e.g. tree name). */
   label?: string
+  /**
+   * Add-and-stack mode: when provided, the card becomes an "Add" affordance —
+   * each tap appends another copy rather than toggling membership — and this
+   * number is the count of copies already installed. The card is always
+   * addable (so the same System/Module can stack), and the count surfaces as a
+   * small "× N" badge instead of a binary selection ring. `selected` is ignored
+   * in this mode.
+   */
+  count?: number
 }
 
 /**
@@ -22,6 +31,12 @@ type SelCardProps = {
  * card inside a Sel selection-ring wrapper. The card stays selection-agnostic;
  * the 3px rust ring is non-layout-shifting. Disabled cells keep the existing
  * pointer-events-none + inline "Budget reached" affordance.
+ *
+ * With `count` set the card switches to the add-and-stack model: each tap
+ * appends a copy (no toggle-off), and the installed count is shown as a "× N"
+ * badge — so duplicates of the same System/Module can be stacked into a
+ * loadout. (Rules-legal: the only limit is slot capacity, which ITUN tracks as
+ * a soft warning — Core Book p.96, "Mech Stats Explained: System Slots".)
  */
 export function SelCard({
   entity,
@@ -31,10 +46,22 @@ export function SelCard({
   disabled = false,
   disabledReason,
   label,
+  count,
 }: SelCardProps) {
+  const isStack = count !== undefined
+  const installed = count ?? 0
+  // In stack mode the card never shows a selection ring; it is always addable,
+  // so the affordance reads "tap to add" with a running count.
+  const ringOn = isStack ? false : selected
+  const ariaLabel = isStack
+    ? installed > 0
+      ? `Add ${name} (${installed} installed)`
+      : `Add ${name}`
+    : name
+
   return (
-    <div className={cn(disabled && 'pointer-events-none opacity-50')}>
-      <Sel selected={selected} onToggle={disabled ? undefined : onToggle} ariaLabel={name}>
+    <div className={cn('relative', disabled && 'pointer-events-none opacity-50')}>
+      <Sel selected={ringOn} onToggle={disabled ? undefined : onToggle} ariaLabel={ariaLabel}>
         <ReferenceEntityDisplay
           data={entity as SURefEntity}
           compact
@@ -43,6 +70,14 @@ export function SelCard({
           label={label}
         />
       </Sel>
+      {isStack && installed > 0 && (
+        <span
+          aria-hidden
+          className="pointer-events-none absolute -right-1.5 -top-1.5 z-10 inline-flex h-6 min-w-6 items-center justify-center rounded-full border-[1.5px] border-rust bg-rust px-1.5 font-cond text-xs font-bold text-paper"
+        >
+          × {installed}
+        </span>
+      )}
       {disabled && disabledReason && (
         <p className="px-3 pb-2 pt-1 text-xs text-rust">{disabledReason}</p>
       )}


### PR DESCRIPTION
> **Stacked PR** — built on top of `fix/itun-install-bio-nanite-tiers`. Merge **after** that PR; the base is intentionally that branch, not `main`.

## Feedback
> Allow stacking multiple copies of the same mech System/Module in the Loadout step.

In the mech wizard's custom Loadout step, a System or Module could only be installed once: the install list was treated as a **set**, with each `SelCard` acting as a toggle (selected → tap removes; unselected → tap adds). There was no way to add a second copy of the same item.

## UX area changed
ITUN mech wizard, **custom (manual) Loadout path** — the `LoadoutStep → InstallStep → SelCard` chain, the `LoadoutPanel` chosen display, and the install handlers in `MechWizard`. Mounted from `src/routes/mechs/new.tsx` and `src/routes/mechs/$id_.edit.tsx`.

## Rules reference
Salvage Union Core Book Digital Edition 2.0a, **p.96 "Mech Stats Explained: System Slots"** (and p.94 Craft your Systems/Modules): the only governing constraint on installs is **slot capacity** — nothing restricts a System or Module to a single copy; two of the same item simply consume slots twice. Duplicates are therefore rules-legal, and ITUN's existing soft `system-over-slots` / `module-over-slots` warnings already model the only real limit (warn, never block).

## Fix
- **MechWizard** — replaced `toggleIn` (add-if-absent / remove-if-present) with `addItem` (always append a copy) + `removeAt` (drop the single occurrence at an index, not every match). Wired `onAddSystem`/`onRemoveSystemAt` and `onAddModule`/`onRemoveModuleAt` in place of the toggle handlers.
- **SelCard** — added an opt-in `count` prop: when set, the card becomes an **Add** affordance (each tap appends a copy) and surfaces the installed count as a `× N` badge instead of a binary selection ring.
- **InstallStep** — derives a per-name installed count for the badges, calls `onAdd` on tap, and passes `onRemoveAt` to the panel.
- **LoadoutPanel** — maps the chosen list **by index** (preserving alignment with `onRemoveAt`) so each copy — including repeats — renders as its own entry with a `Remove {name}` × control; removing one copy leaves the rest of a stack intact.

**No schema / persistence change**: `mech.systems` / `mech.modules` are `z.array(z.string())` and already tolerate duplicates, so stacks round-trip through IndexedDB unchanged. Capacity stays soft — `computeMechCapacity` already sums over the array, so over-capacity continues to warn (never block). No backend, no auth.

## Checks
- `bun run typecheck` — pass
- `bun test` (ITUN 892, suref-react 310) — pass, including a new `MechWizard — loadout stacking` test (stack 3 copies, slot count tracks the multiset, remove a single copy, duplicates persist)
- `bun run lint` — pass
- `bun run format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)