### PR TITLE
test(itun): durability harness — migrations, version skew, export round-trips

### DIFF
--- a/apps/in-the-union-now/src/lib/db/__tests__/migration-ladder.test.ts
+++ b/apps/in-the-union-now/src/lib/db/__tests__/migration-ladder.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Migration ladder harness (durability audit — seeded-fixture coverage).
+ *
+ * migrations.test.ts already proves a v2-shaped database (mech/pattern with
+ * legacy `cargo`, pilot with `rollResults`) migrates cleanly to DB_VERSION.
+ * This file exercises the DISTINCT store-creation × rewrite combinations that
+ * test does not: a database that starts BEFORE the `mechPatterns` store
+ * exists (v1), and one that starts AFTER `mechPatterns` but BEFORE
+ * `encounterNpcs` (v4) — plus the v6 slug rewrite's map-rekeying branch
+ * (systemConditions/moduleConditions/itemUses), which no existing test
+ * exercises.
+ *
+ * Each fixture is seeded with ONLY the object stores that existed at that
+ * real DB_VERSION (mirroring the store-creation branches in ../index.ts),
+ * not the full set — a v1 fixture with a `mechPatterns` store already
+ * present would silently mask a broken v2 store-creation branch.
+ *
+ * Isolation: dedicated per-fixture database names, destroyed before/after
+ * (see migrations.test.ts's isolation note — the shared app db is never
+ * touched here).
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { CrawlerSchema } from '../../schemas/crawler'
+import { MechPatternSchema } from '../../schemas/pattern'
+import { MechSchema } from '../../schemas/mech'
+import { PilotSchema } from '../../schemas/pilot'
+import { SoftLinkSchema } from '../../schemas/softLink'
+import { WorkspaceSchema } from '../../schemas/workspace'
+import { DB_VERSION, openItunDatabase } from '../index'
+import { STORE_NAMES } from '../stores'
+
+const NOW = '2026-01-01T00:00:00.000Z'
+
+/** Delete a dedicated fixture database (never blocks — no other file opens it). */
+async function destroyDatabase(name: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(name)
+    req.onsuccess = () => resolve()
+    req.onerror = () => reject(req.error)
+    req.onblocked = () => reject(new Error(`deleteDatabase(${name}) blocked`))
+  })
+}
+
+/**
+ * Seed a raw fixture database at a given real DB_VERSION, creating ONLY the
+ * object stores that existed at that version (mirroring the store-creation
+ * branches in ../index.ts's upgrade callback):
+ *   v1: pilots, mechs, crawlers, workspaces, softLinks
+ *   v2: + mechPatterns
+ *   v5: + encounterNpcs
+ * Records are written via raw `db.put` — bypassing Zod entirely, matching
+ * what a real old-version browser actually has on disk.
+ */
+async function seedFixtureDatabase(
+  name: string,
+  atVersion: number,
+  records: { store: string; value: unknown }[]
+): Promise<void> {
+  const { openDB } = await import('idb')
+  const db = await openDB(name, atVersion, {
+    upgrade(db) {
+      if (atVersion >= 1) {
+        for (const storeName of [
+          STORE_NAMES.pilots,
+          STORE_NAMES.mechs,
+          STORE_NAMES.crawlers,
+          STORE_NAMES.workspaces,
+          STORE_NAMES.softLinks,
+        ]) {
+          if (!db.objectStoreNames.contains(storeName)) {
+            db.createObjectStore(storeName, { keyPath: 'id' })
+          }
+        }
+      }
+      if (atVersion >= 2 && !db.objectStoreNames.contains(STORE_NAMES.mechPatterns)) {
+        db.createObjectStore(STORE_NAMES.mechPatterns, { keyPath: 'id' })
+      }
+      if (atVersion >= 5 && !db.objectStoreNames.contains(STORE_NAMES.encounterNpcs)) {
+        db.createObjectStore(STORE_NAMES.encounterNpcs, { keyPath: 'id' })
+      }
+    },
+  })
+  for (const { store, value } of records) {
+    await db.put(store, value)
+  }
+  db.close()
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: v1 database (pre-mechPatterns, pre-encounterNpcs, pre-cargoLots,
+// pre-slug-refs, pilot still carries rollResults).
+// ---------------------------------------------------------------------------
+
+describe('migration ladder: v1 fixture → DB_VERSION', () => {
+  const TEST_DB = 'itun-ladder-v1-test'
+
+  beforeEach(async () => {
+    await destroyDatabase(TEST_DB)
+  })
+  afterEach(async () => {
+    await destroyDatabase(TEST_DB)
+  })
+
+  const v1Pilot = {
+    id: 'pilot-v1-1',
+    schemaVersion: 1,
+    name: 'Vex Bramwell',
+    callsign: 'Iron',
+    classRef: 'scavenger',
+    abilities: ['first-aid'],
+    equipment: ['sidearm'],
+    rollResults: [],
+    motto: 'Never look back.',
+    keepsake: 'A cracked visor.',
+    appearance: 'Scarred.',
+    background: 'Wastes-born.',
+    conditions: [],
+    currentHP: 9,
+    createdAt: NOW,
+    updatedAt: NOW,
+  }
+
+  const v1Mech = {
+    id: 'mech-v1-1',
+    schemaVersion: 1,
+    name: 'Rustbucket',
+    chassisRef: 'Iron Mongrel Chassis',
+    systems: ['Welding Rig'],
+    modules: ['Armor Plating'],
+    cargo: ['Scrap metal', 'Fuel cell'],
+    conditions: [],
+    currentSP: 6,
+    createdAt: NOW,
+    updatedAt: NOW,
+  }
+
+  const v1Crawler = {
+    id: 'crawler-v1-1',
+    schemaVersion: 1,
+    name: 'The Rustwalker',
+    techLevel: 'tech-1',
+    systems: ['scanner-array'],
+    createdAt: NOW,
+    updatedAt: NOW,
+  }
+
+  const v1Workspace = {
+    id: 'ws-v1-1',
+    schemaVersion: 1,
+    name: 'Campaign One',
+    createdAt: NOW,
+  }
+
+  const v1SoftLink = {
+    id: 'link-v1-1',
+    from: { type: 'mech', id: 'mech-v1-1' },
+    to: { type: 'pilot', id: 'pilot-v1-1' },
+    type: 'mech-to-pilot',
+    createdAt: NOW,
+  }
+
+  test('store creation AND record rewrites both apply from a bare v1 database', async () => {
+    await seedFixtureDatabase(TEST_DB, 1, [
+      { store: STORE_NAMES.pilots, value: v1Pilot },
+      { store: STORE_NAMES.mechs, value: v1Mech },
+      { store: STORE_NAMES.crawlers, value: v1Crawler },
+      { store: STORE_NAMES.workspaces, value: v1Workspace },
+      { store: STORE_NAMES.softLinks, value: v1SoftLink },
+    ])
+
+    const db = await openItunDatabase(TEST_DB)
+    try {
+      expect(db.version).toBe(DB_VERSION)
+
+      // Stores that did not exist at v1 must now exist (and be empty — no
+      // data was ever written to them, only the ladder created them).
+      expect(db.objectStoreNames.contains(STORE_NAMES.mechPatterns)).toBe(true)
+      expect(db.objectStoreNames.contains(STORE_NAMES.encounterNpcs)).toBe(true)
+      expect(await db.count(STORE_NAMES.mechPatterns)).toBe(0)
+      expect(await db.count(STORE_NAMES.encounterNpcs)).toBe(0)
+
+      // Pilot: v4 rewrite dropped rollResults; strict-parses.
+      const rawPilot = await db.get(STORE_NAMES.pilots, 'pilot-v1-1')
+      expect('rollResults' in (rawPilot as Record<string, unknown>)).toBe(false)
+      const pilot = PilotSchema.parse(rawPilot)
+      expect(pilot.abilities).toEqual(['first-aid'])
+      expect(pilot.currentHP).toBe(9)
+
+      // Mech: v3 cargo→cargoLots AND v6 name→slug both applied.
+      const mech = MechSchema.parse(await db.get(STORE_NAMES.mechs, 'mech-v1-1'))
+      expect(mech.cargoLots.map((l) => l.name)).toEqual(['Scrap metal', 'Fuel cell'])
+      expect(mech.chassisRef).toBe('iron-mongrel-chassis')
+      expect(mech.systems).toEqual(['welding-rig'])
+      expect(mech.modules).toEqual(['armor-plating'])
+      expect(mech.currentSP).toBe(6)
+
+      // Crawler/workspace/softLink: no rewrite touches these shapes — data
+      // survives the ladder untouched and still strict-parses.
+      const crawler = CrawlerSchema.parse(await db.get(STORE_NAMES.crawlers, 'crawler-v1-1'))
+      expect(crawler.name).toBe('The Rustwalker')
+      expect(crawler.systems).toEqual(['scanner-array'])
+
+      const workspace = WorkspaceSchema.parse(await db.get(STORE_NAMES.workspaces, 'ws-v1-1'))
+      expect(workspace.name).toBe('Campaign One')
+
+      const link = SoftLinkSchema.parse(await db.get(STORE_NAMES.softLinks, 'link-v1-1'))
+      expect(link.from.id).toBe('mech-v1-1')
+      expect(link.to.id).toBe('pilot-v1-1')
+    } finally {
+      db.close()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fixture: v4 database (mechPatterns store exists; encounterNpcs does not;
+// cargo already rewritten to cargoLots and rollResults already dropped; refs
+// still name-based — including systemConditions/moduleConditions/itemUses
+// map KEYS, which no other test exercises).
+// ---------------------------------------------------------------------------
+
+describe('migration ladder: v4 fixture → DB_VERSION', () => {
+  const TEST_DB = 'itun-ladder-v4-test'
+
+  beforeEach(async () => {
+    await destroyDatabase(TEST_DB)
+  })
+  afterEach(async () => {
+    await destroyDatabase(TEST_DB)
+  })
+
+  const v4Pilot = {
+    id: 'pilot-v4-1',
+    schemaVersion: 1,
+    name: 'Odessa Kray',
+    callsign: 'Ghost',
+    classRef: 'scavenger',
+    abilities: ['a-1'],
+    equipment: [],
+    motto: '',
+    keepsake: '',
+    appearance: '',
+    background: '',
+    conditions: [],
+    createdAt: NOW,
+    updatedAt: NOW,
+  }
+
+  const v4Mech = {
+    id: 'mech-v4-1',
+    schemaVersion: 1,
+    name: 'Old Guard',
+    chassisRef: 'Ghost Chassis',
+    systems: ['Sensor Suite'],
+    modules: ['Reactive Armor'],
+    cargoLots: [
+      { id: 'lot-a', kind: 'unit', name: 'Medkit', cat: 'SEALED', units: 1, code: 'MED' },
+    ],
+    conditions: [],
+    systemConditions: { 'Sensor Suite': 'damaged' },
+    moduleConditions: { 'Reactive Armor': 'intact' },
+    itemUses: { 'Sensor Suite': 2 },
+    createdAt: NOW,
+    updatedAt: NOW,
+  }
+
+  const v4Pattern = {
+    id: 'pattern-v4-1',
+    schemaVersion: 1,
+    name: 'Recon Loadout',
+    chassisRef: 'Mule Chassis',
+    systems: ['Long Range Scanner'],
+    modules: [],
+    cargoLots: [],
+    createdAt: NOW,
+  }
+
+  test('encounterNpcs store is created AND v6 map-rekeying applies from a v4 database', async () => {
+    await seedFixtureDatabase(TEST_DB, 4, [
+      { store: STORE_NAMES.pilots, value: v4Pilot },
+      { store: STORE_NAMES.mechs, value: v4Mech },
+      { store: STORE_NAMES.mechPatterns, value: v4Pattern },
+    ])
+
+    const db = await openItunDatabase(TEST_DB)
+    try {
+      expect(db.version).toBe(DB_VERSION)
+
+      // encounterNpcs did NOT exist at v4 — the ladder must create it.
+      expect(db.objectStoreNames.contains(STORE_NAMES.encounterNpcs)).toBe(true)
+      expect(await db.count(STORE_NAMES.encounterNpcs)).toBe(0)
+
+      // Pilot already post-v4 (no rollResults) — passes through unchanged.
+      const pilot = PilotSchema.parse(await db.get(STORE_NAMES.pilots, 'pilot-v4-1'))
+      expect(pilot.name).toBe('Odessa Kray')
+
+      // Mech: already cargoLots-shaped (v3 no-op), but refs AND condition-map
+      // keys are still names — v6 must slugify both the ref arrays and the
+      // systemConditions/moduleConditions/itemUses map keys.
+      const mech = MechSchema.parse(await db.get(STORE_NAMES.mechs, 'mech-v4-1'))
+      expect(mech.chassisRef).toBe('ghost-chassis')
+      expect(mech.systems).toEqual(['sensor-suite'])
+      expect(mech.modules).toEqual(['reactive-armor'])
+      expect(mech.systemConditions).toEqual({ 'sensor-suite': 'damaged' })
+      expect(mech.moduleConditions).toEqual({ 'reactive-armor': 'intact' })
+      expect(mech.itemUses).toEqual({ 'sensor-suite': 2 })
+      // Cargo lot untouched by v3 (already cargoLots-shaped) — not re-wrapped.
+      expect(mech.cargoLots).toHaveLength(1)
+      expect(mech.cargoLots[0]?.name).toBe('Medkit')
+
+      // Pattern store already existed at v4 — same v6 rewrite applies there.
+      const pattern = MechPatternSchema.parse(
+        await db.get(STORE_NAMES.mechPatterns, 'pattern-v4-1')
+      )
+      expect(pattern.chassisRef).toBe('mule-chassis')
+      expect(pattern.systems).toEqual(['long-range-scanner'])
+    } finally {
+      db.close()
+    }
+  })
+})

--- a/apps/in-the-union-now/src/lib/db/__tests__/salvage-version-skew.test.ts
+++ b/apps/in-the-union-now/src/lib/db/__tests__/salvage-version-skew.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Version-skew simulation harness (durability audit, item 2).
+ *
+ * ADR-002 documents the salvage-read contract: "a strict parse is attempted
+ * first; on failure the row is re-parsed with a lenient salvage schema
+ * (`.strip()`) and a warning is logged... Salvage-on-read can silently strip
+ * data a tab is too old to understand."
+ *
+ * migrations.test.ts already proves this for ONE case: a pilot record with a
+ * stray TOP-LEVEL unknown field. This file:
+ *
+ *   1. Extends the "top-level unknown field survives" case to every store
+ *      (mechs, crawlers, workspaces, softLinks, mechPatterns, encounterNpcs)
+ *      and asserts every OTHER known field — including nested arrays/objects
+ *      — round-trips exactly. A field silently vanishing that ISN'T the
+ *      injected unknown one would be drift beyond the documented contract.
+ *
+ *   2. Surfaces a boundary ADR-002 does not spell out: `schema.strip()` only
+ *      relaxes unknown-key checking at the TOP level. Every nested `.strict()`
+ *      sub-schema (CargoLotSchema, InjurySchema, EntityRefSchema,
+ *      CrawlerNpcStateSchema, MediatorRollResultSchema, ...) stays strict, so
+ *      an unknown key introduced by a NEWER build inside a nested object
+ *      fails BOTH the strict parse and the salvage parse — the salvage path
+ *      cannot rescue it, and the whole record is skipped (silently, with only
+ *      a console.warn) rather than the offending nested field alone.
+ *
+ *      This is a genuine gap relative to the "nothing beyond the unknown
+ *      field is dropped" expectation: an entire pilot/mech/crawler/etc. can
+ *      vanish from list()/get() until a NEWER build writes to it again. There
+ *      is no migration or code change proposed here for this — see the
+ *      finding note in the PR description; it is flagged as a TODO for a
+ *      follow-up (e.g. teaching `salvageRead` to fall back further, or
+ *      loosening nested schemas to `.strip()` too) rather than guessed at.
+ *
+ * Isolation: uses the SHARED app db (no version games, no deletes beyond
+ * `_clearAllStores()`), matching migrations.test.ts's "salvage read path"
+ * section. Every raw connection opened here is closed before the test ends.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import {
+  _clearAllStores,
+  crawlers,
+  encounterNpcs,
+  mechPatterns,
+  mechs,
+  openItunDatabase,
+  pilots,
+  softLinks,
+  workspaces,
+} from '../index'
+import { STORE_NAMES } from '../stores'
+
+/** Overwrite a record's raw bytes in IDB, bypassing all Zod validation. */
+async function putRaw(storeName: string, record: unknown): Promise<void> {
+  const db = await openItunDatabase()
+  try {
+    await db.put(storeName, record)
+  } finally {
+    db.close()
+  }
+}
+
+function captureWarnings(): { warnings: string[]; restore: () => void } {
+  const warnings: string[] = []
+  const original = console.warn
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(' '))
+  }
+  return { warnings, restore: () => (console.warn = original) }
+}
+
+beforeEach(async () => {
+  await _clearAllStores()
+})
+
+afterEach(async () => {
+  await _clearAllStores()
+})
+
+// ---------------------------------------------------------------------------
+// 1. Top-level unknown field: stripped, record survives, EVERY other known
+//    field (including nested structures) is preserved exactly.
+// ---------------------------------------------------------------------------
+
+describe('salvage read: top-level unknown field strips only that field', () => {
+  test('mech — nested cargoLots/conditions/maps all survive intact', async () => {
+    const created = await mechs.create({
+      schemaVersion: 1,
+      name: 'Test Mech',
+      chassisRef: 'iron-mongrel',
+      systems: ['welding-rig'],
+      modules: ['armor-plating'],
+      cargoLots: [
+        { id: 'lot-1', kind: 'unit', name: 'Medkit', cat: 'SEALED', units: 1, code: 'MED' },
+      ],
+      conditions: ['prone'],
+      currentSP: 5,
+      systemConditions: { 'welding-rig': 'damaged' },
+    })
+
+    await putRaw(STORE_NAMES.mechs, { ...created, fieldFromTheFuture: 'whatever' })
+
+    const { warnings, restore } = captureWarnings()
+    try {
+      const record = await mechs.get(created.id)
+      expect(record).not.toBeNull()
+      expect('fieldFromTheFuture' in (record as unknown as Record<string, unknown>)).toBe(false)
+      // Every other field survives — this is the "nothing else is dropped" check.
+      expect(record).toEqual(created)
+      expect(warnings.some((w) => w.includes('salvage path'))).toBe(true)
+    } finally {
+      restore()
+    }
+  })
+
+  test('crawler — nested crawlerBays/scrapPool survive intact', async () => {
+    const created = await crawlers.create({
+      schemaVersion: 1,
+      name: 'Test Crawler',
+      techLevel: 'tech-2',
+      systems: ['scanner-array'],
+      crawlerBays: [{ bayRef: 'command-bay', npcName: 'Lira', npcCurrentHP: 4 }],
+      scrapPool: { tl1: 3, tl2: 1 },
+    })
+
+    await putRaw(STORE_NAMES.crawlers, { ...created, fieldFromTheFuture: true })
+
+    const { warnings, restore } = captureWarnings()
+    try {
+      const record = await crawlers.get(created.id)
+      expect(record).not.toBeNull()
+      expect('fieldFromTheFuture' in (record as unknown as Record<string, unknown>)).toBe(false)
+      expect(record).toEqual(created)
+      expect(warnings.some((w) => w.includes('salvage path'))).toBe(true)
+    } finally {
+      restore()
+    }
+  })
+
+  test('workspace — survives with all fields intact', async () => {
+    const created = await workspaces.create({ schemaVersion: 1, name: 'Campaign Alpha' })
+
+    await putRaw(STORE_NAMES.workspaces, { ...created, fieldFromTheFuture: 'x' })
+
+    const { warnings, restore } = captureWarnings()
+    try {
+      const record = await workspaces.get(created.id)
+      expect(record).toEqual(created)
+      expect(warnings.some((w) => w.includes('salvage path'))).toBe(true)
+    } finally {
+      restore()
+    }
+  })
+
+  test('softLink — from/to endpoints survive intact', async () => {
+    const created = await softLinks.create({
+      from: { type: 'mech', id: 'mech-1' },
+      to: { type: 'pilot', id: 'pilot-1' },
+      type: 'mech-to-pilot',
+    })
+
+    await putRaw(STORE_NAMES.softLinks, { ...created, fieldFromTheFuture: 1 })
+
+    const { warnings, restore } = captureWarnings()
+    try {
+      const record = await softLinks.get(created.id)
+      expect(record).toEqual(created)
+      expect(warnings.some((w) => w.includes('salvage path'))).toBe(true)
+    } finally {
+      restore()
+    }
+  })
+
+  test('mechPattern — nested cargoLots survives intact', async () => {
+    const created = await mechPatterns.create({
+      schemaVersion: 1,
+      name: 'Scout Loadout',
+      chassisRef: 'mule-chassis',
+      systems: ['sensor-suite'],
+      modules: [],
+      cargoLots: [
+        { id: 'lot-1', kind: 'unit', name: 'Medkit', cat: 'SEALED', units: 1, code: 'MED' },
+      ],
+    })
+
+    await putRaw(STORE_NAMES.mechPatterns, { ...created, fieldFromTheFuture: [] })
+
+    const { warnings, restore } = captureWarnings()
+    try {
+      const record = await mechPatterns.get(created.id)
+      expect(record).toEqual(created)
+      expect(warnings.some((w) => w.includes('salvage path'))).toBe(true)
+    } finally {
+      restore()
+    }
+  })
+
+  test('encounterNpc — all fields survive intact', async () => {
+    const created = await encounterNpcs.create({
+      schemaVersion: 1,
+      refSchema: 'npcs',
+      refSlug: 'raider',
+      refName: 'Raider',
+      name: 'Raider 2',
+      currentHp: 3,
+      maxHp: 3,
+      statKind: 'hp',
+      conditions: ['prone'],
+    })
+
+    await putRaw(STORE_NAMES.encounterNpcs, { ...created, fieldFromTheFuture: null })
+
+    const { warnings, restore } = captureWarnings()
+    try {
+      const record = await encounterNpcs.get(created.id)
+      expect(record).toEqual(created)
+      expect(warnings.some((w) => w.includes('salvage path'))).toBe(true)
+    } finally {
+      restore()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2. FINDING: an unknown key nested inside a `.strict()` sub-schema is NOT
+//    rescued by the top-level salvage `.strip()` — the whole record is
+//    skipped (silently dropped from list()/get(), with only a console.warn).
+// ---------------------------------------------------------------------------
+
+describe('salvage read: unknown key in a NESTED strict sub-schema drops the whole record', () => {
+  test('mech — unknown key inside cargoLots[0] makes the record unreadable', async () => {
+    const created = await mechs.create({
+      schemaVersion: 1,
+      name: 'Test Mech',
+      chassisRef: 'iron-mongrel',
+      systems: [],
+      modules: [],
+      cargoLots: [
+        { id: 'lot-1', kind: 'unit', name: 'Medkit', cat: 'SEALED', units: 1, code: 'MED' },
+      ],
+      conditions: [],
+    })
+
+    const drifted = {
+      ...created,
+      cargoLots: [{ ...created.cargoLots[0], fieldFromTheFuture: 'x' }],
+    }
+    await putRaw(STORE_NAMES.mechs, drifted)
+
+    const { warnings, restore } = captureWarnings()
+    try {
+      // get(): the record cannot even be salvaged — it reads as null, not a
+      // partially-healed record. This is the gap: the whole mech (name,
+      // systems, conditions, everything) is invisible, not just the drifted
+      // cargo lot.
+      const record = await mechs.get(created.id)
+      expect(record).toBeNull()
+      // list() likewise omits it rather than surfacing a partial record.
+      const all = await mechs.list()
+      expect(all.some((m) => m.id === created.id)).toBe(false)
+      expect(warnings.some((w) => w.includes('Skipping unreadable record'))).toBe(true)
+    } finally {
+      restore()
+    }
+  })
+
+  test('pilot — unknown key inside injuries[0] makes the record unreadable', async () => {
+    const created = await pilots.create({
+      schemaVersion: 1,
+      name: 'Test Pilot',
+      callsign: 'TP',
+      classRef: 'scavenger',
+      abilities: [],
+      equipment: [],
+      motto: '',
+      keepsake: '',
+      appearance: '',
+      background: '',
+      conditions: [],
+      injuries: [{ severity: 'minor', note: 'Twisted ankle.' }],
+    })
+
+    const drifted = {
+      ...created,
+      injuries: [{ ...created.injuries?.[0], newSeverityMeta: 'x' }],
+    }
+    await putRaw(STORE_NAMES.pilots, drifted)
+
+    const { warnings, restore } = captureWarnings()
+    try {
+      const record = await pilots.get(created.id)
+      expect(record).toBeNull()
+      const all = await pilots.list()
+      expect(all.some((p) => p.id === created.id)).toBe(false)
+      expect(warnings.some((w) => w.includes('Skipping unreadable record'))).toBe(true)
+    } finally {
+      restore()
+    }
+  })
+
+  test('softLink — unknown key inside the `from` ref makes the record unreadable', async () => {
+    const created = await softLinks.create({
+      from: { type: 'mech', id: 'mech-1' },
+      to: { type: 'pilot', id: 'pilot-1' },
+      type: 'mech-to-pilot',
+    })
+
+    const drifted = { ...created, from: { ...created.from, endpointVersion: 2 } }
+    await putRaw(STORE_NAMES.softLinks, drifted)
+
+    const { warnings, restore } = captureWarnings()
+    try {
+      const record = await softLinks.get(created.id)
+      expect(record).toBeNull()
+      const all = await softLinks.list()
+      expect(all.some((l) => l.id === created.id)).toBe(false)
+      expect(warnings.some((w) => w.includes('Skipping unreadable record'))).toBe(true)
+    } finally {
+      restore()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 3. Heal-on-write: a top-level-drifted record heals back to strict shape on
+//    its next write (already proven for pilots in migrations.test.ts) —
+//    extended here to a second store to confirm it's the general contract,
+//    not a pilot-only behaviour.
+// ---------------------------------------------------------------------------
+
+describe('salvage read: heal on next write', () => {
+  test('a top-level-drifted mech heals to strict shape on its next update', async () => {
+    const created = await mechs.create({
+      schemaVersion: 1,
+      name: 'Test Mech',
+      chassisRef: 'iron-mongrel',
+      systems: [],
+      modules: [],
+      cargoLots: [],
+      conditions: [],
+    })
+    await putRaw(STORE_NAMES.mechs, { ...created, fieldFromTheFuture: true })
+
+    const { restore } = captureWarnings()
+    try {
+      await mechs.update(created.id, { name: 'Healed Mech' })
+    } finally {
+      restore()
+    }
+
+    const db = await openItunDatabase()
+    try {
+      const raw = await db.get(STORE_NAMES.mechs, created.id)
+      expect('fieldFromTheFuture' in (raw as Record<string, unknown>)).toBe(false)
+      expect((raw as Record<string, unknown>)['name']).toBe('Healed Mech')
+    } finally {
+      db.close()
+    }
+  })
+})

--- a/apps/in-the-union-now/src/lib/export/__tests__/export-round-trip.test.ts
+++ b/apps/in-the-union-now/src/lib/export/__tests__/export-round-trip.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Export/import round-trip fidelity harness (durability audit, item 3).
+ *
+ * export.test.ts and export-patterns.test.ts already cover the mechanics
+ * (fresh-id assignment, dedup, dangling-link pruning, legacy-bundle
+ * normalization) with minimal fixtures (mostly just checking `name`). This
+ * file is table-driven over RICH fixtures — every optional/nested field
+ * filled in for each entity type — pushed through the full pipeline:
+ *
+ *   buildExportBundle → JSON.stringify → parseImportBundle → mergeImport
+ *
+ * and asserts every field survives except the three that are INTENTIONALLY
+ * re-minted (id, createdAt, updatedAt) and workspaceId (intentionally
+ * remapped to the newly-created workspace's id — see mergeImport's
+ * doc-comment). That remap is exercised explicitly, not treated as noise.
+ *
+ * No property-testing library (e.g. fast-check) is a dependency of this repo
+ * (checked package.json first, per the harness brief) — this is deliberately
+ * thorough table-driven coverage instead of generative testing.
+ *
+ * Known gap (not fixed here — out of scope, flagged for follow-up): the
+ * `encounterNpcs` store has NO representation in ExportBundleSchema at all.
+ * A full backup silently omits GM encounter-tray state. Not addressed in
+ * this PR (would be a schema/feature change, not a test-harness fix) — see
+ * the PR description.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { _clearAllStores, _resetDbSingleton, mechPatterns } from '../../db/index'
+import { useEntityStore } from '../../../stores/entityStore'
+import { useWorkspaceStore } from '../../../stores/workspaceStore'
+import { buildExportBundle } from '../buildExportBundle'
+import { mergeImport } from '../mergeImport'
+import { parseImportBundle } from '../parseImportBundle'
+import type { ExportBundle } from '../../schemas/exportBundle'
+
+function resetStores(): void {
+  useEntityStore.setState({
+    pilots: [],
+    mechs: [],
+    crawlers: [],
+    softLinks: [],
+    hydrated: { pilots: false, mechs: false, crawlers: false, softLinks: false },
+  })
+  useWorkspaceStore.setState({ workspaces: [], hydrated: false })
+}
+
+beforeEach(async () => {
+  _resetDbSingleton()
+  await _clearAllStores()
+  resetStores()
+})
+
+afterEach(async () => {
+  await _clearAllStores()
+  resetStores()
+})
+
+/** Strip the fields mergeImport intentionally re-mints/remaps on import. */
+function stable(record: Record<string, unknown>): Record<string, unknown> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { id: _id, createdAt: _ca, updatedAt: _ua, workspaceId: _wsId, ...rest } = record
+  return rest
+}
+
+/** Full round trip through the wire format (JSON), not just in-memory objects. */
+async function roundTrip(bundle: ExportBundle): Promise<ExportBundle> {
+  const json = JSON.stringify(bundle)
+  _resetDbSingleton()
+  await _clearAllStores()
+  resetStores()
+  const summary = await mergeImport(
+    parseImportBundle(json),
+    useEntityStore.getState(),
+    useWorkspaceStore.getState()
+  )
+  void summary
+  return parseImportBundle(json) // re-parse for shape assertions below
+}
+
+// ---------------------------------------------------------------------------
+// Rich fixtures — every optional/nested field populated.
+// ---------------------------------------------------------------------------
+
+const richPilotInput = {
+  schemaVersion: 1 as const,
+  name: 'Odessa Kray',
+  callsign: 'Ghost',
+  classRef: 'scavenger',
+  abilities: ['first-aid', 'scrounge'],
+  equipment: ['sidearm', 'medkit'],
+  motto: 'Never look back.',
+  keepsake: 'A cracked visor.',
+  appearance: 'Scarred, wiry.',
+  background: 'Wastes-born.',
+  description: 'Quiet, watchful.',
+  conditions: ['prone'],
+  currentHP: 8,
+  currentAP: 2,
+  equipmentConditions: { sidearm: 'damaged' as const },
+  equipmentChoices: { medkit: { 'bandage-type': ['field-dressing'] } },
+  crawlerLevel: 3,
+  usedAbilities: ['first-aid'],
+  trainingPoints: 2,
+  injuries: [{ severity: 'minor' as const, note: 'Twisted ankle.' }],
+  maxHpModifier: 2,
+  maxApModifier: 1,
+  maxInventorySlotsModifier: 4,
+  equipmentUses: { medkit: 1 },
+  usedToggles: { background: true, keepsake: false, motto: true },
+  genericInventory: [{ id: 'gi-1', name: 'Scrap', slotCost: 3, qty: 2, note: 'raw' }],
+  lastCriticalInjury: {
+    roll: 7,
+    outcome: 'minor-injury' as const,
+    rolledAt: '2026-01-01T00:00:00.000Z',
+  },
+}
+
+const richMechInput = {
+  schemaVersion: 1 as const,
+  name: 'Rustbucket',
+  chassisRef: 'iron-mongrel',
+  systems: ['welding-rig'],
+  modules: ['armor-plating'],
+  cargoLots: [
+    {
+      id: 'lot-unit',
+      kind: 'unit' as const,
+      name: 'Medkit',
+      cat: 'SEALED' as const,
+      units: 1,
+      code: 'MED',
+    },
+    {
+      id: 'lot-bulk',
+      kind: 'bulk' as const,
+      name: 'Tech 2 Scrap',
+      cat: 'SCRAP' as const,
+      tl: 2,
+      qty: 3,
+      units: 3,
+      code: 'SCR-T2',
+    },
+  ],
+  patternName: 'Scout Rig',
+  description: 'Rust-streaked hull.',
+  conditions: ['vulnerable'],
+  maxSpModifier: -5,
+  maxEpModifier: 2,
+  maxHeatModifier: 1,
+  maxCargoModifier: 2,
+  currentHP: 4,
+  currentAP: 3,
+  currentTP: 1,
+  currentSP: 6,
+  currentEP: 4,
+  currentHeat: 5,
+  systemConditions: { 'welding-rig': 'damaged' as const },
+  moduleConditions: { 'armor-plating': 'intact' as const },
+  itemUses: { 'welding-rig': 2 },
+  shutdown: true,
+  vulnerable: true,
+  destroyed: false,
+  lastHeatCheck: {
+    heatCheckRoll: 12,
+    heatAtCheck: 5,
+    overloaded: false,
+    rolledAt: '2026-01-01T00:00:00.000Z',
+  },
+  lastCriticalDamage: {
+    roll: 15,
+    outcome: 'core-damage' as const,
+    rolledAt: '2026-01-01T00:00:00.000Z',
+  },
+}
+
+const richCrawlerInput = {
+  schemaVersion: 1 as const,
+  name: 'The Rustwalker',
+  description: 'A limping veteran crawler.',
+  techLevel: 'tech-3',
+  type: 'battle-crawler',
+  typeNpc: {
+    npcName: 'Sergeant Vole',
+    npcCurrentHP: 3,
+    npcDescription: 'Gravel-voiced.',
+    npcFacts: ['Lost an eye at Ashford.'],
+    condition: 'damaged' as const,
+  },
+  crawlerBays: [
+    {
+      bayRef: 'command-bay',
+      npcName: 'Lira',
+      npcCurrentHP: 4,
+      npcDescription: 'Sharp-eyed.',
+      npcFacts: ['Ex-cartographer.'],
+      condition: 'intact' as const,
+    },
+  ],
+  systems: ['scanner-array'],
+  bayChoices: { 'command-bay': { 'comms-upgrade': ['long-range'] } },
+  currentSP: 22,
+  scrapPool: { tl1: 3, tl2: 1, tl3: 0 },
+  upgradePool: 12,
+  cargoLots: [
+    {
+      id: 'lot-c1',
+      kind: 'unit' as const,
+      name: 'Spare Parts',
+      cat: 'SYSTEM' as const,
+      units: 2,
+      code: 'SPP',
+    },
+  ],
+  maxSpModifier: 5,
+}
+
+const richPatternInput = {
+  schemaVersion: 1 as const,
+  name: 'Heavy Loadout',
+  chassisRef: 'mule-chassis',
+  systems: ['sensor-suite', 'long-range-scanner'],
+  modules: ['armor-plating'],
+  cargoLots: [
+    {
+      id: 'lot-p1',
+      kind: 'bulk' as const,
+      name: 'Tech 1 Scrap',
+      cat: 'SCRAP' as const,
+      tl: 1,
+      qty: 5,
+      units: 5,
+      code: 'SCR-T1',
+    },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Per-entity round-trip fidelity
+// ---------------------------------------------------------------------------
+
+describe('export round-trip — field fidelity', () => {
+  test('pilot: every optional/nested field survives buildExportBundle → JSON → parseImportBundle → mergeImport', async () => {
+    const entityStore = useEntityStore.getState()
+    const workspaceStore = useWorkspaceStore.getState()
+
+    await workspaceStore.hydrate()
+    const ws = await workspaceStore.create({ name: 'Campaign Alpha' })
+
+    await entityStore.hydrate('pilot')
+    const created = await entityStore.create('pilot', { ...richPilotInput, workspaceId: ws.id })
+
+    const bundle = await buildExportBundle(entityStore, workspaceStore)
+    const parsed = await roundTrip(bundle)
+
+    _resetDbSingleton()
+    resetStores()
+    const verifyEntityStore = useEntityStore.getState()
+    const verifyWorkspaceStore = useWorkspaceStore.getState()
+    await verifyEntityStore.hydrate('pilot')
+    await verifyWorkspaceStore.hydrate()
+
+    const importedPilot = verifyEntityStore.list('pilot')[0]
+    const importedWs = verifyWorkspaceStore.list()[0]
+    expect(importedPilot).toBeDefined()
+    expect(importedWs).toBeDefined()
+
+    // Every field except id/createdAt/updatedAt/workspaceId is preserved exactly.
+    expect(stable(importedPilot as unknown as Record<string, unknown>)).toEqual(
+      stable(created as unknown as Record<string, unknown>)
+    )
+    // workspaceId is intentionally remapped — to the NEW workspace's id.
+    expect((importedPilot as { workspaceId?: string }).workspaceId).toBe(importedWs!.id)
+    expect((importedPilot as { workspaceId?: string }).workspaceId).not.toBe(ws.id)
+
+    // Sanity: the exported bundle actually carried the rich fields (i.e. the
+    // round trip exercised them, not an accidentally-empty pilot).
+    expect(parsed.entities.pilots[0]?.injuries).toHaveLength(1)
+    expect(parsed.entities.pilots[0]?.lastCriticalInjury?.outcome).toBe('minor-injury')
+  })
+
+  test('mech: bulk SCRAP + unit cargo lots, condition maps, heat/damage results all survive', async () => {
+    const entityStore = useEntityStore.getState()
+    const workspaceStore = useWorkspaceStore.getState()
+
+    await entityStore.hydrate('mech')
+    const created = await entityStore.create('mech', richMechInput)
+
+    const bundle = await buildExportBundle(entityStore, workspaceStore)
+    await roundTrip(bundle)
+
+    _resetDbSingleton()
+    resetStores()
+    const verifyEntityStore = useEntityStore.getState()
+    await verifyEntityStore.hydrate('mech')
+    const importedMech = verifyEntityStore.list('mech')[0]
+    expect(importedMech).toBeDefined()
+
+    expect(stable(importedMech as unknown as Record<string, unknown>)).toEqual(
+      stable(created as unknown as Record<string, unknown>)
+    )
+  })
+
+  test('crawler: crawlerBays/typeNpc/scrapPool/bayChoices all survive', async () => {
+    const entityStore = useEntityStore.getState()
+    const workspaceStore = useWorkspaceStore.getState()
+
+    await entityStore.hydrate('crawler')
+    const created = await entityStore.create('crawler', richCrawlerInput)
+
+    const bundle = await buildExportBundle(entityStore, workspaceStore)
+    await roundTrip(bundle)
+
+    _resetDbSingleton()
+    resetStores()
+    const verifyEntityStore = useEntityStore.getState()
+    await verifyEntityStore.hydrate('crawler')
+    const importedCrawler = verifyEntityStore.list('crawler')[0]
+    expect(importedCrawler).toBeDefined()
+
+    expect(stable(importedCrawler as unknown as Record<string, unknown>)).toEqual(
+      stable(created as unknown as Record<string, unknown>)
+    )
+  })
+
+  test('mechPattern: bulk SCRAP cargo lot survives (no workspaceId field to remap)', async () => {
+    const entityStore = useEntityStore.getState()
+    const workspaceStore = useWorkspaceStore.getState()
+
+    const created = await mechPatterns.create(richPatternInput)
+
+    const bundle = await buildExportBundle(entityStore, workspaceStore)
+    await roundTrip(bundle)
+
+    const imported = (await mechPatterns.list())[0]
+    expect(imported).toBeDefined()
+
+    expect(stable(imported as unknown as Record<string, unknown>)).toEqual(
+      stable(created as unknown as Record<string, unknown>)
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cross-entity fidelity: softLinks + workspace assignment survive together
+// in one full-backup round trip (not just each entity type in isolation).
+// ---------------------------------------------------------------------------
+
+describe('export round-trip — cross-entity full backup', () => {
+  test('pilot + mech + crawler + softLinks + workspace all round-trip consistently', async () => {
+    const entityStore = useEntityStore.getState()
+    const workspaceStore = useWorkspaceStore.getState()
+
+    await workspaceStore.hydrate()
+    const ws = await workspaceStore.create({ name: 'Campaign Alpha' })
+
+    await entityStore.hydrate('pilot')
+    const pilot = await entityStore.create('pilot', { ...richPilotInput, workspaceId: ws.id })
+
+    await entityStore.hydrate('mech')
+    const mech = await entityStore.create('mech', { ...richMechInput, workspaceId: ws.id })
+
+    await entityStore.hydrate('crawler')
+    const crawler = await entityStore.create('crawler', { ...richCrawlerInput, workspaceId: ws.id })
+
+    await entityStore.hydrate('softLink')
+    await entityStore.create('softLink', {
+      from: { type: 'mech', id: mech.id },
+      to: { type: 'pilot', id: pilot.id },
+      type: 'mech-to-pilot',
+    })
+    await entityStore.create('softLink', {
+      from: { type: 'pilot', id: pilot.id },
+      to: { type: 'crawler', id: crawler.id },
+      type: 'pilot-to-crawler',
+    })
+
+    await mechPatterns.create(richPatternInput)
+
+    const bundle = await buildExportBundle(entityStore, workspaceStore)
+    expect(bundle.entities.pilots).toHaveLength(1)
+    expect(bundle.entities.mechs).toHaveLength(1)
+    expect(bundle.entities.crawlers).toHaveLength(1)
+    expect(bundle.softLinks).toHaveLength(2)
+    expect(bundle.workspaces).toHaveLength(1)
+    expect(bundle.mechPatterns).toHaveLength(1)
+
+    await roundTrip(bundle)
+
+    _resetDbSingleton()
+    resetStores()
+    const verifyEntityStore = useEntityStore.getState()
+    const verifyWorkspaceStore = useWorkspaceStore.getState()
+    await verifyEntityStore.hydrate('pilot')
+    await verifyEntityStore.hydrate('mech')
+    await verifyEntityStore.hydrate('crawler')
+    await verifyEntityStore.hydrate('softLink')
+    await verifyWorkspaceStore.hydrate()
+
+    const importedPilot = verifyEntityStore.list('pilot')[0]!
+    const importedMech = verifyEntityStore.list('mech')[0]!
+    const importedCrawler = verifyEntityStore.list('crawler')[0]!
+    const importedLinks = verifyEntityStore.list('softLink')
+    const importedWs = verifyWorkspaceStore.list()[0]!
+    const importedPatterns = await mechPatterns.list()
+
+    // All three entities re-point at the SAME new workspace id.
+    expect((importedPilot as { workspaceId?: string }).workspaceId).toBe(importedWs.id)
+    expect((importedMech as { workspaceId?: string }).workspaceId).toBe(importedWs.id)
+    expect((importedCrawler as { workspaceId?: string }).workspaceId).toBe(importedWs.id)
+
+    // Both softLinks remapped to the fresh entity ids — no dangling refs.
+    expect(importedLinks).toHaveLength(2)
+    const mechToPilot = importedLinks.find((l) => l.type === 'mech-to-pilot')!
+    const pilotToCrawler = importedLinks.find((l) => l.type === 'pilot-to-crawler')!
+    expect(mechToPilot.from.id).toBe(importedMech.id)
+    expect(mechToPilot.to.id).toBe(importedPilot.id)
+    expect(pilotToCrawler.from.id).toBe(importedPilot.id)
+    expect(pilotToCrawler.to.id).toBe(importedCrawler.id)
+
+    // Pattern store survives the same full-backup round trip.
+    expect(importedPatterns).toHaveLength(1)
+    expect(importedPatterns[0]?.chassisRef).toBe('mule-chassis')
+
+    // Deep field fidelity, same as the per-entity tests above.
+    expect(stable(importedPilot as unknown as Record<string, unknown>)).toEqual(
+      stable({ ...pilot } as unknown as Record<string, unknown>)
+    )
+    expect(stable(importedMech as unknown as Record<string, unknown>)).toEqual(
+      stable({ ...mech } as unknown as Record<string, unknown>)
+    )
+    expect(stable(importedCrawler as unknown as Record<string, unknown>)).toEqual(
+      stable({ ...crawler } as unknown as Record<string, unknown>)
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Adds a fixture-driven durability test harness for ITUN's local-first persistence layer, per ADR-001 ("it's on your device, backups are the user's responsibility") and ADR-002 (salvage-on-read version-skew tolerance). Three new test files, no production code changes.

### 1. Migration ladder (`src/lib/db/__tests__/migration-ladder.test.ts`)

`migrations.test.ts` already proves a v2-shaped fixture migrates cleanly to `DB_VERSION`. This adds two **distinct** fixtures that exercise store-creation × rewrite combinations that test doesn't:

- **v1 fixture** — seeded with only the 5 core stores (pre-`mechPatterns`, pre-`encounterNpcs`), raw pre-v3/v4/v6 shaped records. Proves store creation AND every record rewrite apply together from the bare floor version.
- **v4 fixture** — `mechPatterns` store exists, `encounterNpcs` doesn't yet; records already cargoLots-shaped and rollResults-free, but still name-based refs — including `systemConditions`/`moduleConditions`/`itemUses` map **keys**, which no existing test exercised (only the array-ref rewrite was covered).

### 2. Version-skew salvage-read harness (`src/lib/db/__tests__/salvage-version-skew.test.ts`)

Extends the existing pilot-only "unknown top-level field is stripped, not fatal" test to every store (mechs, crawlers, workspaces, softLinks, mechPatterns, encounterNpcs), asserting every other field — including nested arrays/objects — round-trips exactly.

**Finding surfaced and pinned as a test, not fixed:** `schema.strip()` (the salvage schema) only relaxes unknown-key checking at the *top level*. Every nested `.strict()` sub-schema (`CargoLotSchema`, `InjurySchema`, `EntityRefSchema`, `CrawlerNpcStateSchema`, ...) stays strict. So an unknown key introduced by a *newer* build inside a nested object fails both the strict AND salvage parse — the whole record silently vanishes from `list()`/`get()` (with only a `console.warn`) rather than just the drifted nested field. This is a real gap relative to "nothing beyond the documented field-stripping is lost." No code fix is proposed here — flagged as a TODO for follow-up (e.g. teaching `salvageRead` to fall back further, or making nested schemas `.strip()` too).

### 3. Export/import round-trip fidelity (`src/lib/export/__tests__/export-round-trip.test.ts`)

Table-driven `buildExportBundle → JSON.stringify → parseImportBundle → mergeImport` round trips with every optional/nested field populated per entity type (pilot, mech, crawler, mechPattern), plus one cross-entity full-backup test covering softLinks + workspace remapping together. No property-testing library (e.g. `fast-check`) is a dependency of this repo (checked `package.json` first per the task brief), so this is deliberately thorough table-driven coverage instead of generative testing.

`ExportBundleSchema.schemaVersion: z.literal(1)` already exists and `parseImportBundle` already rejects any other value — **no format-version field was added**, since one was already present and enforced.

### What it doesn't cover (documented, not guessed at)

- `encounterNpcs` has **no representation in `ExportBundleSchema` at all** — a full backup silently omits GM encounter-tray state. Out of scope for a test harness (would be a schema/feature change).
- The nested-strict-schema salvage gap above has no proposed code fix, only a pinning test + comment.
- Not exhaustive of every historical migration — genuinely useful coverage of the distinct branches, not a stub.

## Test plan

- [x] `bun run typecheck` — clean across all workspaces
- [x] `bun --filter in-the-union-now test` — 1302 pass, 0 fail
- [x] `bun run test` (full monorepo) — all workspaces pass
- [x] `bun run lint` — clean
- [x] Pre-commit/pre-push hooks (lint-fix, format, typecheck, test, validate, knip) all passed on commit/push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEaZaV9wE5dvqs9hdw6r2C