### PR TITLE
feat(itun): Blank create escape hatch — skip the wizard and creation-rule limits (Phase 1)

### DIFF
--- a/apps/in-the-union-now/src/components/sheet/__tests__/blank-entity-sheets.test.tsx
+++ b/apps/in-the-union-now/src/components/sheet/__tests__/blank-entity-sheets.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Blank entities render on their live sheets (wizard-refresh Phase 1,
+ * Open Question 4): a blank pilot (classRef ''), blank mech (chassisRef '')
+ * and blank crawler (TL only, no type) — exactly what createBlank persists —
+ * must render /sheet/{kind}/{id} without crashing.
+ *
+ * Follows the sheet-crawler-composition.test.tsx pattern: Sheet with an
+ * injected EntityLookup + SoftLinkStore, no router provider needed.
+ */
+
+import { afterEach, beforeAll, describe, expect, test } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import type { Crawler } from '../../../lib/schemas/crawler'
+import type { Mech } from '../../../lib/schemas/mech'
+import type { Pilot } from '../../../lib/schemas/pilot'
+import { seedDefaultCrawlerBays } from '../../../lib/wizard/crawlerFormState'
+import type { SoftLinkStore } from '../../wiring/useSoftLinks'
+import { Sheet } from '../Sheet'
+import type { EntityLookup } from '../Sheet'
+
+beforeAll(async () => {
+  // The live sheets resolve refs across many schemas; load the full dataset
+  // like the app's GameDataReady gate does.
+  await SalvageUnionReference.preload('all')
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+const now = new Date().toISOString()
+
+const blankPilot: Pilot = {
+  id: 'blank-pilot-1',
+  schemaVersion: 1,
+  name: 'Rook Halden',
+  callsign: 'Static',
+  classRef: '',
+  abilities: [],
+  equipment: [],
+  motto: '',
+  keepsake: '',
+  appearance: '',
+  background: '',
+  conditions: [],
+  currentHP: 10,
+  currentAP: 5,
+  createdAt: now,
+  updatedAt: now,
+}
+
+const blankMech: Mech = {
+  id: 'blank-mech-1',
+  schemaVersion: 1,
+  name: 'Unnamed Hulk',
+  chassisRef: '',
+  systems: [],
+  modules: [],
+  cargoLots: [],
+  conditions: [],
+  currentHeat: 0,
+  createdAt: now,
+  updatedAt: now,
+}
+
+const blankCrawler: Crawler = {
+  id: 'blank-crawler-1',
+  schemaVersion: 1,
+  name: 'The Long Haul',
+  techLevel: 'tech-1',
+  systems: [],
+  crawlerBays: seedDefaultCrawlerBays(),
+  scrapPool: {},
+  upgradePool: 0,
+  currentSP: 20,
+  createdAt: now,
+  updatedAt: now,
+}
+
+const lookup: EntityLookup = {
+  get: (type, id) => {
+    if (type === 'pilot' && id === blankPilot.id) return blankPilot
+    if (type === 'mech' && id === blankMech.id) return blankMech
+    if (type === 'crawler' && id === blankCrawler.id) return blankCrawler
+    return null
+  },
+} as EntityLookup
+
+const noLinks: SoftLinkStore = { softLinks: [] } as unknown as SoftLinkStore
+
+describe('blank entities render on their live sheets', () => {
+  test('blank pilot (classRef "") renders without crashing', () => {
+    render(<Sheet kind="pilot" id={blankPilot.id} entityStore={lookup} softLinkStore={noLinks} />)
+    expect(screen.getAllByText('Rook Halden').length).toBeGreaterThan(0)
+  })
+
+  test('blank mech (chassisRef "") renders without crashing', () => {
+    render(<Sheet kind="mech" id={blankMech.id} entityStore={lookup} softLinkStore={noLinks} />)
+    expect(screen.getAllByText('Unnamed Hulk').length).toBeGreaterThan(0)
+  })
+
+  test('blank crawler (TL 1, no type) renders without crashing', () => {
+    render(
+      <Sheet kind="crawler" id={blankCrawler.id} entityStore={lookup} softLinkStore={noLinks} />
+    )
+    expect(screen.getAllByText('The Long Haul').length).toBeGreaterThan(0)
+  })
+})

--- a/apps/in-the-union-now/src/components/wizard/BlankCreateDialog.tsx
+++ b/apps/in-the-union-now/src/components/wizard/BlankCreateDialog.tsx
@@ -1,0 +1,229 @@
+/**
+ * BlankCreateDialog — collects ONLY the Zod-required fields (plus the
+ * optional escape-valve pick) for a Blank create, then persists via
+ * createBlank and hands the new id back to the route (wizard-refresh Phase 1).
+ *
+ *   Pilot:   Name*, Callsign*, optional class (UNFILTERED — all classes
+ *            including specialisations).
+ *   Mech:    Name*, optional chassis (UNFILTERED — any Tech Level, no
+ *            scrap cost).
+ *   Crawler: Name*, Tech Level 1–6 (default 1 — bare stats derive from
+ *            crawler-tech-levels.json; the default SRD bays are seeded).
+ *
+ * Reuses the app's standard dialog shell (suref-react ModalShell — the same
+ * shell behind ConfirmDialog/SelectorDialog) and Field/Input chrome.
+ */
+
+import { useMemo, useState } from 'react'
+import { SalvageUnionReference, nameToSlug } from 'salvageunion-reference'
+import { Btn, Field, Input, ModalShell } from 'suref-react'
+
+import { createBlank } from '../../lib/wizard/blankCreate'
+import type { BlankCreateKind } from '../../lib/wizard/blankCreate'
+
+type BlankCreateDialogProps = {
+  kind: BlankCreateKind
+  open: boolean
+  /** Dismissed without creating — navigate back to the chooser. */
+  onClose: () => void
+  /** Created — navigate to /sheet/{kind}/{id}. */
+  onCreated: (id: string) => void
+}
+
+const KIND_LABEL: Record<BlankCreateKind, string> = {
+  pilot: 'Pilot',
+  mech: 'Mech',
+  crawler: 'Crawler',
+}
+
+const SELECT_CLASS =
+  'w-full min-h-11 rounded-[3px] border-[1.5px] border-ink bg-paper px-3 py-2.5 font-body text-sm text-ink focus:outline-none focus:ring-[3px] focus:ring-rust/[0.22]'
+
+type RefOption = { value: string; label: string }
+
+/** All classes, id-valued — deliberately unfiltered (incl. specialisations). */
+function classOptions(): RefOption[] {
+  try {
+    const all = SalvageUnionReference.Classes.all() as ReadonlyArray<{ id: string; name: string }>
+    return all.map((c) => ({ value: c.id, label: c.name }))
+  } catch {
+    return []
+  }
+}
+
+/** Sortable rank for a chassis TL (non-numeric TLs — Bio/Nanite — sort last). */
+function tlRank(tl: unknown): number {
+  return typeof tl === 'number' ? tl : Number.POSITIVE_INFINITY
+}
+
+/** All chassis, slug-valued — any Tech Level, labelled with its TL. */
+function chassisOptions(): RefOption[] {
+  try {
+    const all = SalvageUnionReference.Chassis.all()
+    return [...all]
+      .sort((a, b) => tlRank(a.techLevel) - tlRank(b.techLevel) || a.name.localeCompare(b.name))
+      .map((c) => ({
+        value: nameToSlug(c.name),
+        label: `${c.name} · TL ${String(c.techLevel)}`,
+      }))
+  } catch {
+    return []
+  }
+}
+
+/** The six crawler tech levels, numeric-valued, labelled with their names. */
+function techLevelOptions(): RefOption[] {
+  try {
+    const all = SalvageUnionReference.CrawlerTechLevels.all()
+    return [...all]
+      .sort((a, b) => a.techLevel - b.techLevel)
+      .map((t) => ({ value: String(t.techLevel), label: `TL ${t.techLevel} · ${t.name}` }))
+  } catch {
+    return []
+  }
+}
+
+export function BlankCreateDialog({ kind, open, onClose, onCreated }: BlankCreateDialogProps) {
+  const [name, setName] = useState('')
+  const [callsign, setCallsign] = useState('')
+  /** Optional class/chassis ref ('' = decide later on the sheet). */
+  const [refPick, setRefPick] = useState('')
+  const [techLevel, setTechLevel] = useState(1)
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const label = KIND_LABEL[kind]
+  const pickOptions = useMemo(
+    () => (kind === 'pilot' ? classOptions() : kind === 'mech' ? chassisOptions() : []),
+    [kind]
+  )
+  const tlOptions = useMemo(() => (kind === 'crawler' ? techLevelOptions() : []), [kind])
+
+  const canSubmit = name.trim() !== '' && (kind !== 'pilot' || callsign.trim() !== '')
+
+  async function handleCreate() {
+    setPending(true)
+    setError(null)
+    try {
+      let id: string
+      if (kind === 'pilot') {
+        id = await createBlank('pilot', {
+          name: name.trim(),
+          callsign: callsign.trim(),
+          ...(refPick !== '' ? { classRef: refPick } : {}),
+        })
+      } else if (kind === 'mech') {
+        id = await createBlank('mech', {
+          name: name.trim(),
+          ...(refPick !== '' ? { chassisRef: refPick } : {}),
+        })
+      } else {
+        id = await createBlank('crawler', { name: name.trim(), techLevel })
+      }
+      onCreated(id)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : `Failed to create ${label.toLowerCase()}.`)
+      setPending(false)
+    }
+  }
+
+  return (
+    <ModalShell
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose()
+      }}
+      title={`Blank ${label}`}
+      headerBg="bg-su-orange"
+      maxWidth="max-w-md"
+      align="center"
+    >
+      <div className="flex flex-col gap-4 bg-paper p-5">
+        <p className="m-0 font-body text-sm text-wk-muted">
+          An empty sheet — no steps, no limits. Fill in the rest on the live sheet.
+        </p>
+
+        <Field label="Name" required htmlFor={`blank-${kind}-name`}>
+          <Input
+            id={`blank-${kind}-name`}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder={`${label} name`}
+            autoComplete="off"
+          />
+        </Field>
+
+        {kind === 'pilot' && (
+          <Field label="Callsign" required htmlFor="blank-pilot-callsign">
+            <Input
+              id="blank-pilot-callsign"
+              value={callsign}
+              onChange={(e) => setCallsign(e.target.value)}
+              placeholder="Callsign"
+              autoComplete="off"
+            />
+          </Field>
+        )}
+
+        {(kind === 'pilot' || kind === 'mech') && (
+          <Field
+            label={kind === 'pilot' ? 'Class (optional)' : 'Chassis (optional)'}
+            htmlFor={`blank-${kind}-pick`}
+          >
+            <select
+              id={`blank-${kind}-pick`}
+              value={refPick}
+              onChange={(e) => setRefPick(e.target.value)}
+              className={SELECT_CLASS}
+            >
+              <option value="">None — decide on the sheet</option>
+              {pickOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </Field>
+        )}
+
+        {kind === 'crawler' && (
+          <Field label="Tech Level" htmlFor="blank-crawler-tl">
+            <select
+              id="blank-crawler-tl"
+              value={String(techLevel)}
+              onChange={(e) => setTechLevel(Number(e.target.value))}
+              className={SELECT_CLASS}
+            >
+              {tlOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </Field>
+        )}
+
+        {error && (
+          <p className="m-0 font-body text-sm text-danger" role="alert">
+            {error}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <Btn variant="ghost" size="sm" onClick={onClose} disabled={pending}>
+            Cancel
+          </Btn>
+          <Btn
+            variant="primary"
+            size="sm"
+            onClick={() => void handleCreate()}
+            disabled={pending || !canSubmit}
+            aria-label={`Create blank ${label.toLowerCase()}`}
+          >
+            {pending ? 'Creating…' : `Create ${label}`}
+          </Btn>
+        </div>
+      </div>
+    </ModalShell>
+  )
+}

--- a/apps/in-the-union-now/src/components/wizard/CreateModeChooser.tsx
+++ b/apps/in-the-union-now/src/components/wizard/CreateModeChooser.tsx
@@ -1,0 +1,148 @@
+/**
+ * CreateModeChooser — the "which door?" screen every /new opens on
+ * (wizard-refresh Phase 1, mockup Screen 04).
+ *
+ * Two manual-style doors under a poster band: GUIDED (primary — the existing
+ * step wizard) and BLANK (the escape hatch — an empty sheet, no steps, no
+ * limits). For mechs a third door joins the Blank family: Instantiate from
+ * Pattern, which links to the existing /mechs/patterns flow.
+ *
+ * Styling reuses the live sheets' poster language — the `.sheet--{kind}` tone
+ * ground, ink stamps, and the hero band idiom from LiveSheet/SheetHero — so
+ * the chooser reads as a sibling surface, not a bolted-on screen.
+ */
+
+import { cn } from '../../lib/utils'
+import { AppLink } from '../shared/AppLink'
+
+import type { BlankCreateKind } from '../../lib/wizard/blankCreate'
+
+type CreateModeChooserProps = {
+  kind: BlankCreateKind
+  /** Chosen the Guided door — navigate to ?mode=guided. */
+  onGuided: () => void
+  /** Chosen the Blank door — navigate to ?mode=blank. */
+  onBlank: () => void
+}
+
+const KIND_LABEL: Record<BlankCreateKind, string> = {
+  pilot: 'Pilot',
+  mech: 'Mech',
+  crawler: 'Crawler',
+}
+
+/** Guided-door copy + Core Book citation per kind (mockup Screen 04). */
+const GUIDED_COPY: Record<BlankCreateKind, { body: string; cite: string }> = {
+  pilot: {
+    body: 'Step through the Pilot Bay rules, one card at a time — class, abilities, equipment, identity.',
+    cite: 'The Pilot Bay begins on p. 18.',
+  },
+  mech: {
+    body: 'Step through the Mech Bay rules, one card at a time — chassis, pattern, systems and modules.',
+    cite: 'The Mech Bay begins on p. 94.',
+  },
+  crawler: {
+    body: 'Step through crawler creation, one card at a time — type, armament, crew, identity.',
+    cite: 'Union Crawlers begin on p. 212.',
+  },
+}
+
+/** Shared door frame (mockup `.door`) — the two variants restyle it below. */
+const DOOR_CLASS =
+  'relative min-h-[170px] cursor-pointer rounded-xl p-[22px] pb-5 pl-[26px] text-left transition-transform duration-[120ms] hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-rust/[0.22]'
+
+/** Black notched tab overhanging the door's left edge (mockup `.dtab`). */
+const DTAB_CLASS =
+  'absolute -left-3.5 top-[18px] grid h-12 w-11 place-items-center rounded-[2px] bg-ink font-cond text-[22px] font-bold text-su-white shadow-[0_8px_14px_-8px_rgba(0,0,0,0.55)]'
+
+/** Condensed-caps door heading (mockup `.dhead`). */
+const DHEAD_CLASS =
+  'mb-1.5 ml-[34px] block font-cond text-[27px] font-bold uppercase leading-none tracking-[0.04em]'
+
+const DBODY_CLASS = 'ml-[34px] block font-body text-[13px] leading-[1.55]'
+const DCITE_CLASS = 'ml-[34px] mt-2.5 block font-body text-[12.5px] font-bold'
+
+export function CreateModeChooser({ kind, onGuided, onBlank }: CreateModeChooserProps) {
+  const label = KIND_LABEL[kind]
+  const guided = GUIDED_COPY[kind]
+
+  return (
+    <section
+      className={cn(`sheet--${kind}`, 'min-h-dvh')}
+      style={{ background: 'var(--ground)' }}
+      aria-label={`New ${label.toLowerCase()} — choose how to create`}
+    >
+      {/* Poster band (mockup `.band` + `.banner`): tone ground, white
+          condensed banner, a white rule then a tone bandtail below it. */}
+      <header
+        className="border-b-4 border-su-white/95 px-5 pb-3.5 pt-7 sm:px-7"
+        style={{ background: 'var(--tone)' }}
+      >
+        <h1 className="m-0 font-cond text-[clamp(34px,5.2vw,54px)] font-bold uppercase leading-[0.98] tracking-[0.5px] text-su-white [text-shadow:0_2px_0_rgba(0,0,0,0.22)]">
+          New {label}
+        </h1>
+      </header>
+      <div className="h-2.5" style={{ background: 'var(--tone)' }} aria-hidden="true" />
+
+      <div className="mx-auto w-full max-w-4xl px-6 py-8 sm:px-8 sm:py-10">
+        {/* The two doors (mockup `.choosegrid`). */}
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 sm:gap-5">
+          {/* GUIDED — primary: filled in the section tone, double ink ring. */}
+          <button
+            type="button"
+            onClick={onGuided}
+            className={cn(
+              DOOR_CLASS,
+              'shadow-[0_0_0_3px_var(--ground),0_0_0_7px_var(--color-ink),0_18px_30px_-14px_rgba(0,0,0,0.5)]'
+            )}
+            style={{ background: 'var(--tone)' }}
+          >
+            <span className={DTAB_CLASS} aria-hidden="true">
+              ▶
+            </span>
+            <span
+              className={cn(DHEAD_CLASS, 'text-su-white [text-shadow:0_1px_0_rgba(0,0,0,0.38)]')}
+            >
+              Guided
+            </span>
+            <span className={cn(DBODY_CLASS, 'text-ink')}>{guided.body}</span>
+            <span className={cn(DCITE_CLASS, 'text-ink')}>{guided.cite}</span>
+          </button>
+
+          {/* BLANK — the escape hatch: dashed empty door on paper. */}
+          <button
+            type="button"
+            onClick={onBlank}
+            className={cn(
+              DOOR_CLASS,
+              'border-[3px] border-dashed border-ink/55 bg-paper text-ink shadow-[0_14px_26px_-14px_rgba(0,0,0,0.4)]'
+            )}
+          >
+            <span className={DTAB_CLASS} aria-hidden="true">
+              ✎
+            </span>
+            <span className={cn(DHEAD_CLASS, 'text-ink')}>Blank</span>
+            <span className={DBODY_CLASS}>
+              An empty sheet. No steps, no limits. Fill it in on the live sheet.
+            </span>
+            <span className={DCITE_CLASS}>For veterans, imports, and homebrew.</span>
+          </button>
+        </div>
+
+        {/* Mech only: the third Blank-family door — Instantiate from Pattern
+            (mockup `.thirdnote`, made actionable: links to the existing
+            /mechs/patterns flow). */}
+        {kind === 'mech' && (
+          <AppLink
+            href="/mechs/patterns"
+            className="mx-auto mt-6 block w-fit max-w-[92%] rounded-[2px] bg-ink px-4 py-2 text-center font-cond text-[11px] font-bold uppercase leading-relaxed tracking-[0.1em] text-su-white no-underline hover:bg-ink/85"
+          >
+            A third door in the Blank family —{' '}
+            <span className="text-su-orange">Instantiate from Pattern</span> · stamp a saved
+            pattern, then edit freely
+          </AppLink>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/apps/in-the-union-now/src/components/wizard/NewEntityScreen.tsx
+++ b/apps/in-the-union-now/src/components/wizard/NewEntityScreen.tsx
@@ -1,0 +1,55 @@
+/**
+ * NewEntityScreen — the mode switch behind every /new route (wizard-refresh
+ * Phase 1). Router-agnostic so the three routes stay thin and the routing
+ * behaviour is testable without a RouterProvider:
+ *
+ *   mode absent   → CreateModeChooser (Guided vs Blank doors)
+ *   mode 'guided' → the EXISTING wizard, rendered unchanged (`wizard` slot)
+ *   mode 'blank'  → the chooser with the Blank dialog open over it
+ */
+
+import type { ReactNode } from 'react'
+
+import type { BlankCreateKind } from '../../lib/wizard/blankCreate'
+import type { CreateMode } from '../../lib/wizard/createMode'
+import { BlankCreateDialog } from './BlankCreateDialog'
+import { CreateModeChooser } from './CreateModeChooser'
+
+type NewEntityScreenProps = {
+  kind: BlankCreateKind
+  mode: CreateMode
+  /** The existing guided wizard — rendered UNCHANGED when mode==='guided'. */
+  wizard: ReactNode
+  /** Move between modes (routes map this onto the `mode` search param). */
+  onModeChange: (mode: CreateMode) => void
+  /** A Blank entity was persisted — navigate to its live sheet. */
+  onCreated: (id: string) => void
+}
+
+export function NewEntityScreen({
+  kind,
+  mode,
+  wizard,
+  onModeChange,
+  onCreated,
+}: NewEntityScreenProps) {
+  if (mode === 'guided') {
+    return <>{wizard}</>
+  }
+
+  return (
+    <>
+      <CreateModeChooser
+        kind={kind}
+        onGuided={() => onModeChange('guided')}
+        onBlank={() => onModeChange('blank')}
+      />
+      <BlankCreateDialog
+        kind={kind}
+        open={mode === 'blank'}
+        onClose={() => onModeChange(undefined)}
+        onCreated={onCreated}
+      />
+    </>
+  )
+}

--- a/apps/in-the-union-now/src/components/wizard/__tests__/NewEntityScreen.test.tsx
+++ b/apps/in-the-union-now/src/components/wizard/__tests__/NewEntityScreen.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * NewEntityScreen + CreateModeChooser + BlankCreateDialog (wizard-refresh
+ * Phase 1): mode routing renders chooser vs wizard vs blank dialog, the
+ * chooser doors fire their callbacks, and the Blank dialog persists a
+ * schema-valid entity through createBlank.
+ *
+ * Conventions: toBeTruthy() not toBeInTheDocument(), no mock.module().
+ * fake-indexeddb/auto is preloaded via bunfig.toml.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import { _clearAllStores, _resetDbSingleton } from '../../../lib/db/index'
+import { PilotSchema } from '../../../lib/schemas/pilot'
+import { parseCreateMode } from '../../../lib/wizard/createMode'
+import { useEntityStore } from '../../../stores/entityStore'
+import { NewEntityScreen } from '../NewEntityScreen'
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload(['classes', 'chassis', 'crawler-bays', 'crawler-tech-levels'])
+})
+
+function resetEntityStore(): void {
+  useEntityStore.setState({
+    pilots: [],
+    mechs: [],
+    crawlers: [],
+    softLinks: [],
+    hydrated: { pilots: false, mechs: false, crawlers: false, softLinks: false },
+  })
+}
+
+beforeEach(async () => {
+  _resetDbSingleton()
+  await _clearAllStores()
+  resetEntityStore()
+})
+
+afterEach(async () => {
+  cleanup()
+  await _clearAllStores()
+  resetEntityStore()
+})
+
+const noop = () => {}
+
+describe('parseCreateMode', () => {
+  test('narrows valid modes and drops anything else', () => {
+    expect(parseCreateMode('guided')).toBe('guided')
+    expect(parseCreateMode('blank')).toBe('blank')
+    expect(parseCreateMode('nonsense')).toBeUndefined()
+    expect(parseCreateMode(undefined)).toBeUndefined()
+    expect(parseCreateMode(42)).toBeUndefined()
+  })
+})
+
+describe('NewEntityScreen — mode routing', () => {
+  test('mode absent renders the chooser, not the wizard or dialog', () => {
+    render(
+      <NewEntityScreen
+        kind="pilot"
+        mode={undefined}
+        wizard={<div data-testid="stub-wizard" />}
+        onModeChange={noop}
+        onCreated={noop}
+      />
+    )
+    expect(screen.getByRole('heading', { name: /new pilot/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /guided/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /blank/i })).toBeTruthy()
+    expect(screen.queryByTestId('stub-wizard')).toBeFalsy()
+    expect(screen.queryByRole('dialog')).toBeFalsy()
+  })
+
+  test("mode 'guided' renders the wizard slot unchanged, no chooser", () => {
+    render(
+      <NewEntityScreen
+        kind="pilot"
+        mode="guided"
+        wizard={<div data-testid="stub-wizard" />}
+        onModeChange={noop}
+        onCreated={noop}
+      />
+    )
+    expect(screen.getByTestId('stub-wizard')).toBeTruthy()
+    expect(screen.queryByRole('heading', { name: /new pilot/i })).toBeFalsy()
+  })
+
+  test("mode 'blank' opens the blank dialog over the chooser", () => {
+    const { container } = render(
+      <NewEntityScreen
+        kind="pilot"
+        mode="blank"
+        wizard={<div data-testid="stub-wizard" />}
+        onModeChange={noop}
+        onCreated={noop}
+      />
+    )
+    // The chooser stays mounted underneath (base-ui inerts it while the
+    // modal is open, so query structurally rather than by role).
+    expect(container.querySelector('.sheet--pilot')).toBeTruthy()
+    expect(screen.getByRole('dialog')).toBeTruthy()
+    expect(screen.getByLabelText(/callsign/i)).toBeTruthy()
+  })
+
+  test('chooser doors fire onModeChange with the chosen mode', () => {
+    const calls: Array<'guided' | 'blank' | undefined> = []
+    render(
+      <NewEntityScreen
+        kind="crawler"
+        mode={undefined}
+        wizard={null}
+        onModeChange={(next) => calls.push(next)}
+        onCreated={noop}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /guided/i }))
+    fireEvent.click(screen.getByRole('button', { name: /blank/i }))
+    expect(calls).toEqual(['guided', 'blank'])
+  })
+})
+
+describe('CreateModeChooser — mech third door', () => {
+  test('mech chooser surfaces Instantiate from Pattern linking to /mechs/patterns', () => {
+    render(
+      <NewEntityScreen
+        kind="mech"
+        mode={undefined}
+        wizard={null}
+        onModeChange={noop}
+        onCreated={noop}
+      />
+    )
+    const patternDoor = screen.getByRole('link', { name: /instantiate from pattern/i })
+    expect(patternDoor).toBeTruthy()
+    expect((patternDoor as HTMLAnchorElement).href).toContain('/mechs/patterns')
+  })
+
+  test('pilot and crawler choosers do NOT show the pattern door', () => {
+    const { unmount } = render(
+      <NewEntityScreen
+        kind="pilot"
+        mode={undefined}
+        wizard={null}
+        onModeChange={noop}
+        onCreated={noop}
+      />
+    )
+    expect(screen.queryByRole('link', { name: /instantiate from pattern/i })).toBeFalsy()
+    unmount()
+
+    render(
+      <NewEntityScreen
+        kind="crawler"
+        mode={undefined}
+        wizard={null}
+        onModeChange={noop}
+        onCreated={noop}
+      />
+    )
+    expect(screen.queryByRole('link', { name: /instantiate from pattern/i })).toBeFalsy()
+  })
+})
+
+describe('BlankCreateDialog — blank pilot create', () => {
+  test('requires name + callsign, then persists a schema-valid pilot and reports its id', async () => {
+    const created: string[] = []
+    render(
+      <NewEntityScreen
+        kind="pilot"
+        mode="blank"
+        wizard={null}
+        onModeChange={noop}
+        onCreated={(id) => created.push(id)}
+      />
+    )
+
+    const submit = screen.getByRole('button', { name: /create blank pilot/i })
+    expect((submit as HTMLButtonElement).disabled).toBe(true)
+
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'Juno Vale' } })
+    fireEvent.change(screen.getByLabelText(/callsign/i), { target: { value: 'Nomad' } })
+    expect((submit as HTMLButtonElement).disabled).toBe(false)
+
+    fireEvent.click(submit)
+    await waitFor(() => expect(created.length).toBe(1))
+
+    const pilot = useEntityStore.getState().get('pilot', created[0] as string)
+    expect(() => PilotSchema.parse(pilot)).not.toThrow()
+    expect(pilot?.name).toBe('Juno Vale')
+    expect(pilot?.callsign).toBe('Nomad')
+    expect(pilot?.classRef).toBe('')
+  })
+
+  test('class pick is UNFILTERED — every class incl. specialisations is offered', () => {
+    render(
+      <NewEntityScreen
+        kind="pilot"
+        mode="blank"
+        wizard={null}
+        onModeChange={noop}
+        onCreated={noop}
+      />
+    )
+    const select = screen.getByLabelText(/class \(optional\)/i) as HTMLSelectElement
+    // "None" + the complete class catalog, nothing filtered out.
+    expect(select.options.length).toBe(SalvageUnionReference.Classes.all().length + 1)
+  })
+
+  test('mech chassis pick is UNFILTERED — every chassis at every Tech Level', () => {
+    render(
+      <NewEntityScreen
+        kind="mech"
+        mode="blank"
+        wizard={null}
+        onModeChange={noop}
+        onCreated={noop}
+      />
+    )
+    const select = screen.getByLabelText(/chassis \(optional\)/i) as HTMLSelectElement
+    expect(select.options.length).toBe(SalvageUnionReference.Chassis.all().length + 1)
+  })
+
+  test('crawler dialog offers Tech Levels 1–6, defaulting to 1', () => {
+    render(
+      <NewEntityScreen
+        kind="crawler"
+        mode="blank"
+        wizard={null}
+        onModeChange={noop}
+        onCreated={noop}
+      />
+    )
+    const select = screen.getByLabelText(/tech level/i) as HTMLSelectElement
+    expect(select.options.length).toBe(6)
+    expect(select.value).toBe('1')
+  })
+})

--- a/apps/in-the-union-now/src/lib/wizard/__tests__/blankCreate.test.ts
+++ b/apps/in-the-union-now/src/lib/wizard/__tests__/blankCreate.test.ts
@@ -1,0 +1,135 @@
+/**
+ * createBlank — the Blank escape hatch (wizard-refresh Phase 1).
+ *
+ * Contract per kind: yields a PERSISTED, schema-valid entity (the db layer's
+ * strict Zod parse is the only gate), with and without the optional
+ * escape-valve pick. fake-indexeddb/auto is preloaded via bunfig.toml.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import { _clearAllStores, _resetDbSingleton } from '../../db/index'
+import { CrawlerSchema } from '../../schemas/crawler'
+import { MechSchema } from '../../schemas/mech'
+import { PilotSchema } from '../../schemas/pilot'
+import { useEntityStore } from '../../../stores/entityStore'
+import { createBlank } from '../blankCreate'
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload(['classes', 'chassis', 'crawler-bays', 'crawler-tech-levels'])
+})
+
+function resetEntityStore(): void {
+  useEntityStore.setState({
+    pilots: [],
+    mechs: [],
+    crawlers: [],
+    softLinks: [],
+    hydrated: { pilots: false, mechs: false, crawlers: false, softLinks: false },
+  })
+}
+
+beforeEach(async () => {
+  _resetDbSingleton()
+  await _clearAllStores()
+  resetEntityStore()
+})
+
+afterEach(async () => {
+  await _clearAllStores()
+  resetEntityStore()
+})
+
+describe('createBlank — pilot', () => {
+  test('without a class pick: persists a schema-valid pilot with empty classRef', async () => {
+    const id = await createBlank('pilot', { name: 'Rook Halden', callsign: 'Static' })
+
+    const pilot = useEntityStore.getState().get('pilot', id)
+    expect(pilot).toBeTruthy()
+    expect(() => PilotSchema.parse(pilot)).not.toThrow()
+    expect(pilot?.name).toBe('Rook Halden')
+    expect(pilot?.callsign).toBe('Static')
+    expect(pilot?.classRef).toBe('')
+    expect(pilot?.abilities).toEqual([])
+    expect(pilot?.equipment).toEqual([])
+    // Seeded at the base HP/AP rule constants, like the wizard path.
+    expect(pilot?.currentHP).toBe(10)
+    expect(pilot?.currentAP).toBe(5)
+  })
+
+  test('with a class pick (unfiltered): persists the chosen classRef', async () => {
+    const anyClass = SalvageUnionReference.Classes.all()[0] as { id: string }
+    const id = await createBlank('pilot', {
+      name: 'Vex Marlo',
+      callsign: 'Redline',
+      classRef: anyClass.id,
+    })
+
+    const pilot = useEntityStore.getState().get('pilot', id)
+    expect(() => PilotSchema.parse(pilot)).not.toThrow()
+    expect(pilot?.classRef).toBe(anyClass.id)
+  })
+})
+
+describe('createBlank — mech', () => {
+  test('without a chassis pick: persists a schema-valid mech with empty chassisRef', async () => {
+    const id = await createBlank('mech', { name: 'Unnamed Hulk' })
+
+    const mech = useEntityStore.getState().get('mech', id)
+    expect(mech).toBeTruthy()
+    expect(() => MechSchema.parse(mech)).not.toThrow()
+    expect(mech?.name).toBe('Unnamed Hulk')
+    expect(mech?.chassisRef).toBe('')
+    expect(mech?.systems).toEqual([])
+    expect(mech?.modules).toEqual([])
+    // No chassis → no seeded SP/EP; Heat still starts at 0.
+    expect(mech?.currentSP).toBeUndefined()
+    expect(mech?.currentEP).toBeUndefined()
+    expect(mech?.currentHeat).toBe(0)
+  })
+
+  test('with a chassis pick (any TL, no scrap cost): seeds full SP/EP from the chassis', async () => {
+    const id = await createBlank('mech', { name: 'Dust Mule', chassisRef: 'mule' })
+
+    const mech = useEntityStore.getState().get('mech', id)
+    expect(() => MechSchema.parse(mech)).not.toThrow()
+    expect(mech?.chassisRef).toBe('mule')
+
+    const mule = SalvageUnionReference.Chassis.find((c) => c.name === 'Mule')
+    expect(mech?.currentSP).toBe(mule?.structurePoints)
+    expect(mech?.currentEP).toBe(mule?.energyPoints)
+    expect(mech?.currentHeat).toBe(0)
+  })
+})
+
+describe('createBlank — crawler', () => {
+  test('defaults to Tech Level 1 with bare stats and the seeded SRD bay set', async () => {
+    const id = await createBlank('crawler', { name: 'The Long Haul' })
+
+    const crawler = useEntityStore.getState().get('crawler', id)
+    expect(crawler).toBeTruthy()
+    expect(() => CrawlerSchema.parse(crawler)).not.toThrow()
+    expect(crawler?.name).toBe('The Long Haul')
+    expect(crawler?.techLevel).toBe('tech-1')
+    // No crawler type is picked in a Blank create.
+    expect(crawler?.type).toBeUndefined()
+    // Bare SP from crawler-tech-levels.json (TL1 Hamlet = 20).
+    expect(crawler?.currentSP).toBe(20)
+    // Default (non-expansion) SRD bays are seeded, like the wizard path.
+    const baseBays = SalvageUnionReference.CrawlerBays.all().filter(
+      (b) => !(b as { expansion?: boolean }).expansion
+    )
+    expect(crawler?.crawlerBays?.length).toBe(baseBays.length)
+  })
+
+  test('honours a Tech Level pick 1–6 and derives that level’s stats', async () => {
+    const id = await createBlank('crawler', { name: 'Towertown', techLevel: 3 })
+
+    const crawler = useEntityStore.getState().get('crawler', id)
+    expect(() => CrawlerSchema.parse(crawler)).not.toThrow()
+    expect(crawler?.techLevel).toBe('tech-3')
+    // TL3 Town Crawler = 30 SP per crawler-tech-levels.json.
+    expect(crawler?.currentSP).toBe(30)
+  })
+})

--- a/apps/in-the-union-now/src/lib/wizard/blankCreate.ts
+++ b/apps/in-the-union-now/src/lib/wizard/blankCreate.ts
@@ -1,0 +1,123 @@
+/**
+ * Blank create — the escape hatch that skips the wizard and ALL creation-rule
+ * limits (wizard-refresh Phase 1).
+ *
+ * `createBlank` builds a minimal create() payload through the EXISTING pure
+ * form mappers (pilotFormState / mechFormState / crawlerFormState) and calls
+ * the entity store's create() directly — the same persistence path
+ * InstantiateFromPattern and merge-import already use. No WizShell, no rule
+ * gates, no validation beyond the db layer's own strict Zod parse.
+ *
+ * Seeds collect ONLY the Zod-required fields plus the optional escape-valve
+ * picks (class / chassis / tech level) that would otherwise strand the user
+ * until the corresponding sheet editor exists.
+ */
+
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import { useEntityStore } from '../../stores/entityStore'
+import {
+  EMPTY_CRAWLER_FORM_STATE,
+  EMPTY_SCRAP_POOL,
+  crawlerFormToCreateInput,
+  seedDefaultCrawlerBays,
+} from './crawlerFormState'
+import { EMPTY_MECH_FORM_STATE, mechFormToCreateInput } from './mechFormState'
+import { EMPTY_PILOT_FORM_STATE, pilotFormToCreateInput } from './pilotFormState'
+
+/** The three entity kinds a Blank create can produce. */
+export type BlankCreateKind = 'pilot' | 'mech' | 'crawler'
+
+export type BlankPilotSeed = {
+  name: string
+  callsign: string
+  /** Optional class ref (UNFILTERED — any class incl. specialisations). */
+  classRef?: string
+}
+
+export type BlankMechSeed = {
+  name: string
+  /** Optional chassis slug ref (UNFILTERED — any Tech Level, no scrap cost). */
+  chassisRef?: string
+}
+
+export type BlankCrawlerSeed = {
+  name: string
+  /** Optional Tech Level 1–6; defaults to 1 (Hamlet). */
+  techLevel?: number
+}
+
+type BlankSeed = BlankPilotSeed | BlankMechSeed | BlankCrawlerSeed
+
+/**
+ * Creates a blank entity of the given kind and returns its id.
+ *
+ * The db layer still strict-parses the record (Zod is the source of truth) —
+ * but no creation-rule budget, tech-level filter, or scrap cost applies.
+ */
+export async function createBlank(kind: 'pilot', seed: BlankPilotSeed): Promise<string>
+export async function createBlank(kind: 'mech', seed: BlankMechSeed): Promise<string>
+export async function createBlank(kind: 'crawler', seed: BlankCrawlerSeed): Promise<string>
+export async function createBlank(kind: BlankCreateKind, seed: BlankSeed): Promise<string> {
+  const store = useEntityStore.getState()
+
+  if (kind === 'pilot') {
+    const { name, callsign, classRef } = seed as BlankPilotSeed
+    const created = await store.create(
+      'pilot',
+      pilotFormToCreateInput({
+        ...EMPTY_PILOT_FORM_STATE,
+        name,
+        callsign,
+        classId: classRef ?? '',
+      })
+    )
+    return created.id
+  }
+
+  if (kind === 'mech') {
+    const { name, chassisRef } = seed as BlankMechSeed
+    // mechFormToCreateInput resolves the chassis itself: with a pick it seeds
+    // full SP/EP from the chassis (like InstantiateFromPattern); without one
+    // the current stats stay absent and the sheet derives 0-maxima safely.
+    const created = await store.create(
+      'mech',
+      mechFormToCreateInput({
+        ...EMPTY_MECH_FORM_STATE,
+        name,
+        chassisName: chassisRef ?? '',
+      })
+    )
+    return created.id
+  }
+
+  const { name, techLevel } = seed as BlankCrawlerSeed
+  const tl = clampTechLevel(techLevel ?? 1)
+  // Bare stats for the level come straight from crawler-tech-levels.json via
+  // the ORM; the default SRD bay set is seeded exactly like the wizard path.
+  // No crawler type is picked — the schema reads absent `type` as untyped.
+  const maxSP = SalvageUnionReference.CrawlerTechLevels.find(
+    (t) => t.techLevel === tl
+  )?.structurePoints
+  const created = await store.create(
+    'crawler',
+    crawlerFormToCreateInput(
+      {
+        ...EMPTY_CRAWLER_FORM_STATE,
+        name,
+        techLevel: tl,
+        scrapPool: { ...EMPTY_SCRAP_POOL },
+      },
+      {
+        ...(maxSP !== undefined ? { maxSP } : {}),
+        crawlerBays: seedDefaultCrawlerBays(),
+      }
+    )
+  )
+  return created.id
+}
+
+/** Clamp to a whole Tech Level 1–6 (defensive — the dialog offers 1–6 only). */
+function clampTechLevel(tl: number): number {
+  return Math.min(6, Math.max(1, Math.round(tl)))
+}

--- a/apps/in-the-union-now/src/lib/wizard/createMode.ts
+++ b/apps/in-the-union-now/src/lib/wizard/createMode.ts
@@ -1,0 +1,13 @@
+/**
+ * CreateMode — the /new routes' `mode` search param (wizard-refresh Phase 1):
+ *   absent   → CreateModeChooser
+ *   'guided' → the existing wizard, unchanged
+ *   'blank'  → the Blank dialog (escape hatch)
+ */
+
+export type CreateMode = 'guided' | 'blank' | undefined
+
+/** Narrow a raw search param onto the CreateMode union (routes' validateSearch). */
+export function parseCreateMode(value: unknown): CreateMode {
+  return value === 'guided' || value === 'blank' ? value : undefined
+}

--- a/apps/in-the-union-now/src/routes/crawlers/new.tsx
+++ b/apps/in-the-union-now/src/routes/crawlers/new.tsx
@@ -1,13 +1,21 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 
 import { CrawlerBuilder } from '../../components/crawler/CrawlerBuilder'
+import { NewEntityScreen } from '../../components/wizard/NewEntityScreen'
+import { parseCreateMode } from '../../lib/wizard/createMode'
+import type { CreateMode } from '../../lib/wizard/createMode'
 
 export const Route = createFileRoute('/crawlers/new')({
+  // mode: absent → chooser · 'guided' → the wizard · 'blank' → blank dialog
+  validateSearch: (search: Record<string, unknown>): { mode: CreateMode } => ({
+    mode: parseCreateMode(search.mode),
+  }),
   component: CrawlersNewPage,
 })
 
 function CrawlersNewPage() {
   const navigate = useNavigate()
+  const { mode } = Route.useSearch()
 
   function handleComplete() {
     void navigate({ to: '/' })
@@ -19,7 +27,15 @@ function CrawlersNewPage() {
 
   return (
     <main>
-      <CrawlerBuilder onComplete={handleComplete} onCancel={handleCancel} />
+      <NewEntityScreen
+        kind="crawler"
+        mode={mode}
+        wizard={<CrawlerBuilder onComplete={handleComplete} onCancel={handleCancel} />}
+        onModeChange={(next) => void navigate({ to: '/crawlers/new', search: { mode: next } })}
+        onCreated={(id) =>
+          void navigate({ to: '/sheet/$kind/$id', params: { kind: 'crawler', id } })
+        }
+      />
     </main>
   )
 }

--- a/apps/in-the-union-now/src/routes/mechs/new.tsx
+++ b/apps/in-the-union-now/src/routes/mechs/new.tsx
@@ -1,8 +1,15 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { SalvageUnionReference } from 'salvageunion-reference'
 import { MechWizard } from '../../components/mech/MechWizard'
+import { NewEntityScreen } from '../../components/wizard/NewEntityScreen'
+import { parseCreateMode } from '../../lib/wizard/createMode'
+import type { CreateMode } from '../../lib/wizard/createMode'
 
 export const Route = createFileRoute('/mechs/new')({
+  // mode: absent → chooser · 'guided' → the wizard · 'blank' → blank dialog
+  validateSearch: (search: Record<string, unknown>): { mode: CreateMode } => ({
+    mode: parseCreateMode(search.mode),
+  }),
   loader: async () => {
     // Preload game data needed by the wizard before rendering
     await SalvageUnionReference.preload(['chassis', 'systems', 'modules', 'drones', 'traits'])
@@ -13,6 +20,7 @@ export const Route = createFileRoute('/mechs/new')({
 
 function NewMechRoute() {
   const navigate = useNavigate()
+  const { mode } = Route.useSearch()
 
   function handleComplete() {
     void navigate({ to: '/' })
@@ -24,7 +32,13 @@ function NewMechRoute() {
 
   return (
     <main>
-      <MechWizard onComplete={handleComplete} onCancel={handleCancel} />
+      <NewEntityScreen
+        kind="mech"
+        mode={mode}
+        wizard={<MechWizard onComplete={handleComplete} onCancel={handleCancel} />}
+        onModeChange={(next) => void navigate({ to: '/mechs/new', search: { mode: next } })}
+        onCreated={(id) => void navigate({ to: '/sheet/$kind/$id', params: { kind: 'mech', id } })}
+      />
     </main>
   )
 }

--- a/apps/in-the-union-now/src/routes/pilots/new.tsx
+++ b/apps/in-the-union-now/src/routes/pilots/new.tsx
@@ -1,8 +1,15 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { SalvageUnionReference } from 'salvageunion-reference'
 import { PilotWizard } from '../../components/pilot/PilotWizard'
+import { NewEntityScreen } from '../../components/wizard/NewEntityScreen'
+import { parseCreateMode } from '../../lib/wizard/createMode'
+import type { CreateMode } from '../../lib/wizard/createMode'
 
 export const Route = createFileRoute('/pilots/new')({
+  // mode: absent → chooser · 'guided' → the wizard · 'blank' → blank dialog
+  validateSearch: (search: Record<string, unknown>): { mode: CreateMode } => ({
+    mode: parseCreateMode(search.mode),
+  }),
   loader: async () => {
     // Preload game data needed by the wizard before rendering
     await SalvageUnionReference.preload(['classes', 'abilities', 'equipment', 'roll-tables'])
@@ -13,6 +20,7 @@ export const Route = createFileRoute('/pilots/new')({
 
 function NewPilotRoute() {
   const navigate = useNavigate()
+  const { mode } = Route.useSearch()
 
   function handleComplete() {
     // Navigate home; Cycle-4 will wire up the dashboard redirect there
@@ -25,7 +33,13 @@ function NewPilotRoute() {
 
   return (
     <main>
-      <PilotWizard onComplete={handleComplete} onCancel={handleCancel} />
+      <NewEntityScreen
+        kind="pilot"
+        mode={mode}
+        wizard={<PilotWizard onComplete={handleComplete} onCancel={handleCancel} />}
+        onModeChange={(next) => void navigate({ to: '/pilots/new', search: { mode: next } })}
+        onCreated={(id) => void navigate({ to: '/sheet/$kind/$id', params: { kind: 'pilot', id } })}
+      />
     </main>
   )
 }


### PR DESCRIPTION
## Summary

Phase 1 of the create-wizard refresh: every "create a new X" flow gains a **Blank** path that skips the wizard and ALL creation-rule limits — the safety valve that makes later hard enforcement acceptable. The wizards themselves are untouched.

- **`lib/wizard/blankCreate.ts`** — `createBlank(kind, seed) → id` builds a minimal create-input through the EXISTING pure form mappers (`pilotFormToCreateInput` / `mechFormToCreateInput` / `crawlerFormToCreateInput` + `seedDefaultCrawlerBays`) and persists via `entityStore.create()` — the same path `InstantiateFromPattern` already uses. No rule gates; the db layer's strict Zod parse is the only validation.
- **`components/wizard/CreateModeChooser.tsx`** — the mockup's Screen 04 chooser rebuilt on the app's poster tokens: `.sheet--{kind}` tone ground, a poster band banner ("NEW PILOT"), a **Guided** door (tone fill, double ink ring, black ▶ tab, condensed-caps head, page citation) and a **Blank** door (3px dashed ink on paper, ✎ tab, "An empty sheet. No steps, no limits."). For mechs the mockup's thirdnote strip is made actionable — an ink banner door linking to the existing `/mechs/patterns` Instantiate-from-Pattern flow (su-orange accent).
- **`components/wizard/BlankCreateDialog.tsx`** — collects ONLY the Zod-required fields plus the escape-valve pick, on the app's standard `ModalShell` + `Field`/`Input` chrome:
  - Pilot: Name*, Callsign*, optional class — **unfiltered** (`Classes.all()`, incl. specialisations).
  - Mech: Name*, optional chassis — **unfiltered** (`Chassis.all()`, any Tech Level, no scrap cost); picking one seeds full SP/EP like the pattern path.
  - Crawler: Name*, Tech Level 1–6 (default 1) — bare stats derived from `crawler-tech-levels.json`, default SRD bays seeded, **no type** (schema reads absent `type` as untyped, same as legacy crawlers).
  - On submit → `createBlank` → navigate to `/sheet/{kind}/{id}`.
- **`routes/{pilots,mechs,crawlers}/new.tsx`** — a `mode` search param (`validateSearch` + `parseCreateMode`): absent → chooser · `guided` → the EXISTING wizard rendered unchanged · `blank` → the dialog over the chooser. Dashboard/rail "New X" links already point at bare `/new`, so they land on the chooser with no changes.
- **`components/wizard/NewEntityScreen.tsx`** — router-agnostic mode switch so the routing behaviour is testable without a RouterProvider.

## Open Question 4 — do blank entities render?

**Answered by test (`components/sheet/__tests__/blank-entity-sheets.test.tsx`): yes, no mitigation needed.** A blank pilot (`classRef ''`), blank mech (`chassisRef ''`) and blank crawler (TL only, no type) all render their live sheets without crashing:
- Mech derived maxima (`mechMaxSP/EP/Heat/Cargo`) resolve a missing chassis to `{}` → 0-maxima; `resolveChassisRef` returns null, never throws.
- Pilot HP/AP come from base rule constants; `resolveClassName('')` falls back to the raw ref; the sheet already carries a class picker (`PilotIdentity`), as does the mech sheet for chassis (`MechIdentity`).
- Untyped crawlers are an already-supported legacy shape.

So the class/chassis picks stay **optional** in the Blank dialogs.

## Design fidelity notes (Screen 04)

Rebuilt with existing tokens only (no bespoke CSS files): tone/ground vars from the `.sheet--{kind}` theme, ink stamps, paper, the poster band idiom. Two deliberate deviations to review:
- The mockup's guided-door copy promises hard enforcement ("illegal options hidden, unaffordable ones locked") — that lands in Phase 3, so the Phase 1 copy describes the steps without promising enforcement.
- The mockup's per-sheet **card** tone (e.g. pilot's peach step-cards) has no app token yet; the guided door uses `var(--tone)` (the band tone) with the mockup's double ink ring instead.

## check:all

`bun run check:all` → **exit 0** (lint, format, typecheck, tests, validate, knip, audit all green). ITUN suite: **1079 pass / 0 fail** across 113 files (20 new tests: `blankCreate` contract per kind ± the optional pick, mode routing chooser/wizard/dialog, unfiltered pick counts, blank-entity sheet renders). The single Biome warning is pre-existing (`PilotSheet.tsx` `role="group"`), untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuNKAVLVSumokSeATao282
