### PR TITLE
ci: coverage visibility + ratchet, PR-blocking smoke e2e tier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,46 @@ jobs:
       - name: Validate data
         run: bun run validate:all
 
+  coverage:
+    # Coverage visibility + ratchet (previously invisible — `test:coverage`
+    # existed per-workspace but nothing in CI ran or read it).
+    #
+    # This is a SEPARATE job from `test` (deliberately re-running the suite a
+    # second time, with `--coverage` instrumentation) rather than folding
+    # coverage into the `test` job. An earlier coverage job (commit f520ffd1)
+    # was removed for doing exactly that re-run while gating nothing — pure
+    # duplicated cost. This job is the difference: tools/coverage-report.ts
+    # enforces a per-workspace ratchet (coverage-baseline.json) and fails the
+    # job on regression, so the duplicated run buys real regression coverage.
+    # Keeping it separate also means a rare coverage-instrumentation hiccup
+    # can only fail this job, never the primary `test` gate every build job
+    # depends on.
+    needs: [changes, build-package]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Test with coverage
+        run: bun run test:coverage
+
+      - name: Aggregate coverage report + ratchet
+        if: always()
+        run: bun tools/coverage-report.ts
+
+      - name: Upload coverage report artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: coverage-report/
+          retention-days: 14
+          if-no-files-found: warn
+
   audit:
     # Dependency vulnerability scan against the resolved lockfile. Fails on
     # high/critical advisories so a vulnerable dependency blocks merge; lower
@@ -237,6 +277,85 @@ jobs:
       - name: Build discord-bot
         run: bun --filter @suref/discord-bot build
 
+  smoke-web:
+    # PR-blocking smoke tier (previously e2e/visual only ran nightly, so a
+    # broken route could merge to main and sit broken for up to a day). Runs
+    # ONLY apps/suref-web/e2e/smoke.e2e.ts — the full suite stays nightly-only
+    # (.github/workflows/e2e-nightly.yml) so the PR gate stays fast and free of
+    # the flakiness that got browser e2e demoted from PR-blocking in the first
+    # place. Uses the same hermetic `astro build` + `astro preview` pattern the
+    # nightly job already proves works — no live Netlify deploy preview.
+    needs: [changes, build-package, build-suref-web]
+    if: needs.changes.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install Playwright browsers (Chromium)
+        working-directory: apps/suref-web
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run smoke test
+        working-directory: apps/suref-web
+        run: bunx playwright test smoke.e2e.ts
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-smoke-web
+          path: apps/suref-web/playwright-report/
+          retention-days: 7
+
+  smoke-itun:
+    # PR-blocking smoke tier — same rationale as smoke-web. Runs ONLY
+    # apps/in-the-union-now/e2e/smoke.e2e.ts against a self-contained static
+    # build (`vite preview`, no deploy preview), mirroring e2e-nightly.yml's
+    # e2e-itun job.
+    needs: [changes, build-package, build-itun]
+    if: needs.changes.outputs.itun == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install Playwright browsers (Chromium)
+        working-directory: apps/in-the-union-now
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run smoke test
+        working-directory: apps/in-the-union-now
+        run: bunx playwright test smoke.e2e.ts
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-smoke-itun
+          path: apps/in-the-union-now/playwright-report/
+          retention-days: 7
+
   # ---------------------------------------------------------------------------
   # Single aggregate gate. Always runs; fails if any job actually failed (a
   # path-filtered "skipped" job is fine). Branch protection should require just
@@ -252,15 +371,20 @@ jobs:
       - knip
       - typecheck
       - test
+      - coverage
       - validate
       - audit
       - build-suref-web
       - build-itun
       - build-discord-bot
-      # NOTE: browser e2e (ITUN + suref-web) and visual-regression no longer
-      # gate PRs — they moved to a scheduled daily run against main
-      # (.github/workflows/e2e-nightly.yml). This keeps the PR gate fast and
-      # free of preview/browser flakiness; regressions are caught nightly.
+      - smoke-web
+      - smoke-itun
+      # NOTE: the FULL browser e2e suites (ITUN + suref-web) and visual-
+      # regression still only run nightly, not per-PR — see
+      # .github/workflows/e2e-nightly.yml. smoke-web/smoke-itun above cover
+      # only the PR-blocking smoke tier, so the PR gate stays fast and free of
+      # full-suite preview/browser flakiness; deeper regressions are still
+      # caught nightly.
     runs-on: ubuntu-latest
     steps:
       - name: Verify no job failed

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ core
 # Coverage output (bun test --coverage lcov reporter / CI capture file)
 **/coverage/
 coverage-output.txt
+# Aggregated coverage report artifact (tools/coverage-report.ts), CI-only
+/coverage-report/
 
 # Vite
 .vite

--- a/apps/discord-bot/package.json
+++ b/apps/discord-bot/package.json
@@ -17,7 +17,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "bun test",
-    "test:coverage": "bun test --coverage",
+    "test:coverage": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/apps/in-the-union-now/e2e/smoke.e2e.ts
+++ b/apps/in-the-union-now/e2e/smoke.e2e.ts
@@ -4,16 +4,24 @@ import { waitForReady } from './_helpers'
 /**
  * Smoke test — proves the Playwright harness works against the dev server
  * and the app boots without crashing.
+ *
+ * A fresh Playwright browser context has empty IndexedDB, so the dashboard is
+ * always in its "first run" state here (Dashboard.tsx `isFirstRun`, added by
+ * PR #366) — it renders FirstRunWelcome, not the three-column Pilots/Mechs/
+ * Crawlers grid, so there is no "Create Pilot"/"Create Mech"/"Create Crawler"
+ * link to find on a truly empty store. This asserts the actual first-run UI
+ * a real new visitor (and CI) always sees. The populated-dashboard grid and
+ * full pilot/mech/crawler build flows are covered by the other e2e specs
+ * (e.g. dashboard-delete.e2e.ts, pilot-build.e2e.ts) in the nightly suite.
  */
-test('dashboard loads and shows the Create Pilot link', async ({ page }) => {
+test('dashboard loads and shows the first-run welcome', async ({ page }) => {
   await page.goto('/')
   await waitForReady(page)
 
   // App title is present
   await expect(page).toHaveTitle(/In The Union Now/i)
 
-  // The dashboard exposes builder links for all three entity types
-  await expect(page.getByRole('link', { name: /Create Pilot/i }).first()).toBeVisible()
-  await expect(page.getByRole('link', { name: /Create Mech/i }).first()).toBeVisible()
-  await expect(page.getByRole('link', { name: /Create Crawler/i }).first()).toBeVisible()
+  // First-run welcome renders with its single primary CTA.
+  await expect(page.getByRole('heading', { name: /Welcome to In the Union Now/i })).toBeVisible()
+  await expect(page.getByRole('link', { name: /Build your first pilot/i })).toBeVisible()
 })

--- a/apps/in-the-union-now/package.json
+++ b/apps/in-the-union-now/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "bun test",
-    "test:coverage": "bun test --coverage",
+    "test:coverage": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage",
     "test:watch": "bun test --watch",
     "clean": "rm -rf dist .vite node_modules/.vite"
   },

--- a/apps/suref-web/package.json
+++ b/apps/suref-web/package.json
@@ -15,7 +15,7 @@
     "sanity": "bun run lint -- --fix && bun run format && bun run typecheck",
     "format:check": "prettier --check .",
     "test": "bun test",
-    "test:coverage": "bun test --coverage",
+    "test:coverage": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage",
     "test:watch": "bun test --watch",
     "test:e2e": "playwright test",
     "e2e:install": "playwright install --with-deps chromium",

--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -1,0 +1,7 @@
+{
+  "packages/salvageunion-reference": 84,
+  "packages/suref-react": 69,
+  "apps/suref-web": 73,
+  "apps/in-the-union-now": 82,
+  "apps/discord-bot": 68
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,29 @@
+import { base } from './eslint.base.js'
+import { fileURLToPath } from 'url'
+import { dirname } from 'path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// Root-level eslint config. Each workspace (apps/*, packages/*) has its own
+// eslint.config.js and is linted with cwd set to that workspace (`bun run
+// lint` / `bun --filter "*" lint`), so this config is never consulted there.
+// It exists for the one thing that isn't a workspace: root-level tools/**/*.ts
+// (e.g. tools/check-bun-version.ts, tools/coverage-report.ts), which the
+// Lefthook pre-commit hook (`bunx eslint --fix {staged_files}`, run from repo
+// root) needs a config to find — without this file it hard-errors on any
+// staged root-level .ts file.
+export default [
+  {
+    ignores: ['**/node_modules/**', 'apps/**', 'packages/**', '**/*.d.ts'],
+  },
+  ...base,
+  {
+    files: ['tools/**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: ['./tsconfig.json'],
+      },
+    },
+  },
+]

--- a/packages/salvageunion-reference/package.json
+++ b/packages/salvageunion-reference/package.json
@@ -50,7 +50,7 @@
     "validate:all": "bun run validate:ids && bun run validate:slugs && bun run validate:references && bun run validate:actions && bun run validate:action-backrefs && bun run validate:orphans && bun run validate:traits && bun run validate:schemas",
     "typecheck": "tsc --project tsconfig.json --noEmit",
     "test": "bun test",
-    "test:coverage": "bun test --coverage",
+    "test:coverage": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/packages/suref-react/package.json
+++ b/packages/suref-react/package.json
@@ -14,7 +14,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "bun test",
-    "test:coverage": "bun test --coverage",
+    "test:coverage": "bun test --coverage --coverage-reporter=text --coverage-reporter=lcov --coverage-dir=coverage",
     "test:watch": "bun test --watch",
     "test:visual": "bunx playwright test --config playwright.visual.config.ts",
     "test:visual:update": "bunx playwright test --config playwright.visual.config.ts --update-snapshots",

--- a/tools/coverage-report.ts
+++ b/tools/coverage-report.ts
@@ -1,0 +1,190 @@
+#!/usr/bin/env bun
+
+/**
+ * Coverage aggregation + ratchet.
+ *
+ * Each workspace's `test:coverage` script runs `bun test --coverage` with the
+ * `lcov` reporter (see each package.json), writing `<workspace>/coverage/lcov.info`.
+ * This script:
+ *
+ *   1. Parses every workspace's lcov.info and computes line coverage %.
+ *   2. Writes a combined markdown summary (console + $GITHUB_STEP_SUMMARY when
+ *      running in CI) and copies the per-workspace lcov files into
+ *      `coverage-report/` so CI can upload one artifact for the whole repo.
+ *   3. Ratchets: fails if any workspace's coverage % drops below its
+ *      `coverage-baseline.json` entry by more than TOLERANCE_PP. Coverage is
+ *      allowed to increase freely — bump the baseline file to lock in a gain.
+ *
+ * A previous coverage CI job (see commit f520ffd1) was removed for re-running
+ * the whole suite a second time while gating nothing. This script is what
+ * makes a second coverage-instrumented run worth the CI minutes: without an
+ * enforced floor, coverage is just an unread number in a log.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  copyFileSync,
+  appendFileSync,
+} from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+// Percentage points of slack allowed below the recorded baseline before the
+// ratchet fails. Baselines are already committed with a couple of points of
+// headroom below the coverage observed at authoring time (CI runners and
+// future test additions/removals cause small, legitimate wobble); this
+// tolerance absorbs floating-point/line-count noise on top of that.
+const TOLERANCE_PP = 0.5
+
+type WorkspaceCoverage = {
+  workspace: string
+  lcovPath: string
+  linesFound: number
+  linesHit: number
+  pct: number
+}
+
+const WORKSPACES = [
+  'packages/salvageunion-reference',
+  'packages/suref-react',
+  'apps/suref-web',
+  'apps/in-the-union-now',
+  'apps/discord-bot',
+]
+
+function parseLcov(path: string): { linesFound: number; linesHit: number } {
+  const contents = readFileSync(path, 'utf-8')
+  let linesFound = 0
+  let linesHit = 0
+  for (const line of contents.split('\n')) {
+    if (line.startsWith('LF:')) linesFound += Number(line.slice(3))
+    if (line.startsWith('LH:')) linesHit += Number(line.slice(3))
+  }
+  return { linesFound, linesHit }
+}
+
+const results: WorkspaceCoverage[] = []
+const missing: string[] = []
+
+for (const workspace of WORKSPACES) {
+  const lcovPath = join(root, workspace, 'coverage', 'lcov.info')
+  if (!existsSync(lcovPath)) {
+    missing.push(workspace)
+    continue
+  }
+  const { linesFound, linesHit } = parseLcov(lcovPath)
+  const pct = linesFound > 0 ? (linesHit / linesFound) * 100 : 0
+  results.push({ workspace, lcovPath, linesFound, linesHit, pct })
+}
+
+type Baseline = Record<string, number>
+
+const baselinePath = join(root, 'coverage-baseline.json')
+const baseline: Baseline = existsSync(baselinePath)
+  ? JSON.parse(readFileSync(baselinePath, 'utf-8'))
+  : {}
+
+type Row = {
+  workspace: string
+  pct: number | undefined // undefined = coverage output missing entirely
+  baselinePct: number | undefined
+  status: 'regressed' | 'improved' | 'stable' | 'unbaselined' | 'missing'
+}
+
+const rows: Row[] = []
+for (const { workspace, pct } of results) {
+  const baselinePct = baseline[workspace]
+  if (baselinePct === undefined) rows.push({ workspace, pct, baselinePct, status: 'unbaselined' })
+  else if (pct < baselinePct - TOLERANCE_PP)
+    rows.push({ workspace, pct, baselinePct, status: 'regressed' })
+  else if (pct > baselinePct + TOLERANCE_PP)
+    rows.push({ workspace, pct, baselinePct, status: 'improved' })
+  else rows.push({ workspace, pct, baselinePct, status: 'stable' })
+}
+// A baselined workspace with no lcov output at all is a coverage decrease to
+// "unmeasurable" — that must fail the ratchet, not silently pass, or dropping
+// a workspace's test:coverage output entirely would be a free way around it.
+for (const workspace of missing) {
+  const baselinePct = baseline[workspace]
+  if (baselinePct !== undefined) {
+    rows.push({ workspace, pct: undefined, baselinePct, status: 'missing' })
+  }
+}
+
+const regressions = rows.filter((r) => r.status === 'regressed' || r.status === 'missing')
+
+// --- Report -----------------------------------------------------------------
+
+const reportDir = join(root, 'coverage-report')
+mkdirSync(reportDir, { recursive: true })
+
+const lines: string[] = []
+lines.push('## Test coverage')
+lines.push('')
+lines.push('| Workspace | Coverage | Baseline | Status |')
+lines.push('| --- | --- | --- | --- |')
+for (const row of rows) {
+  const baselineCell = row.baselinePct === undefined ? '—' : `${row.baselinePct.toFixed(2)}%`
+  const pctCell = row.pct === undefined ? '(missing)' : `${row.pct.toFixed(2)}%`
+  const statusCell = {
+    regressed: 'FAIL regressed',
+    missing: 'FAIL missing',
+    improved: 'OK improved',
+    stable: 'OK stable',
+    unbaselined: 'NEW no baseline',
+  }[row.status]
+  lines.push(`| ${row.workspace} | ${pctCell} | ${baselineCell} | ${statusCell} |`)
+}
+if (missing.length > 0 && missing.some((w) => baseline[w] === undefined)) {
+  lines.push('')
+  lines.push(
+    `Missing coverage output (no baseline recorded, informational only): ${missing.filter((w) => baseline[w] === undefined).join(', ')}`
+  )
+}
+if (regressions.length > 0) {
+  lines.push('')
+  lines.push('**Coverage ratchet failed** — the following workspaces dropped below their baseline:')
+  for (const r of regressions) {
+    if (r.status === 'missing') {
+      lines.push(
+        `- \`${r.workspace}\`: no coverage output was produced (baseline ${r.baselinePct!.toFixed(2)}%). A workspace with a recorded baseline must keep producing \`coverage/lcov.info\`.`
+      )
+    } else {
+      lines.push(
+        `- \`${r.workspace}\`: ${r.pct!.toFixed(2)}% is below baseline ${r.baselinePct!.toFixed(2)}% (tolerance ${TOLERANCE_PP}pp). Add tests to recover, or if the drop is intentional, lower the baseline in \`coverage-baseline.json\` deliberately.`
+      )
+    }
+  }
+}
+const improved = rows.filter((r) => r.status === 'improved')
+if (improved.length > 0) {
+  lines.push('')
+  lines.push(
+    `Coverage improved beyond baseline + tolerance for: ${improved.map((r) => r.workspace).join(', ')}. Consider bumping \`coverage-baseline.json\` to lock in the gain.`
+  )
+}
+
+const summary = lines.join('\n') + '\n'
+console.log(summary)
+writeFileSync(join(reportDir, 'summary.md'), summary)
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary)
+}
+
+for (const { workspace, lcovPath } of results) {
+  const dest = join(reportDir, `${workspace.replace(/\//g, '__')}.lcov.info`)
+  copyFileSync(lcovPath, dest)
+}
+
+if (regressions.length > 0) {
+  console.error(`Coverage ratchet FAILED for: ${regressions.map((r) => r.workspace).join(', ')}`)
+  process.exit(1)
+}
+
+console.log('Coverage ratchet passed (no workspace dropped below its baseline).')


### PR DESCRIPTION
## Summary

- **Coverage visibility**: every workspace already had a `test:coverage` script, but nothing in CI ran or read it. Each workspace's `test:coverage` now emits `lcov` + `text` reporters to a workspace-local `coverage/` dir; a new `coverage` CI job runs it and `tools/coverage-report.ts` aggregates every workspace's `lcov.info` into a single markdown summary (step summary + uploaded `coverage-report` artifact).
- **Coverage ratchet**: `tools/coverage-report.ts` fails the job if any workspace's line coverage drops more than 0.5pp below its `coverage-baseline.json` entry, or if a baselined workspace stops producing `lcov.info` entirely. Coverage may increase freely — bump the baseline to lock in a gain. Baselines are committed a couple of points below what was observed locally, to absorb CI/runner variance; **confirmed on this PR's own CI run** — every workspace's CI-measured coverage landed within ~0.3pp of the local numbers, well clear of the baseline (see run below).
- **PR-blocking smoke e2e**: new `smoke-web` / `smoke-itun` jobs run *only* the existing `apps/{suref-web,in-the-union-now}/e2e/smoke.e2e.ts` spec (not the full nightly suite) against a hermetic `astro preview` / `vite preview` build — same pattern `e2e-nightly.yml` already proves works, no live Netlify deploy preview dependency. The full nightly suites are unchanged.

Both new job groups are gated by the existing `changes` path-filter outputs and added to the `quality-checks` aggregate gate. Existing jobs' dependency graph is otherwise untouched (additive only), except that `coverage` deliberately duplicates the `test` job's run with `--coverage` instrumentation rather than folding into it — see the in-file comment referencing commit f520ffd1 (an earlier coverage job removed for duplicating cost while gating nothing; this one gates via the ratchet, and staying separate means a rare coverage-instrumentation hiccup can't fail the primary `test` gate every build job depends on).

Also adds a root `eslint.config.js` scoped to `tools/**/*.ts` only (every workspace keeps using its own config) — needed so the Lefthook pre-commit hook can lint newly-staged root-level `tools/*.ts` files; it previously hard-errored with "no config file found" when a root-level tools file was staged.

### Bonus fix: stale `smoke.e2e.ts` (ITUN)

The first CI run on this PR caught `smoke-itun` failing — and it turned out **not** to be caused by this PR. `apps/in-the-union-now/e2e/smoke.e2e.ts` asserted on "Create Pilot"/"Create Mech"/"Create Crawler" dashboard links, but PR #366 (2026-07-04) added a first-run empty state (`Dashboard.tsx` `isFirstRun`): a brand-new Playwright context has empty IndexedDB, so it always renders `FirstRunWelcome` (a single "Build your first pilot" CTA) instead of the three-column grid on a fresh visit. The spec was never updated to match, and `e2e-nightly.yml` has been red on `main` for this exact reason since 2026-07-04. This is exactly the failure mode this PR's smoke tier exists to catch before merge, so fixing the stale assertion felt in-scope rather than shipping a permanently-red new gate — updated the assertion to match the actual first-run UI; the populated-dashboard grid and full build flows stay covered by the other (nightly-only) e2e specs. Should also turn nightly green again.

## Test plan

- [x] `bun run typecheck` / `bun run lint` / `bun run format:check` / `bun run test` / `bun run knip` / `bun run validate:all` — all pass locally
- [x] `tools/coverage-report.ts` manually verified for: pass, value-regression, and missing-lcov-for-baselined-workspace (all three exit correctly)
- [x] `actionlint` clean on the modified `.github/workflows/ci.yml`
- [x] **This PR's own CI run is fully green**, including the new `coverage`, `smoke-web`, and `smoke-itun` jobs and the `quality-checks` aggregate: https://github.com/SalvageUnion-io/SU-SRD/actions/runs/28979412965

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEaZaV9wE5dvqs9hdw6r2C