### PR TITLE
fix(suref-web): resolve catalog masonry hydration mismatch (#418)

### DIFF
--- a/apps/suref-web/src/lib/changelog.ts
+++ b/apps/suref-web/src/lib/changelog.ts
@@ -6,6 +6,13 @@ type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: '2026-06-23',
+    title: 'Steadier catalog grid on load',
+    items: [
+      'Fixed a hydration mismatch on catalog (/schema) pages where the masonry grid rendered one column on the server but two or three in the browser, throwing a React error and forcing the whole grid to re-render on tablet and desktop widths.',
+    ],
+  },
+  {
     date: '2026-06-21',
     title: 'Branded link previews for every entity',
     items: [

--- a/packages/suref-react/src/components/shared/MasonryColumns.tsx
+++ b/packages/suref-react/src/components/shared/MasonryColumns.tsx
@@ -1,4 +1,4 @@
-import { Children, useEffect, useState, type ReactNode } from 'react'
+import { Children, useSyncExternalStore, type ReactNode } from 'react'
 
 type MasonryColumnsProps = {
   children: ReactNode
@@ -23,25 +23,26 @@ function columnsForViewport(): number {
   return 1
 }
 
+// useSyncExternalStore only subscribes after hydration, so `window` is defined
+// whenever this runs.
+function subscribeColumns(onChange: () => void): () => void {
+  const md = window.matchMedia(MD)
+  const xl = window.matchMedia(XL)
+  md.addEventListener('change', onChange)
+  xl.addEventListener('change', onChange)
+  return () => {
+    md.removeEventListener('change', onChange)
+    xl.removeEventListener('change', onChange)
+  }
+}
+
 function useColumnCount(): number {
-  // Islands hydrate client-side, so `window` exists at first render — seeding
-  // from it avoids a 1-column flash before the effect runs.
-  const [count, setCount] = useState(columnsForViewport)
-
-  useEffect(() => {
-    const md = window.matchMedia(MD)
-    const xl = window.matchMedia(XL)
-    const update = () => setCount(columnsForViewport())
-    update()
-    md.addEventListener('change', update)
-    xl.addEventListener('change', update)
-    return () => {
-      md.removeEventListener('change', update)
-      xl.removeEventListener('change', update)
-    }
-  }, [])
-
-  return count
+  // The server snapshot (1 column) is used for SSR *and* the first hydration
+  // render, so the client's initial tree matches the SSR HTML; React then
+  // reconciles to the live viewport column count without a hydration mismatch
+  // (React #418). Seeding useState from `window` instead rendered 1 column on
+  // the server but 2–3 on the client's first render, breaking hydration.
+  return useSyncExternalStore(subscribeColumns, columnsForViewport, () => 1)
 }
 
 /**


### PR DESCRIPTION
## Problem

The classes catalog page (and every `/schema/*` list page) threw **React error #418** — a hydration mismatch (`server rendered HTML didn't match the client`).

Root cause is in `MasonryColumns` (`packages/suref-react/src/components/shared/MasonryColumns.tsx`):

```tsx
const [count, setCount] = useState(columnsForViewport)
```

`columnsForViewport()` returns **1** on the server (`window` is undefined) but reads `window.matchMedia` on the client, returning **2–3** on tablet/desktop widths. So the `useState` initializer produced a 1-column tree in the SSR HTML but a 2–3-column tree on the client's first hydration render → structural mismatch.

It surfaced on catalog pages because the data gate's **skeleton fallback is itself server-rendered through `MasonryColumns`**. The earlier #282 fix hardened the data gate; the #284 masonry rewrite then reintroduced a mismatch one layer down, in the skeleton.

## Fix

Switch to `useSyncExternalStore(subscribe, columnsForViewport, () => 1)` — the same idiom already used in `useGameData`. SSR and the first hydration render both see 1 column (matching the emitted HTML); React then reconciles to the live viewport column count with no mismatch. The `matchMedia` resize listeners move into the store's `subscribe`, so resize behavior is unchanged.

## Scope audit

Swept `suref-web` and `suref-react` for the same bug class (render-time / state-initializer reads of `window`, `matchMedia`, `localStorage`, `Date.now()`, `Math.random()`, etc.). **`MasonryColumns` was the only confirmed site.** `CardImage`, `useGameData`, and the islands are either deterministic or already correctly mitigated. ITUN and discord-bot are excluded (neither is SSR'd).

## Validation

- typecheck ✓
- suref-react: 310 tests ✓
- suref-web: 953 tests ✓
- lint ✓ · prettier ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjgiWyyCmzNrLFWV63V8tm