### PR TITLE
fix(in-the-union-now): self-host Barlow fonts to resolve CSP violation

### DIFF
--- a/apps/in-the-union-now/index.html
+++ b/apps/in-the-union-now/index.html
@@ -7,13 +7,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" sizes="192x192" href="/icon-192.png" />
     <title>In The Union Now</title>
-    <!-- Web fonts: Barlow superfamily via Google Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600;700&family=Barlow+Semi+Condensed:wght@500;600;700&display=swap"
-      rel="stylesheet"
-    />
+    <!-- Barlow superfamily is self-hosted via @fontsource (imported in src/routes/__root.tsx) -->
   </head>
   <body>
     <div id="root"></div>

--- a/apps/in-the-union-now/package.json
+++ b/apps/in-the-union-now/package.json
@@ -17,6 +17,8 @@
     "clean": "rm -rf dist .vite node_modules/.vite"
   },
   "dependencies": {
+    "@fontsource/barlow": "5.2.8",
+    "@fontsource/barlow-semi-condensed": "5.2.7",
     "@netlify/blobs": "^10.7.9",
     "@randsum/roller": "^2.0.0",
     "@sentry/browser": "10.63.0",

--- a/apps/in-the-union-now/src/routes/__root.tsx
+++ b/apps/in-the-union-now/src/routes/__root.tsx
@@ -9,6 +9,15 @@ import { AppHeader } from '../components/shared/AppHeader'
 import { GameDataReady } from '../components/shared/GameDataReady'
 import { GlobalSearch } from '../components/shared/GlobalSearch'
 import { BackupNudgeToast } from '../components/shared/BackupNudgeToast'
+// Self-hosted Barlow superfamily (mirrors suref-web) — keeps fonts on-origin so
+// the CSP needs no external font/style host and the offline PWA renders correctly.
+import '@fontsource/barlow/400.css'
+import '@fontsource/barlow/500.css'
+import '@fontsource/barlow/600.css'
+import '@fontsource/barlow/700.css'
+import '@fontsource/barlow-semi-condensed/500.css'
+import '@fontsource/barlow-semi-condensed/600.css'
+import '@fontsource/barlow-semi-condensed/700.css'
 import '../index.css'
 
 export const Route = createRootRoute({

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,8 @@
       "name": "in-the-union-now",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource/barlow": "5.2.8",
+        "@fontsource/barlow-semi-condensed": "5.2.7",
         "@netlify/blobs": "^10.7.9",
         "@randsum/roller": "^2.0.0",
         "@sentry/browser": "10.63.0",


### PR DESCRIPTION
## Problem

ITUN's console shows a CSP violation and no web fonts load:

> Loading the stylesheet 'https://fonts.googleapis.com/css2?family=Barlow…' violates the following Content Security Policy directive: "style-src 'self' 'unsafe-inline'".

`index.html` pulled the Barlow superfamily from the **Google Fonts CDN** via `<link>` tags, but ITUN's CSP (deliberately mirrored from suref-web) restricts `style-src` to `'self' 'unsafe-inline'` and `font-src` to `'self'` — so the external stylesheet is blocked and the app falls back to system fonts.

## Fix

Mirror suref-web's already-proven strategy: **self-host** Barlow / Barlow Semi Condensed via `@fontsource` instead of poking a hole in the CSP.

- Add `@fontsource/barlow@5.2.8` + `@fontsource/barlow-semi-condensed@5.2.7` (same versions suref-web uses).
- Import the same weight set suref-web imports (Barlow 400/500/600/700, Barlow Semi Condensed 500/600/700 — identical to the old Google Fonts URL) in `src/routes/__root.tsx`.
- Remove the Google Fonts `<link>`/`preconnect` tags from `index.html`.

Why self-host rather than widen the CSP:
- Keeps fonts **on-origin** — no external `style-src`/`font-src`/`connect-src` host needed.
- ITUN is an **offline-capable PWA** — CDN fonts silently fail offline; self-hosted fonts are precached by the service worker and work offline.
- suref-web already does exactly this and even has a test asserting it never references `fonts.googleapis.com`.

## Verification

- `bun run typecheck:itun` ✅
- `bun --filter in-the-union-now test` ✅ (1116 pass, 0 fail)
- `bun run build:itun` ✅ — dist bundles Barlow `.woff2` locally; `grep fonts.googleapis dist/` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113EU8fF716XwYpiUMvGB2V