### PR TITLE
fix(itun): recover from blocked/failed IndexedDB opens instead of hanging on the loading skeleton

### DIFF
--- a/apps/in-the-union-now/src/hooks/queries/__tests__/useHydrateEntities.test.tsx
+++ b/apps/in-the-union-now/src/hooks/queries/__tests__/useHydrateEntities.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * useHydrateOnMount tests (production incident 2026-07-09).
+ *
+ * The load-bearing guarantee: a rejected hydrator (e.g. a blocked or failed
+ * IndexedDB open) must SURFACE to the nearest error boundary — in the app, the
+ * router's RootErrorComponent recovery screen — rather than leaving the caller
+ * on `false` (the loading skeleton) forever. Previously the hook had no error
+ * branch, so a rejected hydrate hung the Dashboard silently.
+ */
+import { afterEach, describe, expect, test } from 'bun:test'
+import { Component, type ReactNode } from 'react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+
+import { useHydrateOnMount } from '../useHydrateEntities'
+
+// biome-ignore lint/style/useComponentExportOnlyModules: local test-only error boundary, no fast-refresh boundary here
+class Boundary extends Component<{ children: ReactNode }, { error: unknown }> {
+  state: { error: unknown } = { error: null }
+  static getDerivedStateFromError(error: unknown) {
+    return { error }
+  }
+  render() {
+    if (this.state.error) {
+      return <div role="alert">caught: {(this.state.error as Error).message}</div>
+    }
+    return this.props.children
+  }
+}
+
+// biome-ignore lint/style/useComponentExportOnlyModules: local test-only probe component
+function Probe({ hydrate }: { hydrate: () => Promise<unknown> }) {
+  const hydrated = useHydrateOnMount(hydrate)
+  return <div>{hydrated ? 'ready' : 'loading'}</div>
+}
+
+afterEach(cleanup)
+
+describe('useHydrateOnMount', () => {
+  test('flips to ready when the hydrator resolves', async () => {
+    render(
+      <Boundary>
+        <Probe hydrate={() => Promise.resolve()} />
+      </Boundary>
+    )
+    await waitFor(() => expect(screen.getByText('ready')).toBeTruthy())
+  })
+
+  test('a rejected hydrator surfaces to the error boundary instead of loading forever', async () => {
+    // React logs the caught error to console.error; silence the expected noise.
+    const originalError = console.error
+    console.error = () => {}
+    try {
+      render(
+        <Boundary>
+          <Probe hydrate={() => Promise.reject(new Error('db open failed'))} />
+        </Boundary>
+      )
+      await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy())
+      expect(screen.getByText(/db open failed/)).toBeTruthy()
+    } finally {
+      console.error = originalError
+    }
+  })
+})

--- a/apps/in-the-union-now/src/hooks/queries/__tests__/useHydrateEntities.test.tsx
+++ b/apps/in-the-union-now/src/hooks/queries/__tests__/useHydrateEntities.test.tsx
@@ -14,14 +14,17 @@ import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { useHydrateOnMount } from '../useHydrateEntities'
 
 // biome-ignore lint/style/useComponentExportOnlyModules: local test-only error boundary, no fast-refresh boundary here
-class Boundary extends Component<{ children: ReactNode }, { error: unknown }> {
-  state: { error: unknown } = { error: null }
+class Boundary extends Component<{ children: ReactNode }, { caught: boolean; error: unknown }> {
+  // Track "caught" separately from the value: a thrown `null`/`undefined` must
+  // still show the fallback (mirrors why the hook uses a symbol sentinel).
+  state: { caught: boolean; error: unknown } = { caught: false, error: null }
   static getDerivedStateFromError(error: unknown) {
-    return { error }
+    return { caught: true, error }
   }
   render() {
-    if (this.state.error) {
-      return <div role="alert">caught: {(this.state.error as Error).message}</div>
+    if (this.state.caught) {
+      const message = this.state.error instanceof Error ? this.state.error.message : 'non-error'
+      return <div role="alert">caught: {message}</div>
     }
     return this.props.children
   }
@@ -57,6 +60,21 @@ describe('useHydrateOnMount', () => {
       )
       await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy())
       expect(screen.getByText(/db open failed/)).toBeTruthy()
+    } finally {
+      console.error = originalError
+    }
+  })
+
+  test('even a null rejection surfaces (sentinel guard), never a silent skeleton', async () => {
+    const originalError = console.error
+    console.error = () => {}
+    try {
+      render(
+        <Boundary>
+          <Probe hydrate={() => Promise.reject(null)} />
+        </Boundary>
+      )
+      await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy())
     } finally {
       console.error = originalError
     }

--- a/apps/in-the-union-now/src/hooks/queries/useHydrateEntities.ts
+++ b/apps/in-the-union-now/src/hooks/queries/useHydrateEntities.ts
@@ -26,15 +26,36 @@ type UseHydrateEntitiesOptions = {
  * first render only, matching the entity variant's once-on-mount semantics.
  */
 export function useHydrateOnMount(hydrate: () => Promise<unknown>): boolean {
-  const [hydrated, setHydrated] = useState(false)
+  const [state, setState] = useState<{ hydrated: boolean; error: unknown }>({
+    hydrated: false,
+    error: null,
+  })
 
   useEffect(() => {
-    void hydrate().then(() => setHydrated(true))
+    let cancelled = false
+    hydrate().then(
+      () => {
+        if (!cancelled) setState({ hydrated: true, error: null })
+      },
+      (err: unknown) => {
+        if (!cancelled) setState({ hydrated: false, error: err })
+      }
+    )
+    return () => {
+      cancelled = true
+    }
     // Only run once on mount; hydrators close over stable Zustand singletons.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  return hydrated
+  // A rejected hydration (e.g. a blocked or otherwise failed IndexedDB open)
+  // must surface as the root error boundary's recovery screen — NEVER an
+  // infinite loading skeleton. Re-throwing during render hands the error to the
+  // nearest router errorComponent (RootErrorComponent). See lib/db/index.ts's
+  // BlockedUpgradeError for the canonical case this guards against.
+  if (state.error !== null) throw state.error
+
+  return state.hydrated
 }
 
 export function useHydrateEntities(

--- a/apps/in-the-union-now/src/hooks/queries/useHydrateEntities.ts
+++ b/apps/in-the-union-now/src/hooks/queries/useHydrateEntities.ts
@@ -25,17 +25,26 @@ type UseHydrateEntitiesOptions = {
  * on mount and flip to true when it resolves. The hydrator is captured on
  * first render only, matching the entity variant's once-on-mount semantics.
  */
+/**
+ * "No error yet" sentinel. A plain `null`/`undefined` can't be used: a hydrator
+ * that rejected with `null` or `undefined` would then be indistinguishable from
+ * the initial state and NOT re-thrown — silently reproducing the stuck-skeleton
+ * bug this hook exists to prevent. A unique symbol can never collide with a
+ * real rejection reason.
+ */
+const NO_ERROR = Symbol('useHydrateOnMount.noError')
+
 export function useHydrateOnMount(hydrate: () => Promise<unknown>): boolean {
   const [state, setState] = useState<{ hydrated: boolean; error: unknown }>({
     hydrated: false,
-    error: null,
+    error: NO_ERROR,
   })
 
   useEffect(() => {
     let cancelled = false
     hydrate().then(
       () => {
-        if (!cancelled) setState({ hydrated: true, error: null })
+        if (!cancelled) setState({ hydrated: true, error: NO_ERROR })
       },
       (err: unknown) => {
         if (!cancelled) setState({ hydrated: false, error: err })
@@ -53,7 +62,7 @@ export function useHydrateOnMount(hydrate: () => Promise<unknown>): boolean {
   // infinite loading skeleton. Re-throwing during render hands the error to the
   // nearest router errorComponent (RootErrorComponent). See lib/db/index.ts's
   // BlockedUpgradeError for the canonical case this guards against.
-  if (state.error !== null) throw state.error
+  if (state.error !== NO_ERROR) throw state.error
 
   return state.hydrated
 }

--- a/apps/in-the-union-now/src/lib/db/__tests__/blocked-upgrade.test.ts
+++ b/apps/in-the-union-now/src/lib/db/__tests__/blocked-upgrade.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Blocked-upgrade tests (production incident 2026-07-09).
+ *
+ * When the app is open in another tab on an older build, that tab holds a
+ * connection at the previous DB version. A reload that needs to upgrade to
+ * DB_VERSION is BLOCKED: IndexedDB leaves the open pending indefinitely, which
+ * used to hang the Dashboard on its loading skeleton forever with no error.
+ *
+ * openItunDatabase now rejects with a typed BlockedUpgradeError after a short
+ * grace window so the root error boundary can show a "close the other tab"
+ * recovery screen. If the blocking connection closes inside the grace window,
+ * the open proceeds normally.
+ *
+ * Isolation: a DEDICATED database name (never the shared app db), and every
+ * blocking connection is opened via RAW indexedDB (no `versionchange` auto-close
+ * handler) so it genuinely blocks the way a real second tab does.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { BlockedUpgradeError, DB_VERSION, openItunDatabase } from '../index'
+import { STORE_NAMES } from '../stores'
+
+const TEST_DB_NAME = 'itun-blocked-upgrade-test'
+
+/** Delete the dedicated test database (never blocks — no other file opens it). */
+async function destroyTestDatabase(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(TEST_DB_NAME)
+    req.onsuccess = () => resolve()
+    req.onerror = () => reject(req.error)
+    req.onblocked = () => reject(new Error('deleteDatabase blocked — a connection is still open'))
+  })
+}
+
+/**
+ * Open a raw connection at `version` and KEEP it open. Deliberately installs no
+ * `onversionchange` handler, so it does not step aside for an upgrade — exactly
+ * how a stale second tab blocks the new one.
+ */
+function openBlockingConnection(version: number): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(TEST_DB_NAME, version)
+    req.onupgradeneeded = () => {
+      const db = req.result
+      for (const storeName of Object.values(STORE_NAMES)) {
+        if (!db.objectStoreNames.contains(storeName)) {
+          db.createObjectStore(storeName, { keyPath: 'id' })
+        }
+      }
+    }
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+}
+
+const tick = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+
+describe('blocked IndexedDB upgrade', () => {
+  beforeEach(destroyTestDatabase)
+  afterEach(destroyTestDatabase)
+
+  test('rejects with BlockedUpgradeError when another connection holds the old version open', async () => {
+    const blocker = await openBlockingConnection(DB_VERSION - 1)
+
+    // Silence the intentional "[itun-db] Upgrade blocked…" warning.
+    const originalWarn = console.warn
+    console.warn = () => {}
+    try {
+      await expect(openItunDatabase(TEST_DB_NAME, undefined, 20)).rejects.toBeInstanceOf(
+        BlockedUpgradeError
+      )
+    } finally {
+      console.warn = originalWarn
+      // Release the blocker; the now-unblocked orphan open resolves and the
+      // opener closes it (settled === true), so cleanup does not hit onblocked.
+      blocker.close()
+      await tick(60)
+    }
+  })
+
+  test('resolves normally when the blocking connection closes within the grace window', async () => {
+    const blocker = await openBlockingConnection(DB_VERSION - 1)
+
+    const originalWarn = console.warn
+    console.warn = () => {}
+    try {
+      // Grace comfortably exceeds the delay before the blocker steps aside.
+      const pending = openItunDatabase(TEST_DB_NAME, undefined, 500)
+      await tick(20)
+      blocker.close()
+      const db = await pending
+      try {
+        expect(db.version).toBe(DB_VERSION)
+      } finally {
+        db.close()
+      }
+    } finally {
+      console.warn = originalWarn
+    }
+  })
+
+  test('a fresh (unblocked) open still resolves at DB_VERSION', async () => {
+    const db = await openItunDatabase(TEST_DB_NAME, undefined, 20)
+    try {
+      expect(db.version).toBe(DB_VERSION)
+    } finally {
+      db.close()
+    }
+  })
+})

--- a/apps/in-the-union-now/src/lib/db/index.ts
+++ b/apps/in-the-union-now/src/lib/db/index.ts
@@ -49,6 +49,32 @@ export const DB_VERSION = 7
 
 const DB_NAME = 'itun-v1'
 
+/**
+ * How long to wait after a `blocked` event before giving up on the upgrade.
+ * A blocked upgrade (another live connection holds the previous version open,
+ * e.g. this site in another tab on an older build) leaves the open pending
+ * INDEFINITELY. We give the blocking connection a brief window to close, then
+ * reject so the UI can recover instead of hanging on the loading skeleton.
+ */
+const BLOCKED_UPGRADE_GRACE_MS = 3000
+
+/**
+ * Thrown when opening the database needs a version upgrade but another live
+ * connection blocks it (typically this site open in another tab on an older
+ * build). IndexedDB leaves such an open pending forever; surfacing it as a
+ * typed error lets the root error boundary show a "close other tabs and reload"
+ * recovery screen rather than an endless loading state.
+ */
+export class BlockedUpgradeError extends Error {
+  constructor() {
+    super(
+      'IndexedDB upgrade is blocked by another open connection. Close other ' +
+        'tabs running In the Union Now, then reload.'
+    )
+    this.name = 'BlockedUpgradeError'
+  }
+}
+
 /** Singleton promise — openDB is called once per page load. */
 let dbPromise: Promise<IDBPDatabase> | null = null
 
@@ -65,65 +91,108 @@ let dbPromise: Promise<IDBPDatabase> | null = null
  */
 export function openItunDatabase(
   name: string = DB_NAME,
-  runMigrationsFn: typeof runMigrations = runMigrations
+  runMigrationsFn: typeof runMigrations = runMigrations,
+  blockedGraceMs: number = BLOCKED_UPGRADE_GRACE_MS
 ): Promise<IDBPDatabase> {
-  return openDB(name, DB_VERSION, {
-    async upgrade(db, oldVersion, _newVersion, transaction) {
-      // v1: create all core object stores with keyPath = 'id'
-      if (oldVersion < 1) {
-        for (const storeName of [
-          STORE_NAMES.pilots,
-          STORE_NAMES.mechs,
-          STORE_NAMES.crawlers,
-          STORE_NAMES.workspaces,
-          STORE_NAMES.softLinks,
-        ]) {
-          if (!db.objectStoreNames.contains(storeName)) {
-            db.createObjectStore(storeName, { keyPath: 'id' })
+  return new Promise<IDBPDatabase>((resolve, reject) => {
+    let settled = false
+    let blockedTimer: ReturnType<typeof setTimeout> | undefined
+
+    const finish = (run: () => void): void => {
+      if (settled) return
+      settled = true
+      if (blockedTimer !== undefined) clearTimeout(blockedTimer)
+      run()
+    }
+
+    const open = openDB(name, DB_VERSION, {
+      async upgrade(db, oldVersion, _newVersion, transaction) {
+        // v1: create all core object stores with keyPath = 'id'
+        if (oldVersion < 1) {
+          for (const storeName of [
+            STORE_NAMES.pilots,
+            STORE_NAMES.mechs,
+            STORE_NAMES.crawlers,
+            STORE_NAMES.workspaces,
+            STORE_NAMES.softLinks,
+          ]) {
+            if (!db.objectStoreNames.contains(storeName)) {
+              db.createObjectStore(storeName, { keyPath: 'id' })
+            }
           }
         }
-      }
-      // v2 (Wave 4, cycle-1): add mechPatterns object store.
-      // See ADR in src/lib/schemas/pattern.ts.
-      if (oldVersion < 2) {
-        if (!db.objectStoreNames.contains(STORE_NAMES.mechPatterns)) {
-          db.createObjectStore(STORE_NAMES.mechPatterns, { keyPath: 'id' })
+        // v2 (Wave 4, cycle-1): add mechPatterns object store.
+        // See ADR in src/lib/schemas/pattern.ts.
+        if (oldVersion < 2) {
+          if (!db.objectStoreNames.contains(STORE_NAMES.mechPatterns)) {
+            db.createObjectStore(STORE_NAMES.mechPatterns, { keyPath: 'id' })
+          }
         }
-      }
-      // v5 (design-review R-5): add encounterNpcs object store (GM encounter
-      // tray). Store creation only — no record rewrites.
-      if (oldVersion < 5) {
-        if (!db.objectStoreNames.contains(STORE_NAMES.encounterNpcs)) {
-          db.createObjectStore(STORE_NAMES.encounterNpcs, { keyPath: 'id' })
+        // v5 (design-review R-5): add encounterNpcs object store (GM encounter
+        // tray). Store creation only — no record rewrites.
+        if (oldVersion < 5) {
+          if (!db.objectStoreNames.contains(STORE_NAMES.encounterNpcs)) {
+            db.createObjectStore(STORE_NAMES.encounterNpcs, { keyPath: 'id' })
+          }
         }
-      }
-      // v3+: record rewrites live in migrations/ — one file per version.
-      // runMigrations only awaits IDB operations on `transaction`, so the
-      // versionchange transaction stays open until every rewrite lands.
-      // On failure we abort the transaction: that rolls back the version bump
-      // AND surfaces as an error on the open request, so openItunDatabase()
-      // rejects rather than handing back a half-migrated database. We do NOT
-      // rethrow — idb does not await the upgrade callback's promise, so a
-      // rejected upgrade would become an unhandled rejection; abort() alone
-      // already fails the open with the failure logged below.
-      try {
-        await runMigrationsFn(db, transaction, oldVersion)
-      } catch (err) {
-        console.error('[itun-db] Migration failed — aborting upgrade transaction.', err)
-        // Guard against a transaction that already settled (e.g. auto-committed
-        // if a migration ever awaited a non-IDB promise) so abort() throwing
-        // cannot itself become an unhandled rejection.
+        // v3+: record rewrites live in migrations/ — one file per version.
+        // runMigrations only awaits IDB operations on `transaction`, so the
+        // versionchange transaction stays open until every rewrite lands.
+        // On failure we abort the transaction: that rolls back the version bump
+        // AND surfaces as an error on the open request, so openItunDatabase()
+        // rejects rather than handing back a half-migrated database. We do NOT
+        // rethrow — idb does not await the upgrade callback's promise, so a
+        // rejected upgrade would become an unhandled rejection; abort() alone
+        // already fails the open with the failure logged below.
         try {
-          // idb eagerly wires `transaction.done`; aborting rejects it. Nothing
-          // on the upgrade path awaits .done, so mark that rejection handled to
-          // keep it from surfacing as an unhandled rejection.
-          void transaction.done.catch(() => {})
-          transaction.abort()
-        } catch {
-          // already aborted/committed — nothing more to do
+          await runMigrationsFn(db, transaction, oldVersion)
+        } catch (err) {
+          console.error('[itun-db] Migration failed — aborting upgrade transaction.', err)
+          // Guard against a transaction that already settled (e.g. auto-committed
+          // if a migration ever awaited a non-IDB promise) so abort() throwing
+          // cannot itself become an unhandled rejection.
+          try {
+            // idb eagerly wires `transaction.done`; aborting rejects it. Nothing
+            // on the upgrade path awaits .done, so mark that rejection handled to
+            // keep it from surfacing as an unhandled rejection.
+            void transaction.done.catch(() => {})
+            transaction.abort()
+          } catch {
+            // already aborted/committed — nothing more to do
+          }
         }
-      }
-    },
+      },
+      blocked() {
+        console.warn(
+          '[itun-db] Upgrade blocked by another open connection — waiting for it to close.'
+        )
+        if (blockedTimer !== undefined) clearTimeout(blockedTimer)
+        blockedTimer = setTimeout(() => {
+          finish(() => reject(new BlockedUpgradeError()))
+        }, blockedGraceMs)
+      },
+      blocking() {
+        // This (older) connection is blocking a newer tab's upgrade. We only
+        // log: the active tab keeps working and the blocked tab surfaces its own
+        // recovery prompt. Auto-closing here would brick this tab's cached
+        // connection mid-session.
+        console.warn('[itun-db] This connection is blocking an upgrade in another tab.')
+      },
+    })
+
+    open.then(
+      (db) => {
+        // If we already rejected on the blocked-grace timeout, the upgrade
+        // eventually went through once the other tab closed — close the orphaned
+        // connection so it does not itself block a future upgrade.
+        if (settled) {
+          void db.close()
+          return
+        }
+        finish(() => resolve(db))
+      },
+      (err: unknown) => finish(() => reject(err))
+    )
   })
 }
 
@@ -153,7 +222,16 @@ export async function requestPersistentStorage(): Promise<void> {
 /** Lazy singleton accessor for the app database — module-private. */
 function getDb(): Promise<IDBPDatabase> {
   if (dbPromise === null) {
-    dbPromise = openItunDatabase()
+    const opening = openItunDatabase()
+    dbPromise = opening
+    // Do NOT cache a rejected open for the page's lifetime. A blocked upgrade
+    // (BlockedUpgradeError) resolves the moment the user closes the other tab —
+    // dropping the cached rejection lets the next getDb() retry cleanly instead
+    // of replaying the same failure. Only clear if we still own this promise
+    // (a concurrent reset/success must not be clobbered).
+    opening.catch(() => {
+      if (dbPromise === opening) dbPromise = null
+    })
     // Fire-and-forget on first open: ask the UA to make this origin's storage
     // eviction-resistant. Never awaited, never rejects (see helper).
     void requestPersistentStorage()

--- a/apps/in-the-union-now/src/routes/__root.tsx
+++ b/apps/in-the-union-now/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import { Btn, EntityHrefProvider, Toaster } from 'suref-react'
 import { queryClient } from '../lib/queryClient'
 import { itunEntityHref } from '../lib/entityHref'
 import { AppHeader } from '../components/shared/AppHeader'
+import { BlockedUpgradeError } from '../lib/db/index'
 import { GameDataReady } from '../components/shared/GameDataReady'
 import { GlobalSearch } from '../components/shared/GlobalSearch'
 import { BackupNudgeToast } from '../components/shared/BackupNudgeToast'
@@ -32,14 +33,24 @@ export const Route = createRootRoute({
  * offers a recovery affordance. Mirrors suref-web's IslandErrorBoundary UX.
  */
 function RootErrorComponent({ error }: ErrorComponentProps) {
+  // A blocked IndexedDB upgrade (this site open in another tab on an older
+  // build) is a distinct, self-serviceable failure — give it its own copy and
+  // CTA instead of the generic "something went wrong". Match on name too, so a
+  // structured clone or re-wrapped error across the router boundary still hits.
+  const isBlockedUpgrade =
+    error instanceof BlockedUpgradeError ||
+    (error as { name?: string } | null)?.name === 'BlockedUpgradeError'
+
   return (
     <main role="alert" className="flex min-h-dvh items-center justify-center bg-wk-bg p-6">
       <div className="flex w-full max-w-xl flex-col items-center gap-4 rounded-[6px] border-chrome border-ink bg-paper p-6 text-center sm:p-8">
         <h1 className="font-cond text-xl font-bold uppercase tracking-caps-tight text-ink">
-          Something went wrong
+          {isBlockedUpgrade ? 'Close the other tab' : 'Something went wrong'}
         </h1>
         <p className="font-body text-sm text-wk-muted">
-          The app hit an unexpected error. Your saved data is stored locally and is not affected.
+          {isBlockedUpgrade
+            ? 'In the Union Now is open in another browser tab running an older version, which is blocking this one from loading. Close every other In the Union Now tab, then reload. Your saved data is safe.'
+            : 'The app hit an unexpected error. Your saved data is stored locally and is not affected.'}
         </p>
         {import.meta.env.DEV && (
           <pre className="max-w-full overflow-auto rounded-[3px] border-chrome border-ink/20 bg-wk-bg p-3 text-left text-xs text-ink">
@@ -47,7 +58,7 @@ function RootErrorComponent({ error }: ErrorComponentProps) {
           </pre>
         )}
         <Btn variant="primary" onClick={() => window.location.reload()}>
-          Reload app
+          {isBlockedUpgrade ? 'Reload' : 'Reload app'}
         </Btn>
       </div>
     </main>


### PR DESCRIPTION
## What

Fixes the live intheunionnow.com incident where the app loaded to a blank page (only the backup-reminder toast showing), content never appeared, and the workspace switcher was inert. Diagnosed as a **blocked IndexedDB upgrade**: a stale second tab on an older build held a connection at the previous schema version, so a reload's upgrade to the new version was blocked and `openDB()` waited **indefinitely**. That hang propagated through an un-`.catch`'d hydration path and pinned the Dashboard on its loading skeleton forever — no error surfaced. Closing the other tab was the manual fix.

## Why it looked like a total hang, not an error

- The backup-nudge toast and `AppHeader` render *outside* the data gate, so they showed while everything below hung.
- `useHydrateOnMount` awaited `store.hydrate()` with **no error branch** — a rejected/hung DB open left `hydrated` false forever (skeleton), and the workspace switcher re-rendered the same skeleton on every selection.
- `getDb()` caches the opened-DB promise in a module singleton, so one failed/hung open poisoned the whole page load.

## Changes

- **`openItunDatabase`** — add a `blocked` handler that rejects with a typed **`BlockedUpgradeError`** after a short grace window (default 3s) instead of hanging; wrap the open so the grace timeout can bail out and any orphaned connection (if the block clears late) is closed. Add a `blocking` log on the older connection (log-only: the active tab keeps working; auto-closing it would brick its cached connection mid-session).
- **`getDb`** — no longer caches a rejected open, so once the user closes the blocking tab the next attempt retries cleanly.
- **`useHydrateOnMount`** — capture a rejected hydrate and re-throw during render so it reaches the router error boundary. This turns *any* failed DB open (blocked upgrade, thrown migration) into a recoverable screen instead of an infinite skeleton.
- **`RootErrorComponent`** — tailored "Close the other tab" copy + Reload CTA when the error is a `BlockedUpgradeError`; generic copy otherwise.

## Tests

- `blocked-upgrade.test.ts` — rejects with `BlockedUpgradeError` when a raw second connection holds the old version open; resolves normally if the blocker closes within the grace window; a fresh unblocked open still resolves at `DB_VERSION`.
- `useHydrateEntities.test.tsx` — a rejected hydrator surfaces to an error boundary (not an infinite loading state); a resolving one flips to ready.

Full ITUN suite: **1121 pass / 0 fail**. Typecheck clean. Lint clean (one pre-existing `useExhaustiveDependencies` warn on the once-on-mount effect, unchanged from `main`).

## Follow-up (not in this PR, deliberately)

Auto-closing + reloading the *older* tab on `blocking` would make recurrence fully seamless (no manual tab-close), but needs reload coordination to avoid bricking an active session — left as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWJM5rHeN6SZLYWeYErZjz