### PR TITLE
feat(suref-react): show Non-Advanceable tag for non-advanceable classes

### DIFF
--- a/apps/suref-web/src/lib/changelog.ts
+++ b/apps/suref-web/src/lib/changelog.ts
@@ -6,6 +6,13 @@ type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: '2026-06-24',
+    title: 'Non-advanceable classes call it out',
+    items: [
+      'Classes that cannot advance to a hybrid class now show a "Non-Advanceable" tag, instead of silently omitting the "Advanceable" label and leaving it ambiguous.',
+    ],
+  },
+  {
     date: '2026-06-23',
     title: 'Steadier catalog grid on load',
     items: [

--- a/packages/suref-react/src/lib/referenceEntityDataExtraction.ts
+++ b/packages/suref-react/src/lib/referenceEntityDataExtraction.ts
@@ -300,8 +300,11 @@ export function extractReferenceEntityDetails(
       details.push({ label: 'Max Abilities', value: data.maxAbilities })
     }
 
-    if (!isHybrid && 'advanceable' in data && data.advanceable) {
-      details.push({ label: 'Advanceable', type: 'meta' })
+    if (!isHybrid && 'advanceable' in data) {
+      details.push({
+        label: data.advanceable ? 'Advanceable' : 'Non-Advanceable',
+        type: 'meta',
+      })
     }
 
     if (isHybrid && 'advancedTree' in data) {


### PR DESCRIPTION
## Summary

Class entity displays now render a **"Non-Advanceable"** meta tag for class records with `advanceable: false`, instead of omitting the tag entirely. Previously, only advanceable classes got an "Advanceable" tag — leaving non-advanceable classes silently unlabeled and the distinction ambiguous.

The non-hybrid `advanceable` branch in `referenceEntityDataExtraction.ts` now always pushes a meta tag, labeled `Advanceable` or `Non-Advanceable` based on the boolean value.

## Changes

- `packages/suref-react/src/lib/referenceEntityDataExtraction.ts` — always emit the meta tag for non-hybrid classes, labeled by the `advanceable` value.
- `apps/suref-web/src/lib/changelog.ts` — changelog entry for the user-visible change.

## Verification

- `bun run lint` — pass
- `bun run typecheck` — pass (all packages)
- `bun --filter suref-react test` — 310 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VCCaRu39b7aooYEHzyx6Ue