### PR TITLE
style(itun): unify shared color tokens, align layout, kill visual jitter

### DIFF
--- a/apps/in-the-union-now/src/components/crawler/CrawlerBuilder.tsx
+++ b/apps/in-the-union-now/src/components/crawler/CrawlerBuilder.tsx
@@ -22,6 +22,8 @@ import {
   seedDefaultCrawlerBays,
 } from '../../lib/wizard/crawlerFormState'
 import type { CrawlerWizardFormState } from '../../lib/wizard/crawlerFormState'
+import type { SoftWarning } from '../../lib/rules/types'
+import { SoftWarningBanner } from '../shared/SoftWarningBanner'
 import { WizShell } from '../wizard/WizShell'
 import { CrawlerCrewStep } from './CrawlerCrewStep'
 import { CrawlerIdentityStep } from './CrawlerIdentityStep'
@@ -308,16 +310,18 @@ export function CrawlerBuilder({
     (v) => v.kind === 'weapon-systems-over-capacity'
   )
 
+  const capacityWarnings: SoftWarning[] = isOverCapacity
+    ? [
+        {
+          code: 'weapon-systems-over-capacity',
+          severity: 'warn',
+          message: `Over capacity — ${crawlerCapacity.weaponSystemsUsed} weapon systems installed, ${crawlerCapacity.weaponSystemsMax} supported for this crawler type. You can still save; review before play.`,
+        },
+      ]
+    : []
   const capacityNotice =
-    isOverCapacity && (step === 'Systems' || step === 'Review') ? (
-      <p
-        role="status"
-        className="rounded-[3px] border-[1.5px] border-rust bg-rust/10 px-3 py-2 text-sm text-ink"
-      >
-        <strong>Over capacity</strong> — {crawlerCapacity.weaponSystemsUsed} weapon systems
-        installed, {crawlerCapacity.weaponSystemsMax} supported for this crawler type. You can still
-        save; review before play.
-      </p>
+    step === 'Systems' || step === 'Review' ? (
+      <SoftWarningBanner warnings={capacityWarnings} />
     ) : undefined
 
   const subtitle = (() => {

--- a/apps/in-the-union-now/src/components/crawler/CrawlerCrewStep.tsx
+++ b/apps/in-the-union-now/src/components/crawler/CrawlerCrewStep.tsx
@@ -50,7 +50,7 @@ export function CrawlerCrewStep({ bays, selectedType, crew, onChange }: CrawlerC
   }
 
   return (
-    <div className="max-w-[760px] space-y-5">
+    <div className="max-w-3xl space-y-5">
       <p className="font-body text-xs text-wk-muted">
         Each crewed bay is run by its own lead, and your crawler type brings a special NPC. Name and
         detail them now, or leave them blank and fill them in during play.
@@ -67,7 +67,7 @@ export function CrawlerCrewStep({ bays, selectedType, crew, onChange }: CrawlerC
             className="space-y-3 rounded-[3px] border-[1.5px] border-wk-faint p-4"
           >
             <header>
-              <h3 className="font-cond text-[13px] font-bold uppercase tracking-[0.1em] text-ink">
+              <h3 className="font-cond text-sm font-bold uppercase tracking-[0.1em] text-ink">
                 {source.label}
               </h3>
               {source.npc.position && (

--- a/apps/in-the-union-now/src/components/crawler/CrawlerIdentityStep.tsx
+++ b/apps/in-the-union-now/src/components/crawler/CrawlerIdentityStep.tsx
@@ -29,7 +29,7 @@ export function CrawlerIdentityStep({
   onChange,
 }: CrawlerIdentityStepProps) {
   return (
-    <div className="max-w-[760px] space-y-5">
+    <div className="max-w-3xl space-y-5">
       <Field label="Crawler Name" required htmlFor="crawler-name">
         <Input
           id="crawler-name"
@@ -43,7 +43,7 @@ export function CrawlerIdentityStep({
 
       <section className="space-y-4 rounded-[3px] border-[1.5px] border-wk-faint p-4">
         <header>
-          <h2 className="font-cond text-[13px] font-bold uppercase tracking-[0.1em] text-ink">
+          <h2 className="font-cond text-sm font-bold uppercase tracking-[0.1em] text-ink">
             Starting Resources
           </h2>
           <p className="mt-0.5 font-body text-xs text-wk-muted">

--- a/apps/in-the-union-now/src/components/crawler/CrawlerReviewStep.tsx
+++ b/apps/in-the-union-now/src/components/crawler/CrawlerReviewStep.tsx
@@ -20,7 +20,7 @@ function KvRow({ label, value }: { label: string; value: string | null }) {
       <span className="w-[120px] shrink-0 font-cond text-xs font-bold uppercase tracking-[0.1em] text-wk-muted">
         {label}
       </span>
-      <span className={value ? 'font-body text-[13.5px] text-ink' : 'text-rust'}>
+      <span className={value ? 'font-body text-sm text-ink' : 'text-rust'}>
         {value ?? 'required'}
       </span>
     </div>
@@ -57,7 +57,7 @@ export function CrawlerReviewStep({
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.1fr_1fr]">
       {/* kv-panel */}
-      <div className="self-start rounded-md border-[1.5px] border-ink bg-paper px-6 py-4 text-sm">
+      <div className="self-start rounded-[3px] border-[1.5px] border-ink bg-paper p-4 text-sm">
         {rows.map(([k, v]) => (
           <KvRow key={k} label={k} value={v} />
         ))}

--- a/apps/in-the-union-now/src/components/crawler/SystemsList.tsx
+++ b/apps/in-the-union-now/src/components/crawler/SystemsList.tsx
@@ -56,7 +56,7 @@ export function SystemsList({
   }
 
   return (
-    <div className="columns-1 gap-3.5 sm:columns-2 [&>*]:mb-3.5 [&>*]:break-inside-avoid">
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
       {systems.map((system) => {
         const selected = selectedSystemSlugs.includes(system.id)
         const disabled = !selected && atCap

--- a/apps/in-the-union-now/src/components/dashboard/Dashboard.tsx
+++ b/apps/in-the-union-now/src/components/dashboard/Dashboard.tsx
@@ -163,12 +163,12 @@ export function Dashboard() {
   }
 
   return (
-    <main className="min-h-screen bg-wk-bg px-4 py-5 sm:px-12 sm:py-10">
+    <main className="min-h-screen bg-wk-bg px-4 py-5 sm:px-8 sm:py-10 lg:px-12">
       {/* Header: h1 + Download all/Import row · workspace faux-select */}
       <div className="border-b-2 border-ink pb-5">
-        <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
-            <h1 className="font-cond text-xl font-bold uppercase leading-none tracking-[.02em] text-ink md:text-[31px]">
+            <h1 className="font-cond text-xl font-bold uppercase leading-none tracking-[0.04em] text-ink md:text-[31px]">
               ITUN
               <span className="ml-1.5 inline-block rounded bg-rust px-1.5 py-0.5 align-[0.35em] font-cond text-[10px] font-bold uppercase leading-none tracking-[0.12em] text-wk-bg md:text-[11px]">
                 Beta
@@ -187,131 +187,135 @@ export function Dashboard() {
         </div>
       </div>
 
-      {!hydratedAll ? (
-        <div aria-label="Loading saved builds" className="py-12 text-center text-wk-muted">
-          Loading…
-        </div>
-      ) : (
-        <>
-          {/* Mobile-endpoint segmented Pilot/Mech/Crawler switch (design §3.7) */}
-          <div className="mt-5 flex gap-2 md:hidden">
-            {SEGMENTS.map((seg) => (
-              <Btn
-                key={seg.kind}
-                size="sm"
-                variant={activeSegment === seg.kind ? 'primary' : 'default'}
-                aria-pressed={activeSegment === seg.kind}
-                onClick={() => setActiveSegment(seg.kind)}
-                className="min-h-11 flex-1"
-              >
-                {seg.label}
-              </Btn>
-            ))}
+      {/* Reserve a stable footprint so the grid replacing "Loading…" doesn't
+          shift the rest of the page on hydration. */}
+      <div className="min-h-[60vh]">
+        {!hydratedAll ? (
+          <div aria-label="Loading saved builds" className="py-12 text-center text-wk-muted">
+            Loading…
           </div>
-
-          <div className="mt-5 grid grid-cols-1 gap-[30px] md:mt-[26px] md:grid-cols-3">
-            <DashboardColumn
-              title="Pilots"
-              headingId="pilots-heading"
-              active={activeSegment === 'pilot'}
-              createHref="/pilots/new"
-              createLabel="Create Pilot"
-              emptyLabel="No pilots yet."
-            >
-              {pilots.map((p) => {
-                const mechLink = softLinks.find(
-                  (l) => l.type === 'mech-to-pilot' && l.to.id === p.id
-                )
-                const crawlerLink = softLinks.find(
-                  (l) => l.type === 'pilot-to-crawler' && l.from.id === p.id
-                )
-                return (
-                  <EntityListItem
-                    key={p.id}
-                    id={p.id}
-                    name={p.name}
-                    href={`/pilots/${p.id}`}
-                    sheetHref={`/sheet/pilot/${p.id}`}
-                    onDeleteClick={(id, name) => openDeleteDialog('pilot', id, name)}
-                    meta={joinMeta([
-                      p.callsign ? `"${p.callsign}"` : null,
-                      resolveClassName(p.classRef),
-                      linkSegment(mechLink && mechNameById.get(mechLink.from.id)),
-                      linkSegment(crawlerLink && crawlerNameById.get(crawlerLink.to.id)),
-                    ])}
-                  />
-                )
-              })}
-            </DashboardColumn>
-
-            <DashboardColumn
-              title="Mechs"
-              headingId="mechs-heading"
-              active={activeSegment === 'mech'}
-              createHref="/mechs/new"
-              createLabel="Create Mech"
-              emptyLabel="No mechs yet."
-              headExtra={
-                <AppLink
-                  href="/mechs/patterns"
-                  className={cn(btnVariants({ variant: 'ghost', size: 'sm' }), 'no-underline')}
+        ) : (
+          <>
+            {/* Mobile-endpoint segmented Pilot/Mech/Crawler switch (design §3.7) */}
+            <div className="mt-5 flex gap-2 md:hidden">
+              {SEGMENTS.map((seg) => (
+                <Btn
+                  key={seg.kind}
+                  size="sm"
+                  variant={activeSegment === seg.kind ? 'primary' : 'default'}
+                  aria-pressed={activeSegment === seg.kind}
+                  onClick={() => setActiveSegment(seg.kind)}
+                  className="min-h-11 flex-1"
                 >
-                  Patterns
-                </AppLink>
-              }
-            >
-              {mechs.map((m) => {
-                const pilotLink = softLinks.find(
-                  (l) => l.type === 'mech-to-pilot' && l.from.id === m.id
-                )
-                return (
-                  <EntityListItem
-                    key={m.id}
-                    id={m.id}
-                    name={m.name}
-                    href={`/mechs/${m.id}`}
-                    sheetHref={`/sheet/mech/${m.id}`}
-                    onDeleteClick={(id, name) => openDeleteDialog('mech', id, name)}
-                    meta={joinMeta([
-                      mechChassisMeta(m.chassisRef),
-                      linkSegment(pilotLink && pilotNameById.get(pilotLink.to.id)),
-                    ])}
-                  />
-                )
-              })}
-            </DashboardColumn>
+                  {seg.label}
+                </Btn>
+              ))}
+            </div>
 
-            <DashboardColumn
-              title="Crawlers"
-              headingId="crawlers-heading"
-              active={activeSegment === 'crawler'}
-              createHref="/crawlers/new"
-              createLabel="Create Crawler"
-              emptyLabel="No crawlers yet."
-            >
-              {crawlers.map((c) => {
-                const crewLinks = softLinks.filter(
-                  (l) => l.type === 'pilot-to-crawler' && l.to.id === c.id
-                )
-                return (
-                  <EntityListItem
-                    key={c.id}
-                    id={c.id}
-                    name={c.name}
-                    href={`/crawlers/${c.id}`}
-                    sheetHref={`/sheet/crawler/${c.id}`}
-                    onDeleteClick={(id, name) => openDeleteDialog('crawler', id, name)}
-                    meta={joinMeta([
-                      crawlerTypeMeta(c.techLevel, c.crawlerBays?.length ?? 0),
-                      ...crewLinks.map((l) => linkSegment(pilotNameById.get(l.from.id))),
-                    ])}
-                  />
-                )
-              })}
-            </DashboardColumn>
-          </div>
-        </>
-      )}
+            <div className="mt-5 grid grid-cols-1 gap-8 md:mt-6 md:grid-cols-3">
+              <DashboardColumn
+                title="Pilots"
+                headingId="pilots-heading"
+                active={activeSegment === 'pilot'}
+                createHref="/pilots/new"
+                createLabel="Create Pilot"
+                emptyLabel="No pilots yet."
+              >
+                {pilots.map((p) => {
+                  const mechLink = softLinks.find(
+                    (l) => l.type === 'mech-to-pilot' && l.to.id === p.id
+                  )
+                  const crawlerLink = softLinks.find(
+                    (l) => l.type === 'pilot-to-crawler' && l.from.id === p.id
+                  )
+                  return (
+                    <EntityListItem
+                      key={p.id}
+                      id={p.id}
+                      name={p.name}
+                      href={`/pilots/${p.id}`}
+                      sheetHref={`/sheet/pilot/${p.id}`}
+                      onDeleteClick={(id, name) => openDeleteDialog('pilot', id, name)}
+                      meta={joinMeta([
+                        p.callsign ? `"${p.callsign}"` : null,
+                        resolveClassName(p.classRef),
+                        linkSegment(mechLink && mechNameById.get(mechLink.from.id)),
+                        linkSegment(crawlerLink && crawlerNameById.get(crawlerLink.to.id)),
+                      ])}
+                    />
+                  )
+                })}
+              </DashboardColumn>
+
+              <DashboardColumn
+                title="Mechs"
+                headingId="mechs-heading"
+                active={activeSegment === 'mech'}
+                createHref="/mechs/new"
+                createLabel="Create Mech"
+                emptyLabel="No mechs yet."
+                headExtra={
+                  <AppLink
+                    href="/mechs/patterns"
+                    className={cn(btnVariants({ variant: 'ghost', size: 'sm' }), 'no-underline')}
+                  >
+                    Patterns
+                  </AppLink>
+                }
+              >
+                {mechs.map((m) => {
+                  const pilotLink = softLinks.find(
+                    (l) => l.type === 'mech-to-pilot' && l.from.id === m.id
+                  )
+                  return (
+                    <EntityListItem
+                      key={m.id}
+                      id={m.id}
+                      name={m.name}
+                      href={`/mechs/${m.id}`}
+                      sheetHref={`/sheet/mech/${m.id}`}
+                      onDeleteClick={(id, name) => openDeleteDialog('mech', id, name)}
+                      meta={joinMeta([
+                        mechChassisMeta(m.chassisRef),
+                        linkSegment(pilotLink && pilotNameById.get(pilotLink.to.id)),
+                      ])}
+                    />
+                  )
+                })}
+              </DashboardColumn>
+
+              <DashboardColumn
+                title="Crawlers"
+                headingId="crawlers-heading"
+                active={activeSegment === 'crawler'}
+                createHref="/crawlers/new"
+                createLabel="Create Crawler"
+                emptyLabel="No crawlers yet."
+              >
+                {crawlers.map((c) => {
+                  const crewLinks = softLinks.filter(
+                    (l) => l.type === 'pilot-to-crawler' && l.to.id === c.id
+                  )
+                  return (
+                    <EntityListItem
+                      key={c.id}
+                      id={c.id}
+                      name={c.name}
+                      href={`/crawlers/${c.id}`}
+                      sheetHref={`/sheet/crawler/${c.id}`}
+                      onDeleteClick={(id, name) => openDeleteDialog('crawler', id, name)}
+                      meta={joinMeta([
+                        crawlerTypeMeta(c.techLevel, c.crawlerBays?.length ?? 0),
+                        ...crewLinks.map((l) => linkSegment(pilotNameById.get(l.from.id))),
+                      ])}
+                    />
+                  )
+                })}
+              </DashboardColumn>
+            </div>
+          </>
+        )}
+      </div>
 
       <DeleteConfirmDialog
         open={deleteTarget !== null}
@@ -362,12 +366,16 @@ function DashboardColumn({
         </h2>
         <div className="flex items-center gap-1.5">
           {headExtra}
-          <AppLink
-            href={createHref}
-            className={cn(btnVariants({ variant: 'default', size: 'sm' }), 'no-underline')}
-          >
-            + {createLabel}
-          </AppLink>
+          {/* One create CTA per column: the header link shows only when the
+              column has rows; the empty state renders its own create CTA. */}
+          {children.length > 0 && (
+            <AppLink
+              href={createHref}
+              className={cn(btnVariants({ variant: 'default', size: 'sm' }), 'no-underline')}
+            >
+              + {createLabel}
+            </AppLink>
+          )}
         </div>
       </div>
       {children.length === 0 ? (

--- a/apps/in-the-union-now/src/components/dashboard/DeleteConfirmDialog.tsx
+++ b/apps/in-the-union-now/src/components/dashboard/DeleteConfirmDialog.tsx
@@ -41,7 +41,7 @@ function DeleteConfirmDialogInner({
       >
         <h2
           id="delete-dialog-title"
-          className="font-cond mb-2 text-lg font-bold uppercase tracking-[.04em] text-ink"
+          className="font-cond mb-2 text-base font-bold uppercase tracking-[.06em] text-ink"
         >
           Delete {entityName}?
         </h2>
@@ -49,10 +49,10 @@ function DeleteConfirmDialogInner({
           This action cannot be undone. {entityName} will be permanently removed.
         </p>
         <div className="flex justify-end gap-3">
-          <Btn variant="ghost" onClick={onCancel}>
+          <Btn variant="ghost" size="sm" onClick={onCancel}>
             Cancel
           </Btn>
-          <Btn variant="danger" onClick={onConfirm}>
+          <Btn variant="danger" size="sm" onClick={onConfirm}>
             Delete
           </Btn>
         </div>

--- a/apps/in-the-union-now/src/components/dashboard/EntityListItem.tsx
+++ b/apps/in-the-union-now/src/components/dashboard/EntityListItem.tsx
@@ -7,6 +7,7 @@
  * so the component works in tests without a RouterProvider.
  */
 
+import { Trash2 } from 'lucide-react'
 import { Btn, btnVariants, Row } from 'suref-react'
 
 import { cn } from '../../lib/utils'
@@ -96,9 +97,9 @@ export function EntityListItem({
               size="sm"
               aria-label={`Delete ${name}`}
               onClick={() => onDeleteClick(id, name)}
-              className="text-danger hover:text-danger"
+              className="px-2 text-danger hover:text-danger"
             >
-              Delete
+              <Trash2 aria-hidden="true" />
             </Btn>
           </>
         }

--- a/apps/in-the-union-now/src/components/mech/CargoLotEditor.tsx
+++ b/apps/in-the-union-now/src/components/mech/CargoLotEditor.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Btn, Field, Input } from 'suref-react'
+import { Btn, Field, Input, MiniBtn } from 'suref-react'
 import type { CargoLot, CargoLotCategory } from '../../lib/schemas/cargoLot'
 import { makeScrapLot, makeUnitLot, totalLotUnits } from '../../lib/schemas/cargoLot'
 import { cn } from '../../lib/utils'
@@ -51,7 +51,7 @@ export function CargoLotEditor({ lots, onChange, className }: CargoLotEditorProp
             <li
               key={lot.id}
               data-testid="cargo-lot"
-              className="flex items-center gap-3 rounded-[2px] border-[1.5px] border-ink bg-paper px-3 py-1.5 text-sm"
+              className="flex items-center gap-3 rounded-[3px] border-[1.5px] border-ink bg-paper px-3 py-1.5 text-sm"
             >
               <span className="min-w-0 flex-1">
                 <span className="block truncate font-cond text-sm font-bold uppercase text-ink">
@@ -67,21 +67,20 @@ export function CargoLotEditor({ lots, onChange, className }: CargoLotEditorProp
                 {lot.units}
                 <span className="text-[10px] text-wk-muted">U</span>
               </span>
-              <Btn
-                variant="ghost"
-                size="sm"
+              <MiniBtn
                 aria-label={`Remove ${lot.name}`}
                 onClick={() => removeLot(lot.id)}
+                className="shrink-0"
               >
-                Remove
-              </Btn>
+                ✕ Remove
+              </MiniBtn>
             </li>
           ))}
         </ul>
       )}
 
       {/* Add-lot form */}
-      <div className="flex flex-wrap items-end gap-2">
+      <div className="grid grid-cols-2 items-end gap-2">
         {cat !== 'SCRAP' && (
           <Field label="Item name" htmlFor="cargo-lot-name" className="min-w-40 flex-1">
             <Input

--- a/apps/in-the-union-now/src/components/mech/InstallCard.tsx
+++ b/apps/in-the-union-now/src/components/mech/InstallCard.tsx
@@ -1,5 +1,6 @@
 import type { SURefEntity } from 'salvageunion-reference'
 import { MiniBtn, ReferenceEntityDisplay } from 'suref-react'
+import { cn } from '../../lib/utils'
 
 type InstallCardProps = {
   /** The reference entity to render as a compact card. */
@@ -31,7 +32,15 @@ export function InstallCard({ entity, name, count, onAdd }: InstallCardProps) {
   const installed = count > 0
 
   return (
-    <div>
+    <div
+      className={cn(
+        'rounded-[5px]',
+        // Card-level selected affordance, matching the wizard Sel ring: a
+        // non-layout-shifting 3px rust box-shadow when one or more copies are
+        // installed (count-based, not a toggle — see component doc above).
+        installed && 'shadow-[0_0_0_3px_var(--color-rust)]'
+      )}
+    >
       <ReferenceEntityDisplay
         data={entity as SURefEntity}
         compact

--- a/apps/in-the-union-now/src/components/mech/InstallStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/InstallStep.tsx
@@ -43,7 +43,7 @@ type InstallStepProps = {
 /**
  * Install Systems / Install Modules step (design §3.2 mech wizard — NOT the
  * master-detail skeleton): a `1fr 300px` grid. Left: TL filter chips over a
- * 2-col grid of compact Sel-wrapped entity cards (gap 25 between columns).
+ * row-major 2-col grid of compact entity cards (gap-4).
  * Right: the 'Loadout · {name}' panel with pip budget tracks + head-mode
  * chosen cards. Selection is never blocked — over-capacity shows honestly in
  * the budget track (capacity stays soft, plan 3.4).
@@ -78,7 +78,7 @@ export function InstallStep({
   }
 
   return (
-    <div className="grid grid-cols-1 gap-[25px] lg:grid-cols-[minmax(0,1fr)_300px]">
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_300px]">
       {/* Left — TL filter chips + 2-col compact Sel grid */}
       <div className="min-w-0">
         <div className="flex flex-wrap gap-2" role="group" aria-label="Filter by tech level">
@@ -93,7 +93,7 @@ export function InstallStep({
           ))}
         </div>
 
-        <div className="mt-[25px] columns-1 gap-3.5 sm:columns-2 [&>*]:mb-3.5 [&>*]:break-inside-avoid">
+        <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
           {visible.map((item) => (
             <InstallCard
               key={item.id}

--- a/apps/in-the-union-now/src/components/mech/LoadoutStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/LoadoutStep.tsx
@@ -76,7 +76,7 @@ export function LoadoutStep({
       <div
         role="tablist"
         aria-label="Loadout"
-        className="mb-5 flex gap-1 border-b-[1.5px] border-wk-faint"
+        className="mb-6 flex gap-1 border-b-[1.5px] border-wk-faint"
       >
         <TabButton active={tab === 'systems'} onClick={() => setTab('systems')}>
           Systems

--- a/apps/in-the-union-now/src/components/mech/MechIdentityStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/MechIdentityStep.tsx
@@ -29,7 +29,7 @@ export function MechIdentityStep({
   const isOver = cargoUsed > cargoMax
 
   return (
-    <div className="max-w-[760px] space-y-6">
+    <div className="max-w-3xl space-y-6">
       <Field label="Mech name" required htmlFor="mech-name">
         <Input
           id="mech-name"

--- a/apps/in-the-union-now/src/components/mech/MechReviewStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/MechReviewStep.tsx
@@ -59,7 +59,7 @@ export function MechReviewStep({ form, isEdit, submitError }: MechReviewStepProp
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.1fr_1fr]">
       {/* kv-panel */}
       <div className="self-start">
-        <div className="rounded-md border-[1.5px] border-ink bg-paper px-6 py-4 text-sm">
+        <div className="rounded-[3px] border-[1.5px] border-ink bg-paper px-6 py-4 text-sm">
           {rows.map(([k, v]) => (
             <KvRow key={k} label={k} value={v} />
           ))}

--- a/apps/in-the-union-now/src/components/mech/Pattern/InstantiateFromPattern.tsx
+++ b/apps/in-the-union-now/src/components/mech/Pattern/InstantiateFromPattern.tsx
@@ -13,7 +13,7 @@ import { useState } from 'react'
 import { findChassisByRef } from '../../../lib/rules/derivedStats'
 import { useEntityStore } from '../../../stores/entityStore'
 import type { MechPattern } from '../../../lib/schemas/pattern'
-import { Button } from '../../ui/button'
+import { Btn } from 'suref-react'
 
 type InstantiateFromPatternProps = {
   pattern: MechPattern
@@ -53,18 +53,17 @@ export function InstantiateFromPattern({ pattern, onSuccess }: InstantiateFromPa
 
   return (
     <div className="flex flex-col gap-1">
-      <Button
+      <Btn
         type="button"
-        variant="outline"
         size="sm"
         onClick={() => void handleInstantiate()}
         disabled={isInstantiating}
         aria-label={`Instantiate mech from pattern ${pattern.name}`}
       >
         {isInstantiating ? 'Creating…' : 'Instantiate'}
-      </Button>
+      </Btn>
       {error && (
-        <p className="text-xs text-destructive" role="alert">
+        <p className="text-xs text-danger" role="alert">
           {error}
         </p>
       )}

--- a/apps/in-the-union-now/src/components/mech/Pattern/PatternList.tsx
+++ b/apps/in-the-union-now/src/components/mech/Pattern/PatternList.tsx
@@ -56,7 +56,7 @@ export function PatternList({ onInstantiated }: PatternListProps) {
 
   if (isLoading) {
     return (
-      <p className="text-sm text-muted-foreground" aria-live="polite">
+      <p className="text-sm text-wk-muted" aria-live="polite">
         Loading patterns…
       </p>
     )
@@ -64,7 +64,7 @@ export function PatternList({ onInstantiated }: PatternListProps) {
 
   if (loadError) {
     return (
-      <p className="text-sm text-destructive" role="alert">
+      <p className="text-sm text-danger" role="alert">
         {loadError}
       </p>
     )
@@ -72,8 +72,8 @@ export function PatternList({ onInstantiated }: PatternListProps) {
 
   if (patterns.length === 0) {
     return (
-      <div className="rounded-md border border-dashed border-border p-6 text-center">
-        <p className="text-sm text-muted-foreground">
+      <div className="rounded-[3px] border-[1.5px] border-dashed border-wk-faint p-6 text-center">
+        <p className="text-sm text-wk-muted">
           No patterns saved yet. Use &ldquo;Save as pattern&rdquo; from the mech builder to save a
           reusable template.
         </p>
@@ -89,12 +89,14 @@ export function PatternList({ onInstantiated }: PatternListProps) {
       {patterns.map((pattern) => (
         <li
           key={pattern.id}
-          className="rounded-md border border-border p-4 flex items-start justify-between gap-4"
+          className="rounded-[3px] border-[1.5px] border-ink p-4 flex items-start justify-between gap-4"
           data-testid="pattern-list-item"
         >
           <div className="flex flex-col gap-0.5 min-w-0">
-            <span className="font-medium text-sm truncate">{pattern.name}</span>
-            <span className="text-xs text-muted-foreground">
+            <span className="truncate font-cond text-sm font-bold uppercase text-ink">
+              {pattern.name}
+            </span>
+            <span className="text-xs text-wk-muted">
               Chassis: {pattern.chassisRef} &mdash; {pattern.systems.length} system
               {pattern.systems.length !== 1 ? 's' : ''}, {pattern.modules.length} module
               {pattern.modules.length !== 1 ? 's' : ''}, {pattern.cargoLots.length} cargo

--- a/apps/in-the-union-now/src/components/mech/Pattern/SavePatternButton.tsx
+++ b/apps/in-the-union-now/src/components/mech/Pattern/SavePatternButton.tsx
@@ -1,7 +1,7 @@
 /**
  * SavePatternButton — captures a mech's configuration as a named reusable pattern.
  *
- * Renders as an outline Button. On click, opens an inline dialog where the user
+ * Renders as a Btn. On click, opens an inline dialog where the user
  * enters a pattern name. On confirm, builds a MechPattern from the supplied
  * configuration and persists it via db.mechPatterns.create().
  *
@@ -14,11 +14,10 @@
  */
 
 import { useRef, useState } from 'react'
-import { toast } from 'suref-react'
+import { Btn, toast } from 'suref-react'
 import * as db from '../../../lib/db/index'
 import type { CargoLot } from '../../../lib/schemas/cargoLot'
 import { useDialogA11y } from '../../shared/useDialogA11y'
-import { Button } from '../../ui/button'
 import { cn } from '../../../lib/utils'
 
 type SavePatternButtonProps = {
@@ -88,15 +87,14 @@ export function SavePatternButton({
 
   return (
     <>
-      <Button
+      <Btn
         type="button"
-        variant="outline"
         onClick={handleOpen}
         className={cn(className)}
         aria-label="Save as pattern"
       >
         Save as pattern
-      </Button>
+      </Btn>
 
       {isOpen && (
         <SavePatternDialog
@@ -168,23 +166,24 @@ function SavePatternDialog({
         </div>
 
         {saveError && (
-          <p className="text-sm text-destructive" role="alert">
+          <p className="text-sm text-danger" role="alert">
             {saveError}
           </p>
         )}
 
         <div className="flex gap-2 justify-end">
-          <Button type="button" variant="outline" onClick={onCancel} disabled={isSaving}>
+          <Btn type="button" variant="ghost" onClick={onCancel} disabled={isSaving}>
             Cancel
-          </Button>
-          <Button
+          </Btn>
+          <Btn
             type="button"
+            variant="primary"
             onClick={() => void onSave()}
             disabled={isSaving || !patternName.trim()}
             aria-label="Save pattern"
           >
             {isSaving ? 'Saving…' : 'Save'}
-          </Button>
+          </Btn>
         </div>
       </div>
     </div>

--- a/apps/in-the-union-now/src/components/mech/PatternStep.tsx
+++ b/apps/in-the-union-now/src/components/mech/PatternStep.tsx
@@ -87,7 +87,7 @@ export function PatternDetail({
 }: PatternDetailProps) {
   if (isCustom) {
     return (
-      <div className="max-w-[760px] space-y-3">
+      <div className="max-w-3xl space-y-3">
         <Field label="Pattern name" required htmlFor="custom-pattern-name">
           <Input
             id="custom-pattern-name"
@@ -123,7 +123,7 @@ export function PatternDetail({
     <div className="space-y-3">
       <SectionSeparator label={`${pattern.name} · Loadout`} fontSize="text-xs" />
       {entities.length > 0 ? (
-        <div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           {entities.map(({ key, entity }) => (
             <ReferenceEntityDisplay
               key={key}

--- a/apps/in-the-union-now/src/components/pilot/AbilitiesStep.tsx
+++ b/apps/in-the-union-now/src/components/pilot/AbilitiesStep.tsx
@@ -135,15 +135,15 @@ export function AbilitiesStep({
           return (
             <section key={tree} className="space-y-3">
               <TreeSep name={tree} />
-              <div className="columns-1 gap-3.5 sm:columns-2 [&>*]:mb-3.5 [&>*]:break-inside-avoid">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 {treeAbilities.map(renderCard)}
               </div>
             </section>
           )
         })
       ) : (
-        // Create mode — flat 3-col grid, tree label on the card frame.
-        <div className="grid grid-cols-[repeat(auto-fill,minmax(15rem,1fr))] gap-3.5">
+        // Create mode — flat grid, tree label on the card frame.
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           {trees.flatMap((tree) => abilitiesIn(tree).map(renderCard))}
         </div>
       )}

--- a/apps/in-the-union-now/src/components/pilot/BackgroundStep.tsx
+++ b/apps/in-the-union-now/src/components/pilot/BackgroundStep.tsx
@@ -16,7 +16,7 @@ type BackgroundStepProps = {
  */
 export function BackgroundStep({ background, onChange, _rollDeps }: BackgroundStepProps) {
   return (
-    <div className="max-w-[760px] space-y-4">
+    <div className="max-w-3xl space-y-5">
       <p className="text-sm text-wk-muted">
         Describe your pilot&apos;s background. Roll for a random prompt or write your own story.
       </p>

--- a/apps/in-the-union-now/src/components/pilot/EquipmentStep.tsx
+++ b/apps/in-the-union-now/src/components/pilot/EquipmentStep.tsx
@@ -38,7 +38,7 @@ export function EquipmentStep({ selectedEquipment, onToggle, budget, _sur }: Equ
 
   return (
     <div className="w-full">
-      <div className="columns-1 gap-3.5 sm:columns-2 [&>*]:mb-3.5 [&>*]:break-inside-avoid">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         {allEquipment.map((item) => {
           const isSelected = selectedEquipment.includes(item.id)
           const isDisabled = !isSelected && isAtBudget

--- a/apps/in-the-union-now/src/components/pilot/IdentityStep.tsx
+++ b/apps/in-the-union-now/src/components/pilot/IdentityStep.tsx
@@ -96,9 +96,7 @@ export function IdentityStep({
   }
 
   return (
-    <div className="max-w-[760px] space-y-5">
-      <p className="text-sm text-wk-muted">Roll for random results or type your own.</p>
-
+    <div className="max-w-3xl space-y-5">
       <Field label="Name" required htmlFor="pilot-name">
         <Input
           id="pilot-name"

--- a/apps/in-the-union-now/src/components/pilot/ReviewStep.tsx
+++ b/apps/in-the-union-now/src/components/pilot/ReviewStep.tsx
@@ -23,7 +23,7 @@ function KvRow({ label, value }: { label: string; value: string | null }) {
       <span className="w-[120px] shrink-0 font-cond text-xs font-bold uppercase tracking-[0.1em] text-wk-muted">
         {label}
       </span>
-      <span className={value ? 'font-body text-[13.5px] text-ink' : 'text-rust'}>
+      <span className={value ? 'font-body text-sm text-ink' : 'text-rust'}>
         {value ?? 'required'}
       </span>
     </div>
@@ -74,7 +74,7 @@ export function ReviewStep({ form, trainingPoints, submitError, _sur }: ReviewSt
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.1fr_1fr]">
       {/* kv-panel */}
-      <div className="self-start rounded-md border-[1.5px] border-ink bg-paper px-6 py-4 text-sm">
+      <div className="self-start rounded-[3px] border-[1.5px] border-ink bg-paper p-4 text-sm">
         {rows.map(([k, v]) => (
           <KvRow key={k} label={k} value={v} />
         ))}

--- a/apps/in-the-union-now/src/components/shared/SoftWarningBanner.tsx
+++ b/apps/in-the-union-now/src/components/shared/SoftWarningBanner.tsx
@@ -38,7 +38,7 @@ type SoftWarningBannerProps = {
 
 const SEVERITY_STRIP: Record<SoftWarningSeverity, string> = {
   info: 'border-[var(--color-su-blue)] bg-[var(--color-su-blue-pale)] text-[var(--color-su-black)]',
-  warn: 'border-[var(--color-roll-failure)] bg-[#d7c37d33] text-[var(--color-su-black)]',
+  warn: 'border-[var(--color-roll-failure)] bg-[var(--color-su-sickly-yellow)]/20 text-[var(--color-su-black)]',
 }
 
 const SEVERITY_ICON: Record<SoftWarningSeverity, string> = {
@@ -59,11 +59,7 @@ export function SoftWarningBanner({
   if (warnings.length === 0) return null
 
   return (
-    <div
-      role="alert"
-      aria-live="polite"
-      className={cn('rounded border px-4 py-3 text-sm', className)}
-    >
+    <div role="alert" aria-live="polite" className={cn('px-4 py-3 text-sm', className)}>
       <ul className={cn('space-y-1', (onSaveAnyway || onFixIt) && 'mb-3')}>
         {warnings.map((w) => (
           <li

--- a/apps/in-the-union-now/src/components/sheet/ConditionsEditor.tsx
+++ b/apps/in-the-union-now/src/components/sheet/ConditionsEditor.tsx
@@ -41,7 +41,9 @@ function chipToneClasses(condition: string): string {
   if (WARN_CONDITIONS.has(condition.trim().toLowerCase())) {
     return 'bg-su-sickly-yellow text-ink'
   }
-  return 'bg-su-blue-pale text-wk-muted'
+  // text-su-ink-soft (not wk-muted) on blue-pale: wk-muted is ~3.96:1 here,
+  // below WCAG AA 4.5:1 for this 11px chip text; su-ink-soft is ~9.2:1.
+  return 'bg-su-blue-pale text-su-ink-soft'
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/in-the-union-now/src/components/sheet/ConditionsEditor.tsx
+++ b/apps/in-the-union-now/src/components/sheet/ConditionsEditor.tsx
@@ -39,9 +39,9 @@ const WARN_CONDITIONS = new Set(['exposed'])
 
 function chipToneClasses(condition: string): string {
   if (WARN_CONDITIONS.has(condition.trim().toLowerCase())) {
-    return 'bg-su-sickly-yellow text-su-black'
+    return 'bg-su-sickly-yellow text-ink'
   }
-  return 'bg-su-blue-pale text-su-ink-soft'
+  return 'bg-su-blue-pale text-wk-muted'
 }
 
 // ---------------------------------------------------------------------------
@@ -92,9 +92,9 @@ export function ConditionsEditor({
     'inline-flex items-center gap-1 rounded-[2px] px-2 py-0.5 font-cond text-[11px] font-semibold uppercase tracking-[.05em]'
 
   return (
-    <div className="flex min-h-12 flex-wrap items-center gap-1.5 rounded border-[1.5px] border-su-black bg-su-paper p-2.5">
+    <div className="flex min-h-12 flex-wrap items-center gap-1.5 rounded border-[1.5px] border-ink bg-su-paper p-2.5">
       {conditions.length === 0 && !adding && (
-        <span className="font-mono text-xs text-muted-foreground">None</span>
+        <span className="font-mono text-xs text-wk-muted">None</span>
       )}
 
       {conditions.map((condition, index) =>
@@ -111,7 +111,7 @@ export function ConditionsEditor({
               onClick={() => {
                 void removeAt(index)
               }}
-              className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-[1px] leading-none hover:bg-su-black/10"
+              className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-[1px] leading-none hover:bg-ink/10"
             >
               <span aria-hidden className="text-[12px]">
                 ×
@@ -141,7 +141,7 @@ export function ConditionsEditor({
             onBlur={() => {
               void commitAdd()
             }}
-            className="w-28 rounded-[2px] border border-su-black bg-su-white px-1.5 py-0.5 font-cond text-[11px] uppercase tracking-[.05em] text-su-black focus:outline-none focus:ring-1 focus:ring-su-orange"
+            className="w-28 rounded-[2px] border border-ink bg-su-white px-1.5 py-0.5 font-cond text-[11px] uppercase tracking-[.05em] text-ink focus:outline-none focus:ring-1 focus:ring-su-orange"
           />
         ) : (
           <button
@@ -150,7 +150,7 @@ export function ConditionsEditor({
             onClick={startAdd}
             className={cn(
               chipBase,
-              'border border-dashed border-su-black/40 bg-transparent text-su-ink-soft hover:border-su-black hover:text-su-black'
+              'border border-dashed border-ink/40 bg-transparent text-wk-muted hover:border-ink hover:text-ink'
             )}
           >
             + Add

--- a/apps/in-the-union-now/src/components/sheet/CrawlerSheet.tsx
+++ b/apps/in-the-union-now/src/components/sheet/CrawlerSheet.tsx
@@ -124,7 +124,7 @@ function CrawlerBayCard({
 
   if (!bay) {
     return (
-      <div className="rounded border border-border px-2 py-1 text-sm text-muted-foreground">
+      <div className="rounded border border-ink px-2 py-1 text-sm text-wk-muted">
         {entry.bayRef}
       </div>
     )
@@ -582,7 +582,7 @@ export function CrawlerSheet({
                   {system ? (
                     <ReferenceEntityDisplay data={system} compact />
                   ) : (
-                    <div className="rounded border border-border px-2 py-1 text-sm text-muted-foreground">
+                    <div className="rounded border border-ink px-2 py-1 text-sm text-wk-muted">
                       {slug}
                     </div>
                   )}

--- a/apps/in-the-union-now/src/components/sheet/Erow.tsx
+++ b/apps/in-the-union-now/src/components/sheet/Erow.tsx
@@ -25,7 +25,7 @@ type EcflowProps = {
 
 /** Justified card row container (design `.ecflow`). */
 export function Ecflow({ children, className }: EcflowProps) {
-  return <div className={cn('flex flex-wrap items-stretch gap-3.5', className)}>{children}</div>
+  return <div className={cn('flex flex-wrap items-stretch gap-4', className)}>{children}</div>
 }
 
 /** The card props Erow may inject (ReferenceEntityDisplay accepts these). */

--- a/apps/in-the-union-now/src/components/sheet/HeatCheckControl.tsx
+++ b/apps/in-the-union-now/src/components/sheet/HeatCheckControl.tsx
@@ -25,7 +25,7 @@
  */
 
 import { useState } from 'react'
-import { Btn, MiniBtn } from 'suref-react'
+import { Btn, MiniBtn, Slab } from 'suref-react'
 
 import { performHeatCheck, performPush } from '../../lib/rules/heatCheck'
 import type { HeatCheckEffect, Roll } from '../../lib/rules/heatCheck'
@@ -128,13 +128,8 @@ export function HeatCheckControl({
   const last = mech.lastHeatCheck
 
   return (
-    <div className="rounded-[3px] border-2 border-ink bg-paper p-3">
-      <h3
-        className="mb-2 font-cond text-sm font-bold uppercase tracking-[0.12em]"
-        style={{ color: 'var(--tone-deep, var(--color-ink))' }}
-      >
-        Heat Check
-      </h3>
+    <div>
+      <Slab label="Heat Check" />
 
       {!readOnly && (
         <div className="flex flex-wrap gap-2">
@@ -159,32 +154,34 @@ export function HeatCheckControl({
         </div>
       )}
 
-      {last && (
-        <p
-          role="status"
-          className="mt-2 font-body text-sm text-ink"
-          data-overloaded={last.overloaded}
-          data-outcome={last.outcome ?? ''}
-        >
-          {describeResult(last)}
-        </p>
-      )}
+      <div className="mt-2 min-h-[1.5rem]">
+        {last && (
+          <p
+            role="status"
+            className="font-body text-sm text-ink"
+            data-overloaded={last.overloaded}
+            data-outcome={last.outcome ?? ''}
+          >
+            {describeResult(last)}
+          </p>
+        )}
 
-      {!readOnly && choicePrompt && (
-        <p
-          role="alert"
-          className="mt-2 rounded-[3px] border-[1.5px] border-status-warn bg-paper px-3 py-2 font-body text-sm text-rust"
-        >
-          {choicePrompt === 'system-destroyed'
-            ? 'Mark one System as Destroyed using its status badge below.'
-            : 'Mark one Module as Destroyed using its status badge below.'}
-        </p>
-      )}
+        {!readOnly && choicePrompt && (
+          <p
+            role="alert"
+            className="mt-2 rounded-[3px] border-[1.5px] border-status-warn bg-paper px-3 py-2 font-body text-sm text-rust"
+          >
+            {choicePrompt === 'system-destroyed'
+              ? 'Mark one System as Destroyed using its status badge below.'
+              : 'Mark one Module as Destroyed using its status badge below.'}
+          </p>
+        )}
+      </div>
 
       {mech.destroyed && (
         <p
           role="alert"
-          className="mt-2 flex flex-wrap items-center gap-2 font-cond text-sm font-bold uppercase text-status-bad"
+          className="mt-1.5 flex flex-wrap items-center gap-2 font-cond text-xs font-bold uppercase text-status-bad"
         >
           Mech destroyed
           {!readOnly && (
@@ -200,7 +197,7 @@ export function HeatCheckControl({
         </p>
       )}
       {mech.shutdown && !mech.destroyed && (
-        <p className="mt-1 flex flex-wrap items-center gap-2 font-cond text-xs font-bold uppercase text-rust">
+        <p className="mt-1.5 flex flex-wrap items-center gap-2 font-cond text-xs font-bold uppercase text-rust">
           Shut down
           {!readOnly && (
             <MiniBtn
@@ -215,7 +212,7 @@ export function HeatCheckControl({
         </p>
       )}
       {mech.vulnerable && !mech.destroyed && (
-        <p className="mt-1 flex flex-wrap items-center gap-2 font-cond text-xs font-bold uppercase text-rust">
+        <p className="mt-1.5 flex flex-wrap items-center gap-2 font-cond text-xs font-bold uppercase text-rust">
           Vulnerable
           {!readOnly && (
             <MiniBtn

--- a/apps/in-the-union-now/src/components/sheet/InlineEditField.tsx
+++ b/apps/in-the-union-now/src/components/sheet/InlineEditField.tsx
@@ -114,7 +114,7 @@ export function InlineEditField({
               }
         }
         className={cn(
-          'inline-flex items-center justify-center min-h-11 sm:min-h-9 font-mono text-lg font-bold text-su-black',
+          'inline-flex items-center justify-center min-h-11 sm:min-h-9 font-mono text-lg font-bold text-ink',
           !readOnly &&
             'cursor-pointer rounded px-1 hover:bg-su-paper focus:outline-none focus:ring-2 focus:ring-ring',
           className
@@ -154,12 +154,12 @@ export function InlineEditField({
           }
         }}
         className={cn(
-          'w-16 rounded border-[1.5px] bg-su-paper px-1 py-0.5 text-center font-mono text-lg font-bold text-su-black focus:outline-none focus:ring-2 focus:ring-ring',
-          error ? 'border-destructive focus:ring-destructive' : 'border-su-black'
+          'w-16 rounded border-[1.5px] bg-su-paper px-1 py-0.5 text-center font-mono text-lg font-bold text-ink focus:outline-none focus:ring-2 focus:ring-ring',
+          error ? 'border-danger focus:ring-danger' : 'border-ink'
         )}
       />
       {error && (
-        <span role="alert" className="text-xs text-destructive">
+        <span role="alert" className="text-xs text-danger">
           {error}
         </span>
       )}

--- a/apps/in-the-union-now/src/components/sheet/InlineEditTextArea.tsx
+++ b/apps/in-the-union-now/src/components/sheet/InlineEditTextArea.tsx
@@ -74,7 +74,7 @@ export function InlineEditTextArea({
         }
         className={cn(
           'block min-h-9 whitespace-pre-wrap rounded px-1.5 py-1 font-mono text-sm',
-          hasValue ? 'text-su-black' : 'text-muted-foreground italic',
+          hasValue ? 'text-ink' : 'text-wk-muted italic',
           !readOnly &&
             'cursor-pointer hover:bg-su-paper focus:outline-none focus:ring-2 focus:ring-ring'
         )}
@@ -103,7 +103,7 @@ export function InlineEditTextArea({
           cancel()
         }
       }}
-      className="w-full rounded border-[1.5px] border-su-black bg-su-paper px-1.5 py-1 font-mono text-sm text-su-black focus:outline-none focus:ring-2 focus:ring-ring"
+      className="w-full rounded border-[1.5px] border-ink bg-su-paper px-1.5 py-1 font-mono text-sm text-ink focus:outline-none focus:ring-2 focus:ring-ring"
     />
   )
 }

--- a/apps/in-the-union-now/src/components/sheet/MechItemCard.tsx
+++ b/apps/in-the-union-now/src/components/sheet/MechItemCard.tsx
@@ -139,7 +139,7 @@ export function MechItemCard({
           >
             &ndash;
           </StepBtn>
-          <span className="font-cond text-[11px] font-bold uppercase leading-none text-ink">
+          <span className="min-w-[4.5rem] text-center font-cond text-[11px] font-bold uppercase leading-none tabular-nums text-ink">
             Uses {remaining}/{maxUses}
           </span>
           <StepBtn
@@ -151,46 +151,52 @@ export function MechItemCard({
           </StepBtn>
         </span>
       )}
-      {condition === 'damaged' &&
-        (confirmingRepair ? (
-          <span className="inline-flex flex-wrap items-center gap-1.5">
+      {condition === 'damaged' && (
+        // Reserve the repair affordance its own full-width foot row so toggling
+        // between the single Repair button and the 3-button confirm cluster
+        // never changes the foot's row count — keeps the equal-height Erow steady.
+        <span className="flex basis-full flex-wrap items-center justify-end gap-1.5">
+          {confirmingRepair ? (
+            <>
+              <Btn
+                size="sm"
+                variant="primary"
+                disabled={deductTl === null}
+                title={deductDisabledReason ?? undefined}
+                aria-label={`Repair ${entity.name} and deduct scrap`}
+                onClick={() => {
+                  onRepair(deductTl, cost)
+                  setConfirmingRepair(false)
+                }}
+              >
+                Deduct {cost} from TL {deductTl ?? Math.max(1, itemTl ?? 1)} pool
+              </Btn>
+              <Btn
+                size="sm"
+                aria-label={`Repair ${entity.name} without deducting scrap`}
+                onClick={() => {
+                  onRepair(null, cost)
+                  setConfirmingRepair(false)
+                }}
+              >
+                Repair without deducting
+              </Btn>
+              <Btn size="sm" variant="ghost" onClick={() => setConfirmingRepair(false)}>
+                Cancel
+              </Btn>
+            </>
+          ) : (
             <Btn
               size="sm"
               variant="primary"
-              disabled={deductTl === null}
-              title={deductDisabledReason ?? undefined}
-              aria-label={`Repair ${entity.name} and deduct scrap`}
-              onClick={() => {
-                onRepair(deductTl, cost)
-                setConfirmingRepair(false)
-              }}
+              aria-label={`Repair ${entity.name}`}
+              onClick={() => setConfirmingRepair(true)}
             >
-              Deduct {cost} from TL {deductTl ?? Math.max(1, itemTl ?? 1)} pool
+              Repair &middot; {cost} Scrap
             </Btn>
-            <Btn
-              size="sm"
-              aria-label={`Repair ${entity.name} without deducting scrap`}
-              onClick={() => {
-                onRepair(null, cost)
-                setConfirmingRepair(false)
-              }}
-            >
-              Repair without deducting
-            </Btn>
-            <Btn size="sm" variant="ghost" onClick={() => setConfirmingRepair(false)}>
-              Cancel
-            </Btn>
-          </span>
-        ) : (
-          <Btn
-            size="sm"
-            variant="primary"
-            aria-label={`Repair ${entity.name}`}
-            onClick={() => setConfirmingRepair(true)}
-          >
-            Repair &middot; {cost} Scrap
-          </Btn>
-        ))}
+          )}
+        </span>
+      )}
     </>
   )
 

--- a/apps/in-the-union-now/src/components/sheet/MechSheet.tsx
+++ b/apps/in-the-union-now/src/components/sheet/MechSheet.tsx
@@ -226,7 +226,7 @@ export function MechSheet({
   }
 
   return (
-    <section aria-labelledby="mech-sheet-heading" className="flex flex-col gap-7">
+    <section aria-labelledby="mech-sheet-heading" className="flex flex-col gap-6">
       {/* The hero already shows the name — this heading is for a11y/print. */}
       <h2 id="mech-sheet-heading" className="sr-only">
         {mech.name}
@@ -311,14 +311,13 @@ export function MechSheet({
       <div>
         <Slab
           label="The Hold"
-          count={`${cargo.state.mechLots.length} ${
-            cargo.state.mechLots.length === 1 ? 'lot' : 'lots'
-          } · ${cargo.usage.used}/${cargo.usage.cap} slots`}
+          count={
+            <span className="tabular-nums">
+              {cargo.state.mechLots.length} {cargo.state.mechLots.length === 1 ? 'lot' : 'lots'} ·{' '}
+              {cargo.usage.used}/{cargo.usage.cap} slots
+            </span>
+          }
         />
-        <p className="mb-3 mt-0 font-body text-xs leading-snug text-wk-muted">
-          Stow moves a whole lot to the crawler hold; SCRAP lots deposit the crawler&rsquo;s
-          matching TL scrap pool. Over-capacity is shown honestly — red pips, never clamped.
-        </p>
         <StorageManifest
           side="mech"
           cargo={cargo}

--- a/apps/in-the-union-now/src/components/sheet/NpcFactsEditor.tsx
+++ b/apps/in-the-union-now/src/components/sheet/NpcFactsEditor.tsx
@@ -64,24 +64,18 @@ export function NpcFactsEditor({
     'inline-flex items-center gap-1 rounded-[2px] px-2 py-0.5 font-cond text-[11px] font-semibold tracking-[.03em]'
 
   return (
-    <div className="flex min-h-10 flex-wrap items-center gap-1.5 rounded border-[1.5px] border-su-black bg-su-paper p-2">
+    <div className="flex min-h-10 flex-wrap items-center gap-1.5 rounded border-[1.5px] border-ink bg-su-paper p-2">
       {facts.length === 0 && !adding && (
-        <span className="font-mono text-xs text-muted-foreground">No facts yet</span>
+        <span className="font-mono text-xs text-wk-muted">No facts yet</span>
       )}
 
       {facts.map((fact, index) =>
         readOnly ? (
-          <span
-            key={`${fact}-${index}`}
-            className={cn(chipBase, 'bg-su-blue-pale text-su-ink-soft')}
-          >
+          <span key={`${fact}-${index}`} className={cn(chipBase, 'bg-su-blue-pale text-wk-muted')}>
             {fact}
           </span>
         ) : (
-          <span
-            key={`${fact}-${index}`}
-            className={cn(chipBase, 'bg-su-blue-pale text-su-ink-soft')}
-          >
+          <span key={`${fact}-${index}`} className={cn(chipBase, 'bg-su-blue-pale text-wk-muted')}>
             {fact}
             <button
               type="button"
@@ -89,7 +83,7 @@ export function NpcFactsEditor({
               onClick={() => {
                 void removeAt(index)
               }}
-              className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-[1px] leading-none hover:bg-su-black/10"
+              className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-[1px] leading-none hover:bg-ink/10"
             >
               <span aria-hidden className="text-[12px]">
                 ×
@@ -119,7 +113,7 @@ export function NpcFactsEditor({
             onBlur={() => {
               void commitAdd()
             }}
-            className="w-40 rounded-[2px] border border-su-black bg-su-white px-1.5 py-0.5 font-cond text-[11px] tracking-[.03em] text-su-black focus:outline-none focus:ring-1 focus:ring-su-orange"
+            className="w-40 rounded-[2px] border border-ink bg-su-white px-1.5 py-0.5 font-cond text-[11px] tracking-[.03em] text-ink focus:outline-none focus:ring-1 focus:ring-su-orange"
           />
         ) : (
           <button
@@ -128,7 +122,7 @@ export function NpcFactsEditor({
             onClick={startAdd}
             className={cn(
               chipBase,
-              'border border-dashed border-su-black/40 bg-transparent text-su-ink-soft hover:border-su-black hover:text-su-black'
+              'border border-dashed border-ink/40 bg-transparent text-wk-muted hover:border-ink hover:text-ink'
             )}
           >
             + Add Fact

--- a/apps/in-the-union-now/src/components/sheet/NpcFactsEditor.tsx
+++ b/apps/in-the-union-now/src/components/sheet/NpcFactsEditor.tsx
@@ -71,11 +71,17 @@ export function NpcFactsEditor({
 
       {facts.map((fact, index) =>
         readOnly ? (
-          <span key={`${fact}-${index}`} className={cn(chipBase, 'bg-su-blue-pale text-wk-muted')}>
+          <span
+            key={`${fact}-${index}`}
+            className={cn(chipBase, 'bg-su-blue-pale text-su-ink-soft')}
+          >
             {fact}
           </span>
         ) : (
-          <span key={`${fact}-${index}`} className={cn(chipBase, 'bg-su-blue-pale text-wk-muted')}>
+          <span
+            key={`${fact}-${index}`}
+            className={cn(chipBase, 'bg-su-blue-pale text-su-ink-soft')}
+          >
             {fact}
             <button
               type="button"

--- a/apps/in-the-union-now/src/components/sheet/ShareSnapshotScreen.tsx
+++ b/apps/in-the-union-now/src/components/sheet/ShareSnapshotScreen.tsx
@@ -119,7 +119,7 @@ export function ShareSnapshotScreen({
     return (
       <main className="mx-auto max-w-5xl p-6">
         <h1 className="mb-2 text-xl font-bold">Nothing to share</h1>
-        <p className="text-muted-foreground mb-4 text-sm">
+        <p className="text-wk-muted mb-4 text-sm">
           This {kind} no longer exists, so there is nothing to publish.
         </p>
         <AppLink href="/" className="text-sm underline">

--- a/apps/in-the-union-now/src/components/sheet/Sheet.tsx
+++ b/apps/in-the-union-now/src/components/sheet/Sheet.tsx
@@ -214,7 +214,7 @@ export function Sheet({
   if (!entity) {
     return (
       <main className="mx-auto max-w-7xl p-3 sm:p-6">
-        <p className="text-muted-foreground text-sm">Entity not found.</p>
+        <p className="text-wk-muted text-sm">Entity not found.</p>
       </main>
     )
   }

--- a/apps/in-the-union-now/src/components/sheet/SheetHero.tsx
+++ b/apps/in-the-union-now/src/components/sheet/SheetHero.tsx
@@ -96,7 +96,7 @@ export function SheetHero({
 
         {(trackers || inset) && (
           <div className="flex flex-col items-end gap-2.5 sm:ml-auto">
-            {trackers && <div className="flex flex-wrap justify-end gap-[9px]">{trackers}</div>}
+            {trackers && <div className="flex flex-wrap justify-end gap-2">{trackers}</div>}
             {inset}
           </div>
         )}

--- a/apps/in-the-union-now/src/components/sheet/SnapshotView.tsx
+++ b/apps/in-the-union-now/src/components/sheet/SnapshotView.tsx
@@ -142,14 +142,12 @@ export function SnapshotView({ snapshot }: SnapshotViewProps) {
     return (
       <main className="mx-auto max-w-5xl p-6">
         <h1 className="mb-2 text-xl font-bold">Could not render snapshot</h1>
-        <p className="text-muted-foreground mb-1 text-sm">
+        <p className="text-wk-muted mb-1 text-sm">
           This snapshot&rsquo;s data doesn&rsquo;t match any build this app knows how to show. It
           may have been published by a newer or older version.
         </p>
         {!result.ok && (
-          <p className="text-muted-foreground mb-4 break-words font-mono text-xs">
-            {result.reason}
-          </p>
+          <p className="text-wk-muted mb-4 break-words font-mono text-xs">{result.reason}</p>
         )}
         <AppLink href="/" className="text-sm underline">
           &larr; Back to dashboard

--- a/apps/in-the-union-now/src/components/sheet/StorageManifest.tsx
+++ b/apps/in-the-union-now/src/components/sheet/StorageManifest.tsx
@@ -124,8 +124,12 @@ function CargoChit({ lot, side, cargo, linked, readOnly }: CargoChitProps) {
         </span>
       </span>
 
-      {/* Units cost cell */}
-      <span className="flex w-9 shrink-0 flex-col items-center justify-center border-l-[1.5px] border-ink py-1">
+      {/* Units cost cell — tinted ground (not a border) separates it from the
+          name cell and, in turn, sets the move button off on its other edge. */}
+      <span
+        className="flex w-9 shrink-0 flex-col items-center justify-center py-1"
+        style={{ background: 'var(--ground-2)' }}
+      >
         <span className="font-body text-[15px] font-bold leading-none text-ink">{lot.units}</span>
         <span className="font-cond text-[8px] uppercase text-wk-muted">U</span>
       </span>
@@ -138,7 +142,7 @@ function CargoChit({ lot, side, cargo, linked, readOnly }: CargoChitProps) {
           title={disabledReason ?? undefined}
           aria-label={`${side === 'mech' ? 'Stow' : 'Load'} ${lot.name}`}
           onClick={handleMove}
-          className="shrink-0 cursor-pointer border-l-[1.5px] border-ink px-2.5 font-cond text-[10px] font-bold uppercase tracking-[0.04em] text-ink transition-colors duration-[120ms] hover:bg-[var(--color-cargo-pale)] disabled:cursor-not-allowed disabled:opacity-40"
+          className="shrink-0 cursor-pointer px-2.5 font-cond text-[10px] font-bold uppercase tracking-[0.04em] text-ink transition-colors duration-[120ms] hover:bg-[var(--color-cargo-pale)] disabled:cursor-not-allowed disabled:opacity-40"
         >
           {label}
         </button>

--- a/apps/in-the-union-now/src/components/ui/buttonVariants.ts
+++ b/apps/in-the-union-now/src/components/ui/buttonVariants.ts
@@ -26,7 +26,7 @@ import { cva } from 'class-variance-authority'
 export const buttonVariants = cva(
   [
     'inline-flex cursor-pointer select-none items-center justify-center gap-2 whitespace-nowrap',
-    'rounded-[0.375rem] border text-sm font-medium leading-5',
+    'rounded-md border text-sm font-medium leading-5',
     'transition-[color,background-color,border-color] duration-150',
     'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-su-orange)] focus-visible:ring-0',
     'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
@@ -64,8 +64,8 @@ export const buttonVariants = cva(
         // min-h-11 (44px) on mobile keeps touch targets WCAG-compliant at the table.
         // sm:min-h-* restores the designed height on larger viewports.
         default: 'h-10 min-h-11 sm:min-h-10 px-4 py-1.5',
-        sm: 'h-9 min-h-11 sm:min-h-9 rounded-[0.375rem] px-3',
-        lg: 'h-11 rounded-[0.375rem] px-6',
+        sm: 'h-9 min-h-11 sm:min-h-9 px-3',
+        lg: 'h-11 px-6',
         icon: 'h-10 w-10 min-h-11 sm:min-h-10',
       },
     },

--- a/apps/in-the-union-now/src/components/wizard/WizShell.tsx
+++ b/apps/in-the-union-now/src/components/wizard/WizShell.tsx
@@ -73,7 +73,7 @@ export function WizShell({
 
   const heading = (
     <header>
-      <h1 className="font-cond text-[23px] font-bold uppercase leading-tight tracking-[0.01em] text-ink">
+      <h1 className="font-cond text-2xl font-bold uppercase leading-tight tracking-[0.01em] text-ink">
         {title}
       </h1>
       {subtitle && <div className="mt-1 font-body text-[13px] text-wk-muted">{subtitle}</div>}
@@ -95,18 +95,19 @@ export function WizShell({
         />
       </aside>
 
-      {/* (b) optional 320px option pane — owns the step heading when present */}
+      {/* (b) optional 320px option pane — carries only its list; the step
+          heading always renders in the main pane so the h1 stays anchored
+          horizontally across every step (option-pane steps and others alike) */}
       {optionPane && (
         <section className="shrink-0 border-b-[1.5px] border-ink px-5 py-5 lg:w-[320px] lg:overflow-y-auto lg:border-b-0 lg:border-r-[1.5px] lg:px-[26px] lg:py-9">
-          {heading}
-          <div className="mt-4">{optionPane}</div>
+          {optionPane}
         </section>
       )}
 
-      {/* (c) flex-1 main pane */}
+      {/* (c) flex-1 main pane — always owns the step heading */}
       <main className="flex min-w-0 flex-1 flex-col px-5 py-5 lg:px-10 lg:py-[34px]">
-        {!optionPane && heading}
-        <div className={cn('min-h-0 flex-1', !optionPane && 'mt-4')}>{children}</div>
+        {heading}
+        <div className="mt-4 min-h-0 flex-1 pb-24">{children}</div>
 
         {notice && <div className="mt-6">{notice}</div>}
 
@@ -119,7 +120,7 @@ export function WizShell({
         <footer className="pointer-events-none sticky bottom-4 z-40 mt-6 flex justify-end">
           <div
             className={cn(
-              'pointer-events-auto flex items-center gap-2 rounded-xl border-[1.5px] border-wk-faint bg-wk-bg/95 p-2 shadow-lg backdrop-blur',
+              'pointer-events-auto flex items-center gap-2 rounded-lg border-[1.5px] border-wk-faint bg-wk-bg/95 p-2 shadow-md backdrop-blur',
               ctaFullWidth && 'w-full flex-col items-stretch sm:w-auto sm:flex-row sm:items-center'
             )}
           >

--- a/apps/in-the-union-now/src/components/workspace/AssignToWorkspaceButton.tsx
+++ b/apps/in-the-union-now/src/components/workspace/AssignToWorkspaceButton.tsx
@@ -99,7 +99,7 @@ export function AssignToWorkspaceButton({
       <div className="flex items-center gap-2">
         <label
           htmlFor={`workspace-assign-${entityId}`}
-          className="text-sm font-medium text-muted-foreground"
+          className="text-sm font-medium text-wk-muted"
         >
           Workspace:
         </label>
@@ -108,7 +108,7 @@ export function AssignToWorkspaceButton({
           value={selectValue}
           onChange={(e) => void handleChange(e)}
           disabled={pending}
-          className="rounded border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
+          className="min-h-11 rounded-[3px] border-[1.5px] border-ink bg-paper py-2 pl-3 pr-8 text-sm focus:outline-none focus:ring-[3px] focus:ring-rust/[0.22] disabled:opacity-50 sm:min-h-9"
           aria-label="Assign to workspace"
         >
           <option value={UNASSIGNED_VALUE}>Unassigned</option>
@@ -120,7 +120,7 @@ export function AssignToWorkspaceButton({
         </select>
       </div>
       {error && (
-        <p className="mt-1 text-xs text-destructive" role="alert">
+        <p className="mt-1 text-xs text-danger" role="alert">
           {error}
         </p>
       )}

--- a/apps/in-the-union-now/src/components/workspace/WorkspaceList.tsx
+++ b/apps/in-the-union-now/src/components/workspace/WorkspaceList.tsx
@@ -195,7 +195,7 @@ function WorkspaceListInner({ onClose, store }: WorkspaceListInnerProps) {
                           if (e.key === 'Enter') void handleRename(ws.id)
                           if (e.key === 'Escape') cancelEditing()
                         }}
-                        className="flex-1 px-2 py-1"
+                        className="min-h-11 flex-1 px-3 py-1.5 sm:min-h-9"
                         aria-label={`Rename workspace ${ws.name}`}
                       />
                       <Btn

--- a/apps/in-the-union-now/src/routes/__root.tsx
+++ b/apps/in-the-union-now/src/routes/__root.tsx
@@ -26,7 +26,7 @@ function RootErrorComponent({ error }: ErrorComponentProps) {
       className="mx-auto flex min-h-dvh w-full max-w-2xl flex-col items-center justify-center gap-4 p-6 text-center"
     >
       <h1 className="text-lg font-bold">Something went wrong</h1>
-      <p className="text-sm text-muted-foreground">
+      <p className="text-sm text-wk-muted">
         The app hit an unexpected error. Your saved data is stored locally and is not affected.
       </p>
       {import.meta.env.DEV && (

--- a/apps/in-the-union-now/src/routes/crawlers/$id.tsx
+++ b/apps/in-the-union-now/src/routes/crawlers/$id.tsx
@@ -48,8 +48,8 @@ function CrawlerDetailPage() {
 
   if (!crawler) {
     return (
-      <main className="mx-auto max-w-7xl px-4 py-8">
-        <p className="text-muted-foreground">Crawler not found.</p>
+      <main className="mx-auto max-w-7xl p-6">
+        <p className="text-wk-muted">Crawler not found.</p>
         <a href="/" className={cn(buttonVariants({ variant: 'link', size: 'sm' }))}>
           Back to dashboard
         </a>
@@ -58,14 +58,14 @@ function CrawlerDetailPage() {
   }
 
   return (
-    <main className="mx-auto max-w-7xl px-4 py-8">
+    <main className="mx-auto max-w-7xl p-6">
       {/* Page header */}
       <div className="mb-6 flex items-start justify-between gap-4">
         <div>
           <h1 className="font-cond text-2xl font-bold uppercase tracking-wide text-su-black">
             {crawler.name}
           </h1>
-          <p className="mt-1 font-cond text-xs font-semibold uppercase tracking-widest text-su-ink-soft">
+          <p className="mt-1 font-cond text-xs font-semibold uppercase tracking-widest text-wk-muted">
             Tech level: {crawler.techLevel}
           </p>
         </div>
@@ -90,19 +90,19 @@ function CrawlerDetailPage() {
       <div className="flex flex-col gap-6 lg:flex-row lg:items-start">
         {/* Left pane — crawler stats summary */}
         <div className="min-w-0 flex-1">
-          <section className="mb-6 rounded-sm border border-su-black bg-white p-4 text-sm">
+          <section className="mb-6 rounded-[3px] border-[1.5px] border-ink bg-paper p-4 text-sm">
             <h2 className="mb-3 font-cond text-sm font-bold uppercase tracking-widest text-su-black">
               Stats
             </h2>
-            <dl className="space-y-2">
+            <dl className="grid grid-cols-2 gap-2">
               <div className="flex gap-2">
-                <dt className="font-cond font-semibold uppercase tracking-wide text-su-ink-soft">
+                <dt className="font-cond font-semibold uppercase tracking-wide text-wk-muted">
                   Bays:
                 </dt>
                 <dd>{(crawler.crawlerBays ?? []).length}</dd>
               </div>
               <div className="flex gap-2">
-                <dt className="font-cond font-semibold uppercase tracking-wide text-su-ink-soft">
+                <dt className="font-cond font-semibold uppercase tracking-wide text-wk-muted">
                   Systems:
                 </dt>
                 <dd>{crawler.systems.length}</dd>
@@ -114,12 +114,12 @@ function CrawlerDetailPage() {
         {/* Right pane — assigned pilots + workspace/actions */}
         <div className="w-full shrink-0 space-y-6 lg:w-72">
           {/* Assigned pilots (via incoming SoftLinks) */}
-          <section className="rounded-sm border border-su-black bg-white p-4">
+          <section className="rounded-[3px] border-[1.5px] border-ink bg-paper p-4">
             <h2 className="mb-3 font-cond text-sm font-bold uppercase tracking-widest text-su-black">
               Assigned Pilots
             </h2>
             {assignedPilots.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
+              <p className="text-sm text-wk-muted">
                 No pilots assigned. Pilots can be assigned from their detail page.
               </p>
             ) : (
@@ -127,7 +127,7 @@ function CrawlerDetailPage() {
                 {assignedPilots.map(({ link, pilot }) => (
                   <li
                     key={link.id}
-                    className="flex items-center gap-2 rounded-sm border border-su-black px-3 py-2 text-sm"
+                    className="flex items-center gap-2 rounded-[3px] border-[1.5px] border-ink px-3 py-2 text-sm"
                   >
                     <span className="flex-1">
                       {pilot ? (
@@ -138,9 +138,7 @@ function CrawlerDetailPage() {
                           {pilot.name}
                         </a>
                       ) : (
-                        <span className="text-muted-foreground">
-                          Unknown pilot ({link.from.id})
-                        </span>
+                        <span className="text-wk-muted">Unknown pilot ({link.from.id})</span>
                       )}
                     </span>
                   </li>
@@ -150,7 +148,7 @@ function CrawlerDetailPage() {
           </section>
 
           {/* Workspace assignment */}
-          <section className="rounded-sm border border-su-black bg-white p-4">
+          <section className="rounded-[3px] border-[1.5px] border-ink bg-paper p-4">
             <h2 className="mb-3 font-cond text-sm font-bold uppercase tracking-widest text-su-black">
               Workspace
             </h2>

--- a/apps/in-the-union-now/src/routes/crawlers/$id_.edit.tsx
+++ b/apps/in-the-union-now/src/routes/crawlers/$id_.edit.tsx
@@ -29,8 +29,8 @@ function EditCrawlerRoute() {
 
   if (!crawler) {
     return (
-      <main className="mx-auto max-w-7xl px-4 py-8">
-        <p className="text-muted-foreground">Crawler not found.</p>
+      <main className="mx-auto max-w-7xl p-6">
+        <p className="text-wk-muted">Crawler not found.</p>
         <Link to="/" className="text-sm underline">
           Back to dashboard
         </Link>
@@ -47,7 +47,7 @@ function EditCrawlerRoute() {
   }
 
   return (
-    <main className="min-h-dvh bg-background">
+    <main>
       <CrawlerBuilder
         key={crawler.id}
         crawlerId={crawler.id}

--- a/apps/in-the-union-now/src/routes/crawlers/new.tsx
+++ b/apps/in-the-union-now/src/routes/crawlers/new.tsx
@@ -18,7 +18,7 @@ function CrawlersNewPage() {
   }
 
   return (
-    <main className="min-h-dvh bg-background">
+    <main>
       <CrawlerBuilder onComplete={handleComplete} onCancel={handleCancel} />
     </main>
   )

--- a/apps/in-the-union-now/src/routes/mechs/$id.tsx
+++ b/apps/in-the-union-now/src/routes/mechs/$id.tsx
@@ -50,8 +50,8 @@ function MechDetailPage() {
 
   if (!mech) {
     return (
-      <main className="mx-auto max-w-7xl px-4 py-8">
-        <p className="text-muted-foreground">Mech not found.</p>
+      <main className="mx-auto max-w-7xl p-6">
+        <p className="text-wk-muted">Mech not found.</p>
         <Link to="/" className={cn(buttonVariants({ variant: 'link', size: 'sm' }))}>
           Back to dashboard
         </Link>
@@ -60,14 +60,14 @@ function MechDetailPage() {
   }
 
   return (
-    <main className="mx-auto max-w-7xl px-4 py-8">
+    <main className="mx-auto max-w-7xl p-6">
       {/* Page header */}
       <div className="mb-6 flex items-start justify-between gap-4">
         <div>
           <h1 className="font-cond text-2xl font-bold uppercase tracking-wide text-su-black">
             {mech.name}
           </h1>
-          <p className="mt-1 font-cond text-xs font-semibold uppercase tracking-widest text-su-ink-soft">
+          <p className="mt-1 font-cond text-xs font-semibold uppercase tracking-widest text-wk-muted">
             Chassis: {mech.chassisRef}
           </p>
         </div>
@@ -92,32 +92,32 @@ function MechDetailPage() {
       <div className="flex flex-col gap-6 lg:flex-row lg:items-start">
         {/* Left pane — mech stats summary */}
         <div className="min-w-0 flex-1">
-          <section className="mb-6 rounded-sm border border-su-black bg-white p-4 text-sm">
+          <section className="mb-6 rounded-[3px] border-[1.5px] border-ink bg-paper p-4 text-sm">
             <h2 className="mb-3 font-cond text-sm font-bold uppercase tracking-widest text-su-black">
               Stats
             </h2>
             <dl className="space-y-2">
               <div className="flex gap-2">
-                <dt className="font-cond font-semibold uppercase tracking-wide text-su-ink-soft">
+                <dt className="font-cond font-semibold uppercase tracking-wide text-wk-muted">
                   Systems:
                 </dt>
                 <dd>{mech.systems.length}</dd>
               </div>
               <div className="flex gap-2">
-                <dt className="font-cond font-semibold uppercase tracking-wide text-su-ink-soft">
+                <dt className="font-cond font-semibold uppercase tracking-wide text-wk-muted">
                   Modules:
                 </dt>
                 <dd>{mech.modules.length}</dd>
               </div>
               <div className="flex gap-2">
-                <dt className="font-cond font-semibold uppercase tracking-wide text-su-ink-soft">
+                <dt className="font-cond font-semibold uppercase tracking-wide text-wk-muted">
                   Cargo slots used:
                 </dt>
                 <dd>{mech.cargoLots.length}</dd>
               </div>
               {mech.conditions.length > 0 && (
                 <div className="flex gap-2">
-                  <dt className="font-cond font-semibold uppercase tracking-wide text-su-ink-soft">
+                  <dt className="font-cond font-semibold uppercase tracking-wide text-wk-muted">
                     Conditions:
                   </dt>
                   <dd>{mech.conditions.join(', ')}</dd>
@@ -146,13 +146,13 @@ function MechDetailPage() {
         {/* Right pane — wiring + actions */}
         <div className="w-full shrink-0 space-y-6 lg:w-72">
           {/* Pilot assignment */}
-          <section className="rounded-sm border border-su-black bg-white p-4">
+          <section className="rounded-[3px] border-[1.5px] border-ink bg-paper p-4">
             <h2 className="mb-3 font-cond text-sm font-bold uppercase tracking-widest text-su-black">
               Pilot
             </h2>
             {pilotLink ? (
               <div className="flex items-center gap-3 text-sm">
-                <span className="flex-1 text-muted-foreground">
+                <span className="flex-1 text-wk-muted">
                   Pilot linked:{' '}
                   <span className="font-medium text-foreground">{pilotLink.to.id}</span>
                 </span>
@@ -164,7 +164,7 @@ function MechDetailPage() {
               </div>
             ) : (
               <div className="flex items-center gap-3">
-                <p className="text-sm text-muted-foreground">No pilot assigned.</p>
+                <p className="text-sm text-wk-muted">No pilot assigned.</p>
                 <AssignPilotToMech
                   mechId={id}
                   onAssigned={() => void navigate({ to: '/mechs/$id', params: { id } })}
@@ -174,7 +174,7 @@ function MechDetailPage() {
           </section>
 
           {/* Workspace assignment */}
-          <section className="rounded-sm border border-su-black bg-white p-4">
+          <section className="rounded-[3px] border-[1.5px] border-ink bg-paper p-4">
             <h2 className="mb-3 font-cond text-sm font-bold uppercase tracking-widest text-su-black">
               Workspace
             </h2>
@@ -220,7 +220,7 @@ type LoadoutSectionProps = {
 /** Installed systems/modules as compact entity cards (gap 24). */
 function LoadoutSection({ title, refs, conditions, resolve, emptyLabel }: LoadoutSectionProps) {
   return (
-    <section className="mb-6 rounded-sm border border-su-black bg-white p-4">
+    <section className="mb-6 rounded-[3px] border-[1.5px] border-ink bg-paper p-4">
       <h2 className="mb-3 font-cond text-sm font-bold uppercase tracking-widest text-su-black">
         {title} · {refs.length}
       </h2>

--- a/apps/in-the-union-now/src/routes/mechs/$id_.edit.tsx
+++ b/apps/in-the-union-now/src/routes/mechs/$id_.edit.tsx
@@ -33,8 +33,8 @@ function EditMechRoute() {
 
   if (!mech) {
     return (
-      <main className="mx-auto max-w-7xl px-4 py-8">
-        <p className="text-muted-foreground">Mech not found.</p>
+      <main className="mx-auto max-w-7xl p-6">
+        <p className="text-wk-muted">Mech not found.</p>
         <Link to="/" className="text-sm underline">
           Back to dashboard
         </Link>
@@ -51,7 +51,7 @@ function EditMechRoute() {
   }
 
   return (
-    <main className="min-h-dvh bg-background">
+    <main>
       <MechWizard
         key={mech.id}
         mechId={mech.id}

--- a/apps/in-the-union-now/src/routes/mechs/new.tsx
+++ b/apps/in-the-union-now/src/routes/mechs/new.tsx
@@ -23,7 +23,7 @@ function NewMechRoute() {
   }
 
   return (
-    <main className="min-h-dvh bg-background">
+    <main>
       <MechWizard onComplete={handleComplete} onCancel={handleCancel} />
     </main>
   )

--- a/apps/in-the-union-now/src/routes/mechs/patterns/index.tsx
+++ b/apps/in-the-union-now/src/routes/mechs/patterns/index.tsx
@@ -9,10 +9,12 @@ function MechPatternsPage() {
   const navigate = useNavigate()
 
   return (
-    <main className="mx-auto max-w-6xl p-6 flex flex-col gap-6">
+    <main className="mx-auto max-w-5xl p-6 flex flex-col gap-6">
       <div>
-        <h1 className="text-2xl font-bold">Mech Patterns</h1>
-        <p className="text-sm text-muted-foreground mt-1">
+        <h1 className="font-cond text-2xl font-bold uppercase tracking-[0.04em] text-ink">
+          Mech Patterns
+        </h1>
+        <p className="font-body text-sm text-wk-muted mt-1">
           Saved mech templates. Instantiate one to create a fresh mech with the same chassis,
           systems, modules, and cargo.
         </p>

--- a/apps/in-the-union-now/src/routes/pilots/$id.tsx
+++ b/apps/in-the-union-now/src/routes/pilots/$id.tsx
@@ -47,8 +47,8 @@ function PilotDetailPage() {
 
   if (!pilot) {
     return (
-      <main className="mx-auto max-w-7xl px-4 py-8">
-        <p className="text-muted-foreground">Pilot not found.</p>
+      <main className="mx-auto max-w-7xl p-6">
+        <p className="text-wk-muted">Pilot not found.</p>
         <Link to="/" className={cn(buttonVariants({ variant: 'link', size: 'sm' }))}>
           Back to dashboard
         </Link>
@@ -57,7 +57,7 @@ function PilotDetailPage() {
   }
 
   return (
-    <main className="mx-auto max-w-7xl px-4 py-8">
+    <main className="mx-auto max-w-7xl p-6">
       {/* Page header */}
       <div className="mb-6 flex items-start justify-between gap-4">
         <div>
@@ -65,9 +65,9 @@ function PilotDetailPage() {
             {pilot.name}
           </h1>
           {pilot.callsign && (
-            <p className="mt-0.5 text-sm text-muted-foreground">&ldquo;{pilot.callsign}&rdquo;</p>
+            <p className="mt-0.5 text-sm text-wk-muted">&ldquo;{pilot.callsign}&rdquo;</p>
           )}
-          <p className="mt-1 font-cond text-xs font-semibold uppercase tracking-widest text-su-ink-soft">
+          <p className="mt-1 font-cond text-xs font-semibold uppercase tracking-widest text-wk-muted">
             Class: {resolveClassName(pilot.classRef)}
           </p>
         </div>
@@ -93,26 +93,31 @@ function PilotDetailPage() {
         {/* Left pane — summary + sheet */}
         <div className="min-w-0 flex-1">
           {/* Summary */}
-          <section className="mb-6 rounded-sm border border-su-black bg-white p-4 text-sm">
-            <dl className="space-y-2">
-              {pilot.conditions.length > 0 && (
-                <div className="flex gap-2">
-                  <dt className="font-cond font-semibold uppercase tracking-wide text-su-ink-soft">
-                    Conditions:
-                  </dt>
-                  <dd>{pilot.conditions.join(', ')}</dd>
-                </div>
-              )}
-              {pilot.motto && (
-                <div className="flex gap-2">
-                  <dt className="font-cond font-semibold uppercase tracking-wide text-su-ink-soft">
-                    Motto:
-                  </dt>
-                  <dd>{pilot.motto}</dd>
-                </div>
-              )}
-            </dl>
-          </section>
+          {(pilot.conditions.length > 0 || pilot.motto) && (
+            <section className="mb-6 rounded-[3px] border-[1.5px] border-ink bg-paper p-4 text-sm">
+              <h2 className="mb-3 font-cond text-sm font-bold uppercase tracking-widest text-su-black">
+                Summary
+              </h2>
+              <dl className="space-y-2">
+                {pilot.conditions.length > 0 && (
+                  <div className="flex gap-2">
+                    <dt className="font-cond font-semibold uppercase tracking-wide text-wk-muted">
+                      Conditions:
+                    </dt>
+                    <dd>{pilot.conditions.join(', ')}</dd>
+                  </div>
+                )}
+                {pilot.motto && (
+                  <div className="flex gap-2">
+                    <dt className="font-cond font-semibold uppercase tracking-wide text-wk-muted">
+                      Motto:
+                    </dt>
+                    <dd>{pilot.motto}</dd>
+                  </div>
+                )}
+              </dl>
+            </section>
+          )}
 
           {/* Abilities + Equipment via the SRD entity display */}
           <section className="mb-6">
@@ -123,13 +128,13 @@ function PilotDetailPage() {
         {/* Right pane — wiring + actions */}
         <div className="w-full shrink-0 space-y-6 lg:w-72">
           {/* Crawler assignment */}
-          <section className="rounded-sm border border-su-black bg-white p-4">
+          <section className="rounded-[3px] border-[1.5px] border-ink bg-paper p-4">
             <h2 className="mb-3 font-cond text-sm font-bold uppercase tracking-widest text-su-black">
               Crawler
             </h2>
             {crawlerLink ? (
               <div className="flex items-center gap-3 text-sm">
-                <span className="flex-1 text-muted-foreground">
+                <span className="flex-1 text-wk-muted">
                   Crawler linked:{' '}
                   <span className="font-medium text-foreground">{crawlerLink.to.id}</span>
                 </span>
@@ -141,7 +146,7 @@ function PilotDetailPage() {
               </div>
             ) : (
               <div className="flex items-center gap-3">
-                <p className="text-sm text-muted-foreground">No crawler assigned.</p>
+                <p className="text-sm text-wk-muted">No crawler assigned.</p>
                 <AssignCrawlerToPilot
                   pilotId={id}
                   onAssigned={() => void navigate({ to: '/pilots/$id', params: { id } })}
@@ -151,7 +156,7 @@ function PilotDetailPage() {
           </section>
 
           {/* Workspace assignment */}
-          <section className="rounded-sm border border-su-black bg-white p-4">
+          <section className="rounded-[3px] border-[1.5px] border-ink bg-paper p-4">
             <h2 className="mb-3 font-cond text-sm font-bold uppercase tracking-widest text-su-black">
               Workspace
             </h2>

--- a/apps/in-the-union-now/src/routes/pilots/$id_.edit.tsx
+++ b/apps/in-the-union-now/src/routes/pilots/$id_.edit.tsx
@@ -29,8 +29,8 @@ function EditPilotRoute() {
 
   if (!pilot) {
     return (
-      <main className="mx-auto max-w-7xl px-4 py-8">
-        <p className="text-muted-foreground">Pilot not found.</p>
+      <main className="mx-auto max-w-7xl p-6">
+        <p className="text-wk-muted">Pilot not found.</p>
         <Link to="/" className="text-sm underline">
           Back to dashboard
         </Link>
@@ -47,7 +47,7 @@ function EditPilotRoute() {
   }
 
   return (
-    <main className="min-h-dvh bg-background">
+    <main>
       <PilotWizard
         key={pilot.id}
         pilotId={pilot.id}

--- a/apps/in-the-union-now/src/routes/pilots/new.tsx
+++ b/apps/in-the-union-now/src/routes/pilots/new.tsx
@@ -24,7 +24,7 @@ function NewPilotRoute() {
   }
 
   return (
-    <main className="min-h-dvh bg-background">
+    <main>
       <PilotWizard onComplete={handleComplete} onCancel={handleCancel} />
     </main>
   )

--- a/apps/in-the-union-now/src/routes/s/$id.tsx
+++ b/apps/in-the-union-now/src/routes/s/$id.tsx
@@ -58,7 +58,7 @@ export function SnapshotPageInner({ snapshot, notFound, error }: SnapshotPageInn
     return (
       <main className="mx-auto max-w-5xl p-6">
         <h1 className="mb-2 text-xl font-bold">Snapshot not found</h1>
-        <p className="mb-4 text-sm text-muted-foreground">
+        <p className="mb-4 text-sm text-wk-muted">
           This snapshot link may have expired or never existed.
         </p>
         <AppLink
@@ -75,7 +75,7 @@ export function SnapshotPageInner({ snapshot, notFound, error }: SnapshotPageInn
     return (
       <main className="mx-auto max-w-5xl p-6">
         <h1 className="mb-2 text-xl font-bold">Failed to load snapshot</h1>
-        <p className="mb-4 text-sm text-muted-foreground">{error}</p>
+        <p className="mb-4 text-sm text-wk-muted">{error}</p>
         <AppLink
           href="/"
           className={cn(buttonVariants({ variant: 'ghost', size: 'sm' }), 'no-underline')}

--- a/apps/in-the-union-now/src/routes/sheet/$kind/$id.tsx
+++ b/apps/in-the-union-now/src/routes/sheet/$kind/$id.tsx
@@ -28,7 +28,7 @@ function SheetKindNotFound() {
   return (
     <main className="mx-auto max-w-5xl p-6">
       <h1 className="mb-2 text-xl font-bold">Sheet not found</h1>
-      <p className="mb-4 text-sm text-muted-foreground">
+      <p className="mb-4 text-sm text-wk-muted">
         &ldquo;{params.kind}&rdquo; is not a sheet type. Sheets exist for pilots, mechs, and
         crawlers.
       </p>

--- a/apps/in-the-union-now/src/routes/sheet/$kind/$id_.share.tsx
+++ b/apps/in-the-union-now/src/routes/sheet/$kind/$id_.share.tsx
@@ -23,7 +23,7 @@ function ShareKindNotFound() {
   return (
     <main className="mx-auto max-w-5xl p-6">
       <h1 className="mb-2 text-xl font-bold">Nothing to share</h1>
-      <p className="text-muted-foreground mb-4 text-sm">
+      <p className="text-wk-muted mb-4 text-sm">
         &ldquo;{params.kind}&rdquo; is not a sheet type. Snapshots exist for pilots, mechs, and
         crawlers.
       </p>

--- a/packages/suref-react/src/components/chrome/OptRow.tsx
+++ b/packages/suref-react/src/components/chrome/OptRow.tsx
@@ -38,20 +38,23 @@ export function OptRow({ name, desc, active = false, onClick, img, className }: 
         </span>
       )}
       <span className="min-w-0 flex-1">
-        <span className="block font-cond text-[19px] font-bold uppercase leading-tight text-ink">
+        <span className="block font-cond text-lg font-bold uppercase leading-tight text-ink">
           {name}
         </span>
         {desc && (
-          <span className="mt-0.5 line-clamp-2 block font-body text-[11.5px] leading-snug text-wk-muted">
+          <span className="mt-0.5 line-clamp-2 block font-body text-xs leading-snug text-wk-muted">
             {desc}
           </span>
         )}
       </span>
-      {active && (
-        <span aria-hidden="true" className="shrink-0 font-cond text-lg font-bold text-rust">
-          ▸
-        </span>
-      )}
+      {/* Always reserve the caret slot so selecting a row doesn't reflow the
+          flex-1 name column (caret only paints when active). */}
+      <span
+        aria-hidden="true"
+        className="w-[1ch] shrink-0 text-center font-cond text-lg font-bold text-rust"
+      >
+        {active ? '▸' : ''}
+      </span>
     </button>
   )
 }


### PR DESCRIPTION
Stacked on #328 (`fix/itun-duplicate-mech-systems`). **Style-only** — no behavior, schema, or data changes.

A five-surface layout audit (dashboard · live mech sheet · mech wizard · pilot/crawler · shared blocks) found ~63 issues clustering into one root cause and a handful of cross-cutting themes. This PR resolves them, converging the app on the **shared `suref-react` design-system tokens** per direction ("one color set, from the shared package").

## One color set, from the shared package
The app spoke two dialects: the wizard/live-sheet brand family (`ink` / `paper` / `wk-muted` / `rust`, all defined in `suref-react/styles/theme.css`) vs. an off-system ShadCN set (`bg-white`, `border-su-black`, `text-muted-foreground`, `text-destructive`) on the detail routes, patterns page, and a few shared blocks. Everything now uses the shared semantic tokens.

## Eliminate visual jitter
- **Masonry → row-major grid** in every selector list (mech Install, pilot Abilities/Equipment, crawler Systems) — cards no longer reshuffle between columns when a tech-tier filter changes the visible set.
- **`tabular-nums` + min-width** on live counters (uses, Hold slots) and a **reserved min-height** for the Heat Check readout — incrementing/rolling no longer twitches adjacent controls or reflows the sheet.
- **Repair-confirm** moved to its own foot row so toggling it stops dragging the equal-height card row.
- **Wizard `h1` anchored** in the main pane across all steps; **OptRow caret slot always reserved** so selecting a row no longer shifts the name.

## Align + declutter
- **Page shells:** detail views kept matched to the test-locked `max-w-7xl` live sheet (the audit's "shrink to 5xl" suggestion would have *introduced* a reflow — see note); patterns gallery `6xl → 5xl`; symmetric `p-6`; wizard route wrappers drop redundant `min-h-dvh`/`bg-background` (WizShell owns the ground).
- **Snap off-scale arbitraries** to the Tailwind scale: `gap-[30px]/[25px]/[9px]`, `mt-[26px]`, `gap-3.5`, `max-w-[760px]`, `text-[23px]/[19px]/[13px]/[13.5px]/[11.5px]`; radius zoo → `rounded-[3px]` (inset) / `rounded-lg` (floating).
- **Button consistency:** remove/confirm actions standardized on `MiniBtn`/`Btn`; crawler capacity warning routed through the shared `SoftWarningBanner`.
- **De-nest** the storage-chit and `SoftWarningBanner` box-in-box borders; drop duplicated subtitle/CTA/prose.
- **Dashboard:** one create CTA per empty column, end-aligned header rail, reserved loading footprint, icon delete button, intermediate gutter stop.

## Preserved by design
The documented `--bw-*` border-weight role system (entity 3px / rail 2.5px / pill 2px / chrome 1.5px) is **intentional and kept**, not flattened.

## Validation
`typecheck` (all pkgs) ✔ · `lint` ✔ · ITUN tests **913** ✔ · suref-react **310** ✔ · suref-web **953** ✔. Only one genuinely shared file changed (`OptRow.tsx`); suref-web does not consume it.

## Deferred / notes
- The audit's page-width recommendation was based on a wrong premise (it missed that `Sheet.tsx` sets its own `max-w-7xl`); detail views were already 7xl-matched to the live sheet, so they stay 7xl.
- Visual confirmation is best done on the Netlify deploy preview for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)