### PR TITLE
feat: rich /su lookup embeds + no text-flash on entity load

### DIFF
--- a/apps/discord-bot/src/__tests__/format.test.ts
+++ b/apps/discord-bot/src/__tests__/format.test.ts
@@ -3,16 +3,9 @@
  * Uses real reference data (preloaded) so /lookup shapes match production.
  */
 import { beforeAll, describe, expect, test } from 'bun:test'
-import { SalvageUnionReference, rollOnTable, getEntitySlug, search } from 'salvageunion-reference'
+import { SalvageUnionReference, rollOnTable } from 'salvageunion-reference'
 
-import {
-  ROLL_EMBED_FOOTER,
-  buildLookupEmbedData,
-  buildRollEmbedData,
-  entityUrl,
-  getColor,
-  truncate,
-} from '../format.js'
+import { ROLL_EMBED_FOOTER, buildRollEmbedData, entityUrl, getColor, truncate } from '../format.js'
 
 beforeAll(async () => {
   await SalvageUnionReference.preload('all')
@@ -76,19 +69,8 @@ describe('buildRollEmbedData', () => {
   })
 })
 
-describe('buildLookupEmbedData / entityUrl', () => {
-  test('links to the suref-web item page and carries stat fields', () => {
-    const [hit] = search({ query: 'welding', limit: 1 })
-    expect(hit).toBeDefined()
-    const data = buildLookupEmbedData(hit!.entity, hit!.schemaName)
-    expect(data.url).toBe(
-      `https://salvageunion.io/schema/${hit!.schemaName}/item/${getEntitySlug(hit!.entity)}`
-    )
-    expect(data.fields[0]!.name).toBe('Type')
-    expect(data.title.length).toBeGreaterThan(0)
-  })
-
-  test('entityUrl matches the schema/item route shape', () => {
+describe('entityUrl', () => {
+  test('matches the schema/item route shape', () => {
     const chassis = SalvageUnionReference.Chassis.all()[0]!
     expect(entityUrl('chassis', chassis)).toMatch(
       /^https:\/\/salvageunion\.io\/schema\/chassis\/item\/[a-z0-9-]+$/

--- a/apps/discord-bot/src/__tests__/lookupEmbed.test.ts
+++ b/apps/discord-bot/src/__tests__/lookupEmbed.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Rich /su lookup embed tests.
+ *
+ * The load-bearing test is the exhaustive pass: EVERY entity in EVERY schema
+ * goes through buildLookupEmbed and must yield a Discord-valid embed. We
+ * can't see embeds in Discord, so this is what proves the formatter never
+ * emits something Discord would reject — across all 27 schemas, not the
+ * three we'd pick by hand.
+ */
+import { beforeAll, describe, expect, test } from 'bun:test'
+import {
+  SalvageUnionReference,
+  getDataMaps,
+  getSchemaCatalog,
+  search,
+} from 'salvageunion-reference'
+import type { SURefEntity, SURefEnumSchemaName } from 'salvageunion-reference'
+
+import { buildLookupEmbed, type LookupEmbed } from '../lookupEmbed.js'
+
+// Discord's hard limits (mirrors lookupEmbed.ts).
+const LIMIT = {
+  title: 256,
+  description: 4096,
+  fieldName: 256,
+  fieldValue: 1024,
+  fields: 25,
+  footer: 2048,
+  total: 6000,
+}
+
+function embedCharTotal(e: LookupEmbed): number {
+  const fields = e.fields.reduce((n, f) => n + f.name.length + f.value.length, 0)
+  return e.title.length + (e.description?.length ?? 0) + e.footer.length + fields
+}
+
+function assertValid(e: LookupEmbed, label: string): void {
+  expect(e.title.length, `${label}: title`).toBeLessThanOrEqual(LIMIT.title)
+  expect(e.description?.length ?? 0, `${label}: description`).toBeLessThanOrEqual(LIMIT.description)
+  expect(e.fields.length, `${label}: field count`).toBeLessThanOrEqual(LIMIT.fields)
+  expect(e.footer.length, `${label}: footer`).toBeLessThanOrEqual(LIMIT.footer)
+  for (const f of e.fields) {
+    expect(f.name.length, `${label}: field name "${f.name}"`).toBeLessThanOrEqual(LIMIT.fieldName)
+    expect(f.value.length, `${label}: field value for "${f.name}"`).toBeLessThanOrEqual(
+      LIMIT.fieldValue
+    )
+  }
+  expect(embedCharTotal(e), `${label}: total chars`).toBeLessThanOrEqual(LIMIT.total)
+}
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+describe('buildLookupEmbed — exhaustive validity across the whole dataset', () => {
+  test('every entity in every non-meta schema yields a Discord-valid embed', () => {
+    const schemas = getSchemaCatalog().schemas.filter((s) => !s.meta)
+    const { dataMap } = getDataMaps()
+    let checked = 0
+    for (const schema of schemas) {
+      const entities = (dataMap[schema.id] as SURefEntity[] | undefined) ?? []
+      for (const entity of entities) {
+        const embed = buildLookupEmbed(
+          entity as SURefEntity & { schemaName?: SURefEnumSchemaName },
+          schema.id as SURefEnumSchemaName
+        )
+        assertValid(embed, `${schema.id}/${entity.id}`)
+        checked++
+      }
+    }
+    // Guard against the loop silently checking nothing (accessor drift).
+    expect(checked).toBeGreaterThan(800)
+  })
+})
+
+describe('buildLookupEmbed — content depth', () => {
+  test('a weapon system renders its action text, stats, and linked traits', () => {
+    const gun = SalvageUnionReference.Systems.find((s) => s.name === '.50 Cal Machine Gun')
+    expect(gun).toBeDefined()
+    const e = buildLookupEmbed(
+      { ...gun!, schemaName: 'systems' } as unknown as SURefEntity & {
+        schemaName: SURefEnumSchemaName
+      },
+      'systems'
+    )
+    expect(e.title).toBe('.50 Cal Machine Gun')
+    expect(e.url).toBe('https://salvageunion.io/schema/systems/item/50-cal-machine-gun')
+    expect(e.fields[0]).toMatchObject({ name: 'Type' })
+    // Action mechanical text is present (not just a summary).
+    expect(e.description).toContain('Range:')
+    expect(e.description).toContain('Damage:')
+    // Traits link out to their glossary pages (nested-entity linking).
+    expect(e.description).toContain('/schema/traits/item/')
+    // Flavor content from the action is inlined.
+    expect(e.description!.toLowerCase()).toContain('ballistic')
+  })
+
+  test('a keyword renders its glossary definition', () => {
+    const [hit] = search({ query: 'cover', schemas: ['keywords'], limit: 1 })
+    expect(hit).toBeDefined()
+    const e = buildLookupEmbed(hit!.entity, 'keywords')
+    expect(e.description && e.description.length).toBeGreaterThan(0)
+    expect(e.fields[0]).toMatchObject({ name: 'Type', value: 'Keyword' })
+  })
+
+  test('a chassis renders its stat grid and links patterns without inlining them', () => {
+    const goliath = SalvageUnionReference.Chassis.find((c) => c.name === 'Goliath')
+    expect(goliath).toBeDefined()
+    const e = buildLookupEmbed(
+      { ...goliath!, schemaName: 'chassis' } as unknown as SURefEntity & {
+        schemaName: SURefEnumSchemaName
+      },
+      'chassis'
+    )
+    const fieldNames = e.fields.map((f) => f.name)
+    expect(fieldNames).toContain('Structure')
+    expect(fieldNames).toContain('System Slots')
+    // Goliath has 14+ community patterns — they're summarized, and the whole
+    // thing still fits the budget (asserted by the exhaustive test too).
+    expect(e.description).toContain('Patterns')
+  })
+
+  test('a roll-table links out instead of inlining its rows', () => {
+    const table = SalvageUnionReference.RollTables.all()[0]!
+    const e = buildLookupEmbed(
+      { ...table, schemaName: 'roll-tables' } as unknown as SURefEntity & {
+        schemaName: SURefEnumSchemaName
+      },
+      'roll-tables'
+    )
+    expect(e.description).toContain('/su roll')
+  })
+})

--- a/apps/discord-bot/src/__tests__/lookupEmbed.test.ts
+++ b/apps/discord-bot/src/__tests__/lookupEmbed.test.ts
@@ -120,6 +120,21 @@ describe('buildLookupEmbed — content depth', () => {
     expect(e.description).toContain('Patterns')
   })
 
+  test('chassis ability text resolves [(CHASSIS)] to the chassis name', () => {
+    // Every chassis with a [(CHASSIS)] placeholder in its ability text must
+    // render the name, never the literal token (regression: PR #336 review).
+    const chassis = (getDataMaps().dataMap['chassis'] as { name: string }[]) ?? []
+    for (const c of chassis) {
+      const e = buildLookupEmbed(
+        { ...c, schemaName: 'chassis' } as unknown as SURefEntity & {
+          schemaName: SURefEnumSchemaName
+        },
+        'chassis'
+      )
+      expect(e.description ?? '', `${c.name} leaks the placeholder`).not.toContain('[(CHASSIS)]')
+    }
+  })
+
   test('a roll-table links out instead of inlining its rows', () => {
     const table = SalvageUnionReference.RollTables.all()[0]!
     const e = buildLookupEmbed(

--- a/apps/discord-bot/src/commands/lookup.ts
+++ b/apps/discord-bot/src/commands/lookup.ts
@@ -8,7 +8,7 @@ import {
 import { search, getEntitySlug, findEntityBySlug } from 'salvageunion-reference'
 import type { SURefEntity, SURefEnumSchemaName } from 'salvageunion-reference'
 
-import { buildLookupEmbedData } from '../format.js'
+import { buildLookupEmbed } from '../lookupEmbed.js'
 
 type Hit = {
   schemaName: SURefEnumSchemaName
@@ -88,13 +88,13 @@ export const lookupCommand = {
       return
     }
 
-    const data = buildLookupEmbedData(hit.entity, hit.schemaName)
+    const data = buildLookupEmbed(hit.entity, hit.schemaName)
     const embed = new EmbedBuilder()
       .setTitle(data.title)
       .setColor(data.color)
-      .addFields(data.fields)
-      .setFooter({ text: 'Salvage Union Reference' })
+      .setFooter({ text: data.footer })
       .setTimestamp()
+    if (data.fields.length) embed.addFields(data.fields)
     if (data.url) embed.setURL(data.url)
     if (data.description) embed.setDescription(data.description)
 

--- a/apps/discord-bot/src/format.ts
+++ b/apps/discord-bot/src/format.ts
@@ -4,8 +4,8 @@
  */
 
 import type { RollOnTableOutcome } from 'salvageunion-reference'
-import { SchemaToDisplayName, getEntitySlug } from 'salvageunion-reference'
-import type { SURefEntity, SURefEnumSchemaName } from 'salvageunion-reference'
+import { getEntitySlug } from 'salvageunion-reference'
+import type { SURefEntity } from 'salvageunion-reference'
 
 const SUREF_WEB_BASE_URL = 'https://salvageunion.io'
 
@@ -86,43 +86,4 @@ export function buildRollEmbedData(tableName: string, outcome: RollOnTableOutcom
 /** Item-page URL on the reference site (matches suref-web staticPaths). */
 export function entityUrl(schemaName: string, entity: SURefEntity): string {
   return `${SUREF_WEB_BASE_URL}/schema/${schemaName}/item/${getEntitySlug(entity)}`
-}
-
-/** Shape a /lookup hit into embed data. */
-export function buildLookupEmbedData(
-  entity: SURefEntity & { schemaName: SURefEnumSchemaName },
-  schemaName: SURefEnumSchemaName
-): EmbedData {
-  const raw = entity as unknown as Record<string, unknown>
-  const displayName = (SchemaToDisplayName as Record<string, string>)[schemaName] ?? schemaName
-  const fields: EmbedData['fields'] = [{ name: 'Type', value: displayName, inline: true }]
-
-  const techLevel = raw['techLevel']
-  if (typeof techLevel === 'number' || typeof techLevel === 'string') {
-    fields.push({ name: 'Tech Level', value: String(techLevel), inline: true })
-  }
-  const salvageValue = raw['salvageValue']
-  if (typeof salvageValue === 'number') {
-    fields.push({ name: 'Salvage Value', value: String(salvageValue), inline: true })
-  }
-  const slots = raw['slotsRequired']
-  if (typeof slots === 'number') {
-    fields.push({ name: 'Slots', value: String(slots), inline: true })
-  }
-
-  const description =
-    typeof raw['description'] === 'string' && raw['description']
-      ? raw['description']
-      : typeof raw['effect'] === 'string'
-        ? raw['effect']
-        : ''
-
-  const name = typeof raw['name'] === 'string' ? (raw['name'] as string) : entity.id
-  return {
-    title: truncate(name, 256),
-    color: NEUTRAL_EMBED_COLOR,
-    description: description ? truncate(description, 2048) : undefined,
-    url: entityUrl(schemaName, entity),
-    fields,
-  }
 }

--- a/apps/discord-bot/src/format.ts
+++ b/apps/discord-bot/src/format.ts
@@ -25,6 +25,7 @@ export function getColor(roll: number): number {
 
 /** Truncate to Discord's limits without splitting mid-word when possible. */
 export function truncate(text: string, max: number): string {
+  if (max <= 0) return ''
   if (text.length <= max) return text
   const cut = text.slice(0, max - 1)
   const lastSpace = cut.lastIndexOf(' ')

--- a/apps/discord-bot/src/lookupEmbed.ts
+++ b/apps/discord-bot/src/lookupEmbed.ts
@@ -29,6 +29,7 @@ import {
   getSlotsRequired,
   getTechLevel,
   nameToSlug,
+  replaceChassisPlaceholder,
 } from 'salvageunion-reference'
 import type { SURefEntity, SURefEnumSchemaName, SURefMetaAction } from 'salvageunion-reference'
 
@@ -96,7 +97,7 @@ function renderDataValues(values: DataValue[]): string {
 }
 
 /** Flatten structured content blocks into Discord-flavored markdown. */
-function flattenContent(blocks: ContentBlock[] | undefined): string {
+function flattenContent(blocks: ContentBlock[] | undefined, chassisName?: string): string {
   if (!Array.isArray(blocks)) return ''
   const sections: string[] = []
   for (const block of blocks) {
@@ -106,7 +107,10 @@ function flattenContent(blocks: ContentBlock[] | undefined): string {
       if (dv) sections.push(dv)
       continue
     }
-    const text = typeof block.value === 'string' ? block.value.trim() : ''
+    const text = replaceChassisPlaceholder(
+      typeof block.value === 'string' ? block.value : '',
+      chassisName
+    ).trim()
     let line = ''
     if (text) {
       switch (type) {
@@ -133,7 +137,12 @@ function flattenContent(blocks: ContentBlock[] | undefined): string {
     }
     const items = Array.isArray(block.items)
       ? block.items
-          .map((it) => (typeof it.value === 'string' ? it.value.trim() : ''))
+          .map((it) =>
+            replaceChassisPlaceholder(
+              typeof it.value === 'string' ? it.value : '',
+              chassisName
+            ).trim()
+          )
           .filter(Boolean)
           .map((v) => `• ${v}`)
       : []
@@ -181,7 +190,7 @@ function actionStatLine(action: AnyRecord): string {
 
 /** Render one resolved action to a markdown chunk. `ownName` suppresses a
  *  redundant title when the action shares the entity's name. */
-function renderAction(action: SURefMetaAction, ownName: string): string {
+function renderAction(action: SURefMetaAction, ownName: string, chassisName?: string): string {
   const a = action as unknown as AnyRecord
   const title = (a['displayName'] as string) || (a['name'] as string) || ''
   const lines: string[] = []
@@ -190,7 +199,7 @@ function renderAction(action: SURefMetaAction, ownName: string): string {
   const stat = actionStatLine(a)
   if (stat) lines.push(stat)
 
-  const body = flattenContent(a['content'] as ContentBlock[] | undefined)
+  const body = flattenContent(a['content'] as ContentBlock[] | undefined, chassisName)
   if (body) lines.push(body)
 
   const traits = renderTraits(a['traits'])
@@ -206,7 +215,7 @@ function renderAction(action: SURefMetaAction, ownName: string): string {
   if (Array.isArray(choices)) {
     for (const c of choices as AnyRecord[]) {
       const cname = typeof c['name'] === 'string' ? c['name'] : 'Choice'
-      const cbody = flattenContent(c['content'] as ContentBlock[] | undefined)
+      const cbody = flattenContent(c['content'] as ContentBlock[] | undefined, chassisName)
       const table =
         typeof c['rollTable'] === 'string' && c['rollTable']
           ? ` (${entityLink('roll-tables', c['rollTable'] as string)})`
@@ -268,6 +277,20 @@ function footerFor(entity: AnyRecord): string {
 }
 
 /**
+ * A truncation cut can land mid-`[label](url)`, which Discord renders as
+ * broken markdown. If the tail holds an unterminated link (a trailing `[`
+ * with no complete `](url)` after it), drop it back to before that `[`.
+ */
+function stripDanglingLink(text: string): string {
+  const lastOpen = text.lastIndexOf('[')
+  if (lastOpen === -1) return text
+  const tail = text.slice(lastOpen)
+  // A complete link at the tail is fine; anything else is a dangling cut.
+  if (/^\[[^\]]*\]\([^)]*\)/.test(tail)) return text
+  return text.slice(0, lastOpen).trimEnd()
+}
+
+/**
  * Trim an assembled embed to Discord's limits: field caps first (title,
  * field names/values, field count, description), then the 6000-char total —
  * shed trailing description with a link-out note rather than emit an invalid
@@ -287,7 +310,8 @@ function enforce(embed: LookupEmbed): LookupEmbed {
   const linkNote = embed.url ? `\n\n[Full entry on salvageunion.io](${embed.url})` : ''
   const budget = LIMIT.total - fixed - linkNote.length
   if (embed.description && embed.description.length > budget) {
-    embed.description = truncate(embed.description, Math.max(0, budget)) + linkNote
+    embed.description =
+      stripDanglingLink(truncate(embed.description, Math.max(0, budget))) + linkNote
   }
   return embed
 }
@@ -311,7 +335,11 @@ export function buildLookupEmbed(
   if (typeof e['description'] === 'string' && e['description']) {
     sections.push(e['description'] as string)
   }
-  const ownContent = flattenContent(e['content'] as ContentBlock[] | undefined)
+  // Chassis ability/flavor text carries [(CHASSIS)] placeholders — replace
+  // with the chassis name, as the web does. Non-chassis entities have no
+  // chassis context, so the token is left as-is (also matching the web).
+  const chassisName = schemaName === 'chassis' ? name : undefined
+  const ownContent = flattenContent(e['content'] as ContentBlock[] | undefined, chassisName)
   if (ownContent) sections.push(ownContent)
 
   if (schemaName === 'chassis') {
@@ -322,7 +350,7 @@ export function buildLookupEmbed(
     if (sv !== undefined) fields.push({ name: 'Salvage Value', value: String(sv), inline: true })
     fields.push(...chassisFields)
     for (const ability of getChassisAbilities(entity) ?? []) {
-      sections.push(renderAction(ability, name))
+      sections.push(renderAction(ability, name, chassisName))
     }
     if (patterns) sections.push(patterns)
   } else if (schemaName === 'roll-tables') {

--- a/apps/discord-bot/src/lookupEmbed.ts
+++ b/apps/discord-bot/src/lookupEmbed.ts
@@ -1,0 +1,346 @@
+/**
+ * Rich /su lookup embed builder — a full, layered representation of any
+ * Salvage Union entity, not a summary.
+ *
+ * The data model has layers: an entity (system, module, equipment, ability,
+ * chassis…) references its mechanical ACTIONS by name; each action carries
+ * range / damage / cost / content and references TRAITS, roll TABLES, and
+ * DRONES. We resolve exactly one hop — entity → its actions, rendered inline
+ * as the entity's own text — and then LINK everything those actions point at
+ * (traits, tables, drones) to their own pages rather than inlining them.
+ * That is "keep the same layers of data, link out to nested entities", and
+ * it is also what keeps big entities inside Discord's embed budget.
+ *
+ * Pure and data-shape-driven: one engine covers all ~27 schemas, with a
+ * couple of genuinely structural special cases (chassis stat grid + patterns,
+ * roll-table summaries). No discord.js here — returns plain EmbedData that
+ * commands/lookup.ts maps onto an EmbedBuilder. Everything degrades to bare
+ * text on an unresolved reference; nothing throws.
+ */
+
+import {
+  SchemaToDisplayName,
+  extractVisibleActions,
+  findEntityBySlug,
+  getChassisAbilities,
+  getEntitySlug,
+  getPageReference,
+  getSalvageValue,
+  getSlotsRequired,
+  getTechLevel,
+  nameToSlug,
+} from 'salvageunion-reference'
+import type { SURefEntity, SURefEnumSchemaName, SURefMetaAction } from 'salvageunion-reference'
+
+import { truncate } from './format.js'
+
+const BASE = 'https://salvageunion.io'
+const NEUTRAL = 0xb7410e
+
+// Discord embed limits (per the API): a single embed's total rendered text
+// across title/description/fields/footer must not exceed 6000 chars.
+const LIMIT = {
+  title: 256,
+  description: 4096,
+  fieldName: 256,
+  fieldValue: 1024,
+  fields: 25,
+  footer: 2048,
+  total: 6000,
+} as const
+
+export type LookupEmbed = {
+  title: string
+  url?: string
+  color: number
+  description?: string
+  fields: { name: string; value: string; inline?: boolean }[]
+  footer: string
+}
+
+type AnyRecord = Record<string, unknown>
+
+/** Escape the chars that would break a markdown link label. */
+function escapeLabel(text: string): string {
+  return text.replace(/[[\]()]/g, '\\$&')
+}
+
+/**
+ * Link `name` to its page in `schema` when it resolves there; otherwise emit
+ * the bare (escaped) name. findEntityBySlug is null-safe on a missing schema.
+ */
+function entityLink(schema: SURefEnumSchemaName, name: string): string {
+  const slug = nameToSlug(name)
+  const resolved = slug ? findEntityBySlug(schema, slug) : null
+  const label = escapeLabel(name)
+  return resolved ? `[${label}](${BASE}/schema/${schema}/item/${slug})` : label
+}
+
+type ContentBlock = {
+  type?: string
+  value?: unknown
+  label?: string
+  items?: { type?: string; value?: unknown; label?: string }[]
+}
+
+type DataValue = { label: string | number; value?: string | number; unit?: string }
+
+function renderDataValues(values: DataValue[]): string {
+  return values
+    .map((dv) =>
+      dv.value !== undefined && dv.value !== ''
+        ? `**${dv.label}:** ${dv.value}${dv.unit ? ` ${dv.unit}` : ''}`
+        : `**${dv.label}**`
+    )
+    .join(' · ')
+}
+
+/** Flatten structured content blocks into Discord-flavored markdown. */
+function flattenContent(blocks: ContentBlock[] | undefined): string {
+  if (!Array.isArray(blocks)) return ''
+  const sections: string[] = []
+  for (const block of blocks) {
+    const type = block.type ?? 'paragraph'
+    if (Array.isArray(block.value)) {
+      const dv = renderDataValues(block.value as DataValue[])
+      if (dv) sections.push(dv)
+      continue
+    }
+    const text = typeof block.value === 'string' ? block.value.trim() : ''
+    let line = ''
+    if (text) {
+      switch (type) {
+        case 'heading':
+          line = `**${text}**`
+          break
+        case 'label':
+          line = block.label ? `**${block.label}:** ${text}` : `**${text}**`
+          break
+        case 'list-item':
+          line = `• ${text}`
+          break
+        case 'hint':
+          line = `> ${text}`
+          break
+        case 'flavor':
+          line = `*${text}*`
+          break
+        default:
+          line = text
+      }
+    } else if (block.label) {
+      line = `**${block.label}**`
+    }
+    const items = Array.isArray(block.items)
+      ? block.items
+          .map((it) => (typeof it.value === 'string' ? it.value.trim() : ''))
+          .filter(Boolean)
+          .map((v) => `• ${v}`)
+      : []
+    const combined = [line, ...items].filter(Boolean).join('\n')
+    if (combined) sections.push(combined)
+  }
+  return sections.join('\n\n')
+}
+
+type Trait = { type?: string; amount?: number }
+type Damage = { amount?: number; damageType?: string }
+
+/** Traits an action carries, each linked to its glossary page. */
+function renderTraits(traits: unknown): string {
+  if (!Array.isArray(traits)) return ''
+  const parts = (traits as Trait[])
+    .filter((t) => typeof t.type === 'string')
+    .map((t) => {
+      const link = entityLink('traits', t.type as string)
+      return typeof t.amount === 'number' ? `${link} ${t.amount}` : link
+    })
+  return parts.join(', ')
+}
+
+/** One-line stat summary for an action (range / damage / cost / type). */
+function actionStatLine(action: AnyRecord): string {
+  const parts: string[] = []
+  if (Array.isArray(action['range']) && action['range'].length) {
+    parts.push(`**Range:** ${(action['range'] as string[]).join('/')}`)
+  }
+  const dmg = action['damage'] as Damage | undefined
+  if (dmg && typeof dmg.amount === 'number') {
+    parts.push(`**Damage:** ${dmg.amount}${dmg.damageType ? ` ${dmg.damageType}` : ''}`)
+  }
+  if (typeof action['activationCost'] === 'number') {
+    const cur =
+      typeof action['activationCurrency'] === 'string' ? ` ${action['activationCurrency']}` : ''
+    parts.push(`**Cost:** ${action['activationCost']}${cur}`)
+  }
+  if (typeof action['actionType'] === 'string' && action['actionType'] !== 'Passive') {
+    parts.push(`**${action['actionType']}**`)
+  }
+  return parts.join(' • ')
+}
+
+/** Render one resolved action to a markdown chunk. `ownName` suppresses a
+ *  redundant title when the action shares the entity's name. */
+function renderAction(action: SURefMetaAction, ownName: string): string {
+  const a = action as unknown as AnyRecord
+  const title = (a['displayName'] as string) || (a['name'] as string) || ''
+  const lines: string[] = []
+  if (title && title !== ownName) lines.push(`__${escapeLabel(title)}__`)
+
+  const stat = actionStatLine(a)
+  if (stat) lines.push(stat)
+
+  const body = flattenContent(a['content'] as ContentBlock[] | undefined)
+  if (body) lines.push(body)
+
+  const traits = renderTraits(a['traits'])
+  if (traits) lines.push(`**Traits:** ${traits}`)
+
+  if (typeof a['tableName'] === 'string' && a['tableName']) {
+    lines.push(`**Rolls on:** ${entityLink('roll-tables', a['tableName'] as string)}`)
+  }
+  if (typeof a['drone'] === 'string' && a['drone']) {
+    lines.push(`**Deploys:** ${entityLink('drones', a['drone'] as string)}`)
+  }
+  const choices = a['choices']
+  if (Array.isArray(choices)) {
+    for (const c of choices as AnyRecord[]) {
+      const cname = typeof c['name'] === 'string' ? c['name'] : 'Choice'
+      const cbody = flattenContent(c['content'] as ContentBlock[] | undefined)
+      const table =
+        typeof c['rollTable'] === 'string' && c['rollTable']
+          ? ` (${entityLink('roll-tables', c['rollTable'] as string)})`
+          : ''
+      lines.push(`**Choice — ${escapeLabel(cname)}:**${table}${cbody ? ` ${cbody}` : ''}`)
+    }
+  }
+  return lines.join('\n')
+}
+
+function statFields(entity: AnyRecord): LookupEmbed['fields'] {
+  const fields: LookupEmbed['fields'] = []
+  const push = (name: string, value: unknown) => {
+    if (value !== undefined && value !== null && value !== '') {
+      fields.push({ name, value: String(value), inline: true })
+    }
+  }
+  const tl = getTechLevel(entity as unknown as SURefEntity)
+  push('Tech Level', tl)
+  push('Salvage Value', getSalvageValue(entity as unknown as SURefEntity))
+  push('Slots', getSlotsRequired(entity as unknown as SURefEntity))
+  return fields
+}
+
+/** Chassis-specific stat grid + patterns (a genuine structural special case). */
+function chassisSections(entity: AnyRecord): { fields: LookupEmbed['fields']; patterns: string } {
+  const fields: LookupEmbed['fields'] = []
+  const push = (name: string, value: unknown) => {
+    if (typeof value === 'number') fields.push({ name, value: String(value), inline: true })
+  }
+  push('Structure', entity['structurePoints'])
+  push('Energy', entity['energyPoints'])
+  push('Heat Cap', entity['heatCapacity'])
+  push('Cargo Cap', entity['cargoCapacity'])
+  push('System Slots', entity['systemSlots'])
+  push('Module Slots', entity['moduleSlots'])
+
+  let patterns = ''
+  if (Array.isArray(entity['patterns']) && entity['patterns'].length) {
+    const rows = (entity['patterns'] as AnyRecord[]).map((p) => {
+      const name = typeof p['name'] === 'string' ? escapeLabel(p['name']) : 'Pattern'
+      const systems = Array.isArray(p['systems']) ? (p['systems'] as AnyRecord[]).length : 0
+      const modules = Array.isArray(p['modules']) ? (p['modules'] as AnyRecord[]).length : 0
+      const legal = p['legalStarting'] ? ' ✅' : ''
+      return `• **${name}**${legal} — ${systems} systems, ${modules} modules`
+    })
+    patterns = `**Patterns**\n${rows.join('\n')}`
+  }
+  return { fields, patterns }
+}
+
+function footerFor(entity: AnyRecord): string {
+  const parts: string[] = []
+  if (typeof entity['source'] === 'string') parts.push(entity['source'])
+  const page = getPageReference(entity as unknown as SURefEntity)
+  if (typeof page === 'number') parts.push(`p.${page}`)
+  parts.push('Salvage Union Reference')
+  return truncate(parts.join(' · '), LIMIT.footer)
+}
+
+/**
+ * Trim an assembled embed to Discord's limits: field caps first (title,
+ * field names/values, field count, description), then the 6000-char total —
+ * shed trailing description with a link-out note rather than emit an invalid
+ * embed. Measures rendered markdown (URLs included).
+ */
+function enforce(embed: LookupEmbed): LookupEmbed {
+  embed.title = truncate(embed.title, LIMIT.title)
+  embed.fields = embed.fields.slice(0, LIMIT.fields).map((f) => ({
+    name: truncate(f.name, LIMIT.fieldName),
+    value: truncate(f.value, LIMIT.fieldValue),
+    inline: f.inline,
+  }))
+  if (embed.description) embed.description = truncate(embed.description, LIMIT.description)
+
+  const fieldsLen = embed.fields.reduce((n, f) => n + f.name.length + f.value.length, 0)
+  const fixed = embed.title.length + embed.footer.length + fieldsLen
+  const linkNote = embed.url ? `\n\n[Full entry on salvageunion.io](${embed.url})` : ''
+  const budget = LIMIT.total - fixed - linkNote.length
+  if (embed.description && embed.description.length > budget) {
+    embed.description = truncate(embed.description, Math.max(0, budget)) + linkNote
+  }
+  return embed
+}
+
+/**
+ * Build the full lookup embed for any entity. `entity` must carry its
+ * `schemaName` (the lookup command attaches it).
+ */
+export function buildLookupEmbed(
+  entity: SURefEntity & { schemaName?: SURefEnumSchemaName },
+  schemaName: SURefEnumSchemaName
+): LookupEmbed {
+  const e = entity as unknown as AnyRecord
+  const name = typeof e['name'] === 'string' ? (e['name'] as string) : entity.id
+  const displayType = (SchemaToDisplayName as Record<string, string>)[schemaName] ?? schemaName
+
+  const fields: LookupEmbed['fields'] = [{ name: 'Type', value: displayType, inline: true }]
+  const sections: string[] = []
+
+  // Lead description: an entity's own `description`, then its content blocks.
+  if (typeof e['description'] === 'string' && e['description']) {
+    sections.push(e['description'] as string)
+  }
+  const ownContent = flattenContent(e['content'] as ContentBlock[] | undefined)
+  if (ownContent) sections.push(ownContent)
+
+  if (schemaName === 'chassis') {
+    const { fields: chassisFields, patterns } = chassisSections(e)
+    const tl = getTechLevel(entity)
+    if (tl !== undefined) fields.push({ name: 'Tech Level', value: String(tl), inline: true })
+    const sv = getSalvageValue(entity)
+    if (sv !== undefined) fields.push({ name: 'Salvage Value', value: String(sv), inline: true })
+    fields.push(...chassisFields)
+    for (const ability of getChassisAbilities(entity) ?? []) {
+      sections.push(renderAction(ability, name))
+    }
+    if (patterns) sections.push(patterns)
+  } else if (schemaName === 'roll-tables') {
+    // Don't inline table rows — that duplicates /su roll and blows budget.
+    sections.push(`Roll on this table with \`/su roll table: ${name}\`.`)
+  } else {
+    fields.push(...statFields(e))
+    for (const action of extractVisibleActions(entity) ?? []) {
+      sections.push(renderAction(action, name))
+    }
+  }
+
+  return enforce({
+    title: name,
+    url: `${BASE}/schema/${schemaName}/item/${getEntitySlug(entity)}`,
+    color: NEUTRAL,
+    description: sections.filter(Boolean).join('\n\n') || undefined,
+    fields,
+    footer: footerFor(e),
+  })
+}

--- a/apps/suref-web/src/layouts/BaseLayout.astro
+++ b/apps/suref-web/src/layouts/BaseLayout.astro
@@ -63,9 +63,11 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : new URL(ogImage, SITE_
         `.js [data-static-fallback] { display:none }` (global.css) hides the
         SEO/no-JS text block for JS users. Without this the naked static text
         painted until the client:visible island hydrated — a text-only flash
-        on every entity load. documentElement persists across ClientRouter
-        view transitions, so this runs once and holds. */}
-    <script is:inline>document.documentElement.classList.add('js')</script>
+        on every entity load. `data-astro-rerun` re-runs it on every
+        ClientRouter view transition: Astro resets <html>'s attributes to the
+        incoming (server) document on swap, which drops `.js`, so it must be
+        re-added on each navigation, not just the first load. */}
+    <script is:inline data-astro-rerun>document.documentElement.classList.add('js')</script>
     <title>{title}</title>
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalUrl} />

--- a/apps/suref-web/src/layouts/BaseLayout.astro
+++ b/apps/suref-web/src/layouts/BaseLayout.astro
@@ -59,6 +59,13 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : new URL(ogImage, SITE_
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    {/* Mark the document as JS-capable synchronously, before first paint, so
+        `.js [data-static-fallback] { display:none }` (global.css) hides the
+        SEO/no-JS text block for JS users. Without this the naked static text
+        painted until the client:visible island hydrated — a text-only flash
+        on every entity load. documentElement persists across ClientRouter
+        view transitions, so this runs once and holds. */}
+    <script is:inline>document.documentElement.classList.add('js')</script>
     <title>{title}</title>
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalUrl} />
@@ -105,9 +112,11 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : new URL(ogImage, SITE_
     <ClientRouter />
 
     {/* The per-entity static block (data-static-fallback) is an SEO / no-JS
-        fallback only — the hydrated card is the real view. ReferenceEntityIsland
-        hides it at hydration and removes it once game data is ready, so a data
-        or render failure never leaves the page blank. */}
+        fallback only — the hydrated card is the real view. It is hidden
+        pre-paint for JS users by the `.js` class set above (see global.css),
+        so the naked text never flashes; ReferenceEntityIsland then removes it
+        from the DOM once game data is ready. No-JS users and crawlers keep the
+        content. */}
   </head>
   <body>
     <div class="flex min-h-screen flex-col bg-su-white">

--- a/apps/suref-web/src/lib/changelog.ts
+++ b/apps/suref-web/src/lib/changelog.ts
@@ -6,6 +6,13 @@ type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: '2026-07-04',
+    title: 'No more text flash when opening an entity',
+    items: [
+      'Opening a chassis, system, ability, or any other entity no longer briefly flashes an unstyled text-only version before the full card appears — the styled card (or its loading skeleton) is what you see from the first paint.',
+    ],
+  },
+  {
     date: '2026-07-03',
     title: 'Discord bot: install page and the /su command',
     items: [

--- a/apps/suref-web/src/pages/schema/[schemaId]/item/[itemId].astro
+++ b/apps/suref-web/src/pages/schema/[schemaId]/item/[itemId].astro
@@ -107,8 +107,10 @@ const ogImage = `/schema/${schemaId}/item/${itemId}.og.png`
 >
   <article class="flex min-h-full flex-1 flex-col items-center justify-center p-4">
     <ReferenceEntityIsland client:visible item={item} titleAs="h1" />
-    {/* SEO / no-JS fallback only — BaseLayout strips it for JS users on load +
-        every view-transition navigation, so the naked text never shows. */}
+    {/* SEO / no-JS fallback only. The `.js` class BaseLayout sets pre-paint
+        hides this for JS users via global.css before first paint (no text
+        flash); the island removes it once game data is ready. No-JS users and
+        crawlers keep the content. */}
     {staticSummary && <StaticEntityContent summary={staticSummary} />}
   </article>
 </BaseLayout>

--- a/apps/suref-web/src/styles/global.css
+++ b/apps/suref-web/src/styles/global.css
@@ -3,6 +3,18 @@
 
 @source "../../../../packages/suref-react/src";
 
+/*
+ * SEO / no-JS entity fallback (data-static-fallback): hidden pre-paint for
+ * JS-capable browsers. BaseLayout adds `.js` to <html> synchronously in
+ * <head>, and this render-blocking stylesheet applies before first paint, so
+ * the static text block never flashes before the hydrated card appears. No-JS
+ * users and crawlers (no `.js`) keep the fallback content. See BaseLayout.astro
+ * and ReferenceEntityIsland.tsx.
+ */
+.js [data-static-fallback] {
+  display: none;
+}
+
 /* Button system */
 .btn {
   display: inline-flex;


### PR DESCRIPTION
Addresses two notes.

## Note 2 — full, rich `/su lookup` embeds

`/su lookup` was a four-field summary (Type / TL / SV / Slots + a truncated description) that **dropped the actual mechanical text**. It now renders a full, layered representation of any entity.

**Architecture** — one pure, data-shape-driven `buildLookupEmbed(entity, schema)` (`apps/discord-bot/src/lookupEmbed.ts`) covering all ~27 schemas:
- **Resolves exactly one hop** — entity → its referenced actions, rendered *inline* as the entity's own text: a stat line (Range / Damage / Cost / action type) + the full content blocks (flavor + rules) as markdown.
- **Links, doesn't inline, nested entities** — traits, roll tables, and drones those actions point at become links to their own pages. That's "keep the same layers of data, link out to nested entities," and it keeps big entities in budget.
- **Structural special cases**: chassis get a stat grid (SP/EP/Heat/Cargo/slots) + summarized, linked patterns; roll-tables link out to `/su roll` instead of dumping rows.
- **Budget-safe**: measures rendered markdown (URLs included) and trims to Discord's limits, shedding trailing description with a "full entry on salvageunion.io" link.
- **Degrades gracefully**: any unresolved reference falls back to bare text; never throws.

**Verification that matters** — embeds can't be eyeballed in CI, so the load-bearing test runs **every one of the 849 non-meta entities** through the formatter and asserts every Discord limit holds (title ≤256, description ≤4096, field name/value ≤256/1024, ≤25 fields, ≤6000 total): 8,383 assertions. Plus targeted depth tests (weapon action text + linked traits, keyword glossary, chassis grid + patterns, roll-table link-out).

## Note 1 — no more text-only flash when opening an entity

Entity item pages briefly flashed the SEO/no-JS `StaticEntityContent` fallback before the `client:visible` island hydrated and hid it. `BaseLayout` now adds a `.js` class synchronously in `<head>` and `global.css` hides `[data-static-fallback]` under `.js`, so the fallback is gone on first paint for JS users while no-JS clients and crawlers still get the text. (Not a recurrence of the prior React #418 hydration-mismatch fixes — a different, FOUC class.)

## Verification

`bun run check:all` green: lint, format, typecheck (bot included), all tests across 4 workspaces, validate (slug + bun-version gates), knip. Bot bundle loads under node; suref-web `astro check` clean. Changelog entry added for the flash fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXm6E8TMa7TgMDC4tV2ZMP