### PR TITLE
feat(in-the-union-now): align ITUN header with the SRD reference site

### DIFF
--- a/apps/in-the-union-now/src/components/shared/AppHeader.tsx
+++ b/apps/in-the-union-now/src/components/shared/AppHeader.tsx
@@ -1,8 +1,11 @@
 /**
  * AppHeader — ITUN's brand chrome. It fills the shared HeaderShell
  * (packages/suref-react/.../HeaderShell.tsx) — the same container + brand
- * lockup the SRD reference site uses — with ITUN's own right-side actions:
- * the encounter tray, the SRD search trigger, and an outbound link to the SRD.
+ * lockup the SRD reference site uses — with ITUN's own right-side actions,
+ * styled to match the SRD site so the two read as siblings: nav links in the
+ * SRD `.nav-link` treatment, a search box mirroring the SRD's search field,
+ * an outbound SRD cross-link to the left of search, and a "Buy the game"
+ * button (the SRD's `.btn.btn-active`).
  *
  * Rendered from the root layout on every route EXCEPT the live-sheet and
  * snapshot surfaces (/sheet/*, /s/*) — those are edge-to-edge play surfaces
@@ -14,15 +17,20 @@ import { HeaderShell } from 'suref-react'
 
 import { AppLink } from './AppLink'
 
-// Shortcut hint mirrors the platform convention (⌘K on Apple, Ctrl K elsewhere).
-// Prefer the modern UA-Client-Hints platform; navigator.platform is the
-// fallback for browsers without it (Safari/Firefox). Cosmetic-only either way.
-const IS_APPLE =
-  typeof navigator !== 'undefined' &&
-  /Mac|iP(hone|ad|od)/.test(
-    (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform ??
-      navigator.platform
-  )
+// SRD `.nav-link` treatment (apps/suref-web/src/styles/global.css), replicated
+// as utilities so ITUN's links read identically to the reference site.
+const NAV_LINK =
+  'inline-flex shrink-0 items-center font-cond text-[15px] font-semibold uppercase tracking-[0.04em] text-su-muted no-underline transition-colors hover:text-su-paper focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-su-orange'
+
+// SRD search-field treatment (SearchIsland's `.srd-search` box): bordered
+// su-black, tight radius, su-white ground, font-mono. It's a trigger button
+// here (opens the GlobalSearch modal) dressed to match the SRD's inline field.
+const SEARCH_BOX =
+  'flex shrink-0 cursor-pointer items-center gap-2 rounded border border-su-black bg-su-white px-3 py-[7px] font-mono text-[13px] text-su-grey-dark transition-colors hover:border-su-orange-dark focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-su-orange lg:w-64'
+
+// SRD `.btn.btn-active` + the buy-link modifiers from TopNavigation.astro.
+const BUY_BUTTON =
+  'inline-flex shrink-0 items-center rounded-md border border-su-orange-dark bg-su-orange-dark px-4 py-1.5 font-cond text-[13px] font-medium uppercase tracking-[0.06em] text-su-white no-underline transition-colors'
 
 type AppHeaderProps = {
   /** Opens the global reference search dialog (also bound to Cmd/Ctrl+K). */
@@ -33,44 +41,46 @@ export function AppHeader({ onSearchClick }: AppHeaderProps) {
   return (
     <HeaderShell
       homeHref="/"
-      wordmark="ITUN"
+      wordmark="IN THE UNION NOW"
       badge="Beta"
-      eyebrow="In The Union Now"
+      eyebrow="A Salvage Union Character Manager"
       HomeLink={AppLink}
+      brandShrink
     >
-      {/* Right side: encounter tray + search trigger + outbound SRD link */}
-      <div className="ml-auto flex shrink-0 items-center gap-3 sm:gap-4">
-        <AppLink
-          href="/encounter"
-          className="shrink-0 font-cond text-sm font-semibold uppercase tracking-caps-snug text-su-paper no-underline transition-colors hover:text-su-orange"
-        >
+      {/* Right side: encounter link + outbound SRD cross-link (left of search) +
+          search trigger + buy-the-game — mirroring the SRD header's right cluster.
+          Secondary items collapse on narrow screens so the row never overflows. */}
+      <div className="ml-auto flex shrink-0 items-center gap-3 sm:gap-4 lg:gap-[26px]">
+        <AppLink href="/encounter" className={NAV_LINK}>
           Encounter
         </AppLink>
+        <a
+          href="https://salvageunion.io"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`${NAV_LINK} hidden sm:inline-flex`}
+        >
+          SRD&nbsp;&#8599;
+        </a>
         {onSearchClick && (
           <button
             type="button"
             onClick={onSearchClick}
             aria-label="Search the SRD"
             aria-keyshortcuts="Meta+K Control+K"
-            className="flex cursor-pointer items-center gap-1.5 rounded-[3px] border border-su-paper/40 px-2.5 py-1.5 font-cond text-sm font-semibold uppercase tracking-caps-snug text-su-paper transition-colors hover:border-su-orange hover:text-su-orange"
+            className={SEARCH_BOX}
           >
-            <Search className="size-3.5" aria-hidden="true" />
-            <span className="hidden sm:inline">Search</span>
-            <kbd
-              aria-hidden="true"
-              className="hidden rounded-[3px] border border-su-paper/40 px-1 py-0.5 font-mono text-label leading-none sm:inline"
-            >
-              {IS_APPLE ? '⌘K' : 'Ctrl K'}
-            </kbd>
+            <Search className="size-3.5 shrink-0 opacity-60" aria-hidden="true" />
+            <span className="hidden sm:inline">Search…</span>
           </button>
         )}
         <a
-          href="https://salvageunion.io"
+          href="https://leyline.press/collections/salvage-union"
           target="_blank"
           rel="noopener noreferrer"
-          className="shrink-0 font-cond text-sm font-semibold uppercase tracking-caps-snug text-su-paper no-underline transition-colors hover:text-su-orange"
+          className={`${BUY_BUTTON} hidden lg:inline-flex`}
         >
-          SRD&nbsp;&#8599;
+          Buy the game
         </a>
       </div>
     </HeaderShell>

--- a/apps/in-the-union-now/src/components/shared/__tests__/AppHeader.test.tsx
+++ b/apps/in-the-union-now/src/components/shared/__tests__/AppHeader.test.tsx
@@ -2,10 +2,11 @@
  * Unit tests for AppHeader (brand chrome, report item P-1).
  *
  * Tests that:
- * - Renders the ITUN wordmark with the Beta pill
+ * - Renders the "IN THE UNION NOW" wordmark with the Beta pill
  * - Brand block links home ("/")
  * - Renders the SU mark image
  * - Renders an outbound SRD link (new tab, safe rel)
+ * - Renders the outbound "Buy the game" link (new tab, safe rel)
  * - Renders the search trigger only when onSearchClick is provided (P-2)
  */
 
@@ -16,12 +17,13 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { AppHeader } from '../AppHeader'
 
 describe('AppHeader', () => {
-  test('renders the ITUN wordmark with the Beta pill, linked home', () => {
+  test('renders the "IN THE UNION NOW" wordmark with the Beta pill, linked home', () => {
     render(<AppHeader />)
-    const brand = screen.getByRole('link', { name: /ITUN/i }) as HTMLAnchorElement
+    const brand = screen.getByRole('link', { name: /IN THE UNION NOW/i }) as HTMLAnchorElement
     expect(brand.getAttribute('href')).toBe('/')
-    expect(brand.textContent).toContain('ITUN')
+    expect(brand.textContent).toContain('IN THE UNION NOW')
     expect(brand.textContent).toContain('Beta')
+    expect(brand.textContent).toContain('A Salvage Union Character Manager')
   })
 
   test('renders the SU mark', () => {
@@ -36,6 +38,14 @@ describe('AppHeader', () => {
     expect(srdLink.getAttribute('href')).toBe('https://salvageunion.io')
     expect(srdLink.getAttribute('target')).toBe('_blank')
     expect(srdLink.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+
+  test('links out to buy the game in a new tab', () => {
+    render(<AppHeader />)
+    const buyLink = screen.getByRole('link', { name: /buy the game/i }) as HTMLAnchorElement
+    expect(buyLink.getAttribute('href')).toBe('https://leyline.press/collections/salvage-union')
+    expect(buyLink.getAttribute('target')).toBe('_blank')
+    expect(buyLink.getAttribute('rel')).toBe('noopener noreferrer')
   })
 
   test('renders the search trigger when onSearchClick is provided and fires it', () => {

--- a/packages/suref-react/src/components/shared/HeaderShell.tsx
+++ b/packages/suref-react/src/components/shared/HeaderShell.tsx
@@ -37,6 +37,13 @@ type HeaderShellProps = {
   logoAlt?: string
   /** Link component for the brand. Defaults to a plain anchor; ITUN passes AppLink. */
   HomeLink?: ElementType
+  /**
+   * Allow the brand lockup to shrink so a long wordmark/eyebrow wraps instead
+   * of forcing horizontal overflow (ITUN's "IN THE UNION NOW" +
+   * "A Salvage Union Character Manager"). Defaults to false — the brand stays
+   * `shrink-0`, preserving the SRD's single-line lockup exactly.
+   */
+  brandShrink?: boolean
   /** Right-side actions — unique per app (nav links, search, outbound cross-link). */
   children?: ReactNode
   /** Extra classes merged onto the container. */
@@ -59,6 +66,7 @@ export function HeaderShell({
   logoSrc = '/logos/su-cargo-dark.svg',
   logoAlt = 'Salvage Union',
   HomeLink = 'a',
+  brandShrink = false,
   children,
   className,
   viewTransitionName,
@@ -68,8 +76,17 @@ export function HeaderShell({
       className={cn(CONTAINER_CLASS, className)}
       style={viewTransitionName ? { viewTransitionName } : undefined}
     >
-      {/* Brand: SU cargo mark + wordmark (+ optional accent/badge) + eyebrow */}
-      <HomeLink href={homeHref} className="flex shrink-0 items-center gap-[14px] no-underline">
+      {/* Brand: SU cargo mark + wordmark (+ optional accent/badge) + eyebrow.
+          With `brandShrink`, the lockup may shrink (min-w-0) so a long
+          wordmark/eyebrow wraps instead of forcing horizontal overflow; the
+          default keeps it `shrink-0`, preserving the SRD's single-line lockup. */}
+      <HomeLink
+        href={homeHref}
+        className={cn(
+          'flex items-center gap-[14px] no-underline',
+          brandShrink ? 'min-w-0' : 'shrink-0'
+        )}
+      >
         <img
           src={logoSrc}
           alt={logoAlt}
@@ -87,7 +104,14 @@ export function HeaderShell({
               </span>
             )}
           </span>
-          <span className="mt-[7px] whitespace-nowrap font-cond text-[13px] font-semibold uppercase leading-none tracking-[0.22em] text-su-orange sm:mt-[9px]">
+          <span
+            className={cn(
+              'mt-[7px] font-cond text-[13px] font-semibold uppercase tracking-[0.22em] text-su-orange sm:mt-[9px]',
+              // When the brand can shrink, let a long eyebrow wrap (with room
+              // between lines); otherwise keep the SRD's single-line eyebrow.
+              brandShrink ? 'leading-tight' : 'whitespace-nowrap leading-none'
+            )}
+          >
             {eyebrow}
           </span>
         </span>


### PR DESCRIPTION
## What

Makes ITUN's header a visual sibling of the SRD reference site's header (both already fill the shared `HeaderShell` from #389). Per the request: the links and search should be the same on both — styled after the SRD — ITUN gets a "Buy the game" button, the SRD cross-link moves left of search, and the wordmark/subheader are updated.

## Changes

`apps/in-the-union-now/.../AppHeader.tsx`
- **Links** use the SRD `.nav-link` treatment (`su-muted → su-paper`, `font-cond` 15px / 0.04em uppercase), replicated as Tailwind utilities.
- **Search** trigger mirrors the SRD's `.srd-search` field — `su-white` ground, `su-black` border, `font-mono`, magnifying glass, `Search…` placeholder text; drops the `⌘K` kbd hint to match. Widens to a field (`lg:w-64`) on desktop. (Still opens the existing `GlobalSearch` modal; `Cmd/Ctrl+K` still works.)
- Adds a **"Buy the game"** button (SRD `.btn.btn-active`) → `leyline.press`.
- Moves the outbound **SRD cross-link to the left of the search box**.
- Wordmark → **"IN THE UNION NOW"** with subheader **"A Salvage Union Character Manager"** (Beta pill kept).

`packages/suref-react/.../HeaderShell.tsx` (shared)
- Brand lockup may now **shrink** (`min-w-0`) and its **eyebrow may wrap** (`leading-tight`, no `whitespace-nowrap`) so a long wordmark/eyebrow wraps instead of forcing horizontal overflow. No-op for the short SRD brand, which still fits on one line.

## Responsive note

The longer wordmark plus a busier right cluster would overcrowd small screens, so secondary items collapse progressively (mirroring the SRD, which hides its full nav below `lg`): SRD cross-link hidden `< sm`, "Buy the game" hidden `< lg`, search label hidden `< sm` (icon-only). **Encounter** (the header's only entry point to `/encounter`) and the search box stay visible at every width.

## Verification

- `bun run typecheck` ✅ · `bun run lint` (0 new) ✅ · `bun run format` ✅
- Tests: `in-the-union-now` 1117 ✅ · `suref-react` 378 ✅ · `suref-web` 986 ✅ (AppHeader tests updated for the new wordmark + Buy link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYNpgbd9TuSRbfYmqkbMsH