### PR TITLE
feat(header): shared HeaderShell across SRD + ITUN, cross-link the two

### DIFF
--- a/apps/in-the-union-now/src/components/shared/AppHeader.tsx
+++ b/apps/in-the-union-now/src/components/shared/AppHeader.tsx
@@ -1,8 +1,8 @@
 /**
- * AppHeader — ITUN's brand chrome, mirroring the SRD site's signature header
- * (apps/suref-web/src/components/TopNavigation.astro): su-ink-dark ground,
- * 3px su-orange-dark bottom border, SU mark, font-cond wordmark with a
- * tracked eyebrow, and a right-side link out to the SRD site.
+ * AppHeader — ITUN's brand chrome. It fills the shared HeaderShell
+ * (packages/suref-react/.../HeaderShell.tsx) — the same container + brand
+ * lockup the SRD reference site uses — with ITUN's own right-side actions:
+ * the encounter tray, the SRD search trigger, and an outbound link to the SRD.
  *
  * Rendered from the root layout on every route EXCEPT the live-sheet and
  * snapshot surfaces (/sheet/*, /s/*) — those are edge-to-edge play surfaces
@@ -10,6 +10,7 @@
  */
 
 import { Search } from 'lucide-react'
+import { HeaderShell } from 'suref-react'
 
 import { AppLink } from './AppLink'
 
@@ -30,29 +31,13 @@ type AppHeaderProps = {
 
 export function AppHeader({ onSearchClick }: AppHeaderProps) {
   return (
-    <header className="flex items-center gap-3 border-b-entity border-su-orange-dark bg-su-ink-dark px-4 py-2.5 sm:px-8 sm:py-3">
-      {/* Brand: SU mark + ITUN wordmark (with the Beta pill) + eyebrow */}
-      <AppLink href="/" className="flex min-w-0 shrink-0 items-center gap-3 no-underline">
-        <img
-          src="/logos/su-cargo-dark.svg"
-          alt="Salvage Union"
-          width={44}
-          height={44}
-          className="block size-10 shrink-0 rounded-md sm:size-11"
-        />
-        <span className="flex min-w-0 flex-col">
-          <span className="font-cond text-xl font-bold leading-none tracking-[0.005em] text-su-paper sm:text-2xl">
-            ITUN
-            <span className="ml-1.5 inline-block rounded bg-rust px-1.5 py-0.5 align-[0.3em] font-cond text-label font-bold uppercase leading-none tracking-caps-wide text-su-paper">
-              Beta
-            </span>
-          </span>
-          <span className="mt-1.5 whitespace-nowrap font-cond text-xs font-semibold uppercase leading-none tracking-eyebrow text-su-orange">
-            In The Union Now
-          </span>
-        </span>
-      </AppLink>
-
+    <HeaderShell
+      homeHref="/"
+      wordmark="ITUN"
+      badge="Beta"
+      eyebrow="In The Union Now"
+      HomeLink={AppLink}
+    >
       {/* Right side: encounter tray + search trigger + outbound SRD link */}
       <div className="ml-auto flex shrink-0 items-center gap-3 sm:gap-4">
         <AppLink
@@ -85,9 +70,9 @@ export function AppHeader({ onSearchClick }: AppHeaderProps) {
           rel="noopener noreferrer"
           className="shrink-0 font-cond text-sm font-semibold uppercase tracking-caps-snug text-su-paper no-underline transition-colors hover:text-su-orange"
         >
-          <span className="hidden sm:inline">SalvageUnion.io&nbsp;</span>SRD&nbsp;&#8599;
+          SRD&nbsp;&#8599;
         </a>
       </div>
-    </header>
+    </HeaderShell>
   )
 }

--- a/apps/in-the-union-now/src/components/shared/GlobalSearch.tsx
+++ b/apps/in-the-union-now/src/components/shared/GlobalSearch.tsx
@@ -14,9 +14,8 @@
  * - ITUN's whole tree renders behind GameDataReady (root layout), so
  *   search() is always safe here (ready defaults to true).
  *
- * Mounted once from the root layout so the shortcut works on every surface —
- * including live sheets and snapshots, where AppHeader (the visible trigger)
- * is suppressed.
+ * Mounted once from the root layout so the Cmd/Ctrl+K shortcut works on every
+ * surface, alongside the AppHeader search trigger (now present on every route).
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react'

--- a/apps/in-the-union-now/src/components/sheet/LiveSheet.tsx
+++ b/apps/in-the-union-now/src/components/sheet/LiveSheet.tsx
@@ -182,8 +182,8 @@ export function LiveSheet({
             aria-label={`Back to ${back.label.toLowerCase()}`}
             className="flex shrink-0 items-center gap-2 font-cond text-caption font-semibold uppercase tracking-caps-tight text-ink no-underline hover:text-rust"
           >
-            {/* Small SU mark keeps the brand chrome present on sheets — the
-                global AppHeader is suppressed on /sheet/* (play surface). */}
+            {/* Small SU mark anchors the sheet's own back affordance; the
+                global AppHeader (brand chrome) sits above this sticky bar. */}
             <img
               src="/logos/su-cargo-dark.svg"
               alt=""

--- a/apps/in-the-union-now/src/routes/__root.tsx
+++ b/apps/in-the-union-now/src/routes/__root.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { createRootRoute, Outlet, useRouterState } from '@tanstack/react-router'
+import { createRootRoute, Outlet } from '@tanstack/react-router'
 import type { ErrorComponentProps } from '@tanstack/react-router'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { Btn, EntityHrefProvider, Toaster } from 'suref-react'
@@ -54,34 +54,25 @@ function RootErrorComponent({ error }: ErrorComponentProps) {
   )
 }
 
-/**
- * Brand chrome is suppressed on the edge-to-edge play surfaces: live sheets
- * (/sheet/*) carry their own sticky bar (a global header would double-stack),
- * and shared snapshots (/s/*) are the same read-only sheet surface, kept
- * chrome-light for recipients.
- */
-function useShowAppHeader(): boolean {
-  const pathname = useRouterState({ select: (s) => s.location.pathname })
-  return !pathname.startsWith('/sheet/') && !pathname.startsWith('/s/')
-}
-
 function RootComponent() {
-  const showAppHeader = useShowAppHeader()
   const [searchOpen, setSearchOpen] = useState(false)
 
   return (
     <QueryClientProvider client={queryClient}>
       <EntityHrefProvider value={itunEntityHref}>
-        {/* AppHeader renders ONE level above the game-data gate (a sibling of
-            GameDataReady, not a child of it) — see GameDataReady.tsx's doc
-            comment for why: brand chrome touches no reference data, so it
-            paints immediately instead of sitting behind the full preload. */}
-        {showAppHeader && <AppHeader onSearchClick={() => setSearchOpen(true)} />}
+        {/* The shared brand header renders on EVERY route — including the live
+            sheet (/sheet/*) and snapshot (/s/*) play surfaces, which sit below
+            it and keep their own sticky control bar. It renders ONE level above
+            the game-data gate (a sibling of GameDataReady, not a child) — see
+            GameDataReady.tsx's doc comment: brand chrome touches no reference
+            data, so it paints immediately instead of sitting behind the full
+            preload. */}
+        <AppHeader onSearchClick={() => setSearchOpen(true)} />
         <GameDataReady>
           <Outlet />
           {/* Mounted on every route (inside the game-data gate, so search()
-              is always safe) — the Cmd/Ctrl+K shortcut works on live sheets
-              and snapshots too, where the AppHeader trigger is suppressed. */}
+              is always safe) so the Cmd/Ctrl+K shortcut works everywhere,
+              alongside the always-present AppHeader search trigger. */}
           <GlobalSearch open={searchOpen} onOpenChange={setSearchOpen} />
         </GameDataReady>
         <Toaster />

--- a/apps/suref-web/src/components/TopNavigation.astro
+++ b/apps/suref-web/src/components/TopNavigation.astro
@@ -1,10 +1,12 @@
 ---
+import { HeaderShell } from 'suref-react'
 import { getSchemaCatalog, SalvageUnionReference, getReferenceEntityData } from '../lib/gameData'
 import { MobileNavIsland } from './islands/MobileNavIsland'
 import { MobileSearchIsland } from './islands/MobileSearchIsland'
 import { SearchIsland } from './islands/SearchIsland'
 import { getCatalogBg, getCatalogLabel } from '../lib/catalogColors'
 import { buildCatalogCategories } from '../lib/catalogHelpers'
+import { ITUN_URL } from '../lib/constants'
 
 type BreadcrumbItem = {
   name: string
@@ -39,31 +41,16 @@ function isActive(path: string) {
 }
 ---
 
-<!-- Cargo brand header: SU mark + SalvageUnion.io wordmark on the left, existing
-     nav links pushed to the right. Dark su-ink ground, 3px rust bottom border. -->
-<nav aria-label="Main navigation" class="flex items-center gap-[14px] bg-su-ink-dark px-5 py-3 z-50 border-b-[3px] border-su-orange-dark sm:px-[34px] sm:py-[14px]" transition:name="nav" transition:animate="none">
-  <!-- Brand: solid-orange SU mark + wordmark + sub-tag -->
-  <a href="/" class="flex shrink-0 items-center gap-[14px] no-underline">
-    <img
-      src="/logos/su-cargo-dark.svg"
-      alt="Salvage Union"
-      width="64"
-      height="64"
-      class="block size-12 shrink-0 rounded-xl sm:size-16"
-    />
-    <!-- Optical tuning: wordmark 26->34px responsive, tightened leading/tracking;
-         sub-tag 13px eyebrow at 0.22em tracking. -->
-    <span class="flex min-w-0 flex-col">
-      <span class="font-cond text-[26px] font-bold leading-[0.98] tracking-[0.005em] text-su-paper sm:text-[34px]">
-        SalvageUnion<span class="text-su-orange-dark">.io</span>
-      </span>
-      <span class="mt-[7px] whitespace-nowrap font-cond text-[13px] font-semibold uppercase leading-none tracking-[0.22em] text-su-orange sm:mt-[9px]">
-        The Salvage Union SRD
-      </span>
-    </span>
-  </a>
-
-  <!-- Existing nav links + search + buy — moved to the right (margin-left:auto) -->
+<!-- Cargo brand header via the shared HeaderShell (also used by the ITUN builder):
+     SU mark + SalvageUnion.io wordmark on the left, SRD-specific nav pushed right. -->
+<HeaderShell
+  homeHref="/"
+  wordmark="SalvageUnion"
+  wordmarkAccent=".io"
+  eyebrow="The Salvage Union SRD"
+  viewTransitionName="nav"
+>
+  <!-- Existing nav links + BUILDER cross-link + search + buy — pushed right -->
   <div class="ml-auto hidden items-center gap-[26px] lg:flex">
     <a href="/" class:list={['nav-link', isActive('/schema') || currentPath === '/' ? 'nav-link-active' : '']} aria-current={isActive('/schema') || currentPath === '/' ? 'page' : undefined}>
       SRD
@@ -85,6 +72,11 @@ function isActive(path: string) {
       API
     </a>
 
+    <!-- Cross-link out to the ITUN character builder (external) -->
+    <a href={ITUN_URL} target="_blank" rel="noopener noreferrer" class="nav-link">
+      BUILDER&nbsp;&#8599;
+    </a>
+
     <SearchIsland client:idle />
     <a href="https://leyline.press/collections/salvage-union" target="_blank" rel="noopener noreferrer" class="btn btn-active shrink-0 font-cond text-[13px] uppercase tracking-[0.06em]">
       BUY THE GAME
@@ -100,7 +92,7 @@ function isActive(path: string) {
       currentPath={currentPath}
     />
   </div>
-</nav>
+</HeaderShell>
 
 {breadcrumbs && breadcrumbs.length > 0 && (
   <>

--- a/apps/suref-web/src/components/TopNavigation.astro
+++ b/apps/suref-web/src/components/TopNavigation.astro
@@ -51,7 +51,7 @@ function isActive(path: string) {
   viewTransitionName="nav"
 >
   <!-- Existing nav links + BUILDER cross-link + search + buy — pushed right -->
-  <div class="ml-auto hidden items-center gap-[26px] lg:flex">
+  <nav aria-label="Main navigation" class="ml-auto hidden items-center gap-[26px] lg:flex">
     <a href="/" class:list={['nav-link', isActive('/schema') || currentPath === '/' ? 'nav-link-active' : '']} aria-current={isActive('/schema') || currentPath === '/' ? 'page' : undefined}>
       SRD
     </a>
@@ -81,7 +81,7 @@ function isActive(path: string) {
     <a href="https://leyline.press/collections/salvage-union" target="_blank" rel="noopener noreferrer" class="btn btn-active shrink-0 font-cond text-[13px] uppercase tracking-[0.06em]">
       BUY THE GAME
     </a>
-  </div>
+  </nav>
 
   <!-- Mobile: persistent search trigger + hamburger -->
   <div class="flex lg:hidden items-center gap-1 ml-auto">

--- a/apps/suref-web/src/components/islands/MobileNavIsland.tsx
+++ b/apps/suref-web/src/components/islands/MobileNavIsland.tsx
@@ -154,6 +154,15 @@ export function MobileNavIsland({ categories, currentPath }: MobileNavIslandProp
                 DISCORD
               </Button>
               <a
+                href="https://in-the-union-now.netlify.app"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-inactive block text-center text-sm"
+                onClick={() => setOpen(false)}
+              >
+                BUILDER ↗
+              </a>
+              <a
                 href="https://leyline.press/collections/salvage-union"
                 target="_blank"
                 rel="noopener noreferrer"

--- a/apps/suref-web/src/lib/changelog.ts
+++ b/apps/suref-web/src/lib/changelog.ts
@@ -7,6 +7,13 @@ type ChangelogEntry = {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     date: '2026-07-09',
+    title: 'Link to the character builder',
+    items: [
+      'The top bar now has a BUILDER link out to In The Union Now — the no-account character builder & game manager — so you can jump straight from the reference to building pilots, mechs, and crawlers.',
+    ],
+  },
+  {
+    date: '2026-07-09',
     title: 'Faster page loads',
     items: [
       'Entity and category pages now download only the reference data they actually need, instead of the entire dataset — item and listing pages load noticeably faster, especially on slower connections.',

--- a/apps/suref-web/src/lib/constants.ts
+++ b/apps/suref-web/src/lib/constants.ts
@@ -1,4 +1,7 @@
 export const SITE_URL = 'https://salvageunion.io'
 
+/** In The Union Now — the companion character builder & game manager. */
+export const ITUN_URL = 'https://in-the-union-now.netlify.app'
+
 /** Default OG image path — the 1200×630 branded card. */
 export const DEFAULT_OG_IMAGE = '/og-image.png'

--- a/packages/suref-react/src/components/shared/HeaderShell.tsx
+++ b/packages/suref-react/src/components/shared/HeaderShell.tsx
@@ -1,0 +1,98 @@
+import type { ElementType, ReactNode } from 'react'
+
+import { cn } from '../../utils/cn'
+
+/**
+ * HeaderShell — the shared brand chrome for both SU surfaces (the SRD reference
+ * site `suref-web` and the `in-the-union-now` builder). It owns the container
+ * styling and the brand lockup (SU cargo mark + font-cond wordmark + tracked
+ * eyebrow) so the two apps read as siblings; each app supplies its own
+ * right-side actions via `children`.
+ *
+ * The canonical look is the SRD site's signature header (su-ink-dark ground,
+ * 3px su-orange-dark bottom border, 26→34px wordmark, 13px/0.22em eyebrow).
+ *
+ * Data-source agnostic (per suref-react conventions): the brand is described
+ * with primitive props so it renders identically from Astro (static, no islands
+ * inside the lockup) and from React. `HomeLink` lets React consumers inject a
+ * router-aware link (ITUN's AppLink); it defaults to a plain anchor for Astro.
+ */
+
+const CONTAINER_CLASS =
+  'flex items-center gap-[14px] bg-su-ink-dark px-5 py-3 z-50 border-b-[3px] border-su-orange-dark sm:px-[34px] sm:py-[14px]'
+
+type HeaderShellProps = {
+  /** Destination for the brand/home link (e.g. "/"). */
+  homeHref: string
+  /** Primary wordmark text (e.g. "SalvageUnion", "ITUN"). */
+  wordmark: string
+  /** Optional accent appended to the wordmark, rendered in orange (e.g. ".io"). */
+  wordmarkAccent?: string
+  /** Optional badge pill after the wordmark (e.g. "Beta"). */
+  badge?: string
+  /** Small uppercase eyebrow beneath the wordmark. */
+  eyebrow: string
+  /** Logo image src (defaults to the SU cargo mark, present in both apps' public dirs). */
+  logoSrc?: string
+  logoAlt?: string
+  /** Link component for the brand. Defaults to a plain anchor; ITUN passes AppLink. */
+  HomeLink?: ElementType
+  /** Right-side actions — unique per app (nav links, search, outbound cross-link). */
+  children?: ReactNode
+  /** Extra classes merged onto the container. */
+  className?: string
+  /**
+   * Stable CSS `view-transition-name` for the header. Astro's ClientRouter uses
+   * it to keep the (identical) bar pinned across client-side navigations instead
+   * of cross-fading it. Astro's `transition:*` directives don't forward onto a
+   * framework component's root, so suref-web passes the name here instead.
+   */
+  viewTransitionName?: string
+}
+
+export function HeaderShell({
+  homeHref,
+  wordmark,
+  wordmarkAccent,
+  badge,
+  eyebrow,
+  logoSrc = '/logos/su-cargo-dark.svg',
+  logoAlt = 'Salvage Union',
+  HomeLink = 'a',
+  children,
+  className,
+  viewTransitionName,
+}: HeaderShellProps) {
+  return (
+    <header
+      className={cn(CONTAINER_CLASS, className)}
+      style={viewTransitionName ? { viewTransitionName } : undefined}
+    >
+      {/* Brand: SU cargo mark + wordmark (+ optional accent/badge) + eyebrow */}
+      <HomeLink href={homeHref} className="flex shrink-0 items-center gap-[14px] no-underline">
+        <img
+          src={logoSrc}
+          alt={logoAlt}
+          width={64}
+          height={64}
+          className="block size-12 shrink-0 rounded-xl sm:size-16"
+        />
+        <span className="flex min-w-0 flex-col">
+          <span className="font-cond text-[26px] font-bold leading-[0.98] tracking-[0.005em] text-su-paper sm:text-[34px]">
+            {wordmark}
+            {wordmarkAccent && <span className="text-su-orange-dark">{wordmarkAccent}</span>}
+            {badge && (
+              <span className="ml-2 inline-block rounded bg-rust px-1.5 py-0.5 align-[0.32em] font-cond text-[13px] font-bold uppercase leading-none tracking-[0.08em] text-su-paper">
+                {badge}
+              </span>
+            )}
+          </span>
+          <span className="mt-[7px] whitespace-nowrap font-cond text-[13px] font-semibold uppercase leading-none tracking-[0.22em] text-su-orange sm:mt-[9px]">
+            {eyebrow}
+          </span>
+        </span>
+      </HomeLink>
+      {children}
+    </header>
+  )
+}

--- a/packages/suref-react/src/index.ts
+++ b/packages/suref-react/src/index.ts
@@ -57,6 +57,7 @@ export type {
   UseSearchComboboxOptions,
 } from './components/shared/useSearchCombobox'
 export { Footer } from './components/shared/Footer'
+export { HeaderShell } from './components/shared/HeaderShell'
 export { ValueDisplay } from './components/shared/ValueDisplay'
 export { StatDisplay } from './components/shared/StatDisplay'
 export { StatControl } from './components/shared/StatControl'


### PR DESCRIPTION
## What

The SRD reference site (`suref-web`) and the ITUN builder (`in-the-union-now`) now **share one header component** — `HeaderShell` in `suref-react` — taking the SRD site's signature top bar as the canonical style. Each app fills the shared container/brand lockup with only the actions that make sense for it, and the two now cross-link:

- **SRD → ITUN:** new external **BUILDER ↗** link (desktop nav + mobile drawer).
- **ITUN → SRD:** existing outbound link, relabelled to just **SRD ↗**.

## How

- **New `packages/suref-react/src/components/shared/HeaderShell.tsx`** — owns the container styling (su-ink-dark ground, 3px su-orange-dark border, padding, flex) and the brand lockup (SU cargo mark + font-cond wordmark + tracked eyebrow), lifted verbatim from the SRD site's `TopNavigation`. The brand is described with **primitive props** (`wordmark` / `wordmarkAccent` / `badge` / `eyebrow`) so it renders identically from Astro (static, no islands inside the lockup) and from React. `HomeLink` lets React consumers inject a router-aware link (ITUN's `AppLink`); it defaults to a plain `<a>` for Astro. Right-side content is `children`.
- **`suref-web/TopNavigation.astro`** — now renders `<HeaderShell>` with its SRD nav links + `SearchIsland` + `MobileNavIsland` as children (the `client:idle` islands still hydrate correctly inside the static React shell — verified in the build output). Adds the BUILDER link.
- **`in-the-union-now/AppHeader.tsx`** — now renders `<HeaderShell>` with ITUN's encounter/search/SRD actions; adopts the canonical (larger) brand sizing.
- **View transitions:** Astro's `transition:*` directives don't forward onto a framework component's root, so the header's stable `view-transition-name: nav` (which keeps the bar pinned across client-side navigations) is passed as a `viewTransitionName` prop instead. Verified the header carries `style="view-transition-name:nav"` in the build and no dead CSS rule remains.
- Added the ITUN URL as a `suref-web` constant and a `/changelog` entry for the new nav item (per `suref-web/CLAUDE.md`).

## Verification

- `typecheck` (astro check + tsc, all packages) ✅
- Tests: suref-web 986 ✅ · ITUN 1116 ✅ (incl. `AppHeader.test.tsx`) · suref-react 378 ✅
- Builds: `suref-web` (islands confirmed hydrating inside the shell) ✅ · ITUN ✅
- Changed files lint clean; format check clean.

## For review

- **Please eyeball the two headers on the Netlify deploy previews** (I couldn't launch a browser in this environment) — especially ITUN's **Beta** pill vertical alignment against the now-larger 34px wordmark.
- Interpretation taken: "shared **container** for styling, unique renderings each," canonical = the SRD header. If you meant a fuller single-component extraction that also absorbs the search/mobile-drawer wiring, say the word and I'll take it further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gRhovgkahuNYDfPWzs8Xn