### PR TITLE
feat(discord-bot): inline full roll-table contents, linkify [[trait]] refs, symbol buttons

### DIFF
--- a/apps/discord-bot/src/__tests__/customId.test.ts
+++ b/apps/discord-bot/src/__tests__/customId.test.ts
@@ -45,7 +45,8 @@ describe('rollAgainRow', () => {
     const json = row!.toJSON() as { components: { custom_id?: string; label?: string }[] }
     expect(json.components).toHaveLength(1)
     expect(json.components[0]!.custom_id).toBe('su:roll:Core Mechanic')
-    expect(json.components[0]!.label).toBe('Roll again')
+    // Label is prefixed with the ↻ repeat symbol (a typographic glyph, not an emoji).
+    expect(json.components[0]!.label).toBe('↻ Roll again')
   })
 })
 

--- a/apps/discord-bot/src/__tests__/lookupEmbed.test.ts
+++ b/apps/discord-bot/src/__tests__/lookupEmbed.test.ts
@@ -135,14 +135,50 @@ describe('buildLookupEmbed — content depth', () => {
     }
   })
 
-  test('a roll-table links out instead of inlining its rows', () => {
-    const table = SalvageUnionReference.RollTables.all()[0]!
+  test('[[Trait]] references in body text become links, never literal brackets', () => {
+    const overpower = SalvageUnionReference.Abilities.find((a) => a.name === 'Overpower')
+    expect(overpower).toBeDefined()
+    const e = buildLookupEmbed(
+      { ...overpower!, schemaName: 'abilities' } as unknown as SURefEntity & {
+        schemaName: SURefEnumSchemaName
+      },
+      'abilities'
+    )
+    // [[Vulnerable]] resolves to a masked link, and no raw bracket ref survives.
+    expect(e.description).toContain(
+      '[Vulnerable](https://salvageunion.io/schema/traits/item/vulnerable)'
+    )
+    expect(e.description).not.toContain('[[')
+  })
+
+  test('a standard roll-table inlines its full rows and keeps a roll hint', () => {
+    const table = SalvageUnionReference.RollTables.all().find((t) => t.table.type === 'standard')!
     const e = buildLookupEmbed(
       { ...table, schemaName: 'roll-tables' } as unknown as SURefEntity & {
         schemaName: SURefEnumSchemaName
       },
       'roll-tables'
     )
+    // The roll hint survives, and every d20 bucket is inlined as a row (backtick key).
     expect(e.description).toContain('/su roll')
+    expect(e.description).toContain('`20`')
+    expect(e.description).toContain('`11-19`')
+    expect(e.description).toContain('`1`')
+  })
+
+  test('a columns roll-table inlines each column bucket as a field', () => {
+    const table = SalvageUnionReference.RollTables.all().find((t) => t.table.type === 'columns')!
+    const e = buildLookupEmbed(
+      { ...table, schemaName: 'roll-tables' } as unknown as SURefEntity & {
+        schemaName: SURefEnumSchemaName
+      },
+      'roll-tables'
+    )
+    const fieldNames = e.fields.map((f) => f.name)
+    expect(fieldNames).toContain('Roll 1-4')
+    expect(fieldNames).toContain('Roll 17-20')
+    // The entries within a column are listed (1-20), not just linked out.
+    const firstColumn = e.fields.find((f) => f.name === 'Roll 1-4')!
+    expect(firstColumn.value).toContain('1.')
   })
 })

--- a/apps/discord-bot/src/customId.ts
+++ b/apps/discord-bot/src/customId.ts
@@ -17,6 +17,14 @@ import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js'
 /** Namespace prefix for every one of this bot's component ids. */
 export const CUSTOM_ID_NS = 'su'
 
+/**
+ * Leading glyph on every re-roll button label. A typographic symbol (U+21BB
+ * clockwise open circle arrow), NOT an emoji — it reads as "roll again / repeat"
+ * and has broad font coverage across Discord clients, where a colored emoji
+ * would clash with the plain-text embed styling.
+ */
+const REROLL_SYMBOL = '↻'
+
 /** Discord caps a component customId at 100 characters. */
 const CUSTOM_ID_MAX = 100
 
@@ -63,8 +71,7 @@ export function rollAgainRow(
   if (!customId) return null
   const button = new ButtonBuilder()
     .setCustomId(customId)
-    .setLabel(label)
+    .setLabel(`${REROLL_SYMBOL} ${label}`)
     .setStyle(ButtonStyle.Secondary)
-    .setEmoji('🎲')
   return new ActionRowBuilder<ButtonBuilder>().addComponents(button)
 }

--- a/apps/discord-bot/src/lookupEmbed.ts
+++ b/apps/discord-bot/src/lookupEmbed.ts
@@ -77,6 +77,27 @@ function entityLink(schema: SURefEnumSchemaName, name: string): string {
   return resolved ? `[${label}](${BASE}/schema/${schema}/item/${slug})` : label
 }
 
+/**
+ * Inline trait references in body text, in the two bracket forms the data uses
+ * (mirrors suref-react's parseTraitReferences):
+ *   [[Trait Name]]              → link to the trait's page
+ *   [[[Trait Name] (param)]]    → link + the parameter (e.g. "[[[Melee] (2)]]")
+ * Every ref resolves against the `traits` schema, exactly as the web does; an
+ * unresolved name degrades to its bare text (matching TraitKeywordDisplayView,
+ * which renders plain text on a miss rather than falling back to keywords).
+ */
+const TRAIT_REF = /\[\[\[([^\]]+)\]\s*\(([^)]+)\)\]\]|\[\[([^\]]+)\]\]/g
+function linkifyTraitRefs(text: string): string {
+  return text.replace(TRAIT_REF, (_match, paramName, paramValue, simpleName) => {
+    if (paramName !== undefined) {
+      const link = entityLink('traits', String(paramName).trim())
+      const value = String(paramValue).trim()
+      return value ? `${link} ${value}` : link
+    }
+    return entityLink('traits', String(simpleName).trim())
+  })
+}
+
 type ContentBlock = {
   type?: string
   value?: unknown
@@ -107,10 +128,12 @@ function flattenContent(blocks: ContentBlock[] | undefined, chassisName?: string
       if (dv) sections.push(dv)
       continue
     }
-    const text = replaceChassisPlaceholder(
-      typeof block.value === 'string' ? block.value : '',
-      chassisName
-    ).trim()
+    const text = linkifyTraitRefs(
+      replaceChassisPlaceholder(
+        typeof block.value === 'string' ? block.value : '',
+        chassisName
+      ).trim()
+    )
     let line = ''
     if (text) {
       switch (type) {
@@ -144,7 +167,7 @@ function flattenContent(blocks: ContentBlock[] | undefined, chassisName?: string
             ).trim()
           )
           .filter(Boolean)
-          .map((v) => `• ${v}`)
+          .map((v) => `• ${linkifyTraitRefs(v)}`)
       : []
     const combined = [line, ...items].filter(Boolean).join('\n')
     if (combined) sections.push(combined)
@@ -316,6 +339,62 @@ function enforce(embed: LookupEmbed): LookupEmbed {
   return embed
 }
 
+type TableEntry = { label?: string; value?: string }
+
+/** The first number in a roll key ("11-19" → 11, "20" → 20). */
+function rollKeyStart(key: string): number {
+  const n = Number.parseInt(key.split('-')[0]?.trim() ?? '', 10)
+  return Number.isNaN(n) ? 0 : n
+}
+
+/** A table's roll keys (excluding the `type` discriminant), high roll first to
+ *  match the web's RollTable ordering. */
+function tableRollKeys(table: AnyRecord): string[] {
+  return Object.keys(table)
+    .filter((key) => key !== 'type')
+    .sort((a, b) => rollKeyStart(b) - rollKeyStart(a))
+}
+
+/** One row of a d20 table: `` `key` **label** — value ``, trait refs linked. */
+function renderTableRow(key: string, entry: TableEntry): string {
+  const label = entry.label ? `**${escapeLabel(entry.label)}** — ` : ''
+  return `\`${key}\` ${label}${linkifyTraitRefs(entry.value ?? '')}`.trimEnd()
+}
+
+/**
+ * Render a roll-table's full contents into the embed. Flat-family tables go
+ * into the description (which enforce() sheds to fit the 6000-char budget,
+ * appending a link-out on the largest tables). A `columns` table is
+ * two-dimensional — roll a column, then a 1-20 entry within it — so each column
+ * bucket becomes its own field.
+ */
+function rollTableSections(
+  table: AnyRecord,
+  name: string,
+  sections: string[],
+  fields: LookupEmbed['fields']
+): void {
+  const hint = `Roll it with \`/su roll table: ${name}\`.`
+  if (table['type'] === 'columns') {
+    sections.push(`${hint} Two rolls: first the column, then the entry (1-20).`)
+    for (const columnKey of Object.keys(table).filter((key) => key !== 'type')) {
+      const column = table[columnKey] as AnyRecord
+      const entries = Object.keys(column)
+        .sort((a, b) => rollKeyStart(a) - rollKeyStart(b))
+        .map((entryKey) => {
+          const entry = column[entryKey] as TableEntry
+          return `${entryKey}. ${linkifyTraitRefs(entry?.value ?? '')}`
+        })
+      fields.push({ name: `Roll ${columnKey}`, value: entries.join('\n') || '—', inline: true })
+    }
+    return
+  }
+  // Lead with the roll hint so it survives description-shedding on huge tables.
+  sections.push(hint)
+  const rows = tableRollKeys(table).map((key) => renderTableRow(key, table[key] as TableEntry))
+  if (rows.length) sections.push(rows.join('\n'))
+}
+
 /**
  * Build the full lookup embed for any entity. `entity` must carry its
  * `schemaName` (the lookup command attaches it).
@@ -333,7 +412,7 @@ export function buildLookupEmbed(
 
   // Lead description: an entity's own `description`, then its content blocks.
   if (typeof e['description'] === 'string' && e['description']) {
-    sections.push(e['description'] as string)
+    sections.push(linkifyTraitRefs(e['description'] as string))
   }
   // Chassis ability/flavor text carries [(CHASSIS)] placeholders — replace
   // with the chassis name, as the web does. Non-chassis entities have no
@@ -354,8 +433,10 @@ export function buildLookupEmbed(
     }
     if (patterns) sections.push(patterns)
   } else if (schemaName === 'roll-tables') {
-    // Don't inline table rows — that duplicates /su roll and blows budget.
-    sections.push(`Roll on this table with \`/su roll table: ${name}\`.`)
+    const table = e['table']
+    if (table && typeof table === 'object') {
+      rollTableSections(table as AnyRecord, name, sections, fields)
+    }
   } else {
     fields.push(...statFields(e))
     for (const action of extractVisibleActions(entity) ?? []) {


### PR DESCRIPTION
## What & why

Four fixes to `/su lookup` and the interactive roll buttons so they render more of the dataset and match the web's formatting.

### 1. `/su lookup` shows full roll-table contents
Previously a roll-table lookup only printed a "roll it with `/su roll`" pointer. Now it inlines every row:
- **Flat-family tables** (standard/alternate/flat/dramatic/duos/bio-chassis/salvage-cache/octet) render into the **description**, one `` `key` **label** — value `` row per bucket, high roll first (matching the web's `RollTable` ordering). `enforce()` still sheds the largest tables (e.g. the ~6.2k *Anomalous Zone*) to the 6000-char embed budget with a link-out.
- **Columns tables** (the two-roll *Callsign* table) render each of the five column buckets as a **field** listing its 1-20 entries.

### 2. `[[Trait]]` references become links
`[[Vulnerable]]` and `[[[Melee] (2)]]`-style refs in body text now resolve to masked links to the trait page, mirroring suref-react's `parseTraitReferences`. All 28 distinct trait refs in the data resolve; an unresolved name degrades to plain text — matching `TraitKeywordDisplayView`, which renders plain text on a miss (no keyword fallback).

### 3. Roll buttons use a symbol, not an emoji
The "Roll again" / "Roll on this table" buttons now prefix their label with **↻** (U+21BB) instead of the 🎲 emoji.

> **Symbol choice — please confirm.** I picked `↻` because it reads as "roll again / repeat" and has broad font coverage across Discord clients. If you'd prefer a die glyph or a different symbol, it's a one-line change (`REROLL_SYMBOL` in `customId.ts`). I left the `🎲` in the `/su check` **embed title** untouched — it's not a "Roll again button", and `↻` would be semantically wrong on a first roll — but happy to change that too.

### 4. Making the most of the embed
Kept in scope: the table/linkify formatting above uses fields vs. description deliberately. I did **not** redesign the other embeds (per the repo's "no unrequested changes" rule).

## Testing
`bun --filter '@suref/discord-bot' test` — 52 pass / 0 fail. The load-bearing **exhaustive embed-validity pass** (every entity in every schema, all 96 roll-tables → a Discord-valid embed) still holds, which is what proves the new table rendering never blows the 6000-char / 1024-field / 25-field limits. Typecheck + lint clean.

New/updated tests: inlined-rows assertion + a columns case, a `[[trait]]` linkification test, and the button-label test now expects the `↻` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJ517kPRido52KuqGjiswL