### PR TITLE
refactor(reference): drop stale asset_url from schema contract + API docs

### DIFF
--- a/apps/suref-web/src/pages/api.astro
+++ b/apps/suref-web/src/pages/api.astro
@@ -249,12 +249,11 @@ Content-Type: application/json</code></pre>
           </a>.
         </p>
         <p>
-          The licence covers game text and mechanics only. Artwork referenced
-          by <code class="rounded bg-su-blue-pale px-1 py-0.5">asset_url</code>{' '}
-          fields is <strong>not</strong> covered — those images are used on this
-          site with special permission from Leyline Press and may not be
-          redistributed. Republication of licensed text must include the legal
-          notices required by the Salvage Union Open Game Licence 1.0b.
+          The licence covers game text and mechanics only. Entity artwork is{' '}
+          <strong>not</strong> covered — those images are used on this site with
+          special permission from Leyline Press and may not be redistributed.
+          Republication of licensed text must include the legal notices required
+          by the Salvage Union Open Game Licence 1.0b.
         </p>
       </section>
 

--- a/packages/salvageunion-reference/schemas/shared/common.schema.json
+++ b/packages/salvageunion-reference/schemas/shared/common.schema.json
@@ -18,11 +18,6 @@
       "type": "string",
       "description": "Unique identifier for the entry"
     },
-    "asset_url": {
-      "type": "string",
-      "format": "uri",
-      "description": "URL to an image asset for this entry"
-    },
     "activationCost": {
       "description": "Cost in ability points to activate an ability",
       "oneOf": [

--- a/packages/salvageunion-reference/schemas/shared/objects.schema.json
+++ b/packages/salvageunion-reference/schemas/shared/objects.schema.json
@@ -617,9 +617,6 @@
       "description": "Basic entity with name, content, source, and page reference",
       "required": ["id", "name", "page", "source"],
       "properties": {
-        "asset_url": {
-          "$ref": "common.schema.json#/definitions/asset_url"
-        },
         "content": {
           "$ref": "#/definitions/content"
         },
@@ -680,9 +677,6 @@
       "description": "Advanced or hybrid character class",
       "required": ["advancedTree", "legendaryTree"],
       "properties": {
-        "asset_url": {
-          "$ref": "common.schema.json#/definitions/asset_url"
-        },
         "content": {
           "$ref": "#/definitions/content"
         },


### PR DESCRIPTION
## Summary

`asset_url` is derived in software via `getAssetUrl()` (`schemaName` + slug + `hasArtwork` → `…/{schema}/{slug}.webp`) and hasn't lived in the data since #301. This finishes that cleanup by removing the field's lingering declarations from the schema contract and the API docs.

## Changes

- **`packages/salvageunion-reference/schemas/shared/common.schema.json`** — remove the `asset_url` definition.
- **`packages/salvageunion-reference/schemas/shared/objects.schema.json`** — remove the two `$ref`s to it (`baseEntity`, `advancedClass`) that would otherwise dangle.
- **`apps/suref-web/src/pages/api.astro`** — drop the `asset_url` field reference from the licensing note; the legal meaning (entity artwork not covered by the OGL, used with permission, not redistributable) is preserved.

The lookup stays fully at the software level — `getAssetUrl()` / `getReferenceEntityData()` are untouched.

## Verification

- `bun run build:package` regenerates the per-entity schemas with **no drift** — confirming the `shared/*.schema.json` files are hand-maintained (the generator only emits per-entity files), so these hand edits are durable.
- `bun run validate:all` — PASS (27/27 data files).
- `bun --filter salvageunion-reference test` — 601 pass, 0 fail.
- `bun run typecheck` — clean across all packages.

## Out of scope (noted, not changed)

Test descriptions in `utilities.test.ts` and a comment in `tools/upload-lp-assets.ts` still say "asset_url" as a concept label — neither is the SRD nor the API docs, so left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yzTfHfmFkAWXP4d8dVn2J