### PR TITLE
fix(itun): balance live-sheet hero band vertical padding

### DIFF
--- a/apps/in-the-union-now/src/components/sheet/SheetHero.tsx
+++ b/apps/in-the-union-now/src/components/sheet/SheetHero.tsx
@@ -86,7 +86,7 @@ export function SheetHero({
       {/* Band — poster top region: name row, then IDENTITY (left) vs VITALS
           (right). Collapses to a single-column stack on mobile in the poster's
           reading order (identity → vitals). */}
-      <div className="flex flex-col gap-[18px] px-4 pb-[15px] pt-6 sm:px-5">
+      <div className="flex flex-col gap-[18px] px-4 py-[18px] sm:px-5">
         <div className="min-w-0">
           <h1 className="m-0 inline bg-ink box-decoration-clone px-2 font-cond text-[26px] font-bold uppercase leading-[1.28] text-su-white sm:text-[31px]">
             {name}


### PR DESCRIPTION
## What

The live-sheet hero band (`SheetHero`) carried a **top-heavy** vertical weight — `pt-6` (24px top) vs `pb-[15px]` (15px bottom) — so content hugged the bottom edge while the top had generous breathing room. Since the hero renders on **every** pilot / mech / crawler live sheet, this read across "many containers" with the odd top-thick / bottom-thin-rail look.

## Change

One line: balance the band to a symmetric `py-[18px]`, aligned with the band's own internal `gap-[18px]` rhythm.

```diff
- <div className="flex flex-col gap-[18px] px-4 pb-[15px] pt-6 sm:px-5">
+ <div className="flex flex-col gap-[18px] px-4 py-[18px] sm:px-5">
```

Even top/bottom padding — no more thin bottom rail. Horizontal responsive padding (`px-4 sm:px-5`) is unchanged.

## Verification

- `bun run lint` — clean
- `bun --filter in-the-union-now test` — 1071 pass / 0 fail

## Note

This is a stylistic tweak I couldn't screenshot from the sandbox — worth an eyeball on the three live sheets (pilot/mech/crawler) to confirm the balance reads right. If other sheet containers show the same weighting, happy to extend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQddU8Kiq2Fz4yJn7DYLKf