### PR TITLE
fix(itun): seed only base crawler bays on new crawlers

### DIFF
--- a/apps/in-the-union-now/src/components/crawler/__tests__/CrawlerBuilder.test.tsx
+++ b/apps/in-the-union-now/src/components/crawler/__tests__/CrawlerBuilder.test.tsx
@@ -295,9 +295,16 @@ describe('CrawlerBuilder — create mode', () => {
       expect(c.scrapPool).toEqual({ tl2: 3 })
       expect(c.upgradePool).toBe(12)
 
-      // Full SRD bay set seeded, NPCs at max HP (4) where the bay has one.
-      const srdBays = SalvageUnionReference.CrawlerBays.all()
-      expect(c.crawlerBays?.length).toBe(srdBays.length)
+      // Base bay set seeded (expansion bays excluded), NPCs at max HP (4)
+      // where the bay has one.
+      const baseBays = SalvageUnionReference.CrawlerBays.all().filter((b) => !b.expansion)
+      expect(c.crawlerBays?.length).toBe(baseBays.length)
+      // No expansion bay is ever auto-installed on a fresh crawler.
+      const expansionBays = SalvageUnionReference.CrawlerBays.all().filter((b) => b.expansion)
+      expect(expansionBays.length).toBeGreaterThan(0)
+      for (const exp of expansionBays) {
+        expect(c.crawlerBays?.some((e) => e.bayRef === exp.id)).toBe(false)
+      }
       const seeded = c.crawlerBays?.find((e) => e.bayRef === commandBay.id)
       expect(seeded?.npcCurrentHP).toBe(4)
       expect(seeded?.npcName).toBe('Maddox')

--- a/apps/in-the-union-now/src/lib/wizard/crawlerFormState.ts
+++ b/apps/in-the-union-now/src/lib/wizard/crawlerFormState.ts
@@ -175,26 +175,32 @@ export function crawlerFormToUpdatePatch(form: CrawlerWizardFormState): CrawlerW
 /**
  * Build the default crawler-bay set seeded onto every new crawler.
  *
- * The official crawler sheets pre-print all SRD bays as fixed sections, so a
- * fresh crawler installs the full catalog. Each entry seeds the embedded NPC's
- * current HP from the bay's `npc.hitPoints` (4). The array is extensible — a
- * crawler can gain more bays later.
+ * Only the BASE crawler facilities are pre-installed: the Core Book's Union
+ * Crawler Bays (Command, Mech, Storage, …; "Your Union Crawler has the
+ * following Bays", Core Book p.221). Expansion bays (`expansion: true` —
+ * Bio-Mech Bay, Bio-Crafting Bay, Nanite Processing Bay, VR Tubes) are
+ * acquired during play (built for a resource cost or found as a scenario
+ * facility), so they are filtered out of the seed. Each seeded entry seeds the
+ * embedded NPC's current HP from the bay's `npc.hitPoints` (4). The array is
+ * extensible — a crawler can gain expansion bays later.
  */
 export function seedDefaultCrawlerBays(): CrawlerBayEntry[] {
-  type BayWithNpc = { id: string; npc?: { hitPoints?: number } }
+  type BayWithNpc = { id: string; expansion?: boolean; npc?: { hitPoints?: number } }
   let bays: BayWithNpc[]
   try {
     bays = SalvageUnionReference.CrawlerBays.all() as unknown as BayWithNpc[]
   } catch {
     bays = []
   }
-  return bays.map((bay) => {
-    const maxHP = bay.npc?.hitPoints
-    return {
-      bayRef: bay.id,
-      ...(typeof maxHP === 'number' ? { npcCurrentHP: maxHP } : {}),
-    }
-  })
+  return bays
+    .filter((bay) => !bay.expansion)
+    .map((bay) => {
+      const maxHP = bay.npc?.hitPoints
+      return {
+        bayRef: bay.id,
+        ...(typeof maxHP === 'number' ? { npcCurrentHP: maxHP } : {}),
+      }
+    })
 }
 
 /** Structured npcName/npcDescription patch from a crew form (only set keys). */

--- a/packages/salvageunion-reference/data/crawler-bays.json
+++ b/packages/salvageunion-reference/data/crawler-bays.json
@@ -1035,6 +1035,7 @@
   {
     "id": "9ed4cb34-718a-4515-a1a5-b718c2cbe23d",
     "name": "Bio-Mech Bay",
+    "expansion": true,
     "source": "We Were Here First!",
     "cost": {
       "scrap": 5,
@@ -1052,6 +1053,7 @@
   {
     "id": "fb183632-8b3e-4962-82a8-df28e2d9479e",
     "name": "Bio-Crafting Bay",
+    "expansion": true,
     "source": "We Were Here First!",
     "cost": {
       "scrap": 5,
@@ -1069,6 +1071,7 @@
   {
     "id": "3d0b6a77-6213-4596-bc90-00eb1c7eb6ee",
     "name": "Nanite Processing Bay",
+    "expansion": true,
     "source": "False Flag",
     "cost": {
       "scrap": 5,
@@ -1085,6 +1088,7 @@
   {
     "id": "f9fe912f-5a92-4c00-8648-18432ea2988b",
     "name": "VR Tubes",
+    "expansion": true,
     "source": "Rainmaker",
     "techLevel": 5,
     "salvageValue": 1,

--- a/packages/salvageunion-reference/lib/crawlerBays.test.ts
+++ b/packages/salvageunion-reference/lib/crawlerBays.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test'
+import { SalvageUnionReference } from './index.js'
+
+/**
+ * The `expansion` data tag distinguishes base crawler facilities (pre-installed
+ * on every Union Crawler — Core Book "Union Crawler Bays", p.221) from
+ * expansion "upgrade"/found bays acquired during play (built for a resource
+ * cost or found as a scenario facility). ITUN's crawler wizard seeds only the
+ * base bays, so this tag must stay accurate.
+ */
+describe('CrawlerBays expansion tag', () => {
+  const EXPANSION_BAY_NAMES = [
+    'Bio-Mech Bay',
+    'Bio-Crafting Bay',
+    'Nanite Processing Bay',
+    'VR Tubes',
+  ]
+
+  it('tags exactly the expansion-source bays with expansion: true', () => {
+    const tagged = SalvageUnionReference.CrawlerBays.all()
+      .filter((bay) => bay.expansion === true)
+      .map((bay) => bay.name)
+      .sort()
+    expect(tagged).toEqual([...EXPANSION_BAY_NAMES].sort())
+  })
+
+  it('leaves base facilities untagged (expansion absent/false)', () => {
+    const baseBays = SalvageUnionReference.CrawlerBays.all().filter(
+      (bay) => !EXPANSION_BAY_NAMES.includes(bay.name)
+    )
+    expect(baseBays.length).toBeGreaterThan(0)
+    for (const bay of baseBays) {
+      expect(bay.expansion ?? false).toBe(false)
+    }
+  })
+})

--- a/packages/salvageunion-reference/lib/schemas/entities.ts
+++ b/packages/salvageunion-reference/lib/schemas/entities.ts
@@ -164,6 +164,12 @@ export const CrawlerBayCostSchema = z
  *   and/or `techLevel`, and typically no crew NPC or damaged effect.
  */
 export const CrawlerBaySchema = BaseEntitySchema.extend({
+  expansion: z
+    .boolean()
+    .describe(
+      'True for expansion "upgrade"/found bays acquired during play (built for a resource cost or found as a scenario facility); absent/false for base facilities pre-installed on every Union Crawler. A stored data tag (mirrors the legalStarting convention) — never computed from source/cost/techLevel.'
+    )
+    .optional(),
   damagedEffect: z.string().describe('Effect when this bay is damaged').optional(),
   npc: NpcSchema.describe('NPC crew member who operates this bay').optional(),
   techLevel: TechLevelSchema.describe('Tech level of this bay').optional(),

--- a/packages/salvageunion-reference/schemas/crawler-bays.schema.json
+++ b/packages/salvageunion-reference/schemas/crawler-bays.schema.json
@@ -211,6 +211,10 @@
         },
         "description": "Other source books where this entity is reprinted"
       },
+      "expansion": {
+        "type": "boolean",
+        "description": "True for expansion \"upgrade\"/found bays acquired during play (built for a resource cost or found as a scenario facility); absent/false for base facilities pre-installed on every Union Crawler. A stored data tag (mirrors the legalStarting convention) — never computed from source/cost/techLevel."
+      },
       "damagedEffect": { "type": "string", "description": "Effect when this bay is damaged" },
       "npc": {
         "description": "NPC crew member who operates this bay",


### PR DESCRIPTION
## Feedback

> Crawler wizard auto-installs expansion bays (Bio/Nanite/VR Tubes) on new crawlers; seed base bays only.

When a new Crawler is created in ITUN, the wizard seeded the **entire** crawler-bay catalog onto it, including expansion bays that should only be acquired later in play (built with resources or found in scenarios). `seedDefaultCrawlerBays()` mapped every bay from `SalvageUnionReference.CrawlerBays.all()` into the crawler's `crawlerBays` array unconditionally, and nothing in the schema distinguished base facilities from expansion bays.

## UX area

`apps/in-the-union-now` Crawler creation wizard — `seedDefaultCrawlerBays()` in `src/lib/wizard/crawlerFormState.ts`, consumed by `CrawlerBuilder.tsx`. Underlying data/schema in `packages/salvageunion-reference` (`data/crawler-bays.json` + `lib/schemas/entities.ts` `CrawlerBaySchema`).

## SURules reference

- **Salvage Union Core Book Digital Edition 2.0a, "Union Crawler Bays" (p.221):** "Your Union Crawler has the following Bays that your Pilots have access to during Downtime." This enumerates the base facilities (Command, Mech, Storage, Armament, Crafting, Trading, Med, Pilot, Armoury, Cantina) as the crawler's built-in sections — the bays that ARE pre-installed.
- **Expansion booklets** (recorded in `crawler-bays.json` `source`/`page`): Bio-Mech Bay & Bio-Crafting Bay (*We Were Here First!* p.61), Nanite Processing Bay (*False Flag* p.66), VR Tubes (*Rainmaker* p.57). Each expansion bay's own text specifies it must be acquired during play — built for a resource cost (e.g. Bio-Mech Bay: 10 Bio-Salvage + 5 Tech-1 Scrap; Nanite Processing Bay: 5 Tech-6 Scrap) or found as a scenario facility (VR Tubes). They are explicitly upgrades/found bays, NOT pre-installed.

The data confirmed exactly four expansion-source entries (all from expansion booklets, all without a crew NPC, all with a `cost`/`techLevel`), versus ten base facilities (all *Salvage Union Workshop Manual*, each with a crew `npc`). **Bio-Crafting Bay is confirmed as expansion** (*We Were Here First!* p.61), so it is tagged too.

## Fix

- Added an explicit `expansion: z.boolean().optional()` data tag to `CrawlerBaySchema` (mirrors the established `legalStarting` data-tag convention from PR #292 — a stored tag, never computed from source/cost/techLevel).
- Tagged the four expansion-source bays in `crawler-bays.json` with `expansion: true` (Bio-Mech Bay, Bio-Crafting Bay, Nanite Processing Bay, VR Tubes); base bays left untagged. Edited via text-level insertion to preserve array formatting.
- Rebuilt the package (`bun run build:package` regenerated `schemas/crawler-bays.schema.json`).
- Changed `seedDefaultCrawlerBays()` to `bays.filter((b) => !b.expansion).map(...)`, so only base facilities are pre-installed.
- Updated the `CrawlerBuilder` seeded-count assertion to the base-bay count and added a guard that no expansion bay is auto-installed; added a reference-package test asserting the expansion bays carry the flag and base bays do not.

Existing crawlers in IndexedDB are unaffected (their `crawlerBays` arrays are already persisted); only newly-created crawlers get the corrected seed.

## Checks

- `bun run build:package` — passed
- `bun run validate:all` — passed
- `bun run typecheck` — passed
- `bun --filter salvageunion-reference test` (590 pass) + `bun --filter in-the-union-now test` (891 pass) — passed
- `bun run lint` — clean
- `bun run format` — applied
- Pre-commit (lint-fix, format) and pre-push (typecheck, test, validate:all, knip) hooks — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)