### PR TITLE
test(itun): fix stale cancel-confirm and print-visibility e2e assertions (regressed in #334)

### DIFF
--- a/apps/in-the-union-now/e2e/pilot-corner-cases.e2e.ts
+++ b/apps/in-the-union-now/e2e/pilot-corner-cases.e2e.ts
@@ -23,7 +23,14 @@ test('cancel mid-wizard leaves the dashboard with no new pilot', async ({ page }
   await page.goto('/pilots/new')
   await waitForReady(page)
   await pickByName(page, 'Engineer')
+  // The form is now dirty (a class was picked), so #334's `confirmCancel`
+  // routes Cancel through a confirm dialog instead of navigating directly.
+  // Confirm the discard, then the wizard abandons and navigates home.
   await page.getByRole('button', { name: /^Cancel$/ }).click()
+  await page
+    .getByRole('dialog')
+    .getByRole('button', { name: /^Discard$/ })
+    .click()
   await page.waitForURL(/\/$/)
   await waitForReady(page)
 

--- a/apps/in-the-union-now/e2e/print-preview.e2e.ts
+++ b/apps/in-the-union-now/e2e/print-preview.e2e.ts
@@ -27,10 +27,16 @@ test.describe('sheet print preview', () => {
     await page.setViewportSize({ width: 794, height: 1123 })
     await page.emulateMedia({ media: 'print' })
 
-    // The pilot's name should be visible in print (LiveSheet hero chip).
-    await expect(page.getByText('Print Test').first()).toBeVisible()
-    // The class chip should also render.
-    await expect(page.getByText('Engineer').first()).toBeVisible()
+    // The pilot's name should be visible in print (LiveSheet hero <h1>).
+    // #334's print CSS hides the <header>, whose condensed copy of the name is
+    // a <span>; role=heading targets the visible hero <h1> and dodges it.
+    await expect(page.getByRole('heading', { name: 'Print Test' })).toBeVisible()
+    // The class chip should also render — scope to the hero region landmark
+    // (`<section aria-label="… sheet header">`) so we hit the visible MChip,
+    // not any duplicate outside the hero.
+    await expect(
+      page.getByRole('region', { name: /sheet header/i }).getByText('Engineer')
+    ).toBeVisible()
     // Stat pips keep their print hooks (filled pips survive the bg reset).
     expect(await page.locator('[data-pip]').count()).toBeGreaterThan(0)
     // Top-bar navigation is hidden under print (`header a` rule).
@@ -43,7 +49,9 @@ test.describe('sheet print preview', () => {
     await page.setViewportSize({ width: 816, height: 1056 })
     await page.emulateMedia({ media: 'print' })
 
-    await expect(page.getByText('Print Test').first()).toBeVisible()
-    await expect(page.getByText('Engineer').first()).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Print Test' })).toBeVisible()
+    await expect(
+      page.getByRole('region', { name: /sheet header/i }).getByText('Engineer')
+    ).toBeVisible()
   })
 })


### PR DESCRIPTION
Fixes the two ITUN e2e tests that regressed in #334 — the root-cause investigation showed these fail **deterministically** (not flaky): identical in static and preview mode, every retry. (#340's timeout hardening did not address them.)

**1. `pilot-corner-cases.e2e.ts` — cancel-mid-wizard hang.** #334 added `confirmCancel={formDirty}` to the wizards, so clicking Cancel on a dirty form now opens a confirm modal (`ConfirmDialog`, `confirmLabel="Discard"`) instead of navigating. The test clicked Cancel and waited for the dashboard URL forever. Fix: click the dialog's **Discard** affirmative before `waitForURL`.

**2. `print-preview.e2e.ts` — print-visibility assertions.** #334 added `@media print { header { display:none } }`. The pilot name renders twice (hidden `<span>` in `<header>`, visible `<h1>` hero); the test's `getByText(...).first()` grabbed the hidden copy. Fix: target the visible hero via `getByRole('heading', {name})` for the name and the `sheet header` region landmark for the class chip (the live sheet has no `<main>`).

Validation: `bun --filter in-the-union-now typecheck` passes; the browser suite is validated via the nightly e2e workflow (`workflow_dispatch` on this branch) since it can't run in the authoring env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sp7zjV7jH7REjJimQnw5gw
