### PR TITLE
feat(in-the-union-now): add Discord link to app header

### DIFF
--- a/apps/in-the-union-now/src/components/shared/AppHeader.tsx
+++ b/apps/in-the-union-now/src/components/shared/AppHeader.tsx
@@ -65,6 +65,14 @@ export function AppHeader({ onSearchClick }: AppHeaderProps) {
         >
           SRD&nbsp;&#8599;
         </a>
+        <a
+          href="https://salvageunion.io/discord/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`${NAV_LINK} hidden lg:inline-flex`}
+        >
+          Discord&nbsp;&#8599;
+        </a>
         {onSearchClick && (
           <button
             type="button"

--- a/apps/in-the-union-now/src/components/shared/AppHeaderMobileMenu.tsx
+++ b/apps/in-the-union-now/src/components/shared/AppHeaderMobileMenu.tsx
@@ -80,6 +80,14 @@ export function AppHeaderMobileMenu() {
             >
               SalvageUnion.io SRD&nbsp;&#8599;
             </a>
+            <a
+              href="https://salvageunion.io/discord/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={DRAWER_LINK}
+            >
+              Discord&nbsp;&#8599;
+            </a>
 
             <a
               href="https://leyline.press/collections/salvage-union"

--- a/apps/in-the-union-now/src/components/shared/__tests__/AppHeader.test.tsx
+++ b/apps/in-the-union-now/src/components/shared/__tests__/AppHeader.test.tsx
@@ -40,6 +40,14 @@ describe('AppHeader', () => {
     expect(srdLink.getAttribute('rel')).toBe('noopener noreferrer')
   })
 
+  test('links out to the SRD Discord page in a new tab', () => {
+    render(<AppHeader />)
+    const discordLink = screen.getByRole('link', { name: /discord/i }) as HTMLAnchorElement
+    expect(discordLink.getAttribute('href')).toBe('https://salvageunion.io/discord/')
+    expect(discordLink.getAttribute('target')).toBe('_blank')
+    expect(discordLink.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+
   test('links out to buy the game in a new tab', () => {
     render(<AppHeader />)
     const buyLink = screen.getByRole('link', { name: /buy the game/i }) as HTMLAnchorElement
@@ -73,6 +81,10 @@ describe('AppHeader', () => {
     const drawer = screen.getByRole('dialog')
     expect(within(drawer).getByRole('link', { name: /encounter/i })).toBeTruthy()
     expect(within(drawer).getByRole('link', { name: /SRD/i })).toBeTruthy()
+    const drawerDiscord = within(drawer).getByRole('link', {
+      name: /discord/i,
+    }) as HTMLAnchorElement
+    expect(drawerDiscord.getAttribute('href')).toBe('https://salvageunion.io/discord/')
     const buy = within(drawer).getByRole('link', {
       name: /buy the game/i,
     }) as HTMLAnchorElement


### PR DESCRIPTION
## What

Adds an outbound **Discord ↗** link to the ITUN app header, pointing at the SRD site's Discord page (`https://salvageunion.io/discord/`).

## Where

- **Desktop** — new nav link in the right-side cluster of `AppHeader.tsx`, placed right after the existing SRD cross-link, using the same `NAV_LINK` treatment.
- **Mobile** — matching link in the hamburger drawer (`AppHeaderMobileMenu.tsx`), after the SRD link, using the same `DRAWER_LINK` treatment.

Mirrors the existing SRD cross-link pattern exactly (`target="_blank"`, `rel="noopener noreferrer"`, trailing ↗), so it reads as a sibling of what's already there.

## Tests

Added coverage in `AppHeader.test.tsx`:
- Desktop Discord link → correct href, new tab, safe rel.
- Drawer Discord link → correct href when the hamburger is open.

## Verification

- `bun run typecheck` — green across all packages.
- `bun --filter in-the-union-now test` — green (9/9 in AppHeader.test.tsx, full ITUN suite passing).
- `bunx biome check` on the 3 touched files — clean.

_Note: the local pre-push hook surfaced pre-existing flaky timeouts in suref-web's `schemaPreloadDeps` render-equivalence tests (5s per-test budget exceeded under parallel CPU load); they are unrelated to this ITUN-only change and are gated by CI on dedicated runners._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEeDWtdqKURzdTeyrpHuv6