### PR TITLE
perf(suref-web): per-route reference-data preload + build-time search index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,6 +338,49 @@ jobs:
           path: apps/suref-web/playwright-report/
           retention-days: 7
 
+  bundle-budget-web:
+    # PR-blocking bundle-size regression guard for suref-web's per-route data
+    # loading (src/lib/schemaPreloadDeps.ts, src/lib/searchIndexBuild.ts —
+    # see those files' doc comments and the accompanying ADR/audit notes).
+    # Runs ONLY apps/suref-web/e2e/bundle-budget.e2e.ts against the same
+    # hermetic `astro build` + `astro preview` target as smoke-web, asserting
+    # (a) large schema-specific data chunks never load on pages that don't
+    # need them and (b) total per-route JS stays under a byte budget. Kept as
+    # its own job (not folded into smoke-web) so a budget regression reads as
+    # its own clearly-named failure rather than an ambiguous smoke failure.
+    needs: [changes, build-package, build-suref-web]
+    if: needs.changes.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install Playwright browsers (Chromium)
+        working-directory: apps/suref-web
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run bundle-budget test
+        working-directory: apps/suref-web
+        run: bunx playwright test bundle-budget.e2e.ts
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-bundle-budget-web
+          path: apps/suref-web/playwright-report/
+          retention-days: 7
+
   smoke-itun:
     # PR-blocking smoke tier — same rationale as smoke-web. Runs ONLY
     # apps/in-the-union-now/e2e/smoke.e2e.ts against a self-contained static
@@ -446,6 +489,7 @@ jobs:
       - build-itun
       - build-discord-bot
       - smoke-web
+      - bundle-budget-web
       - smoke-itun
       # NOTE: the FULL browser e2e suites (ITUN + suref-web) still only run
       # nightly, not per-PR — see .github/workflows/e2e-nightly.yml.

--- a/apps/in-the-union-now/src/components/shared/GameDataReady.tsx
+++ b/apps/in-the-union-now/src/components/shared/GameDataReady.tsx
@@ -9,13 +9,32 @@ import { srdEntityExternalLink } from '../contextual/srdEntityExternalLink'
  * `body[data-game-data-ready="true"]` so E2E tests can latch onto a stable
  * "ready" signal across every route.
  *
- * Why preload everything: the entity-display layer pulls trait keywords,
+ * Why preload everything (still true — this is the "everything" half of the
+ * middle path, see below): the entity-display layer pulls trait keywords,
  * actions, and other cross-schema references inline. Routes used to preload
  * only what their wizard needed (classes/abilities/equipment for /pilots/new)
  * which left ReferenceEntityDisplay throwing "Schema 'traits' not loaded"
- * when it rendered a chosen entity. A single root-level preload removes the
- * matrix of per-route preload lists and matches the local-first MVP model
- * (the dataset is ~1-2 MB JSON; loading it up front is fine).
+ * when it rendered a chosen entity. A single preload of the full dataset
+ * removes the matrix of per-route preload lists and matches the local-first
+ * MVP model (the dataset is ~1-2 MB JSON; loading it up front is fine) — see
+ * docs/architecture/data-flow.md for the fuller rationale.
+ *
+ * Off the critical rendering path (the "deprioritized after first paint"
+ * half): this component only wraps `<Outlet />` + `<GlobalSearch />` in
+ * routes/__root.tsx — `<AppHeader />` (brand chrome, touches no reference
+ * data) now renders as a SIBLING one level up, outside this Suspense
+ * boundary, so it paints on the very first frame instead of sitting behind
+ * the full preload like every other route. This is deliberately the
+ * smallest useful cut, not per-route preload lists (which would reintroduce
+ * exactly the "Schema 'traits' not loaded" footgun the full-preload model
+ * above exists to avoid) and not an app-wide non-blocking preload (which
+ * would need every ORM-touching component, not just this one gate, to
+ * tolerate a not-ready state — a much larger change). One known trade-off:
+ * `GameDataFallback` below still sizes itself to `min-h-dvh`, so while
+ * `AppHeader` is also visible the fallback overshoots the remaining viewport
+ * by the header's height for the brief loading window — acceptable given
+ * it's transient and avoids threading `showAppHeader` through as a prop for
+ * a purely cosmetic fix.
  */
 
 let preloadPromise: Promise<unknown> | null = null

--- a/apps/in-the-union-now/src/routes/__root.tsx
+++ b/apps/in-the-union-now/src/routes/__root.tsx
@@ -63,8 +63,12 @@ function RootComponent() {
   return (
     <QueryClientProvider client={queryClient}>
       <EntityHrefProvider value={itunEntityHref}>
+        {/* AppHeader renders ONE level above the game-data gate (a sibling of
+            GameDataReady, not a child of it) — see GameDataReady.tsx's doc
+            comment for why: brand chrome touches no reference data, so it
+            paints immediately instead of sitting behind the full preload. */}
+        {showAppHeader && <AppHeader onSearchClick={() => setSearchOpen(true)} />}
         <GameDataReady>
-          {showAppHeader && <AppHeader onSearchClick={() => setSearchOpen(true)} />}
           <Outlet />
           {/* Mounted on every route (inside the game-data gate, so search()
               is always safe) — the Cmd/Ctrl+K shortcut works on live sheets

--- a/apps/suref-web/e2e/bundle-budget.e2e.ts
+++ b/apps/suref-web/e2e/bundle-budget.e2e.ts
@@ -1,0 +1,123 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Bundle-size budget suite — proves the per-route preload lists
+ * (`src/lib/schemaPreloadDeps.ts`) and the build-time compact search index
+ * (`src/lib/searchIndexBuild.ts`) actually keep large data chunks off pages
+ * that don't need them, and stay under a byte budget. This is the
+ * regression guard for ADR-005's promise ("apps pay only for the data they
+ * load") actually holding for suref-web — a change that widens a per-route
+ * preload list, or reintroduces `preload('all')` on an island, fails this
+ * suite instead of silently regressing bundle size.
+ *
+ * Budgets are set with real headroom above current measured sizes (see the
+ * PR description for before/after numbers) — they should fail on a
+ * meaningful regression, not on every dependency bump.
+ */
+
+type ResourceTotals = { count: number; bytes: number; names: string[] }
+
+/** Sum transferred bytes of same-origin `_astro/*.js` chunks requested during
+ *  a page load, keyed by response so redirects/duplicates aren't double
+ *  counted. `names` records the chunk filenames for assert-not-present checks. */
+async function captureAstroJsTotals(
+  page: import('@playwright/test').Page,
+  navigate: () => Promise<unknown>
+): Promise<ResourceTotals> {
+  const totals: ResourceTotals = { count: 0, bytes: 0, names: [] }
+  const seen = new Set<string>()
+
+  page.on('response', (response) => {
+    const url = response.url()
+    if (!url.includes('/_astro/') || !url.endsWith('.js')) return
+    if (seen.has(url)) return
+    seen.add(url)
+    totals.names.push(url.split('/_astro/')[1] ?? url)
+    totals.count += 1
+  })
+
+  await navigate()
+  await page.waitForLoadState('networkidle')
+
+  // Sizes via the Resource Timing API (transferSize — actual bytes over the
+  // wire, 0 for cached/opaque responses) rather than re-fetching each URL.
+  const sizes = await page.evaluate(() =>
+    performance
+      .getEntriesByType('resource')
+      .filter((e) => e.name.includes('/_astro/') && e.name.endsWith('.js'))
+      .map(
+        (e) =>
+          (e as PerformanceResourceTiming).transferSize ||
+          (e as PerformanceResourceTiming).encodedBodySize
+      )
+  )
+  totals.bytes = sizes.reduce((sum, n) => sum + n, 0)
+
+  return totals
+}
+
+test.describe('bundle-size budget', () => {
+  test('a leaf-schema item page never loads the large content/chassis data chunks', async ({
+    page,
+  }) => {
+    const totals = await captureAstroJsTotals(page, () => page.goto('/schema/traits/item/missile/'))
+
+    // The big, schema-specific data chunks (actions ~360KB, chassis ~150KB,
+    // roll-tables' own listing chunk) must not be among the requested files —
+    // schemaPreloadDeps.ts's ALWAYS_CORE bundle for leaf schemas excludes
+    // every CONTENT_BUNDLE/CHASSIS_BUNDLE-only schema.
+    const forbidden = ['chassis.', 'crawler-bays.', 'guides.', 'meld.']
+    for (const name of forbidden) {
+      expect(totals.names.some((n) => n.startsWith(name))).toBe(false)
+    }
+
+    // Total JS (react-vendor + shared island framework + the small
+    // ALWAYS_CORE data chunks) — ~2x headroom over the measured baseline
+    // (~277 KB at the time this budget was set; preload('all') on this same
+    // route measured ~555 KB, so this also guards against regressing back
+    // toward that).
+    expect(totals.bytes).toBeLessThan(550_000)
+  })
+
+  test('a chassis item page loads chassis-bundle data but not unrelated content schemas', async ({
+    page,
+  }) => {
+    const totals = await captureAstroJsTotals(page, () => page.goto('/schema/chassis/item/mule/'))
+
+    // Schemas with no chassis-pattern relationship (per CHASSIS_BUNDLE in
+    // schemaPreloadDeps.ts) should never be fetched on a chassis page.
+    const forbidden = ['crawler-bays.', 'guides.', 'meld.', 'bio-titans.', 'creatures.']
+    for (const name of forbidden) {
+      expect(totals.names.some((n) => n.startsWith(name))).toBe(false)
+    }
+
+    // ~2x headroom over the measured baseline (~461 KB — the most
+    // data-heavy page category, chassis + systems + modules + actions).
+    expect(totals.bytes).toBeLessThan(900_000)
+  })
+
+  test('search never loads the salvageunion-reference data chunks — only the compact index', async ({
+    page,
+  }) => {
+    const jsTotals = await captureAstroJsTotals(page, () => page.goto('/'))
+
+    let sawSearchIndex = false
+    page.on('response', (response) => {
+      if (response.url().endsWith('/search-index.json')) sawSearchIndex = true
+    })
+
+    const search = page.getByRole('combobox', { name: /search the srd/i }).first()
+    await search.click()
+    await search.fill('Mule')
+    await expect(page.getByRole('listbox').getByRole('option').first()).toBeVisible({
+      timeout: 30_000,
+    })
+
+    expect(sawSearchIndex).toBe(true)
+    // Zero salvageunion-reference schema data chunks — search runs entirely
+    // against the compact index, never the ORM.
+    const dataChunkPattern =
+      /^(actions|chassis|systems|modules|equipment|abilities|traits|keywords|roll-tables)\./
+    expect(jsTotals.names.some((n) => dataChunkPattern.test(n))).toBe(false)
+  })
+})

--- a/apps/suref-web/src/components/islands/ReferenceEntityIsland.tsx
+++ b/apps/suref-web/src/components/islands/ReferenceEntityIsland.tsx
@@ -9,7 +9,7 @@ import {
   EntityHrefProvider,
   EntityDetailLinkProvider,
 } from 'suref-react'
-import { GameDataGate, useGameData } from '../../lib/useGameData'
+import { GameDataGate, useGameData, type SchemaList } from '../../lib/useGameData'
 import { srdEntityHref } from '../../lib/entityHref'
 import { IslandErrorBoundary } from './IslandErrorBoundary'
 
@@ -17,17 +17,21 @@ type ReferenceEntityIslandProps = {
   item: SURefEntity
   compact?: boolean
   titleAs?: 'span' | 'h1'
+  /** Which schemas to preload — defaults to `'all'`. Pass the per-route list
+   *  from `../../lib/schemaPreloadDeps.ts` to load only what this item needs. */
+  preloadSchemas?: SchemaList
 }
 
 export function ReferenceEntityIsland({
   item,
   compact = false,
   titleAs,
+  preloadSchemas,
 }: ReferenceEntityIslandProps) {
   const classSelections = useMemo(() => getClassSelections(item), [item])
   const classEntity = classSelections.selectedClass || classSelections.selectedAdvancedClass
 
-  const { ready } = useGameData()
+  const { ready } = useGameData({ schemas: preloadSchemas })
 
   // The static SEO/no-JS fallback stays in the served HTML (crawlers and no-JS
   // users keep the content, including the page's only <h1>). For JS users it
@@ -50,6 +54,7 @@ export function ReferenceEntityIsland({
   return (
     <IslandErrorBoundary>
       <GameDataGate
+        schemas={preloadSchemas}
         fallback={
           <div className="mx-auto w-full max-w-6xl p-4">
             <ReferenceEntityCardSkeleton compact={compact} />

--- a/apps/suref-web/src/components/islands/SchemaViewerIsland.tsx
+++ b/apps/suref-web/src/components/islands/SchemaViewerIsland.tsx
@@ -12,7 +12,7 @@ import {
   EntityHrefProvider,
   EntityDetailLinkProvider,
 } from 'suref-react'
-import { GameDataGate } from '../../lib/useGameData'
+import { GameDataGate, type SchemaList } from '../../lib/useGameData'
 import { srdEntityHref } from '../../lib/entityHref'
 import { IslandErrorBoundary } from './IslandErrorBoundary'
 
@@ -48,6 +48,9 @@ type SchemaViewerIslandProps = {
   schemaId: string
   techLevels: (number | 'B' | 'N')[]
   sources: string[]
+  /** Which schemas to preload — defaults to `'all'`. Pass the per-route list
+   *  from `../../lib/schemaPreloadDeps.ts` to load only what this listing needs. */
+  preloadSchemas?: SchemaList
 }
 
 export function SchemaViewerIsland({
@@ -55,6 +58,7 @@ export function SchemaViewerIsland({
   schemaId,
   techLevels,
   sources,
+  preloadSchemas,
 }: SchemaViewerIslandProps) {
   // Filter state initializes from the URL on mount so a shared/bookmarked link
   // restores the exact filtered view. Lazy initializers run once; the reads are
@@ -157,6 +161,7 @@ export function SchemaViewerIsland({
   return (
     <IslandErrorBoundary>
       <GameDataGate
+        schemas={preloadSchemas}
         fallback={
           <div className={containerClass}>
             <div className="w-full min-w-0 px-2 pb-6 md:px-6">

--- a/apps/suref-web/src/components/islands/SearchIsland.tsx
+++ b/apps/suref-web/src/components/islands/SearchIsland.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { getEntitySlug } from 'salvageunion-reference'
 import { useSearchCombobox } from 'suref-react'
 import type { SearchComboboxResult } from 'suref-react'
-import { useGameData } from '../../lib/useGameData'
+import { useSearchIndex } from '../../lib/useSearchIndex'
+import { searchCompactIndex } from '../../lib/searchCompactIndex'
 import { IslandErrorBoundary } from './IslandErrorBoundary'
 
 type SearchIslandProps = {
@@ -18,9 +19,15 @@ function resultUrl(result: SearchComboboxResult): string {
 }
 
 export function SearchIsland({ navigate }: SearchIslandProps = {}) {
-  // Deferred: the game-data chunks don't download until first user intent
-  // (focusing the input or typing) — keeps them off every page's critical path.
-  const { ready, load } = useGameData({ defer: true })
+  // Deferred: the compact search index doesn't download until first user
+  // intent (focusing the input or typing) — keeps it off every page's
+  // critical path. Unlike the reference-entity islands, search never
+  // preloads the ORM at all — it matches against a small build-time index.
+  const { ready, index, load } = useSearchIndex({ defer: true })
+  const searchFn = useMemo(
+    () => (options: Parameters<typeof searchCompactIndex>[1]) => searchCompactIndex(index, options),
+    [index]
+  )
   // Dropdown-open is DERIVED: open while a search has run, unless the user
   // dismissed THIS results set (Escape/outside click). A new search run
   // produces a fresh results reference, which re-opens automatically —
@@ -54,6 +61,7 @@ export function SearchIsland({ navigate }: SearchIslandProps = {}) {
   } = useSearchCombobox({
     ready,
     onSubmit: (result) => doNavigate(resultUrl(result)),
+    searchFn,
   })
 
   const onInput = useCallback(
@@ -166,7 +174,7 @@ export function SearchIsland({ navigate }: SearchIslandProps = {}) {
             className="absolute right-0 top-full z-50 mt-1 max-h-96 w-80 overflow-y-auto rounded-md border border-su-grey-light bg-su-white shadow-lg"
           >
             {!ready ? (
-              <div className="px-4 py-3 text-sm text-su-grey-dark">Loading game data…</div>
+              <div className="px-4 py-3 text-sm text-su-grey-dark">Loading search index…</div>
             ) : results.length > 0 ? (
               results.map((result, index) => (
                 <a

--- a/apps/suref-web/src/components/islands/SearchResultsIsland.tsx
+++ b/apps/suref-web/src/components/islands/SearchResultsIsland.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useState } from 'react'
-import { getEntitySlug, search } from 'salvageunion-reference'
+import { getEntitySlug } from 'salvageunion-reference'
 import type { SearchResult } from 'salvageunion-reference'
 import { FilterChip, FilterRow } from 'suref-react'
-import { GameDataGate } from '../../lib/useGameData'
+import { useSearchIndex } from '../../lib/useSearchIndex'
+import { searchCompactIndex } from '../../lib/searchCompactIndex'
+import type { CompactSearchEntry } from '../../lib/searchIndexTypes'
 import { IslandErrorBoundary } from './IslandErrorBoundary'
 
 const PARAM_QUERY = 'q'
@@ -31,6 +33,7 @@ function resultUrl(result: SearchResult): string {
  */
 export function SearchResultsIsland() {
   const [query, setQuery] = useState(() => readQueryParam())
+  const { ready, index } = useSearchIndex()
 
   // Keep the URL in sync with the editable input so the page stays shareable
   // (replaceState — don't spam history on each keystroke).
@@ -82,20 +85,25 @@ export function SearchResultsIsland() {
           </div>
         </form>
 
-        <GameDataGate fallback={<p className="text-sm text-su-grey-dark">Loading game data…</p>}>
-          <SearchResults query={query} />
-        </GameDataGate>
+        {ready ? (
+          <SearchResults query={query} index={index} />
+        ) : (
+          <p className="text-sm text-su-grey-dark">Loading search index…</p>
+        )}
       </div>
     </IslandErrorBoundary>
   )
 }
 
-function SearchResults({ query }: { query: string }) {
+function SearchResults({ query, index }: { query: string; index: CompactSearchEntry[] }) {
   const trimmed = query.trim()
   const [schemaFacet, setSchemaFacet] = useState<string | null>(null)
 
   // Uncapped: no `limit`, so the full result set comes back.
-  const results = useMemo(() => (trimmed ? search({ query: trimmed }) : []), [trimmed])
+  const results = useMemo(
+    () => (trimmed ? searchCompactIndex(index, { query: trimmed }) : []),
+    [trimmed, index]
+  )
 
   // Facet options: distinct schemas present in the current result set, with counts.
   const facets = useMemo(() => {

--- a/apps/suref-web/src/components/islands/__tests__/SearchIsland.test.tsx
+++ b/apps/suref-web/src/components/islands/__tests__/SearchIsland.test.tsx
@@ -1,11 +1,32 @@
-import { describe, test, expect, afterEach, mock, spyOn } from 'bun:test'
+import { describe, test, expect, afterEach, beforeEach, mock, spyOn, type Mock } from 'bun:test'
 import { render, screen, cleanup, fireEvent, act } from '@testing-library/react'
-import { SalvageUnionReference } from 'salvageunion-reference'
 import { SearchIsland } from '../SearchIsland'
-import { resetPreloadForTests } from '../../../lib/useGameData'
+import { buildSearchIndexEntries } from '../../../lib/searchIndexBuild'
+import { resetSearchIndexForTests } from '../../../lib/useSearchIndex'
+
+// SearchIsland now fetches the build-time compact index (`/search-index.json`)
+// instead of preloading the ORM — mock `fetch` to serve the real index (built
+// from the already-preloaded test data, see test/preload-reference.ts) so
+// these stay real integration tests against real search behavior.
+const index = buildSearchIndexEntries()
 
 describe('SearchIsland', () => {
-  afterEach(cleanup)
+  let fetchSpy: Mock<typeof fetch> | undefined
+
+  beforeEach(() => {
+    resetSearchIndexForTests()
+    const mockFetch = (async () =>
+      new Response(JSON.stringify(index), {
+        headers: { 'Content-Type': 'application/json' },
+      })) as unknown as typeof fetch
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(mockFetch)
+  })
+
+  afterEach(() => {
+    cleanup()
+    fetchSpy?.mockRestore()
+    resetSearchIndexForTests()
+  })
 
   test('renders an sr-only aria-live region', () => {
     const { container } = render(<SearchIsland />)
@@ -20,7 +41,7 @@ describe('SearchIsland', () => {
 
     await act(async () => {
       fireEvent.change(input, { target: { value: 'chassis' } })
-      // Wait for debounce (150ms)
+      // Wait for debounce (150ms) + the mocked fetch's microtask
       await new Promise((r) => setTimeout(r, 200))
     })
 
@@ -117,7 +138,7 @@ describe('SearchIsland', () => {
   })
 
   test('deferred loading: search works after focusing the input and typing', async () => {
-    // SearchIsland defers the game-data preload to first intent (focus/typing).
+    // SearchIsland defers the index fetch to first intent (focus/typing).
     // Behavioral check: focus then type — results must still appear.
     render(<SearchIsland />)
     const input = screen.getByRole('combobox')
@@ -135,41 +156,41 @@ describe('SearchIsland', () => {
   })
 
   test('typing before data is ready shows the loading row, then real hits once ready', async () => {
-    // Force the deferred pre-ready state: isLoaded() false at mount and a
-    // preload promise we resolve by hand. This exercises the stale-debounce
-    // re-run in SearchIsland's useEffect([ready]) that the other deferred test
-    // (which mounts with data already loaded) never reaches.
-    resetPreloadForTests()
-    const isLoadedSpy = spyOn(SalvageUnionReference, 'isLoaded').mockReturnValue(false)
-    let resolvePreload!: () => void
-    const preloadSpy = spyOn(SalvageUnionReference, 'preload').mockImplementation(
-      () => new Promise<void>((res) => (resolvePreload = res))
-    )
+    // Force the deferred pre-ready state: the fetch never resolves until we
+    // resolve it by hand. This exercises the stale-debounce re-run in
+    // SearchIsland's useEffect([ready]) that the other deferred test (which
+    // mounts with data already loaded) never reaches.
+    resetSearchIndexForTests()
+    let resolveFetch!: (res: Response) => void
+    fetchSpy?.mockRestore()
+    const pendingFetch = (() =>
+      new Promise<Response>((res) => (resolveFetch = res))) as unknown as typeof fetch
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(pendingFetch)
 
     try {
       render(<SearchIsland />)
       const input = screen.getByRole('combobox')
 
-      // Type while the preload is still pending — the debounce fires against the
+      // Type while the fetch is still pending — the debounce fires against the
       // pre-ready closure, so the dropdown shows the loading row and no options.
       await act(async () => {
         fireEvent.focus(input)
         fireEvent.change(input, { target: { value: 'chassis' } })
         await new Promise((r) => setTimeout(r, 200))
       })
-      expect(screen.getByRole('listbox').textContent).toContain('Loading game data')
+      expect(screen.getByRole('listbox').textContent).toContain('Loading search index')
       expect(screen.queryAllByRole('option').length).toBe(0)
 
       // Data lands → the [ready] effect re-runs the pending query with real data.
       await act(async () => {
-        resolvePreload()
+        resolveFetch(
+          new Response(JSON.stringify(index), { headers: { 'Content-Type': 'application/json' } })
+        )
         await new Promise((r) => setTimeout(r, 0))
       })
       expect(screen.getAllByRole('option').length).toBeGreaterThan(0)
     } finally {
-      isLoadedSpy.mockRestore()
-      preloadSpy.mockRestore()
-      resetPreloadForTests()
+      resetSearchIndexForTests()
     }
   })
 

--- a/apps/suref-web/src/components/islands/__tests__/SearchResultsIsland.test.tsx
+++ b/apps/suref-web/src/components/islands/__tests__/SearchResultsIsland.test.tsx
@@ -1,50 +1,75 @@
-import { describe, test, expect, afterEach, spyOn } from 'bun:test'
-import { render, screen, cleanup, fireEvent } from '@testing-library/react'
-import { search } from 'salvageunion-reference'
+import { describe, test, expect, afterEach, beforeEach, spyOn, type Mock } from 'bun:test'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
 import { SearchResultsIsland } from '../SearchResultsIsland'
+import { buildSearchIndexEntries } from '../../../lib/searchIndexBuild'
+import { searchCompactIndex } from '../../../lib/searchCompactIndex'
+import { resetSearchIndexForTests } from '../../../lib/useSearchIndex'
+
+// SearchResultsIsland now fetches the build-time compact index
+// (`/search-index.json`) instead of preloading the ORM — mock `fetch` to
+// serve the real index (built from the already-preloaded test data, see
+// test/preload-reference.ts) so these stay real integration tests against
+// real search behavior.
+const index = buildSearchIndexEntries()
 
 describe('SearchResultsIsland', () => {
+  let fetchSpy: Mock<typeof fetch> | undefined
+
+  beforeEach(() => {
+    resetSearchIndexForTests()
+    const mockFetch = (async () =>
+      new Response(JSON.stringify(index), {
+        headers: { 'Content-Type': 'application/json' },
+      })) as unknown as typeof fetch
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(mockFetch)
+  })
+
   // happy-dom only reflects location changes from an href assignment (not from a
   // relative replaceState), so arrange/reset the URL via href.
   afterEach(() => {
     cleanup()
+    fetchSpy?.mockRestore()
+    resetSearchIndexForTests()
     window.location.href = 'http://localhost/'
   })
 
-  test('reads ?q= from the URL and renders the FULL (uncapped) result set', () => {
+  test('reads ?q= from the URL and renders the FULL (uncapped) result set', async () => {
     // A broad term that matches well over the combobox's ~10-row cap.
     const term = 'gun'
-    const expected = search({ query: term })
+    const expected = searchCompactIndex(index, { query: term })
     // Guard: only meaningful if this term actually exceeds the dropdown cap.
     expect(expected.length).toBeGreaterThan(10)
 
     window.location.href = `http://localhost/search?q=${term}`
     const { container } = render(<SearchResultsIsland />)
 
-    const links = container.querySelectorAll('ul li a')
-    expect(links.length).toBe(expected.length)
+    await waitFor(() => {
+      expect(container.querySelectorAll('ul li a').length).toBe(expected.length)
+    })
   })
 
-  test('shows a no-results message for a nonsense query', () => {
+  test('shows a no-results message for a nonsense query', async () => {
     window.location.href = 'http://localhost/search?q=zzzzxxxxnonsense99999'
     render(<SearchResultsIsland />)
-    expect(screen.getByText(/No results found/)).toBeTruthy()
+    expect(await screen.findByText(/No results found/)).toBeTruthy()
   })
 
-  test('editing the input writes the term to the ?q= URL param (replaceState)', () => {
+  test('editing the input writes the term to the ?q= URL param (replaceState)', async () => {
     window.location.href = 'http://localhost/search?q=chassis'
     const replaceSpy = spyOn(window.history, 'replaceState')
 
     try {
       render(<SearchResultsIsland />)
 
-      const input = screen.getByRole('searchbox', { name: 'Search the SRD' })
+      const input = await screen.findByRole('searchbox', { name: 'Search the SRD' })
       expect((input as HTMLInputElement).value).toBe('chassis')
 
       fireEvent.change(input, { target: { value: 'module' } })
 
-      const urls = replaceSpy.mock.calls.map((c) => String(c[2]))
-      expect(urls.some((u) => u.includes('q=module'))).toBe(true)
+      await waitFor(() => {
+        const urls = replaceSpy.mock.calls.map((c) => String(c[2]))
+        expect(urls.some((u) => u.includes('q=module'))).toBe(true)
+      })
     } finally {
       replaceSpy.mockRestore()
     }

--- a/apps/suref-web/src/lib/__tests__/schemaPreloadDeps.test.tsx
+++ b/apps/suref-web/src/lib/__tests__/schemaPreloadDeps.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, afterEach } from 'bun:test'
+import { Suspense } from 'react'
+import { render, cleanup } from '@testing-library/react'
+import {
+  SalvageUnionReference,
+  getEntitySchemas,
+  getModel,
+  resetAllForTesting,
+  type SURefEntity,
+} from 'salvageunion-reference'
+import {
+  ReferenceEntityDisplay,
+  EntityHrefProvider,
+  EntityDetailLinkProvider,
+  ReferenceEntityCardSkeleton,
+} from 'suref-react'
+import { getSchemaPreloadList } from '../schemaPreloadDeps'
+import { srdEntityHref } from '../entityHref'
+
+/**
+ * Render-equivalence safety net for schemaPreloadDeps.ts (see that file's
+ * header for the evidence behind each bundle). A hand-derived per-route
+ * preload list is only safe if it renders *identically* to a full preload —
+ * some missing-schema lookups throw, but others silently degrade (an empty
+ * Map, a dropped tooltip wrapper) without throwing, so "no exception" alone
+ * is not a strong enough check. This renders every entity of every schema
+ * that has a route twice — once with the computed per-route list, once with
+ * `'all'` — and asserts byte-identical markup. Any future change (data or
+ * component) that adds a new cross-schema dependency not covered by the map
+ * fails this test instead of silently shipping degraded content.
+ */
+
+/**
+ * Strip React's auto-generated `useId` ids before comparing markup — they're
+ * allocated per render-tree position and are not guaranteed to be identical
+ * literal strings across two independent `render()` calls even when the
+ * rendered content itself is identical.
+ */
+function normalize(html: string): string {
+  return html
+    .replace(/\bid="[^"]*"/g, 'id="…"')
+    .replace(/aria-describedby="[^"]*"/g, 'aria-describedby="…"')
+    .replace(/aria-controls="[^"]*"/g, 'aria-controls="…"')
+    .replace(/aria-labelledby="[^"]*"/g, 'aria-labelledby="…"')
+}
+
+function renderEntity(entity: SURefEntity): string {
+  const { container, unmount } = render(
+    <EntityHrefProvider value={srdEntityHref}>
+      <EntityDetailLinkProvider value={true}>
+        <Suspense fallback={<ReferenceEntityCardSkeleton />}>
+          <ReferenceEntityDisplay data={entity} />
+        </Suspense>
+      </EntityDetailLinkProvider>
+    </EntityHrefProvider>
+  )
+  const html = normalize(container.innerHTML)
+  unmount()
+  return html
+}
+
+afterEach(async () => {
+  cleanup()
+  resetAllForTesting()
+  await SalvageUnionReference.preload('all')
+})
+
+describe('schemaPreloadDeps render-equivalence', () => {
+  for (const schema of getEntitySchemas()) {
+    const preloadList = getSchemaPreloadList(schema.id)
+    // 'all' means this schema is intentionally unoptimized (e.g. `guides`) —
+    // nothing to verify, it already gets everything.
+    if (preloadList === 'all') continue
+
+    it(`${schema.id}: computed preload list (${preloadList.join(', ')}) renders identically to 'all'`, async () => {
+      const model = getModel(schema.id)
+      const entities = (model?.all() ?? []) as SURefEntity[]
+      expect(entities.length).toBeGreaterThan(0)
+
+      resetAllForTesting()
+      await SalvageUnionReference.preload('all')
+      const baseline = entities.map((entity) => renderEntity(entity))
+
+      resetAllForTesting()
+      await SalvageUnionReference.preload(preloadList)
+      const computed = entities.map((entity) => renderEntity(entity))
+
+      expect(computed).toEqual(baseline)
+    })
+  }
+})

--- a/apps/suref-web/src/lib/changelog.ts
+++ b/apps/suref-web/src/lib/changelog.ts
@@ -6,6 +6,14 @@ type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: '2026-07-09',
+    title: 'Faster page loads',
+    items: [
+      'Entity and category pages now download only the reference data they actually need, instead of the entire dataset — item and listing pages load noticeably faster, especially on slower connections.',
+      'Search now runs against a small pre-built index instead of downloading the full dataset, so search starts working faster the first time you use it.',
+    ],
+  },
+  {
     date: '2026-07-06',
     title: 'Discord bot Terms & Privacy pages',
     items: [

--- a/apps/suref-web/src/lib/schemaPreloadDeps.ts
+++ b/apps/suref-web/src/lib/schemaPreloadDeps.ts
@@ -1,0 +1,158 @@
+/**
+ * Per-schema preload lists — which `salvageunion-reference` schemas a given
+ * `/schema/[schemaId]/` listing page or `/schema/[schemaId]/item/[itemId]/`
+ * item page actually needs loaded client-side, instead of every island
+ * calling `SalvageUnionReference.preload('all')` (the full ~1.3 MB corpus).
+ *
+ * This is deliberately conservative and coarse-grained (per audit advice):
+ * cross-schema references in this dataset are pervasive, and a few are
+ * unconditional — `ReferenceEntityDisplay` itself, regardless of the
+ * entity's schema, always calls `getTable()` (-> `roll-tables`, for
+ * `tableName` refs), always renders `RangeValueDisplay` for any `range`
+ * DataValue (-> `distances`), and always resolves ability-tree prerequisite
+ * text via `extractReferenceEntityDetails` (-> `ability-tree-requirements`).
+ * So trying to compute a minimal *per-item* closure is a correctness trap —
+ * a missed edge silently drops content (some lookups warn-and-degrade) or
+ * throws (LazyModel access on an unloaded schema throws synchronously, and
+ * several of the "unconditional" lookups above go through LazyModel).
+ * Instead this defines one small ALWAYS_CORE bundle every schema gets, plus
+ * two shared "extra" bundles for schemas with further cross-references, all
+ * verified by the render-equivalence test in
+ * `__tests__/schemaPreloadDeps.test.tsx` (renders every entity of every
+ * schema twice — once with the computed list, once with `'all'` — and
+ * asserts identical markup). That test is what actually found ALWAYS_CORE's
+ * members; treat this file as verified-by-test, not verified-by-reading.
+ *
+ * Evidence for each bundle (see also the test file for the enforcement):
+ *
+ * - ALWAYS_CORE — every `ReferenceEntityDisplay` render, regardless of
+ *   schema, unconditionally touches:
+ *   - `roll-tables`: `getTable()` (utilities.ts) checks the entity's own
+ *     `tableName` field via a LazyModel `.find()`.
+ *   - `distances`: `RangeValueDisplay` resolves any `range`-type DataValue
+ *     via a LazyModel lookup.
+ *   - `ability-tree-requirements`: `extractReferenceEntityDetails`
+ *     (referenceEntityDataExtraction.ts) resolves ability-tree requirement
+ *     text the same way for any entity that carries a tree.
+ *   - `traits` / `keywords`: `[[trait]]` bracket refs in free text
+ *     (`traits`), and structured `DataValue` entries of type `'trait'` /
+ *     `'keyword'` (`DataValueDisplayView.tsx`, via `TraitKeywordDisplayView`).
+ * - CONTENT_BUNDLE — every schema with its own `actions` field renders
+ *   `ActionCard`, which needs `actions` (+ ALWAYS_CORE's `roll-tables`,
+ *   already covered) resolved. `classes` entities additionally resolve
+ *   their full ability tree via `ClassAbilityTreeDisplay` ->
+ *   `SalvageUnionReference.Abilities.all()` (unconditional LazyModel
+ *   access), and `abilities` can `grant` equipment/npcs/vehicles
+ *   (ReferenceEntityGrants). Simplest correct answer: give every
+ *   CONTENT_BUNDLE schema the same shared list rather than a bespoke
+ *   per-schema subset.
+ * - CHASSIS_BUNDLE — `chassis` patterns embed systems/modules *by name*
+ *   (useChassisPatternConfig -> `SalvageUnionReference.Systems.find` /
+ *   `.Modules.find`, both LazyModel access) — needs those two schemas
+ *   (themselves CONTENT_BUNDLE members, so also need `actions`). A chassis
+ *   ability can also carry a `.drone` reference, resolved via
+ *   `SalvageUnionReference.findIn('drones', ...)`
+ *   (ReferenceEntityDisplayContent.tsx). `factions` formation entries
+ *   resolve to a full entity via `resolveFormationMember`
+ *   (utilities.ts) — `member.schema` is one of a fixed, documented set
+ *   (`chassis` default, or `vehicles`/`drones`/`squads`/`npcs`), each then
+ *   run through `useChassisPatternConfig` too (ReferenceEntityFormation.tsx)
+ *   — same bundle, not just `chassis` + `factions` themselves.
+ * - `guides` steps reference an arbitrary schema chosen in the guide's own
+ *   JSON data (`step.schema[0]`, resolved via
+ *   `SalvageUnionReference.findAllIn(schemaName, ...)` in
+ *   GuideStepsDisplay.resolveSchemaEntities) — this is the same
+ *   "any route can render any cross-referenced entity" situation ADR-005
+ *   describes for ITUN. Not safely narrowable; kept at `'all'`.
+ * - Every other schema (no `actions` field, not chassis/classes/factions/
+ *   guides) never reaches `ActionCard`/`ClassAbilityTreeDisplay`/chassis-
+ *   pattern resolution, so it only needs ALWAYS_CORE. => LEAF schemas.
+ */
+
+/** Every `ReferenceEntityDisplay` render touches these regardless of the
+ *  entity's own schema — see file header. */
+export const ALWAYS_CORE: readonly string[] = [
+  'roll-tables',
+  'distances',
+  'ability-tree-requirements',
+  'traits',
+  'keywords',
+]
+
+/** Schemas with their own `actions` field, `classes` (ability-tree lookup),
+ *  and everything `abilities` can `grant`. Shared bundle — see file header. */
+export const CONTENT_BUNDLE: readonly string[] = [
+  'abilities',
+  'bio-titans',
+  'classes',
+  'crawlers',
+  'creatures',
+  'drones',
+  'equipment',
+  'meld',
+  'modules',
+  'npcs',
+  'squads',
+  'systems',
+  'vehicles',
+  'actions',
+  ...ALWAYS_CORE,
+]
+
+/** `chassis` itself, and any schema that resolves a full Chassis entity
+ *  (currently just `factions`, via formation rosters). See file header. */
+export const CHASSIS_BUNDLE: readonly string[] = [
+  'chassis',
+  'systems',
+  'modules',
+  'drones',
+  'vehicles',
+  'squads',
+  'npcs',
+  'actions',
+  ...ALWAYS_CORE,
+]
+
+/** Schemas whose entities are data-driven, arbitrary cross-references into
+ *  any other schema (guide steps) — not safely narrowable. */
+const ARBITRARY_SCHEMAS: ReadonlySet<string> = new Set(['guides'])
+
+const SCHEMA_PRELOAD_DEPS: Readonly<Record<string, readonly string[]>> = {
+  chassis: CHASSIS_BUNDLE,
+  factions: CHASSIS_BUNDLE,
+  abilities: CONTENT_BUNDLE,
+  'bio-titans': CONTENT_BUNDLE,
+  classes: CONTENT_BUNDLE,
+  crawlers: CONTENT_BUNDLE,
+  creatures: CONTENT_BUNDLE,
+  drones: CONTENT_BUNDLE,
+  equipment: CONTENT_BUNDLE,
+  meld: CONTENT_BUNDLE,
+  modules: CONTENT_BUNDLE,
+  npcs: CONTENT_BUNDLE,
+  squads: CONTENT_BUNDLE,
+  systems: CONTENT_BUNDLE,
+  vehicles: CONTENT_BUNDLE,
+  // Leaf schemas: ALWAYS_CORE only (see file header).
+  'crawler-bays': ALWAYS_CORE,
+  'crawler-tech-levels': ALWAYS_CORE,
+  distances: ALWAYS_CORE,
+  keywords: ALWAYS_CORE,
+  'roll-tables': ALWAYS_CORE,
+  sources: ALWAYS_CORE,
+  'tech-levels': ALWAYS_CORE,
+  traits: ALWAYS_CORE,
+}
+
+/**
+ * The list to pass to `SalvageUnionReference.preload(...)` (or `useGameData`
+ * / `GameDataGate`'s `schemas` option) for a given `/schema/[schemaId]/`
+ * route. Falls back to `'all'` for `guides` and any schema not covered above
+ * (new schemas default to the safe, unoptimized behavior until added here).
+ */
+export function getSchemaPreloadList(schemaId: string): string[] | 'all' {
+  if (ARBITRARY_SCHEMAS.has(schemaId)) return 'all'
+  const deps = SCHEMA_PRELOAD_DEPS[schemaId]
+  if (!deps) return 'all'
+  return [...new Set([schemaId, ...deps])]
+}

--- a/apps/suref-web/src/lib/searchCompactIndex.ts
+++ b/apps/suref-web/src/lib/searchCompactIndex.ts
@@ -1,0 +1,104 @@
+/**
+ * Client-side matcher for the build-time compact search index
+ * (`searchIndexTypes.ts` / `searchIndexBuild.ts`). Deliberately simpler than
+ * `salvageunion-reference`'s ORM-backed `search()`: it matches against one
+ * concatenated `text` field instead of per-field breakdown, so it drops
+ * `matchedFields`-based scoring (never surfaced in the suref-web UI — the
+ * only consumers, `SearchIsland`/`SearchResultsIsland`, don't render match
+ * reasons) and the `+10` description-specific boost. It keeps the
+ * name-priority scoring tiers and typo tolerance (`withinEditDistance1`,
+ * ported from search.ts) so ranking/UX parity holds for the common cases.
+ * This trade-off is what makes entity search fully decoupled from the ORM —
+ * no preload, no `salvageunion-reference` import — at the cost of losing
+ * fine-grained field-match ranking.
+ */
+import type { SearchOptions, SearchResult, SURefEnumSchemaName } from 'salvageunion-reference'
+import type { CompactSearchEntry } from './searchIndexTypes'
+
+/** Minimum token length before typo (edit-distance-1) matching applies —
+ *  mirrors salvageunion-reference's search.ts. */
+const TYPO_MIN_TOKEN_LENGTH = 4
+
+/**
+ * True when `token` is within edit distance 1 of `word` (insert, delete, or
+ * substitute one character). Ported verbatim from search.ts so typo
+ * tolerance behaves identically to the ORM-backed search.
+ */
+function withinEditDistance1(token: string, word: string): boolean {
+  const lenDiff = token.length - word.length
+  if (lenDiff < -1 || lenDiff > 1) return false
+  let i = 0
+  while (i < token.length && i < word.length && token[i] === word[i]) i++
+  if (i === token.length && i === word.length) return true
+  if (lenDiff === 0) return token.slice(i + 1) === word.slice(i + 1)
+  if (lenDiff === 1) return token.slice(i + 1) === word.slice(i)
+  return token.slice(i) === word.slice(i + 1)
+}
+
+/**
+ * Search a compact index built by `searchIndexBuild.ts`. Same call/result
+ * shape as `salvageunion-reference`'s `search()` (`SearchOptions` in,
+ * `SearchResult[]` out) so it's a drop-in `searchFn` for
+ * `useSearchCombobox`. `entity` on each result is a minimal stub
+ * (`{ id, name, schemaName }`) — the only thing suref-web reads off it is
+ * `getEntitySlug(entity)` (name-only), never the full entity shape.
+ */
+export function searchCompactIndex(
+  index: readonly CompactSearchEntry[],
+  options: SearchOptions
+): SearchResult[] {
+  const { query, schemas: schemaFilter, limit } = options
+  const loweredQuery = query.trim().toLowerCase()
+  if (!loweredQuery) return []
+  const tokens = loweredQuery.split(/\s+/)
+  const schemasToSearch = schemaFilter ? new Set(schemaFilter) : null
+
+  const results: SearchResult[] = []
+
+  for (const entry of index) {
+    if (schemasToSearch && !schemasToSearch.has(entry.schemaName as SURefEnumSchemaName)) continue
+
+    const nameText = entry.name.toLowerCase()
+    let usedTypo = false
+    let matches = true
+    for (const token of tokens) {
+      if (entry.text.includes(token)) continue
+      if (token.length >= TYPO_MIN_TOKEN_LENGTH) {
+        const nameWords = nameText.split(/[^a-z0-9]+/).filter(Boolean)
+        if (nameWords.some((word) => withinEditDistance1(token, word))) {
+          usedTypo = true
+          continue
+        }
+      }
+      matches = false
+      break
+    }
+    if (!matches) continue
+
+    let score = 0
+    if (nameText === loweredQuery) score += 100
+    else if (nameText.startsWith(loweredQuery)) score += 50
+    else if (nameText.includes(loweredQuery)) score += 25
+    else if (tokens.every((t) => nameText.includes(t))) score += 20
+    if (usedTypo) score -= 15
+
+    results.push({
+      schemaName: entry.schemaName as SURefEnumSchemaName,
+      schemaTitle: entry.schemaTitle,
+      // Minimal stub — see doc comment above. `as` is intentional/narrow: the
+      // full SURefEntity shape is never read by any suref-web consumer.
+      entity: {
+        id: entry.id,
+        name: entry.name,
+        schemaName: entry.schemaName,
+      } as SearchResult['entity'],
+      entityId: entry.id,
+      entityName: entry.name,
+      matchedFields: [],
+      matchScore: score,
+    })
+  }
+
+  results.sort((a, b) => b.matchScore - a.matchScore)
+  return limit && results.length > limit ? results.slice(0, limit) : results
+}

--- a/apps/suref-web/src/lib/searchIndexBuild.ts
+++ b/apps/suref-web/src/lib/searchIndexBuild.ts
@@ -1,0 +1,82 @@
+/**
+ * Build-time compact search index generator (Node-only — imports gameData.ts,
+ * which preloads the full ORM at module load; never import this from a
+ * client island). Consumed by `src/pages/search-index.json.ts`, an Astro
+ * static endpoint generated once at `astro build` and fetched lazily by
+ * `useSearchIndex.ts` on first search interaction.
+ *
+ * Mirrors the field extraction `salvageunion-reference`'s internal
+ * `buildSearchIndex` (lib/search.ts) uses — name, description, effect,
+ * goals, assets, weaknesses, content, and resolved action content — but
+ * flattens everything into one lowercased `text` field and drops the full
+ * entity, since the client only needs to match a query and link to the
+ * entity's page (see `searchIndexTypes.ts`). This is a deliberate,
+ * documented trade-off (see `searchCompactIndex.ts`): the client matcher
+ * loses per-field match weighting, in exchange for not shipping the full
+ * corpus to the browser.
+ */
+import { getEntitySchemas, getModel, SalvageUnionReference } from './gameData'
+import { getEntitySlug } from 'salvageunion-reference'
+import type { SURefEntity, SURefMetaEntity } from 'salvageunion-reference'
+import type { CompactSearchEntry } from './searchIndexTypes'
+
+/** Recursively extract display text from a ContentBlock tree (mirrors
+ *  salvageunion-reference's internal search.ts#extractContentText). */
+function extractContentText(content: unknown): string {
+  if (!content) return ''
+  if (Array.isArray(content)) return content.map(extractContentText).join(' ')
+  if (typeof content === 'object' && content !== null) {
+    const block = content as Record<string, unknown>
+    let text = ''
+    if ('value' in block && typeof block.value === 'string') text += block.value + ' '
+    if ('label' in block && typeof block.label === 'string') text += block.label + ' '
+    if ('items' in block && Array.isArray(block.items)) text += extractContentText(block.items)
+    return text
+  }
+  return ''
+}
+
+const TEXT_FIELDS = ['description', 'effect', 'goals', 'assets', 'weaknesses'] as const
+
+export function buildSearchIndexEntries(): CompactSearchEntry[] {
+  const entries: CompactSearchEntry[] = []
+
+  for (const schema of getEntitySchemas()) {
+    const model = getModel(schema.id)
+    if (!model) continue
+
+    for (const entity of model.all() as SURefEntity[]) {
+      const parts: string[] = [entity.name]
+
+      for (const field of TEXT_FIELDS) {
+        if (field in entity && typeof (entity as Record<string, unknown>)[field] === 'string') {
+          parts.push((entity as Record<string, unknown>)[field] as string)
+        }
+      }
+
+      if ('content' in entity && (entity as Record<string, unknown>).content) {
+        parts.push(extractContentText((entity as Record<string, unknown>).content))
+      }
+
+      const resolvedActions = SalvageUnionReference.resolveActions(entity as SURefMetaEntity)
+      if (resolvedActions) {
+        for (const action of resolvedActions) {
+          if (action && typeof action === 'object' && 'content' in action) {
+            parts.push(extractContentText((action as { content: unknown }).content))
+          }
+        }
+      }
+
+      entries.push({
+        id: entity.id,
+        name: entity.name,
+        slug: getEntitySlug(entity),
+        schemaName: schema.id,
+        schemaTitle: schema.title,
+        text: parts.join(' ').toLowerCase(),
+      })
+    }
+  }
+
+  return entries
+}

--- a/apps/suref-web/src/lib/searchIndexTypes.ts
+++ b/apps/suref-web/src/lib/searchIndexTypes.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared shape between the build-time compact search index generator
+ * (`searchIndexBuild.ts`, Node-only) and the client-side matcher
+ * (`searchCompactIndex.ts`). Deliberately slim — no full entity data, just
+ * enough to match a query and link to the entity's page — so the index
+ * ships to the browser as a small static JSON asset instead of the full
+ * ~1.3 MB reference corpus.
+ */
+export type CompactSearchEntry = {
+  id: string
+  name: string
+  slug: string
+  schemaName: string
+  schemaTitle: string
+  /** Lowercased, concatenated searchable text (name + description/effect/
+   *  goals/assets/weaknesses/content + resolved action content). */
+  text: string
+}

--- a/apps/suref-web/src/lib/useGameData.tsx
+++ b/apps/suref-web/src/lib/useGameData.tsx
@@ -2,43 +2,69 @@
  * Client-side preload hook for React islands.
  *
  * Islands that use salvageunion-reference ORM methods must call this hook
- * and wait for `ready` before making any ORM calls. The preload runs once
- * and is shared across all islands via the module-scoped promise.
+ * and wait for `ready` before making any ORM calls. Preloads are keyed by
+ * their exact schema list (`'all'`, or a sorted, comma-joined array) so
+ * different islands on the same page can request different subsets —
+ * see `../lib/schemaPreloadDeps.ts` for how per-route lists are computed —
+ * while multiple islands requesting the *same* list still share one
+ * in-flight preload promise.
  */
 import { useState, useEffect, useCallback, useSyncExternalStore, type ReactNode } from 'react'
 import { SalvageUnionReference } from 'salvageunion-reference'
 
-let preloadPromise: Promise<void> | null = null
-let preloadDone = false
-const readyListeners = new Set<() => void>()
+/** A preload request: every schema (`'all'`), or an explicit subset. */
+export type SchemaList = string[] | 'all'
+
+type PreloadState = { promise: Promise<void> | null; done: boolean }
+
+const preloadStates = new Map<string, PreloadState>()
+const readyListeners = new Map<string, Set<() => void>>()
 
 /**
- * Test-only escape hatch: clears the module-level preload state so tests
+ * Test-only escape hatch: clears all module-level preload state so tests
  * that mock SalvageUnionReference.preload() don't leak state into each other.
  * Production code must never call this.
  */
 export function resetPreloadForTests(): void {
-  preloadPromise = null
-  preloadDone = false
+  preloadStates.clear()
+  readyListeners.clear()
 }
 
-function emitReady(): void {
-  for (const listener of readyListeners) listener()
+/** Stable cache/listener key for a schema list — order-independent. */
+function keyFor(schemas: SchemaList): string {
+  return schemas === 'all' ? 'all' : [...schemas].sort().join(',')
 }
 
-function subscribeReady(onChange: () => void): () => void {
-  readyListeners.add(onChange)
+function emitReady(key: string): void {
+  const listeners = readyListeners.get(key)
+  if (!listeners) return
+  for (const listener of listeners) listener()
+}
+
+function subscribeReady(key: string, onChange: () => void): () => void {
+  let listeners = readyListeners.get(key)
+  if (!listeners) {
+    listeners = new Set()
+    readyListeners.set(key, listeners)
+  }
+  listeners.add(onChange)
   return () => {
-    readyListeners.delete(onChange)
+    listeners!.delete(onChange)
   }
 }
 
+/** True once every schema in the list has been preloaded. */
+function isSchemaListLoaded(schemas: SchemaList): boolean {
+  if (schemas === 'all') return SalvageUnionReference.isLoaded('chassis')
+  return schemas.every((schema) => SalvageUnionReference.isLoaded(schema))
+}
+
 /**
- * Client snapshot: ready once the shared preload has resolved (or the data was
- * already loaded at mount).
+ * Client snapshot: ready once this key's shared preload has resolved (or the
+ * data was already loaded at mount).
  */
-function getReadySnapshot(): boolean {
-  return preloadDone || SalvageUnionReference.isLoaded('chassis')
+function getReadySnapshot(key: string, schemas: SchemaList): boolean {
+  return (preloadStates.get(key)?.done ?? false) || isSchemaListLoaded(schemas)
 }
 
 /**
@@ -53,43 +79,61 @@ function getReadyServerSnapshot(): boolean {
   return false
 }
 
-function ensurePreloaded(): Promise<void> {
-  if (SalvageUnionReference.isLoaded('chassis')) {
-    preloadDone = true
+function ensurePreloaded(key: string, schemas: SchemaList): Promise<void> {
+  if (isSchemaListLoaded(schemas)) {
+    const state = preloadStates.get(key) ?? { promise: null, done: false }
+    state.done = true
+    preloadStates.set(key, state)
     return Promise.resolve()
   }
-  if (!preloadPromise) {
-    preloadPromise = SalvageUnionReference.preload('all').then(() => {
-      preloadDone = true
-      emitReady()
+  let state = preloadStates.get(key)
+  if (!state) {
+    state = { promise: null, done: false }
+    preloadStates.set(key, state)
+  }
+  if (!state.promise) {
+    const pending = state
+    pending.promise = SalvageUnionReference.preload(schemas).then(() => {
+      pending.done = true
+      emitReady(key)
     })
   }
-  return preloadPromise
+  return state.promise!
 }
 
 /**
  * @param options.defer When true, the preload does not start on mount —
  * it waits until `load()` is called (first user intent, e.g. focusing the
- * search input). Keeps the ~1.4 MB data corpus off the critical path of
- * pages that only need it on interaction. Defaults to eager preload.
+ * search input). Keeps the data corpus off the critical path of pages that
+ * only need it on interaction. Defaults to eager preload.
+ * @param options.schemas Which schemas to preload — defaults to `'all'`.
+ * Pass the per-route list from `schemaPreloadDeps.ts` to load only what the
+ * page actually needs instead of the full corpus.
  *
- * Note: the preload promise is module-shared, so `defer` only keeps data off
- * the critical path on pages that render *no* eager consumer. On a page that
- * also mounts an eager `useGameData()` (e.g. item pages with a
- * ReferenceEntityIsland, which need the entity immediately), that eager
- * consumer starts the shared preload on mount and the deferred consumer simply
- * rides the in-flight promise — by design, not a missed optimization.
+ * Note: the preload promise is shared per exact schema list, so `defer` only
+ * keeps data off the critical path on pages that render *no* eager consumer
+ * requesting an overlapping list. On a page that also mounts an eager
+ * `useGameData()` for the same list, that eager consumer starts the shared
+ * preload on mount and the deferred consumer simply rides the in-flight
+ * promise — by design, not a missed optimization.
  */
-export function useGameData(options?: { defer?: boolean }): {
+export function useGameData(options?: { defer?: boolean; schemas?: SchemaList }): {
   ready: boolean
   error: Error | null
   load: () => void
 } {
+  const schemas = options?.schemas ?? 'all'
+  // Order-independent, primitive dependency key — safe even when callers pass
+  // a fresh array literal each render (as build-time-computed props do).
+  const key = keyFor(schemas)
+
+  const subscribe = useCallback((onChange: () => void) => subscribeReady(key, onChange), [key])
+  const getSnapshot = useCallback(() => getReadySnapshot(key, schemas), [key, schemas])
   // `ready` is read through useSyncExternalStore so the server (and the first
   // hydration render) always sees the fallback while the client tracks the live
   // preload state — keeping hydration consistent without seeding state from a
   // client-only value during render.
-  const ready = useSyncExternalStore(subscribeReady, getReadySnapshot, getReadyServerSnapshot)
+  const ready = useSyncExternalStore(subscribe, getSnapshot, getReadyServerSnapshot)
   const [wanted, setWanted] = useState(!options?.defer)
   const [error, setError] = useState<Error | null>(null)
 
@@ -98,16 +142,17 @@ export function useGameData(options?: { defer?: boolean }): {
     // clearing it re-runs this effect, which retries the (reset) preload.
     if (ready || !wanted || error) return
     let cancelled = false
-    ensurePreloaded().catch((e: unknown) => {
-      // Reset the module-level promise so a retry issues a fresh request
-      // instead of re-awaiting the same rejection.
-      preloadPromise = null
+    ensurePreloaded(key, schemas).catch((e: unknown) => {
+      // Reset this key's state so a retry issues a fresh request instead of
+      // re-awaiting the same rejection.
+      preloadStates.set(key, { promise: null, done: false })
       if (!cancelled) setError(e instanceof Error ? e : new Error(String(e)))
     })
     return () => {
       cancelled = true
     }
-  }, [ready, wanted, error])
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `key` is the stable, order-independent identity of `schemas`
+  }, [ready, wanted, error, key])
 
   // Stable identity: consumers (e.g. SearchIsland) put `load` in callback
   // dependency arrays, so recreating it each render would churn their memoized
@@ -129,11 +174,16 @@ export function useGameData(options?: { defer?: boolean }): {
 export function GameDataGate({
   children,
   fallback,
+  schemas,
 }: {
   children: ReactNode
   fallback?: ReactNode
+  /** Which schemas to preload — defaults to `'all'`. See `useGameData`. */
+  schemas?: SchemaList
 }) {
-  const { ready, error, load } = useGameData()
+  // useGameData keys its preload effect off `keyFor(schemas)` (content-, not
+  // reference-based), so a fresh `[...]` array literal each render is safe.
+  const { ready, error, load } = useGameData({ schemas })
   if (error) {
     return (
       <div className="flex flex-col items-start gap-3 p-4">

--- a/apps/suref-web/src/lib/useSearchIndex.ts
+++ b/apps/suref-web/src/lib/useSearchIndex.ts
@@ -1,0 +1,91 @@
+/**
+ * Client-side loader for the build-time compact search index
+ * (`search-index.json.ts`). Mirrors `useGameData.tsx`'s SSR-safe,
+ * shared-promise pattern, but fetches a small static JSON asset instead of
+ * preloading the ORM — search islands never import `salvageunion-reference`.
+ */
+import { useState, useEffect, useCallback, useSyncExternalStore } from 'react'
+import type { CompactSearchEntry } from './searchIndexTypes'
+
+let indexPromise: Promise<CompactSearchEntry[]> | null = null
+let indexData: CompactSearchEntry[] | null = null
+const readyListeners = new Set<() => void>()
+
+/** Test-only escape hatch, mirroring `resetPreloadForTests` in useGameData.tsx. */
+export function resetSearchIndexForTests(): void {
+  indexPromise = null
+  indexData = null
+}
+
+function emitReady(): void {
+  for (const listener of readyListeners) listener()
+}
+
+function subscribeReady(onChange: () => void): () => void {
+  readyListeners.add(onChange)
+  return () => {
+    readyListeners.delete(onChange)
+  }
+}
+
+function getReadySnapshot(): boolean {
+  return indexData !== null
+}
+
+/** Server snapshot: always false — see useGameData.tsx's identical rationale
+ *  (SSR/first-hydration-render consistency; no fetch happens on the server). */
+function getReadyServerSnapshot(): boolean {
+  return false
+}
+
+function ensureLoaded(): Promise<CompactSearchEntry[]> {
+  if (indexData) return Promise.resolve(indexData)
+  if (!indexPromise) {
+    indexPromise = fetch('/search-index.json')
+      .then((res) => {
+        if (!res.ok) throw new Error(`Failed to load search index: ${res.status}`)
+        return res.json() as Promise<CompactSearchEntry[]>
+      })
+      .then((data) => {
+        indexData = data
+        emitReady()
+        return data
+      })
+  }
+  return indexPromise
+}
+
+/**
+ * @param options.defer When true, the fetch does not start on mount — it
+ * waits until `load()` is called (first user intent, e.g. focusing the
+ * search input). Mirrors `useGameData`'s `defer` option.
+ */
+export function useSearchIndex(options?: { defer?: boolean }): {
+  ready: boolean
+  error: Error | null
+  index: CompactSearchEntry[]
+  load: () => void
+} {
+  const ready = useSyncExternalStore(subscribeReady, getReadySnapshot, getReadyServerSnapshot)
+  const [wanted, setWanted] = useState(!options?.defer)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    if (ready || !wanted || error) return
+    let cancelled = false
+    ensureLoaded().catch((e: unknown) => {
+      indexPromise = null
+      if (!cancelled) setError(e instanceof Error ? e : new Error(String(e)))
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [ready, wanted, error])
+
+  const load = useCallback(() => {
+    setWanted(true)
+    setError(null)
+  }, [])
+
+  return { ready, error, index: indexData ?? [], load }
+}

--- a/apps/suref-web/src/pages/schema/[schemaId]/index.astro
+++ b/apps/suref-web/src/pages/schema/[schemaId]/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../../layouts/BaseLayout.astro'
 import { getSchemaStaticPaths } from '../../../lib/staticPaths'
 import { SchemaViewerIsland } from '../../../components/islands/SchemaViewerIsland'
 import { getUniqueTechLevels, getUniqueSources } from '../../../lib/gameData'
+import { getSchemaPreloadList } from '../../../lib/schemaPreloadDeps'
 import { SITE_URL } from '../../../lib/constants'
 
 export function getStaticPaths() {
@@ -65,6 +66,7 @@ const structuredData = {
         schemaId={schemaId!}
         techLevels={techLevels}
         sources={sources}
+        preloadSchemas={getSchemaPreloadList(schemaId!)}
       />
     </div>
   </div>

--- a/apps/suref-web/src/pages/schema/[schemaId]/item/[itemId].astro
+++ b/apps/suref-web/src/pages/schema/[schemaId]/item/[itemId].astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../../../layouts/BaseLayout.astro'
 import { getItemStaticPaths } from '../../../../lib/staticPaths'
 import { ReferenceEntityIsland } from '../../../../components/islands/ReferenceEntityIsland'
 import { getReferenceEntityData, extractStaticEntitySummary } from '../../../../lib/gameData'
+import { getSchemaPreloadList } from '../../../../lib/schemaPreloadDeps'
 import StaticEntityContent from '../../../../components/StaticEntityContent.astro'
 import { SITE_URL } from '../../../../lib/constants'
 
@@ -106,7 +107,12 @@ const ogImage = `/schema/${schemaId}/item/${itemId}.og.png`
   ]}
 >
   <article class="flex min-h-full flex-1 flex-col items-center justify-center p-4">
-    <ReferenceEntityIsland client:visible item={item} titleAs="h1" />
+    <ReferenceEntityIsland
+      client:visible
+      item={item}
+      titleAs="h1"
+      preloadSchemas={getSchemaPreloadList(schemaId!)}
+    />
     {/* SEO / no-JS fallback only. The `.js` class BaseLayout sets pre-paint
         hides this for JS users via global.css before first paint (no text
         flash); the island removes it once game data is ready. No-JS users and

--- a/apps/suref-web/src/pages/search-index.json.ts
+++ b/apps/suref-web/src/pages/search-index.json.ts
@@ -1,0 +1,15 @@
+import type { APIRoute } from 'astro'
+import { buildSearchIndexEntries } from '../lib/searchIndexBuild'
+
+/**
+ * Compact, build-time-generated search index — a small static JSON asset
+ * (id/name/slug/schemaName/schemaTitle/text per entity, no full entity data)
+ * fetched lazily by `useSearchIndex.ts` on first search interaction, instead
+ * of the search islands preloading the full ~1.3 MB reference corpus just to
+ * run `search()`.
+ */
+export const GET: APIRoute = () => {
+  return new Response(JSON.stringify(buildSearchIndexEntries()), {
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/packages/suref-react/src/components/shared/useSearchCombobox.ts
+++ b/packages/suref-react/src/components/shared/useSearchCombobox.ts
@@ -54,6 +54,14 @@ export type UseSearchComboboxOptions = {
   /** Invoked on Enter (highlighted row, else first row) — and by row clicks
    *  when the caller wires them through submit(). */
   onSubmit: (result: SearchComboboxResult) => void
+  /**
+   * Override the entity-search implementation. Defaults to the ORM-backed
+   * `search()` from `salvageunion-reference`. Pass a different implementation
+   * to decouple entity search from the full ORM/dataset — e.g. suref-web's
+   * SearchIsland runs a build-time-generated compact index instead of
+   * preloading the ~1.3 MB corpus just to power search.
+   */
+  searchFn?: (options: Parameters<typeof search>[0]) => SearchResult[]
 }
 
 function matchSchemas(query: string, slots: number): SearchComboboxResult[] {
@@ -94,6 +102,7 @@ export function useSearchCombobox({
   limit = 10,
   schemaSlots = 3,
   onSubmit,
+  searchFn = search,
 }: UseSearchComboboxOptions) {
   const [query, setQuery] = useState('')
   const [rawResults, setRawResults] = useState<SearchComboboxResult[]>([])
@@ -118,12 +127,14 @@ export function useSearchCombobox({
         return
       }
       const schemaResults = matchSchemas(searchQuery, schemaSlots)
-      const hits = ready ? search({ query: searchQuery, limit: limit - schemaResults.length }) : []
+      const hits = ready
+        ? searchFn({ query: searchQuery, limit: limit - schemaResults.length })
+        : []
       setRawResults([...schemaResults, ...hits.map(toEntityResult)])
       setHasSearched(true)
       setSelectedIndex(-1)
     },
-    [ready, limit, schemaSlots]
+    [ready, limit, schemaSlots, searchFn]
   )
 
   const handleInput = useCallback(


### PR DESCRIPTION
## Summary

ADR-005 promises "apps pay only for the data they load" via `LazyModel`/dynamic imports — but every consumer was calling `SalvageUnionReference.preload('all')`, so the lazy-loading machinery bought nothing in practice. This PR fixes it for the two apps where it's safe to fix, and explicitly leaves it alone where the codebase's own docs say it's deliberate.

### suref-web (the higher-value, lower-risk target — static site, no auth/backend, SEO/first-paint sensitive per ADR-012)

**Per-route preload lists** (`src/lib/schemaPreloadDeps.ts`) — `ReferenceEntityIsland` and `SchemaViewerIsland` now preload a computed per-schema list instead of `'all'`. This is **deliberately coarse-grained**, not a minimal per-item closure: I traced the actual cross-schema access patterns in `suref-react`'s display layer and found several *unconditional* lookups regardless of entity schema — `getTable()` always checks `roll-tables`, `RangeValueDisplay` always resolves `distances`, ability-tree prerequisite text always resolves `ability-tree-requirements`, and `[[trait]]`/keyword `DataValue`s always resolve `traits`/`keywords`. A literal minimal-per-item closure would be a correctness trap here (some misses throw via `LazyModel`, others silently degrade), so schemas are grouped into a small `ALWAYS_CORE` bundle plus two shared "extra" bundles (`CONTENT_BUNDLE`, `CHASSIS_BUNDLE`), each schema mapped to one of them.

This is backed by a **render-equivalence test** (`schemaPreloadDeps.test.tsx`): it renders every entity of every schema twice — once with the computed list, once with `'all'` — and asserts byte-identical markup. This is what actually *found* several of the bundle members (e.g. chassis abilities resolving `drones`, faction formations resolving `chassis`/`vehicles`/`squads`/`npcs`) rather than me reasoning them out by hand. Any future data or component change that adds an uncovered cross-reference fails this test instead of silently shipping degraded content.

**Build-time compact search index** — `search-index.json.ts` (a static Astro endpoint) + `lib/searchIndexBuild.ts` generate a small index (id/name/slug/schemaName/schemaTitle/text per entity, no full entity data) at build time. `SearchIsland`/`SearchResultsIsland` fetch it lazily on first interaction (`lib/useSearchIndex.ts`) and match against it (`lib/searchCompactIndex.ts`, keeps typo tolerance via a ported `withinEditDistance1`, drops per-field match weighting as a documented trade-off) instead of preloading the full ORM just to call `search()`. `suref-react`'s `useSearchCombobox` gained an optional `searchFn` override (additive, defaults to the existing ORM-backed `search()`) so this doesn't touch ITUN's `GlobalSearch`, which still uses the real ORM search.

**Bundle-size budget in CI** (`e2e/bundle-budget.e2e.ts`, new `bundle-budget-web` CI job) — asserts large schema-specific chunks (`actions`, `chassis`, etc.) never load on pages that don't need them, and total per-route JS stays under budget. No new dependency — reuses the Playwright infra already wired for `smoke.e2e.ts`.

**Measured before/after** (via Resource Timing API, `astro build` + `astro preview`, same route with `getSchemaPreloadList` temporarily forced to `'all'` for the "before" number):

| Route | Before (`preload('all')`) | After | Change |
| --- | --- | --- | --- |
| Leaf-schema item page (`/schema/traits/item/missile/`) | ~555 KB | ~277 KB | **-50%** |
| Chassis item page (`/schema/chassis/item/mule/`) | ~555 KB | ~461 KB | **-17%** (most data-heavy category — chassis+systems+modules+actions) |
| Search | full ~1.3 MB corpus via ORM | ~485 KB static index, fetched lazily | ORM removed from the search path entirely |

### in-the-union-now (flagged tension — `docs/architecture/data-flow.md` documents `preload('all')` as deliberate: "so every route can render any cross-referenced entity without per-route preload lists." This is a real, load-bearing trade-off, not an oversight, and this PR does **not** remove it)

The "middle path": `routes/__root.tsx` now renders `AppHeader` as a **sibling** of `GameDataReady` instead of a **child** of it. `GameDataReady` still wraps `<Outlet />` + `<GlobalSearch />` behind the exact same full `preload('all')` Suspense gate as before — same guarantee, same data-loading behavior, zero per-route lists introduced (avoiding the exact footgun ADR-005 warns about). The only change: brand chrome (which touches no reference data) paints on the first frame instead of sitting behind the full preload alongside everything else. This is the smallest cut that gets data-independent content off the critical rendering path without touching how any data-dependent component loads — see the updated doc comment in `GameDataReady.tsx` for the full reasoning and one documented cosmetic trade-off (the loading fallback still sizes to `min-h-dvh`, so it slightly overshoots the remaining viewport while the header is also visible during the brief loading window).

`apps/discord-bot` was not touched — its single-process `preload('all')` at startup is correct and out of scope, per the task.

## Test plan

- [x] `bun run typecheck` (full monorepo) — 0 errors
- [x] `bun --filter suref-web test` — 986 pass
- [x] `bun --filter in-the-union-now test` — 1116 pass
- [x] `bun run lint` / `bun run format:check` — pass (pre-existing warnings elsewhere untouched)
- [x] `bun run validate:all` — pass
- [x] `bun run build:package` — no drift
- [x] `bun run build` (package + web + itun + bot) — all build clean
- [x] `bun run test:coverage` + `bun tools/coverage-report.ts` — ratchet passed, every workspace improved vs. baseline
- [x] `apps/suref-web` e2e (smoke + json-api + new bundle-budget) — 7/7 pass against a real `astro build` + `astro preview`
- [x] `apps/in-the-union-now` e2e smoke, `pilot-build`, `dashboard-delete` — 4/4 pass, confirming the root-layout restructure doesn't break wizard/dashboard flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HEaZaV9wE5dvqs9hdw6r2C