### PR TITLE
fix(itun): allow duplicate mech systems/modules in the wizard

### DIFF
--- a/apps/in-the-union-now/src/components/mech/PatternStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/PatternStep.tsx
@@ -4,16 +4,21 @@ import { Field, Input, OptRow, ReferenceEntityDisplay, SectionSeparator } from '
 import { patternsForChassis } from './patternData'
 import type { PatternLike } from './patternData'
 
-/** Resolve a pattern's system/module name refs to display entities. */
+/**
+ * Resolve a pattern's system/module name refs to display entities. Keys carry
+ * the source index so a pattern that installs duplicate equipment renders one
+ * card per copy (duplicates are valid — slots are the only limit), instead of
+ * colliding on a name-based key and silently dropping the repeat.
+ */
 function resolvePatternEntities(pattern: PatternLike): { key: string; entity: SURefEntity }[] {
   return [
-    ...(pattern.systems ?? []).flatMap((s) => {
+    ...(pattern.systems ?? []).flatMap((s, i) => {
       const found = SalvageUnionReference.Systems.find((x) => x.name === s.name)
-      return found ? [{ key: `sys-${s.name}`, entity: found as unknown as SURefEntity }] : []
+      return found ? [{ key: `sys-${i}-${s.name}`, entity: found as unknown as SURefEntity }] : []
     }),
-    ...(pattern.modules ?? []).flatMap((m) => {
+    ...(pattern.modules ?? []).flatMap((m, i) => {
       const found = SalvageUnionReference.Modules.find((x) => x.name === m.name)
-      return found ? [{ key: `mod-${m.name}`, entity: found as unknown as SURefEntity }] : []
+      return found ? [{ key: `mod-${i}-${m.name}`, entity: found as unknown as SURefEntity }] : []
     }),
   ]
 }

--- a/apps/in-the-union-now/src/components/mech/__tests__/MechWizard.test.tsx
+++ b/apps/in-the-union-now/src/components/mech/__tests__/MechWizard.test.tsx
@@ -351,6 +351,56 @@ describe('MechWizard — duplicate installs', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Canonical patterns: duplicate equipment in a pre-made pattern survives copy
+// ---------------------------------------------------------------------------
+
+describe('MechWizard — pattern duplicates', () => {
+  it('preserves duplicate systems/modules when copying a canonical pattern', async () => {
+    // Find a chassis whose pattern data contains a repeated system or module.
+    const allChassis = SalvageUnionReference.Chassis.all()
+    let target:
+      | { chassisName: string; pattern: ReturnType<typeof patternsForChassis>[number] }
+      | undefined
+    for (const c of allChassis) {
+      for (const p of patternsForChassis(c.name)) {
+        const sysNames = (p.systems ?? []).map((s) => s.name)
+        const modNames = (p.modules ?? []).map((m) => m.name)
+        const hasDup =
+          new Set(sysNames).size !== sysNames.length || new Set(modNames).size !== modNames.length
+        if (hasDup) {
+          target = { chassisName: c.name, pattern: p }
+          break
+        }
+      }
+      if (target) break
+    }
+
+    if (!target) {
+      // No canonical pattern ships with duplicates today — nothing to assert.
+      return
+    }
+
+    render(<MechWizard onComplete={() => {}} onCancel={() => {}} />)
+    await pick(target.chassisName)
+    await clickNext() // Pattern
+    await pick(target.pattern.name) // canonical pattern — skips Loadout
+    await clickNext() // Identity
+    await typeInto(/Mech name/i, 'Pattern Build')
+    await clickNext() // Review
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Create Mech/i }))
+    })
+
+    await waitFor(() => {
+      const m = useEntityStore.getState().list('mech')[0]!
+      // Duplicates from the canonical pattern survive the copy + render path.
+      expect(m.systems).toEqual((target!.pattern.systems ?? []).map((s) => s.name))
+      expect(m.modules).toEqual((target!.pattern.modules ?? []).map((mod) => mod.name))
+    })
+  }, 30000)
+})
+
+// ---------------------------------------------------------------------------
 // Edit mode: upsert branch — loadout edits without duplicating
 // ---------------------------------------------------------------------------
 

--- a/apps/in-the-union-now/src/components/mech/__tests__/MechWizard.test.tsx
+++ b/apps/in-the-union-now/src/components/mech/__tests__/MechWizard.test.tsx
@@ -355,36 +355,57 @@ describe('MechWizard — duplicate installs', () => {
 // ---------------------------------------------------------------------------
 
 describe('MechWizard — pattern duplicates', () => {
-  it('preserves duplicate systems/modules when copying a canonical pattern', async () => {
-    // Find a chassis whose pattern data contains a repeated system or module.
+  it('renders one preview card per copy and preserves duplicates when copying a canonical pattern', async () => {
+    // Find a chassis whose pattern data contains a repeated system or module,
+    // and capture the repeated name + its copy count.
     const allChassis = SalvageUnionReference.Chassis.all()
     let target:
-      | { chassisName: string; pattern: ReturnType<typeof patternsForChassis>[number] }
+      | {
+          chassisName: string
+          pattern: ReturnType<typeof patternsForChassis>[number]
+          dupName: string
+          dupCount: number
+        }
       | undefined
     for (const c of allChassis) {
       for (const p of patternsForChassis(c.name)) {
-        const sysNames = (p.systems ?? []).map((s) => s.name)
-        const modNames = (p.modules ?? []).map((m) => m.name)
-        const hasDup =
-          new Set(sysNames).size !== sysNames.length || new Set(modNames).size !== modNames.length
-        if (hasDup) {
-          target = { chassisName: c.name, pattern: p }
+        const names = [...(p.systems ?? []), ...(p.modules ?? [])].map((e) => e.name)
+        const counts = new Map<string, number>()
+        for (const n of names) counts.set(n, (counts.get(n) ?? 0) + 1)
+        const dup = [...counts.entries()].find(([, count]) => count > 1)
+        if (dup) {
+          target = { chassisName: c.name, pattern: p, dupName: dup[0], dupCount: dup[1] }
           break
         }
       }
       if (target) break
     }
 
-    if (!target) {
-      // No canonical pattern ships with duplicates today — nothing to assert.
-      return
-    }
+    // Fail loudly rather than silently no-op: a canonical pattern with
+    // duplicate equipment is required fixture data (today: Trooper / DronTek,
+    // with Articulated Rigging Arm ×2). If this ever returns undefined the
+    // fixture has drifted and the test must be updated, not silently skipped.
+    expect(
+      target,
+      'expected a canonical pattern shipping duplicate equipment (fixture drift?)'
+    ).toBeDefined()
+    const { chassisName, pattern, dupName, dupCount } = target!
 
     render(<MechWizard onComplete={() => {}} onCancel={() => {}} />)
-    await pick(target.chassisName)
+    await pick(chassisName)
     await clickNext() // Pattern
-    await pick(target.pattern.name) // canonical pattern — skips Loadout
-    await clickNext() // Identity
+
+    // Select the canonical pattern — its Loadout preview renders below.
+    await pick(pattern.name)
+
+    // The preview renders one head card per copy: the repeated entity's name
+    // appears `dupCount` times (the per-index keys keep both copies mounted
+    // instead of collapsing the repeat onto a single name-keyed card).
+    await waitFor(() => {
+      expect(screen.getAllByText(dupName).length).toBe(dupCount)
+    })
+
+    await clickNext() // Identity (canonical pattern skips Loadout)
     await typeInto(/Mech name/i, 'Pattern Build')
     await clickNext() // Review
     await act(async () => {
@@ -393,9 +414,9 @@ describe('MechWizard — pattern duplicates', () => {
 
     await waitFor(() => {
       const m = useEntityStore.getState().list('mech')[0]!
-      // Duplicates from the canonical pattern survive the copy + render path.
-      expect(m.systems).toEqual((target!.pattern.systems ?? []).map((s) => s.name))
-      expect(m.modules).toEqual((target!.pattern.modules ?? []).map((mod) => mod.name))
+      // Duplicates from the canonical pattern survive the copy + persistence.
+      expect(m.systems).toEqual((pattern.systems ?? []).map((s) => s.name))
+      expect(m.modules).toEqual((pattern.modules ?? []).map((mod) => mod.name))
     })
   }, 30000)
 })


### PR DESCRIPTION
> **STACKED PR** — this builds on `fix/itun-installed-stat-bonuses` and should merge **after** it. The base is that branch, not `main`; review its diff there.

## Feedback

ITUN's mech builder could not install two copies of the same system or module, and pre-made patterns that contained duplicate equipment lost those duplicates. The mech wizard modeled a loadout as a set of item *names* (`string[]`) with `includes()`/toggle semantics, so adding an item already present toggled it off instead of adding a second instance. Selection cards were binary (selected vs not) with no quantity, and the loadout/preview panels keyed chosen entities by id (or by name), so duplicates collapsed visually too. The same set-style path ran for canonical patterns, which is why pre-made patterns also appeared to have their duplicate entries stripped.

The persisted Zod schemas (`mech.ts` / `pattern.ts`: `systems`/`modules` are `z.array(z.string())`) already permit duplicates — `["x","x"]` is valid — so this was purely a UI-layer restriction, not a data constraint.

## UX area

`apps/in-the-union-now` mech wizard (route `src/routes/mechs`):
- `components/mech/MechWizard.tsx` — `toggleIn` → `addCopy`/`removeCopy`
- `components/mech/InstallStep.tsx`, `LoadoutStep.tsx` — count-driven add/remove instead of toggle
- `components/wizard/SelCard.tsx` — opt-in quantity mode (count + ＋/− steppers)
- `components/mech/LoadoutPanel.tsx`, `MechReviewStep.tsx`, `PatternStep.tsx` — key chosen entities by position so duplicates each render

## Salvage Union rule

There is no rule forbidding duplicate installs — **slots are the only limit**, and ITUN already treats slot capacity as a soft warning:
- *Salvage Union Core Book Digital Edition 2.0a*, **p. 97** ("Systems & Modules"): a Mech's System/Module Slot value "represents how many Systems/Modules it can mount." The constraint is slot count, not uniqueness.
- *Core 2.0a*, **Mount action, p. 178**: "You can Mount or Dismount **any number** of Systems and Modules… The Mech must have enough System or Module Slots to mount the new System or Module and the slots must be empty." The only gate is free slots.

## Fix

Stop treating the loadout as a name-set; allow repeated entries.
- **SelCard** gains an opt-in quantity mode: when `onAdd` is supplied it renders a per-item count badge with add (＋) / remove (−) steppers in place of the binary toggle. Existing binary callers (pilot abilities/equipment, crawler systems) are untouched.
- **InstallStep / LoadoutStep / MechWizard**: card count comes from `selected.filter(n => n === item.name).length`; "add" appends a copy, "remove" drops the first match. No more `includes()`/toggle dedup.
- **LoadoutPanel / MechReviewStep / PatternStep**: key chosen entities by array position (not id/name) so duplicate copies — including canonical-pattern duplicates — each render instead of colliding on a shared key.
- Capacity stays soft: over-slot installs warn but never block (existing behavior preserved).

No schema change (arrays already allow duplicates). New tests cover: appending a second copy instead of toggling off, single-copy removal via the stepper, and canonical patterns preserving duplicate equipment.

## Checks

- `bun run typecheck` — pass
- `bun --filter in-the-union-now test` — 899 pass / 0 fail (incl. 3 new duplicate-install tests)
- `bun run lint` — pass (all packages)
- `bun run format` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)