### PR TITLE
fix(salvageunion-reference): resolve CodeQL js/polynomial-redos in nameToSlug

### DIFF
--- a/packages/salvageunion-reference/lib/slug.test.ts
+++ b/packages/salvageunion-reference/lib/slug.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'bun:test'
+import { nameToSlug } from './slug.js'
+
+/**
+ * Regression coverage for CodeQL alert js/polynomial-redos on `nameToSlug`.
+ * The original trailing-hyphen trim (`/^-+|-+$/g`) had a quantifier directly
+ * before an anchor with nothing after it to guarantee the match — the
+ * classic O(n^2) backtracking shape. The fix collapses whitespace/hyphen runs
+ * to a single hyphen first, guaranteeing at most one boundary hyphen remains,
+ * then trims with a non-quantified `/^-|-$/g`. These tests pin the exact
+ * output contract (so the fix can't silently change behavior) and exercise
+ * the quadratic-trigger shape to confirm it now resolves in linear time.
+ */
+describe('nameToSlug', () => {
+  it('lowercases and slugifies a normal name', () => {
+    expect(nameToSlug('Iron Mongrel')).toBe('iron-mongrel')
+  })
+
+  it('strips special characters not in word/space/hyphen classes', () => {
+    expect(nameToSlug("Rebar's Reckoning (Mk. II)!")).toBe('rebars-reckoning-mk-ii')
+  })
+
+  it('collapses multiple consecutive spaces into a single hyphen', () => {
+    expect(nameToSlug('Multi   Space   Name')).toBe('multi-space-name')
+  })
+
+  it('collapses multiple consecutive hyphens into a single hyphen', () => {
+    expect(nameToSlug('Already--Hyphenated---Name')).toBe('already-hyphenated-name')
+  })
+
+  it('collapses mixed runs of whitespace and hyphens into a single hyphen', () => {
+    expect(nameToSlug('Mixed - -  Run')).toBe('mixed-run')
+  })
+
+  it('removes leading and trailing hyphens', () => {
+    expect(nameToSlug('-Leading and Trailing-')).toBe('leading-and-trailing')
+  })
+
+  it('removes leading/trailing whitespace that becomes leading/trailing hyphens', () => {
+    expect(nameToSlug('  Padded Name  ')).toBe('padded-name')
+  })
+
+  it('handles a name that is only hyphens/whitespace by returning an empty string', () => {
+    expect(nameToSlug('   ---   ')).toBe('')
+  })
+
+  it('handles a single-hyphen input', () => {
+    expect(nameToSlug('-')).toBe('')
+  })
+
+  it('returns an empty string for empty input', () => {
+    expect(nameToSlug('')).toBe('')
+  })
+
+  it('is idempotent on an already-valid slug', () => {
+    const slug = nameToSlug('Improvised Explosive Device (Flint Children Squad)')
+    expect(nameToSlug(slug)).toBe(slug)
+  })
+
+  it('preserves underscores and digits as word characters', () => {
+    expect(nameToSlug('Unit_42 Type-A')).toBe('unit_42-type-a')
+  })
+
+  it('handles the longest real entity name in the dataset unchanged by the length cap', () => {
+    expect(nameToSlug('Improvised Explosive Device (Flint Children Squad)')).toBe(
+      'improvised-explosive-device-flint-children-squad'
+    )
+  })
+
+  it('truncates pathologically long input rather than processing it unbounded', () => {
+    const longName = 'A'.repeat(10_000)
+    const result = nameToSlug(longName)
+    // Truncated to the defensive cap, then fully lowercased with no hyphens
+    // (a single run of word characters has nothing for the separator/trim
+    // regexes to act on).
+    expect(result).toBe('a'.repeat(256))
+    expect(result.length).toBe(256)
+  })
+
+  it('resolves the classic quadratic-backtracking trigger shape quickly and correctly', () => {
+    // "a" + "-".repeat(n) + "a" is the textbook input that forces an O(n^2)
+    // retry-at-every-start-position search against a trailing `-+$` pattern.
+    // Going through the public API, the 256-char cap alone would make this
+    // fast regardless of the regex shape, so this only pins the *correct*
+    // end-to-end output for a pathological input (the capped prefix collapses
+    // to a single hyphen run, trimmed to the leading 'a').
+    const n = 100_000
+    const input = 'a' + '-'.repeat(n) + 'a'
+    expect(nameToSlug(input)).toBe('a')
+  })
+
+  it('the trim regex itself is linear, independent of the length cap', () => {
+    // This isolates the actual CodeQL js/polynomial-redos fix: the old
+    // trailing-trim pattern `/^-+|-+$/g` had a quantifier directly before an
+    // anchor with nothing after it, the classic O(n^2) backtracking shape on
+    // "a" + "-".repeat(n) + "a". The new pattern in slug.ts, `/^-|-$/g`, has
+    // no quantifier at all, so it's linear regardless of input size — proven
+    // here directly against the pattern (bypassing nameToSlug's length cap,
+    // which is defense-in-depth, not the mechanism that fixes the ReDoS).
+    // Keep this pattern literal in sync with the trim step in `nameToSlug`.
+    const trimPattern = /^-|-$/g
+    const n = 2_000_000
+    const input = 'a' + '-'.repeat(n) + 'a'
+
+    const start = performance.now()
+    const result = input.replace(trimPattern, '')
+    const elapsed = performance.now() - start
+
+    // Neither alternative matches: the string starts and ends with 'a', not
+    // '-', so this is a genuine no-op — the adversarial part is entirely in
+    // how much backtracking work the engine does to conclude that, not in
+    // the output.
+    expect(result).toBe(input)
+    expect(elapsed).toBeLessThan(500)
+  })
+})

--- a/packages/salvageunion-reference/lib/slug.ts
+++ b/packages/salvageunion-reference/lib/slug.ts
@@ -10,20 +10,42 @@ import type { SURefEntity, SURefEnumSchemaName } from './types/index.js'
 import { getDataMaps } from './ModelFactory.js'
 
 /**
+ * Defensive cap on input length before any regex processing in `nameToSlug`.
+ * `nameToSlug` is exported public API — real entity names in `data/*.json` top
+ * out at ~50 characters, so this is generous headroom, never expected to
+ * truncate real data. It bounds worst-case regex work to a constant for any
+ * caller (current or future) that passes untrusted/oversized input; it is
+ * belt-and-suspenders alongside the quantifier fix below, not a substitute
+ * for it (see CodeQL js/polynomial-redos note on `nameToSlug`).
+ */
+const MAX_SLUG_INPUT_LENGTH = 256
+
+/**
  * Converts a name to a URL-safe slug
  * - Converts to lowercase
  * - Replaces spaces and special characters with hyphens
  * - Removes multiple consecutive hyphens
  * - Trims hyphens from start and end
+ *
+ * CodeQL js/polynomial-redos note: the trailing-hyphen-trim regex used to be
+ * `/^-+|-+$/g`. The `-+$` branch has a quantifier immediately followed by an
+ * anchor with nothing after it in the string to guarantee the match, which is
+ * the classic superlinear (O(n^2)) backtracking shape for the query
+ * (e.g. `"a" + "-".repeat(n) + "a"` forces a retry at every start position).
+ * The fix collapses whitespace/hyphen runs into a single hyphen first
+ * (`[\s-]+` — safe: nothing follows the quantifier, so no backtracking), which
+ * guarantees at most one leading and one trailing hyphen remains. That lets
+ * the final trim drop its quantifier entirely (`/^-|-$/g`), leaving no
+ * superlinear regex in the function.
  */
 export function nameToSlug(name: string): string {
-  return name
+  const input = name.length > MAX_SLUG_INPUT_LENGTH ? name.slice(0, MAX_SLUG_INPUT_LENGTH) : name
+  return input
     .toLowerCase()
     .trim()
     .replace(/[^\w\s-]/g, '') // Remove special characters except word chars, spaces, and hyphens
-    .replace(/\s+/g, '-') // Replace spaces with hyphens
-    .replace(/-+/g, '-') // Replace multiple hyphens with single hyphen
-    .replace(/^-+|-+$/g, '') // Remove leading/trailing hyphens
+    .replace(/[\s-]+/g, '-') // Collapse runs of whitespace and/or hyphens into a single hyphen
+    .replace(/^-|-$/g, '') // Remove a leading/trailing hyphen (at most one remains after the collapse above)
 }
 
 /**


### PR DESCRIPTION
## Summary

CodeQL flagged a high-severity `js/polynomial-redos` alert in `nameToSlug` (`packages/salvageunion-reference/lib/slug.ts`). This alert was already open on `main` before this PR — it surfaced as "new" on #382 because that PR's new exports changed CodeQL's reachability graph, not because #382 introduced it. This PR fixes the underlying vulnerability directly so it stops being an open alert at all, unblocking #382 (and anything else) once merged.

## Root cause

Not the chain of `.replace()` calls in general — three of the four regexes are fine. The actual trigger is the trailing-hyphen trim:

```
/^-+|-+$/g
```

The `-+$` branch has a `+` quantifier directly before an anchor with nothing after it to bound the match — the textbook O(n²) backtracking shape. On input like `"a" + "-".repeat(n) + "a"`, the engine retries the match starting position at every offset.

## Fix

- Combined the two hyphen-normalizing passes (`\s+` → `-` and `-+` → `-`) into a single `[\s-]+` → `-` pass. This guarantees at most one hyphen ever appears at either boundary.
- That means the final trim no longer needs a quantifier at all: `/^-+|-+$/g` → `/^-|-$/g`. Zero superlinear regexes remain in the function.
- Added a defensive 256-character input-length cap (`MAX_SLUG_INPUT_LENGTH`) as belt-and-suspenders hardening — not the actual fix for the CodeQL pattern, but cheap insurance since the function is exported and could be called with untrusted input in the future. Real dataset entity names top out around 50 characters.

## Exploitability investigation

Audited every call site of `nameToSlug`, `findEntityBySlug`, and `getEntitySlug` across the monorepo before deciding how much to invest in this:

- `suref-web`'s `/schema/[schemaId]/item/[itemId]` route is fully static (`getStaticPaths`, build-time only) — no runtime path exists.
- `apps/in-the-union-now` is local-first, no backend/auth — worst case is a self-inflicted slowdown in the user's own tab.
- `findEntityBySlug` never runs `nameToSlug` on its own untrusted `slug` argument — it only strict-equality-compares against `nameToSlug(trusted item.name)`.
- The one nominally-remote path: Discord bot's `interaction.customId` → `parseCustomId` → `buildTableLookupMessage` → `nameToSlug` (`apps/discord-bot/src/buttons.ts` → `commands/lookup.ts:64`). CodeQL treats `customId` as remote input; in practice every customId the bot emits is built from a curated table name, never raw free text. Real severity today is low — but this is exactly why hardening the exported function is still worth doing rather than dismissing the alert.

## Tests

16 new tests in `packages/salvageunion-reference/lib/slug.test.ts`: normal/special-character names, space/hyphen collapsing, boundary trimming, empty/hyphen-only inputs, idempotency, the longest real dataset name, length-cap truncation, and the quadratic-trigger shape tested both end-to-end and directly against the fixed regex pattern (proving linear time independent of the length cap).

## Validation

`typecheck` (full monorepo), `lint` (full monorepo), `bun --filter salvageunion-reference test` (648/648), `test:coverage` (648/648), `validate:all`, `build:package` (no drift) — all pass. Pre-push hook (typecheck/test/validate/knip) passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: alxjrvs <alxjrvs+claude@gmail.com>
Claude-Session: https://claude.ai/code/session_01HEaZaV9wE5dvqs9hdw6r2C