### PR TITLE
fix(itun): resolve installed mech systems/modules by slug

### DIFF
--- a/apps/in-the-union-now/src/components/sheet/__tests__/mechItemRules.test.ts
+++ b/apps/in-the-union-now/src/components/sheet/__tests__/mechItemRules.test.ts
@@ -17,6 +17,7 @@ import {
   mechConditionsPatch,
   repairPoolTl,
   repairScrapCost,
+  resolveModule,
   resolveSystem,
 } from '../mechItemRules'
 
@@ -51,6 +52,27 @@ describe('itemEconomy', () => {
     const economy = itemEconomy(entity!)
     expect(economy.epCost).toBe(0)
     expect(economy.heat).toBe(2)
+  })
+})
+
+describe('resolveSystem / resolveModule ref forms', () => {
+  // Installed loadout refs are stored as slugs (e.g. Starter Set mechs), so
+  // slug resolution is the load-bearing case — id/name are legacy-tolerated.
+  test('resolveSystem matches a slug ref', () => {
+    const bySlug = resolveSystem('mini-mortar')
+    expect(bySlug).toBeTruthy()
+    expect(bySlug!.name).toBe('Mini Mortar')
+    expect(resolveSystem('Mini Mortar')?.id).toBe(bySlug!.id)
+  })
+
+  test('resolveModule matches a slug ref', () => {
+    const bySlug = resolveModule('comms-module')
+    expect(bySlug).toBeTruthy()
+    expect(bySlug!.name).toBe('Comms Module')
+  })
+
+  test('unresolvable ref returns null (no throw)', () => {
+    expect(resolveSystem('not-a-real-system')).toBeNull()
   })
 })
 

--- a/apps/in-the-union-now/src/components/sheet/mechItemRules.ts
+++ b/apps/in-the-union-now/src/components/sheet/mechItemRules.ts
@@ -16,19 +16,25 @@ import type {
 } from 'salvageunion-reference'
 
 import { scrapPoolBucket } from '../../lib/cargo/cargoTransfer'
+import { resolveModuleRef, resolveSystemRef } from '../../lib/rules/resolveRefs'
 import type { ScrapPool } from '../../lib/schemas/crawler'
 import type { ItemCondition, Mech } from '../../lib/schemas/mech'
 
 export type MechItem = SURefSystem | SURefModule
 
+/**
+ * Installed system/module refs are stored as SLUGS (`escape-hatch`), so these
+ * delegate to the canonical slug-aware resolvers (ADR-006) rather than the old
+ * id/name-only match — which never matched a slug and rendered every installed
+ * item as "(unknown reference)" (notably every Starter Set mech). The canonical
+ * resolvers still tolerate legacy name/id refs.
+ */
 export function resolveSystem(slug: string): SURefSystem | null {
-  const all = SalvageUnionReference.Systems.all() as ReadonlyArray<SURefSystem>
-  return all.find((s) => s.id === slug || s.name === slug) ?? null
+  return resolveSystemRef(slug)
 }
 
 export function resolveModule(slug: string): SURefModule | null {
-  const all = SalvageUnionReference.Modules.all() as ReadonlyArray<SURefModule>
-  return all.find((m) => m.id === slug || m.name === slug) ?? null
+  return resolveModuleRef(slug)
 }
 
 /**


### PR DESCRIPTION
## Problem

Starter Set mechs (and any mech built through the wizard) render every installed system and module as `<slug> (unknown reference)` instead of a proper entity card. Screenshot from the report: "MR DIG" (Bobcat) shows `escape-hatch (unknown reference)`, `comms-module (unknown reference)`, etc.

## Root cause

Installed loadout refs are stored as **slugs** (`escape-hatch`, `comms-module`) — the repo-wide "entity links use slugs" convention, and exactly what `MechWizard` (`nameToSlug(...)`) and the Starter Set seed (#371) write.

But `mechItemRules.resolveSystem`/`resolveModule` — used by the `/mechs/$id` detail route (`LoadoutSection`) and `MechSheet` — matched only:

```ts
all.find((s) => s.id === slug || s.name === slug)
```

`s.id` is a UUID and `s.name` is the display name (`"Escape Hatch"`), so a stored slug matched **neither**. Every installed item fell through to the `(unknown reference)` placeholder — the "radically simplified" rendering.

A canonical, slug-first resolver already exists in the package (`salvageunion-reference/rules` → `resolveSystemRef`/`resolveModuleRef`, ADR-006), and the wizard's `MechReviewStep` already uses it. `mechItemRules` was a divergent, id/name-only duplicate.

## Fix

Delegate `resolveSystem`/`resolveModule` to the canonical `resolveSystemRef`/`resolveModuleRef` (slug-first, legacy name/id tolerated). Removes the duplicate logic; no schema or data changes.

## Tests

- Added regression coverage in `mechItemRules.test.ts`: slug resolution for a system and a module, and the null (unresolvable) path.
- Full ITUN suite green (1119 pass, 0 fail); `typecheck` clean repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179cTmGA7XmPwzVdcQwZnHv