### PR TITLE
test(itun): de-flake e2e-itun-preview against cold Netlify previews

### DIFF
--- a/apps/in-the-union-now/e2e/_helpers.ts
+++ b/apps/in-the-union-now/e2e/_helpers.ts
@@ -40,8 +40,12 @@ export async function gotoStable(page: Page, path: string): Promise<void> {
       const message = error instanceof Error ? error.message : String(error)
       if (!/ERR_ABORTED|frame was detached/i.test(message)) throw error
       lastError = error
-      // Let the competing client navigation settle before re-issuing the goto.
-      await page.waitForTimeout(500)
+      // Let the competing client navigation settle deterministically before
+      // re-issuing the goto — wait for the superseding load to reach
+      // `domcontentloaded` rather than blindly sleeping a fixed delay. Swallow:
+      // the aborted load may already be gone, in which case there is nothing to
+      // wait for and we retry immediately.
+      await page.waitForLoadState('domcontentloaded').catch(() => {})
     }
   }
   throw lastError
@@ -130,7 +134,7 @@ export async function buildPilot(page: Page, name: string, callsign: string): Pr
   await clickNext(page) // -> Background
   await clickNext(page) // -> Review
   await page.getByRole('button', { name: /Create Pilot/i }).click()
-  await page.waitForURL((url) => url.pathname === '/', { timeout: 15_000 })
+  await page.waitForURL((url) => url.pathname === '/', { timeout: 30_000 })
 }
 
 /** Build a mech (Chassis → Pattern → Loadout → Identity → Review). */
@@ -146,7 +150,7 @@ export async function buildMech(page: Page, name: string): Promise<void> {
   await page.getByLabel(/Mech name/i).fill(name)
   await clickNext(page) // -> Review
   await page.getByRole('button', { name: /Create Mech/i }).click()
-  await page.waitForURL((url) => url.pathname === '/', { timeout: 15_000 })
+  await page.waitForURL((url) => url.pathname === '/', { timeout: 30_000 })
 }
 
 /** Build a crawler (Crawler type → Systems → Crew → Identity → Review). */
@@ -160,7 +164,7 @@ export async function buildCrawler(page: Page, name: string): Promise<void> {
   await page.getByLabel(/Crawler Name/i).fill(name)
   await clickNext(page) // -> Review
   await page.getByRole('button', { name: /Create Crawler/i }).click()
-  await page.waitForURL((url) => url.pathname === '/', { timeout: 15_000 })
+  await page.waitForURL((url) => url.pathname === '/', { timeout: 30_000 })
 }
 
 /**
@@ -175,7 +179,7 @@ export async function openSheetFor(page: Page, name: string): Promise<void> {
     timeout: 15_000,
   })
   await row.getByRole('link', { name: /^Sheet$/ }).click()
-  await page.waitForURL(/\/sheet\//, { timeout: 10_000 })
+  await page.waitForURL(/\/sheet\//, { timeout: 20_000 })
 }
 
 /**

--- a/apps/in-the-union-now/e2e/print-preview.e2e.ts
+++ b/apps/in-the-union-now/e2e/print-preview.e2e.ts
@@ -15,6 +15,9 @@ import { buildPilot, openSheetFor } from './_helpers'
  */
 test.describe('sheet print preview', () => {
   test.beforeEach(async ({ page }) => {
+    // This spec's beforeEach pays two full cold page-loads (buildPilot +
+    // openSheetFor), so triple Playwright's time budget for the whole test.
+    test.slow()
     await buildPilot(page, 'Print Test', 'PT')
     await openSheetFor(page, 'Print Test')
   })

--- a/apps/in-the-union-now/playwright.config.ts
+++ b/apps/in-the-union-now/playwright.config.ts
@@ -33,8 +33,14 @@ export default defineConfig({
   // + builder routes pull in salvageunion-reference (large JSON dataset) so
   // the first navigation per test takes ~30-60 s on GHA Ubuntu runners.
   // 90 s gives enough headroom without masking real hangs.
-  timeout: 90_000,
-  expect: { timeout: 15_000 },
+  //
+  // Against an external Netlify Deploy Preview (E2E_BASE_URL) every test pays
+  // cold-load costs (preview cold start + real Functions/Blobs round-trips), so
+  // widen the per-test and per-assertion budgets ONLY in that mode. The local
+  // static-preview path keeps the tighter budgets so it stays fast and still
+  // surfaces real hangs.
+  timeout: externalBaseURL ? 150_000 : 90_000,
+  expect: { timeout: externalBaseURL ? 20_000 : 15_000 },
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,


### PR DESCRIPTION
## Problem

The `e2e-itun-preview` CI job runs the ITUN Playwright suite against the Netlify Deploy Preview (`E2E_BASE_URL` set), which serves the real Functions + Blobs. It has been flaking on **cold-preview timing**, with these signatures:

- `beforeEach` hook hitting the 90s per-test timeout (the build-heavy specs pay two full cold page-loads before the test body even starts).
- `Target page/context/browser has been closed` mid-navigation.
- A blind `await page.waitForTimeout(500)` in `gotoStable`'s `ERR_ABORTED` catch — a fixed sleep that's simultaneously too short on a cold preview and non-deterministic.
- Tight `waitForURL` budgets (10s/15s) on the create→dashboard and dashboard→sheet redirects, which overrun when the preview is cold.
- print-preview / wizard-cancel specs timing out because their `beforeEach` build cost eats the whole budget.

## Changes (tolerance + determinism only — no assertions touched)

1. **`_helpers.ts` `gotoStable()`** — replace the blind `waitForTimeout(500)` in the `ERR_ABORTED`/detached-frame catch with a deterministic `page.waitForLoadState('domcontentloaded').catch(() => {})`: wait for the competing client navigation to actually settle before retrying, swallowing the case where the aborted load is already gone. Keeps the 4-attempt loop and the ERR_ABORTED-only guard.
2. **`_helpers.ts` builder redirects** — bump the create→dashboard `waitForURL` from `15_000` → `30_000` in `buildPilot`/`buildMech`/`buildCrawler`, and `openSheetFor`'s `/sheet/` wait from `10_000` → `20_000`.
3. **`playwright.config.ts`** — widen the per-test `timeout` (`90_000` → `150_000`) and per-assertion `expect.timeout` (`15_000` → `20_000`) **only when `E2E_BASE_URL` is set**. The local static-preview path keeps the tighter budgets, so it stays fast and still surfaces real hangs.
4. **`print-preview.e2e.ts`** — add `test.slow()` at the top of `beforeEach` (two cold page-loads: `buildPilot` + `openSheetFor`) so Playwright triples the budget for that build-heavy spec.

## Why this is safe

Every change only **adds** headroom or makes a wait **deterministic** — no budget is tightened, no locator is refactored, no assertion is changed, and no `retries`/`workers`/`globalSetup` changes. In the worst case (a preview that's already fast) these are no-ops. They cannot reduce stability.

## Validation

`bun --filter in-the-union-now typecheck` passes. The browser e2e suite cannot run in the authoring environment (no Chromium) — **CI's `e2e-itun-preview` job, which runs the real Netlify preview e2e, is the validation.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sp7zjV7jH7REjJimQnw5gw