### PR TITLE
feat(observability): Sentry release tagging, ITUN sourcemap upload, nightly-e2e GitHub-issue alerts

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -4,8 +4,12 @@ name: E2E (nightly)
 # per-PR gates. They are slow and (for the Netlify deploy-preview variant)
 # flaky against cold previews, so gating every PR on them stalled merges. This
 # job keeps full e2e coverage — it just runs it once a day against the merged
-# main branch instead. Failures surface in the Actions tab (and can be wired to
-# notifications later); they do not block PR merges.
+# main branch instead. They do not block PR merges.
+#
+# Failures are surfaced two ways: the Actions tab (as always), and a tracking
+# GitHub Issue (notify-failure/notify-recovery below) opened/commented on
+# failure and closed on the next green run — GitHub-native, no external
+# notification service or webhook secret.
 #
 # Trigger manually any time via the "Run workflow" button (workflow_dispatch).
 
@@ -133,3 +137,96 @@ jobs:
           name: visual-regression-report
           path: packages/suref-react/playwright-report/
           retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # Notification — GitHub-native, no external service or webhook secret. On
+  # any suite failure, open (or comment on) a single tracking issue labeled
+  # `nightly-e2e-failure`; on the next all-green run, comment + close it. Uses
+  # the default GITHUB_TOKEN (issues: write, scoped to just these two jobs) —
+  # nothing to provision.
+  #
+  # NOTE: visual-regression currently has no committed Playwright baselines
+  # (see that job's comment above), and Playwright fails a toHaveScreenshot
+  # assertion the first time a baseline is missing rather than passing. Until
+  # baselines are generated and committed, this job fails every night and
+  # notify-failure will re-fire every night — expected noise, not a bug in the
+  # notification wiring. Generate baselines to quiet it.
+  # ---------------------------------------------------------------------------
+  notify-failure:
+    needs: [e2e-itun, e2e-suref-web, visual-regression]
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the nightly-e2e-failure tracking issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = 'nightly-e2e-failure'
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            const body = [
+              `Nightly E2E (\`e2e-nightly.yml\`) failed on \`${context.ref}\`.`,
+              '',
+              `Run: ${runUrl}`,
+            ].join('\n')
+
+            const { data: open } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+            })
+
+            if (open.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: open[0].number,
+                body,
+              })
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: 'Nightly E2E failing',
+                body,
+                labels: [label],
+              })
+            }
+
+  notify-recovery:
+    needs: [e2e-itun, e2e-suref-web, visual-regression]
+    if: success()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Close any open nightly-e2e-failure tracking issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = 'nightly-e2e-failure'
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+
+            const { data: open } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+            })
+
+            for (const issue of open) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Nightly E2E passed again on \`${context.ref}\` — closing. Run: ${runUrl}`,
+              })
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              })
+            }

--- a/apps/discord-bot/src/__tests__/ready.test.ts
+++ b/apps/discord-bot/src/__tests__/ready.test.ts
@@ -1,12 +1,23 @@
 /**
  * ready handler test — on login the bot sets a steady presence so it reads as a
  * live, first-class app ("Playing Salvage Union") rather than an idle script.
+ *
+ * ready.ts now imports observability.ts, which transitively imports config.ts
+ * (which throws when DISCORD_TOKEN is unset), so we set the env and import it
+ * dynamically after — same pattern as interactionCreate.test.ts.
  */
-import { describe, expect, test } from 'bun:test'
+import { beforeAll, describe, expect, test } from 'bun:test'
 import { ActivityType } from 'discord.js'
 import type { Client } from 'discord.js'
 
-import { handleReady } from '../events/ready.js'
+process.env.DISCORD_TOKEN ??= 'test-token'
+process.env.DISCORD_CLIENT_ID ??= 'test-client-id'
+
+let handleReady: typeof import('../events/ready.js').handleReady
+
+beforeAll(async () => {
+  ;({ handleReady } = await import('../events/ready.js'))
+})
 
 type PresenceArg = { status?: string; activities?: { name: string; type: number }[] }
 

--- a/apps/discord-bot/src/config.ts
+++ b/apps/discord-bot/src/config.ts
@@ -17,4 +17,8 @@ export const config = {
   // Optional error tracking. When SENTRY_DSN is unset, observability is a no-op.
   sentryDsn: optionalEnv('SENTRY_DSN'),
   nodeEnv: optionalEnv('NODE_ENV'),
+  // Render auto-populates this for every service/worker (no provisioning
+  // needed) — the deployed commit SHA, used to tag Sentry events with a
+  // release so an error maps back to the exact deploy that produced it.
+  releaseSha: optionalEnv('RENDER_GIT_COMMIT'),
 } as const

--- a/apps/discord-bot/src/events/ready.ts
+++ b/apps/discord-bot/src/events/ready.ts
@@ -1,4 +1,5 @@
 import { ActivityType, type Client } from 'discord.js'
+import { captureMessage } from '../observability.js'
 
 export function handleReady(client: Client<true>): void {
   console.log(`Logged in as ${client.user.tag}`)
@@ -8,5 +9,13 @@ export function handleReady(client: Client<true>): void {
   client.user.setPresence({
     status: 'online',
     activities: [{ name: 'Salvage Union', type: ActivityType.Playing }],
+  })
+  // Liveness signal (no-op unless SENTRY_DSN is set): a Render worker has no
+  // HTTP port to health-probe, so a Sentry info event on every successful
+  // login/reconnect is the basic "process is alive" alert path — an unusual
+  // gap between these (e.g. Sentry's own alerting on event absence) signals
+  // the worker went dark.
+  captureMessage('discord-bot ready', {
+    guildCount: client.guilds.cache.size,
   })
 }

--- a/apps/discord-bot/src/observability.ts
+++ b/apps/discord-bot/src/observability.ts
@@ -28,6 +28,10 @@ export function initObservability(): void {
   Sentry.init({
     dsn: config.sentryDsn,
     environment: config.nodeEnv ?? 'production',
+    // Tags events with the deployed commit SHA (Render's RENDER_GIT_COMMIT)
+    // so a Sentry error maps back to the exact deploy that produced it.
+    // Undefined when unset (e.g. local dev) — Sentry simply omits the tag.
+    release: config.releaseSha,
   })
   enabled = true
   console.log('[observability] Sentry error tracking enabled')
@@ -55,5 +59,18 @@ export async function flushObservability(timeoutMs = 2000): Promise<void> {
 export function captureException(error: unknown, context?: Record<string, unknown>): void {
   if (enabled) {
     Sentry.captureException(error, context ? { extra: context } : undefined)
+  }
+}
+
+/**
+ * Reports an informational message to Sentry when enabled; otherwise a no-op.
+ * Used as the worker's liveness signal (see `handleReady`): a Render worker
+ * has no HTTP port to health-probe, so a breadcrumb on every successful login
+ * is the cheapest "the process is alive and connected" alert path — a gap in
+ * the expected daily cadence of these events is itself the signal.
+ */
+export function captureMessage(message: string, context?: Record<string, unknown>): void {
+  if (enabled) {
+    Sentry.captureMessage(message, context ? { extra: context } : undefined)
   }
 }

--- a/apps/in-the-union-now/netlify.toml
+++ b/apps/in-the-union-now/netlify.toml
@@ -8,7 +8,12 @@
 # See docs/adrs/ADR-004-snapshot-netlify-functions.md.
 
 [build]
-  command = "bun install --frozen-lockfile && bun --filter in-the-union-now build"
+  # VITE_COMMIT_REF is exported from Netlify's own build-shell COMMIT_REF so
+  # the client bundle can tag Sentry events with a release (see
+  # src/lib/observability.ts and src/vite-env.d.ts). SENTRY_AUTH_TOKEN /
+  # SENTRY_ORG / SENTRY_PROJECT (set as Netlify site env vars, not here) turn
+  # on sourcemap upload for that same release in vite.config.ts.
+  command = "bun install --frozen-lockfile && VITE_COMMIT_REF=\"$COMMIT_REF\" bun --filter in-the-union-now build"
   publish = "apps/in-the-union-now/dist"
   functions = "apps/in-the-union-now/netlify/functions"
   # Skip the build when nothing affecting ITUN changed since the last published

--- a/apps/in-the-union-now/netlify/functions/_observability.ts
+++ b/apps/in-the-union-now/netlify/functions/_observability.ts
@@ -19,7 +19,19 @@ export function initObservability(): void {
   initialized = true
   const dsn = process.env.SENTRY_DSN
   if (!dsn) return
-  Sentry.init({ dsn, environment: process.env.NODE_ENV ?? 'production' })
+  Sentry.init({
+    dsn,
+    environment: process.env.NODE_ENV ?? 'production',
+    // Tags events with the deployed commit so an error maps back to a
+    // specific deploy. COMMIT_REF is a Netlify-provided deploy-metadata var —
+    // confirmed present in the *build* shell (netlify.toml's ignore scripts
+    // read it directly); whether it also reaches the Function's *runtime*
+    // environment is unconfirmed. If release tags don't show up on function
+    // errors in Sentry, that's the reason — the fallback is to bake the
+    // commit SHA into the bundle at build time (e.g. via an esbuild define)
+    // instead of reading it from process.env at runtime.
+    release: process.env.COMMIT_REF,
+  })
   enabled = true
 }
 

--- a/apps/in-the-union-now/package.json
+++ b/apps/in-the-union-now/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@playwright/test": "1.61.1",
+    "@sentry/vite-plugin": "5.3.0",
     "@types/qrcode": "1.5.6",
     "@vitejs/plugin-react": "^6.0.3",
     "eslint-plugin-react-refresh": "^0.5.3",

--- a/apps/in-the-union-now/src/components/sheet/ShareSnapshotScreen.tsx
+++ b/apps/in-the-union-now/src/components/sheet/ShareSnapshotScreen.tsx
@@ -42,6 +42,7 @@ import {
   pilotMaxHP,
 } from '../../lib/rules/derivedStats'
 import { useEntity } from '../../hooks/queries'
+import { captureMessage } from '../../lib/observability'
 import { deleteSnapshot, probeSnapshotService, publishSnapshot } from '../../lib/snapshot/client'
 import type { PublishResult, SnapshotPayload } from '../../lib/snapshot/client'
 import {
@@ -117,12 +118,21 @@ export function ShareSnapshotScreen({
   useEffect(() => {
     let cancelled = false
     void probeFn().then((available) => {
-      if (!cancelled) setService(available ? 'available' : 'unavailable')
+      if (!cancelled) {
+        setService(available ? 'available' : 'unavailable')
+        // Surface the outage this feature-detect already silently absorbs
+        // (no-op unless VITE_SENTRY_DSN is set): on a production deploy the
+        // snapshot Functions are always present, so "unavailable" here means
+        // the backend is actually down, not a feature that was never built.
+        if (!available) {
+          captureMessage('snapshot service unavailable', { kind, id })
+        }
+      }
     })
     return () => {
       cancelled = true
     }
-  }, [probeFn])
+  }, [probeFn, kind, id])
 
   const entity = entityStore ? entityStore.get(kind, id) : liveEntity
 

--- a/apps/in-the-union-now/src/lib/observability.ts
+++ b/apps/in-the-union-now/src/lib/observability.ts
@@ -17,6 +17,7 @@
  */
 
 let initialized = false
+let sentryModule: typeof import('@sentry/browser') | null = null
 
 /**
  * Initializes browser Sentry when `VITE_SENTRY_DSN` is configured. Idempotent
@@ -32,11 +33,31 @@ export async function initBrowserObservability(): Promise<void> {
   initialized = true
 
   const Sentry = await import('@sentry/browser')
+  sentryModule = Sentry
   Sentry.init({
     dsn,
     environment: import.meta.env.MODE,
+    // Tags events with the deployed commit so an error maps back to a
+    // specific deploy. VITE_COMMIT_REF is set by netlify.toml's build command
+    // (`VITE_COMMIT_REF="$COMMIT_REF" bun ... build`), mirroring Netlify's own
+    // COMMIT_REF; unset locally, so dev builds simply omit the tag. Must stay
+    // in sync with the release name @sentry/vite-plugin uploads sourcemaps
+    // under (see vite.config.ts) — a mismatch means sourcemaps silently don't
+    // apply to production errors.
+    release: import.meta.env.VITE_COMMIT_REF || undefined,
     // Errors only — no performance tracing or session replay. Keeps network
     // chatter minimal and avoids additional CSP surface.
     tracesSampleRate: 0,
   })
+}
+
+/**
+ * Reports an informational message to Sentry when enabled; otherwise a no-op.
+ * Used to surface snapshot-backend outages that `probeSnapshotService`
+ * already feature-detects (see ShareSnapshotScreen) — this does not add a new
+ * probe, it just makes an existing silent feature-detect alert-worthy.
+ */
+export function captureMessage(message: string, context?: Record<string, unknown>): void {
+  if (!sentryModule) return
+  sentryModule.captureMessage(message, context ? { extra: context } : undefined)
 }

--- a/apps/in-the-union-now/src/vite-env.d.ts
+++ b/apps/in-the-union-now/src/vite-env.d.ts
@@ -7,6 +7,13 @@ interface ImportMetaEnv {
    * tree-shaken out entirely. Never committed — supplied via the host env.
    */
   readonly VITE_SENTRY_DSN?: string
+  /**
+   * Deployed commit SHA, injected by netlify.toml's build command from
+   * Netlify's own COMMIT_REF. Used to tag Sentry events with a release (see
+   * src/lib/observability.ts) so an error maps back to a specific deploy.
+   * Unset in local dev — the release tag is simply omitted.
+   */
+  readonly VITE_COMMIT_REF?: string
 }
 
 interface ImportMeta {

--- a/apps/in-the-union-now/vite.config.ts
+++ b/apps/in-the-union-now/vite.config.ts
@@ -68,6 +68,13 @@ export default defineConfig({
           sourcemaps: {
             filesToDeleteAfterUpload: ['dist/**/*.map'],
           },
+          // Observability tooling that can take down a deploy is an
+          // anti-pattern: an expired token, wrong org/project, or a Sentry
+          // API blip should degrade to "no sourcemaps this deploy", not fail
+          // the Netlify build. Warn instead of the plugin's default throw.
+          errorHandler: (error) => {
+            console.warn('[sentry-vite-plugin] sourcemap upload failed (non-fatal):', error)
+          },
         })
       : false,
   ],

--- a/apps/in-the-union-now/vite.config.ts
+++ b/apps/in-the-union-now/vite.config.ts
@@ -3,6 +3,14 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
 import { VitePWA } from 'vite-plugin-pwa'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
+
+// Sourcemap upload is entirely env-gated on SENTRY_AUTH_TOKEN, mirroring the
+// discipline of src/lib/observability.ts: absent locally and in CI (no token
+// provisioned there), so the plugin is inert and no sourcemaps are generated
+// or shipped. Provisioned only on the Netlify production build via site env
+// vars (SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT — not committed).
+const sentryAuthToken = process.env.SENTRY_AUTH_TOKEN
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -44,7 +52,31 @@ export default defineConfig({
         ],
       },
     }),
+    // Must run last in the plugins array (Sentry's own requirement — it needs
+    // to see the final Rollup output to attach + upload sourcemaps). Inert
+    // (returns nothing) unless sentryAuthToken is set.
+    sentryAuthToken
+      ? sentryVitePlugin({
+          org: process.env.SENTRY_ORG,
+          project: process.env.SENTRY_PROJECT,
+          authToken: sentryAuthToken,
+          // Explicit release name pinned to the same VITE_COMMIT_REF the
+          // client tags itself with at runtime (src/lib/observability.ts) —
+          // auto-detecting from git would use Netlify's shallow clone and
+          // could silently mismatch, which breaks sourcemap resolution.
+          release: { name: process.env.VITE_COMMIT_REF, inject: false },
+          sourcemaps: {
+            filesToDeleteAfterUpload: ['dist/**/*.map'],
+          },
+        })
+      : false,
   ],
+  build: {
+    // Only emit sourcemaps when actually uploading them (see sentryAuthToken
+    // above) — the upload step deletes them from dist/ afterward, so default
+    // builds (local, CI, unconfigured deploys) never generate or ship maps.
+    sourcemap: !!sentryAuthToken,
+  },
   // Pre-bundle the game-data package so esbuild inlines its dynamic
   // `import('../data/*.json', { with: { type: 'json' } })` (+ schema) imports.
   // Without this, vite dev serves those JSON modules as `text/javascript`, which

--- a/apps/suref-web/netlify.toml
+++ b/apps/suref-web/netlify.toml
@@ -8,7 +8,10 @@
   # exact browser build its imported `playwright-core` expects (`bunx` resolves
   # a registry copy, which installed a mismatched build). If the Netlify image
   # ever lacks chromium's shared libs, add `--with-deps` to that script.
-  command = "bun install --frozen-lockfile && bun --filter suref-web og:install-browser && bun --filter suref-web build"
+  # PUBLIC_COMMIT_REF is exported from Netlify's own build-shell COMMIT_REF so
+  # the client bundle can tag Sentry events with a release (see
+  # src/lib/observability.ts and src/env.d.ts).
+  command = "bun install --frozen-lockfile && bun --filter suref-web og:install-browser && PUBLIC_COMMIT_REF=\"$COMMIT_REF\" bun --filter suref-web build"
   publish = "apps/suref-web/dist"
   # Skip the build when nothing affecting suref-web changed since the last
   # published deploy. `git diff --quiet` exits 0 (→ Netlify cancels the build)

--- a/apps/suref-web/src/env.d.ts
+++ b/apps/suref-web/src/env.d.ts
@@ -7,4 +7,11 @@ interface ImportMetaEnv {
    * and `@sentry/browser` is dead-code-eliminated from the bundle.
    */
   readonly PUBLIC_SENTRY_DSN?: string
+  /**
+   * Deployed commit SHA, injected by netlify.toml's build command from
+   * Netlify's own COMMIT_REF. Used to tag Sentry events with a release (see
+   * src/lib/observability.ts) so an error maps back to a specific deploy.
+   * Unset in local dev — the release tag is simply omitted.
+   */
+  readonly PUBLIC_COMMIT_REF?: string
 }

--- a/apps/suref-web/src/lib/observability.ts
+++ b/apps/suref-web/src/lib/observability.ts
@@ -38,6 +38,12 @@ export async function initBrowserObservability(): Promise<void> {
   Sentry.init({
     dsn,
     environment: import.meta.env.MODE,
+    // Tags events with the deployed commit so an error maps back to a
+    // specific deploy. PUBLIC_COMMIT_REF is set by netlify.toml's build
+    // command (`PUBLIC_COMMIT_REF="$COMMIT_REF" bun ... build`), mirroring
+    // Netlify's own COMMIT_REF; unset locally, so dev builds simply omit the
+    // tag.
+    release: import.meta.env.PUBLIC_COMMIT_REF || undefined,
     // Errors only — no performance tracing or session replay. Keeps network
     // chatter minimal and avoids additional CSP surface.
     tracesSampleRate: 0,

--- a/bun.lock
+++ b/bun.lock
@@ -22,15 +22,13 @@
         "eslint-plugin-react-hooks": "7.1.1",
         "globals": "17.7.0",
         "knip": "6.24.0",
+        "lefthook": "2.1.9",
         "prettier": "3.9.4",
         "puppeteer-core": "25.3.0",
         "sharp": "0.35.3",
         "tailwindcss": "4.3.2",
         "typescript": "6.0.3",
         "typescript-eslint": "8.62.1",
-      },
-      "optionalDependencies": {
-        "lefthook": "2.1.9",
       },
     },
     "apps/discord-bot": {
@@ -69,6 +67,7 @@
       },
       "devDependencies": {
         "@playwright/test": "1.61.1",
+        "@sentry/vite-plugin": "5.3.0",
         "@types/qrcode": "1.5.6",
         "@vitejs/plugin-react": "^6.0.3",
         "eslint-plugin-react-refresh": "^0.5.3",
@@ -863,9 +862,31 @@
 
     "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
 
+    "@sentry/babel-plugin-component-annotate": ["@sentry/babel-plugin-component-annotate@5.3.0", "", {}, "sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA=="],
+
     "@sentry/browser": ["@sentry/browser@10.63.0", "", { "dependencies": { "@sentry/browser-utils": "10.63.0", "@sentry/core": "10.63.0", "@sentry/feedback": "10.63.0", "@sentry/replay": "10.63.0", "@sentry/replay-canvas": "10.63.0" } }, "sha512-0mi56YOkwgyjdLOcN5cB1//EcYzEOt3NZ2GLygE92B3zAAwVM1WgbmibZCXToKFClH7z1uH3VWVfBffmkwIMYw=="],
 
     "@sentry/browser-utils": ["@sentry/browser-utils@10.63.0", "", { "dependencies": { "@sentry/core": "10.63.0" } }, "sha512-DhUGNN+CH8fzAs6qAsueKPU70qShyTX3NxLhIP+l5DbGXDSXpYXBT6s8ubZus0/LhxpLvI0iSyNIDvZRD/gZaA=="],
+
+    "@sentry/bundler-plugin-core": ["@sentry/bundler-plugin-core@5.3.0", "", { "dependencies": { "@babel/core": "^7.18.5", "@sentry/babel-plugin-component-annotate": "5.3.0", "@sentry/cli": "^2.58.5", "dotenv": "^16.3.1", "find-up": "^5.0.0", "glob": "^13.0.6", "magic-string": "~0.30.8" } }, "sha512-L5T60sWdAI3qWwdg3Ptwek/0TY59PERrxyqp4XMUkroayQvGd9r5dIW9Q1kSeXX9iJ442nXbFZKAOyCKV4Z13Q=="],
+
+    "@sentry/cli": ["@sentry/cli@2.58.6", "", { "dependencies": { "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.7", "progress": "^2.0.3", "proxy-from-env": "^1.1.0", "which": "^2.0.2" }, "optionalDependencies": { "@sentry/cli-darwin": "2.58.6", "@sentry/cli-linux-arm": "2.58.6", "@sentry/cli-linux-arm64": "2.58.6", "@sentry/cli-linux-i686": "2.58.6", "@sentry/cli-linux-x64": "2.58.6", "@sentry/cli-win32-arm64": "2.58.6", "@sentry/cli-win32-i686": "2.58.6", "@sentry/cli-win32-x64": "2.58.6" }, "bin": { "sentry-cli": "bin/sentry-cli" } }, "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg=="],
+
+    "@sentry/cli-darwin": ["@sentry/cli-darwin@2.58.6", "", { "os": "darwin" }, "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA=="],
+
+    "@sentry/cli-linux-arm": ["@sentry/cli-linux-arm@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm" }, "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw=="],
+
+    "@sentry/cli-linux-arm64": ["@sentry/cli-linux-arm64@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm64" }, "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g=="],
+
+    "@sentry/cli-linux-i686": ["@sentry/cli-linux-i686@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "ia32" }, "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg=="],
+
+    "@sentry/cli-linux-x64": ["@sentry/cli-linux-x64@2.58.6", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "x64" }, "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q=="],
+
+    "@sentry/cli-win32-arm64": ["@sentry/cli-win32-arm64@2.58.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A=="],
+
+    "@sentry/cli-win32-i686": ["@sentry/cli-win32-i686@2.58.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg=="],
+
+    "@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@2.58.6", "", { "os": "win32", "cpu": "x64" }, "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA=="],
 
     "@sentry/conventions": ["@sentry/conventions@0.12.0", "", {}, "sha512-z1JQrl/1SLY+8wpzvork6vl+fpsg/oCCxM7HWWhUnI/R+OGNyoIzieQuggX3uUMY7NBtp8UWCQx6FeFazzOF9g=="],
 
@@ -883,7 +904,11 @@
 
     "@sentry/replay-canvas": ["@sentry/replay-canvas@10.63.0", "", { "dependencies": { "@sentry/core": "10.63.0", "@sentry/replay": "10.63.0" } }, "sha512-1Dg6yo+KDNZcE9M6V2EP4DGgTDJMcUgg5ui69w/E96ZZPWErS/bibK2bGj20H3qwpJXlnEwXB5YAJ2fZ620T1A=="],
 
+    "@sentry/rollup-plugin": ["@sentry/rollup-plugin@5.3.0", "", { "dependencies": { "@sentry/bundler-plugin-core": "5.3.0", "magic-string": "~0.30.8" }, "peerDependencies": { "rollup": ">=3.2.0" }, "optionalPeers": ["rollup"] }, "sha512-hgPGPYdQJ/G1cGYOxAb7d4z3V+/k/E5/P/5TFPEEBLuIbFFk+JG0CISUDJdzXJjO382Lb99PBJuXGbueBmO79w=="],
+
     "@sentry/server-utils": ["@sentry/server-utils@10.63.0", "", { "dependencies": { "@apm-js-collab/code-transformer": "^0.15.0", "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0", "@apm-js-collab/tracing-hooks": "^0.10.0", "@sentry/conventions": "^0.12.0", "@sentry/core": "10.63.0", "magic-string": "~0.30.0" } }, "sha512-7NN//DG9Yak8t2+6WiEcNmN269iHRVdtZtZIwucEd0OXyZ3FEBBDaBF+bT9V6H/kPtUvVMkHQ72Bn2Xs5JYGxg=="],
+
+    "@sentry/vite-plugin": ["@sentry/vite-plugin@5.3.0", "", { "dependencies": { "@sentry/bundler-plugin-core": "5.3.0", "@sentry/rollup-plugin": "5.3.0" } }, "sha512-qcoSzo4n2MulVQ70UUPLq6dTleb2a2HwL2wuwvAgWhPChrYTuk6A6mDg6aQb9fairPAwFPiU9PzOANpoDJcz1A=="],
 
     "@shikijs/core": ["@shikijs/core@4.2.0", "", { "dependencies": { "@shikijs/primitive": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ=="],
 
@@ -1116,6 +1141,8 @@
     "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
@@ -1383,6 +1410,8 @@
 
     "dot-prop": ["dot-prop@9.0.0", "", { "dependencies": { "type-fest": "^4.18.2" } }, "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ=="],
 
+    "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
+
     "dset": ["dset@3.1.4", "", {}, "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
@@ -1563,7 +1592,7 @@
 
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
-    "glob": ["glob@11.1.0", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.1.1", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw=="],
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -1646,6 +1675,8 @@
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
     "http-errors": ["http-errors@1.8.1", "", { "dependencies": { "depd": "~1.1.2", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": ">= 1.5.0 < 2", "toidentifier": "1.0.1" } }, "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g=="],
+
+    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "idb": ["idb@8.0.3", "", {}, "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg=="],
 
@@ -2039,6 +2070,8 @@
 
     "nlcst-to-string": ["nlcst-to-string@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0" } }, "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA=="],
 
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
 
     "node-mock-http": ["node-mock-http@1.0.4", "", {}, "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ=="],
@@ -2157,9 +2190,13 @@
 
     "process-ancestry": ["process-ancestry@0.1.0", "", {}, "sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg=="],
 
+    "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
+
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 
     "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
@@ -2847,6 +2884,8 @@
 
     "msw/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
+    "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
     "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
@@ -2886,6 +2925,8 @@
     "workbox-background-sync/idb": ["idb@7.1.1", "", {}, "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="],
 
     "workbox-build/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "workbox-build/glob": ["glob@11.1.0", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.1.1", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw=="],
 
     "workbox-build/pretty-bytes": ["pretty-bytes@5.6.0", "", {}, "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="],
 
@@ -3026,6 +3067,10 @@
     "msw/yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "msw/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 

--- a/render.yaml
+++ b/render.yaml
@@ -19,3 +19,10 @@ services:
       # Sentry error tracking — set the value in the Render dashboard.
       - key: SENTRY_DSN
         sync: false
+      # NOT declared here on purpose: RENDER_GIT_COMMIT (the deployed commit
+      # SHA) is a Render "reserved" env var Render injects automatically into
+      # every service's environment — it can't be set via envVars and needs no
+      # provisioning. apps/discord-bot/src/observability.ts reads it to tag
+      # Sentry events with a release. Verify the exact var name in the Render
+      # dashboard's "Environment" tab for this service if release tags don't
+      # show up — Render's reserved-var set has changed name before.


### PR DESCRIPTION
## Summary

Three pieces of operational-alerting/observability infra, per the three deploy surfaces (Netlify x2, Render):

1. **Sentry release tagging** on every existing (already env-gated) Sentry setup, so errors map back to a specific deploy/commit:
   - `apps/discord-bot` (Render worker) — tags with `RENDER_GIT_COMMIT`, which Render auto-injects into every service; no provisioning needed.
   - ITUN + suref-web Netlify Functions (`_observability.ts`) — tags with `process.env.COMMIT_REF`. Confirmed present in the Netlify *build* shell (the existing `netlify.toml` ignore scripts already read it); whether it also reaches the *Function runtime* is unconfirmed — documented as a fallback note in the file. Harmless either way (`release` is just omitted if unset).
   - ITUN + suref-web browser bundles — `netlify.toml` build commands now export `VITE_COMMIT_REF` / `PUBLIC_COMMIT_REF` from Netlify's own `$COMMIT_REF`, read at runtime by each app's `observability.ts`. **Verified by building both apps locally with the DSN + commit vars set and grepping the built `dist/` output for the injected value** — confirmed it inlines correctly in both the Vite (ITUN) and Astro (suref-web) pipelines.

2. **Sourcemap upload** for ITUN's browser-facing PWA bundle via `@sentry/vite-plugin`, entirely gated on `SENTRY_AUTH_TOKEN` (mirrors this repo's existing env-gated observability discipline — inert with no sourcemaps generated or shipped unless the token is set). Release name is pinned explicitly to the same `VITE_COMMIT_REF` used at runtime so uploaded maps actually match live errors (not vite-plugin auto-detected, which would use Netlify's shallow clone and could mismatch).
   - **Verified the failure mode too**: an invalid/expired token makes `@sentry/cli` exit non-zero, which the plugin's default behavior throws and would fail the whole Netlify build. Wired an `errorHandler` so this instead warns and lets the build continue — confirmed locally with a fake token (build exits 0, ships normally).
   - suref-web sourcemap upload was **intentionally not** mirrored — the task named ITUN specifically ("e.g."), so I kept it scoped there. Happy to mirror it if wanted; it'd be a small, symmetric addition.
   - Known minor gap: `vite-plugin-pwa`'s generated `sw.js.map` / `workbox-*.js.map` can survive the plugin's `dist/**` cleanup depending on plugin hook ordering — small service-worker plumbing maps (not app source), left as a follow-up rather than engineered around here.

3. **Liveness / outage alerting** — deliberately *not* a new health-check endpoint or probe (Render workers have no HTTP port to probe; ITUN's snapshot outage detection already exists):
   - `discord-bot`: a `captureMessage()` liveness signal on every `ClientReady` (login/reconnect). Combined with the pre-existing crash → `captureException` → flush → `process.exit(1)` path, this is the alert surface for a worker with no HTTP port.
   - ITUN: `ShareSnapshotScreen`'s existing `probeSnapshotService()` feature-detect (which previously silently hid the Publish button on failure) now also calls a new `captureMessage()` export when the snapshot backend is unavailable — surfacing an outage that was previously absorbed silently. No new probe was built.

4. **Nightly e2e failure alerts** (`.github/workflows/e2e-nightly.yml`) — **GitHub-native, not Discord.** (The original brief suggested a Discord webhook as a natural fit for this Discord-bot-adjacent repo, but the repo owner asked mid-implementation for GitHub-native mechanisms only, no new external secret — this PR reflects that.) Two new jobs:
   - `notify-failure`: on any of the three nightly suites failing, opens (or comments on) a single tracking issue labeled `nightly-e2e-failure`.
   - `notify-recovery`: on the next all-green nightly run, comments on and closes that issue.
   - Both use the default `GITHUB_TOKEN` (`issues: write`, scoped to just these two jobs) — **no new secret required.**

## Provisioning needed before this is fully live

- **`SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`** — set as Netlify **site environment variables** on `in-the-union-now` to turn on sourcemap upload. Without them the plugin stays inert (no sourcemaps generated or shipped) — non-breaking, just no sourcemap-backed stack traces until set.
- Nothing else. `RENDER_GIT_COMMIT` and `COMMIT_REF` are both auto-injected by their respective platforms; the nightly-issue notifier uses the default `GITHUB_TOKEN`.

## Known noise to be aware of

`visual-regression` in `e2e-nightly.yml` has **no committed Playwright baselines** yet (pre-existing condition, unrelated to this PR — see that job's existing comment). Playwright fails a `toHaveScreenshot` assertion the first time a baseline is missing rather than passing, so this job fails every night regardless of real regressions, and `notify-failure` will re-fire (well, re-comment on the same issue) every night until baselines are generated and committed. Not fixed here — out of scope — but flagging so it doesn't read as a bug in the new notification wiring.

## Test plan

- [x] `bun run typecheck` — all workspaces pass
- [x] `bun run lint` — all workspaces pass
- [x] `bun run test` — all workspaces pass (0 failures)
- [x] `bun run validate:all` — passes
- [x] `bun run knip` — no new issues (only pre-existing config hints)
- [x] Verified `VITE_COMMIT_REF`/`PUBLIC_COMMIT_REF` actually inline into built `dist/` output for both ITUN (Vite) and suref-web (Astro)
- [x] Verified the Sentry sourcemap-upload failure path is non-fatal to the build (simulated invalid token)
- [x] Pre-push hook (validate/knip/typecheck/test) passed on push
- [ ] Manual: reviewer confirms `SENTRY_AUTH_TOKEN`/`SENTRY_ORG`/`SENTRY_PROJECT` provisioning intent before merging, or explicitly defers it

https://claude.ai/code/session_01HEaZaV9wE5dvqs9hdw6r2C