### PR TITLE
feat(suref-web): Discord bot Terms of Service & Privacy Policy pages

### DIFF
--- a/apps/suref-web/src/layouts/BaseLayout.astro
+++ b/apps/suref-web/src/layouts/BaseLayout.astro
@@ -133,7 +133,13 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : new URL(ogImage, SITE_
       <main class="flex flex-1 flex-col bg-su-blue-pale" transition:animate="fade">
         <slot />
       </main>
-      <Footer poweredBySalvageUrl="/Powered_by_Salvage_Black.webp" />
+      <Footer
+        poweredBySalvageUrl="/Powered_by_Salvage_Black.webp"
+        legalLinks={[
+          { label: 'Bot Terms', href: '/bot/terms' },
+          { label: 'Bot Privacy', href: '/bot/privacy' },
+        ]}
+      />
     </div>
   </body>
 </html>

--- a/apps/suref-web/src/lib/changelog.ts
+++ b/apps/suref-web/src/lib/changelog.ts
@@ -6,6 +6,13 @@ type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: '2026-07-06',
+    title: 'Discord bot Terms & Privacy pages',
+    items: [
+      'Added Terms of Service and Privacy Policy pages for the Salvage Union Discord bot, linked from the site footer.',
+    ],
+  },
+  {
     date: '2026-07-04',
     title: 'First-class search and shareable filtered views',
     items: [

--- a/apps/suref-web/src/pages/bot/privacy.astro
+++ b/apps/suref-web/src/pages/bot/privacy.astro
@@ -1,0 +1,87 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro'
+
+const lastUpdated = '6 July 2026'
+---
+
+<BaseLayout
+  title="Discord Bot Privacy Policy - Salvage Union SRD"
+  description="Privacy Policy for the Salvage Union Discord bot. The Bot is stateless and stores no personal data."
+>
+  <div class="flex w-full flex-1 flex-col py-12">
+    <div class="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6">
+      <h1 class="page-heading">Salvage Union Bot — Privacy Policy</h1>
+      <p class="text-xs uppercase tracking-wider text-su-black/60">Last updated: {lastUpdated}</p>
+
+      <section class="flex flex-col gap-4 text-sm leading-relaxed">
+        <p class="font-bold">
+          Short version: the Bot does not have a database and does not store your personal data.
+        </p>
+
+        <div>
+          <h2 class="page-subheading mb-1">What we collect</h2>
+          <p>
+            Nothing persistent. The Bot is stateless. It responds to slash-command and button
+            interactions in real time and keeps no record of them afterward.
+          </p>
+          <ul class="mt-2 flex list-disc flex-col gap-1 pl-5">
+            <li>
+              The Bot requests only the &ldquo;Guilds&rdquo; gateway intent. It does <strong
+                >not</strong
+              > read message content.
+            </li>
+            <li>
+              It does not store your messages, user ID, server data, dice results, or command
+              history in any database.
+            </li>
+            <li>
+              Interactive buttons (&ldquo;Roll again,&rdquo; &ldquo;See table&rdquo;) work by
+              encoding the table name or dice notation into the button itself — not by storing
+              anything on a server.
+            </li>
+          </ul>
+        </div>
+
+        <div>
+          <h2 class="page-subheading mb-1">Error diagnostics</h2>
+          <p>
+            To keep the Bot reliable, unexpected errors may be sent to our error-monitoring provider
+            (Sentry). These reports can include technical details about the error and the interaction
+            that triggered it. They are used only to diagnose and fix bugs and are retained per that
+            provider&rsquo;s standard retention.
+          </p>
+        </div>
+
+        <div>
+          <h2 class="page-subheading mb-1">Third parties</h2>
+          <ul class="flex list-disc flex-col gap-1 pl-5">
+            <li>
+              <strong>Discord</strong> — your use of the Bot is also governed by Discord&rsquo;s
+              Privacy Policy.
+            </li>
+            <li><strong>Sentry</strong> — used for error monitoring, as described above.</li>
+          </ul>
+        </div>
+
+        <div>
+          <h2 class="page-subheading mb-1">Data requests</h2>
+          <p>
+            Because we store no personal data, there is nothing to export or delete. For any privacy
+            questions, contact{' '}
+            <a
+              href="mailto:privacy@salvageunion.io"
+              class="font-bold text-su-orange-dark hover:underline">privacy@salvageunion.io</a
+            >.
+          </p>
+        </div>
+
+        <p class="text-xs text-su-black/60">
+          See also the{' '}
+          <a href="/bot/terms" class="font-bold text-su-orange-dark hover:underline"
+            >Terms of Service</a
+          >.
+        </p>
+      </section>
+    </div>
+  </div>
+</BaseLayout>

--- a/apps/suref-web/src/pages/bot/terms.astro
+++ b/apps/suref-web/src/pages/bot/terms.astro
@@ -1,0 +1,83 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro'
+
+const lastUpdated = '6 July 2026'
+---
+
+<BaseLayout
+  title="Discord Bot Terms of Service - Salvage Union SRD"
+  description="Terms of Service for the Salvage Union Discord bot — an unofficial, community reference tool for the Salvage Union TTRPG."
+>
+  <div class="flex w-full flex-1 flex-col py-12">
+    <div class="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6">
+      <h1 class="page-heading">Salvage Union Bot — Terms of Service</h1>
+      <p class="text-xs uppercase tracking-wider text-su-black/60">Last updated: {lastUpdated}</p>
+
+      <section class="flex flex-col gap-4 text-sm leading-relaxed">
+        <p>
+          By adding or using the Salvage Union bot (&ldquo;the Bot&rdquo;) in a Discord server or via
+          user install, you agree to these terms.
+        </p>
+
+        <div>
+          <h2 class="page-subheading mb-1">The service</h2>
+          <p>
+            The Bot provides dice-rolling and reference lookups for the Salvage Union tabletop
+            roleplaying game via Discord slash commands (<code>/su</code>). It is provided free of
+            charge, &ldquo;as is,&rdquo; without warranty of any kind. We may change, suspend, or
+            discontinue the Bot at any time.
+          </p>
+        </div>
+
+        <div>
+          <h2 class="page-subheading mb-1">Acceptable use</h2>
+          <p>
+            Don&rsquo;t use the Bot to break Discord&rsquo;s Terms of Service or Community
+            Guidelines, to abuse or overload the service, or for any unlawful purpose.
+          </p>
+        </div>
+
+        <div>
+          <h2 class="page-subheading mb-1">Intellectual property</h2>
+          <p>
+            Salvage Union is copyrighted by{' '}
+            <a
+              href="https://leyline.press"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="font-bold text-su-orange-dark hover:underline">Leyline Press</a
+            >. The Bot is an unofficial, community reference tool and is not affiliated with or
+            endorsed by Leyline Press. Game data is drawn from the community reference at{' '}
+            <a href="/" class="font-bold text-su-orange-dark hover:underline">salvageunion.io</a>.
+          </p>
+        </div>
+
+        <div>
+          <h2 class="page-subheading mb-1">Liability</h2>
+          <p>
+            To the maximum extent permitted by law, the operators of the Bot are not liable for any
+            damages arising from its use or unavailability.
+          </p>
+        </div>
+
+        <div>
+          <h2 class="page-subheading mb-1">Contact</h2>
+          <p>
+            Questions about these terms:{' '}
+            <a
+              href="mailto:privacy@salvageunion.io"
+              class="font-bold text-su-orange-dark hover:underline">privacy@salvageunion.io</a
+            >.
+          </p>
+        </div>
+
+        <p class="text-xs text-su-black/60">
+          See also the{' '}
+          <a href="/bot/privacy" class="font-bold text-su-orange-dark hover:underline"
+            >Privacy Policy</a
+          >.
+        </p>
+      </section>
+    </div>
+  </div>
+</BaseLayout>

--- a/packages/suref-react/src/components/shared/Footer.tsx
+++ b/packages/suref-react/src/components/shared/Footer.tsx
@@ -1,9 +1,17 @@
+type FooterLink = {
+  label: string
+  href: string
+}
+
 type FooterProps = {
   /** URL for the "Powered by Salvage" logo image — passed by consuming app */
   poweredBySalvageUrl: string
+  /** Optional legal / utility links (e.g. Terms, Privacy) rendered as a small
+   *  row beneath the attribution. Omitted entirely when not provided. */
+  legalLinks?: FooterLink[]
 }
 
-export function Footer({ poweredBySalvageUrl }: FooterProps) {
+export function Footer({ poweredBySalvageUrl, legalLinks }: FooterProps) {
   return (
     <footer className="border-t border-su-grey-light bg-su-white py-3 lg:shadow-sm">
       <div className="mx-auto flex max-w-7xl flex-row flex-wrap items-center justify-center gap-4 text-xs text-su-black">
@@ -45,6 +53,18 @@ export function Footer({ poweredBySalvageUrl }: FooterProps) {
             </a>
             .
           </p>
+          {legalLinks && legalLinks.length > 0 && (
+            <p className="mt-1">
+              {legalLinks.map((link, i) => (
+                <span key={link.href}>
+                  {i > 0 && <span className="px-1.5 text-su-grey-light">·</span>}
+                  <a href={link.href} className="underline hover:text-su-orange-dark">
+                    {link.label}
+                  </a>
+                </span>
+              ))}
+            </p>
+          )}
         </div>
         <div className="inline-block shrink-0 rounded-md p-2">
           <img

--- a/packages/suref-react/src/components/shared/__tests__/Footer.test.tsx
+++ b/packages/suref-react/src/components/shared/__tests__/Footer.test.tsx
@@ -45,4 +45,26 @@ describe('Footer', () => {
       expect(link.getAttribute('rel')).toContain('noopener')
     }
   })
+
+  test('omits legal links when none are provided', () => {
+    render(<Footer poweredBySalvageUrl="/test-logo.webp" />)
+    expect(screen.queryByText('Bot Terms')).toBeNull()
+  })
+
+  test('renders provided legal links as same-tab internal links', () => {
+    render(
+      <Footer
+        poweredBySalvageUrl="/test-logo.webp"
+        legalLinks={[
+          { label: 'Bot Terms', href: '/bot/terms' },
+          { label: 'Bot Privacy', href: '/bot/privacy' },
+        ]}
+      />
+    )
+    const terms = screen.getByText('Bot Terms')
+    expect(terms.getAttribute('href')).toBe('/bot/terms')
+    // Internal links must NOT open a new tab.
+    expect(terms.getAttribute('target')).toBeNull()
+    expect(screen.getByText('Bot Privacy').getAttribute('href')).toBe('/bot/privacy')
+  })
 })


### PR DESCRIPTION
Gives the Salvage Union Discord bot the **Terms of Service** and **Privacy Policy** URLs that Discord verification and the App Directory require.

## What's here
- **`/bot/terms`** and **`/bot/privacy`** — new static Astro pages on `BaseLayout`. Build emits both routes (`dist/bot/terms/index.html`, `dist/bot/privacy/index.html`).
- The **Privacy Policy is accurate, not boilerplate** — it reflects the bot's real stateless design: no database, only the `Guilds` gateway intent (no message content), stateless buttons that encode their payload, and Sentry-only error diagnostics. Contact: `privacy@salvageunion.io`. IP attribution: Leyline Press (matching the site footer).
- **Footer** (`suref-react`) gains an optional `legalLinks` prop; **suref-web** passes "Bot Terms" / "Bot Privacy" so the pages are discoverable site-wide. **`in-the-union-now` is unaffected** — it doesn't pass the prop, so its footer is unchanged.
- Changelog entry.

## Testing
- `suref-react` suite: **378 pass / 0 fail**, incl. 2 new Footer tests (renders internal same-tab legal links; omits them when not provided).
- `suref-web` **build succeeds** and emits both routes; typecheck (`astro check`) + lint clean.

## Context
Part of making the bot read as an official app (branding/presence landed in #369). The `privacy@salvageunion.io` mailbox is being set up separately via DNS forwarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJ517kPRido52KuqGjiswL