### PR TITLE
docs(reference): retire npm publishing, document JSON API as public interface

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,21 +53,22 @@ MADR-style records of architecturally significant decisions that are **live in
 the code today**. Read the matching ADR before proposing alternatives to a
 decision made here.
 
-| ADR                                                           | Topic                                                                   |
-| ------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| [ADR-001](adrs/ADR-001-local-first-no-backend.md)             | Local-first, no backend, no auth                                        |
-| [ADR-002](adrs/ADR-002-indexeddb-idb-zod.md)                  | IndexedDB via `idb`, Zod as schema source, salvage-read resilience      |
-| [ADR-003](adrs/ADR-003-zustand-hydration.md)                  | Zustand state — lazy hydration, write-through, cross-tab invalidation   |
-| [ADR-004](adrs/ADR-004-snapshot-netlify-functions.md)         | Snapshot sharing — unauthenticated Netlify Functions + Blobs            |
-| [ADR-005](adrs/ADR-005-reference-data-orm.md)                 | Game-data ORM — Zod → generated JSON Schema, lazy data loading          |
-| [ADR-006](adrs/ADR-006-pure-rules-logic.md)                   | Rules/combat logic as pure functions                                    |
-| [ADR-007](adrs/ADR-007-automation-boundary.md)                | **Automation boundary** — consult before building rules-driven features |
-| [ADR-008](adrs/ADR-008-sequential-mutations.md)               | Sequential client-side mutations for action execution                   |
-| [ADR-009](adrs/ADR-009-condition-model-destroyed-color.md)    | Item condition model + destroyed semantic color                         |
-| [ADR-010](adrs/ADR-010-srd-choices-ephemeral-vs-persisted.md) | Choices — ephemeral in the SRD, persisted in ITUN                       |
-| [ADR-011](adrs/ADR-011-suref-react-source-no-build.md)        | `suref-react` ships as TypeScript source (no build step)                |
-| [ADR-012](adrs/ADR-012-suref-web-astro-static.md)             | `suref-web` as an Astro static site with React islands                  |
-| [ADR-013](adrs/ADR-013-csp-zod-jitless.md)                    | CSP-compliant Zod (jitless) constraint                                  |
+| ADR                                                              | Topic                                                                   |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| [ADR-001](adrs/ADR-001-local-first-no-backend.md)                | Local-first, no backend, no auth                                        |
+| [ADR-002](adrs/ADR-002-indexeddb-idb-zod.md)                     | IndexedDB via `idb`, Zod as schema source, salvage-read resilience      |
+| [ADR-003](adrs/ADR-003-zustand-hydration.md)                     | Zustand state — lazy hydration, write-through, cross-tab invalidation   |
+| [ADR-004](adrs/ADR-004-snapshot-netlify-functions.md)            | Snapshot sharing — unauthenticated Netlify Functions + Blobs            |
+| [ADR-005](adrs/ADR-005-reference-data-orm.md)                    | Game-data ORM — Zod → generated JSON Schema, lazy data loading          |
+| [ADR-006](adrs/ADR-006-pure-rules-logic.md)                      | Rules/combat logic as pure functions                                    |
+| [ADR-007](adrs/ADR-007-automation-boundary.md)                   | **Automation boundary** — consult before building rules-driven features |
+| [ADR-008](adrs/ADR-008-sequential-mutations.md)                  | Sequential client-side mutations for action execution                   |
+| [ADR-009](adrs/ADR-009-condition-model-destroyed-color.md)       | Item condition model + destroyed semantic color                         |
+| [ADR-010](adrs/ADR-010-srd-choices-ephemeral-vs-persisted.md)    | Choices — ephemeral in the SRD, persisted in ITUN                       |
+| [ADR-011](adrs/ADR-011-suref-react-source-no-build.md)           | `suref-react` ships as TypeScript source (no build step)                |
+| [ADR-012](adrs/ADR-012-suref-web-astro-static.md)                | `suref-web` as an Astro static site with React islands                  |
+| [ADR-013](adrs/ADR-013-csp-zod-jitless.md)                       | CSP-compliant Zod (jitless) constraint                                  |
+| [ADR-014](adrs/ADR-014-json-api-public-interface-npm-retired.md) | Dataset public interface is the JSON API; npm publishing retired        |
 
 ### Per-package CLAUDE.md
 

--- a/docs/adrs/ADR-014-json-api-public-interface-npm-retired.md
+++ b/docs/adrs/ADR-014-json-api-public-interface-npm-retired.md
@@ -1,0 +1,99 @@
+# ADR-014: Dataset Public Interface Is the JSON API; npm Publishing Is Retired
+
+## Status
+
+Accepted
+
+## Context
+
+`packages/salvageunion-reference` was historically published to npm (133
+versions exist on the registry, latest `2.4.0` at the time of writing). The
+package ships TypeScript source directly and has no compile step
+([ADR-011](ADR-011-suref-react-source-no-build.md) established this pattern
+for `suref-react`; `salvageunion-reference` follows the same shape) — `bun run
+build:package` only regenerates `schemas/*.schema.json` from the Zod source
+([ADR-005](ADR-005-reference-data-orm.md)). Publishing TypeScript source to
+npm as a library was never a good fit for external consumers, and the repo
+owner has decided to stop publishing it altogether.
+
+Since `apps/suref-web` added `/schema/v1` JSON API endpoints (#107), it has
+served the same dataset publicly as a CORS-enabled JSON API — one JSON
+document and one JSON Schema document per schema, plus per-item lookups:
+
+- `apps/suref-web/src/pages/schema/[schemaId].json.ts` — full dataset for a
+  schema
+- `apps/suref-web/src/pages/schema/[schemaId].schema.json.ts` — the schema's
+  JSON Schema
+- `apps/suref-web/src/pages/schema/[schemaId]/item/[itemId].json.ts` —
+  single-item lookup
+- `apps/suref-web/src/pages/api.astro` — human-readable documentation of the
+  above, plus `llms.txt` for machine discovery
+
+This API requires no install, no auth, and no build step — it is strictly
+easier for an external consumer to use than an npm package that ships raw
+TypeScript. The package's own `README.md` already documents a deprecation
+notice pointing at this API, and `package.json` is already `private: true`.
+However, that notice only exists in the repository; it is not reflected on
+the live npm registry listing (fixing that requires the repo owner's own npm
+publish credentials to run `npm deprecate`, which is a separate manual step
+outside this decision's scope).
+
+**Version discrepancy, noted here for the record (not "fixed" by this ADR):**
+the local `package.json` `version` field reads `2.3.5`, but the npm
+registry's latest published version is `2.4.0` — local is _behind_
+published. The full git history of `packages/salvageunion-reference/package.json`
+(across all branches) never contains the string `2.4.0`; the version field
+progresses `2.3.4` → `2.3.5` and stops there locally. There is also no
+npm-publish workflow anywhere in `.github/workflows/` — every one of the 133
+versions on the npm registry was published by hand (`npm publish`), never by
+CI. The npm-published `2.4.0` package metadata's `repository` field points to
+`alxjrvs/salvageunion-data`, a standalone repo that now 404s on GitHub —
+different from (and older than) the `SalvageUnion-io/SU-SRD` URL already
+correct in the local `package.json`. Taken together, this indicates
+`salvageunion-reference` originated as a standalone repo
+(`alxjrvs/salvageunion-data`) later absorbed into this monorepo, and `2.4.0`
+was published by hand from that old standalone checkout (or some other
+out-of-band location) after the absorption — it was never synced back into
+`SU-SRD`'s git history. Local `2.3.5` is the accurate source-of-record for
+this repository; `2.4.0` on npm is an orphaned publish from outside this
+repo's history. This ADR does not change the local `version` field.
+
+## Decision
+
+- The dataset's public interface is the `suref-web` JSON API, not an npm
+  package. External consumers should fetch
+  `https://salvageunion.io/schema/{schemaId}.json` (and the sibling
+  `.schema.json` / item endpoints), not `npm install salvageunion-reference`.
+- `packages/salvageunion-reference` remains a **private, workspace-internal**
+  module, consumed only via the `workspace:*` protocol by other packages in
+  this monorepo. It is not published to npm going forward.
+- npm-publish-only metadata in `packages/salvageunion-reference/package.json`
+  (`files`, `keywords`, `engines`, `repository`, `bugs`, `homepage`, `author`)
+  is removed as dead weight, since it has no effect once the package is never
+  packed or published. `private: true`, `description`, `license` (and the
+  `LICENCE` file, which remains legally load-bearing regardless of
+  distribution channel), and the `exports` map remain — they are load-bearing
+  for the workspace-internal resolution path or otherwise still useful.
+- The package's `CHANGELOG.md` is frozen as a historical record (see the note
+  added at its top) rather than deleted or continued, since there is no
+  future npm release for it to document.
+- Actually deprecating the live npm registry listing (`npm deprecate
+salvageunion-reference`) is **out of scope for this decision** — it
+  requires the repo owner's own npm publish credentials and is being handled
+  separately.
+
+## Consequences
+
+- Documentation (`docs/architecture/package-contracts.md`, this ADR) now
+  matches the package's actual `package.json` shape: no `dist/`, no build
+  step, no npm distribution.
+- External consumers have one clear, always-current integration path (the
+  JSON API) instead of two (a stale npm package and the API).
+- The npm registry listing for `salvageunion-reference` is not touched by
+  this change — `npm install salvageunion-reference` will continue to
+  silently succeed against the last-published version until the repo owner
+  runs `npm deprecate` themselves. This is a known gap, not an oversight.
+- The version-field discrepancy (`2.3.5` local vs. `2.4.0` published) is
+  explained (an orphaned out-of-band publish predating or bypassing this
+  repo's history — see above) but not "fixed": the local field is left as-is
+  rather than bumped to match a publish this repo's history never produced.

--- a/docs/architecture/package-contracts.md
+++ b/docs/architecture/package-contracts.md
@@ -5,7 +5,7 @@ This document defines what each package exposes, what it consumes, and the rules
 ## Dependency Graph
 
 ```
-salvageunion-reference (game data ORM, built)
+salvageunion-reference (game data ORM, no build step)
   |
   +---> suref-react (shared UI components, no build step)
   |       |
@@ -23,23 +23,36 @@ All workspace dependencies use `workspace:*` protocol. React 19.2.0+ is aligned 
 ## salvageunion-reference
 
 **Location:** `packages/salvageunion-reference/`
-**Build required:** Yes (`bun run build:package`)
+**Build required:** No (ships TS source; `bun run build:package` only regenerates `schemas/*.schema.json` from Zod)
+
+### Public Interface
+
+**This package is private and workspace-internal — it is not published to npm.**
+It has no npm distribution and is consumed only within this monorepo via the
+`workspace:*` protocol. The dataset's actual public interface is the
+CORS-enabled JSON API served by `suref-web`
+(`apps/suref-web/src/pages/schema/[schemaId].json.ts`,
+`schema/[schemaId].schema.json.ts`, `schema/[schemaId]/item/[itemId].json.ts`,
+documented at `apps/suref-web/src/pages/api.astro`). External consumers should
+use that API, not `npm install salvageunion-reference`. See
+[ADR-014](../adrs/ADR-014-json-api-public-interface-npm-retired.md) for the
+full rationale.
 
 ### Entry Points
 
 ```json
 {
   ".": {
-    "types": "./dist/index.d.ts",
-    "development": "./lib/index.ts",
-    "import": "./dist/index.js"
+    "types": "./lib/index.ts",
+    "default": "./lib/index.ts"
   },
   "./data/*": { "import": "./data/*.json" },
   "./schemas/*": { "import": "./schemas/*.json" }
 }
 ```
 
-In development, consuming apps resolve `lib/index.ts` directly (via the `development` condition). In production builds, they use `dist/index.js`.
+Consuming apps resolve `lib/index.ts` directly — there is no `dist/` build and
+no `development`/`import` condition split.
 
 ### Public API
 
@@ -69,12 +82,11 @@ All entity types (`SURef*`), enum types (`SURefEnum*`), common types (`SURefComm
 
 ### Dependencies
 
-- **Runtime:** `zod` (^4.3.6)
+- **Runtime:** `zod` (^4.4.3)
 - **Dev only:** none (`devDependencies` is empty — validation tooling runs on Bun + the runtime deps)
 
 ### Generated Files (do not edit)
 
-- `dist/` — Compiled JS + type declarations
 - `schemas/*.schema.json` — Generated from Zod schemas
 
 To change output: edit Zod schemas in `lib/schemas/`, then `bun run build:package`.

--- a/packages/salvageunion-reference/CHANGELOG.md
+++ b/packages/salvageunion-reference/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+> **Frozen.** This package is no longer published to npm — see
+> [ADR-014](../../docs/adrs/ADR-014-json-api-public-interface-npm-retired.md).
+> The last entry below is `2.0.1`; the package's `version` field has since
+> moved well past that without corresponding changelog entries. This file is
+> kept as a historical record of the pre-retirement `2.x` migration and is not
+> maintained going forward.
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/packages/salvageunion-reference/package.json
+++ b/packages/salvageunion-reference/package.json
@@ -24,13 +24,6 @@
   "sideEffects": [
     "./lib/zod.ts"
   ],
-  "files": [
-    "lib",
-    "data",
-    "schemas",
-    "README.md",
-    "LICENCE"
-  ],
   "scripts": {
     "build": "bun run generate:json-schemas",
     "build:full": "bun run build && bun run format && bun run lint",
@@ -56,37 +49,9 @@
     "format:check": "prettier --check .",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/SalvageUnion-io/SU-SRD.git"
-  },
-  "keywords": [
-    "salvage-union",
-    "tabletop-rpg",
-    "ttrpg",
-    "game-data",
-    "json-schema",
-    "leyline-press",
-    "orm",
-    "typescript",
-    "mech",
-    "post-apocalyptic",
-    "reference-data",
-    "game-mechanics",
-    "schema-validation",
-    "type-safe"
-  ],
-  "author": "Alex Jarvis",
   "license": "SEE LICENSE IN LICENCE",
-  "bugs": {
-    "url": "https://github.com/SalvageUnion-io/SU-SRD/issues"
-  },
-  "homepage": "https://github.com/SalvageUnion-io/SU-SRD#readme",
   "dependencies": {
     "zod": "^4.4.3"
   },
-  "devDependencies": {},
-  "engines": {
-    "node": ">=18.0.0"
-  }
+  "devDependencies": {}
 }


### PR DESCRIPTION
## Summary

`salvageunion-reference` was historically published to npm (133 versions, latest `2.4.0`), but the repo owner has decided to stop publishing it going forward — the dataset's real public interface is now the JSON API served by `apps/suref-web`. This PR is docs + metadata cleanup only; no application code (`lib/`, `data/`, `schemas/`) is touched, and no npm registry action is taken.

- **`docs/architecture/package-contracts.md`**: corrected the stale `dist/`-based build description (it claimed `dist/index.d.ts`, a `development` export condition, "Build required: Yes") to match the real `package.json` — no build step, `bun run build:package` only regenerates `schemas/*.schema.json` from Zod, consumers resolve `lib/index.ts` directly. Added an explicit statement that the package's public interface is the `suref-web` JSON API, not npm distribution — the package itself is private and workspace-internal.
- **New `docs/adrs/ADR-014-json-api-public-interface-npm-retired.md`**: documents this decision, citing the JSON API route handlers (`schema/[schemaId].json.ts`, `schema/[schemaId].schema.json.ts`, `schema/[schemaId]/item/[itemId].json.ts`, `api.astro`) and the README's existing (but registry-invisible) deprecation notice. Added to the ADR index in `docs/README.md`.
- **`packages/salvageunion-reference/package.json`**: removed all npm-registry-only metadata — `files`, `keywords`, `engines`, `repository`, `bugs`, `homepage`, `author` — verified unreferenced by any build/CI step (grepped `.github/workflows/` and `tools/`). Kept `private: true`, `description`, `license`, `type`, `main`, `types`, the `exports` map, `sideEffects`, `scripts`, `dependencies`, `devDependencies` — all load-bearing for workspace-internal resolution or otherwise still useful. The `LICENCE` file is untouched (legally load-bearing regardless of distribution channel). **`version` is deliberately left as `2.3.5`** — see the open question below.
- **`packages/salvageunion-reference/CHANGELOG.md`**: frozen with a note at the top pointing to ADR-014, rather than deleted (no other file in the repo references it) or continued (there's no future npm release for it to document).

## Open question for the repo owner: version mismatch (`2.3.5` local vs. `2.4.0` on npm)

Local `package.json` reads `2.3.5`; the npm registry's latest published version is `2.4.0` — local is *behind* published. I did **not** touch the local version field. Research findings, also recorded in ADR-014:

- The full git history of `packages/salvageunion-reference/package.json` (across all branches) never contains the string `2.4.0` — the version field progresses `2.3.4` → `2.3.5` and stops there locally.
- There is no npm-publish workflow anywhere in `.github/workflows/` — every one of the 133 npm-registry versions was published by hand (`npm publish`), never by CI.
- The npm-published `2.4.0` package metadata's `repository` field points to `alxjrvs/salvageunion-data`, a standalone repo that now 404s on GitHub — different from (and older than) the `SalvageUnion-io/SU-SRD` URL already correct in the local `package.json`.

**Conclusion:** `salvageunion-reference` appears to have originated as a standalone repo (`alxjrvs/salvageunion-data`) that was later absorbed into this monorepo. The npm-registry `2.4.0` was almost certainly published by hand from that old standalone checkout (or some other out-of-band location) after the absorption, and was never synced back into `SU-SRD`'s git history. Local `2.3.5` is the accurate source-of-record for this repository; `2.4.0` on npm is an orphaned publish from outside this repo's history. This PR does not attempt to resolve or paper over the discrepancy — that's a call for the repo owner.

## Out of scope (explicitly, per the task brief)

- **Actually deprecating the npm registry listing** (`npm deprecate salvageunion-reference`) is a separate manual step requiring the repo owner's own npm publish credentials. Not attempted here.
- `lib/`, `data/`, `schemas/`, and all application code are untouched.
- **Known pre-existing drift not fixed here** (flagged for a reviewer, left deliberately untouched to stay in scope): `docs/adrs/ADR-005-reference-data-orm.md` still describes `dist/` as generated and the build step as a "hard prerequisite" — this is the same kind of staleness fixed in `package-contracts.md`, but ADR-005 is out of this PR's scope. Worth a follow-up.

## Test plan

- [x] `bun run typecheck` — passes (ran twice, before and after the scope-expansion edits)
- [x] `bun run lint` — passes
- [x] `bun run validate:all` — passes (reference package data integrity unaffected, as expected)
- [x] `bun run format` — no drift on any touched file
- [x] Pre-push hook (typecheck, test, validate, knip) — all passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEaZaV9wE5dvqs9hdw6r2C