### PR TITLE
feat: /su command namespace + Discord bot install page

### DIFF
--- a/apps/discord-bot/src/__tests__/format.test.ts
+++ b/apps/discord-bot/src/__tests__/format.test.ts
@@ -6,6 +6,7 @@ import { beforeAll, describe, expect, test } from 'bun:test'
 import { SalvageUnionReference, rollOnTable, getEntitySlug, search } from 'salvageunion-reference'
 
 import {
+  ROLL_EMBED_FOOTER,
   buildLookupEmbedData,
   buildRollEmbedData,
   entityUrl,
@@ -92,5 +93,12 @@ describe('buildLookupEmbedData / entityUrl', () => {
     expect(entityUrl('chassis', chassis)).toMatch(
       /^https:\/\/salvageunion\.io\/schema\/chassis\/item\/[a-z0-9-]+$/
     )
+  })
+})
+
+describe('roll embed footer attribution', () => {
+  test('credits Randsum.dev, since rolls are powered by @randsum/roller', () => {
+    expect(ROLL_EMBED_FOOTER).toContain('Powered by Randsum.dev')
+    expect(ROLL_EMBED_FOOTER).toContain('Salvage Union Reference')
   })
 })

--- a/apps/discord-bot/src/__tests__/su.test.ts
+++ b/apps/discord-bot/src/__tests__/su.test.ts
@@ -1,0 +1,54 @@
+/**
+ * /su namespace command — builder shape + subcommand dispatch.
+ *
+ * The handlers' behavior is covered by format.test.ts (pure functions);
+ * these tests pin the registration contract: one top-level command named
+ * `su` carrying exactly the roll and lookup subcommands, with execute/
+ * autocomplete routed by getSubcommand().
+ */
+import { describe, expect, test } from 'bun:test'
+
+import { commands } from '../commands/index.js'
+import { suCommand } from '../commands/su.js'
+
+describe('/su command', () => {
+  test('is the only registered top-level command', () => {
+    expect([...commands.keys()]).toEqual(['su'])
+  })
+
+  test('registers roll and lookup as subcommands with their options', () => {
+    const json = suCommand.data.toJSON()
+    expect(json.name).toBe('su')
+    const subs = (json.options ?? []).map((o) => o.name).sort()
+    expect(subs).toEqual(['lookup', 'roll'])
+
+    const roll = (json.options ?? []).find((o) => o.name === 'roll')
+    const lookup = (json.options ?? []).find((o) => o.name === 'lookup')
+    expect(
+      (roll as { options?: { name: string; autocomplete?: boolean }[] }).options?.[0]
+    ).toMatchObject({ name: 'table', autocomplete: true, required: false })
+    expect(
+      (lookup as { options?: { name: string; autocomplete?: boolean }[] }).options?.[0]
+    ).toMatchObject({ name: 'entity', autocomplete: true, required: true })
+  })
+
+  test('execute throws loudly on an unknown subcommand', async () => {
+    const interaction = {
+      options: { getSubcommand: () => 'nonsense' },
+    } as unknown as Parameters<typeof suCommand.execute>[0]
+    await expect(suCommand.execute(interaction)).rejects.toThrow('Unknown /su subcommand')
+  })
+
+  test('autocomplete responds empty on an unknown subcommand', async () => {
+    let responded: unknown = null
+    const interaction = {
+      options: { getSubcommand: () => 'nonsense' },
+      respond: (choices: unknown) => {
+        responded = choices
+        return Promise.resolve()
+      },
+    } as unknown as Parameters<typeof suCommand.autocomplete>[0]
+    await suCommand.autocomplete(interaction)
+    expect(responded).toEqual([])
+  })
+})

--- a/apps/discord-bot/src/commands/index.ts
+++ b/apps/discord-bot/src/commands/index.ts
@@ -2,21 +2,22 @@ import {
   Collection,
   type SlashCommandBuilder,
   type SlashCommandOptionsOnlyBuilder,
+  type SlashCommandSubcommandsOnlyBuilder,
   type ChatInputCommandInteraction,
   type AutocompleteInteraction,
 } from 'discord.js'
 
-import { lookupCommand } from './lookup.js'
-import { rollCommand } from './roll.js'
+import { suCommand } from './su.js'
 
 export type Command = {
-  data: SlashCommandBuilder | SlashCommandOptionsOnlyBuilder
+  data: SlashCommandBuilder | SlashCommandOptionsOnlyBuilder | SlashCommandSubcommandsOnlyBuilder
   execute: (interaction: ChatInputCommandInteraction) => Promise<void>
   autocomplete?: (interaction: AutocompleteInteraction) => Promise<void>
 }
 
 export const commands = new Collection<string, Command>()
 
-// Register all commands
-commands.set(rollCommand.data.name, rollCommand)
-commands.set(lookupCommand.data.name, lookupCommand)
+// One top-level command; roll/lookup live under it as subcommands (see su.ts).
+// deploy-commands.ts bulk-overwrites the registered set, so the retired
+// standalone /roll and /lookup deregister automatically on the next deploy.
+commands.set(suCommand.data.name, suCommand)

--- a/apps/discord-bot/src/commands/lookup.ts
+++ b/apps/discord-bot/src/commands/lookup.ts
@@ -1,9 +1,9 @@
 import {
-  SlashCommandBuilder,
   EmbedBuilder,
   MessageFlags,
   type ChatInputCommandInteraction,
   type AutocompleteInteraction,
+  type SlashCommandSubcommandBuilder,
 } from 'discord.js'
 import { search, getEntitySlug, findEntityBySlug } from 'salvageunion-reference'
 import type { SURefEntity, SURefEnumSchemaName } from 'salvageunion-reference'
@@ -36,16 +36,19 @@ function findByChoiceValue(value: string): Hit | null {
 }
 
 export const lookupCommand = {
-  data: new SlashCommandBuilder()
-    .setName('lookup')
-    .setDescription('Look up any Salvage Union entity (equipment, chassis, systems, keywords, …)')
-    .addStringOption((option) =>
-      option
-        .setName('entity')
-        .setDescription('What to look up')
-        .setRequired(true)
-        .setAutocomplete(true)
-    ),
+  /** Options for the `/su lookup` subcommand (registered by su.ts). */
+  subcommand(sub: SlashCommandSubcommandBuilder): SlashCommandSubcommandBuilder {
+    return sub
+      .setName('lookup')
+      .setDescription('Look up any Salvage Union entity (equipment, chassis, systems, keywords, …)')
+      .addStringOption((option) =>
+        option
+          .setName('entity')
+          .setDescription('What to look up')
+          .setRequired(true)
+          .setAutocomplete(true)
+      )
+  },
 
   async autocomplete(interaction: AutocompleteInteraction): Promise<void> {
     const focusedValue = interaction.options.getFocused()

--- a/apps/discord-bot/src/commands/roll.ts
+++ b/apps/discord-bot/src/commands/roll.ts
@@ -1,9 +1,9 @@
 import {
-  SlashCommandBuilder,
   EmbedBuilder,
   MessageFlags,
   type ChatInputCommandInteraction,
   type AutocompleteInteraction,
+  type SlashCommandSubcommandBuilder,
 } from 'discord.js'
 import { roll as rollDie } from '@randsum/roller'
 import { SalvageUnionReference, rollOnTable } from 'salvageunion-reference'
@@ -28,16 +28,19 @@ function rollD20(): number {
 }
 
 export const rollCommand = {
-  data: new SlashCommandBuilder()
-    .setName('roll')
-    .setDescription('Roll on a Salvage Union table')
-    .addStringOption((option) =>
-      option
-        .setName('table')
-        .setDescription('The table to roll on (defaults to Core Mechanic)')
-        .setRequired(false)
-        .setAutocomplete(true)
-    ),
+  /** Options for the `/su roll` subcommand (registered by su.ts). */
+  subcommand(sub: SlashCommandSubcommandBuilder): SlashCommandSubcommandBuilder {
+    return sub
+      .setName('roll')
+      .setDescription('Roll on a Salvage Union table')
+      .addStringOption((option) =>
+        option
+          .setName('table')
+          .setDescription('The table to roll on (defaults to Core Mechanic)')
+          .setRequired(false)
+          .setAutocomplete(true)
+      )
+  },
 
   async autocomplete(interaction: AutocompleteInteraction): Promise<void> {
     const focusedValue = interaction.options.getFocused().toLowerCase()

--- a/apps/discord-bot/src/commands/roll.ts
+++ b/apps/discord-bot/src/commands/roll.ts
@@ -8,7 +8,7 @@ import {
 import { roll as rollDie } from '@randsum/roller'
 import { SalvageUnionReference, rollOnTable } from 'salvageunion-reference'
 
-import { buildRollEmbedData } from '../format.js'
+import { ROLL_EMBED_FOOTER, buildRollEmbedData } from '../format.js'
 
 // Roll tables load lazily once SalvageUnionReference.preload() has run at startup.
 // Accessing them at module load would throw before preload completes, so defer to first use.
@@ -84,7 +84,7 @@ export const rollCommand = {
       .setTitle(data.title)
       .setColor(data.color)
       .addFields(data.fields)
-      .setFooter({ text: 'Salvage Union Reference' })
+      .setFooter({ text: ROLL_EMBED_FOOTER })
       .setTimestamp()
     if (data.description) {
       embed.setDescription(data.description)

--- a/apps/discord-bot/src/commands/su.ts
+++ b/apps/discord-bot/src/commands/su.ts
@@ -1,0 +1,55 @@
+/**
+ * /su — the bot's single top-level command; everything else is a subcommand.
+ *
+ * Namespacing fixes the collision problem for good: every dice bot on a
+ * server registers /roll, so ours competed in the command picker on avatar
+ * alone. Typing /su filters the picker to this bot, and every future
+ * subcommand (encounter cards, snapshot lookups, …) lands collision-proof
+ * with zero naming deliberation.
+ *
+ * The subcommand option shapes live with their handlers (roll.ts,
+ * lookup.ts); this module only composes the builder and dispatches on
+ * `getSubcommand()`. Handlers read their options identically under a
+ * subcommand, so their logic and tests are untouched.
+ */
+
+import {
+  SlashCommandBuilder,
+  type AutocompleteInteraction,
+  type ChatInputCommandInteraction,
+} from 'discord.js'
+
+import { lookupCommand } from './lookup.js'
+import { rollCommand } from './roll.js'
+
+export const suCommand = {
+  data: new SlashCommandBuilder()
+    .setName('su')
+    .setDescription('Salvage Union reference tools')
+    .addSubcommand((sub) => rollCommand.subcommand(sub))
+    .addSubcommand((sub) => lookupCommand.subcommand(sub)),
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    switch (interaction.options.getSubcommand()) {
+      case 'roll':
+        return rollCommand.execute(interaction)
+      case 'lookup':
+        return lookupCommand.execute(interaction)
+      default:
+        // Unreachable while the builder above and this switch agree; loud
+        // beats silent if they ever drift.
+        throw new Error(`Unknown /su subcommand: ${interaction.options.getSubcommand()}`)
+    }
+  },
+
+  async autocomplete(interaction: AutocompleteInteraction): Promise<void> {
+    switch (interaction.options.getSubcommand()) {
+      case 'roll':
+        return rollCommand.autocomplete(interaction)
+      case 'lookup':
+        return lookupCommand.autocomplete(interaction)
+      default:
+        await interaction.respond([])
+    }
+  },
+}

--- a/apps/discord-bot/src/format.ts
+++ b/apps/discord-bot/src/format.ts
@@ -39,6 +39,13 @@ type EmbedData = {
   fields: { name: string; value: string; inline: boolean }[]
 }
 
+/**
+ * Footer for /su roll embeds. Rolls are powered by @randsum/roller, so the
+ * roll output carries a "Powered by Randsum.dev" attribution (Discord embed
+ * footers are plain text — not clickable — so the URL reads as bare text).
+ */
+export const ROLL_EMBED_FOOTER = 'Salvage Union Reference · Powered by Randsum.dev'
+
 /** Shape a /roll outcome into embed data (works for flat + columns tables). */
 export function buildRollEmbedData(tableName: string, outcome: RollOnTableOutcome): EmbedData {
   if (!outcome.success) {

--- a/apps/suref-web/src/components/TopNavigation.astro
+++ b/apps/suref-web/src/components/TopNavigation.astro
@@ -76,6 +76,10 @@ function isActive(path: string) {
       CHANGELOG
     </a>
 
+    <a href="/discord/" class:list={['nav-link', isActive('/discord') ? 'nav-link-active' : '']} aria-current={isActive('/discord') ? 'page' : undefined}>
+      DISCORD
+    </a>
+
     <a href="/api/" class:list={['nav-link', isActive('/api') ? 'nav-link-active' : '']} aria-current={isActive('/api') ? 'page' : undefined}>
       API
     </a>

--- a/apps/suref-web/src/components/islands/MobileNavIsland.tsx
+++ b/apps/suref-web/src/components/islands/MobileNavIsland.tsx
@@ -145,6 +145,14 @@ export function MobileNavIsland({ categories, currentPath }: MobileNavIslandProp
               >
                 CHANGELOG
               </Button>
+              <Button
+                href="/discord/"
+                active={isActive('/discord')}
+                className="block text-sm"
+                onClick={() => setOpen(false)}
+              >
+                DISCORD
+              </Button>
               <a
                 href="https://leyline.press/collections/salvage-union"
                 target="_blank"

--- a/apps/suref-web/src/lib/changelog.ts
+++ b/apps/suref-web/src/lib/changelog.ts
@@ -7,6 +7,14 @@ type ChangelogEntry = {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     date: '2026-07-03',
+    title: 'Discord bot: install page and the /su command',
+    items: [
+      'New Discord page (in the nav) with a one-click install button and a reference for using the bot at your table.',
+      'Bot commands now live under a single /su namespace \u2014 /su roll and /su lookup \u2014 so they no longer collide with other bots\u2019 /roll in the command picker.',
+    ],
+  },
+  {
+    date: '2026-07-03',
     title: '55 community Mech Monday patterns',
     items: [
       'Seven chassis — Mule, Scrapper, Thresher, Spectrum, Mazona, Goliath, and Bobcat — now carry the community-designed patterns from Leyline Press\u2019s official Mech Monday compilations: 55 new patterns in all, each transcribed from the published cards.',

--- a/apps/suref-web/src/pages/discord.astro
+++ b/apps/suref-web/src/pages/discord.astro
@@ -1,0 +1,169 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro'
+import { SITE_URL } from '../lib/constants'
+
+// The client id is public by design — it appears in every Discord invite
+// URL. The bot itself authenticates with its token, never this id.
+const DISCORD_CLIENT_ID = '1442878052823470172'
+const INSTALL_URL = `https://discord.com/oauth2/authorize?client_id=${DISCORD_CLIENT_ID}&scope=bot%20applications.commands&permissions=0`
+
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'SURef Discord Bot',
+  applicationCategory: 'UtilitiesApplication',
+  operatingSystem: 'Discord',
+  description:
+    'Roll on Salvage Union tables and look up any game entity without leaving your Discord server.',
+  url: `${SITE_URL}/discord/`,
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  isPartOf: {
+    '@type': 'WebSite',
+    name: 'Salvage Union System Reference Document',
+    url: `${SITE_URL}/`,
+  },
+}
+
+const breadcrumbs = [
+  { name: 'Home', url: `${SITE_URL}/` },
+  { name: 'Discord Bot', url: `${SITE_URL}/discord/` },
+]
+---
+
+<BaseLayout
+  title="Discord Bot - Salvage Union System Reference Document"
+  description="Add the SURef bot to your Discord server: roll on every Salvage Union table and look up any chassis, system, module, or piece of equipment with /su."
+  structuredData={structuredData}
+  breadcrumbs={breadcrumbs}
+>
+  <div class="flex w-full flex-1 flex-col py-12">
+    <div class="mx-auto flex w-full max-w-3xl flex-col gap-8 px-6">
+      <h1 class="page-heading">Discord Bot</h1>
+
+      <!-- Overview + install -->
+      <section class="flex flex-col gap-4 text-sm leading-relaxed">
+        <p>
+          The SURef bot brings this reference to your table&rsquo;s Discord server: roll on every
+          Salvage Union table and look up any game entity — chassis, systems, modules, equipment,
+          keywords, and more — without leaving the conversation. Results link back to the full
+          entry on this site.
+        </p>
+        <p>
+          It asks for no server permissions — it only ever replies to slash commands. Free, no
+          account, no configuration.
+        </p>
+        <p>
+          <a
+            href={INSTALL_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="btn btn-active inline-block font-cond text-base uppercase tracking-[0.06em]"
+          >
+            Add to your Discord server
+          </a>
+        </p>
+      </section>
+
+      <!-- Commands -->
+      <section class="flex flex-col gap-6">
+        <h2 class="page-subheading">Commands</h2>
+
+        <div class="rounded-md border-2 border-su-grey-light bg-su-white">
+          <div class="border-b-2 border-su-grey-light px-5 py-3">
+            <p class="mt-1 font-mono text-base font-bold">
+              /su roll <span class="text-su-orange-dark">[table]</span>
+            </p>
+          </div>
+          <div class="flex flex-col gap-3 px-5 py-4 text-sm leading-relaxed">
+            <p>
+              Rolls a d20 on any Salvage Union table. Leave <code
+                class="rounded bg-su-blue-pale px-1 py-0.5">table</code
+              > empty to roll on the <strong>Core Mechanic</strong> table — the game&rsquo;s basic
+              d20 resolution roll.
+            </p>
+            <p>
+              Start typing a table name and autocomplete suggests matches from all 96 tables —
+              Critical Damage, Reactor Overload, Area Salvage, NPC generators, Keepsakes, Mottos,
+              and every table from the expansions. Column tables (like the NPC tables) roll two
+              d20s: one for the column, one for the entry.
+            </p>
+            <p>
+              <strong>Examples:</strong>
+            </p>
+            <ul class="ml-5 flex list-disc flex-col gap-1">
+              <li><code class="rounded bg-su-blue-pale px-1 py-0.5">/su roll</code> — Core Mechanic d20</li>
+              <li>
+                <code class="rounded bg-su-blue-pale px-1 py-0.5">/su roll table: Critical Damage</code
+                > — what happens at 0 SP
+              </li>
+              <li>
+                <code class="rounded bg-su-blue-pale px-1 py-0.5">/su roll table: Group Initiative</code
+                > — who acts first
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="rounded-md border-2 border-su-grey-light bg-su-white">
+          <div class="border-b-2 border-su-grey-light px-5 py-3">
+            <p class="mt-1 font-mono text-base font-bold">
+              /su lookup <span class="text-su-orange-dark">entity</span>
+            </p>
+          </div>
+          <div class="flex flex-col gap-3 px-5 py-4 text-sm leading-relaxed">
+            <p>
+              Looks up any entity in the reference — the same search as this site&rsquo;s
+              <kbd class="rounded border border-su-grey-light bg-su-blue-pale px-1.5 py-0.5 font-mono text-xs"
+                >Cmd&nbsp;K</kbd
+              > box. Autocomplete searches as you type (multi-word queries and small typos are fine);
+              the reply shows the entity&rsquo;s key stats and links to its full page here.
+            </p>
+            <p>
+              <strong>Examples:</strong>
+            </p>
+            <ul class="ml-5 flex list-disc flex-col gap-1">
+              <li>
+                <code class="rounded bg-su-blue-pale px-1 py-0.5">/su lookup entity: heavy laser</code>
+              </li>
+              <li>
+                <code class="rounded bg-su-blue-pale px-1 py-0.5">/su lookup entity: iron mongrel</code>
+              </li>
+              <li>
+                <code class="rounded bg-su-blue-pale px-1 py-0.5">/su lookup entity: overheat</code>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- Notes -->
+      <section class="flex flex-col gap-3 text-sm leading-relaxed">
+        <h2 class="page-subheading">Good to know</h2>
+        <ul class="ml-5 flex list-disc flex-col gap-2">
+          <li>
+            Typing <code class="rounded bg-su-blue-pale px-1 py-0.5">/su</code> filters
+            Discord&rsquo;s command picker to just this bot — no more fishing your roll out of a
+            pile of identically-named commands from other bots.
+          </li>
+          <li>
+            The bot serves the same dataset as this site, including expansion content and the
+            community Mech Monday patterns. It updates automatically when the reference does.
+          </li>
+          <li>
+            It never reads messages — its only Discord capability is answering slash commands.
+          </li>
+        </ul>
+        <p class="rounded-md border-l-4 border-su-orange-dark bg-su-blue-pale px-4 py-3">
+          <strong>Running a campaign?</strong> Pair the bot with{' '}
+          <a
+            href="https://in-the-union-now.netlify.app"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="font-bold text-su-orange-dark hover:underline">In The Union Now</a
+          >, the no-account character builder &amp; game manager — sheets can be shared into
+          Discord as snapshot links.
+        </p>
+      </section>
+    </div>
+  </div>
+</BaseLayout>

--- a/apps/suref-web/src/pages/discord.astro
+++ b/apps/suref-web/src/pages/discord.astro
@@ -164,6 +164,17 @@ const breadcrumbs = [
           Discord as snapshot links.
         </p>
       </section>
+
+      <!-- Attribution -->
+      <p class="border-t border-su-grey-light pt-6 text-center text-xs text-su-grey-dark">
+        Dice rolling powered by{' '}
+        <a
+          href="https://randsum.dev"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="font-bold text-su-orange-dark hover:underline">Randsum.dev</a
+        >.
+      </p>
     </div>
   </div>
 </BaseLayout>


### PR DESCRIPTION
## What

Two related changes shipping together:

1. **Bot: `/su` command namespace** — the standalone `/roll` and `/lookup` become `/su roll` and `/su lookup` under one top-level command.
2. **Site: `/discord` page** — a nav-linked install page for the bot, with a one-click add button and a usage reference.

## Why

Every dice bot on a server registers `/roll`, so ours competed in Discord's command picker on avatar alone. Typing `/su` filters the picker to this bot exclusively, and every future subcommand lands collision-proof. The site had no way to discover or install the bot at all.

## Bot changes

- `su.ts` composes one `SlashCommandBuilder` and dispatches on `getSubcommand()` — the roll/lookup handlers and their logic are untouched; they export their option shapes as subcommand builders.
- `deploy-commands.ts` bulk-overwrites the registered set, so the retired standalone `/roll` and `/lookup` deregister automatically on the first deploy after merge (~1h global propagation window).
- `su.test.ts` pins the registration contract.

## Site changes

- New `/discord` page: install button (bot + `applications.commands` scopes, **zero** server permissions), command reference for `/su roll` and `/su lookup` with examples + autocomplete notes, and a pointer to the ITUN builder.
- Added to desktop and mobile nav; changelog entry.
- Uses the public Discord client id (`1442878052823470172`) — the same id in every invite link; the bot authenticates with its token, never this id.

## Live status

Bot confirmed **live on Render** (`suref-discord-bot`, latest deploy `live` as of the audit-sweep merge). Once this merges, Render redeploys and the `/su` swap propagates.

## Verification

Bot: 18 tests, tsc, eslint, bundle smoke. Site: 956 tests, `astro check` (0 errors/warnings), production build renders `/discord`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXm6E8TMa7TgMDC4tV2ZMP