### PR TITLE
fix(itun): include encounterNpcs in export/import backup bundle

### DIFF
--- a/apps/in-the-union-now/src/lib/export/__tests__/export-patterns.test.ts
+++ b/apps/in-the-union-now/src/lib/export/__tests__/export-patterns.test.ts
@@ -108,7 +108,7 @@ describe('mergeImport — mech patterns', () => {
 })
 
 describe('parseImportBundle — legacy compatibility', () => {
-  test('a pre-rename bundle (mech cargo: string[], no mechPatterns) still imports', () => {
+  test('a pre-rename bundle (mech cargo: string[], no mechPatterns/encounterNpcs) still imports', () => {
     const legacyBundle = {
       schemaVersion: 1,
       exportedAt: '2026-01-01T00:00:00.000Z',
@@ -136,6 +136,7 @@ describe('parseImportBundle — legacy compatibility', () => {
 
     const parsed = parseImportBundle(JSON.stringify(legacyBundle))
     expect(parsed.mechPatterns).toEqual([]) // schema default fills
+    expect(parsed.encounterNpcs).toEqual([]) // schema default fills (added later than mechPatterns, same pattern)
     const mech = parsed.entities.mechs[0]
     expect(mech?.cargoLots).toHaveLength(1)
     expect(mech?.cargoLots[0]?.name).toBe('Salvaged plating')

--- a/apps/in-the-union-now/src/lib/export/__tests__/export-round-trip.test.ts
+++ b/apps/in-the-union-now/src/lib/export/__tests__/export-round-trip.test.ts
@@ -18,15 +18,15 @@
  * (checked package.json first, per the harness brief) — this is deliberately
  * thorough table-driven coverage instead of generative testing.
  *
- * Known gap (not fixed here — out of scope, flagged for follow-up): the
- * `encounterNpcs` store has NO representation in ExportBundleSchema at all.
- * A full backup silently omits GM encounter-tray state. Not addressed in
- * this PR (would be a schema/feature change, not a test-harness fix) — see
- * the PR description.
+ * Formerly a known gap, now fixed: the `encounterNpcs` store previously had
+ * NO representation in ExportBundleSchema at all, so a full backup silently
+ * omitted GM encounter-tray state. `encounterNpcs` is now part of the bundle
+ * (additive `.default([])` field, no schemaVersion bump — see
+ * `exportBundle.ts`) and is covered below the same way mechPatterns is.
  */
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
-import { _clearAllStores, _resetDbSingleton, mechPatterns } from '../../db/index'
+import { _clearAllStores, _resetDbSingleton, encounterNpcs, mechPatterns } from '../../db/index'
 import { useEntityStore } from '../../../stores/entityStore'
 import { useWorkspaceStore } from '../../../stores/workspaceStore'
 import { buildExportBundle } from '../buildExportBundle'
@@ -235,6 +235,25 @@ const richPatternInput = {
   ],
 }
 
+const richEncounterNpcInput = {
+  schemaVersion: 1 as const,
+  refSchema: 'npcs' as const,
+  refSlug: 'wasteland-raider',
+  refName: 'Wasteland Raider',
+  name: 'Raider 2',
+  currentHp: 3,
+  maxHp: 6,
+  statKind: 'hp' as const,
+  conditions: ['bleeding'],
+  lastMediatorRoll: {
+    table: 'morale' as const,
+    roll: 14,
+    label: 'Steady',
+    value: 'Holds the line.',
+    rolledAt: '2026-01-01T00:00:00.000Z',
+  },
+}
+
 // ---------------------------------------------------------------------------
 // Per-entity round-trip fidelity
 // ---------------------------------------------------------------------------
@@ -339,6 +358,41 @@ describe('export round-trip — field fidelity', () => {
       stable(created as unknown as Record<string, unknown>)
     )
   })
+
+  test('encounterNpc: conditions + lastMediatorRoll survive, workspaceId remaps to new workspace', async () => {
+    const entityStore = useEntityStore.getState()
+    const workspaceStore = useWorkspaceStore.getState()
+
+    await workspaceStore.hydrate()
+    const ws = await workspaceStore.create({ name: 'Campaign Alpha' })
+
+    const created = await encounterNpcs.create({ ...richEncounterNpcInput, workspaceId: ws.id })
+
+    const bundle = await buildExportBundle(entityStore, workspaceStore)
+    expect(bundle.encounterNpcs).toHaveLength(1)
+    const parsed = await roundTrip(bundle)
+
+    _resetDbSingleton()
+    resetStores()
+    const verifyWorkspaceStore = useWorkspaceStore.getState()
+    await verifyWorkspaceStore.hydrate()
+    const importedWs = verifyWorkspaceStore.list()[0]
+    const imported = (await encounterNpcs.list())[0]
+    expect(imported).toBeDefined()
+    expect(importedWs).toBeDefined()
+
+    // Every field except id/createdAt/updatedAt/workspaceId is preserved exactly.
+    expect(stable(imported as unknown as Record<string, unknown>)).toEqual(
+      stable(created as unknown as Record<string, unknown>)
+    )
+    // workspaceId is intentionally remapped — to the NEW workspace's id.
+    expect((imported as { workspaceId?: string }).workspaceId).toBe(importedWs!.id)
+    expect((imported as { workspaceId?: string }).workspaceId).not.toBe(ws.id)
+
+    // Sanity: the exported bundle actually carried the rich fields.
+    expect(parsed.encounterNpcs[0]?.conditions).toEqual(['bleeding'])
+    expect(parsed.encounterNpcs[0]?.lastMediatorRoll?.table).toBe('morale')
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -376,6 +430,7 @@ describe('export round-trip — cross-entity full backup', () => {
     })
 
     await mechPatterns.create(richPatternInput)
+    await encounterNpcs.create({ ...richEncounterNpcInput, workspaceId: ws.id })
 
     const bundle = await buildExportBundle(entityStore, workspaceStore)
     expect(bundle.entities.pilots).toHaveLength(1)
@@ -384,6 +439,7 @@ describe('export round-trip — cross-entity full backup', () => {
     expect(bundle.softLinks).toHaveLength(2)
     expect(bundle.workspaces).toHaveLength(1)
     expect(bundle.mechPatterns).toHaveLength(1)
+    expect(bundle.encounterNpcs).toHaveLength(1)
 
     await roundTrip(bundle)
 
@@ -403,6 +459,7 @@ describe('export round-trip — cross-entity full backup', () => {
     const importedLinks = verifyEntityStore.list('softLink')
     const importedWs = verifyWorkspaceStore.list()[0]!
     const importedPatterns = await mechPatterns.list()
+    const importedEncounterNpcs = await encounterNpcs.list()
 
     // All three entities re-point at the SAME new workspace id.
     expect((importedPilot as { workspaceId?: string }).workspaceId).toBe(importedWs.id)
@@ -421,6 +478,11 @@ describe('export round-trip — cross-entity full backup', () => {
     // Pattern store survives the same full-backup round trip.
     expect(importedPatterns).toHaveLength(1)
     expect(importedPatterns[0]?.chassisRef).toBe('mule-chassis')
+
+    // Encounter NPC survives too, workspaceId re-pointed at the same new workspace.
+    expect(importedEncounterNpcs).toHaveLength(1)
+    expect(importedEncounterNpcs[0]?.refSlug).toBe('wasteland-raider')
+    expect((importedEncounterNpcs[0] as { workspaceId?: string }).workspaceId).toBe(importedWs.id)
 
     // Deep field fidelity, same as the per-entity tests above.
     expect(stable(importedPilot as unknown as Record<string, unknown>)).toEqual(

--- a/apps/in-the-union-now/src/lib/export/__tests__/export.test.ts
+++ b/apps/in-the-union-now/src/lib/export/__tests__/export.test.ts
@@ -101,6 +101,7 @@ describe('parseImportBundle', () => {
       workspaces: [],
       softLinks: [],
       mechPatterns: [],
+      encounterNpcs: [],
     }
     const result = parseImportBundle(JSON.stringify(bundle))
     expect(result.schemaVersion).toBe(1)
@@ -119,6 +120,7 @@ describe('parseImportBundle', () => {
       workspaces: [],
       softLinks: [],
       mechPatterns: [],
+      encounterNpcs: [],
     }
     expect(() => parseImportBundle(JSON.stringify(badBundle))).toThrow('unsupported schemaVersion')
   })
@@ -413,6 +415,7 @@ describe('mergeImport — round-trip', () => {
       workspaces: [],
       softLinks: [],
       mechPatterns: [],
+      encounterNpcs: [],
     }
 
     const summary = await mergeImport(bundle, entityStore, workspaceStore)

--- a/apps/in-the-union-now/src/lib/export/buildExportBundle.ts
+++ b/apps/in-the-union-now/src/lib/export/buildExportBundle.ts
@@ -1,5 +1,6 @@
 import { recordExport } from '../backupNudge'
 import * as db from '../db/index'
+import type { EncounterNpc } from '../schemas/encounterNpc'
 import type { ExportBundle } from '../schemas/exportBundle'
 import type { MechPattern } from '../schemas/pattern'
 import type { EntityType } from '../../stores/types'
@@ -30,6 +31,15 @@ type ExportPatternStore = {
 }
 
 /**
+ * Minimal encounter-NPC source for export. Like patterns, encounterNpcs are
+ * not in entityStore — they live in their own Zustand store/db object store;
+ * tests may pass a double.
+ */
+type ExportEncounterNpcStore = {
+  list: () => Promise<EncounterNpc[]>
+}
+
+/**
  * buildExportBundle — full backup of all entities, workspaces, and softLinks.
  *
  * Hydrates every store type first so the caller does not need to pre-hydrate.
@@ -38,10 +48,12 @@ type ExportPatternStore = {
 export async function buildExportBundle(
   entityStore: ExportStore,
   workspaceStore: ExportWorkspaceStore,
-  patternStore: ExportPatternStore = db.mechPatterns
+  patternStore: ExportPatternStore = db.mechPatterns,
+  encounterNpcStore: ExportEncounterNpcStore = db.encounterNpcs
 ): Promise<ExportBundle> {
-  const [mechPatterns] = await Promise.all([
+  const [mechPatterns, encounterNpcs] = await Promise.all([
     patternStore.list(),
+    encounterNpcStore.list(),
     entityStore.hydrate('pilot'),
     entityStore.hydrate('mech'),
     entityStore.hydrate('crawler'),
@@ -60,6 +72,7 @@ export async function buildExportBundle(
     workspaces: workspaceStore.list(),
     softLinks: entityStore.list('softLink'),
     mechPatterns,
+    encounterNpcs,
   }
   // A full backup resets the backup-nudge clock (plan 2.6).
   recordExport()
@@ -101,6 +114,7 @@ export async function buildEntityExport(
         workspaces: [],
         softLinks: attachedLinks,
         mechPatterns: [],
+        encounterNpcs: [],
       }
     }
     case 'mech': {
@@ -112,6 +126,7 @@ export async function buildEntityExport(
         workspaces: [],
         softLinks: attachedLinks,
         mechPatterns: [],
+        encounterNpcs: [],
       }
     }
     case 'crawler': {
@@ -123,6 +138,7 @@ export async function buildEntityExport(
         workspaces: [],
         softLinks: attachedLinks,
         mechPatterns: [],
+        encounterNpcs: [],
       }
     }
   }

--- a/apps/in-the-union-now/src/lib/export/mergeImport.ts
+++ b/apps/in-the-union-now/src/lib/export/mergeImport.ts
@@ -1,4 +1,5 @@
 import * as db from '../db/index'
+import type { EncounterNpc } from '../schemas/encounterNpc'
 import type { ExportBundle } from '../schemas/exportBundle'
 import type { MechPattern } from '../schemas/pattern'
 import type { EntityType } from '../../stores/types'
@@ -31,6 +32,16 @@ type MergePatternStore = {
   create: (input: Omit<MechPattern, 'id' | 'createdAt'>) => Promise<MechPattern>
 }
 
+/**
+ * Minimal encounter-NPC store for import. Like patterns, encounterNpcs are
+ * not in entityStore — they default to the db layer; tests may pass a
+ * double.
+ */
+type MergeEncounterNpcStore = {
+  list: () => Promise<EncounterNpc[]>
+  create: (input: Omit<EncounterNpc, 'id' | 'createdAt' | 'updatedAt'>) => Promise<EncounterNpc>
+}
+
 export type MergeSummary = {
   created: {
     pilots: number
@@ -39,6 +50,7 @@ export type MergeSummary = {
     workspaces: number
     softLinks: number
     mechPatterns: number
+    encounterNpcs: number
   }
   remappedLinks: number
   skippedDuplicates: number
@@ -53,7 +65,7 @@ export type MergeSummary = {
  *   3. Build an old-id → new-id map.
  *   4. Remap:
  *        - softLink.from.id / softLink.to.id through the map.
- *        - pilot/mech/crawler.workspaceId through the map.
+ *        - pilot/mech/crawler/encounterNpc.workspaceId through the map.
  *   5. Create each remapped entity via store.create() (NEVER overwrite).
  *
  * Entities whose old id already exists in the store are skipped (counted in
@@ -67,7 +79,8 @@ export async function mergeImport(
   bundle: ExportBundle,
   entityStore: MergeEntityStore,
   workspaceStore: MergeWorkspaceStore,
-  patternStore: MergePatternStore = db.mechPatterns
+  patternStore: MergePatternStore = db.mechPatterns,
+  encounterNpcStore: MergeEncounterNpcStore = db.encounterNpcs
 ): Promise<MergeSummary> {
   // Hydrate so we can check for existing ids.
   await Promise.all([
@@ -95,6 +108,7 @@ export async function mergeImport(
       workspaces: 0,
       softLinks: 0,
       mechPatterns: 0,
+      encounterNpcs: 0,
     },
     remappedLinks: 0,
     skippedDuplicates: 0,
@@ -225,6 +239,30 @@ export async function mergeImport(
     const { id: _id, createdAt: _ca, ...rest } = pattern
     await patternStore.create(rest)
     summary.created.mechPatterns++
+  }
+
+  // -------------------------------------------------------------------------
+  // 7. Encounter NPCs — fresh UUIDs, exact-id dedupe (same policy as
+  //    entities). workspaceId is remapped through idMap the same way
+  //    pilot/mech/crawler are (dropped if the referenced workspace was not
+  //    part of this bundle / not in the map).
+  // -------------------------------------------------------------------------
+  const existingEncounterNpcIds = new Set((await encounterNpcStore.list()).map((n) => n.id))
+  for (const npc of bundle.encounterNpcs) {
+    if (existingEncounterNpcIds.has(npc.id)) {
+      summary.skippedDuplicates++
+      continue
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { id: _id, createdAt: _ca, updatedAt: _ua, workspaceId, ...rest } = npc
+    const remappedWorkspaceId =
+      workspaceId !== undefined ? (idMap.get(workspaceId) ?? undefined) : undefined
+
+    await encounterNpcStore.create({
+      ...rest,
+      ...(remappedWorkspaceId !== undefined ? { workspaceId: remappedWorkspaceId } : {}),
+    })
+    summary.created.encounterNpcs++
   }
 
   return summary

--- a/apps/in-the-union-now/src/lib/export/parseImportBundle.ts
+++ b/apps/in-the-union-now/src/lib/export/parseImportBundle.ts
@@ -56,7 +56,9 @@ function normalizeLegacyBundle(raw: unknown): unknown {
  * Legacy compatibility: mechs/patterns carrying the pre-rename
  * `cargo: string[]` field are normalized to `cargoLots` and pilots carrying
  * the removed `rollResults` field have it dropped before validation;
- * bundles without `mechPatterns` get an empty array (schema default).
+ * bundles without `mechPatterns` or `encounterNpcs` get an empty array
+ * (schema default) — both fields were added additively, no schemaVersion
+ * bump required.
  *
  * On success returns the validated ExportBundle.
  */

--- a/apps/in-the-union-now/src/lib/schemas/exportBundle.ts
+++ b/apps/in-the-union-now/src/lib/schemas/exportBundle.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { CrawlerSchema } from './crawler'
+import { EncounterNpcSchema } from './encounterNpc'
 import { MechSchema } from './mech'
 import { MechPatternSchema } from './pattern'
 import { PilotSchema } from './pilot'
@@ -14,12 +15,22 @@ import { WorkspaceSchema } from './workspace'
  *
  * Entity scope:
  *   - Full backup (buildExportBundle): all pilots, mechs, crawlers, workspaces,
- *     and softLinks currently in the store.
+ *     softLinks, mechPatterns, and encounterNpcs currently in the store.
  *   - Single-entity export (buildEntityExport): the entity itself plus any
  *     softLinks whose `from` or `to` ref points to that entity id. Workspaces
  *     are NOT included in a single-entity export — the importing side will have
  *     its own workspaces, and the remapping step in mergeImport handles
  *     workspaceId by dropping links to missing workspaces gracefully.
+ *
+ * Versioning: new top-level entity arrays (mechPatterns, encounterNpcs) are
+ * added with `.default([])` rather than bumping schemaVersion. This is
+ * additive-safe: old bundles simply lack the field and the default fills it
+ * in on parse (parseImportBundle), and old app builds that don't know a
+ * field ignore it rather than choking on it. A version bump is reserved for
+ * BREAKING shape changes (renames, removed/narrowed fields) — see the
+ * `cargo` → `cargoLots` rewrite in parseImportBundle's `normalizeLegacyBundle`
+ * for how those are handled without a version bump either, by normalizing
+ * the raw shape before validation.
  */
 export const ExportBundleSchema = z.object({
   schemaVersion: z.literal(1),
@@ -37,6 +48,13 @@ export const ExportBundleSchema = z.object({
    * written before this field existed still import.
    */
   mechPatterns: z.array(MechPatternSchema).default([]),
+  /**
+   * GM encounter-tray NPC instances (durability audit finding: encounterNpcs
+   * had NO representation in ExportBundleSchema at all, so a full backup
+   * silently dropped GM tray state). Defaulted so bundles written before this
+   * field existed still import cleanly.
+   */
+  encounterNpcs: z.array(EncounterNpcSchema).default([]),
 })
 
 export type ExportBundle = z.infer<typeof ExportBundleSchema>


### PR DESCRIPTION
## Summary

A prior durability-audit task found that `encounterNpcs` (GM encounter-tray NPC instances, design-review R-5) had **no representation in `ExportBundleSchema` at all**. Because ITUN is local-first with no backend (ADR-001), a full backup/export is the user's *only* safety net — a GM who exported their data and later restored it (or shared a snapshot) would silently lose any encounter-tray NPCs they'd set up, with no warning that this happened.

This PR closes that gap, following the same additive pattern already established for `mechPatterns` (added for the same reason — export used to omit patterns too).

- `ExportBundleSchema`: add `encounterNpcs: z.array(EncounterNpcSchema).default([])`.
- `buildExportBundle`: reads from `db.encounterNpcs` (injectable store param defaulting to the real db layer, mirroring `patternStore`) and includes it in the bundle. `buildEntityExport` (single-entity export) sets `encounterNpcs: []` — GM tray state doesn't belong in a "send this pilot to a friend" export, same reasoning already applied to `mechPatterns` there.
- `parseImportBundle`: validated via the schema default — no legacy-bundle normalization needed since this is a brand-new field, not a rename.
- `mergeImport`: merges `encounterNpcs` with fresh UUIDs + exact-id dedupe (same policy as `mechPatterns`), remapping `workspaceId` through the same `idMap` used for pilot/mech/crawler (workspaces are remapped first in the function, so the map is already populated by the time `encounterNpcs` are processed).
- Tests: extended `export-round-trip.test.ts` with a rich `encounterNpc` fixture (conditions, `lastMediatorRoll`, workspaceId remap) covering the full `buildExportBundle → JSON → parseImportBundle → mergeImport` cycle, both in isolation and as part of the cross-entity full-backup test. Also added an explicit assertion in `export-patterns.test.ts`'s legacy-bundle test that a bundle missing `encounterNpcs` still imports cleanly (defaults to `[]`).

## Versioning / backward-compatibility reasoning

No `schemaVersion` bump. `ExportBundleSchema` is a plain `z.object()`, which strips unknown keys on parse and leaves declared-but-missing fields to their `.default()`. That makes this an additive-safe change in both directions:

- **Old bundle → new app**: the bundle simply lacks `encounterNpcs`; the schema's `.default([])` fills it in during `parseImportBundle`, so old backups keep importing exactly as before.
- **New bundle → old app**: an older build's `ExportBundleSchema` (without the `encounterNpcs` key) would just strip the unrecognized field on parse — no crash, no data corruption, just quiet ignoring of the newer field (not really a supported case today, but does not break).

A version bump is reserved for genuinely breaking shape changes — renames or narrowed/removed fields (see the `cargo: string[]` → `cargoLots` rewrite in `parseImportBundle`'s `normalizeLegacyBundle`, which handles that kind of change via raw-shape normalization *before* validation, again without a version bump). Adding a new top-level entity array is not that kind of change, and this mirrors exactly how `mechPatterns` was added previously.

## Test plan

- [x] `bun run typecheck` — clean across all packages
- [x] `bun --filter in-the-union-now test` — 1304 pass, 0 fail
- [x] `bun run lint` — clean
- [x] `bun run check:all` (lint, format:check, typecheck, test, validate:all, knip, audit) — exits 0, all packages green
- [x] Pre-push hook (typecheck/test/validate:all/knip) passed on `git push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEaZaV9wE5dvqs9hdw6r2C