### PR TITLE
feat(itun): add Bio & Nanite chips to mech Install tech-tier filter

### DIFF
--- a/apps/in-the-union-now/src/components/mech/InstallStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/InstallStep.tsx
@@ -84,7 +84,7 @@ export function InstallStep({
               label={typeof tl === 'number' ? `TL${tl}` : tl === 'B' ? 'Bio' : 'Nanite'}
               active={activeTls.includes(tl)}
               onClick={() => toggleTl(tl)}
-              swatchStyle={`var(--color-tl-${tl})`}
+              swatchStyle={`var(--color-tl-${typeof tl === 'number' ? tl : tl.toLowerCase()})`}
             />
           ))}
         </div>

--- a/apps/in-the-union-now/src/components/mech/InstallStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/InstallStep.tsx
@@ -8,11 +8,18 @@ import { LoadoutPanel } from './LoadoutPanel'
 type InstallItemLike = {
   id: string
   name: string
-  techLevel: number
+  techLevel: TechLevel
   slotsRequired: number
 }
 
-const ALL_TLS: TechLevel[] = [1, 2, 3, 4, 5, 6]
+const ALL_TLS: TechLevel[] = [1, 2, 3, 4, 5, 6, 'B', 'N']
+
+/** Sort rank for a tech level: numeric tiers 1–6, then Bio (B), then Nanite (N). */
+function tlRank(tl: TechLevel): number {
+  if (tl === 'B') return 7
+  if (tl === 'N') return 8
+  return tl
+}
 
 type InstallStepProps = {
   /** Which dataset this step installs from. */
@@ -54,13 +61,13 @@ export function InstallStep({
     const accessor =
       kind === 'systems' ? SalvageUnionReference.Systems : SalvageUnionReference.Modules
     const items = accessor.all() as unknown as InstallItemLike[]
-    return [...items].sort((a, b) => a.techLevel - b.techLevel || a.name.localeCompare(b.name))
+    return [...items].sort(
+      (a, b) => tlRank(a.techLevel) - tlRank(b.techLevel) || a.name.localeCompare(b.name)
+    )
   }, [kind])
 
   const visible =
-    activeTls.length === 0
-      ? allItems
-      : allItems.filter((i) => activeTls.includes(i.techLevel as TechLevel))
+    activeTls.length === 0 ? allItems : allItems.filter((i) => activeTls.includes(i.techLevel))
 
   function toggleTl(tl: TechLevel) {
     setActiveTls((prev) => (prev.includes(tl) ? prev.filter((t) => t !== tl) : [...prev, tl]))
@@ -74,7 +81,7 @@ export function InstallStep({
           {ALL_TLS.map((tl) => (
             <FilterChip
               key={tl}
-              label={`TL${tl}`}
+              label={typeof tl === 'number' ? `TL${tl}` : tl === 'B' ? 'Bio' : 'Nanite'}
               active={activeTls.includes(tl)}
               onClick={() => toggleTl(tl)}
               swatchStyle={`var(--color-tl-${tl})`}

--- a/apps/in-the-union-now/src/components/mech/__tests__/InstallStep.test.tsx
+++ b/apps/in-the-union-now/src/components/mech/__tests__/InstallStep.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for InstallStep's tech-tier FilterChip row.
+ *
+ * Focus: the Bio (B) and Nanite (N) chips are reachable and actually filter the
+ * catalog down to their non-numeric tier — the behaviour added alongside the
+ * numeric TL1–6 chips. Renders against real SalvageUnionReference data; the
+ * step reads the ORM directly (no entityStore), so no DB scaffolding is needed.
+ *
+ * SalvageUnionReference is preloaded in beforeAll.
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+import type { TechLevel } from '../../../lib/rules/types'
+import { InstallStep } from '../InstallStep'
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+/** First entity of `kind` at exactly the given tech level, from real data. */
+function firstAtTL(kind: 'systems' | 'modules', tl: TechLevel): { id: string; name: string } {
+  const accessor =
+    kind === 'systems' ? SalvageUnionReference.Systems : SalvageUnionReference.Modules
+  const found = (
+    accessor.all() as unknown as Array<{ id: string; name: string; techLevel: TechLevel }>
+  ).find((s) => s.techLevel === tl)
+  if (!found) throw new Error(`No ${kind} at tech level ${String(tl)} in reference data`)
+  return found
+}
+
+function renderStep(kind: 'systems' | 'modules') {
+  return render(
+    <InstallStep
+      kind={kind}
+      selected={[]}
+      onToggle={() => {}}
+      loadoutName="Test Mech"
+      slotsUsed={0}
+      slotsMax={4}
+      energyValue={0}
+      energyMax={4}
+    />
+  )
+}
+
+describe('InstallStep — Bio/Nanite tech-tier filter', () => {
+  it('renders the Bio and Nanite chips alongside the numeric tiers', () => {
+    renderStep('systems')
+    expect(screen.getByRole('button', { name: 'Bio' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Nanite' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'TL1' })).toBeTruthy()
+  })
+
+  it('the Bio chip narrows the systems catalog to Bio-tier systems', () => {
+    const bio = firstAtTL('systems', 'B')
+    const numeric = firstAtTL('systems', 1)
+    renderStep('systems')
+
+    // Unfiltered: both a Bio system and a numeric-TL system are reachable.
+    expect(screen.getByRole('button', { name: bio.name })).toBeTruthy()
+    expect(screen.getByRole('button', { name: numeric.name })).toBeTruthy()
+
+    // Activate the Bio filter — only Bio-tier systems remain.
+    fireEvent.click(screen.getByRole('button', { name: 'Bio' }))
+    expect(screen.getByRole('button', { name: bio.name })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: numeric.name })).toBeNull()
+  })
+
+  it('the Nanite chip narrows the modules catalog to Nanite-tier modules', () => {
+    const nanite = firstAtTL('modules', 'N')
+    const numeric = firstAtTL('modules', 1)
+    renderStep('modules')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Nanite' }))
+    expect(screen.getByRole('button', { name: nanite.name })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: numeric.name })).toBeNull()
+  })
+})

--- a/apps/in-the-union-now/src/lib/rules/scrap.ts
+++ b/apps/in-the-union-now/src/lib/rules/scrap.ts
@@ -57,6 +57,9 @@ export function scrapCostFor(item: ScrapableItem): number {
  */
 export function tierUpgradeCost(fromTL: TechLevel, toTL: TechLevel): number | null {
   if (fromTL === toTL) return 0
+  // Upgrade costs are only defined for the numeric crawler tiers (1–6). The
+  // non-numeric equipment tiers ('B'/'N') have no sequential upgrade path.
+  if (typeof fromTL !== 'number' || typeof toTL !== 'number') return null
   if (fromTL > toTL) return null // downgrade; use a soft warning instead
 
   let total = 0

--- a/apps/in-the-union-now/src/lib/rules/types.ts
+++ b/apps/in-the-union-now/src/lib/rules/types.ts
@@ -13,9 +13,12 @@
  */
 
 /**
- * Tech level — 1 through 6 as defined in salvageunion-reference tech-levels.json.
+ * Tech level — matches salvageunion-reference's `TechLevelSchema`: the numeric
+ * tiers 1–6 plus the two non-numeric equipment tiers 'B' (Bio) and 'N' (Nanite).
+ * Per the Core Book "TECH LEVELS" box (p.3), TECH 6 covers "BIO AND NANITE TECH";
+ * Bio/Nanite systems & modules exist in the catalog and must be selectable.
  */
-export type TechLevel = 1 | 2 | 3 | 4 | 5 | 6
+export type TechLevel = 1 | 2 | 3 | 4 | 5 | 6 | 'B' | 'N'
 
 /**
  * A system installed on a mech, identified by a name reference into the

--- a/packages/suref-react/src/styles/theme.css
+++ b/packages/suref-react/src/styles/theme.css
@@ -48,6 +48,9 @@
   --color-tl-4: rgb(48, 107, 128);
   --color-tl-5: rgb(30, 83, 100);
   --color-tl-6: rgb(6, 52, 65);
+  /* Non-numeric equipment tiers (Core Book p.3 "TECH LEVELS"): Bio + Nanite */
+  --color-tl-B: rgb(86, 156, 104);
+  --color-tl-N: rgb(146, 109, 184);
 
   /* Entity colors (semantic) */
   --color-pilot: var(--color-su-orange);

--- a/packages/suref-react/src/styles/theme.css
+++ b/packages/suref-react/src/styles/theme.css
@@ -48,9 +48,12 @@
   --color-tl-4: rgb(48, 107, 128);
   --color-tl-5: rgb(30, 83, 100);
   --color-tl-6: rgb(6, 52, 65);
-  /* Non-numeric equipment tiers (Core Book p.3 "TECH LEVELS"): Bio + Nanite */
-  --color-tl-B: rgb(86, 156, 104);
-  --color-tl-N: rgb(146, 109, 184);
+  /* Non-numeric equipment tiers (Core Book p.3 "TECH LEVELS"): Bio + Nanite.
+     Lowercase keys (kebab convention) so the `var(--color-tl-${tl})` swatch
+     interpolation stays case-stable — CSS custom-property names are
+     case-sensitive. */
+  --color-tl-b: rgb(86, 156, 104);
+  --color-tl-n: rgb(146, 109, 184);
 
   /* Entity colors (semantic) */
   --color-pilot: var(--color-su-orange);


### PR DESCRIPTION
## Feedback

In the mech wizard custom Loadout step (Install Systems / Install Modules), the tech-tier filter chip row only offered chips for tiers 1-6. The chips are entity **filters** (toggles that narrow the available list by tier). Bio (B) and Nanite (N) chips were missing, so a player could not filter to the 16 Bio/Nanite systems & modules that exist in the salvageunion-reference dataset — and once any numeric tier chip was active, B/N items became unreachable.

## UX area

`apps/in-the-union-now/src/components/mech/InstallStep.tsx` — the tech-tier filter chip row (`ALL_TLS`). The chips stay a filter concept; the card selection mechanism is **not** changed here (that is the sibling Add-button PR). The crawler builder is out of scope and untouched (its TL-gating correctly excludes non-numeric tiers).

## Rules reference

- **Salvage Union Core Book Digital Edition 2.0a.pdf, "TECH LEVELS" quick-reference box (p.3):** "TECH 6 — STATE OF THE ART, SECRET PROJECTS THAT BEGIN WITH X, BIO AND NANITE TECH." Bio and Nanite are legitimate equipment tech tiers, and B/N-tier systems and modules exist in the catalog (Systems/Modules tables, pp.183-189), so the builder must let a player filter to them. Confirmed in the dataset: 10 Bio + 6 Nanite = 16 entries.

The canonical type source is salvageunion-reference's `TechLevelSchema` (`common.ts`): `number 1-6 | 'B' | 'N'`.

## Fix

- Widen `TechLevel` in `apps/in-the-union-now/src/lib/rules/types.ts` to `1|2|3|4|5|6|'B'|'N'` to match `TechLevelSchema`.
- Guard `tierUpgradeCost` in `apps/in-the-union-now/src/lib/rules/scrap.ts` to numeric tiers only (Bio/Nanite have no sequential crawler upgrade path) so it still typechecks.
- In `InstallStep.tsx`: extend `ALL_TLS` to include `'B'`/`'N'`, replace the numeric `a.techLevel - b.techLevel` sort with a rank comparator (1-6, then B, then N), and render readable "Bio"/"Nanite" chip labels. The existing `activeTls.includes(...)` filter works unchanged.
- Add `--color-tl-B` / `--color-tl-N` swatch CSS vars in `packages/suref-react/src/styles/theme.css` so the new chips render a swatch.

No schema/persistence/backend change. The card selection/toggle mechanism is untouched.

## Checks

- `bun run build:package` — pass
- `bun run typecheck` — pass (all packages)
- `bun --filter in-the-union-now test` — 891 pass / 0 fail
- `bun --filter suref-react test` — 310 pass / 0 fail
- `bun run lint` — pass (all packages)
- `bun run format` — clean

(The root-level `bun test` shows pre-existing failures from missing per-package happy-dom preload — unrelated to this change; the per-package suites that own the touched files pass.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)