### PR TITLE
fix(netlify): force build when ignore-rule comparison base is degenerate

### DIFF
--- a/apps/in-the-union-now/netlify.toml
+++ b/apps/in-the-union-now/netlify.toml
@@ -16,10 +16,19 @@
   # these paths differ, and 1 (→ build proceeds) when they do. Paths: this app
   # (SPA + snapshot Functions) + the shared packages it consumes (suref-react,
   # which itself depends on salvageunion-reference) + the root build inputs
-  # (lockfile, root scripts/config). On the first deploy $CACHED_COMMIT_REF is
-  # empty so git errors non-zero and the build runs — the safe default. Applies
-  # to every context: production (main), branch deploys, and deploy previews.
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/in-the-union-now packages/suref-react packages/salvageunion-reference bun.lock package.json bunfig.toml tsconfig.json"
+  # (lockfile, root scripts/config). Applies to every context: production (main),
+  # branch deploys, and deploy previews.
+  #
+  # The leading guard FORCES a build (exit 1) whenever the comparison base is
+  # degenerate, so a `git diff` against the wrong/empty base can never silently
+  # cancel a real deploy:
+  #   - $CACHED_COMMIT_REF empty   → first deploy, nothing to compare against.
+  #   - == $COMMIT_REF             → Netlify handed us HEAD as the base; diffing a
+  #                                  commit against itself is always empty, which
+  #                                  would wrongly cancel (this wedged suref-web's
+  #                                  production after #318 — see that netlify.toml).
+  #   - unreachable in the (shallow) clone → can't diff it reliably.
+  ignore = 'if [ -z "$CACHED_COMMIT_REF" ] || [ "$CACHED_COMMIT_REF" = "$COMMIT_REF" ] || ! git cat-file -e "$CACHED_COMMIT_REF^{commit}" 2>/dev/null; then exit 1; fi; git diff --quiet "$CACHED_COMMIT_REF" "$COMMIT_REF" -- apps/in-the-union-now packages/suref-react packages/salvageunion-reference bun.lock package.json bunfig.toml tsconfig.json'
 
 [build.environment]
   BUN_VERSION = "1.3.14"

--- a/apps/suref-web/netlify.toml
+++ b/apps/suref-web/netlify.toml
@@ -8,10 +8,20 @@
   # when none of these paths differ, and 1 (→ build proceeds) when they do.
   # Paths: this app + the shared packages it consumes (suref-react, which itself
   # depends on salvageunion-reference) + the root build inputs (lockfile, root
-  # scripts/config). On the first deploy $CACHED_COMMIT_REF is empty so git
-  # errors non-zero and the build runs — the safe default. Applies to every
-  # context: production (main), branch deploys, and deploy previews.
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/suref-web packages/suref-react packages/salvageunion-reference bun.lock package.json bunfig.toml tsconfig.json"
+  # scripts/config). Applies to every context: production (main), branch
+  # deploys, and deploy previews.
+  #
+  # The leading guard FORCES a build (exit 1) whenever the comparison base is
+  # degenerate, so a `git diff` against the wrong/empty base can never silently
+  # cancel a real deploy:
+  #   - $CACHED_COMMIT_REF empty   → first deploy, nothing to compare against.
+  #   - == $COMMIT_REF             → Netlify handed us HEAD as the base; diffing a
+  #                                  commit against itself is always empty, which
+  #                                  would wrongly cancel. This wedged production:
+  #                                  every post-#318 main deploy cancelled with
+  #                                  "no content change", freezing the site.
+  #   - unreachable in the (shallow) clone → can't diff it reliably.
+  ignore = 'if [ -z "$CACHED_COMMIT_REF" ] || [ "$CACHED_COMMIT_REF" = "$COMMIT_REF" ] || ! git cat-file -e "$CACHED_COMMIT_REF^{commit}" 2>/dev/null; then exit 1; fi; git diff --quiet "$CACHED_COMMIT_REF" "$COMMIT_REF" -- apps/suref-web packages/suref-react packages/salvageunion-reference bun.lock package.json bunfig.toml tsconfig.json'
 
 [build.environment]
   BUN_VERSION = "1.3.10" # keep in sync with .bun-version


### PR DESCRIPTION
## Problem

Production (salvageunion.io) has been **frozen at #318** since June 23. Every `main` deploy since then is in Netlify state `error` with:

> `Failed during stage 'checking build content for changes': Canceled build due to no content change`

That stage is the deploy-skip `ignore` rule that **#318 itself added** to `apps/suref-web/netlify.toml` and `apps/in-the-union-now/netlify.toml`. It silently cancelled the deploys carrying real changes — including the React **#418** masonry hydration fix (#320), which merged to `main` but never reached users. (The Netlify dashboard shows a "Quick setup" placeholder on these because no build output was ever produced.)

## Root cause

`git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF` exits `0` (→ cancel) whenever the two refs resolve to the same tree — including the degenerate case where Netlify hands `HEAD` as the comparison base, i.e. **diffing a commit against itself**. The original rule had no guard for that, and once every build cancels, no new cache ref is ever established, so the site stays wedged.

Locally the rule's path logic is correct (it returns "build" for the real commits); the failure is purely the comparison base.

## Fix

Prepend a guard that **forces a build** (`exit 1`) when the base is:
- empty (first deploy),
- equal to `$COMMIT_REF` (diff-against-self — the case that wedged prod),
- unreachable in Netlify's shallow clone.

A genuinely empty diff between two distinct, present refs still cancels, so the build-skip optimization is preserved. Applied to both `suref-web` and `ITUN`.

Validated locally across all four cases (degenerate → BUILD, real change → BUILD, truly-identical tree → cancel); both `netlify.toml` files parse.

## Follow-up

After merge, production needs a one-time manual deploy to break the cycle (the `ignore` command only runs on Netlify's git-triggered builds) — this PR's own merge build should now go through, shipping the #418 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)