### PR TITLE
test(itun): block service workers in e2e to fix preview flake

### DIFF
--- a/apps/in-the-union-now/playwright.config.ts
+++ b/apps/in-the-union-now/playwright.config.ts
@@ -45,6 +45,13 @@ export default defineConfig({
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
+    // The app is a PWA (vite-plugin-pwa, registerType: 'autoUpdate'). When the
+    // service worker activates it triggers a page reload; if that reload lands
+    // mid-navigation, page.goto/page.reload abort with
+    // `net::ERR_ABORTED; maybe frame was detached?`. This flaked the preview
+    // suite (E2E_BASE_URL) where a real SW registers. No e2e here exercises
+    // offline/installability, so block SW registration to remove the race.
+    serviceWorkers: 'block',
   },
   projects: [
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } },


### PR DESCRIPTION
## Problem

The ITUN **e2e preview** suite (`e2e-itun-preview`, run against a live Netlify Deploy Preview via `E2E_BASE_URL`) intermittently fails with navigation aborts:

```
Error: page.goto: net::ERR_ABORTED; maybe frame was detached?
Error: page.reload: net::ERR_ABORTED; maybe frame was detached?
```

This blocked PR #318 — the failure recurred across all 3 retries, then passed cleanly on a manual re-run, confirming it's a race rather than a real regression.

## Root cause

The app is a PWA. It registers a service worker (`src/lib/sw/register.ts` → `navigator.serviceWorker.register('/sw.js')`) and `vite-plugin-pwa` is configured `registerType: 'autoUpdate'`. When a new SW activates it triggers a page reload; when that reload lands **mid-navigation**, Playwright's awaited `page.goto`/`page.reload` aborts (`ERR_ABORTED; maybe frame was detached?`). Against the live preview a real SW registers every run, so the race surfaces there far more than on the local preview server.

## Fix

Block service-worker registration in the Playwright context:

```ts
use: { serviceWorkers: 'block' }
```

This is Playwright's first-class option for exactly this scenario. No e2e in the suite exercises offline / installability / SW behaviour (the SW unit test in `src/lib/sw/__tests__/` is unaffected — it's a Bun test, not Playwright), so blocking registration removes the reload-during-navigation race for the whole suite with no loss of coverage.

## Verification

- Local: typecheck + lint + unit tests green (pre-push hooks).
- The real proof is this PR's own `e2e-itun-preview` run — it executes the full preview suite **with** the fix against a live preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRDi4FGjMoC81TGy8EeY7z