### PR TITLE
ci(netlify): skip per-site deploys when the app is unaffected

### DIFF
--- a/apps/in-the-union-now/netlify.toml
+++ b/apps/in-the-union-now/netlify.toml
@@ -11,6 +11,15 @@
   command = "bun install --frozen-lockfile && bun run build:package:ci && bun --filter in-the-union-now build"
   publish = "apps/in-the-union-now/dist"
   functions = "apps/in-the-union-now/netlify/functions"
+  # Skip the build when nothing affecting ITUN changed since the last published
+  # deploy. `git diff --quiet` exits 0 (→ Netlify cancels the build) when none of
+  # these paths differ, and 1 (→ build proceeds) when they do. Paths: this app
+  # (SPA + snapshot Functions) + the shared packages it consumes (suref-react,
+  # which itself depends on salvageunion-reference) + the root build inputs
+  # (lockfile, root scripts/config). On the first deploy $CACHED_COMMIT_REF is
+  # empty so git errors non-zero and the build runs — the safe default. Applies
+  # to every context: production (main), branch deploys, and deploy previews.
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/in-the-union-now packages/suref-react packages/salvageunion-reference bun.lock package.json bunfig.toml tsconfig.json"
 
 [build.environment]
   BUN_VERSION = "1.3.14"

--- a/apps/suref-web/netlify.toml
+++ b/apps/suref-web/netlify.toml
@@ -3,6 +3,15 @@
 [build]
   command = "bun install --frozen-lockfile && bun run build:package:ci && bun --filter suref-web build"
   publish = "apps/suref-web/dist"
+  # Skip the build when nothing affecting suref-web changed since the last
+  # published deploy. `git diff --quiet` exits 0 (→ Netlify cancels the build)
+  # when none of these paths differ, and 1 (→ build proceeds) when they do.
+  # Paths: this app + the shared packages it consumes (suref-react, which itself
+  # depends on salvageunion-reference) + the root build inputs (lockfile, root
+  # scripts/config). On the first deploy $CACHED_COMMIT_REF is empty so git
+  # errors non-zero and the build runs — the safe default. Applies to every
+  # context: production (main), branch deploys, and deploy previews.
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/suref-web packages/suref-react packages/salvageunion-reference bun.lock package.json bunfig.toml tsconfig.json"
 
 [build.environment]
   BUN_VERSION = "1.3.10" # keep in sync with .bun-version


### PR DESCRIPTION
## What

Both the **suref-web** (`suindex` → salvageunion.io) and **in-the-union-now** Netlify sites currently rebuild on every push to `main`, regardless of what changed. This adds an [`ignore` build directive](https://docs.netlify.com/configure-builds/ignore-builds/) to each site's `netlify.toml` so a deploy is **cancelled** unless a path affecting that app changed since the last published deploy.

## How

`git diff --quiet <last-published> <current> -- <paths>` exits `0` (Netlify cancels the build) when none of the watched paths differ, and `1` (build proceeds) when they do.

Each site watches:
- its own app dir,
- the shared packages it consumes (`suref-react`, which itself depends on `salvageunion-reference`),
- root build inputs (`bun.lock`, `package.json`, `bunfig.toml`, `tsconfig.json`).

First-ever deploy has an empty `$CACHED_COMMIT_REF`, so git errors non-zero and the build runs — the safe default.

## Net effect

| Change | suref-web | ITUN |
|---|---|---|
| `apps/suref-web/**` | ✅ builds | ⏭️ skipped |
| `apps/in-the-union-now/**` | ⏭️ skipped | ✅ builds |
| `packages/**`, root lockfile/config | ✅ builds | ✅ builds |
| `apps/discord-bot`, `apps/su-assets`, `docs/`, `rules/` | ⏭️ skipped | ⏭️ skipped |

## Enforcement

Config-as-code in each committed `netlify.toml`: it overrides any per-site UI build setting and applies uniformly across production (`main`), branch deploys, and deploy previews. Netlify runs the `ignore` command from each site's base directory — the repo root for both sites (confirmed: both use root-relative `publish`/`functions` paths), so the root-relative diff paths resolve correctly.

> Note: this gates on git paths, not build-graph reachability — a `packages/salvageunion-reference` change rebuilds both sites even if only one consumed the changed export. That's the conservative, correct direction (never skips a build that mattered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRDi4FGjMoC81TGy8EeY7z