### PR TITLE
feat(in-the-union-now): mobile-friendly header via SRD hamburger-drawer pattern

### DIFF
--- a/apps/in-the-union-now/package.json
+++ b/apps/in-the-union-now/package.json
@@ -17,6 +17,7 @@
     "clean": "rm -rf dist .vite node_modules/.vite"
   },
   "dependencies": {
+    "@base-ui/react": "1.6.0",
     "@fontsource/barlow": "5.2.8",
     "@fontsource/barlow-semi-condensed": "5.2.7",
     "@netlify/blobs": "^10.7.9",

--- a/apps/in-the-union-now/src/components/shared/AppHeader.tsx
+++ b/apps/in-the-union-now/src/components/shared/AppHeader.tsx
@@ -16,6 +16,7 @@ import { Search } from 'lucide-react'
 import { HeaderShell } from 'suref-react'
 
 import { AppLink } from './AppLink'
+import { AppHeaderMobileMenu } from './AppHeaderMobileMenu'
 
 // SRD `.nav-link` treatment (apps/suref-web/src/styles/global.css), replicated
 // as utilities so ITUN's links read identically to the reference site.
@@ -49,16 +50,18 @@ export function AppHeader({ onSearchClick }: AppHeaderProps) {
     >
       {/* Right side: encounter link + outbound SRD cross-link (left of search) +
           search trigger + buy-the-game — mirroring the SRD header's right cluster.
-          Secondary items collapse on narrow screens so the row never overflows. */}
+          Below `lg` the nav links collapse into a hamburger drawer
+          (AppHeaderMobileMenu) so the row never overflows on a phone; search
+          stays inline as its own icon button. */}
       <div className="ml-auto flex shrink-0 items-center gap-3 sm:gap-4 lg:gap-[26px]">
-        <AppLink href="/encounter" className={NAV_LINK}>
+        <AppLink href="/encounter" className={`${NAV_LINK} hidden lg:inline-flex`}>
           Encounter
         </AppLink>
         <a
           href="https://salvageunion.io"
           target="_blank"
           rel="noopener noreferrer"
-          className={`${NAV_LINK} hidden sm:inline-flex`}
+          className={`${NAV_LINK} hidden lg:inline-flex`}
         >
           SRD&nbsp;&#8599;
         </a>
@@ -82,6 +85,9 @@ export function AppHeader({ onSearchClick }: AppHeaderProps) {
         >
           Buy the game
         </a>
+        <div className="lg:hidden">
+          <AppHeaderMobileMenu />
+        </div>
       </div>
     </HeaderShell>
   )

--- a/apps/in-the-union-now/src/components/shared/AppHeaderMobileMenu.tsx
+++ b/apps/in-the-union-now/src/components/shared/AppHeaderMobileMenu.tsx
@@ -1,0 +1,97 @@
+/**
+ * AppHeaderMobileMenu — the hamburger + slide-in drawer that holds AppHeader's
+ * secondary nav below the `lg` breakpoint.
+ *
+ * Mirrors the SRD reference site's mobile pattern
+ * (apps/suref-web/.../islands/MobileNavIsland.tsx): a base-ui `Dialog` with a
+ * hamburger `Dialog.Trigger`, a dimmed `Dialog.Backdrop`, and a full-height,
+ * right-side `Dialog.Popup` that slides in via the shared
+ * `animate-slide-in-right`/`-out` utilities (see src/index.css). Below `lg`,
+ * AppHeader collapses its Encounter / SRD / Buy links in here so the header row
+ * never overflows on a phone; search stays inline as its own icon button.
+ */
+
+import { Dialog } from '@base-ui/react/dialog'
+import { Menu, X } from 'lucide-react'
+
+import { AppLink } from './AppLink'
+
+// Full-width vertical restatements of AppHeader's `.nav-link`/buy-button looks,
+// sized up for touch targets inside the drawer.
+const DRAWER_LINK =
+  'flex items-center rounded-md border border-su-black bg-su-white px-4 py-3 font-cond text-base font-semibold uppercase tracking-[0.04em] text-su-black no-underline transition-colors hover:border-su-orange-dark hover:text-su-orange-dark focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-su-orange'
+
+const DRAWER_BUY =
+  'flex items-center justify-center rounded-md border border-su-orange-dark bg-su-orange-dark px-4 py-3 font-cond text-base font-medium uppercase tracking-[0.06em] text-su-white no-underline transition-colors hover:bg-su-orange focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-su-orange'
+
+export function AppHeaderMobileMenu() {
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger
+        render={
+          <button
+            type="button"
+            aria-label="Open menu"
+            className="flex items-center justify-center rounded-md p-1.5 text-su-paper transition-colors hover:text-su-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-su-orange"
+          >
+            <Menu className="size-6" aria-hidden="true" />
+          </button>
+        }
+      />
+
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-50 bg-black/50" />
+        <Dialog.Popup className="fixed inset-y-0 right-0 z-50 flex w-72 max-w-[85vw] flex-col bg-su-white p-4 shadow-lg data-[closed]:animate-slide-out-right data-[open]:animate-slide-in-right">
+          <Dialog.Title className="sr-only">Menu</Dialog.Title>
+
+          {/* Header row: wordmark tag | Close */}
+          <div className="mb-4 flex items-center justify-between">
+            <span className="inline-flex shrink-0 border border-su-black font-cond text-sm font-bold uppercase leading-none tracking-tight">
+              <span className="bg-su-black px-1.5 py-1 text-su-white">In the Union</span>
+              <span className="bg-su-white px-1.5 py-1 text-su-black">Now</span>
+            </span>
+            <Dialog.Close
+              render={
+                <button
+                  type="button"
+                  aria-label="Close menu"
+                  className="flex items-center justify-center rounded-md p-1 text-su-black/60 transition-colors hover:bg-su-black/10 hover:text-su-black focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-su-orange"
+                >
+                  <X className="size-5" aria-hidden="true" />
+                </button>
+              }
+            />
+          </div>
+
+          {/* Nav links */}
+          <div className="flex flex-1 flex-col gap-2 overflow-y-auto">
+            <Dialog.Close
+              render={
+                <AppLink href="/encounter" className={DRAWER_LINK}>
+                  Encounter
+                </AppLink>
+              }
+            />
+            <a
+              href="https://salvageunion.io"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={DRAWER_LINK}
+            >
+              SalvageUnion.io SRD&nbsp;&#8599;
+            </a>
+
+            <a
+              href="https://leyline.press/collections/salvage-union"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`${DRAWER_BUY} mt-auto`}
+            >
+              Buy the game
+            </a>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/apps/in-the-union-now/src/components/shared/__tests__/AppHeader.test.tsx
+++ b/apps/in-the-union-now/src/components/shared/__tests__/AppHeader.test.tsx
@@ -12,7 +12,7 @@
 
 import '@testing-library/jest-dom'
 import { describe, expect, mock, test } from 'bun:test'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
 
 import { AppHeader } from '../AppHeader'
 
@@ -59,5 +59,23 @@ describe('AppHeader', () => {
   test('omits the search trigger when onSearchClick is not provided', () => {
     render(<AppHeader />)
     expect(screen.queryByRole('button', { name: 'Search the SRD' })).toBeFalsy()
+  })
+
+  test('renders a hamburger trigger for the mobile nav drawer, closed by default', () => {
+    render(<AppHeader />)
+    expect(screen.getByRole('button', { name: 'Open menu' })).toBeTruthy()
+    expect(screen.queryByRole('dialog')).toBeFalsy()
+  })
+
+  test('opening the hamburger reveals the collapsed nav links in the drawer', () => {
+    render(<AppHeader />)
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }))
+    const drawer = screen.getByRole('dialog')
+    expect(within(drawer).getByRole('link', { name: /encounter/i })).toBeTruthy()
+    expect(within(drawer).getByRole('link', { name: /SRD/i })).toBeTruthy()
+    const buy = within(drawer).getByRole('link', {
+      name: /buy the game/i,
+    }) as HTMLAnchorElement
+    expect(buy.getAttribute('href')).toBe('https://leyline.press/collections/salvage-union')
   })
 })

--- a/apps/in-the-union-now/src/index.css
+++ b/apps/in-the-union-now/src/index.css
@@ -71,6 +71,32 @@
   }
 
   /*
+   * Mobile nav drawer slide (AppHeaderMobileMenu) — mirrors the SRD reference
+   * site's `animate-slide-in-right`/`-out` (apps/suref-web/.../global.css) so
+   * the two headers' hamburger drawers animate identically.
+   */
+  --animate-slide-in-right: slide-in-right 0.2s ease-out;
+  --animate-slide-out-right: slide-out-right 0.2s ease-in;
+
+  @keyframes slide-in-right {
+    from {
+      transform: translateX(100%);
+    }
+    to {
+      transform: translateX(0);
+    }
+  }
+
+  @keyframes slide-out-right {
+    from {
+      transform: translateX(0);
+    }
+    to {
+      transform: translateX(100%);
+    }
+  }
+
+  /*
    * === ITUN semantic type scale (design review T-5) ===
    *
    * Named steps for the sub-`text-xs` sizes the design spec uses but

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
       "name": "in-the-union-now",
       "version": "0.0.0",
       "dependencies": {
+        "@base-ui/react": "1.6.0",
         "@fontsource/barlow": "5.2.8",
         "@fontsource/barlow-semi-condensed": "5.2.7",
         "@netlify/blobs": "^10.7.9",


### PR DESCRIPTION
## What

Makes the ITUN app header mobile-friendly by mirroring the SRD reference site's mobile nav pattern.

Previously `AppHeader` copied the SRD site's *visual chrome* but never its responsive nav pattern — below narrow widths the `Encounter` / `SRD` / `Buy the game` links stayed inline and competed with the brand lockup for a single non-wrapping row, risking overflow/cramping on a phone.

## How

- Below the `lg` breakpoint the secondary nav links now collapse into a **hamburger-triggered base-ui `Dialog` slide-in drawer** (new `AppHeaderMobileMenu.tsx`), directly mirroring `apps/suref-web`'s `MobileNavIsland`. Search stays inline as its own icon button (same as the SRD site keeps a separate mobile search).
- Ported the SRD's `slide-in-right` / `slide-out-right` keyframes into ITUN's `index.css` `@theme` block so both headers animate identically (same pattern as the existing `--animate-loader-slide`).
- Added `@base-ui/react` (`1.6.0`, already resolved transitively via `suref-react`) as a direct ITUN dependency.

## Behavior

| Width | Right cluster |
|---|---|
| `< lg` | Search icon button + hamburger → drawer holds Encounter / SRD / Buy |
| `≥ lg` | Full inline row (unchanged) |

base-ui `Dialog` provides the focus trap, Escape/backdrop dismiss, and mount-through-exit animation for free.

## Testing

- `bun run typecheck` — clean across all packages
- `bun --filter in-the-union-now test` — 1125 pass (2 new: hamburger renders + drawer reveals collapsed links)
- Adversarial review pass: no blocking correctness/robustness/a11y/version issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMF1dmZ5YcLGVDBCvBLR6L