### PR TITLE
feat(itun): Play Cockpit Phase 1 — read-only shell (/play/$id)

### DIFF
--- a/apps/in-the-union-now/src/components/play/CockpitCanvas.tsx
+++ b/apps/in-the-union-now/src/components/play/CockpitCanvas.tsx
@@ -1,0 +1,68 @@
+/**
+ * CockpitCanvas — the fixed 1280×800 design canvas, scaled to fit its host with
+ * a single `transform: scale(...)`, letterboxed, never scrolling (proposed
+ * ADR-020). Below the clamp floor the fixed canvas is abandoned for a stacked
+ * fallback (Phase 1 renders a placeholder message there; the real phone reflow
+ * is a later phase).
+ */
+
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+
+const CANVAS_W = 1280
+const CANVAS_H = 800
+const MIN_SCALE = 0.62
+const MAX_SCALE = 1.3
+
+export function CockpitCanvas({ children }: { children: ReactNode }) {
+  const hostRef = useRef<HTMLDivElement>(null)
+  const [scale, setScale] = useState(1)
+  const [reflow, setReflow] = useState(false)
+
+  useEffect(() => {
+    const host = hostRef.current
+    if (!host) return
+    const compute = () => {
+      const w = host.clientWidth
+      const h = host.clientHeight
+      if (!w || !h) return
+      const raw = Math.min(w / CANVAS_W, h / CANVAS_H)
+      setReflow(raw < MIN_SCALE)
+      setScale(Math.max(MIN_SCALE, Math.min(MAX_SCALE, raw)))
+    }
+    compute()
+    // ResizeObserver is absent in some test/SSR environments — fall back to
+    // a window resize listener so the canvas still sizes (and never throws).
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', compute)
+      return () => window.removeEventListener('resize', compute)
+    }
+    const ro = new ResizeObserver(compute)
+    ro.observe(host)
+    return () => ro.disconnect()
+  }, [])
+
+  return (
+    <div
+      ref={hostRef}
+      className="pc-root flex h-full w-full items-center justify-center overflow-hidden"
+      style={{ background: 'var(--pc-ground)' }}
+    >
+      {reflow ? (
+        <div className="pc-reflow">
+          <p>
+            The Play Cockpit is a landscape, single-screen HUD. This viewport is below its size
+            floor — rotate to landscape or use a larger screen. (A dedicated phone layout is
+            planned.)
+          </p>
+        </div>
+      ) : (
+        <div
+          className="pc-canvas shrink-0"
+          style={{ transform: `scale(${scale})`, transformOrigin: 'center center' }}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/play/PlayCockpit.tsx
+++ b/apps/in-the-union-now/src/components/play/PlayCockpit.tsx
@@ -1,0 +1,61 @@
+/**
+ * PlayCockpit — the Play Cockpit ("Pit HUD") root for a single mech.
+ *
+ * Phase 1 (read-only shell): loads the real mech from `entityStore`, lays the
+ * locked four-surface grid inside the scale-to-fit canvas, and wires the rail.
+ * The Active Item, Dial, and Display are placeholders here; later phases fill
+ * them with instruments, the rotary dial, and the SRD reference/actions view.
+ * No mutations happen yet.
+ *
+ * See docs/architecture/play-cockpit.md for the full plan.
+ */
+
+import { useEntityStore } from '../../stores/entityStore'
+import { usePlayStateStore } from '../../stores/playStateStore'
+import { CockpitCanvas } from './CockpitCanvas'
+import { RailBar } from './RailBar'
+
+export function PlayCockpit({ id }: { id: string }) {
+  const mech = useEntityStore((s) => s.get('mech', id))
+  // The active-row entity drives the whole-canvas tint (proposed ADR-018).
+  // Phase 1 defaults to the boarded mech; the mount transitions land in Phase 2.
+  const mount = usePlayStateStore((s) => s.mount)
+
+  if (!mech) {
+    return (
+      <CockpitCanvas>
+        <div className="pc-grid">
+          <div className="pc-rail">
+            <span className="pc-stamp pc-stamp-mech">Mech not found</span>
+          </div>
+          <div className="pc-primary">
+            <div className="pc-placeholder">No mech with id “{id}”.</div>
+          </div>
+          <div className="pc-display">
+            <div className="pc-fill">—</div>
+          </div>
+          <div className="pc-wheel">
+            <div className="pc-placeholder">Dial</div>
+          </div>
+        </div>
+      </CockpitCanvas>
+    )
+  }
+
+  return (
+    <CockpitCanvas>
+      <div className="pc-grid" data-mount={mount}>
+        <RailBar title={`Mech · ${mech.name}`} />
+        <div className="pc-primary">
+          <div className="pc-placeholder">Active Item — instrument bays (Phase 2)</div>
+        </div>
+        <div className="pc-display">
+          <div className="pc-fill">Main display — SRD reference &amp; actions (Phase 4)</div>
+        </div>
+        <div className="pc-wheel">
+          <div className="pc-placeholder">Dial (Phase 3)</div>
+        </div>
+      </div>
+    </CockpitCanvas>
+  )
+}

--- a/apps/in-the-union-now/src/components/play/RailBar.tsx
+++ b/apps/in-the-union-now/src/components/play/RailBar.tsx
@@ -1,0 +1,22 @@
+/**
+ * RailBar — the cockpit's top rail: return-to-workspace, the active entity
+ * stamp, and (later) settings / rules-source affordances. Bordered (a "forward"
+ * surface). Phase 1 wires Return to Workspace; Settings is a placeholder.
+ */
+
+import { AppLink } from '../shared/AppLink'
+
+export function RailBar({ title }: { title: string }) {
+  return (
+    <div className="pc-rail">
+      <AppLink href="/" className="pc-railbtn">
+        ◄ Return to Workspace
+      </AppLink>
+      <span className="pc-stamp pc-stamp-mech">{title}</span>
+      <span className="flex-1" />
+      <button type="button" className="pc-railbtn" title="Rules & sources — planned" disabled>
+        ⚙ Settings
+      </button>
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/play/__tests__/PlayCockpit.test.tsx
+++ b/apps/in-the-union-now/src/components/play/__tests__/PlayCockpit.test.tsx
@@ -1,0 +1,23 @@
+/**
+ * Smoke test for the Play Cockpit shell (Phase 1).
+ *
+ * Renders the not-found path (no mech in the store → `entityStore.get` returns
+ * null), which exercises PlayCockpit + CockpitCanvas without needing router
+ * context or a seeded store. Confirms the shell mounts and shows the four
+ * surfaces' placeholders rather than throwing.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+
+import { PlayCockpit } from '../PlayCockpit'
+
+// Convention (see sheet-smoke.test.tsx): toBeTruthy(), not toBeInTheDocument()
+// — jest-dom's matcher types aren't augmented onto bun:test's expect.
+describe('PlayCockpit shell', () => {
+  test('renders a not-found shell for an unknown mech id', () => {
+    render(<PlayCockpit id="does-not-exist" />)
+    expect(screen.getByText('Mech not found')).toBeTruthy()
+    expect(screen.getByText(/No mech with id/)).toBeTruthy()
+  })
+})

--- a/apps/in-the-union-now/src/components/play/play.css
+++ b/apps/in-the-union-now/src/components/play/play.css
@@ -1,0 +1,164 @@
+/*
+ * Play Cockpit ("Pit HUD") styling foundation.
+ *
+ * The cockpit is a self-contained DARK instrument world (the SU brand-header
+ * palette), distinct from the light workspace chrome. Colour is scoped to
+ * `.pc-root` so it never bleeds into the rest of the app. Hue encodes ONTOLOGY
+ * (mech green / pilot orange / crawler pink), never identity; the single hard
+ * 2.5px border marks a surface that reads "forward" (the rail and, later, the
+ * main display). Everything else is flat/inset (proposed ADR-018).
+ *
+ * Phase 1 lays the palette, the fixed-canvas grid, and placeholder surfaces;
+ * later phases replace the placeholders with real instruments.
+ */
+
+.pc-root {
+  --pc-ground: #1b1712;
+  --pc-panel: #282019;
+  --pc-text: #f3ede2;
+  --pc-muted: #9b9488;
+  --pc-line: rgba(243, 237, 226, 0.16);
+  --pc-line-hard: rgba(243, 237, 226, 0.5);
+  --pc-mech: #7a978a;
+  --pc-mech-deep: #2f4338;
+  --pc-pilot: #ef894f;
+  --pc-pilot-deep: #a85222;
+  --pc-crawler: #ce5898;
+  --pc-crawler-deep: #7e2a5b;
+  color: var(--pc-text);
+  font-family: 'Barlow', system-ui, sans-serif;
+}
+
+/* Fixed design canvas — scaled to fit by CockpitCanvas. Never scrolls. */
+.pc-canvas {
+  width: 1280px;
+  height: 800px;
+  background: var(--pc-ground);
+  position: relative;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1.5px var(--pc-line);
+}
+
+.pc-grid {
+  display: grid;
+  height: 100%;
+  width: 100%;
+  gap: 10px;
+  padding: 8px 6px 8px 10px;
+  grid-template-columns: 1fr 260px;
+  grid-template-rows: 40px 168px 1fr;
+  grid-template-areas:
+    'rail rail'
+    'primary wheel'
+    'display wheel';
+}
+
+.pc-rail {
+  grid-area: rail;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 2.5px solid var(--pc-line-hard);
+  border-radius: 5px;
+  padding: 0 12px;
+}
+/* Active-entity tint on the rail (extends to the Active Item band in Phase 2). */
+.pc-grid[data-mount='mech'] .pc-rail {
+  border-color: color-mix(in oklab, var(--pc-mech) 60%, transparent);
+}
+.pc-grid[data-mount='pilot'] .pc-rail {
+  border-color: color-mix(in oklab, var(--pc-pilot) 60%, transparent);
+}
+.pc-grid[data-mount='downtime'] .pc-rail {
+  border-color: color-mix(in oklab, var(--pc-crawler) 60%, transparent);
+}
+
+.pc-primary {
+  grid-area: primary;
+}
+.pc-display {
+  grid-area: display;
+  border: 2.5px solid var(--pc-line-hard);
+  border-radius: 5px;
+  background: color-mix(in oklab, var(--pc-panel) 90%, #000);
+}
+.pc-wheel {
+  grid-area: wheel;
+}
+
+/* Phase-1 placeholder for a surface not yet built. */
+.pc-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  border: 1.5px solid var(--pc-line);
+  border-radius: 5px;
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 12px;
+  color: var(--pc-muted);
+}
+
+/* Centered muted label used inside an already-bordered surface (e.g. the display). */
+.pc-fill {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 12px;
+  text-align: center;
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 12px;
+  color: var(--pc-muted);
+}
+
+.pc-stamp {
+  display: inline-block;
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 13px;
+  line-height: 1;
+  padding: 5px 9px 6px;
+  border-radius: 2px;
+  color: #fff;
+}
+.pc-stamp-mech {
+  background: var(--pc-mech-deep);
+}
+
+.pc-railbtn {
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 11px;
+  padding: 6px 10px;
+  border: 1.5px solid var(--pc-line);
+  border-radius: 2px;
+  background: transparent;
+  color: var(--pc-text);
+  cursor: pointer;
+  text-decoration: none;
+}
+.pc-railbtn:hover {
+  border-color: var(--pc-muted);
+}
+
+/* Below the scale floor (phones / heavy zoom) the fixed canvas is abandoned. */
+.pc-reflow {
+  max-width: 340px;
+  padding: 32px;
+  text-align: center;
+  color: var(--pc-muted);
+  font-family: 'Barlow', sans-serif;
+  font-size: 13px;
+  line-height: 1.5;
+}

--- a/apps/in-the-union-now/src/routeTree.gen.ts
+++ b/apps/in-the-union-now/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as EncounterRouteImport } from './routes/encounter'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SIdRouteImport } from './routes/s/$id'
+import { Route as PlayIdRouteImport } from './routes/play/$id'
 import { Route as PilotsNewRouteImport } from './routes/pilots/new'
 import { Route as PilotsIdRouteImport } from './routes/pilots/$id'
 import { Route as MechsNewRouteImport } from './routes/mechs/new'
@@ -35,6 +36,11 @@ const IndexRoute = IndexRouteImport.update({
 const SIdRoute = SIdRouteImport.update({
   id: '/s/$id',
   path: '/s/$id',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PlayIdRoute = PlayIdRouteImport.update({
+  id: '/play/$id',
+  path: '/play/$id',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PilotsNewRoute = PilotsNewRouteImport.update({
@@ -92,6 +98,7 @@ export interface FileRoutesByFullPath {
   '/mechs/new': typeof MechsNewRoute
   '/pilots/$id': typeof PilotsIdRoute
   '/pilots/new': typeof PilotsNewRoute
+  '/play/$id': typeof PlayIdRoute
   '/s/$id': typeof SIdRoute
   '/sheet/$kind/$id': typeof SheetKindIdRoute
   '/mechs/patterns/': typeof MechsPatternsIndexRoute
@@ -106,6 +113,7 @@ export interface FileRoutesByTo {
   '/mechs/new': typeof MechsNewRoute
   '/pilots/$id': typeof PilotsIdRoute
   '/pilots/new': typeof PilotsNewRoute
+  '/play/$id': typeof PlayIdRoute
   '/s/$id': typeof SIdRoute
   '/sheet/$kind/$id': typeof SheetKindIdRoute
   '/mechs/patterns': typeof MechsPatternsIndexRoute
@@ -121,6 +129,7 @@ export interface FileRoutesById {
   '/mechs/new': typeof MechsNewRoute
   '/pilots/$id': typeof PilotsIdRoute
   '/pilots/new': typeof PilotsNewRoute
+  '/play/$id': typeof PlayIdRoute
   '/s/$id': typeof SIdRoute
   '/sheet/$kind/$id': typeof SheetKindIdRoute
   '/mechs/patterns/': typeof MechsPatternsIndexRoute
@@ -137,6 +146,7 @@ export interface FileRouteTypes {
     | '/mechs/new'
     | '/pilots/$id'
     | '/pilots/new'
+    | '/play/$id'
     | '/s/$id'
     | '/sheet/$kind/$id'
     | '/mechs/patterns/'
@@ -151,6 +161,7 @@ export interface FileRouteTypes {
     | '/mechs/new'
     | '/pilots/$id'
     | '/pilots/new'
+    | '/play/$id'
     | '/s/$id'
     | '/sheet/$kind/$id'
     | '/mechs/patterns'
@@ -165,6 +176,7 @@ export interface FileRouteTypes {
     | '/mechs/new'
     | '/pilots/$id'
     | '/pilots/new'
+    | '/play/$id'
     | '/s/$id'
     | '/sheet/$kind/$id'
     | '/mechs/patterns/'
@@ -180,6 +192,7 @@ export interface RootRouteChildren {
   MechsNewRoute: typeof MechsNewRoute
   PilotsIdRoute: typeof PilotsIdRoute
   PilotsNewRoute: typeof PilotsNewRoute
+  PlayIdRoute: typeof PlayIdRoute
   SIdRoute: typeof SIdRoute
   SheetKindIdRoute: typeof SheetKindIdRoute
   MechsPatternsIndexRoute: typeof MechsPatternsIndexRoute
@@ -207,6 +220,13 @@ declare module '@tanstack/react-router' {
       path: '/s/$id'
       fullPath: '/s/$id'
       preLoaderRoute: typeof SIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/play/$id': {
+      id: '/play/$id'
+      path: '/play/$id'
+      fullPath: '/play/$id'
+      preLoaderRoute: typeof PlayIdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/pilots/new': {
@@ -284,6 +304,7 @@ const rootRouteChildren: RootRouteChildren = {
   MechsNewRoute: MechsNewRoute,
   PilotsIdRoute: PilotsIdRoute,
   PilotsNewRoute: PilotsNewRoute,
+  PlayIdRoute: PlayIdRoute,
   SIdRoute: SIdRoute,
   SheetKindIdRoute: SheetKindIdRoute,
   MechsPatternsIndexRoute: MechsPatternsIndexRoute,

--- a/apps/in-the-union-now/src/routes/play/$id.tsx
+++ b/apps/in-the-union-now/src/routes/play/$id.tsx
@@ -1,0 +1,36 @@
+/**
+ * Play Cockpit route — /play/:id
+ *
+ * id: a mech entity id in entityStore. The cockpit runs a mech at the table
+ * (see docs/architecture/play-cockpit.md). The loader hydrates all entity
+ * kinds + SoftLinks so linked entities (pilot, crawler) resolve synchronously,
+ * mirroring the sheet route.
+ *
+ * Phase 1: read-only shell. Later phases add the instruments, dial, and display.
+ */
+
+import { createFileRoute } from '@tanstack/react-router'
+
+import { useEntityStore } from '../../stores/entityStore'
+import { PlayCockpit } from '../../components/play/PlayCockpit'
+// Cockpit stylesheet is loaded at the route (like __root loads index.css), so
+// leaf components stay CSS-import-free and unit-testable under the bun runner.
+import '../../components/play/play.css'
+
+export const Route = createFileRoute('/play/$id')({
+  loader: async () => {
+    const store = useEntityStore.getState()
+    await Promise.all([
+      store.hydrate('mech'),
+      store.hydrate('pilot'),
+      store.hydrate('crawler'),
+      store.hydrate('softLink'),
+    ])
+  },
+  component: PlayPage,
+})
+
+function PlayPage() {
+  const { id } = Route.useParams()
+  return <PlayCockpit id={id} />
+}

--- a/apps/in-the-union-now/src/stores/__tests__/playStateStore.test.ts
+++ b/apps/in-the-union-now/src/stores/__tests__/playStateStore.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Unit tests for playStateStore — the ephemeral cockpit play-state.
+ *
+ * Verifies the default mount (boarded mech) and the setters. This store is
+ * intentionally non-persisted; there is no IndexedDB behaviour to test.
+ */
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { usePlayStateStore } from '../playStateStore'
+
+describe('playStateStore', () => {
+  beforeEach(() => {
+    usePlayStateStore.setState({ mount: 'mech', wheel: 0 })
+  })
+
+  test('defaults to the boarded mech, dial at 0', () => {
+    const s = usePlayStateStore.getState()
+    expect(s.mount).toBe('mech')
+    expect(s.wheel).toBe(0)
+  })
+
+  test('setMount switches the active-row entity', () => {
+    usePlayStateStore.getState().setMount('downtime')
+    expect(usePlayStateStore.getState().mount).toBe('downtime')
+    usePlayStateStore.getState().setMount('pilot')
+    expect(usePlayStateStore.getState().mount).toBe('pilot')
+  })
+
+  test('setWheel moves the dial index', () => {
+    usePlayStateStore.getState().setWheel(3)
+    expect(usePlayStateStore.getState().wheel).toBe(3)
+  })
+})

--- a/apps/in-the-union-now/src/stores/playStateStore.ts
+++ b/apps/in-the-union-now/src/stores/playStateStore.ts
@@ -1,0 +1,34 @@
+/**
+ * playStateStore — EPHEMERAL cockpit play-state (Play Cockpit / "Pit HUD").
+ *
+ * This is deliberately NOT persisted and NOT an IndexedDB collection: the mount
+ * state machine (which entity is "active" — mech boarded / pilot on foot /
+ * downtime) and the dial focus are a *play-session* concern, never character
+ * data. Keeping them out of the entity schemas prevents them leaking into live
+ * sheets or shared snapshots (see docs/architecture/play-cockpit.md, proposed
+ * ADR-019). It resets on reload — that is intended.
+ *
+ * Phase 1 (read-only shell) tracks only the mount state and dial index; later
+ * phases extend it (range band, push-armed, overlays, dial config, etc.).
+ */
+
+import { create } from 'zustand'
+
+/** Which entity currently "owns" the cockpit — the active-row entity. */
+export type MountState = 'mech' | 'pilot' | 'downtime'
+
+type PlayState = {
+  /** Active-row entity. Defaults to the boarded mech. */
+  mount: MountState
+  /** Selected index on the rotary Dial. */
+  wheel: number
+  setMount: (mount: MountState) => void
+  setWheel: (wheel: number) => void
+}
+
+export const usePlayStateStore = create<PlayState>((set) => ({
+  mount: 'mech',
+  wheel: 0,
+  setMount: (mount) => set({ mount }),
+  setWheel: (wheel) => set({ wheel }),
+}))


### PR DESCRIPTION
## What

First increment of the **Play Cockpit** ("Pit HUD"), implementing Phase 1 of the plan in [`docs/architecture/play-cockpit.md`](https://github.com/SalvageUnion-io/SU-SRD/pull/423) (#423). Ships the frame end-to-end with **no mutations** — proves the route, canvas, state store, and locked four-surface layout before wiring instruments.

## Changes

- **`/play/$id` route** — loads the mech (+ pilot/crawler/softLink hydration, mirroring the sheet route). Route tree regenerated.
- **`CockpitCanvas`** — the fixed **1280×800** design canvas, `transform: scale(...)` to fit, clamped `[0.62, 1.3]`, with a below-floor reflow placeholder (proposed ADR-020). `ResizeObserver`-guarded.
- **`playStateStore`** — ephemeral, non-persisted mount state machine (mech/pilot/downtime) + dial index, deliberately kept out of the entity schemas/snapshots (proposed ADR-019). Drives the active-entity tint via `data-mount`.
- **`RailBar`** + the locked four-surface grid (rail / Active Item / Dial / Display). Active Item, Dial, Display are placeholders filled by later phases.
- **`play.css`** — the dark "workshop-manual" cockpit palette scoped to `.pc-root`, loaded at the route so leaf components stay CSS-import-free and unit-testable.

## Verification

- `bun run typecheck` — clean (all 4 packages)
- ITUN suite — **1110 pass / 0 fail** (incl. 2 new: `playStateStore` unit + `PlayCockpit` shell smoke)
- `biome lint` clean; pre-push validate/knip/typecheck/test all green

## Not in this phase

Instrument bays + gauges (Phase 2), the rotary Dial (Phase 3), the SRD reference/actions display (Phase 4), and beyond — see the plan's phasing. This is intentionally a read-only shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNeL9Bxgw2HRKJpSimK1Wm