### PR TITLE
feat(suref-react): visual-regression harness — story coverage, Ladle preload fix, CI wiring (#30)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       web: ${{ steps.filter.outputs.web }}
       bot: ${{ steps.filter.outputs.bot }}
       code: ${{ steps.filter.outputs.code }}
+      srefReact: ${{ steps.filter.outputs.srefReact }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -67,6 +68,18 @@ jobs:
               - *shared
               - 'apps/**'
               - 'packages/**'
+            # Narrower than itun/web on purpose: the visual-regression PR job
+            # below only screenshots suref-react's own Ladle stories, so it
+            # only needs to re-run when suref-react itself changes (not on
+            # every reference-data or root-config touch that the broader
+            # `itun`/`web` filters above chase). One known gap: a
+            # salvageunion-reference data change CAN alter what a story
+            # renders (e.g. renaming/removing the "Auto-Turret" ability the
+            # ReferenceEntityGrants stories fixture on) without tripping this
+            # filter — deliberate trade-off for the literal "only on
+            # suref-react changes" scoping; flagged in the PR description.
+            srefReact:
+              - 'packages/suref-react/**'
 
   lint:
     # Always runs — format:check covers docs (markdown/yaml) too.
@@ -238,6 +251,54 @@ jobs:
         run: bun --filter @suref/discord-bot build
 
   # ---------------------------------------------------------------------------
+  # PR-level visual-diff (issue #30 follow-up). Additive and deliberately NOT
+  # part of the quality-checks gate below (continue-on-error, and absent from
+  # its `needs` list) — same non-blocking posture as the nightly
+  # `visual-regression` job in e2e-nightly.yml, just scoped to the PR's own
+  # diff instead of a daily run against main. Compares against the committed
+  # Linux baselines in packages/suref-react/visual/__screenshots__ (none are
+  # committed yet — see PR description — so this currently just reports "no
+  # baseline" until a maintainer runs the generate-visual-baselines workflow
+  # and commits the result).
+  # ---------------------------------------------------------------------------
+  visual-regression-pr:
+    needs: [changes]
+    if: needs.changes.outputs.srefReact == 'true'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install Playwright browsers (Chromium)
+        run: bunx playwright install --with-deps chromium
+
+      - name: Build Ladle
+        run: bun --filter suref-react ladle:build
+
+      - name: Run visual regression
+        working-directory: packages/suref-react
+        run: bunx playwright test --config playwright.visual.config.ts
+
+      - name: Upload visual diff report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: visual-regression-pr-report
+          path: packages/suref-react/playwright-report/
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
   # Single aggregate gate. Always runs; fails if any job actually failed (a
   # path-filtered "skipped" job is fine). Branch protection should require just
   # this one check (`quality-checks`) so the per-area gating above never leaves
@@ -261,6 +322,9 @@ jobs:
       # gate PRs — they moved to a scheduled daily run against main
       # (.github/workflows/e2e-nightly.yml). This keeps the PR gate fast and
       # free of preview/browser flakiness; regressions are caught nightly.
+      # visual-regression-pr (above) is deliberately excluded here too, for
+      # the same reason plus one more: no Linux baselines are committed yet,
+      # so it can only ever report "no baseline" today.
     runs-on: ubuntu-latest
     steps:
       - name: Verify no job failed

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -97,10 +97,16 @@ jobs:
   visual-regression:
     # Visual-regression snapshots of the suref-react Ladle stories (issue #30)
     # via Playwright's toHaveScreenshot. Requires committed per-OS baselines
-    # under packages/suref-react/visual/__screenshots__ (generate with
-    # `bun --filter suref-react ladle:build && test:visual:update` on a Linux
-    # runner). Until baselines land this job reports "no baseline" — nightly is
-    # the right home for it (informational, non-blocking).
+    # under packages/suref-react/visual/__screenshots__ (generate them with the
+    # `generate-visual-baselines` workflow — Actions tab -> Run workflow — which
+    # runs on ubuntu-latest and uploads reviewable candidates as an artifact;
+    # a maintainer commits the ones they've eyeballed. Same effect locally via
+    # `bun --filter suref-react ladle:build && test:visual:update`, but MUST
+    # run on Linux to match this job). Until Linux baselines land this job
+    # reports "no baseline" — nightly is the right home for it (informational,
+    # non-blocking). A PR-scoped counterpart (`visual-regression-pr`) also
+    # exists in ci.yml, gated on packages/suref-react/** changes, same
+    # non-blocking posture.
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/generate-visual-baselines.yml
+++ b/.github/workflows/generate-visual-baselines.yml
@@ -1,0 +1,61 @@
+name: Generate Visual Baselines
+
+# Manually-triggered helper (issue #30 follow-up) that produces the *actual*
+# Linux-rendered Playwright baselines for the suref-react Ladle
+# visual-regression suite (packages/suref-react/visual/). Uploads them as a
+# downloadable artifact for a maintainer to eyeball and commit — this
+# workflow never commits anything itself. CLAUDE.md requires visual changes
+# to be confirmed by a human before they become ground truth, so this only
+# ever produces reviewable candidates, not accepted baselines.
+#
+# Must run on Linux: toHaveScreenshot suffixes each baseline with the
+# rendering platform (font/AA differences make macOS/Windows renders diff
+# pixel-for-pixel against Linux), and both the nightly `visual-regression`
+# job (e2e-nightly.yml) and the PR-scoped `visual-regression-pr` job (ci.yml)
+# run on ubuntu-latest — only `-linux.png` baselines are ever valid there.
+#
+# Usage: run this workflow (Actions tab -> Generate Visual Baselines -> Run
+# workflow), download the `visual-baselines-candidate` artifact, review each
+# PNG, then copy the reviewed files into
+# packages/suref-react/visual/__screenshots__/stories.visual.ts-snapshots/
+# and commit them.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install Playwright browsers (Chromium)
+        run: bunx playwright install --with-deps chromium
+
+      - name: Build Ladle
+        run: bun --filter suref-react ladle:build
+
+      - name: Generate baselines
+        working-directory: packages/suref-react
+        run: bunx playwright test --config playwright.visual.config.ts --update-snapshots
+
+      - name: Upload candidate baselines
+        uses: actions/upload-artifact@v7
+        with:
+          name: visual-baselines-candidate
+          path: packages/suref-react/visual/__screenshots__/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,14 @@ docs/rules/
 apps/in-the-union-now/playwright-report
 apps/in-the-union-now/test-results
 .design-bundle/
+
+# Visual-regression baselines (packages/suref-react/visual/__screenshots__) are
+# OS-specific — Playwright's toHaveScreenshot suffixes each file with the
+# rendering platform (font/AA differences make macOS/Windows renders diff
+# against Linux pixel-for-pixel), and CI always runs on Linux. Only
+# `-linux.png` baselines are ever valid there, so non-Linux renders are
+# ignored here to stop a contributor's local `test:visual:update` run from
+# accidentally committing a baseline CI can never match against. Generate the
+# real ones via the `generate-visual-baselines` workflow (Linux runner).
+packages/suref-react/visual/__screenshots__/**/*-darwin.png
+packages/suref-react/visual/__screenshots__/**/*-win32.png

--- a/packages/suref-react/.ladle/components.tsx
+++ b/packages/suref-react/.ladle/components.tsx
@@ -1,6 +1,37 @@
 import type { GlobalProvider } from '@ladle/react'
+import { Suspense, use, type ReactNode } from 'react'
+import { SalvageUnionReference } from 'salvageunion-reference'
 import '../src/styles/ladle.css'
 
+/**
+ * Every story reads `SalvageUnionReference.*` fixtures at module top level
+ * (e.g. `SalvageUnionReference.Systems.all()[0]`), which runs the instant
+ * Ladle's router dynamically imports that story's chunk. Without a preload
+ * gate ahead of that import, every model access throws "Schema not loaded"
+ * (see salvageunion-reference's LazyModel guard) and the story renders
+ * nothing — silently blank, not an error page. `apps/in-the-union-now`'s
+ * `GameDataReady` and `apps/suref-web`'s `useGameData` use the same
+ * `use()` + `Suspense` gate for the same reason; mirrored here so Ladle
+ * (and the visual-regression harness built on it) actually renders content.
+ */
+let preloadPromise: Promise<void> | null = null
+
+function getPreloadPromise(): Promise<void> {
+  if (!preloadPromise) {
+    preloadPromise = SalvageUnionReference.preload('all')
+  }
+  return preloadPromise
+}
+
+function PreloadGate({ children }: { children: ReactNode }) {
+  use(getPreloadPromise())
+  return <>{children}</>
+}
+
 export const Provider: GlobalProvider = ({ children }) => (
-  <div style={{ padding: '1rem', fontFamily: 'Fira Code, monospace' }}>{children}</div>
+  <div style={{ padding: '1rem', fontFamily: 'Fira Code, monospace' }}>
+    <Suspense fallback={null}>
+      <PreloadGate>{children}</PreloadGate>
+    </Suspense>
+  </div>
 )

--- a/packages/suref-react/playwright.visual.config.ts
+++ b/packages/suref-react/playwright.visual.config.ts
@@ -20,7 +20,12 @@ import { defineConfig, devices } from '@playwright/test'
  * ever fails, a maintainer runs `bun add -d @playwright/test` here.
  */
 const PORT = 61000
-const BASE_URL = `http://127.0.0.1:${PORT}`
+// `localhost` (not a hardcoded 127.0.0.1) — `ladle preview`'s underlying Vite
+// preview server binds per-OS loopback defaults (IPv6-only `::1` on some
+// macOS/Node combinations), so a literal IPv4 address can fail to connect
+// even though the server is up. `localhost` resolves correctly wherever the
+// server actually listens.
+const BASE_URL = `http://localhost:${PORT}`
 
 export default defineConfig({
   testDir: './visual',

--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay.stories.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay.stories.tsx
@@ -1,6 +1,6 @@
 import type { Story } from '@ladle/react'
 import { ReferenceEntityDisplay } from './ReferenceEntityDisplay/index'
-import { SalvageUnionReference } from 'salvageunion-reference'
+import { SalvageUnionReference, getChoices } from 'salvageunion-reference'
 
 export default {
   title: 'ReferenceEntity/ReferenceEntityDisplay',
@@ -18,6 +18,13 @@ const wwhfEntity =
   SalvageUnionReference.Systems.all().find((s) => s.source === 'We Were Here First!') ?? system
 const falseFlagEntity =
   SalvageUnionReference.Systems.all().find((s) => s.source === 'False Flag') ?? system
+
+// Fixtures for the choice-card / grants-collapse coverage below (same fixtures
+// used by the ReferenceEntityGrants / grantedEquipmentDisplay test suites).
+const grantingAbility = SalvageUnionReference.Abilities.all().find((a) => a.name === 'Auto-Turret')
+const choiceBearingEquipment = SalvageUnionReference.Equipment.all().find(
+  (e) => e.name === 'Custom Sniper Rifle'
+)
 
 export const DefaultSystem: Story = () => (
   <div className="w-[600px]">
@@ -82,6 +89,59 @@ export const DimHeader: Story = () => (
     <ReferenceEntityDisplay data={ability} dimHeader />
   </div>
 )
+
+export const CompactDamaged: Story = () => (
+  <div className="w-[400px]">
+    <ReferenceEntityDisplay data={system} compact damaged />
+  </div>
+)
+
+export const ListingDisabled: Story = () => (
+  <div className="w-[600px]">
+    <ReferenceEntityDisplay data={system} listing disabled />
+  </div>
+)
+
+/** Grants-collapse, expanded: the ability's own content/Actions are suppressed
+ * in favor of a "Grants" block with a nested, fully-expanded equipment card. */
+export const GrantingAbilityExpanded: Story = () => (
+  <div className="w-[600px]">
+    <ReferenceEntityDisplay data={grantingAbility} />
+  </div>
+)
+
+/** Grants-collapse, collapsed: in compact mode the nested granted entity
+ * itself collapses to a header-only listing card. */
+export const GrantingAbilityCompactCollapsed: Story = () => (
+  <div className="w-[420px]">
+    <ReferenceEntityDisplay data={grantingAbility} compact />
+  </div>
+)
+
+/** Choice-bearing equipment: interactive ChoiceGroups render in the card body
+ * (Not Chosen state, unresolved "Choose:" prompt in the header row). */
+export const ChoiceBearingEquipment: Story = () => (
+  <div className="w-[600px]">
+    <ReferenceEntityDisplay data={choiceBearingEquipment} compact />
+  </div>
+)
+
+/** Same choice-bearing equipment with a controlled selection pre-seeded
+ * (Chosen state), as ITUN's persistence layer would render it. */
+export const ChoiceBearingEquipmentSelected: Story = () => {
+  const weaponTypeChoice = choiceBearingEquipment
+    ? getChoices(choiceBearingEquipment)?.find((c) => c.name === 'Weapon Type')
+    : undefined
+  return (
+    <div className="w-[600px]">
+      <ReferenceEntityDisplay
+        data={choiceBearingEquipment}
+        compact
+        selections={weaponTypeChoice ? { [weaponTypeChoice.id]: ['Ballistic'] } : undefined}
+      />
+    </div>
+  )
+}
 
 export const ExpansionRainmaker: Story = () => (
   <div className="w-[600px] py-6">

--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/ReferenceEntityGrants.stories.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/ReferenceEntityGrants.stories.tsx
@@ -1,0 +1,48 @@
+import type { Story } from '@ladle/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+import type { SURefEntity } from 'salvageunion-reference'
+import { ReferenceEntityGrants } from './ReferenceEntityGrants'
+
+export default {
+  title: 'ReferenceEntity/ReferenceEntityGrants',
+}
+
+const singleGrant = SalvageUnionReference.Abilities.find(
+  (a) => a.name === 'Auto-Turret'
+) as SURefEntity
+const doubleGrant = SalvageUnionReference.Abilities.find(
+  (a) => a.name === 'Mecha Packmaster'
+) as SURefEntity
+const choiceBearingGrant = SalvageUnionReference.Abilities.find(
+  (a) => a.name === 'Custom Sniper Rifle'
+) as SURefEntity
+
+/** A single granted entity, expanded (full nested card). */
+export const SingleGrant: Story = () => (
+  <div className="w-[600px]">
+    <ReferenceEntityGrants data={singleGrant} />
+  </div>
+)
+
+/** Two entities granted by one ability — one nested card per grant. */
+export const DoubleGrant: Story = () => (
+  <div className="w-[600px]">
+    <ReferenceEntityGrants data={doubleGrant} />
+  </div>
+)
+
+/** Granted equipment that itself carries choices — nested choice cards render
+ * inside the granted entity's own expanded card. */
+export const GrantWithChoices: Story = () => (
+  <div className="w-[600px]">
+    <ReferenceEntityGrants data={choiceBearingGrant} />
+  </div>
+)
+
+/** Collapsed: when the parent ability renders compact, granted entities
+ * collapse to header-only listing cards (no body/choices). */
+export const CompactCollapsed: Story = () => (
+  <div className="w-[420px]">
+    <ReferenceEntityGrants data={choiceBearingGrant} compact />
+  </div>
+)

--- a/packages/suref-react/src/components/referenceEntity/choiceCard/ChoiceCard.stories.tsx
+++ b/packages/suref-react/src/components/referenceEntity/choiceCard/ChoiceCard.stories.tsx
@@ -1,0 +1,127 @@
+import type { Story } from '@ladle/react'
+import { useState } from 'react'
+import { ChoiceCard, FreeTextChoiceCard, StaticChoiceCard } from './ChoiceCard'
+
+export default {
+  title: 'ReferenceEntity/ChoiceCard',
+}
+
+export const NotChosen: Story = () => (
+  <div className="w-[280px] pt-3">
+    <ChoiceCard
+      label="Ballistic"
+      description="Deals kinetic damage."
+      chosen={false}
+      onToggle={() => {}}
+      parentHeaderBg="bg-su-green"
+    />
+  </div>
+)
+
+export const Chosen: Story = () => (
+  <div className="w-[280px] pt-3">
+    <ChoiceCard
+      label="Energy"
+      description="Deals energy damage."
+      chosen
+      onToggle={() => {}}
+      parentHeaderBg="bg-su-green"
+    />
+  </div>
+)
+
+export const Disabled: Story = () => (
+  <div className="w-[280px] pt-3">
+    <ChoiceCard
+      label="Rangefinder"
+      description="Increases Range to Far."
+      chosen={false}
+      disabled
+      parentHeaderBg="bg-su-green"
+    />
+  </div>
+)
+
+export const Compact: Story = () => (
+  <div className="w-[220px] pt-3">
+    <ChoiceCard
+      label="Laser Guidance"
+      description="Spend 2 AP to hit."
+      chosen
+      compact
+      onToggle={() => {}}
+      parentHeaderBg="bg-su-green"
+    />
+  </div>
+)
+
+/** Interactive toggle — click cycles Not Chosen -> Chosen. */
+export const Interactive: Story = () => {
+  const [chosen, setChosen] = useState(false)
+  return (
+    <div className="w-[280px] pt-3">
+      <ChoiceCard
+        label="High Calibre Rounds"
+        description="+1 SP damage."
+        chosen={chosen}
+        onToggle={() => setChosen((c) => !c)}
+        parentHeaderBg="bg-su-green"
+      />
+    </div>
+  )
+}
+
+export const FreeTextEditable: Story = () => (
+  <div className="w-[320px] pt-3">
+    <FreeTextChoiceCard
+      label="Name"
+      description="The name of your companion."
+      value=""
+      onValueChange={() => {}}
+      parentHeaderBg="bg-su-green"
+    />
+  </div>
+)
+
+export const FreeTextWithValue: Story = () => (
+  <div className="w-[320px] pt-3">
+    <FreeTextChoiceCard
+      label="Appearance"
+      value="A rusted quadruped drone with a single glowing optic."
+      onValueChange={() => {}}
+      multiline
+      parentHeaderBg="bg-su-green"
+    />
+  </div>
+)
+
+export const FreeTextReadOnly: Story = () => (
+  <div className="w-[320px] pt-3">
+    <FreeTextChoiceCard
+      label="A.I. Personality"
+      value="Cheerfully paranoid."
+      onValueChange={() => {}}
+      readOnly
+      parentHeaderBg="bg-su-green"
+    />
+  </div>
+)
+
+export const StaticListItem: Story = () => (
+  <div className="w-[320px] pt-3">
+    <StaticChoiceCard
+      label="Scavenger's Luck"
+      description="Once per session, reroll a failed Salvage check."
+      parentHeaderBg="bg-su-green"
+    />
+  </div>
+)
+
+export const StaticUnlabelledBullet: Story = () => (
+  <div className="w-[320px] pt-3">
+    <StaticChoiceCard
+      description="Scour the wastelands for a working power cell."
+      parentHeaderBg="bg-su-green"
+    />
+  </div>
+)

--- a/packages/suref-react/src/components/referenceEntity/choiceCard/ChoiceGroups.stories.tsx
+++ b/packages/suref-react/src/components/referenceEntity/choiceCard/ChoiceGroups.stories.tsx
@@ -1,0 +1,115 @@
+import type { Story } from '@ladle/react'
+import type { SURefObjectChoice } from 'salvageunion-reference'
+import { ChoiceGroups } from './ChoiceGroups'
+
+export default {
+  title: 'ReferenceEntity/ChoiceGroups',
+}
+
+const weaponTypeChoice: SURefObjectChoice = {
+  id: 'weapon-type',
+  name: 'Weapon Type',
+  choiceType: 'permanent',
+  schema: ['traits'],
+  schemaEntities: ['Ballistic', 'Energy'],
+}
+
+const modificationChoice: SURefObjectChoice = {
+  id: 'modification',
+  name: 'Modification',
+  choiceType: 'permanent',
+  multiSelect: true,
+  constraints: { scalesWithField: 'techLevel' },
+  choiceOptions: [
+    { label: 'Rangefinder', value: 'Rangefinder', description: 'Increases Range to Far.' },
+    { label: 'Laser Guidance', value: 'Laser Guidance', description: 'Spend 2 AP to hit.' },
+    { label: 'High Calibre Rounds', value: 'High Calibre Rounds', description: '+1 SP damage.' },
+  ],
+}
+
+const nameChoice: SURefObjectChoice = {
+  id: 'name',
+  name: 'Name',
+  choiceType: 'freeform',
+  content: [{ type: 'paragraph', value: 'The name of your companion.' }],
+}
+
+const parent = { techLevel: 2 }
+
+/** Exclusive (single-select) choice — no selection yet, all "Not Chosen". */
+export const ExclusiveChoiceUnselected: Story = () => (
+  <div className="w-[500px]">
+    <ChoiceGroups choices={[weaponTypeChoice]} parent={parent} parentHeaderBg="bg-su-green" />
+  </div>
+)
+
+/** Exclusive (single-select) choice with a pre-seeded controlled selection. */
+export const ExclusiveChoiceSelected: Story = () => (
+  <div className="w-[500px]">
+    <ChoiceGroups
+      choices={[weaponTypeChoice]}
+      parent={parent}
+      selections={{ 'weapon-type': ['Ballistic'] }}
+      parentHeaderBg="bg-su-green"
+    />
+  </div>
+)
+
+/** Multi-select with a resolved (scalesWithField) cap counter, none selected. */
+export const MultiSelectWithCap: Story = () => (
+  <div className="w-[500px]">
+    <ChoiceGroups choices={[modificationChoice]} parent={parent} parentHeaderBg="bg-su-green" />
+  </div>
+)
+
+/** Multi-select with two options already selected (cap counter reflects it). */
+export const MultiSelectPartiallySelected: Story = () => (
+  <div className="w-[500px]">
+    <ChoiceGroups
+      choices={[modificationChoice]}
+      parent={parent}
+      selections={{ modification: ['Rangefinder', 'Laser Guidance'] }}
+      parentHeaderBg="bg-su-green"
+    />
+  </div>
+)
+
+export const FreeTextChoice: Story = () => (
+  <div className="w-[400px]">
+    <ChoiceGroups choices={[nameChoice]} parent={parent} parentHeaderBg="bg-su-green" />
+  </div>
+)
+
+export const FreeTextChoiceReadOnly: Story = () => (
+  <div className="w-[400px]">
+    <ChoiceGroups
+      choices={[nameChoice]}
+      parent={parent}
+      selections={{ name: ['Rex'] }}
+      readOnly
+      parentHeaderBg="bg-su-green"
+    />
+  </div>
+)
+
+/** All choice types together, as they render on a real granted-equipment card. */
+export const MixedChoiceGroups: Story = () => (
+  <div className="w-[500px]">
+    <ChoiceGroups
+      choices={[weaponTypeChoice, modificationChoice]}
+      parent={parent}
+      parentHeaderBg="bg-su-green"
+    />
+  </div>
+)
+
+export const Compact: Story = () => (
+  <div className="w-[420px]">
+    <ChoiceGroups
+      choices={[weaponTypeChoice, modificationChoice]}
+      parent={parent}
+      compact
+      parentHeaderBg="bg-su-green"
+    />
+  </div>
+)

--- a/packages/suref-react/src/components/shared/DisplayCard.stories.tsx
+++ b/packages/suref-react/src/components/shared/DisplayCard.stories.tsx
@@ -1,0 +1,155 @@
+import type { Story } from '@ladle/react'
+import { DisplayCard } from './DisplayCard'
+import type { DisplayCardTab } from './DisplayCard'
+import { Text } from '../base/Text'
+
+export default {
+  title: 'Shared/DisplayCard',
+}
+
+const headerContent = (
+  <Text variant="pseudoheader" as="span">
+    Sample Card
+  </Text>
+)
+
+const bodyContent = (
+  <div className="p-3">
+    <Text as="p" className="text-sm">
+      Card body content goes here.
+    </Text>
+  </div>
+)
+
+export const Default: Story = () => (
+  <div className="w-[400px]">
+    <DisplayCard headerBg="bg-su-green" headerContent={headerContent}>
+      {bodyContent}
+    </DisplayCard>
+  </div>
+)
+
+export const Compact: Story = () => (
+  <div className="w-[350px]">
+    <DisplayCard headerBg="bg-su-green" headerContent={headerContent} compact>
+      {bodyContent}
+    </DisplayCard>
+  </div>
+)
+
+export const Listing: Story = () => (
+  <div className="w-[400px]">
+    <DisplayCard headerBg="bg-su-green" headerContent={headerContent} listing>
+      {bodyContent}
+    </DisplayCard>
+  </div>
+)
+
+export const CompactListing: Story = () => (
+  <div className="w-[350px]">
+    <DisplayCard headerBg="bg-su-green" headerContent={headerContent} compact listing>
+      {bodyContent}
+    </DisplayCard>
+  </div>
+)
+
+export const Disabled: Story = () => (
+  <div className="w-[400px]">
+    <DisplayCard headerBg="bg-su-green" headerContent={headerContent} disabled>
+      {bodyContent}
+    </DisplayCard>
+  </div>
+)
+
+export const StatusIntact: Story = () => (
+  <div className="w-[400px] pt-3">
+    <DisplayCard headerBg="bg-su-green" headerContent={headerContent} status="intact">
+      {bodyContent}
+    </DisplayCard>
+  </div>
+)
+
+export const StatusDamaged: Story = () => (
+  <div className="w-[400px] pt-3">
+    <DisplayCard headerBg="bg-su-green" headerContent={headerContent} status="damaged">
+      {bodyContent}
+    </DisplayCard>
+  </div>
+)
+
+export const StatusDestroyed: Story = () => (
+  <div className="w-[400px] pt-3">
+    <DisplayCard headerBg="bg-su-green" headerContent={headerContent} status="destroyed">
+      {bodyContent}
+    </DisplayCard>
+  </div>
+)
+
+const demoTabs: DisplayCardTab[] = [
+  { key: 'stats', label: 'Stats', content: <div className="p-3 text-sm">Stats tab content.</div> },
+  {
+    key: 'notes',
+    label: 'Notes',
+    content: <div className="p-3 text-sm">Notes tab content.</div>,
+  },
+]
+
+/** Default (Info) tab active — the tab bar renders alongside the standard body. */
+export const WithTabs: Story = () => (
+  <div className="w-[420px]">
+    <DisplayCard headerBg="bg-su-blue" headerContent={headerContent} tabs={demoTabs}>
+      {bodyContent}
+    </DisplayCard>
+  </div>
+)
+
+export const WithFootActionsAndMeta: Story = () => (
+  <div className="w-[420px]">
+    <DisplayCard
+      headerBg="bg-su-green"
+      headerContent={headerContent}
+      footActions={
+        <button type="button" className="rounded-[2px] border border-su-black px-2 py-1 text-xs">
+          Repair
+        </button>
+      }
+      footMeta={[{ label: 'AP Cost', value: 1 }]}
+    >
+      {bodyContent}
+    </DisplayCard>
+  </div>
+)
+
+/**
+ * Sticky header inside a scrollable container. The screenshot captures the
+ * card at rest (scrollTop 0) — sticky positioning itself only manifests on
+ * scroll, so this baseline documents the structural markup (header wrapper +
+ * scrollable body) rather than the stuck-to-top visual, which needs a human
+ * to verify interactively (see PR description).
+ */
+export const WithStickyHeader: Story = () => (
+  <div className="h-[300px] w-[420px] overflow-y-auto border border-su-grey-dark/30">
+    <DisplayCard headerBg="bg-su-blue" headerContent={headerContent} stickyHeader>
+      <div className="flex flex-col gap-3 p-3">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <Text as="p" className="text-sm" key={i}>
+            Scrollable body line {i + 1}.
+          </Text>
+        ))}
+      </div>
+    </DisplayCard>
+  </div>
+)
+
+export const Label: Story = () => (
+  <div className="w-[400px] pt-3">
+    <DisplayCard
+      headerBg="bg-su-green"
+      headerContent={headerContent}
+      label="Tech Level"
+      labelBadge="2"
+    >
+      {bodyContent}
+    </DisplayCard>
+  </div>
+)

--- a/packages/suref-react/visual/stories.visual.ts
+++ b/packages/suref-react/visual/stories.visual.ts
@@ -34,8 +34,30 @@ test.describe('Ladle story visual regression', () => {
 
       // `mode=preview` renders the isolated story with no Ladle nav chrome.
       await page.goto(`/?story=${encodeURIComponent(id)}&mode=preview`)
-      // Ladle sets [data-storyloaded] once the story component has mounted.
+      // Ladle sets [data-storyloaded] on <html> as a cleanup effect when its
+      // own lazy-loading spinner unmounts (i.e. once the story chunk's
+      // dynamic import resolves) — but that fires as soon as React starts
+      // committing the replacement, not once it has actually finished
+      // committing + the browser has painted it. Measured directly: content
+      // that is provably present half a second later reads back as a
+      // completely empty `<body>` immediately after this selector resolves.
+      // A blank frame is also *stable* (unchanging), so toHaveScreenshot's own
+      // frame-stability retry happily locks in that blank frame as "settled"
+      // — it never gets a chance to see the real content. So: don't trust the
+      // attribute: wait for the story to have actually produced DOM content
+      // (survives router/Suspense/lazy-import timing) and paint (fonts +
+      // a couple of animation frames) before ever taking a screenshot.
       await page.waitForSelector('[data-storyloaded]', { timeout: 15_000 })
+      // Fixed settle delay rather than a DOM-shape predicate: story bodies
+      // range from a single <Text> node to a full nested card tree, so no
+      // single "enough elements exist" threshold fits every story. 500ms was
+      // confirmed (by direct before/after DOM dumps) to comfortably outlast
+      // the commit+paint gap above.
+      await page.waitForTimeout(500)
+      await page.evaluate(() => document.fonts.ready)
+      await page.evaluate(
+        () => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)))
+      )
       await expect(page).toHaveScreenshot(`${id}.png`, {
         fullPage: true,
         animations: 'disabled',


### PR DESCRIPTION
## Summary

Lands the pieces the nightly `visual-regression` job (`.github/workflows/e2e-nightly.yml`) has been waiting on since #30 — it currently reports "no baseline" and this PR does not change that yet (see **Human review needed** below). Framed explicitly as **harness + candidate baselines awaiting human visual review**, not confirmed-correct output.

### 1. Story coverage (17 → 118 Ladle stories)

Expanded coverage of the entity-display system, focused on the highest-traffic pieces called out in the task: `ReferenceEntityDisplay`, and the compact/listing card patterns shared by both apps.

- **`DisplayCard.stories.tsx`** (new) — compact/listing, status badges (intact/damaged/destroyed), tabs, sticky header, foot actions/meta, label callout.
- **`ChoiceCard.stories.tsx`** (new) — `ChoiceCard` (chosen/not-chosen/disabled/compact/interactive), `FreeTextChoiceCard` (editable/pre-filled/read-only), `StaticChoiceCard` (labelled/unlabelled).
- **`ChoiceGroups.stories.tsx`** (new) — exclusive choice, capped multi-select, free-text, mixed groups, compact.
- **`ReferenceEntityGrants.stories.tsx`** (new) — single grant, double grant, grant with nested choices, compact-collapsed.
- **`ReferenceEntityDisplay.stories.tsx`** (expanded) — granting-ability expanded/collapsed (grants-collapse), choice-bearing equipment (default + pre-seeded selection), combined compact+damaged / listing+disabled states.

**Not covered** (explicitly out of scope per the task): exhaustive coverage of every schema type, `NPC`/`Formation`/`ClassAbilityTree` display variants, and anything ITUN-app-specific.

### 2. Fixed a real, pre-existing bug: every Ladle story rendered blank

While generating candidate screenshots, every single story — old and new — came back as a blank white page. Root-caused to two independent bugs in the existing (partially-wired) harness:

1. **`.ladle/components.tsx` never preloaded `salvageunion-reference`.** Every story reads `SalvageUnionReference.*` fixtures at module top level, which runs the instant Ladle lazy-imports that story's chunk. Without a preload gate first, every model access threw `"Schema not loaded"` — uncaught, so the story silently rendered nothing. Fixed with the same `use()` + `Suspense` preload gate `apps/in-the-union-now`'s `GameDataReady` and `apps/suref-web`'s `useGameData` already use for the identical reason. This fixes `ladle serve` (day-to-day dev) too, not just the screenshot harness.
2. **`visual/stories.visual.ts`'s `[data-storyloaded]` wait fired too early.** That attribute is Ladle's own loading-spinner-unmount signal — it fires as React *starts* committing the real story, not once it's finished committing and the browser has painted. Confirmed directly: `document.body.textContent` immediately after the selector resolves was empty; 500ms later, fully rendered. A blank frame is also *stable*, so `toHaveScreenshot`'s own frame-stability retry was locking in the blank capture. Added a settle wait + `fonts.ready` + double `requestAnimationFrame` before ever screenshotting.

Also fixed `playwright.visual.config.ts`'s hardcoded `127.0.0.1` webServer URL (fails to connect when the underlying Vite preview server binds IPv6-only loopback — `localhost` resolves everywhere).

### 3. CI wiring

- **New `generate-visual-baselines.yml`** (`workflow_dispatch`, `ubuntu-latest`) — builds Ladle and runs `test:visual:update`, uploading the result as a downloadable artifact. Produces the *real* Linux-rendered candidates for a maintainer to review and commit — mirrors CLAUDE.md's human-in-the-loop requirement for visual changes; this workflow never commits anything itself.
- **New `visual-regression-pr` job in `ci.yml`** — additive, gated on a new `srefReact` paths-filter output scoped to `packages/suref-react/**` (per the task's literal ask; **known gap**: a `salvageunion-reference` data change, e.g. renaming the "Auto-Turret" ability the `ReferenceEntityGrants` stories fixture on, can alter what a story renders without tripping this filter — noted in the workflow comment). `continue-on-error: true` and excluded from `quality-checks`, same non-blocking posture as the existing nightly job — this PR does **not** restructure any existing job.
- **`.gitignore`**: Playwright suffixes baselines by OS (`-darwin` vs `-linux`), and CI is Linux-only, so a macOS/Windows render can never pixel-match. Ignored `*-darwin.png` / `*-win32.png` under `visual/__screenshots__` so a contributor's local `test:visual:update` run can't accidentally get committed as a baseline CI will never match against.

## Human review needed

**No baselines are committed by this PR** — for the reason above, my local (macOS) renders are structurally the right content but can never serve as the Linux CI baseline. Two things for a maintainer:

1. **Visual QA pass:** I generated all 118 macOS-rendered candidate screenshots locally and spot-checked a broad sample (no blank/failed captures across two consecutive full runs). The screenshots most worth a careful look: `DisplayCard`'s new `with-tabs` and `with-sticky-header` stories (first coverage of those features — the sticky-header capture is necessarily at scroll-top, since a static screenshot can't show the stuck-to-top state), the grants-collapse expanded/collapsed pair (`ReferenceEntityDisplay`'s `GrantingAbilityExpanded`/`GrantingAbilityCompactCollapsed`), the deepest nesting case (`ReferenceEntityGrants`'s `GrantWithChoices` — Grants divider → nested card → choice groups → option cards), the two-card `DoubleGrant` layout, the CSS-columns masonry in `ChoiceGroups`' `MixedChoiceGroups`, and the four-card stacked `AllExpansions` story. I can publish these as a reviewable gallery on request — didn't include the link here since it wasn't something you asked for and Claude Code's auto-mode classifier flagged proactively sharing it in the PR body as out of scope for this session.
2. **Generate + commit the real baselines:** run the new `generate-visual-baselines` workflow (Actions tab → Run workflow), download the `visual-baselines-candidate` artifact, review, then commit the reviewed PNGs into `packages/suref-react/visual/__screenshots__/stories.visual.ts-snapshots/`. Once committed, both `visual-regression` (nightly) and `visual-regression-pr` (this PR's new job, and future PRs touching `packages/suref-react/**`) start actually diffing instead of reporting "no baseline."

## Test plan

- [x] `bun run typecheck` — full monorepo, 0 errors
- [x] `bun --filter suref-react test` — 378 pass / 0 fail
- [x] `bun run lint` — clean across all workspaces
- [x] `bun run format:check` — clean
- [x] `bun run validate:all` — clean
- [x] `bun run knip` — no new dead code (pre-existing config hints only)
- [x] `bun --filter suref-react ladle:build` + `bunx playwright test --config playwright.visual.config.ts --update-snapshots` run twice consecutively with zero blank captures (verified via file-size + visual spot-checks)
- [ ] Human visual QA of the candidate screenshots (see above)
- [ ] Real Linux baselines generated, reviewed, and committed in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEaZaV9wE5dvqs9hdw6r2C