### PR TITLE
fix(itun): dedupe salvageunion-reference across subpath imports (fixes "Schema not loaded" crash)

### DIFF
--- a/apps/in-the-union-now/vite.config.ts
+++ b/apps/in-the-union-now/vite.config.ts
@@ -90,8 +90,27 @@ export default defineConfig({
   // strict browsers reject under import-attribute enforcement ("Failed to fetch
   // dynamically imported module"), breaking all reference-data loading in dev.
   // Mirrors the suref-web astro.config optimizeDeps fix (#260).
+  //
+  // List EVERY imported entry point of salvageunion-reference (main + each
+  // subpath), not just '.'. The package's stateful ORM singletons — the
+  // per-schema LazyModel instances that preload('all') installs data into —
+  // live in lib/index.ts. If only '.' is pre-bundled, esbuild bakes one copy
+  // of lib/index.ts into deps/salvageunion-reference.js, while the './rules'
+  // and './zod' subpaths (served as raw source) pull a SECOND copy of
+  // lib/index.ts with its own, never-preloaded LazyModel singletons. Rules
+  // helpers (mechMaxSP/crawlerMaxSP via 'salvageunion-reference/rules') then
+  // read that un-preloaded copy and throw `Schema "chassis" not loaded` even
+  // though GameDataReady already preloaded the main-entry copy. Listing the
+  // subpaths here makes esbuild bundle them in one pass and dedupe lib/index.ts
+  // to a single shared instance. (ADR-006 moved the rules modules into the
+  // package behind the './rules' subpath, which is what first split the
+  // instance.)
   optimizeDeps: {
-    include: ['salvageunion-reference'],
+    include: [
+      'salvageunion-reference',
+      'salvageunion-reference/rules',
+      'salvageunion-reference/zod',
+    ],
     entries: ['index.html', 'src/**/*.{ts,tsx}'],
   },
   server: {


### PR DESCRIPTION
## Problem

Opening a live sheet (e.g. `/sheet/crawler/starter-crawler-tenacity`) crashed with:

```
Error: Schema "chassis" not loaded. Call SalvageUnionReference.preload(['chassis']) ...
  at LazyModel.all (LazyModel.ts:65)
  at buildRefMap (resolveRefs.ts:47)
  at mechMaxSP (derivedStats.ts:168)
  at MechRailStats (SheetRailParts.tsx:52)
```

…even though `GameDataReady` had already `await`ed `preload('all')` and opened the game-data gate. A hard reload did not help.

## Root cause — duplicate module instances

ITUN's Vite `optimizeDeps.include` listed only the package's **main** entry, `salvageunion-reference`. esbuild pre-bundled one copy of `lib/index.ts` — the module that owns the per-schema `LazyModel` singletons that `preload()` installs data into (copy **A**).

`derivedStats.ts` (`mechMaxSP`/`crawlerMaxSP`) imports from the **`salvageunion-reference/rules`** subpath, which was *not* in the include list. Vite served it as raw source, pulling a **second** copy of `lib/index.ts` (copy **B**) with its own, never-preloaded singletons.

`GameDataReady` preloaded copy A and opened the Suspense gate; the rules helpers rendered and read copy B → `Schema not loaded`. The `/rules` subpath was introduced by ADR-006 (#382), which is what first split the instance (previously `derivedStats` lived in-app and imported the bare main entry).

## Fix

List the imported subpaths (`/rules`, `/zod`) alongside the main entry in `optimizeDeps.include`, so esbuild bundles them in one pass and dedupes `lib/index.ts` to a single shared instance.

## Verification

Headless browser against a `--force`-rebuilt dev server:

- The optimized bundles for `.` and `/rules` now both import `SalvageUnionReference` from the same shared `lib-*.js` chunk (single instance).
- Preloading via the **main** entry only (as `GameDataReady` does), then calling `crawlerMaxSP({ techLevel: 'tech-1' })` from the `/rules` subpath returns `20` with `chassisLoaded: true` and **no throw**.
- `bun run typecheck:itun` passes; Biome format/lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkTGwCzaY8RvozDff2GJYJ