### PR TITLE
feat(itun): per-entity Add + N-Installed count and remove-one in mech Loadout

### DIFF
--- a/apps/in-the-union-now/e2e/_helpers.ts
+++ b/apps/in-the-union-now/e2e/_helpers.ts
@@ -80,6 +80,21 @@ export async function pickByName(page: Page, name: string): Promise<void> {
 }
 
 /**
+ * Install a Loadout System/Module by name. The mech wizard's Loadout step
+ * (InstallStep) is no longer a one-shot Sel toggle on the card itself — each
+ * entity card carries its own aria-labelled "Add {name}" button that appends
+ * one copy (installing the same System/Module twice is rules-legal), so we
+ * target that button rather than clicking the card.
+ */
+export async function installLoadoutItem(page: Page, name: string): Promise<void> {
+  const add = page.getByRole('button', { name: `Add ${name}` })
+  await expect(add, `"Add ${name}" install button should render`).toBeVisible({
+    timeout: 15_000,
+  })
+  await add.click()
+}
+
+/**
  * Click the wizard's Next button. WizShell wizards label the CTA from the
  * steps array ('Next · Abilities →'); legacy builders use a bare 'Next'.
  */

--- a/apps/in-the-union-now/e2e/mech-build.e2e.ts
+++ b/apps/in-the-union-now/e2e/mech-build.e2e.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { clickNext, pickByName, waitForReady } from './_helpers'
+import { clickNext, installLoadoutItem, pickByName, waitForReady } from './_helpers'
 
 /**
  * Mech-only build — steps through the chassis-first WizShell wizard
@@ -22,7 +22,7 @@ test('build a mech from scratch', async ({ page }) => {
   await clickNext(page) // -> Loadout
 
   // Step 3 — Loadout (Systems tab by default; optional, soft budget)
-  await pickByName(page, 'Cargo Pod')
+  await installLoadoutItem(page, 'Cargo Pod')
   await clickNext(page) // -> Identity
 
   // Step 4 — Identity
@@ -73,7 +73,7 @@ test('edit a mech loadout via /mechs/$id/edit', async ({ page }) => {
   await expect(page.getByText('Edit Mech')).toBeVisible()
   await clickNext(page) // -> Pattern
   await clickNext(page) // -> Loadout
-  await pickByName(page, 'Cargo Pod') // install a system in edit mode
+  await installLoadoutItem(page, 'Cargo Pod') // install a system in edit mode
   await clickNext(page) // -> Identity
   await clickNext(page) // -> Review
   await page.getByRole('button', { name: /Save Mech/i }).click()

--- a/apps/in-the-union-now/src/components/mech/InstallCard.tsx
+++ b/apps/in-the-union-now/src/components/mech/InstallCard.tsx
@@ -1,0 +1,55 @@
+import type { SURefEntity } from 'salvageunion-reference'
+import { MiniBtn, ReferenceEntityDisplay } from 'suref-react'
+
+type InstallCardProps = {
+  /** The reference entity to render as a compact card. */
+  entity: unknown
+  /** Entity name used for the Add button's accessible label. */
+  name: string
+  /** How many copies of this entity are currently installed. */
+  count: number
+  /** Append one more copy of this entity to the loadout. */
+  onAdd: () => void
+}
+
+/**
+ * Mech-loadout install cell: a compact entity card with a per-entity "Add"
+ * affordance (an entity SELECT — distinct from the tier-filter chips). Unlike
+ * the shared Sel-based SelCard, installing the same System/Module twice is
+ * rules-legal (Core Book p.94 "Craft your Systems/Modules" + p.96 "System
+ * Slots" — nothing restricts a System/Module to a single copy; only slot
+ * capacity limits it, and capacity is soft here), so this card is a count-based
+ * adder rather than a one-shot toggle:
+ *
+ * - not installed → an "Add" button (appends one copy)
+ * - installed → an "N Installed" label beside an "Add another" button (each
+ *   click appends one more copy)
+ *
+ * Removal happens per-entry in the right-hand Loadout panel.
+ */
+export function InstallCard({ entity, name, count, onAdd }: InstallCardProps) {
+  const installed = count > 0
+
+  return (
+    <div>
+      <ReferenceEntityDisplay
+        data={entity as SURefEntity}
+        compact
+        hide={{ actions: true, choices: true }}
+      />
+      <div className="mt-1.5 flex items-center gap-2 px-1">
+        {installed && (
+          <span
+            className="font-cond text-[11px] font-bold uppercase tracking-[0.08em] text-rust"
+            data-testid="install-count"
+          >
+            {count} Installed
+          </span>
+        )}
+        <MiniBtn onClick={onAdd} aria-label={`Add ${name}`}>
+          {installed ? '+ Add another' : '+ Add'}
+        </MiniBtn>
+      </div>
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/mech/InstallCard.tsx
+++ b/apps/in-the-union-now/src/components/mech/InstallCard.tsx
@@ -41,7 +41,7 @@ export function InstallCard({ entity, name, count, onAdd }: InstallCardProps) {
         {installed && (
           <span
             className="font-cond text-[11px] font-bold uppercase tracking-[0.08em] text-rust"
-            data-testid="install-count"
+            data-testid={`install-count-${name}`}
           >
             {count} Installed
           </span>

--- a/apps/in-the-union-now/src/components/mech/InstallStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/InstallStep.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import { SalvageUnionReference } from 'salvageunion-reference'
 import { FilterChip } from 'suref-react'
 import type { TechLevel } from '../../lib/rules/types'
-import { SelCard } from '../wizard/SelCard'
+import { InstallCard } from './InstallCard'
 import { LoadoutPanel } from './LoadoutPanel'
 
 type InstallItemLike = {
@@ -24,9 +24,12 @@ function tlRank(tl: TechLevel): number {
 type InstallStepProps = {
   /** Which dataset this step installs from. */
   kind: 'systems' | 'modules'
-  /** Name refs currently installed. */
+  /** Name refs currently installed (may contain duplicates). */
   selected: string[]
-  onToggle: (name: string) => void
+  /** Append one copy of the named entity. */
+  onAdd: (name: string) => void
+  /** Remove the single chosen entry at `index` (drops one copy). */
+  onRemove: (index: number) => void
   /** Loadout panel header name (mech name, falling back to chassis). */
   loadoutName: string
   /** 'SYSTEM SLOTS' / 'MODULE SLOTS' budget figures (soft — never blocks). */
@@ -48,7 +51,8 @@ type InstallStepProps = {
 export function InstallStep({
   kind,
   selected,
-  onToggle,
+  onAdd,
+  onRemove,
   loadoutName,
   slotsUsed,
   slotsMax,
@@ -91,12 +95,12 @@ export function InstallStep({
 
         <div className="mt-[25px] columns-1 gap-3.5 sm:columns-2 [&>*]:mb-3.5 [&>*]:break-inside-avoid">
           {visible.map((item) => (
-            <SelCard
+            <InstallCard
               key={item.id}
               entity={item}
               name={item.name}
-              selected={selected.includes(item.name)}
-              onToggle={() => onToggle(item.name)}
+              count={selected.filter((ref) => ref === item.name).length}
+              onAdd={() => onAdd(item.name)}
             />
           ))}
         </div>
@@ -114,6 +118,7 @@ export function InstallStep({
         energyValue={energyValue}
         energyMax={energyMax}
         chosen={selected}
+        onRemove={onRemove}
         kind={kind}
         className="lg:sticky lg:top-4"
       />

--- a/apps/in-the-union-now/src/components/mech/LoadoutPanel.tsx
+++ b/apps/in-the-union-now/src/components/mech/LoadoutPanel.tsx
@@ -1,6 +1,6 @@
 import { SalvageUnionReference } from 'salvageunion-reference'
 import type { SURefEntity } from 'salvageunion-reference'
-import { Panel, ReferenceEntityDisplay, statBlockRowStarts } from 'suref-react'
+import { MiniBtn, Panel, ReferenceEntityDisplay, statBlockRowStarts } from 'suref-react'
 import { cn } from '../../lib/utils'
 
 type BudgetTrackProps = {
@@ -76,8 +76,10 @@ type LoadoutPanelProps = {
   /** Current/max Energy Points — informational is-ap track. */
   energyValue: number
   energyMax: number
-  /** Name refs of the chosen systems or modules (head-mode cards). */
+  /** Name refs of the chosen systems or modules (may contain duplicates). */
   chosen: string[]
+  /** Remove the single chosen entry at `index` (drops one copy). */
+  onRemove: (index: number) => void
   /** Which dataset resolves the chosen refs. */
   kind: 'systems' | 'modules'
   className?: string
@@ -96,15 +98,27 @@ export function LoadoutPanel({
   energyValue,
   energyMax,
   chosen,
+  onRemove,
   kind,
   className,
 }: LoadoutPanelProps) {
   const accessor =
     kind === 'systems' ? SalvageUnionReference.Systems : SalvageUnionReference.Modules
-  const chosenEntities = chosen.flatMap((ref) => {
+
+  // Keep the original index for each chosen ref so removal drops exactly ONE
+  // occurrence (remove-by-index, not filter-all-matches — duplicates are legal).
+  // `copy` is the 1-based ordinal among same-named entries, shown when there's
+  // more than one copy of an item so each entry reads as "Name · N".
+  const seen = new Map<string, number>()
+  const chosenEntries = chosen.flatMap((ref, index) => {
     const found = accessor.find((x) => x.name === ref)
-    return found ? [found as unknown as SURefEntity] : []
+    if (!found) return []
+    const copy = (seen.get(ref) ?? 0) + 1
+    seen.set(ref, copy)
+    return [{ entity: found as unknown as SURefEntity, ref, index, copy }]
   })
+  const totals = new Map<string, number>()
+  for (const ref of chosen) totals.set(ref, (totals.get(ref) ?? 0) + 1)
 
   return (
     <Panel className={cn('self-start px-4 py-4', className)}>
@@ -118,15 +132,33 @@ export function LoadoutPanel({
       </div>
 
       <div className="mt-4 space-y-2">
-        {chosenEntities.map((entity, i) => (
-          <ReferenceEntityDisplay
-            key={`${(entity as { id?: string }).id ?? i}`}
-            data={entity}
-            mode="head"
-            hide={{ actions: true, choices: true }}
-          />
-        ))}
-        {chosenEntities.length === 0 && (
+        {chosenEntries.map(({ entity, ref, index, copy }) => {
+          const total = totals.get(ref) ?? 1
+          return (
+            <div key={index} data-testid="loadout-entry" className="flex items-start gap-2">
+              <div className="min-w-0 flex-1">
+                <ReferenceEntityDisplay
+                  data={entity}
+                  mode="head"
+                  hide={{ actions: true, choices: true }}
+                />
+                {total > 1 && (
+                  <span className="mt-0.5 block px-1 font-cond text-[10px] font-bold uppercase tracking-[0.08em] text-wk-muted">
+                    Copy {copy} of {total}
+                  </span>
+                )}
+              </div>
+              <MiniBtn
+                onClick={() => onRemove(index)}
+                aria-label={`Remove ${ref}`}
+                className="mt-0.5 shrink-0"
+              >
+                ✕ Remove
+              </MiniBtn>
+            </div>
+          )
+        })}
+        {chosenEntries.length === 0 && (
           <p className="font-body text-xs text-wk-muted">Nothing installed yet.</p>
         )}
       </div>

--- a/apps/in-the-union-now/src/components/mech/LoadoutPanel.tsx
+++ b/apps/in-the-union-now/src/components/mech/LoadoutPanel.tsx
@@ -134,6 +134,12 @@ export function LoadoutPanel({
       <div className="mt-4 space-y-2">
         {chosenEntries.map(({ entity, ref, index, copy }) => {
           const total = totals.get(ref) ?? 1
+          // `index` (the original chosen-array position) is a deliberate,
+          // safe key here: duplicates are allowed so name/ref is non-unique,
+          // and these rows are stateless (head-mode display + stateless
+          // MiniBtn, onRemove closes over the live index each render). Do NOT
+          // add per-row local state on this index key without switching to a
+          // stable id — a removal shifts indices and would desync it.
           return (
             <div key={index} data-testid="loadout-entry" className="flex items-start gap-2">
               <div className="min-w-0 flex-1">

--- a/apps/in-the-union-now/src/components/mech/LoadoutStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/LoadoutStep.tsx
@@ -7,8 +7,12 @@ type LoadoutTab = 'systems' | 'modules'
 type LoadoutStepProps = {
   systems: string[]
   modules: string[]
-  onToggleSystem: (name: string) => void
-  onToggleModule: (name: string) => void
+  /** Append one copy of the named system/module (duplicates allowed). */
+  onAddSystem: (name: string) => void
+  onAddModule: (name: string) => void
+  /** Remove the single chosen entry at `index` (drops one copy). */
+  onRemoveSystem: (index: number) => void
+  onRemoveModule: (index: number) => void
   loadoutName: string
   systemSlotsUsed: number
   systemSlotsMax: number
@@ -53,8 +57,10 @@ function TabButton({
 export function LoadoutStep({
   systems,
   modules,
-  onToggleSystem,
-  onToggleModule,
+  onAddSystem,
+  onAddModule,
+  onRemoveSystem,
+  onRemoveModule,
   loadoutName,
   systemSlotsUsed,
   systemSlotsMax,
@@ -84,7 +90,8 @@ export function LoadoutStep({
         <InstallStep
           kind="systems"
           selected={systems}
-          onToggle={onToggleSystem}
+          onAdd={onAddSystem}
+          onRemove={onRemoveSystem}
           loadoutName={loadoutName}
           slotsUsed={systemSlotsUsed}
           slotsMax={systemSlotsMax}
@@ -95,7 +102,8 @@ export function LoadoutStep({
         <InstallStep
           kind="modules"
           selected={modules}
-          onToggle={onToggleModule}
+          onAdd={onAddModule}
+          onRemove={onRemoveModule}
           loadoutName={loadoutName}
           slotsUsed={moduleSlotsUsed}
           slotsMax={moduleSlotsMax}

--- a/apps/in-the-union-now/src/components/mech/MechReviewStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/MechReviewStep.tsx
@@ -86,7 +86,7 @@ export function MechReviewStep({ form, isEdit, submitError }: MechReviewStepProp
       <div className="space-y-3">
         {[...chosenSystems, ...chosenModules].map((entity, i) => (
           <ReferenceEntityDisplay
-            key={`${(entity as { id?: string }).id ?? i}`}
+            key={`${(entity as { id?: string }).id ?? 'entity'}-${i}`}
             data={entity}
             compact
             status={isEdit ? undefined : 'intact'}

--- a/apps/in-the-union-now/src/components/mech/MechWizard.tsx
+++ b/apps/in-the-union-now/src/components/mech/MechWizard.tsx
@@ -91,8 +91,16 @@ export function MechWizard({ onComplete, onCancel, mechId, initialState }: MechW
     setForm((prev) => ({ ...prev, ...patch }))
   }
 
-  function toggleIn(list: string[], name: string): string[] {
-    return list.includes(name) ? list.filter((x) => x !== name) : [...list, name]
+  // Append one copy of `name`. Duplicates are rules-legal (Core Book p.94/96 —
+  // only slot capacity limits installs, and capacity is soft here).
+  function addCopy(list: string[], name: string): string[] {
+    return [...list, name]
+  }
+
+  // Remove the single occurrence at `index` (not filter-all-matches, so other
+  // copies of the same item survive).
+  function removeAt(list: string[], index: number): string[] {
+    return list.filter((_, i) => i !== index)
   }
 
   // Changing the chassis invalidates any chosen pattern/loadout.
@@ -324,8 +332,10 @@ export function MechWizard({ onComplete, onCancel, mechId, initialState }: MechW
         <LoadoutStep
           systems={form.systems}
           modules={form.modules}
-          onToggleSystem={(name) => updateForm({ systems: toggleIn(form.systems, name) })}
-          onToggleModule={(name) => updateForm({ modules: toggleIn(form.modules, name) })}
+          onAddSystem={(name) => updateForm({ systems: addCopy(form.systems, name) })}
+          onAddModule={(name) => updateForm({ modules: addCopy(form.modules, name) })}
+          onRemoveSystem={(index) => updateForm({ systems: removeAt(form.systems, index) })}
+          onRemoveModule={(index) => updateForm({ modules: removeAt(form.modules, index) })}
           loadoutName={loadoutName}
           systemSlotsUsed={capacity.systemSlotsUsed}
           systemSlotsMax={capacity.systemSlotsMax}

--- a/apps/in-the-union-now/src/components/mech/__tests__/InstallStep.test.tsx
+++ b/apps/in-the-union-now/src/components/mech/__tests__/InstallStep.test.tsx
@@ -39,7 +39,8 @@ function renderStep(kind: 'systems' | 'modules') {
     <InstallStep
       kind={kind}
       selected={[]}
-      onToggle={() => {}}
+      onAdd={() => {}}
+      onRemove={() => {}}
       loadoutName="Test Mech"
       slotsUsed={0}
       slotsMax={4}
@@ -48,6 +49,10 @@ function renderStep(kind: 'systems' | 'modules') {
     />
   )
 }
+
+// Each catalog cell is an InstallCard whose add affordance is a MiniBtn with
+// aria-label `Add {name}` — so an item is present iff its Add button renders.
+const addBtn = (name: string) => ({ name: `Add ${name}` })
 
 describe('InstallStep — Bio/Nanite tech-tier filter', () => {
   it('renders the Bio and Nanite chips alongside the numeric tiers', () => {
@@ -63,13 +68,13 @@ describe('InstallStep — Bio/Nanite tech-tier filter', () => {
     renderStep('systems')
 
     // Unfiltered: both a Bio system and a numeric-TL system are reachable.
-    expect(screen.getByRole('button', { name: bio.name })).toBeTruthy()
-    expect(screen.getByRole('button', { name: numeric.name })).toBeTruthy()
+    expect(screen.getByRole('button', addBtn(bio.name))).toBeTruthy()
+    expect(screen.getByRole('button', addBtn(numeric.name))).toBeTruthy()
 
     // Activate the Bio filter — only Bio-tier systems remain.
     fireEvent.click(screen.getByRole('button', { name: 'Bio' }))
-    expect(screen.getByRole('button', { name: bio.name })).toBeTruthy()
-    expect(screen.queryByRole('button', { name: numeric.name })).toBeNull()
+    expect(screen.getByRole('button', addBtn(bio.name))).toBeTruthy()
+    expect(screen.queryByRole('button', addBtn(numeric.name))).toBeNull()
   })
 
   it('the Nanite chip narrows the modules catalog to Nanite-tier modules', () => {
@@ -78,7 +83,7 @@ describe('InstallStep — Bio/Nanite tech-tier filter', () => {
     renderStep('modules')
 
     fireEvent.click(screen.getByRole('button', { name: 'Nanite' }))
-    expect(screen.getByRole('button', { name: nanite.name })).toBeTruthy()
-    expect(screen.queryByRole('button', { name: numeric.name })).toBeNull()
+    expect(screen.getByRole('button', addBtn(nanite.name))).toBeTruthy()
+    expect(screen.queryByRole('button', addBtn(numeric.name))).toBeNull()
   })
 })

--- a/apps/in-the-union-now/src/components/mech/__tests__/MechWizard.test.tsx
+++ b/apps/in-the-union-now/src/components/mech/__tests__/MechWizard.test.tsx
@@ -93,6 +93,28 @@ async function clickTab(name: 'Systems' | 'Modules'): Promise<void> {
   })
 }
 
+/**
+ * Loadout install cards expose a per-entity "Add" button (aria-label
+ * "Add {name}"). Each click appends one copy — duplicates are rules-legal.
+ */
+async function addInstall(name: string): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: `Add ${name}` }))
+  })
+}
+
+/**
+ * Each chosen loadout entry in the right-hand panel has a "Remove {name}"
+ * button that drops a single copy (remove-by-index). When duplicates exist
+ * there are multiple matching buttons; click the first.
+ */
+async function removeInstall(name: string): Promise<void> {
+  const buttons = screen.getAllByRole('button', { name: `Remove ${name}` })
+  await act(async () => {
+    fireEvent.click(buttons[0]!)
+  })
+}
+
 async function typeInto(label: RegExp, value: string): Promise<void> {
   const input = screen.getByLabelText(label) as HTMLInputElement
   await act(async () => {
@@ -134,10 +156,10 @@ describe('MechWizard — custom pattern happy path', () => {
 
     // --- Step 3: Loadout — combined Systems / Modules tabs ---
     expect(screen.getByTestId('system-slot-count').textContent).toContain('0 /')
-    await pick('Cargo Pod')
+    await addInstall('Cargo Pod')
     expect(screen.getByTestId('system-slot-count').textContent).toContain('1 /')
     await clickTab('Modules')
-    await pick('Comms Module')
+    await addInstall('Comms Module')
     expect(screen.getByTestId('module-slot-count').textContent).toContain('1 /')
     await clickNext()
 
@@ -246,15 +268,85 @@ describe('MechWizard — gates', () => {
 
     // Mule has 2 module slots — install three 1-slot modules to breach it.
     await clickTab('Modules')
-    await pick('Comms Module')
-    await pick('Equipment Locker')
-    await pick('Firewall')
+    await addInstall('Comms Module')
+    await addInstall('Equipment Locker')
+    await addInstall('Firewall')
 
     // Soft warning banner appears…
     expect(screen.getByTestId('module-slot-count').textContent).toContain('3 /')
     expect(screen.getByText(/Module slots exceeded/i)).toBeTruthy()
     // …and Next stays enabled (capacity is soft — warn, never block).
     expect(getNextButton().disabled).toBe(false)
+  }, 30000)
+})
+
+// ---------------------------------------------------------------------------
+// Duplicate installs: per-entity "Add" appends copies; remove drops ONE
+// ---------------------------------------------------------------------------
+
+describe('MechWizard — duplicate installs', () => {
+  it('adds multiple copies of the same system and persists every copy', async () => {
+    render(<MechWizard onComplete={() => {}} onCancel={() => {}} />)
+
+    await pick('Mule')
+    await clickNext() // Pattern
+    await pick('Custom Pattern')
+    await typeInto(/Pattern name/i, 'Twin Rig')
+    await clickNext() // Loadout
+
+    // First click installs one; the card flips to an "Add another" affordance
+    // and an "N Installed" count.
+    await addInstall('Cargo Pod')
+    expect(screen.getByTestId('install-count').textContent).toContain('1 Installed')
+    await addInstall('Cargo Pod') // "Add another"
+    expect(screen.getByTestId('install-count').textContent).toContain('2 Installed')
+    expect(screen.getByTestId('system-slot-count').textContent).toContain('2 /')
+    // The Loadout panel lists each copy as its own removable entry.
+    expect(screen.getAllByTestId('loadout-entry').length).toBe(2)
+
+    await clickNext() // Identity
+    await typeInto(/Mech name/i, 'Iron Fist')
+    await clickNext() // Review
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Create Mech/i }))
+    })
+
+    await waitFor(() => {
+      const m = useEntityStore.getState().list('mech')[0]!
+      expect(m.systems).toEqual(['Cargo Pod', 'Cargo Pod'])
+    })
+  }, 30000)
+
+  it('removes a single copy (by index) leaving the other duplicate intact', async () => {
+    render(<MechWizard onComplete={() => {}} onCancel={() => {}} />)
+
+    await pick('Mule')
+    await clickNext() // Pattern
+    await pick('Custom Pattern')
+    await typeInto(/Pattern name/i, 'Twin Rig')
+    await clickNext() // Loadout
+
+    await addInstall('Cargo Pod')
+    await addInstall('Cargo Pod')
+    expect(screen.getAllByTestId('loadout-entry').length).toBe(2)
+
+    // Remove ONE copy — the count drops to 1, one entry remains.
+    await removeInstall('Cargo Pod')
+    expect(screen.getAllByTestId('loadout-entry').length).toBe(1)
+    expect(screen.getByTestId('install-count').textContent).toContain('1 Installed')
+    expect(screen.getByTestId('system-slot-count').textContent).toContain('1 /')
+
+    await clickNext() // Identity
+    await typeInto(/Mech name/i, 'Iron Fist')
+    await clickNext() // Review
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Create Mech/i }))
+    })
+
+    await waitFor(() => {
+      const m = useEntityStore.getState().list('mech')[0]!
+      expect(m.systems).toEqual(['Cargo Pod'])
+    })
   }, 30000)
 })
 
@@ -303,9 +395,9 @@ describe('MechWizard — edit mode', () => {
 
     // Loadout panel shows the prefilled install (no empty-state message).
     expect(screen.queryByText(/Nothing installed yet/i)).toBeNull()
-    await pick('Armour Plating') // add a second system
+    await addInstall('Armour Plating') // add a second system
     await clickTab('Modules')
-    await pick('Comms Module')
+    await addInstall('Comms Module')
     await clickNext() // Identity (name prefilled)
     await clickNext() // Review
 
@@ -344,7 +436,7 @@ describe('MechWizard — edit mode', () => {
 
     await clickNext() // Pattern
     await clickNext() // Loadout
-    await pick('Cargo Pod') // toggle OFF the only system
+    await removeInstall('Cargo Pod') // remove the only system via the Loadout panel
     await clickNext() // Identity
     await clickNext() // Review
 

--- a/apps/in-the-union-now/src/components/mech/__tests__/MechWizard.test.tsx
+++ b/apps/in-the-union-now/src/components/mech/__tests__/MechWizard.test.tsx
@@ -297,9 +297,9 @@ describe('MechWizard — duplicate installs', () => {
     // First click installs one; the card flips to an "Add another" affordance
     // and an "N Installed" count.
     await addInstall('Cargo Pod')
-    expect(screen.getByTestId('install-count').textContent).toContain('1 Installed')
+    expect(screen.getByTestId('install-count-Cargo Pod').textContent).toContain('1 Installed')
     await addInstall('Cargo Pod') // "Add another"
-    expect(screen.getByTestId('install-count').textContent).toContain('2 Installed')
+    expect(screen.getByTestId('install-count-Cargo Pod').textContent).toContain('2 Installed')
     expect(screen.getByTestId('system-slot-count').textContent).toContain('2 /')
     // The Loadout panel lists each copy as its own removable entry.
     expect(screen.getAllByTestId('loadout-entry').length).toBe(2)
@@ -333,7 +333,7 @@ describe('MechWizard — duplicate installs', () => {
     // Remove ONE copy — the count drops to 1, one entry remains.
     await removeInstall('Cargo Pod')
     expect(screen.getAllByTestId('loadout-entry').length).toBe(1)
-    expect(screen.getByTestId('install-count').textContent).toContain('1 Installed')
+    expect(screen.getByTestId('install-count-Cargo Pod').textContent).toContain('1 Installed')
     expect(screen.getByTestId('system-slot-count').textContent).toContain('1 /')
 
     await clickNext() // Identity


### PR DESCRIPTION
## Feedback

> Per-entity "Add" button select with "N Installed" count and per-entry remove in mech Loadout.
> In the mech wizard custom Loadout step a System/Module can only be installed ONCE: the cards use a toggle/set selection model (tap selected → removes, tap unselected → adds), so multiples are impossible. Replace this with a per-entity "Add" button (an entity SELECT — a separate concept from the tier-filter chips). A not-installed entity shows an "Add" button; once installed it shows an "Installed" label with an "Add another" button next to it, with the label reflecting the count ("2 Installed", "3 Installed", …). The chosen list shows each entry and has a remove control that drops a single copy. Installing the same item twice is rules-legal (only slot capacity limits it).

## UX area

`apps/in-the-union-now` mech wizard **custom Loadout** path (`MechWizard → LoadoutStep → InstallStep + LoadoutPanel`). The tier-filter chips are a separate concept and are left untouched.

## SURules reference

- **Salvage Union Core Book Digital Edition 2.0a**, p.94 (*Craft your Systems/Modules*) and p.96 (*System Slots* / Mech Stats). Nothing restricts a System/Module to a single copy — two of the same simply consume slots twice. The only constraint is slot capacity, which ITUN already models as a **soft** over-capacity warning (`computeMechCapacity`). This is a UX-model change, not a rules exception.

## Fix

- New mech-only **`InstallCard`** (count-based adder): not installed → **"+ Add"**; installed → an **"N Installed"** label beside **"+ Add another"**, each click appending one copy. The shared toggle `SelCard` used by the pilot/crawler steps is left **untouched** (so this is additive, not a breaking change to those flows).
- **`MechWizard`** add/remove handlers: `addCopy` appends one copy; `removeAt` removes a single occurrence **by index** (not filter-all-matches). Threaded through `LoadoutStep → InstallStep → LoadoutPanel`.
- **`LoadoutPanel`** renders each chosen entry as its own removable row (keyed by index), annotated "Copy N of M" when duplicated, each with a **"✕ Remove"** control that drops exactly one copy.
- No schema change: `mech.systems` / `mech.modules` are already `z.array(z.string())` and tolerate duplicates; the slot/energy budget already sums over the array, so over-capacity keeps **warning, not blocking**.
- Local-first, reuses suref-react primitives (`MiniBtn`, `ReferenceEntityDisplay`, `Panel`); no backend.

## Tests

Extended `MechWizard.test.tsx` with duplicate-copy add (`['Cargo Pod', 'Cargo Pod']` persisted, "2 Installed" count, 2 loadout entries) and remove-one-by-index (drops one copy, the other survives) paths, plus updated the existing happy/edit-mode flows to the new Add/Remove affordances.

## Checks

- `bun --filter in-the-union-now typecheck` ✅ (suref-web has a pre-existing unrelated `satori` module-resolution error, untouched here)
- `bun --filter in-the-union-now test` ✅ 893 pass / 0 fail
- `bun run lint` ✅ (all packages)
- `bun run format` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

