### PR TITLE
feat(itun): tag Encounter as Alpha; swap SRD/Discord header link order

### DIFF
--- a/apps/in-the-union-now/src/components/encounter/EncounterScreen.tsx
+++ b/apps/in-the-union-now/src/components/encounter/EncounterScreen.tsx
@@ -111,8 +111,11 @@ export function EncounterScreen({
     <main className="min-h-screen bg-wk-bg px-4 py-5 sm:px-8 sm:py-10 lg:px-12">
       <div className="border-b-2 border-ink pb-5">
         <div className="flex flex-wrap items-end justify-between gap-4">
-          <h1 className="m-0 font-cond text-xl font-bold uppercase tracking-caps-tight text-ink">
+          <h1 className="m-0 flex items-center gap-2 font-cond text-xl font-bold uppercase tracking-caps-tight text-ink">
             Encounter Tray
+            <span className="inline-block rounded bg-rust px-1.5 py-0.5 font-cond text-[11px] font-bold uppercase leading-none tracking-[0.08em] text-su-paper">
+              Alpha
+            </span>
           </h1>
           <WorkspaceSwitcher
             activeWorkspaceId={activeWorkspaceId}

--- a/apps/in-the-union-now/src/components/shared/AppHeader.tsx
+++ b/apps/in-the-union-now/src/components/shared/AppHeader.tsx
@@ -33,6 +33,11 @@ const SEARCH_BOX =
 const BUY_BUTTON =
   'inline-flex shrink-0 items-center rounded-md border border-su-orange-dark bg-su-orange-dark px-4 py-1.5 font-cond text-[13px] font-medium uppercase tracking-[0.06em] text-su-white no-underline transition-colors'
 
+// Small "Alpha" pill — same rust treatment as HeaderShell's "Beta" badge,
+// sized down to sit inline beside the Encounter nav link.
+const ALPHA_TAG =
+  'ml-1.5 inline-block rounded bg-rust px-1 py-0.5 font-cond text-[10px] font-bold uppercase leading-none tracking-[0.08em] text-su-paper'
+
 type AppHeaderProps = {
   /** Opens the global reference search dialog (also bound to Cmd/Ctrl+K). */
   onSearchClick?: () => void
@@ -56,15 +61,8 @@ export function AppHeader({ onSearchClick }: AppHeaderProps) {
       <div className="ml-auto flex shrink-0 items-center gap-3 sm:gap-4 lg:gap-[26px]">
         <AppLink href="/encounter" className={`${NAV_LINK} hidden lg:inline-flex`}>
           Encounter
+          <span className={ALPHA_TAG}>Alpha</span>
         </AppLink>
-        <a
-          href="https://salvageunion.io"
-          target="_blank"
-          rel="noopener noreferrer"
-          className={`${NAV_LINK} hidden lg:inline-flex`}
-        >
-          SRD&nbsp;&#8599;
-        </a>
         <a
           href="https://salvageunion.io/discord/"
           target="_blank"
@@ -72,6 +70,14 @@ export function AppHeader({ onSearchClick }: AppHeaderProps) {
           className={`${NAV_LINK} hidden lg:inline-flex`}
         >
           Discord&nbsp;&#8599;
+        </a>
+        <a
+          href="https://salvageunion.io"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`${NAV_LINK} hidden lg:inline-flex`}
+        >
+          SRD&nbsp;&#8599;
         </a>
         {onSearchClick && (
           <button

--- a/apps/in-the-union-now/src/components/shared/AppHeaderMobileMenu.tsx
+++ b/apps/in-the-union-now/src/components/shared/AppHeaderMobileMenu.tsx
@@ -24,6 +24,10 @@ const DRAWER_LINK =
 const DRAWER_BUY =
   'flex items-center justify-center rounded-md border border-su-orange-dark bg-su-orange-dark px-4 py-3 font-cond text-base font-medium uppercase tracking-[0.06em] text-su-white no-underline transition-colors hover:bg-su-orange focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-su-orange'
 
+// Small "Alpha" pill — same rust treatment as HeaderShell's "Beta" badge.
+const ALPHA_TAG =
+  'ml-2 inline-block rounded bg-rust px-1.5 py-0.5 font-cond text-[11px] font-bold uppercase leading-none tracking-[0.08em] text-su-paper'
+
 export function AppHeaderMobileMenu() {
   return (
     <Dialog.Root>
@@ -69,17 +73,10 @@ export function AppHeaderMobileMenu() {
               render={
                 <AppLink href="/encounter" className={DRAWER_LINK}>
                   Encounter
+                  <span className={ALPHA_TAG}>Alpha</span>
                 </AppLink>
               }
             />
-            <a
-              href="https://salvageunion.io"
-              target="_blank"
-              rel="noopener noreferrer"
-              className={DRAWER_LINK}
-            >
-              SalvageUnion.io SRD&nbsp;&#8599;
-            </a>
             <a
               href="https://salvageunion.io/discord/"
               target="_blank"
@@ -87,6 +84,14 @@ export function AppHeaderMobileMenu() {
               className={DRAWER_LINK}
             >
               Discord&nbsp;&#8599;
+            </a>
+            <a
+              href="https://salvageunion.io"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={DRAWER_LINK}
+            >
+              SalvageUnion.io SRD&nbsp;&#8599;
             </a>
 
             <a


### PR DESCRIPTION
## Summary

Two small ITUN header/nav changes:

- **Alpha tag on Encounter** — adds a rust "Alpha" pill (reusing HeaderShell's "Beta" badge treatment) to:
  - the desktop header **Encounter** nav link
  - the mobile drawer **Encounter** link
  - the **Encounter Tray** page `<h1>`
- **Swap SRD / Discord order** — Discord now precedes SRD in both the desktop header and the mobile drawer.

## Testing

- `bun run typecheck:itun` — clean
- `bun --filter in-the-union-now test` — 1126 pass, 0 fail
- `bun run lint` / `bun run format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SU8h1isH3ZMJtRG7fzmF3