### PR TITLE
feat(itun): Play Cockpit Phase 2 — gauges + mount state machine

### DIFF
--- a/apps/in-the-union-now/src/components/play/ActiveItemBand.tsx
+++ b/apps/in-the-union-now/src/components/play/ActiveItemBand.tsx
@@ -1,0 +1,186 @@
+/**
+ * ActiveItemBand — the Active Item (primary row): the entity you're currently
+ * running, laid out as responsibility "bays" (a gauge cluster + its own button
+ * grid). Dispatches by mount state (playStateStore): the boarded mech, or the
+ * pilot on foot.
+ *
+ * Phase 2 scope: gauges are bound to the real live stats (currentSP/EP/Heat/HP/
+ * AP + derived maxima) and are read-only; only the mount transitions
+ * (Board / Dismount / Eject) mutate anything. The heat/damage/action buttons
+ * are present but disabled — they get wired to the rules engine in Phase 5,
+ * under the ADR-007 automation boundary.
+ */
+
+import {
+  mechMaxCargo,
+  mechMaxEP,
+  mechMaxHeat,
+  mechMaxSP,
+  pilotMaxAP,
+  pilotMaxHP,
+} from '../../lib/rules/derivedStats'
+import { resolveChassisRef } from '../../lib/rules/resolveRefs'
+import { totalLotUnits } from '../../lib/schemas/cargoLot'
+import type { Mech } from '../../lib/schemas/mech'
+import type { Pilot } from '../../lib/schemas/pilot'
+import { usePlayStateStore } from '../../stores/playStateStore'
+import { CockpitGauge } from './CockpitGauge'
+
+const PHASE5 = 'Wired to the rules engine in a later phase'
+
+type ActiveItemBandProps = {
+  mech: Mech
+  pilot: Pilot | null
+}
+
+export function ActiveItemBand({ mech, pilot }: ActiveItemBandProps) {
+  const mount = usePlayStateStore((s) => s.mount)
+  const setMount = usePlayStateStore((s) => s.setMount)
+
+  if (mount === 'pilot' && pilot) {
+    return <PilotBand pilot={pilot} onBoard={() => setMount('mech')} />
+  }
+  return <MechBand mech={mech} hasPilot={pilot !== null} onDismount={() => setMount('pilot')} />
+}
+
+function MechBand({
+  mech,
+  hasPilot,
+  onDismount,
+}: {
+  mech: Mech
+  hasPilot: boolean
+  onDismount: () => void
+}) {
+  const chassis = resolveChassisRef(mech.chassisRef)
+  const maxSP = mechMaxSP(mech, chassis)
+  const maxEP = mechMaxEP(mech, chassis)
+  const maxHeat = mechMaxHeat(mech, chassis)
+  const maxCargo = mechMaxCargo(mech, chassis)
+  const sp = Math.min(mech.currentSP ?? maxSP, maxSP)
+  const ep = Math.min(mech.currentEP ?? maxEP, maxEP)
+  const heat = Math.min(mech.currentHeat ?? maxHeat, maxHeat)
+  const cargo = totalLotUnits(mech.cargoLots)
+
+  return (
+    <div className="pc-band" data-fam="mech">
+      <div className="pc-band-id">
+        <span className="pc-stamp pc-stamp-mech">Mech · {mech.name}</span>
+      </div>
+      <div className="pc-bays">
+        <div className="pc-bay">
+          <span className="pc-bay-lab">Reactor</span>
+          <div className="pc-bay-gauges">
+            <CockpitGauge
+              label="Heat"
+              value={heat}
+              max={maxHeat}
+              tone="mech"
+              danger={Math.max(0, maxHeat - 2)}
+            />
+            <CockpitGauge label="EP" value={ep} max={maxEP} tone="mech" />
+          </div>
+          <div className="pc-btn-grid">
+            <button type="button" className="pc-btn pc-btn-danger" disabled title={PHASE5}>
+              Push
+            </button>
+            <button type="button" className="pc-btn pc-btn-danger" disabled title={PHASE5}>
+              Heat Chk
+            </button>
+            <button type="button" className="pc-btn" disabled title={PHASE5}>
+              Vent
+            </button>
+            <button type="button" className="pc-btn" disabled title={PHASE5}>
+              Shutdn
+            </button>
+          </div>
+        </div>
+        <div className="pc-bay">
+          <span className="pc-bay-lab">Chassis</span>
+          <div className="pc-bay-gauges">
+            <CockpitGauge label="SP" value={sp} max={maxSP} tone="mech" />
+            <CockpitGauge label="Cargo" value={cargo} max={maxCargo} tone="mech" />
+          </div>
+          <div className="pc-btn-grid">
+            <button type="button" className="pc-btn" disabled title={PHASE5}>
+              Take Dmg
+            </button>
+            <button type="button" className="pc-btn" disabled title={PHASE5}>
+              Storage
+            </button>
+          </div>
+        </div>
+        <div className="pc-bay">
+          <span className="pc-bay-lab">Egress</span>
+          <div className="pc-btn-grid">
+            <button
+              type="button"
+              className="pc-btn"
+              onClick={onDismount}
+              disabled={!hasPilot}
+              title={hasPilot ? 'Exit the mech (calm)' : 'No pilot assigned to this mech'}
+            >
+              Dismount
+            </button>
+            <button
+              type="button"
+              className="pc-btn pc-btn-danger"
+              onClick={onDismount}
+              disabled={!hasPilot}
+              title={hasPilot ? 'Emergency exit' : 'No pilot assigned to this mech'}
+            >
+              Eject
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function PilotBand({ pilot, onBoard }: { pilot: Pilot; onBoard: () => void }) {
+  const maxHP = Math.max(0, pilotMaxHP(pilot))
+  const maxAP = Math.max(0, pilotMaxAP(pilot))
+  const hp = Math.min(pilot.currentHP ?? maxHP, maxHP)
+  const ap = Math.min(pilot.currentAP ?? maxAP, maxAP)
+
+  return (
+    <div className="pc-band" data-fam="pilot">
+      <div className="pc-band-id">
+        <span className="pc-stamp" style={{ background: 'var(--pc-pilot-deep)' }}>
+          Pilot · {pilot.name}
+        </span>
+      </div>
+      <div className="pc-bays">
+        <div className="pc-bay">
+          <span className="pc-bay-lab">Vitals</span>
+          <div className="pc-bay-gauges">
+            <CockpitGauge label="HP" value={hp} max={maxHP} tone="pilot" />
+            <CockpitGauge label="AP" value={ap} max={maxAP} tone="pilot" />
+          </div>
+          <div className="pc-btn-grid">
+            <button type="button" className="pc-btn" disabled title={PHASE5}>
+              Take Dmg
+            </button>
+            <button type="button" className="pc-btn pc-btn-danger" disabled title={PHASE5}>
+              Crit Injury
+            </button>
+          </div>
+        </div>
+        <div className="pc-bay">
+          <span className="pc-bay-lab">Mount</span>
+          <div className="pc-btn-grid">
+            <button
+              type="button"
+              className="pc-btn pc-btn-go pc-btn-wide"
+              onClick={onBoard}
+              title="Board the mech"
+            >
+              ▶ Board Mech
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/play/CockpitGauge.tsx
+++ b/apps/in-the-union-now/src/components/play/CockpitGauge.tsx
@@ -1,0 +1,53 @@
+/**
+ * CockpitGauge — the bespoke DARK instrument readout for the Active Item and
+ * (later) the dial. A horizontal segmented bar: label stamp, one flex row of
+ * segments (filled up to `value` in the tone colour, empty recessed), and the
+ * value/max numeral.
+ *
+ * Deliberately NOT `suref-react`'s VitalGauge: that gauge is light-themed
+ * (ink text, paper segments) for the sheet/display. The cockpit instruments are
+ * bespoke and dark (proposed ADR-017/018); VitalGauge is reused in the light
+ * display surface instead (Phase 4). Read-only here — Phase 2 is read-mostly.
+ */
+
+import type { CSSProperties } from 'react'
+
+export type GaugeTone = 'mech' | 'pilot' | 'crawler'
+
+const TONES: Record<GaugeTone, [string, string]> = {
+  mech: ['var(--pc-mech)', 'var(--pc-mech-deep)'],
+  pilot: ['var(--pc-pilot)', 'var(--pc-pilot-deep)'],
+  crawler: ['var(--pc-crawler)', 'var(--pc-crawler-deep)'],
+}
+
+type CockpitGaugeProps = {
+  label: string
+  value: number
+  max: number
+  tone?: GaugeTone
+  /** First 0-based segment index that reads as danger (redline) when filled. */
+  danger?: number
+}
+
+export function CockpitGauge({ label, value, max, tone = 'mech', danger }: CockpitGaugeProps) {
+  const total = Math.max(max, value, 0)
+  const [t, td] = TONES[tone]
+  const segs = []
+  for (let i = 0; i < total; i++) {
+    const filled = i < value
+    const isDanger = danger !== undefined && i >= danger
+    let cls = 'pc-seg'
+    if (filled) cls += isDanger ? ' danger' : ' on'
+    segs.push(<span key={i} className={cls} />)
+  }
+  const style = { '--pc-gtone': t, '--pc-gtone-deep': td } as CSSProperties
+  return (
+    <div className="pc-gauge" style={style} role="img" aria-label={`${label} ${value} of ${max}`}>
+      <span className="pc-gauge-lab">{label}</span>
+      <div className="pc-gauge-track">{segs}</div>
+      <span className="pc-gauge-num">
+        {value}/{max}
+      </span>
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/play/PlayCockpit.tsx
+++ b/apps/in-the-union-now/src/components/play/PlayCockpit.tsx
@@ -12,14 +12,17 @@
 
 import { useEntityStore } from '../../stores/entityStore'
 import { usePlayStateStore } from '../../stores/playStateStore'
+import { resolveSheetComposition } from '../sheet/composition'
+import type { EntityLookup } from '../sheet/composition'
+import { ActiveItemBand } from './ActiveItemBand'
 import { CockpitCanvas } from './CockpitCanvas'
 import { RailBar } from './RailBar'
 
 export function PlayCockpit({ id }: { id: string }) {
-  const mech = useEntityStore((s) => s.get('mech', id))
+  const storeState = useEntityStore()
   // The active-row entity drives the whole-canvas tint (proposed ADR-018).
-  // Phase 1 defaults to the boarded mech; the mount transitions land in Phase 2.
   const mount = usePlayStateStore((s) => s.mount)
+  const mech = storeState.get('mech', id)
 
   if (!mech) {
     return (
@@ -42,12 +45,27 @@ export function PlayCockpit({ id }: { id: string }) {
     )
   }
 
+  // Cast mirrors Sheet.tsx: the store's generic get is compatible with the
+  // EntityLookup shape but TS can't align the conditional return types.
+  const lookup: EntityLookup = {
+    get: (type, entityId) => storeState.get(type, entityId),
+  } as EntityLookup
+  const composition = resolveSheetComposition({
+    kind: 'mech',
+    id,
+    links: storeState.softLinks,
+    store: lookup,
+  })
+  const pilot = composition.pilot
+  const onFoot = mount === 'pilot' && pilot !== null
+  const railTitle = onFoot && pilot ? `Pilot · ${pilot.name}` : `Mech · ${mech.name}`
+
   return (
     <CockpitCanvas>
       <div className="pc-grid" data-mount={mount}>
-        <RailBar title={`Mech · ${mech.name}`} />
+        <RailBar title={railTitle} fam={onFoot ? 'pilot' : 'mech'} />
         <div className="pc-primary">
-          <div className="pc-placeholder">Active Item — instrument bays (Phase 2)</div>
+          <ActiveItemBand mech={mech} pilot={pilot} />
         </div>
         <div className="pc-display">
           <div className="pc-fill">Main display — SRD reference &amp; actions (Phase 4)</div>

--- a/apps/in-the-union-now/src/components/play/RailBar.tsx
+++ b/apps/in-the-union-now/src/components/play/RailBar.tsx
@@ -4,15 +4,27 @@
  * surface). Phase 1 wires Return to Workspace; Settings is a placeholder.
  */
 
+import type { CSSProperties } from 'react'
+
 import { AppLink } from '../shared/AppLink'
 
-export function RailBar({ title }: { title: string }) {
+type RailFam = 'mech' | 'pilot' | 'crawler'
+
+const STAMP_BG: Record<RailFam, string> = {
+  mech: 'var(--pc-mech-deep)',
+  pilot: 'var(--pc-pilot-deep)',
+  crawler: 'var(--pc-crawler-deep)',
+}
+
+export function RailBar({ title, fam = 'mech' }: { title: string; fam?: RailFam }) {
   return (
     <div className="pc-rail">
       <AppLink href="/" className="pc-railbtn">
         ◄ Return to Workspace
       </AppLink>
-      <span className="pc-stamp pc-stamp-mech">{title}</span>
+      <span className="pc-stamp" style={{ background: STAMP_BG[fam] } as CSSProperties}>
+        {title}
+      </span>
       <span className="flex-1" />
       <button type="button" className="pc-railbtn" title="Rules & sources — planned" disabled>
         ⚙ Settings

--- a/apps/in-the-union-now/src/components/play/__tests__/ActiveItemBand.test.tsx
+++ b/apps/in-the-union-now/src/components/play/__tests__/ActiveItemBand.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Tests for ActiveItemBand — the Active Item and its mount state machine.
+ *
+ * The gauges derive maxima from the reference ORM, so preload('all') runs once.
+ * Mount transitions (Board / Dismount) are the only mutations in Phase 2.
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import type { Mech } from '../../../lib/schemas/mech'
+import type { Pilot } from '../../../lib/schemas/pilot'
+import { usePlayStateStore } from '../../../stores/playStateStore'
+import { ActiveItemBand } from '../ActiveItemBand'
+
+const mech = {
+  id: 'm1',
+  name: 'Iron Mongrel',
+  chassisRef: 'unknown-chassis',
+  systems: [],
+  modules: [],
+  cargoLots: [],
+} as unknown as Mech
+
+const pilot = {
+  id: 'p1',
+  name: 'Vesh',
+  abilities: [],
+  equipment: [],
+  conditions: [],
+} as unknown as Pilot
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+describe('ActiveItemBand', () => {
+  beforeEach(() => {
+    usePlayStateStore.setState({ mount: 'mech', wheel: 0 })
+  })
+
+  test('boarded → shows the mech band and its bays', () => {
+    render(<ActiveItemBand mech={mech} pilot={null} />)
+    expect(screen.getByText('Mech · Iron Mongrel')).toBeTruthy()
+    expect(screen.getByText('Reactor')).toBeTruthy()
+    expect(screen.getByText('Chassis')).toBeTruthy()
+  })
+
+  test('Dismount is disabled when no pilot is assigned', () => {
+    render(<ActiveItemBand mech={mech} pilot={null} />)
+    expect((screen.getByText('Dismount') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  test('Dismount → pilot band, Board → back to the mech band', () => {
+    render(<ActiveItemBand mech={mech} pilot={pilot} />)
+    fireEvent.click(screen.getByText('Dismount'))
+    expect(screen.getByText('Pilot · Vesh')).toBeTruthy()
+    fireEvent.click(screen.getByText('▶ Board Mech'))
+    expect(screen.getByText('Mech · Iron Mongrel')).toBeTruthy()
+  })
+})

--- a/apps/in-the-union-now/src/components/play/__tests__/CockpitGauge.test.tsx
+++ b/apps/in-the-union-now/src/components/play/__tests__/CockpitGauge.test.tsx
@@ -1,0 +1,28 @@
+/**
+ * Unit tests for CockpitGauge — the bespoke dark instrument bar.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { render } from '@testing-library/react'
+
+import { CockpitGauge } from '../CockpitGauge'
+
+describe('CockpitGauge', () => {
+  test('renders max segments, fills up to value, shows value/max', () => {
+    const { container, getByText } = render(<CockpitGauge label="Heat" value={4} max={6} />)
+    expect(container.querySelectorAll('.pc-seg').length).toBe(6)
+    expect(container.querySelectorAll('.pc-seg.on').length).toBe(4)
+    expect(getByText('4/6')).toBeTruthy()
+  })
+
+  test('filled segments at/after the danger index read as danger (redline)', () => {
+    const { container } = render(<CockpitGauge label="Heat" value={6} max={6} danger={4} />)
+    expect(container.querySelectorAll('.pc-seg.danger').length).toBe(2)
+  })
+
+  test('over-capacity values render extra segments honestly', () => {
+    const { container } = render(<CockpitGauge label="SP" value={8} max={6} />)
+    expect(container.querySelectorAll('.pc-seg').length).toBe(8)
+    expect(container.querySelectorAll('.pc-seg.on').length).toBe(8)
+  })
+})

--- a/apps/in-the-union-now/src/components/play/play.css
+++ b/apps/in-the-union-now/src/components/play/play.css
@@ -25,6 +25,8 @@
   --pc-pilot-deep: #a85222;
   --pc-crawler: #ce5898;
   --pc-crawler-deep: #7e2a5b;
+  --pc-bad: #c0563f;
+  --pc-seg-empty: rgba(216, 201, 164, 0.12);
   color: var(--pc-text);
   font-family: 'Barlow', system-ui, sans-serif;
 }
@@ -150,6 +152,141 @@
 }
 .pc-railbtn:hover {
   border-color: var(--pc-muted);
+}
+
+/* ---- Active Item band: responsibility bays (gauge + button grid) ---- */
+.pc-band {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  height: 100%;
+}
+.pc-band-id {
+  flex: 0 0 auto;
+}
+.pc-bays {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  align-items: stretch;
+}
+.pc-bay {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+  padding: 2px 13px;
+}
+.pc-bay + .pc-bay {
+  border-left: 1.5px solid var(--pc-line);
+}
+.pc-bay-lab {
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.11em;
+  font-size: 9px;
+  line-height: 1;
+  color: var(--pc-muted);
+}
+.pc-bay-gauges {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.pc-btn-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  margin-top: auto;
+  grid-auto-rows: 27px;
+  align-content: end;
+}
+.pc-btn-wide {
+  grid-column: 1 / -1;
+}
+.pc-btn {
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 11px;
+  padding: 0 8px;
+  border: 1.5px solid var(--pc-line);
+  border-radius: 2px;
+  background: color-mix(in oklab, var(--pc-panel) 50%, #000);
+  color: var(--pc-text);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  width: 100%;
+}
+.pc-btn:hover:not(:disabled) {
+  border-color: var(--pc-muted);
+  background: color-mix(in oklab, var(--pc-panel) 64%, #000);
+}
+.pc-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.pc-btn-go {
+  border-color: var(--pc-pilot);
+  color: #fff;
+  background: var(--pc-pilot-deep);
+}
+.pc-btn-danger {
+  border-color: color-mix(in oklab, var(--pc-bad) 70%, #000);
+  color: #e0917f;
+}
+
+/* ---- CockpitGauge: bespoke dark segmented instrument bar ---- */
+.pc-gauge {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+.pc-gauge-lab {
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 10px;
+  min-width: 40px;
+  color: var(--pc-text);
+}
+.pc-gauge-track {
+  display: flex;
+  gap: 3px;
+  flex: 1;
+  min-width: 0;
+}
+.pc-seg {
+  flex: 1 1 0;
+  height: 14px;
+  border: 1.5px solid var(--pc-line);
+  border-radius: 2px;
+  background: var(--pc-seg-empty);
+}
+.pc-seg.on {
+  background: var(--pc-gtone, var(--pc-mech));
+  border-color: var(--pc-gtone-deep, var(--pc-mech-deep));
+}
+.pc-seg.danger {
+  background: var(--pc-bad);
+  border-color: var(--pc-bad);
+}
+.pc-gauge-num {
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  font-size: 15px;
+  min-width: 46px;
+  text-align: right;
+  color: var(--pc-text);
 }
 
 /* Below the scale floor (phones / heavy zoom) the fixed canvas is abandoned. */


### PR DESCRIPTION
## What

Phase 2 of the Play Cockpit ([plan §9.2](https://github.com/SalvageUnion-io/SU-SRD/pull/423)). **Stacked on #424** (base = `worktree-play-cockpit-phase1`) — merge #424 first, then this retargets to `main`.

Binds the Active Item to **real live stats** and wires the **mount state machine**. Read-mostly: only mount transitions mutate; action resolution is Phase 5.

## Changes

- **`ActiveItemBand`** — responsibility "bays" (gauge cluster + button grid).
  - *Mech band*: Reactor (Heat redline + EP) / Chassis (SP + Cargo) / Egress.
  - *Pilot band*: Vitals (HP + AP) / Mount.
  - Gauges bound to `currentSP/EP/Heat/HP/AP` + derived maxima via the existing `derivedStats` (`mechMax*`, `pilotMax*`) + `resolveChassisRef` — no new math.
- **Mount state machine** — Board / Dismount / Eject flip `playStateStore.mount`; the active entity drives the rail stamp + `data-mount` tint. Dismount/Eject disable when no pilot is soft-linked (resolved via `resolveSheetComposition`, same as the sheet).
- **`CockpitGauge`** — bespoke **dark** segmented instrument bar (label + flex segments + value/max, redline via `danger`). Intentionally *not* `suref-react`'s light-themed `VitalGauge` (which is reused later in the light display) — see proposed ADR-017/018.
- Heat/damage/action buttons render but are **disabled** (wired in Phase 5).

## Verification

- `bun run typecheck` clean (all packages); ITUN suite **1132 pass / 0 fail** (new: `CockpitGauge` unit + `ActiveItemBand` mount transitions)
- `biome lint` clean; pre-push validate/knip/typecheck/test all green

## Not in this phase

Action deck + resolve flow, heat/push/overload, damage→critical (Phase 5); the rotary Dial (Phase 3); the SRD display (Phase 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNeL9Bxgw2HRKJpSimK1Wm