### PR TITLE
fix(suref-web): point ITUN builder link at canonical intheunionnow.com

### DIFF
--- a/apps/suref-web/src/components/islands/MobileNavIsland.tsx
+++ b/apps/suref-web/src/components/islands/MobileNavIsland.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react'
 import { Dialog } from '@base-ui/react/dialog'
 import { SearchIsland } from './SearchIsland'
 import { Button } from '../Button'
+import { ITUN_URL } from '../../lib/constants'
 
 type SchemaLink = {
   id: string
@@ -154,7 +155,7 @@ export function MobileNavIsland({ categories, currentPath }: MobileNavIslandProp
                 DISCORD
               </Button>
               <a
-                href="https://in-the-union-now.netlify.app"
+                href={ITUN_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="btn btn-inactive block text-center text-sm"

--- a/apps/suref-web/src/lib/constants.ts
+++ b/apps/suref-web/src/lib/constants.ts
@@ -1,7 +1,7 @@
 export const SITE_URL = 'https://salvageunion.io'
 
 /** In The Union Now — the companion character builder & game manager. */
-export const ITUN_URL = 'https://in-the-union-now.netlify.app'
+export const ITUN_URL = 'https://intheunionnow.com'
 
 /** Default OG image path — the 1200×630 branded card. */
 export const DEFAULT_OG_IMAGE = '/og-image.png'

--- a/apps/suref-web/src/pages/discord.astro
+++ b/apps/suref-web/src/pages/discord.astro
@@ -156,7 +156,7 @@ const breadcrumbs = [
         <p class="rounded-md border-l-4 border-su-orange-dark bg-su-blue-pale px-4 py-3">
           <strong>Running a campaign?</strong> Pair the bot with{' '}
           <a
-            href="https://in-the-union-now.netlify.app"
+            href="https://intheunionnow.com"
             target="_blank"
             rel="noopener noreferrer"
             class="font-bold text-su-orange-dark hover:underline">In The Union Now</a

--- a/apps/suref-web/src/pages/discord.astro
+++ b/apps/suref-web/src/pages/discord.astro
@@ -1,6 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro'
-import { SITE_URL } from '../lib/constants'
+import { SITE_URL, ITUN_URL } from '../lib/constants'
 
 // The client id is public by design — it appears in every Discord invite
 // URL. The bot itself authenticates with its token, never this id.
@@ -156,7 +156,7 @@ const breadcrumbs = [
         <p class="rounded-md border-l-4 border-su-orange-dark bg-su-blue-pale px-4 py-3">
           <strong>Running a campaign?</strong> Pair the bot with{' '}
           <a
-            href="https://intheunionnow.com"
+            href={ITUN_URL}
             target="_blank"
             rel="noopener noreferrer"
             class="font-bold text-su-orange-dark hover:underline">In The Union Now</a


### PR DESCRIPTION
## What

The **BUILDER ↗** nav link (and the mobile-nav builder link + the Discord page's "In The Union Now" link) pointed at the Netlify preview URL `in-the-union-now.netlify.app`. This updates them to the canonical custom domain **`intheunionnow.com`**.

## How

- Update the shared `ITUN_URL` constant (`apps/suref-web/src/lib/constants.ts`) → `https://intheunionnow.com`. This drives the desktop `BUILDER ↗` nav link (`TopNavigation.astro`) automatically.
- Route the two previously-hardcoded builder links through the constant so they can't drift:
  - `MobileNavIsland.tsx`
  - `discord.astro`

## Verification

- `bun --filter suref-web typecheck` — clean
- `bun --filter suref-web test` — 986 pass, 0 fail
- Full `bun run test` suite — green across all workspaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fgchsvt3ycYMqsVuxHJMuU