### PR TITLE
feat(itun): crawler wizard — book-order steps + type/weapon/SP enforcement (Phase 5)

### DIFF
--- a/apps/in-the-union-now/src/components/crawler/CrawlerBuilder.tsx
+++ b/apps/in-the-union-now/src/components/crawler/CrawlerBuilder.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { SalvageUnionReference } from 'salvageunion-reference'
 import type {
@@ -7,12 +7,22 @@ import type {
   SURefMetaCrawlerTechLevel,
   SURefSystem,
 } from 'salvageunion-reference'
+import { isLegalCreationCrawlerWeapon } from 'salvageunion-reference/rules'
 import { toast } from 'suref-react'
 
-import { useEntityStore } from '../../stores/entityStore'
-import { CrawlerSchema } from '../../lib/schemas/crawler'
+import { useMechs, usePilots } from '../../hooks/queries'
 import { computeCrawlerCapacity } from '../../lib/rules/crawlerCapacity'
+import {
+  clampCrawlerCreationDraft,
+  crawlerCreationStepGate,
+  crawlerWeaponSlotsFor,
+} from '../../lib/rules/creation'
+import type { CrawlerWizardStepId, StepGateResult } from '../../lib/rules/creation'
 import { isWeaponSystem } from '../../lib/rules/crawlerSystems'
+import { crawlerMaxSP } from '../../lib/rules/derivedStats'
+import type { SoftWarning } from '../../lib/rules/types'
+import { CrawlerSchema } from '../../lib/schemas/crawler'
+import { applyCrawlerCrewAndTypeEdit } from '../../lib/wizard/applyCrawlerEdit'
 import {
   EMPTY_CRAWLER_FORM_STATE,
   crawlerFormToCreateInput,
@@ -20,8 +30,13 @@ import {
   seedDefaultCrawlerBays,
 } from '../../lib/wizard/crawlerFormState'
 import type { CrawlerWizardFormState } from '../../lib/wizard/crawlerFormState'
-import { applyCrawlerCrewAndTypeEdit } from '../../lib/wizard/applyCrawlerEdit'
-import type { SoftWarning } from '../../lib/rules/types'
+import {
+  clearWizardDraft,
+  readWizardDraft,
+  useWizardDraftSync,
+  wizardDraftKey,
+} from '../../lib/wizard/wizardDraft'
+import { useEntityStore } from '../../stores/entityStore'
 import { SoftWarningBanner } from '../shared/SoftWarningBanner'
 import { RuleBrief } from '../wizard/RuleBrief'
 import type { StepRule } from '../wizard/RuleBrief'
@@ -29,27 +44,43 @@ import { WizShell, WizTracker } from '../wizard/WizShell'
 import { CrawlerCrewStep } from './CrawlerCrewStep'
 import { CrawlerIdentityStep } from './CrawlerIdentityStep'
 import { CrawlerReviewStep } from './CrawlerReviewStep'
-import { CrawlerTypeOptionList, CrawlerTypeDetail } from './CrawlerTypeStep'
+import { CrawlerStatsStep } from './CrawlerStatsStep'
+import { CrawlerTypeSelectStep } from './CrawlerTypeStep'
 import { SystemsList } from './SystemsList'
-import {
-  clearWizardDraft,
-  readWizardDraft,
-  useWizardDraftSync,
-  wizardDraftKey,
-} from '../../lib/wizard/wizardDraft'
 
-const STEPS = ['Crawler', 'Systems', 'Crew', 'Identity', 'Review'] as const
-type Step = (typeof STEPS)[number]
+/**
+ * Book-order steps (Union Crawler pp.212–213 + Review — plan §4.3). Edit mode
+ * (§5.2) hides the display-only Statistics step and keeps the rest
+ * (1, 3, 4, 5, Review).
+ */
+const CREATE_STEPS: readonly CrawlerWizardStepId[] = [
+  'type',
+  'stats',
+  'weapons',
+  'crew',
+  'identity',
+  'review',
+]
+const EDIT_STEPS: readonly CrawlerWizardStepId[] = CREATE_STEPS.filter((s) => s !== 'stats')
 
-/** Step heading copy (design §3.2). */
-const STEP_TITLES: Record<Step, string> = {
-  Crawler: 'Choose Your Crawler',
-  // This step installs weapon systems into the Armament Bay (the only place a
-  // crawler mounts weapons); the title names it so the mount is unambiguous.
-  Systems: 'Arm the Armament Bay',
-  Crew: 'Meet Your Crew',
-  Identity: 'Name Your Crawler',
-  Review: 'Review',
+/** Stepper-rail labels (mockup Screen 03 `.rlabel`). */
+const STEP_LABELS: Record<CrawlerWizardStepId, string> = {
+  type: 'Crawler Type',
+  stats: 'Statistics',
+  weapons: 'Armament Bay',
+  crew: 'Crew',
+  identity: 'Name',
+  review: 'Review',
+}
+
+/** Step headings — the book's own step names (pp.212–213). */
+const STEP_TITLES: Record<CrawlerWizardStepId, string> = {
+  type: 'Choose a Crawler Type',
+  stats: 'Note your Crawler Statistics',
+  weapons: 'Arm the Armament Bay',
+  crew: 'Name your Crew',
+  identity: 'Name your Crawler',
+  review: 'Review',
 }
 
 type CrawlerBuilderProps = {
@@ -59,8 +90,9 @@ type CrawlerBuilderProps = {
   onCancel: () => void
   /**
    * Id of an existing crawler being edited. When provided, handleSubmit takes
-   * the update branch (never duplicates) and the seeded bay set / live-play
-   * state stays untouched (plan 3.1).
+   * the update branch (never duplicates), the hard creation gates relax to
+   * presence checks, budgets lift (no weapon cap), and the TL filter lifts
+   * (all tech levels — plan §5.2).
    */
   crawlerId?: string
   /**
@@ -70,32 +102,52 @@ type CrawlerBuilderProps = {
   initialState?: CrawlerWizardFormState
 }
 
-/**
- * Returns WEAPONS systems whose numeric techLevel <= the crawler's selected TL.
- * The Systems step installs into the Armament Bay, which holds weapons systems
- * only (Core Book p. 213), so non-weapon systems (Armour Plating, Cargo Pod, …)
- * are excluded outright. Systems with non-numeric TL (Bio/Nanite) are also
- * excluded from TL filtering.
- */
-function filterSystemsByTL(allSystems: SURefSystem[], tl: number | null): SURefSystem[] {
-  if (tl === null) return []
-  return allSystems.filter((s) => {
-    if (typeof s.techLevel !== 'number') return false
-    if (s.techLevel > tl) return false
-    return isWeaponSystem(s)
-  })
+/** Edit-mode gates: presence checks only (plan §5.2 — soft regime). */
+function crawlerEditStepGate(
+  step: CrawlerWizardStepId,
+  form: CrawlerWizardFormState
+): StepGateResult {
+  const hasName = form.name.trim() !== ''
+  switch (step) {
+    // Editing a legacy (untyped) crawler can advance without a type — the
+    // type stays absent and the stored TL is preserved.
+    case 'identity':
+    case 'review':
+      return hasName ? { ok: true } : { ok: false, reason: 'Name your Crawler to continue' }
+    default:
+      return { ok: true }
+  }
+}
+
+/** Slot pips for the tracker tab: ●○ (capped so the tab stays a tab). */
+function slotPips(used: number, max: number): string {
+  if (max <= 0 || max > 12) return ''
+  const filled = Math.max(0, Math.min(used, max))
+  return `${'●'.repeat(filled)}${'○'.repeat(max - filled)} `
 }
 
 /**
- * Multi-step crawler wizard on the shared WizShell skeleton (plan 3.2).
+ * Multi-step crawler wizard on the shared WizShell skeleton, restructured to
+ * the Union Crawler's 5 book steps + Review (wizard-refresh Phase 5, plan
+ * §4.3, mockup Screen 03 — magenta band, peach step card) with the crawler
+ * creation rules enforced HARD (§5):
  *
- * Edit seams are layout-agnostic (plan 3.1): the entity→form mapping happens
- * in lib/wizard/crawlerFormState.ts, the upsert branch lives in handleSubmit,
- * and step components carry NO edit logic.
- *
- * Crawler bays are NOT chosen here — every crawler installs the full SRD bay
- * set on creation (seeded via crawlerFormState.seedDefaultCrawlerBays); the
- * Crawler step's detail pane previews that complement as a 2-col head grid.
+ *   - exactly 1 of 5 types (radio, entity cards); the type's stored
+ *     `mutations` drive the Armament-Bay cap AND the Max SP bonus (never an
+ *     action-name string match); changing type re-clamps step 3 with a toast;
+ *   - Tech Level is FIXED at 1 (display-only Statistics step, no input);
+ *     Max SP stores the BARE tech-level value — the type's +5 applies at
+ *     READ (crawlerMaxSP), so type swaps re-derive correctly both ways;
+ *   - only Tech 1 WEAPONS systems are offered; MINIMUM 1 to advance; the cap
+ *     is clamped at selection time (Battle = 2);
+ *   - the 10 base bays auto-seed (never choosable); expansion bays never
+ *     appear; NPC HP is fixed by data; crew flavor is optional;
+ *   - the name is required; `upgradePool` is fixed at 0 (input removed);
+ *     `scrapPool` is an explicit optional input relocated to step 5;
+ *   - SoftWarningBanner is REMOVED from the create flow — nothing can be in
+ *     violation. Edit mode keeps the soft regime (§5.2): Statistics hidden,
+ *     budgets undefined, TL filter lifted, gates relaxed to presence checks,
+ *     advisory warnings remain.
  */
 export function CrawlerBuilder({
   onComplete,
@@ -104,36 +156,63 @@ export function CrawlerBuilder({
   initialState,
 }: CrawlerBuilderProps) {
   const isEdit = crawlerId !== undefined
+  const steps = isEdit ? EDIT_STEPS : CREATE_STEPS
 
   const [techLevels, setTechLevels] = useState<SURefMetaCrawlerTechLevel[]>([])
   const [allSystems, setAllSystems] = useState<SURefSystem[]>([])
   const [allBays, setAllBays] = useState<SURefEntity[]>([])
   const [types, setTypes] = useState<SURefCrawler[]>([])
+
+  // Advisory prelude context (plan §4.3 step 0): a gentle count of existing
+  // pilots/mechs in this workspace — surfaced in step 1's RuleBrief, NEVER a
+  // blocker (the whole table's state can't be verified).
+  const pilotCount = usePilots().length
+  const mechCount = useMechs().length
+
   // Draft-aware init: a stored session draft (refresh, back-nav, PWA reload)
   // wins over the pristine initial state; cleared on submit/cancelled exit.
+  // Create-mode drafts pass through the deterministic clamp (§5.3): illegal
+  // types/weapons drop, then weapons clamp NEWEST-first to the type's slots;
+  // removals are announced once, by toast.
   const draftKey = wizardDraftKey('crawler', crawlerId)
-  const [form, setForm] = useState<CrawlerWizardFormState>(
-    () =>
-      readWizardDraft<CrawlerWizardFormState>(draftKey) ?? initialState ?? EMPTY_CRAWLER_FORM_STATE
-  )
+  const clampRemovedRef = useRef<string[] | null>(null)
+  const [form, setForm] = useState<CrawlerWizardFormState>(() => {
+    const draft = readWizardDraft<CrawlerWizardFormState>(draftKey)
+    if (draft && !isEdit) {
+      const { form: clamped, removed } = clampCrawlerCreationDraft(draft)
+      if (removed.length > 0) clampRemovedRef.current = removed
+      return clamped
+    }
+    return draft ?? initialState ?? EMPTY_CRAWLER_FORM_STATE
+  })
+  useEffect(() => {
+    const removed = clampRemovedRef.current
+    if (removed && removed.length > 0) {
+      clampRemovedRef.current = null
+      toast.info(`Draft trimmed to the starting rules — removed ${removed.join(', ')}.`)
+    }
+  }, [])
   const formDirty = useWizardDraftSync(draftKey, form, initialState ?? EMPTY_CRAWLER_FORM_STATE)
-  const [step, setStep] = useState<Step>('Crawler')
+  const [step, setStep] = useState<CrawlerWizardStepId>(steps[0] ?? 'type')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
 
-  const currentIndex = STEPS.indexOf(step)
+  const currentIndex = steps.indexOf(step)
 
   useEffect(() => {
-    // crawlers drives the type selection; crawler-bays seeds the default bays
-    // + the Crew step; crawler-tech-levels stays for the SP/capacity lookup;
-    // actions resolves each system's damage so isWeaponSystem can filter the
-    // Systems list down to weapons.
+    // crawlers drives the type selection (and its mutations-derived budgets);
+    // crawler-bays seeds the default bays + the Crew step; crawler-tech-levels
+    // backs the Statistics step + the SP derivation; actions resolves each
+    // system's damage so isWeaponSystem can filter to weapons; roll-tables
+    // backs the Crawler Name d20 assist. The route loader preloads the same
+    // set, so this resolves instantly on the normal path.
     void SalvageUnionReference.preload([
       'crawlers',
       'crawler-tech-levels',
       'systems',
       'crawler-bays',
       'actions',
+      'roll-tables',
     ]).then(() => {
       const tls = SalvageUnionReference.CrawlerTechLevels.all()
       setTechLevels([...tls].sort((a, b) => a.techLevel - b.techLevel))
@@ -147,48 +226,49 @@ export function CrawlerBuilder({
     setForm((prev) => ({ ...prev, ...patch }))
   }
 
-  /**
-   * Choose a crawler type. When switching away from a previously-chosen type,
-   * drop that old type's crew entry (keyed by the old type id) so it can never
-   * be persisted as a phantom bay / stale type NPC on save.
-   */
-  function selectType(type: string) {
-    setForm((prev) => {
-      if (prev.type === type) return { ...prev, type }
-      const nextCrew = { ...prev.crew }
-      if (prev.type !== null) delete nextCrew[prev.type]
-      return { ...prev, type, crew: nextCrew }
-    })
+  function weaponName(ref: string): string {
+    return allSystems.find((s) => s.id === ref)?.name ?? ref
   }
 
-  function canAdvance(): boolean {
-    switch (step) {
-      case 'Crawler':
-        // New crawlers must choose a type; editing a legacy (untyped) crawler
-        // can advance without one (type stays absent, TL is preserved).
-        return isEdit || form.type !== null
-      case 'Systems':
-        return true // systems are optional
-      case 'Crew':
-        return true // crew details are all optional
-      case 'Identity':
-        return form.name.trim() !== ''
-      case 'Review':
-        return (isEdit || form.type !== null) && form.name.trim() !== ''
+  /**
+   * Choose a crawler type (radio). The type's mutations re-derive the
+   * downstream budgets, so switching in create mode RE-CLAMPS step 3's
+   * weapons to the new Armament-Bay cap (newest dropped first) — never a
+   * silent mutation, the toast names what was removed (§5.3). Switching away
+   * from a previously-chosen type also drops that old type's crew entry
+   * (keyed by the old type id) so it can never persist as a phantom bay /
+   * stale type NPC on save.
+   */
+  function selectType(typeId: string) {
+    if (form.type === typeId) return
+    const nextCrew = { ...form.crew }
+    if (form.type !== null) delete nextCrew[form.type]
+
+    let nextSystems = form.systems
+    if (!isEdit) {
+      const slots = crawlerWeaponSlotsFor(typeId)
+      if (form.systems.length > slots) {
+        const dropped = form.systems.slice(slots).map(weaponName)
+        nextSystems = form.systems.slice(0, slots)
+        toast.info(
+          `Type changed — this type mounts ${slots} Weapons System${slots === 1 ? '' : 's'}; removed ${dropped.join(', ')}.`
+        )
+      }
     }
+    updateForm({ type: typeId, crew: nextCrew, systems: nextSystems })
   }
 
   function goNext() {
-    if (step === 'Review') {
+    if (step === 'review') {
       void handleSubmit()
       return
     }
-    const next = STEPS[currentIndex + 1]
+    const next = steps[currentIndex + 1]
     if (next) setStep(next)
   }
 
   function goBack() {
-    const prev = STEPS[currentIndex - 1]
+    const prev = steps[currentIndex - 1]
     if (currentIndex > 0 && prev) setStep(prev)
   }
 
@@ -199,7 +279,7 @@ export function CrawlerBuilder({
     try {
       const store = useEntityStore.getState()
 
-      // Upsert branch (plan 3.1): update when editing — NEVER a second create.
+      // Upsert branch: update when editing — NEVER a second create.
       // The patch touches only wizard-owned fields; bays/NPC live state stays.
       if (crawlerId) {
         // Read the stored record BEFORE the wizard patch so we know the old
@@ -221,8 +301,17 @@ export function CrawlerBuilder({
       }
 
       const now = new Date().toISOString()
-      const maxSP = techLevels.find((t) => t.techLevel === form.techLevel)?.structurePoints
-      // Seed the full SRD bay set — the official sheets pre-print every bay.
+      // Fresh crawlers start at FULL SP — the DERIVED max (bare tech-level
+      // base + the type's read-applied bonus; Battle = 20 + 5 = 25). The
+      // record itself stores no SP maximum: maxSP stays derived-at-read.
+      const maxSP =
+        form.techLevel !== null
+          ? crawlerMaxSP({
+              techLevel: `tech-${form.techLevel}`,
+              ...(form.type !== null ? { type: form.type } : {}),
+            })
+          : undefined
+      // Seed the full base bay set — the official sheets pre-print every bay.
       const rawInput = crawlerFormToCreateInput(form, {
         maxSP,
         crawlerBays: seedDefaultCrawlerBays(),
@@ -255,33 +344,42 @@ export function CrawlerBuilder({
   }
 
   const selectedTechLevel = techLevels.find((t) => t.techLevel === form.techLevel)
-  const selectedType = types.find((t) => t.id === form.type)
+  const selectedType = types.find((t) => t.id === form.type || t.name === form.type)
   // Bays with an embedded crew NPC (the 10 base bays) — the Crew step's roster.
-  const crewBays = allBays.filter(
-    (b): b is SURefEntity & { npc: object } => (b as { npc?: unknown }).npc != null
-  ) as unknown as Array<{
-    id: string
-    name: string
-    npc?: { position?: string; choices?: ReadonlyArray<{ id: string; name: string }> }
-  }>
-  const filteredSystems = filterSystemsByTL(allSystems, form.techLevel)
+  const crewBays = allBays.filter((b) => (b as { npc?: unknown }).npc != null)
+  // The auto-seeded base set (expansion-tagged bays never appear — a STORED
+  // data flag, never computed).
+  const baseBayCount = allBays.filter((b) => !(b as { expansion?: boolean }).expansion).length
+
+  /**
+   * The Armament-Bay catalog: WEAPONS systems only (the bay holds nothing
+   * else — Core Book p.213). Guided create is HARD-filtered to Tech 1
+   * (`isLegalCreationCrawlerWeapon`); edit lifts the TL filter entirely
+   * (plan §5.2). Systems with non-numeric TL (Bio/Nanite) are never Tech 1.
+   */
+  const weaponCatalog = useMemo(() => {
+    const weapons = allSystems.filter((s) => isWeaponSystem(s))
+    if (isEdit) return weapons
+    return weapons.filter((s) => isLegalCreationCrawlerWeapon(s.techLevel))
+  }, [allSystems, isEdit])
+
   const chosenSystems = form.systems
     .map((id) => allSystems.find((s) => s.id === id))
     .filter((s): s is SURefSystem => s !== undefined)
 
-  // The Weapons System cap is gated by crawler type, not tech level: every
-  // crawler mounts one system, except the Battle Crawler (two). The Battle
-  // Crawler is the type whose special ability is "Improved Armour and
-  // Armaments" (Core Book p. 216) — gating off the action name rather than the
-  // display name keeps this stable if the type is renamed.
-  const isBattleCrawler = selectedType?.actions?.includes('Improved Armour and Armaments') ?? false
+  // The Armament-Bay cap comes from the type's STORED `mutations` rows
+  // (weapon_slots; Battle = 2) — plan §4.3, replacing the old action-name
+  // string match. Create clamps at this; edit lifts the budget (§5.2).
+  const weaponSlots = crawlerWeaponSlotsFor(form.type)
+  const installedWeaponCount = form.systems.filter((id) => {
+    const system = allSystems.find((s) => s.id === id)
+    return system ? isWeaponSystem(system) : false
+  }).length
 
-  // Live capacity computation (soft-warn only — does NOT block submit).
-  // Crawler bays are the fixed SRD set, so only the system soft-cap surfaces.
+  // Edit-mode advisory capacity warning (soft — never blocks; §5.2). The
+  // create flow renders NO SoftWarningBanner: violations are impossible by
+  // construction.
   const crawlerCapacity = useMemo(() => {
-    // Only WEAPONS systems count toward the Armament-Bay cap (Core Book p. 213 /
-    // p. 216); non-weapon systems (Armour Plating, Cargo Pod, …) are unlimited.
-    // Resolve each chosen system and keep the damage-dealing ones.
     const weaponSystems = form.systems.filter((id) => {
       const system = allSystems.find((s) => s.id === id)
       return system ? isWeaponSystem(system) : false
@@ -290,9 +388,9 @@ export function CrawlerBuilder({
       techLevel: form.techLevel ?? 0,
       bays: [],
       weaponSystems,
-      isBattleCrawler,
+      isBattleCrawler: weaponSlots > 1,
     })
-  }, [form.techLevel, form.systems, allSystems, isBattleCrawler])
+  }, [form.techLevel, form.systems, allSystems, weaponSlots])
   const isOverCapacity = crawlerCapacity.violations.some(
     (v) => v.kind === 'weapon-systems-over-capacity'
   )
@@ -307,75 +405,108 @@ export function CrawlerBuilder({
       ]
     : []
   const capacityNotice =
-    step === 'Systems' || step === 'Review' ? (
+    isEdit && (step === 'weapons' || step === 'review') ? (
       <SoftWarningBanner warnings={capacityWarnings} />
     ) : undefined
 
-  // Per-step RuleBrief copy (wizard-refresh Phase 2): the step's existing
-  // description on the poster callout (exact per-step rule copy is filled in
-  // by Phases 3–5).
+  // Next-gating (§5.3): guided create runs the hard step gates; edit runs
+  // presence checks. The gate's reason renders in the footerNote so a locked
+  // Next always explains itself.
+  const gate = isEdit ? crawlerEditStepGate(step, form) : crawlerCreationStepGate(step, form)
+
+  // Per-step RuleBrief: the Core Book's own Union Crawler copy, pp.212–213
+  // (create); edit variants describe the lifted soft regime.
   const stepRule: StepRule = (() => {
     switch (step) {
-      case 'Crawler':
+      case 'type':
+        return isEdit
+          ? {
+              rule: 'Change your Crawler type — one of five. Changing it resets the special NPC and re-derives the Armament-Bay cap and Max SP; over-cap weapons warn, never block.',
+              cite: 'Core Book · pp.216–217',
+            }
+          : {
+              rule: (
+                <>
+                  Once all players have created their Pilot and Mech, the final step is for everyone
+                  to create the Union Crawler they share. Your Crawler type provides a unique
+                  Ability that only it can do, as well as a special NPC who resides on the Crawler
+                  and confers their own bonuses.{' '}
+                  <span className="text-ink-2">
+                    (This workspace has {pilotCount} Pilot{pilotCount === 1 ? '' : 's'} and{' '}
+                    {mechCount} Mech{mechCount === 1 ? '' : 's'} so far — context only, never a
+                    blocker.)
+                  </span>
+                </>
+              ),
+              cite: 'Core Book · p.212 · Crawler types pp.216–217',
+            }
+      case 'stats':
         return {
-          rule: 'Pick a crawler type. It grants a special action and a special NPC — every crawler ships with the full bay set and starts at Tech Level 1.',
-          cite: 'Core Book · pp.212–213',
+          rule: 'Your Crawler has a set of statistics based on its Tech Level. This includes its Structure Points, Upkeep, and Upgrade cost. Note these down on your Crawler Sheet.',
+          cite: 'Core Book · p.212 · Crawler Stats p.218',
         }
-      case 'Systems':
+      case 'weapons':
+        return isEdit
+          ? {
+              rule: 'Mount Weapons Systems in the Armament Bay — any tech level. Over-capacity warns on the sheet, never blocks.',
+              cite: 'Core Book · p.213',
+            }
+          : {
+              rule: 'A Union Crawler can mount a single Weapons System in its Armament Bay. To start, this can be any Tech 1 Weapons System of the players’ choice — a Battle Crawler mounts two. Note this down on your Crawler Sheet.',
+              cite: 'Core Book · p.213 · The System list p.162',
+            }
+      case 'crew':
         return {
-          rule: `Mount your crawler’s Weapons Systems in the Armament Bay — Tech Level ${form.techLevel ?? '—'} and below. The Armament-Bay cap is enforced — one Weapons System per crawler (two for a Battle Crawler).`,
-          cite: 'Core Book · pp.212–213',
+          rule: 'The Crawler is made of a number of Bays. Each Bay has an NPC assigned to it based on their experience and skill in operating the Bay. You can flesh them out with a Name, Background, Keepsake, and Motto. Each has 4 HP.',
+          cite: 'Core Book · p.213 · The Crawler Bay list p.221',
         }
-      case 'Crew':
+      case 'identity':
         return {
-          rule: 'Name and detail each bay’s crew lead and your crawler type’s special NPC. All optional.',
-          cite: 'Core Book · pp.212–213',
+          rule: 'Provide your Union Crawler with a unique name and tag. For example, Crawler #132 is also known as ‘Tin Lizzy’. Note these down on your Crawler Sheet. The Scrap Pool below holds the group’s banked Scrap — including whatever your Pilots didn’t spend crafting their Mechs.',
+          cite: 'Core Book · p.212 · The Crawler Names Table p.226',
         }
-      case 'Identity':
+      case 'review':
         return {
-          rule: 'Name your crawler and set its starting resources.',
-          cite: 'Core Book · pp.212–213',
-        }
-      case 'Review':
-        return {
-          rule: isEdit ? 'Check the changes, then save.' : 'Check the build, then create.',
+          rule: isEdit
+            ? 'Check the changes, then save.'
+            : 'Check the build, then create your Crawler.',
+          cite: isEdit ? undefined : 'Core Book · pp.212–213',
         }
     }
   })()
 
-  // Tracker tabs (Phase 2 chrome): reflect today's Armament-Bay usage in the
-  // action pill — no new budget math.
+  // Tracker tab in the action pill (create only — edit lifts the budgets):
+  // the WEAPONS pip chip rides on the Armament step (mockup Screen 03).
   const trackers =
-    step === 'Systems' ? (
+    !isEdit && step === 'weapons' ? (
       <WizTracker
         label="Weapons"
         value={
           <span data-testid="weapon-system-count">
-            {crawlerCapacity.weaponSystemsUsed} /{' '}
-            {crawlerCapacity.weaponSystemsMax > 0 ? crawlerCapacity.weaponSystemsMax : '—'}
+            {slotPips(installedWeaponCount, weaponSlots)}
+            {installedWeaponCount} / {weaponSlots}
           </span>
         }
       />
     ) : undefined
 
+  const footerNote = !gate.ok ? gate.reason : undefined
+
   return (
     <WizShell
       kind="crawler"
-      eyebrow={isEdit ? 'Edit Crawler' : 'New Crawler'}
-      steps={STEPS}
+      eyebrow={isEdit ? 'Edit Crawler' : 'Union Crawler'}
+      steps={steps.map((s) => STEP_LABELS[s])}
       active={currentIndex}
       onStepClick={(i) => {
-        const s = STEPS[i]
+        const s = steps[i]
         if (s) setStep(s)
       }}
       title={STEP_TITLES[step]}
-      trackers={trackers}
-      optionPane={
-        step === 'Crawler' ? (
-          <CrawlerTypeOptionList types={types} selectedType={form.type} onSelect={selectType} />
-        ) : undefined
-      }
+      tintedStepCard
       notice={capacityNotice}
+      trackers={trackers}
+      footerNote={footerNote}
       onBack={currentIndex > 0 ? goBack : undefined}
       onCancel={() => {
         clearWizardDraft(draftKey)
@@ -383,22 +514,27 @@ export function CrawlerBuilder({
       }}
       confirmCancel={formDirty}
       onNext={goNext}
-      nextDisabled={!canAdvance()}
+      nextDisabled={!gate.ok}
       busy={isSubmitting}
       submitLabel={isEdit ? 'Save Crawler' : 'Create Crawler ✦'}
     >
       <RuleBrief rule={stepRule.rule} cite={stepRule.cite} className="mb-5" />
-      {step === 'Crawler' && <CrawlerTypeDetail selected={selectedType} />}
-      {step === 'Systems' && (
+      {step === 'type' && (
+        <CrawlerTypeSelectStep types={types} selectedType={form.type} onSelect={selectType} />
+      )}
+      {step === 'stats' && (
+        <CrawlerStatsStep techLevel={selectedTechLevel} selectedType={selectedType} />
+      )}
+      {step === 'weapons' && (
         <SystemsList
-          systems={filteredSystems}
+          systems={weaponCatalog}
           selectedSystemSlugs={form.systems}
-          maxSelectable={crawlerCapacity.weaponSystemsMax}
-          installedWeaponCount={crawlerCapacity.weaponSystemsUsed}
+          maxSelectable={isEdit ? undefined : weaponSlots}
+          installedWeaponCount={installedWeaponCount}
           onChange={(systems) => updateForm({ systems })}
         />
       )}
-      {step === 'Crew' && (
+      {step === 'crew' && (
         <CrawlerCrewStep
           bays={crewBays}
           selectedType={selectedType}
@@ -406,21 +542,21 @@ export function CrawlerBuilder({
           onChange={updateForm}
         />
       )}
-      {step === 'Identity' && (
+      {step === 'identity' && (
         <CrawlerIdentityStep
           name={form.name}
           description={form.description}
           scrapPool={form.scrapPool}
-          upgradePool={form.upgradePool}
           onChange={updateForm}
         />
       )}
-      {step === 'Review' && (
+      {step === 'review' && (
         <CrawlerReviewStep
           form={form}
           techLevel={selectedTechLevel}
+          selectedType={selectedType}
           systems={chosenSystems}
-          bayCount={allBays.length}
+          bayCount={baseBayCount}
           submitError={submitError}
         />
       )}

--- a/apps/in-the-union-now/src/components/crawler/CrawlerCrewStep.tsx
+++ b/apps/in-the-union-now/src/components/crawler/CrawlerCrewStep.tsx
@@ -1,48 +1,77 @@
-import type { SURefCrawler } from 'salvageunion-reference'
-import { Field, Input } from 'suref-react'
+import { useState } from 'react'
+import type { SURefCrawler, SURefEntity } from 'salvageunion-reference'
+import { ReferenceEntityDisplay, navigateControl } from 'suref-react'
 
 import { findNpcChoiceByName } from '../../lib/crawlerRefs'
 import type { ResolvedNpc } from '../../lib/crawlerRefs'
 import type { CrawlerWizardFormState, CrewNpcForm } from '../../lib/wizard/crawlerFormState'
+import { IdentityField } from '../sheet/IdentityField'
 
 type NpcSource = {
   /** Stable key — the bay ref or the type ref. */
   ref: string
-  /** Heading label (bay name or 'Crawler Type'). */
-  label: string
+  /** The SRD entity (bay or crawler type) — rendered as its entity card. */
+  entity: SURefEntity
   npc: ResolvedNpc
 }
 
 type CrawlerCrewStepProps = {
-  /** Base bays that carry an NPC (the 10 crewed bays). */
-  bays: ReadonlyArray<{ id: string; name: string; npc?: ResolvedNpc }>
-  /** The selected crawler type (its special NPC joins the crew), if any. */
+  /** Base bays that carry an NPC (the 10 crewed bays), as SRD entities. */
+  bays: ReadonlyArray<SURefEntity>
+  /** The selected crawler type (its special NPC heads the crew), if any. */
   selectedType: SURefCrawler | undefined
   /** Crew form state keyed by bay/type ref. */
   crew: Record<string, CrewNpcForm>
   onChange: (patch: Partial<CrawlerWizardFormState>) => void
 }
 
+/** Read the embedded NPC off a bay/type entity (data-shape check). */
+function npcOf(entity: SURefEntity): ResolvedNpc | undefined {
+  return 'npc' in entity && entity.npc != null ? (entity.npc as ResolvedNpc) : undefined
+}
+
 /**
- * Crew step (plan §3): name and detail each base bay's crew lead plus the
- * crawler-type's special NPC. Every field is optional — the step always
- * advances. Augmented's A.I. NPC only carries Name/Description (no
- * Keepsake/Motto), so those fields are guarded off the NPC's own choice set.
+ * Step 4 · Name your Crew (Union Crawler p.213) — the bay roster, restyled to
+ * the poster idiom (wizard-refresh Phase 5): the 10 base bays auto-seed (not
+ * choosable, not removable; expansion bays never appear) and each renders as
+ * its SRD entity card (the universal entity-card rule), header-only until its
+ * row expands into the sheets' IdentityFields for the NPC's four crew facts
+ * (Name, Background, Keepsake, Motto — guarded off the NPC's own choice set:
+ * Augmented's A.I. carries neither Keepsake nor Motto). NPC HP is fixed by
+ * the data (4; Grizzled Veteran 10; the A.I. none) — nothing to input. The
+ * type's special NPC heads the list. Every field is optional — the step
+ * always advances.
  */
 export function CrawlerCrewStep({ bays, selectedType, crew, onChange }: CrawlerCrewStepProps) {
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set())
+
   const sources: NpcSource[] = []
 
-  if (selectedType?.npc) {
+  const typeNpc = selectedType ? npcOf(selectedType as unknown as SURefEntity) : undefined
+  if (selectedType && typeNpc) {
     sources.push({
       ref: selectedType.id,
-      label: `${selectedType.name} Crawler`,
-      npc: selectedType.npc as ResolvedNpc,
+      entity: selectedType as unknown as SURefEntity,
+      npc: typeNpc,
     })
   }
 
   for (const bay of bays) {
-    if (!bay.npc) continue
-    sources.push({ ref: bay.id, label: bay.name, npc: bay.npc })
+    const npc = npcOf(bay)
+    if (!npc) continue
+    sources.push({ ref: (bay as { id: string }).id, entity: bay, npc })
+  }
+
+  function toggle(ref: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(ref)) {
+        next.delete(ref)
+      } else {
+        next.add(ref)
+      }
+      return next
+    })
   }
 
   function updateNpc(ref: string, patch: Partial<CrewNpcForm>) {
@@ -50,73 +79,64 @@ export function CrawlerCrewStep({ bays, selectedType, crew, onChange }: CrawlerC
   }
 
   return (
-    <div className="max-w-3xl space-y-5">
-      <p className="font-body text-xs text-wk-muted">
-        Each crewed bay is run by its own lead, and your crawler type brings a special NPC. Name and
-        detail them now, or leave them blank and fill them in during play.
+    <div className="max-w-3xl space-y-3">
+      <p className="m-0 font-body text-sm text-current">
+        Each crewed Bay is run by its own lead, and your Crawler type brings a special NPC. Open a
+        row to name and detail them now, or leave them blank and fill them in during play.
       </p>
 
       {sources.map((source) => {
         const value = crew[source.ref] ?? {}
+        const isOpen = expanded.has(source.ref)
         const showKeepsake = findNpcChoiceByName(source.npc, 'Keepsake') !== undefined
         const showMotto = findNpcChoiceByName(source.npc, 'Motto') !== undefined
-        const idBase = `crew-${source.ref}`
         return (
-          <section
-            key={source.ref}
-            className="space-y-3 rounded-[3px] border-chrome border-wk-faint p-4"
-          >
-            <header>
-              <h3 className="font-cond text-sm font-bold uppercase tracking-widest text-ink">
-                {source.label}
-              </h3>
-              {source.npc.position && (
-                <p className="mt-0.5 font-body text-xs text-wk-muted">{source.npc.position}</p>
-              )}
-            </header>
-
-            <Field label="Name" htmlFor={`${idBase}-name`}>
-              <Input
-                id={`${idBase}-name`}
-                type="text"
-                value={value.name ?? ''}
-                onChange={(e) => updateNpc(source.ref, { name: e.target.value })}
-                placeholder="Name this crew lead"
-              />
-            </Field>
-
-            <Field label="Description" htmlFor={`${idBase}-description`}>
-              <Input
-                id={`${idBase}-description`}
-                type="text"
-                value={value.description ?? ''}
-                onChange={(e) => updateNpc(source.ref, { description: e.target.value })}
-                placeholder="Appearance and personality"
-              />
-            </Field>
-
-            {showKeepsake && (
-              <Field label="Keepsake" htmlFor={`${idBase}-keepsake`}>
-                <Input
-                  id={`${idBase}-keepsake`}
-                  type="text"
-                  value={value.keepsake ?? ''}
-                  onChange={(e) => updateNpc(source.ref, { keepsake: e.target.value })}
-                  placeholder="A personal item"
+          <section key={source.ref} className="space-y-3">
+            <ReferenceEntityDisplay
+              data={source.entity}
+              mode={isOpen ? 'compact' : 'head'}
+              hide={{ actions: true, choices: true }}
+              controls={[navigateControl(() => toggle(source.ref))]}
+            />
+            {isOpen && (
+              <div className="grid grid-cols-1 gap-3 pb-2 pl-3 sm:grid-cols-2">
+                <IdentityField
+                  label="Name"
+                  value={value.name ?? ''}
+                  editing
+                  onSave={(next) => updateNpc(source.ref, { name: next })}
+                  placeholder="Name this crew lead"
+                  ariaLabel={`${source.npc.position ?? 'crew'} name`}
                 />
-              </Field>
-            )}
-
-            {showMotto && (
-              <Field label="Motto" htmlFor={`${idBase}-motto`}>
-                <Input
-                  id={`${idBase}-motto`}
-                  type="text"
-                  value={value.motto ?? ''}
-                  onChange={(e) => updateNpc(source.ref, { motto: e.target.value })}
-                  placeholder="A personal saying"
+                <IdentityField
+                  label="Background"
+                  value={value.description ?? ''}
+                  editing
+                  onSave={(next) => updateNpc(source.ref, { description: next })}
+                  placeholder="Appearance and personality"
+                  ariaLabel={`${source.npc.position ?? 'crew'} background`}
                 />
-              </Field>
+                {showKeepsake && (
+                  <IdentityField
+                    label="Keepsake"
+                    value={value.keepsake ?? ''}
+                    editing
+                    onSave={(next) => updateNpc(source.ref, { keepsake: next })}
+                    placeholder="A personal item"
+                    ariaLabel={`${source.npc.position ?? 'crew'} keepsake`}
+                  />
+                )}
+                {showMotto && (
+                  <IdentityField
+                    label="Motto"
+                    value={value.motto ?? ''}
+                    editing
+                    onSave={(next) => updateNpc(source.ref, { motto: next })}
+                    placeholder="A personal saying"
+                    ariaLabel={`${source.npc.position ?? 'crew'} motto`}
+                  />
+                )}
+              </div>
             )}
           </section>
         )

--- a/apps/in-the-union-now/src/components/crawler/CrawlerIdentityStep.tsx
+++ b/apps/in-the-union-now/src/components/crawler/CrawlerIdentityStep.tsx
@@ -1,5 +1,8 @@
-import { Field, Input } from 'suref-react'
+import { Btn, Field, Input } from 'suref-react'
 import type { CrawlerWizardFormState, ScrapPoolForm } from '../../lib/wizard/crawlerFormState'
+import { IdentityField } from '../sheet/IdentityField'
+import { rollCrawlerName } from './crawlerRollTables'
+import type { CrawlerRollTableDeps } from './crawlerRollTables'
 
 const SCRAP_BUCKETS = ['tl1', 'tl2', 'tl3', 'tl4', 'tl5', 'tl6'] as const
 
@@ -7,8 +10,9 @@ type CrawlerIdentityStepProps = {
   name: string
   description: string
   scrapPool: ScrapPoolForm
-  upgradePool: number
   onChange: (patch: Partial<CrawlerWizardFormState>) => void
+  /** Injectable roll deps for testing. */
+  _rollDeps?: CrawlerRollTableDeps
 }
 
 function parseCount(raw: string): number {
@@ -17,51 +21,59 @@ function parseCount(raw: string): number {
 }
 
 /**
- * Identity step (design §3.2 Identity variant): max-w-760 form — Crawler Name
- * (required) plus the crawler's starting resources (plan: scrapPool /
- * upgradePool editable in identity where sensible). The shared scrap pool is
- * TL-bucketed (rules C5); the Upgrade Pool accumulates toward the next tech
- * level (rules C4).
+ * Step 5 · Name your Crawler (Union Crawler p.212): the sheets' IdentityField
+ * idiom (the wizard previews exactly the live sheet) with a d20 Crawler Names
+ * Table assist (p.226) — the roll writes into the field and stays editable.
+ * The Scrap Pool relocates here (wizard-refresh Phase 5): an explicit,
+ * OPTIONAL numeric input — the manual landing spot for the group's banked
+ * Scrap, including whatever Pilots didn't spend on their Mechs (the mech
+ * wizard's banking callout is text-only; this is where the number lands).
+ * The Upgrade Pool input is REMOVED — it is fixed at 0 at creation.
  */
 export function CrawlerIdentityStep({
   name,
   description,
   scrapPool,
-  upgradePool,
   onChange,
+  _rollDeps,
 }: CrawlerIdentityStepProps) {
+  function handleRoll() {
+    const result = rollCrawlerName(_rollDeps)
+    if (result !== null) onChange({ name: result })
+  }
+
   return (
     <div className="max-w-3xl space-y-5">
-      <Field label="Crawler Name" required htmlFor="crawler-name">
-        <Input
-          id="crawler-name"
-          type="text"
-          value={name}
-          onChange={(e) => onChange({ name: e.target.value })}
-          placeholder="The Wandering Throne"
-          required
-        />
-      </Field>
+      <IdentityField
+        label="Crawler Name"
+        value={name}
+        editing
+        onSave={(next) => onChange({ name: next })}
+        placeholder="e.g. Crawler #132, aka ‘Tin Lizzy’"
+        labelAction={
+          <Btn size="sm" onClick={handleRoll} className="shrink-0">
+            <span aria-hidden="true">⚄</span> Roll
+          </Btn>
+        }
+      />
 
-      <Field label="Description" htmlFor="crawler-description">
-        <textarea
-          id="crawler-description"
-          value={description}
-          onChange={(e) => onChange({ description: e.target.value })}
-          placeholder="What the crawler is, its build and history."
-          rows={4}
-          className="w-full rounded-[3px] border-chrome border-ink bg-paper px-3 py-2.5 font-body text-sm text-ink placeholder:text-wk-faint focus:outline-none focus:ring-[3px] focus:ring-rust/[0.22]"
-        />
-      </Field>
+      <IdentityField
+        label="Description"
+        value={description}
+        editing
+        multiline
+        onSave={(next) => onChange({ description: next })}
+        placeholder="What the crawler is, its build and history."
+      />
 
       <section className="space-y-4 rounded-[3px] border-chrome border-wk-faint p-4">
         <header>
-          <h2 className="font-cond text-sm font-bold uppercase tracking-widest text-ink">
-            Starting Resources
+          <h2 className="m-0 font-cond text-sm font-bold uppercase tracking-widest text-ink">
+            Scrap Pool
           </h2>
           <p className="mt-0.5 font-body text-xs text-wk-muted">
-            The party&rsquo;s shared scrap pool, bucketed by tech level, plus any Upgrade Pool
-            progress. Leave at 0 for a fresh crawler.
+            The group&rsquo;s banked Scrap, bucketed by tech level — including whatever your Pilots
+            didn&rsquo;t spend crafting their Mechs. Optional; leave at 0 for a fresh start.
           </p>
         </header>
 
@@ -88,16 +100,6 @@ export function CrawlerIdentityStep({
             )
           })}
         </div>
-
-        <Field label="Upgrade Pool" htmlFor="crawler-upgrade-pool" className="max-w-[180px]">
-          <Input
-            id="crawler-upgrade-pool"
-            type="number"
-            min={0}
-            value={upgradePool}
-            onChange={(e) => onChange({ upgradePool: parseCount(e.target.value) })}
-          />
-        </Field>
       </section>
     </div>
   )

--- a/apps/in-the-union-now/src/components/crawler/CrawlerReviewStep.tsx
+++ b/apps/in-the-union-now/src/components/crawler/CrawlerReviewStep.tsx
@@ -1,4 +1,10 @@
-import type { SURefEntity, SURefMetaCrawlerTechLevel, SURefSystem } from 'salvageunion-reference'
+import type {
+  SURefCrawler,
+  SURefEntity,
+  SURefMetaCrawlerTechLevel,
+  SURefSystem,
+} from 'salvageunion-reference'
+import { crawlerMaxSPParts } from 'salvageunion-reference/rules'
 import { ReferenceEntityDisplay } from 'suref-react'
 import { LAYOUT } from '../../lib/layout'
 import { cn } from '../../lib/utils'
@@ -9,6 +15,8 @@ type CrawlerReviewStepProps = {
   form: CrawlerWizardFormState
   /** Resolved tech-level entity for the form's chosen level. */
   techLevel: SURefMetaCrawlerTechLevel | undefined
+  /** The chosen crawler type, resolved. */
+  selectedType: SURefCrawler | undefined
   /** Chosen systems resolved from the form's system ids. */
   systems: SURefSystem[]
   /** Number of SRD bays the crawler ships with (seeded automatically). */
@@ -35,13 +43,18 @@ function KvRow({ label, value }: { label: string; value: string | null }) {
 }
 
 /**
- * Review step (design §3.2 Review): kv-panel of the build's fields on the
- * left, the chosen system cards stacked on the right (fresh systems carry an
- * 'Intact' status badge).
+ * Review (Union Crawler pp.212–213 + wizard-refresh Phase 5): kv-panel recap
+ * of type / ability / weapon(s) / stat block / scrap pool / crew on the left;
+ * the chosen type and weapon entity cards stacked on the right (the universal
+ * entity-card rule — fresh weapons carry an 'Intact' badge). Structure Points
+ * render through the derived-at-read arithmetic (`20 + 5 type bonus = 25` for
+ * Battle). The Augmented type re-surfaces its +1 Training Point reminder —
+ * TEXT ONLY, never a cross-pilot write (ADR-007).
  */
 export function CrawlerReviewStep({
   form,
   techLevel,
+  selectedType,
   systems,
   bayCount,
   submitError,
@@ -51,32 +64,70 @@ export function CrawlerReviewStep({
     .map(([bucket, qty]) => `T${bucket.slice(2)} ×${qty}`)
     .join(' · ')
 
+  const sp = techLevel
+    ? crawlerMaxSPParts({ techLevel: `tech-${techLevel.techLevel}`, type: selectedType?.id })
+    : undefined
+  const spSummary = sp
+    ? sp.typeBonus > 0
+      ? `${sp.base} + ${sp.typeBonus} type bonus = ${sp.total} SP (starts at full)`
+      : `${sp.total} SP (starts at full)`
+    : null
+
+  const crewNames = Object.values(form.crew)
+    .map((entry) => entry.name?.trim())
+    .filter((name): name is string => !!name && name.length > 0)
+
+  const isAugmented = selectedType?.name === 'Augmented'
+
   const rows: [string, string | null][] = [
     ['Name', form.name.trim() || null],
+    ['Type', selectedType ? selectedType.name : null],
+    [
+      'Ability',
+      selectedType?.actions && selectedType.actions.length > 0
+        ? selectedType.actions.join(', ')
+        : '—',
+    ],
     ['Crawler', techLevel ? `${techLevel.name} · Tech Level ${techLevel.techLevel}` : null],
-    ['Structure', techLevel ? `${techLevel.structurePoints} SP (starts at full)` : null],
-    ['Bays', `Full SRD set · ${bayCount} bays, seeded automatically`],
-    ['Systems', systems.length > 0 ? systems.map((s) => s.name).join(', ') : 'none'],
+    ['Structure', spSummary],
+    ['Bays', `Full base set · ${bayCount} bays, seeded automatically · all Intact`],
+    ['Weapons', systems.length > 0 ? systems.map((s) => s.name).join(', ') : null],
     ['Scrap Pool', scrapSummary || '—'],
-    ['Upgrade Pool', form.upgradePool > 0 ? String(form.upgradePool) : '—'],
+    ['Crew', crewNames.length > 0 ? crewNames.join(', ') : 'Unnamed — fill in during play'],
   ]
 
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1.1fr_1fr]">
       {/* kv-panel */}
-      <div className="self-start rounded-[3px] border-chrome border-ink bg-paper p-4 text-sm">
-        {rows.map(([k, v]) => (
-          <KvRow key={k} label={k} value={v} />
-        ))}
-        {submitError && (
-          <p role="alert" className="mt-3 text-sm text-rust">
-            {submitError}
+      <div className="space-y-3 self-start">
+        <div className="rounded-[3px] border-chrome border-ink bg-paper p-4 text-sm">
+          {rows.map(([k, v]) => (
+            <KvRow key={k} label={k} value={v} />
+          ))}
+          {submitError && (
+            <p role="alert" className="mt-3 text-sm text-rust">
+              {submitError}
+            </p>
+          )}
+        </div>
+        {isAugmented && (
+          <p className="m-0 rounded-[3px] border-chrome border-ink bg-paper px-3 py-2.5 font-body text-sm text-ink">
+            <span className="font-cond font-bold uppercase tracking-caps">Reminder — </span>
+            every Pilot gains <strong>+1 Training Point</strong> (Augment ability tree only). Apply
+            it on each Pilot&rsquo;s sheet yourself.
           </p>
         )}
       </div>
 
       {/* chosen cards */}
       <div className="space-y-3">
+        {selectedType && (
+          <ReferenceEntityDisplay
+            data={selectedType as unknown as SURefEntity}
+            compact
+            hide={{ choices: true }}
+          />
+        )}
         {systems.map((system) => (
           <ReferenceEntityDisplay
             key={system.id}
@@ -86,7 +137,9 @@ export function CrawlerReviewStep({
             hide={{ actions: true, choices: true }}
           />
         ))}
-        {systems.length === 0 && <p className="text-sm text-wk-muted">No systems chosen.</p>}
+        {systems.length === 0 && (
+          <p className="m-0 font-body text-sm text-current">No weapons mounted.</p>
+        )}
       </div>
     </div>
   )

--- a/apps/in-the-union-now/src/components/crawler/CrawlerStatsStep.tsx
+++ b/apps/in-the-union-now/src/components/crawler/CrawlerStatsStep.tsx
@@ -1,0 +1,105 @@
+import type { SURefCrawler, SURefMetaCrawlerTechLevel } from 'salvageunion-reference'
+import { crawlerMaxSPParts } from 'salvageunion-reference/rules'
+import { StatBlock } from 'suref-react'
+
+type CrawlerStatsStepProps = {
+  /** The Tech Level 1 (Hamlet Crawler) entity — creation is fixed there. */
+  techLevel: SURefMetaCrawlerTechLevel | undefined
+  /** The chosen crawler type — its max_sp_bonus mutations surface at read. */
+  selectedType: SURefCrawler | undefined
+}
+
+/**
+ * Step 2 · Note your Crawler Statistics (Union Crawler p.212) — display only.
+ * A new crawler is FIXED at Tech Level 1 (a Hamlet Crawler): no input exists.
+ * Max SP renders through the derived-at-read arithmetic (`crawlerMaxSPParts`)
+ * so a Battle crawler shows its breakdown — `20 + 5 type bonus = 25` — while
+ * the RECORD stores only the bare tech-level value (wizard-refresh Phase 5).
+ * The Upgrade Pool starts at 0 (no input — it accumulates in play) and every
+ * bay starts Intact. Nothing to choose — Next always enabled.
+ */
+export function CrawlerStatsStep({ techLevel, selectedType }: CrawlerStatsStepProps) {
+  if (!techLevel) {
+    return (
+      <p className="m-0 font-body text-sm text-current">
+        Tech Level 1 statistics are loading — they appear here.
+      </p>
+    )
+  }
+
+  const sp = crawlerMaxSPParts({
+    techLevel: `tech-${techLevel.techLevel}`,
+    type: selectedType?.id,
+  })
+
+  return (
+    <div className="w-full space-y-5">
+      <div className="flex flex-wrap gap-4">
+        <StatBlock
+          code="TL"
+          name="Tech Level"
+          size="sm"
+          value={techLevel.techLevel}
+          pips={false}
+          editable={false}
+        />
+        <StatBlock
+          code="SP"
+          name="Structure Pts"
+          stat="sp"
+          size="sm"
+          value={sp.total}
+          max={sp.total}
+          editable={false}
+        />
+        <StatBlock
+          code="UPKEEP"
+          name="Upkeep Cost"
+          size="sm"
+          value={techLevel.upkeepCost ?? 0}
+          pips={false}
+          editable={false}
+        />
+        <StatBlock
+          code="UPG"
+          name="Upgrade Cost"
+          size="sm"
+          value={techLevel.upgradeCost ?? 0}
+          pips={false}
+          editable={false}
+        />
+        <StatBlock
+          code="POOL"
+          name="Upgrade Pool"
+          size="sm"
+          value={0}
+          pips={false}
+          editable={false}
+        />
+      </div>
+
+      <div className="max-w-[64ch] space-y-1.5 font-body text-sm leading-relaxed text-current">
+        {sp.typeBonus > 0 && selectedType ? (
+          <p className="m-0" data-testid="sp-breakdown">
+            Structure Points: {sp.base} + {sp.typeBonus} type bonus ({selectedType.name}) ={' '}
+            <strong>{sp.total}</strong> — the bonus derives from your Crawler type, so it follows a
+            type change automatically.
+          </p>
+        ) : (
+          <p className="m-0" data-testid="sp-breakdown">
+            Structure Points: <strong>{sp.total}</strong> — the {techLevel.name} base.
+          </p>
+        )}
+        <p className="m-0">
+          A new Crawler is a <strong>{techLevel.name}</strong>
+          {typeof techLevel.populationMin === 'number' &&
+          typeof techLevel.populationMax === 'number'
+            ? ` — population ${techLevel.populationMin}–${techLevel.populationMax}`
+            : ''}
+          . The Upgrade Pool starts at 0 and fills during play; every Bay starts{' '}
+          <strong>Intact</strong>.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/crawler/CrawlerTypeStep.tsx
+++ b/apps/in-the-union-now/src/components/crawler/CrawlerTypeStep.tsx
@@ -1,5 +1,8 @@
 import type { SURefCrawler, SURefEntity } from 'salvageunion-reference'
-import { OptRow, ReferenceEntityDisplay } from 'suref-react'
+import { crawlerMaxSpBonus, crawlerWeaponSlots } from 'salvageunion-reference/rules'
+import { OptRow, ReferenceEntityDisplay, TreeSep } from 'suref-react'
+import { SelCard } from '../wizard/SelCard'
+import { SelMasonry } from '../wizard/SelMasonry'
 
 type CrawlerTypeOptionListProps = {
   types: SURefCrawler[]
@@ -55,4 +58,81 @@ export function CrawlerTypeDetail({ selected }: CrawlerTypeDetailProps) {
     )
   }
   return <ReferenceEntityDisplay data={selected as unknown as SURefEntity} />
+}
+
+type CrawlerTypeSelectStepProps = {
+  types: SURefCrawler[]
+  selectedType: string | null
+  onSelect: (id: string) => void
+}
+
+/**
+ * Step 1 · Choose a Crawler Type (Union Crawler p.212) — exactly one of the
+ * five types, radio semantics, each rendered as the SRD entity card inside a
+ * SelCard (the universal entity-card rule; wizard-refresh Phase 5). A type's
+ * stored `mutations` surface as footMeta badges (Battle: 2 weapon slots ·
+ * +5 max SP — read from the data, never string-matched). The selected type's
+ * FULL card renders below the grid — its unique Ability, its special NPC, and
+ * (Augmented) the A.I. Personality roll — plus the Augmented type's
+ * instructional +1 Training Point callout (TEXT ONLY: the wizard never writes
+ * to other characters — ADR-007 automation boundary).
+ */
+export function CrawlerTypeSelectStep({
+  types,
+  selectedType,
+  onSelect,
+}: CrawlerTypeSelectStepProps) {
+  const selected = types.find((t) => t.id === selectedType)
+  const isAugmented = selected?.name === 'Augmented'
+
+  return (
+    <div className="w-full space-y-5">
+      <TreeSep name="Crawler Types" suffix="Choose 1" />
+      <SelMasonry radio ariaLabel="Crawler type">
+        {types.map((type) => {
+          const slots = crawlerWeaponSlots(type.mutations)
+          const spBonus = crawlerMaxSpBonus(type.mutations)
+          return (
+            <SelCard
+              key={type.id}
+              entity={type}
+              name={type.name}
+              selected={type.id === selectedType}
+              onToggle={() => onSelect(type.id)}
+              radio
+              entityProps={{
+                footMeta: [
+                  { label: 'Weapon slots', value: String(slots) },
+                  ...(spBonus > 0 ? [{ label: 'Max SP', value: `+${spBonus}` }] : []),
+                ],
+              }}
+            />
+          )
+        })}
+      </SelMasonry>
+
+      {selected ? (
+        <>
+          <TreeSep name="Your Crawler Type" suffix={selected.name} />
+          <div className="max-w-3xl space-y-3">
+            <ReferenceEntityDisplay data={selected as unknown as SURefEntity} />
+            {isAugmented && (
+              <p className="m-0 rounded-[3px] border-chrome border-ink bg-paper px-3 py-2.5 font-body text-sm text-ink">
+                <span className="font-cond font-bold uppercase tracking-caps">
+                  Augmented bonus —{' '}
+                </span>
+                every Pilot gains <strong>+1 Training Point</strong>, spendable on the{' '}
+                <strong>Augment ability tree only</strong>. Apply it on each Pilot&rsquo;s sheet
+                yourself — the wizard never writes to other characters.
+              </p>
+            )}
+          </div>
+        </>
+      ) : (
+        <p className="m-0 font-body text-sm text-current">
+          Pick a type to preview its unique Ability and special NPC.
+        </p>
+      )}
+    </div>
+  )
 }

--- a/apps/in-the-union-now/src/components/crawler/SystemsList.tsx
+++ b/apps/in-the-union-now/src/components/crawler/SystemsList.tsx
@@ -3,16 +3,18 @@ import { SelCard } from '../wizard/SelCard'
 import { SelMasonry } from '../wizard/SelMasonry'
 
 type SystemsListProps = {
-  /** Weapons systems available to install, already filtered by tech level. */
+  /** Weapons systems available to install, already filtered by the parent. */
   systems: SURefSystem[]
   selectedSystemSlugs: string[]
   /**
-   * Hard cap on how many WEAPONS systems may be installed — the crawler type's
-   * Armament-Bay weapons-system allowance (1, or 2 for a Battle Crawler; Core
-   * Book p. 213 / p. 216). Once this many weapons are installed, the remaining
-   * cards are disabled until one is removed.
+   * Hard cap on how many WEAPONS systems may be installed — the crawler
+   * type's Armament-Bay allowance, read from its stored `mutations` (1, or 2
+   * for a Battle Crawler; Core Book p. 213 / p. 216). Once this many weapons
+   * are installed, the remaining cards disable with a reason chip until one
+   * is removed. `undefined` lifts the cap entirely (edit mode's soft regime —
+   * plan §5.2: budgets undefined, over-cap warns instead).
    */
-  maxSelectable: number
+  maxSelectable?: number
   /**
    * How many WEAPONS systems are currently installed. The cap counts weapons
    * only — NOT `selectedSystemSlugs.length`. A crawler may also carry
@@ -27,11 +29,14 @@ type SystemsListProps = {
 }
 
 /**
- * Systems step grid — 3-col Sel-grid WizShell variant (design §3.2). The
- * parent owns the weapons + TL filter (weapons systems at the crawler's tech
- * level and below); selection is HARD-capped at `maxSelectable` — the crawler
- * type's Armament-Bay allowance — so a crawler can never install more weapons
- * systems than its type permits.
+ * Step 3 · Arm the Armament Bay (Union Crawler p.213) — the weapons-system
+ * Sel grid, every option rendered as the SRD entity card inside a SelCard
+ * (the universal entity-card rule). The parent owns the weapons + TL filter
+ * (guided create: Tech 1 only); selection is HARD-capped at `maxSelectable`
+ * — the type's mutations-derived Armament-Bay allowance — and an at-cap card
+ * dims with a reason chip naming the gate (mockup Screen 02), visible, never
+ * hidden. Edit mode passes `maxSelectable: undefined` and keeps the soft
+ * over-cap warning instead.
  */
 export function SystemsList({
   systems,
@@ -40,7 +45,7 @@ export function SystemsList({
   installedWeaponCount,
   onChange,
 }: SystemsListProps) {
-  const atCap = installedWeaponCount >= maxSelectable
+  const atCap = maxSelectable !== undefined && installedWeaponCount >= maxSelectable
 
   function toggle(systemId: string) {
     if (selectedSystemSlugs.includes(systemId)) {
@@ -51,9 +56,7 @@ export function SystemsList({
   }
 
   if (systems.length === 0) {
-    return (
-      <p className="text-sm text-wk-muted">Select a tech level to see available weapons systems.</p>
-    )
+    return <p className="m-0 font-body text-sm text-current">No weapons systems available.</p>
   }
 
   return (
@@ -68,6 +71,9 @@ export function SystemsList({
             name={system.name}
             selected={selected}
             disabled={disabled}
+            disabledReason={
+              disabled ? `Armament Bay full · ${installedWeaponCount} mounted` : undefined
+            }
             onToggle={() => toggle(system.id)}
           />
         )

--- a/apps/in-the-union-now/src/components/crawler/__tests__/CrawlerBuilder-responsive.test.tsx
+++ b/apps/in-the-union-now/src/components/crawler/__tests__/CrawlerBuilder-responsive.test.tsx
@@ -25,6 +25,8 @@ beforeAll(async () => {
     'crawler-tech-levels',
     'systems',
     'crawler-bays',
+    'actions',
+    'roll-tables',
   ])
 })
 
@@ -42,11 +44,11 @@ describe('CrawlerBuilder — responsive wizard layout', () => {
     expect(shell).toBeTruthy()
   })
 
-  test('renders a stepper navigation rail with all five steps', async () => {
+  test('renders a stepper navigation rail with all six book-order steps', async () => {
     const { container } = await renderBuilder()
     const stepper = container.querySelector('nav[aria-label="Steps"]')
     expect(stepper).toBeTruthy()
-    for (const label of ['Crawler', 'Systems', 'Crew', 'Identity', 'Review']) {
+    for (const label of ['Crawler Type', 'Statistics', 'Armament Bay', 'Crew', 'Name', 'Review']) {
       expect(stepper?.textContent).toContain(label)
     }
   })

--- a/apps/in-the-union-now/src/components/crawler/__tests__/CrawlerBuilder.test.tsx
+++ b/apps/in-the-union-now/src/components/crawler/__tests__/CrawlerBuilder.test.tsx
@@ -1,15 +1,17 @@
 /**
  * Integration tests for CrawlerBuilder (create + edit on the WizShell
- * skeleton).
+ * skeleton), restructured to the Union Crawler's book order (wizard-refresh
+ * Phase 5, pp.212–213):
  *
- * Exercises Crawler (master-detail TYPE pick with feature preview) →
- * Systems (TL-filtered Sel grid) → Crew (NPC details) → Identity (name +
- * starting resources) → Review → submit using the real wizard, real
- * SalvageUnionReference data, real Zod validation, and a fake-indexeddb-backed
- * entityStore.
+ *   Choose a Crawler Type (radio entity cards) → Note your Crawler
+ *   Statistics (display-only, create) → Arm the Armament Bay (Tech-1
+ *   weapons, min 1, mutations-derived cap) → Name your Crew (roster rows →
+ *   IdentityFields) → Name your Crawler (name + scrap pool) → Review →
+ *   submit.
  *
- * fake-indexeddb/auto is preloaded via bunfig.toml.
- * SalvageUnionReference is preloaded in beforeAll.
+ * Uses the real wizard, real SalvageUnionReference data, real Zod validation,
+ * and a fake-indexeddb-backed entityStore (fake-indexeddb/auto preloaded via
+ * bunfig.toml; SalvageUnionReference preloaded in beforeAll).
  */
 
 import { afterEach, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
@@ -55,6 +57,7 @@ function resetEntityStore(): void {
 }
 
 beforeEach(async () => {
+  sessionStorage.clear()
   _resetDbSingleton()
   await _clearAllStores()
   resetEntityStore()
@@ -65,6 +68,7 @@ afterEach(async () => {
   await act(async () => {
     cleanup()
   })
+  sessionStorage.clear()
   await _clearAllStores()
   resetEntityStore()
 })
@@ -73,18 +77,19 @@ afterEach(async () => {
 // Helpers (WizShell skeleton)
 // ---------------------------------------------------------------------------
 
-/**
- * Tech-level rows are OptRow <button>s whose accessible text starts with the
- * level name; system cards are Sel wrappers — div[role="button"] with
- * aria-label set to the entity name. Both report role=button.
- */
+/** Crawler-type cells are radio SelCards (exactly-one semantics). */
+async function pickType(name: string): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('radio', { name }))
+  })
+}
+
+/** Weapon cards are Sel wrappers — div[role="button"] with aria-label. */
 function getPickByName(name: string): HTMLElement {
   const candidates = screen.getAllByRole('button')
   const exact = candidates.find((b) => b.getAttribute('aria-label') === name)
-  if (exact) return exact
-  const row = candidates.find((b) => (b.textContent ?? '').includes(name))
-  if (!row) throw new Error(`No role=button pick for "${name}"`)
-  return row
+  if (!exact) throw new Error(`No role=button pick for "${name}"`)
+  return exact
 }
 
 async function pick(name: string): Promise<void> {
@@ -104,10 +109,32 @@ async function clickNext(): Promise<void> {
   })
 }
 
+/** Expand a crew roster row by clicking its entity card (cardClick → button). */
+async function expandRow(name: string): Promise<void> {
+  const card = screen
+    .getAllByRole('button')
+    .find((b) => (b.textContent ?? '').includes(name) && b.getAttribute('aria-label') === null)
+  if (!card) throw new Error(`No clickable roster card for "${name}"`)
+  await act(async () => {
+    fireEvent.click(card)
+  })
+}
+
+/** Fill a click-to-edit IdentityField (open → type → blur commits). */
+async function fillField(editLabel: string, value: string): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: editLabel }))
+  })
+  const input = screen.getByRole('textbox', { name: editLabel }) as HTMLInputElement
+  await act(async () => {
+    fireEvent.change(input, { target: { value } })
+    fireEvent.blur(input, { target: { value } })
+  })
+}
+
 /**
- * First WEAPONS (damage-dealing) system at a tech level. The crawler subtitle
- * counts only weapons systems toward the Armament-Bay cap, so count assertions
- * must install a weapon, not just any system.
+ * First WEAPONS (damage-dealing) system at a tech level. The Armament-Bay cap
+ * counts only weapons systems, so count assertions must install a weapon.
  */
 function weaponSystemAtTL(tl: number): { id: string; name: string } {
   const found = SalvageUnionReference.Systems.findAll(
@@ -117,7 +144,7 @@ function weaponSystemAtTL(tl: number): { id: string; name: string } {
   return found as { id: string; name: string }
 }
 
-/** All WEAPONS systems at or below a tech level (the Systems-step catalog). */
+/** All WEAPONS systems at or below a tech level. */
 function weaponSystemsUpToTL(tl: number): Array<{ id: string; name: string }> {
   return SalvageUnionReference.Systems.findAll(
     (s) => typeof s.techLevel === 'number' && s.techLevel <= tl && isWeaponSystem(s)
@@ -138,74 +165,102 @@ function nonWeaponSystemAtTL(tl: number): { id: string; name: string } {
 // ---------------------------------------------------------------------------
 
 describe('CrawlerBuilder — create mode', () => {
-  it('renders the master-detail Crawler step with TYPE rows and a feature preview', async () => {
+  it('step 1 renders the five types as radio entity cards with a mutations badge + detail', async () => {
     render(<CrawlerBuilder onComplete={() => {}} onCancel={() => {}} />)
 
-    expect(screen.getByText('Choose Your Crawler')).toBeTruthy()
+    expect(screen.getAllByText('Choose a Crawler Type').length).toBeGreaterThan(0)
     await waitFor(() => {
-      expect(getPickByName('Battle')).toBeTruthy()
+      expect(screen.getByRole('radio', { name: 'Battle' })).toBeTruthy()
     })
+    for (const name of ['Augmented', 'Engineering', 'Exploratory', 'Trade Caravan']) {
+      expect(screen.getByRole('radio', { name })).toBeTruthy()
+    }
 
-    // No selection yet — Next is disabled, detail pane shows the empty hint.
+    // No selection yet — Next is gated with a reason.
     expect(getNextButton().disabled).toBe(true)
-    expect(screen.getByText(/Select a crawler type to preview/i)).toBeTruthy()
+    expect(screen.getByText(/Choose your Crawler type/i)).toBeTruthy()
 
-    // Selecting a type shows its feature card (special action + NPC), NOT a bay grid.
-    await pick('Battle')
+    // Selecting Battle shows its full detail card: the unique Ability + NPC.
+    await pickType('Battle')
     await waitFor(() => {
-      // The special action is unique to the detail card.
-      expect(screen.getByText('Improved Armour and Armaments')).toBeTruthy()
-      // The special NPC's position surfaces (also in the OptRow desc → multiple).
+      expect(screen.getAllByText('Improved Armour and Armaments').length).toBeGreaterThan(0)
       expect(screen.getAllByText('Grizzled Veteran').length).toBeGreaterThan(0)
     })
     expect(getNextButton().disabled).toBe(false)
   }, 30000)
 
-  it('TL-filters the Systems step to Tech Level 1 (fixed for new crawlers)', async () => {
+  it('the Augmented type surfaces the +1 Training Point callout (text only)', async () => {
+    render(<CrawlerBuilder onComplete={() => {}} onCancel={() => {}} />)
+    await waitFor(() => screen.getByRole('radio', { name: 'Augmented' }))
+    await pickType('Augmented')
+    await waitFor(() => {
+      expect(screen.getByText(/\+1 Training Point/)).toBeTruthy()
+      expect(screen.getByText(/Augment ability tree only/)).toBeTruthy()
+    })
+  }, 30000)
+
+  it('step 2 displays fixed TL1 statistics with the derived SP breakdown (Battle 20 + 5 = 25)', async () => {
+    render(<CrawlerBuilder onComplete={() => {}} onCancel={() => {}} />)
+    await waitFor(() => screen.getByRole('radio', { name: 'Battle' }))
+    await pickType('Battle')
+    await clickNext() // -> Statistics
+
+    const breakdown = screen.getByTestId('sp-breakdown')
+    expect(breakdown.textContent).toContain('20 + 5 type bonus')
+    expect(breakdown.textContent).toContain('25')
+    // Display-only: no Tech Level input exists, Next is never gated here.
+    expect(screen.queryByLabelText(/Tech Level/i)).toBeNull()
+    expect(getNextButton().disabled).toBe(false)
+  }, 30000)
+
+  it('TL-filters the Armament step to Tech 1 weapons only (non-weapons excluded)', async () => {
     render(<CrawlerBuilder onComplete={() => {}} onCancel={() => {}} />)
 
-    await waitFor(() => getPickByName('Battle'))
-    await pick('Battle')
-    await clickNext()
+    await waitFor(() => screen.getByRole('radio', { name: 'Battle' }))
+    await pickType('Battle')
+    await clickNext() // Statistics
+    await clickNext() // -> Armament Bay
 
-    // The catalog is weapons-only, so isolate the TL behaviour with weapons.
     const tl1 = weaponSystemAtTL(1)
     const tl2 = weaponSystemAtTL(2)
+    const nonWeapon = nonWeaponSystemAtTL(1)
     await waitFor(() => {
       expect(screen.getByRole('button', { name: tl1.name })).toBeTruthy()
     })
+    // Higher-TL weapons are FILTERED OUT (never rendered), as are non-weapons.
     expect(screen.queryByRole('button', { name: tl2.name })).toBeNull()
-  }, 30000)
-
-  it('lists only WEAPONS systems — non-weapon systems never appear', async () => {
-    render(<CrawlerBuilder onComplete={() => {}} onCancel={() => {}} />)
-
-    await waitFor(() => getPickByName('Battle'))
-    await pick('Battle')
-    await clickNext() // -> Systems
-
-    const weapon = weaponSystemAtTL(1)
-    const nonWeapon = nonWeaponSystemAtTL(1)
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: weapon.name })).toBeTruthy()
-    })
-    // A non-weapon system at the same TL is filtered out of the catalog.
     expect(screen.queryByRole('button', { name: nonWeapon.name })).toBeNull()
   }, 30000)
 
-  it('hard-caps installs at the crawler-type allowance (Engineering = 1)', async () => {
+  it('gates the Armament step on the minimum-1 weapon mount', async () => {
     render(<CrawlerBuilder onComplete={() => {}} onCancel={() => {}} />)
 
-    // Engineering is a non-Battle type: one Weapons System (Core Book p. 213).
-    await waitFor(() => getPickByName('Engineering'))
-    await pick('Engineering')
-    await clickNext() // -> Systems
+    await waitFor(() => screen.getByRole('radio', { name: 'Engineering' }))
+    await pickType('Engineering')
+    await clickNext() // Statistics
+    await clickNext() // -> Armament Bay
+
+    // Nothing mounted — Next is locked with the reason in the footer.
+    expect(getNextButton().disabled).toBe(true)
+    expect(screen.getByText(/Mount at least one Weapons System/i)).toBeTruthy()
+
+    const weapon = weaponSystemAtTL(1)
+    await pick(weapon.name)
+    expect(getNextButton().disabled).toBe(false)
+  }, 30000)
+
+  it('hard-caps installs at the mutations-derived type allowance (Engineering = 1)', async () => {
+    render(<CrawlerBuilder onComplete={() => {}} onCancel={() => {}} />)
+
+    await waitFor(() => screen.getByRole('radio', { name: 'Engineering' }))
+    await pickType('Engineering')
+    await clickNext() // Statistics
+    await clickNext() // -> Armament Bay
 
     const weapons = weaponSystemsUpToTL(1)
     expect(weapons.length).toBeGreaterThanOrEqual(2)
     const [first, second] = weapons
 
-    // Both weapons are selectable before anything is installed.
     await waitFor(() => {
       expect(screen.getByRole('button', { name: must(first).name })).toBeTruthy()
     })
@@ -227,58 +282,70 @@ describe('CrawlerBuilder — create mode', () => {
     })
   }, 30000)
 
-  it('walks through every step and creates a TL1 typed crawler with seeded bays, crew + resources', async () => {
+  it('a Battle Crawler mounts two — and a type change re-clamps with a toast', async () => {
+    render(<CrawlerBuilder onComplete={() => {}} onCancel={() => {}} />)
+
+    await waitFor(() => screen.getByRole('radio', { name: 'Battle' }))
+    await pickType('Battle')
+    await clickNext() // Statistics
+    await clickNext() // -> Armament Bay
+
+    const weapons = weaponSystemsUpToTL(1)
+    const [first, second] = weapons
+    await waitFor(() => screen.getByRole('button', { name: must(first).name }))
+    await pick(must(first).name)
+    await pick(must(second).name)
+    expect(screen.getByTestId('weapon-system-count').textContent).toContain('2 / 2')
+
+    // Back to step 1: switching Battle → Engineering re-clamps to 1 slot,
+    // dropping the NEWEST mount.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Crawler Type/i }))
+    })
+    await pickType('Engineering')
+    await clickNext() // Statistics
+    await clickNext() // -> Armament Bay
+    expect(screen.getByTestId('weapon-system-count').textContent).toContain('1 / 1')
+  }, 30000)
+
+  it('walks every book step and creates a TL1 Battle crawler seeded at the DERIVED full SP', async () => {
     const onComplete = mock(() => {})
     render(<CrawlerBuilder onComplete={onComplete} onCancel={() => {}} />)
 
     const battle = must(SalvageUnionReference.Crawlers.find((c) => c.name === 'Battle'))
     const commandBay = must(SalvageUnionReference.CrawlerBays.find((b) => b.name === 'Command Bay'))
 
-    // --- Step 1: Crawler — pick a TYPE ---
-    await waitFor(() => getPickByName('Battle'))
-    await pick('Battle')
+    // --- Step 1: Choose a Crawler Type ---
+    await waitFor(() => screen.getByRole('radio', { name: 'Battle' }))
+    await pickType('Battle')
     await clickNext()
 
-    // --- Step 2: Systems — live weapon-system count in subtitle ---
+    // --- Step 2: Note your Crawler Statistics (display-only) ---
+    expect(screen.getByTestId('sp-breakdown')).toBeTruthy()
+    await clickNext()
+
+    // --- Step 3: Arm the Armament Bay (min 1, Tech 1 weapons) ---
     const tl1 = weaponSystemAtTL(1)
     await pick(tl1.name)
     expect(screen.getByTestId('weapon-system-count').textContent).toContain('1 /')
     await clickNext()
 
-    // --- Step 3: Crew — fill the Command Bay lead + the type NPC ---
-    const byId = (id: string): HTMLElement => {
-      const el = document.getElementById(id)
-      if (!el) throw new Error(`No element #${id}`)
-      return el
-    }
-    await waitFor(() => byId(`crew-${commandBay.id}-name`))
-    fireEvent.change(byId(`crew-${commandBay.id}-name`), {
-      target: { value: 'Maddox' },
-    })
-    fireEvent.change(byId(`crew-${commandBay.id}-keepsake`), {
-      target: { value: 'A medal' },
-    })
-    fireEvent.change(byId(`crew-${battle.id}-name`), {
-      target: { value: 'Vex' },
-    })
-    fireEvent.change(byId(`crew-${battle.id}-motto`), {
-      target: { value: 'No retreat' },
-    })
+    // --- Step 4: Name your Crew (roster rows → IdentityFields) ---
+    await expandRow('Battle')
+    await fillField('Edit grizzled veteran name', 'Vex')
+    await fillField('Edit grizzled veteran motto', 'No retreat')
+    await expandRow('Command Bay')
+    await fillField('Edit princeps name', 'Maddox')
+    await fillField('Edit princeps keepsake', 'A medal')
     await clickNext()
 
-    // --- Step 4: Identity — name + starting resources ---
-    fireEvent.change(screen.getByLabelText(/Crawler Name/i), {
-      target: { value: 'Bay Wagon' },
-    })
-    fireEvent.change(screen.getByLabelText(/Scrap T2/i), {
-      target: { value: '3' },
-    })
-    fireEvent.change(screen.getByLabelText(/Upgrade Pool/i), {
-      target: { value: '12' },
-    })
+    // --- Step 5: Name your Crawler (+ scrap pool; NO upgrade pool input) ---
+    expect(screen.queryByLabelText(/Upgrade Pool/i)).toBeNull()
+    await fillField('Edit crawler name', 'Bay Wagon')
+    fireEvent.change(screen.getByLabelText(/Scrap T2/i), { target: { value: '3' } })
     await clickNext()
 
-    // --- Step 5: Review → submit ('Create Crawler ✦') ---
+    // --- Review → submit ('Create Crawler ✦') ---
     const submit = screen.getByRole('button', { name: /Create Crawler/i })
     await act(async () => {
       fireEvent.click(submit)
@@ -294,13 +361,17 @@ describe('CrawlerBuilder — create mode', () => {
       expect(c.schemaVersion).toBe(1)
       expect(c.systems).toEqual([tl1.id])
       expect(c.scrapPool).toEqual({ tl2: 3 })
-      expect(c.upgradePool).toBe(12)
+      // upgradePool is FIXED at 0 at creation (input removed).
+      expect(c.upgradePool).toBe(0)
+      // The record stores NO SP maximum and NO type bonus — max SP derives at
+      // read. currentSP seeds at the DERIVED full (20 base + 5 Battle) = 25.
+      expect(c.maxSpModifier).toBeUndefined()
+      expect(c.currentSP).toBe(25)
 
       // Base bay set seeded (expansion bays excluded), NPCs at max HP (4)
       // where the bay has one.
       const baseBays = SalvageUnionReference.CrawlerBays.all().filter((b) => !b.expansion)
       expect(c.crawlerBays?.length).toBe(baseBays.length)
-      // No expansion bay is ever auto-installed on a fresh crawler.
       const expansionBays = SalvageUnionReference.CrawlerBays.all().filter((b) => b.expansion)
       expect(expansionBays.length).toBeGreaterThan(0)
       for (const exp of expansionBays) {
@@ -316,12 +387,9 @@ describe('CrawlerBuilder — create mode', () => {
       ).id
       expect(c.bayChoices?.[commandBay.id]?.[keepsakeId]).toEqual(['A medal'])
       expect(c.typeNpc?.npcName).toBe('Vex')
+      expect(c.typeNpc?.npcCurrentHP).toBe(10) // the Grizzled Veteran's fixed HP
       const mottoId = must(must(must(battle.npc).choices).find((ch) => ch.name === 'Motto')).id
       expect(c.bayChoices?.[battle.id]?.[mottoId]).toEqual(['No retreat'])
-
-      // Fresh crawlers start at full SP for Tech Level 1.
-      const tl = must(SalvageUnionReference.CrawlerTechLevels.find((t) => t.techLevel === 1))
-      expect(c.currentSP).toBe(tl.structurePoints)
     })
     expect(onComplete).toHaveBeenCalledTimes(1)
   }, 30000)
@@ -329,14 +397,17 @@ describe('CrawlerBuilder — create mode', () => {
   it('name gate: cannot reach Create with an empty name', async () => {
     render(<CrawlerBuilder onComplete={() => {}} onCancel={() => {}} />)
 
-    await waitFor(() => getPickByName('Battle'))
-    await pick('Battle')
-    await clickNext() // Systems
+    await waitFor(() => screen.getByRole('radio', { name: 'Battle' }))
+    await pickType('Battle')
+    await clickNext() // Statistics
+    await clickNext() // Armament Bay
+    await pick(weaponSystemAtTL(1).name) // satisfy the min-1 mount
     await clickNext() // Crew
-    await clickNext() // Identity
+    await clickNext() // Name
 
     // Name left empty — Next stays disabled, Review/Create is unreachable.
     expect(getNextButton().disabled).toBe(true)
+    expect(screen.getByText(/Name your Crawler to continue/i)).toBeTruthy()
     expect(useEntityStore.getState().list('crawler').length).toBe(0)
   }, 30000)
 
@@ -350,20 +421,19 @@ describe('CrawlerBuilder — create mode', () => {
     expect(onCancel).toHaveBeenCalledTimes(1)
   })
 
-  it('offers no bay catalog in the Crawler step — bays are seeded, not chosen', async () => {
+  it('offers no bay catalog anywhere — bays are seeded, not chosen', async () => {
     render(<CrawlerBuilder onComplete={() => {}} onCancel={() => {}} />)
 
-    await waitFor(() => getPickByName('Battle'))
-    await pick('Battle')
+    await waitFor(() => screen.getByRole('radio', { name: 'Battle' }))
+    await pickType('Battle')
 
-    // The type detail card shows features, not a 2-col bay head grid.
     expect(screen.queryByLabelText('Bay entity slug')).toBeNull()
     expect(screen.queryByRole('button', { name: /Add Bay/i })).toBeNull()
   }, 30000)
 })
 
 // ---------------------------------------------------------------------------
-// Edit mode: upsert branch — live-play state never clobbered
+// Edit mode: upsert branch — soft regime, live-play state never clobbered
 // ---------------------------------------------------------------------------
 
 async function seedCrawler(overrides?: { techLevel?: number; type?: string }) {
@@ -384,7 +454,7 @@ async function seedCrawler(overrides?: { techLevel?: number; type?: string }) {
 }
 
 describe('CrawlerBuilder — edit mode', () => {
-  it('prefills from the crawler and updates without duplicating or touching live state', async () => {
+  it('hides the Statistics step and prefills; updates without duplicating or touching live state', async () => {
     const crawler = await seedCrawler()
     // Simulate play: SP knocked down + a bay NPC wounded.
     const playedBayRef = must(must(crawler.crawlerBays)[0]).bayRef
@@ -405,19 +475,23 @@ describe('CrawlerBuilder — edit mode', () => {
       />
     )
 
-    // Eyebrow flips to edit mode; TL is prefilled so Next is enabled.
+    // Eyebrow flips to edit mode; the display-only Statistics step is hidden.
     expect(screen.getByText('Edit Crawler')).toBeTruthy()
+    const rail = document.querySelector('nav[aria-label="Steps"]')
+    expect(rail?.textContent).not.toContain('Statistics')
+
+    // Legacy (untyped) crawler advances without a type — presence checks only.
     await waitFor(() => {
       expect(getNextButton().disabled).toBe(false)
     })
-    await clickNext() // Systems
+    await clickNext() // -> Armament Bay
 
     // Add a weapons system in edit mode (the catalog is weapons-only).
     const tl1 = weaponSystemAtTL(1)
     await waitFor(() => screen.getByRole('button', { name: tl1.name }))
     await pick(tl1.name)
     await clickNext() // Crew (all optional)
-    await clickNext() // Identity (name prefilled)
+    await clickNext() // Name (prefilled)
     await clickNext() // Review
 
     // Review → 'Save Crawler' (never 'Create')
@@ -444,6 +518,41 @@ describe('CrawlerBuilder — edit mode', () => {
     expect(onComplete).toHaveBeenCalledWith(crawler.id)
   }, 30000)
 
+  it('edit lifts the Tech-1 filter (all-TL weapons offered) and the hard cap', async () => {
+    const crawler = await seedCrawler()
+    const played = must(useEntityStore.getState().get('crawler', crawler.id))
+    render(
+      <CrawlerBuilder
+        crawlerId={crawler.id}
+        initialState={crawlerToFormState(played)}
+        onComplete={() => {}}
+        onCancel={() => {}}
+      />
+    )
+
+    await waitFor(() => {
+      expect(getNextButton().disabled).toBe(false)
+    })
+    await clickNext() // -> Armament Bay
+
+    // A TL2 weapon renders in edit mode (guided create filters it out).
+    const tl2 = weaponSystemAtTL(2)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: tl2.name })).toBeTruthy()
+    })
+
+    // No hard cap: a second weapon stays selectable; the over-cap advisory
+    // SoftWarningBanner appears instead (soft regime, §5.2).
+    const tl1 = weaponSystemAtTL(1)
+    await pick(tl1.name)
+    await pick(tl2.name)
+    await waitFor(() => {
+      expect(screen.getByText(/Over capacity/i)).toBeTruthy()
+    })
+    // Still saveable — Next is not blocked by the overage.
+    expect(getNextButton().disabled).toBe(false)
+  }, 30000)
+
   it('preserves a higher stored tech level on save (only create fixes TL1)', async () => {
     // A pre-feature crawler at Tech 3 with no chosen type.
     const crawler = await seedCrawler({ techLevel: 3 })
@@ -459,13 +568,12 @@ describe('CrawlerBuilder — edit mode', () => {
       />
     )
 
-    // Type-unselected (legacy crawler), but TL is preserved so Next gates on name.
     await waitFor(() => {
       expect(getNextButton().disabled).toBe(false)
     })
-    await clickNext() // Systems
+    await clickNext() // Armament Bay
     await clickNext() // Crew
-    await clickNext() // Identity
+    await clickNext() // Name
     await clickNext() // Review
 
     const save = screen.getByRole('button', { name: /Save Crawler/i })
@@ -496,7 +604,7 @@ describe('CrawlerBuilder — edit mode', () => {
         scrapPool: { ...EMPTY_SCRAP_POOL },
         upgradePool: 0,
       },
-      { maxSP: 20, crawlerBays: seedDefaultCrawlerBays() }
+      { maxSP: 25, crawlerBays: seedDefaultCrawlerBays() }
     )
     const crawler = await useEntityStore.getState().create('crawler', input)
     expect(crawler.typeNpc?.npcName).toBe('Old Vex')
@@ -516,12 +624,12 @@ describe('CrawlerBuilder — edit mode', () => {
       />
     )
 
-    // Switch the type: Battle → Engineering on the Crawler step.
-    await waitFor(() => getPickByName('Engineering'))
-    await pick('Engineering')
-    await clickNext() // Systems
+    // Switch the type: Battle → Engineering on the type step.
+    await waitFor(() => screen.getByRole('radio', { name: 'Engineering' }))
+    await pickType('Engineering')
+    await clickNext() // Armament Bay
     await clickNext() // Crew
-    await clickNext() // Identity
+    await clickNext() // Name
     await clickNext() // Review
 
     const save = screen.getByRole('button', { name: /Save Crawler/i })
@@ -554,12 +662,11 @@ describe('CrawlerBuilder — edit mode', () => {
   }, 30000)
 
   it('a legacy crawler carrying a non-weapon system does not lock the weapons picker', async () => {
-    // Regression: the Armament-Bay cap counts WEAPONS only. A legacy crawler
-    // that carries a non-weapon system (Cargo Pod, Armour Plating, …) — which
-    // the old wizard allowed and which never appears in the weapons-only
-    // catalog — must NOT count toward the cap. Counting all selected slugs
-    // would lock the picker (can't add the allowed weapon, can't remove the
-    // stranded system → permanent dead-end).
+    // Regression: the Armament-Bay accounting counts WEAPONS only. A legacy
+    // crawler that carries a non-weapon system (Cargo Pod, Armour Plating, …)
+    // — which the old wizard allowed and which never appears in the
+    // weapons-only catalog — must NOT count toward the cap math, and must be
+    // preserved alongside a newly-mounted weapon on save.
     const nonWeapon = nonWeaponSystemAtTL(1)
     const input = crawlerFormToCreateInput(
       {
@@ -589,24 +696,19 @@ describe('CrawlerBuilder — edit mode', () => {
     await waitFor(() => {
       expect(getNextButton().disabled).toBe(false)
     })
-    await clickNext() // -> Systems
+    await clickNext() // -> Armament Bay
 
-    // The stranded non-weapon system does NOT count toward the weapons cap.
+    // The stranded non-weapon system triggers no over-capacity warning …
+    expect(screen.queryByText(/Over capacity/i)).toBeNull()
+    // … and the allowed weapon is still selectable — the picker is not locked.
     const weapon = weaponSystemAtTL(1)
     await waitFor(() => {
-      expect(screen.getByTestId('weapon-system-count').textContent).toContain('0 / 1')
+      expect(screen.getByRole('button', { name: weapon.name })).toBeTruthy()
     })
-    // The allowed weapon is still selectable — the picker is not locked.
-    const weaponBtn = screen.getByRole('button', { name: weapon.name })
-    expect(weaponBtn).toBeTruthy()
-
-    // Installing it ticks the weapon count to the cap; the non-weapon system
-    // is preserved alongside it on save (never silently dropped).
     await pick(weapon.name)
-    expect(screen.getByTestId('weapon-system-count').textContent).toContain('1 / 1')
 
     await clickNext() // Crew
-    await clickNext() // Identity
+    await clickNext() // Name
     await clickNext() // Review
     const save = screen.getByRole('button', { name: /Save Crawler/i })
     await act(async () => {

--- a/apps/in-the-union-now/src/components/crawler/__tests__/CrawlerCrewStep.test.tsx
+++ b/apps/in-the-union-now/src/components/crawler/__tests__/CrawlerCrewStep.test.tsx
@@ -1,18 +1,21 @@
 /**
- * Unit tests for CrawlerCrewStep — the wizard's crew/NPC details step.
+ * Unit tests for CrawlerCrewStep — the wizard's crew/NPC roster step
+ * (wizard-refresh Phase 5: entity-card rows expanding to IdentityFields).
  *
  * Renders the 10 crewed base bays (the 4 expansion bays carry no NPC →
- * excluded) plus the selected crawler type's special NPC. Each NPC exposes the
- * SRD freeform set Name/Description/Keepsake/Motto, guarded off the NPC's own
- * choices: the Augmented type's A.I. has only Name/Description.
+ * excluded) plus the selected crawler type's special NPC HEADING the list.
+ * Each row is the SRD entity card, header-only until expanded; the expanded
+ * row exposes the freeform set Name/Background/Keepsake/Motto through
+ * click-to-edit IdentityFields, guarded off the NPC's own choices: the
+ * Augmented type's A.I. has only Name/Background.
  *
  * Uses real SalvageUnionReference data. NO mock.module().
  */
 
 import { afterEach, beforeAll, describe, expect, it, mock } from 'bun:test'
-import { cleanup, fireEvent, render } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { SalvageUnionReference } from 'salvageunion-reference'
-import type { SURefCrawler } from 'salvageunion-reference'
+import type { SURefCrawler, SURefEntity } from 'salvageunion-reference'
 
 import { CrawlerCrewStep } from '../CrawlerCrewStep'
 import type { CrewNpcForm } from '../../../lib/wizard/crawlerFormState'
@@ -26,100 +29,121 @@ afterEach(() => {
   cleanup()
 })
 
-function crewedBays() {
-  return (
-    SalvageUnionReference.CrawlerBays.all() as Array<{ id: string; name: string; npc?: unknown }>
-  ).filter((b) => b.npc != null) as Array<{
-    id: string
-    name: string
-    npc?: { position?: string; choices?: ReadonlyArray<{ id: string; name: string }> }
-  }>
+function crewedBays(): SURefEntity[] {
+  return (SalvageUnionReference.CrawlerBays.all() as unknown as SURefEntity[]).filter(
+    (b) => (b as { npc?: unknown }).npc != null
+  )
 }
 
-function byId(container: HTMLElement, id: string): HTMLElement {
-  const el = container.querySelector(`#${id}`)
-  if (!el) throw new Error(`No element #${id}`)
-  return el as HTMLElement
+function bayByName(name: string): SURefEntity {
+  return must(crewedBays().find((b) => (b as { name?: string }).name === name))
+}
+
+/** Expand a roster row by clicking its entity card (cardClick → role=button). */
+function expandRow(name: string): void {
+  const card = screen
+    .getAllByRole('button')
+    .find((b) => (b.textContent ?? '').includes(name) && b.getAttribute('aria-label') === null)
+  if (!card) throw new Error(`No clickable roster card for "${name}"`)
+  fireEvent.click(card)
+}
+
+/** Open a click-to-edit IdentityField and return its input. */
+function openField(editLabel: string): HTMLInputElement {
+  fireEvent.click(screen.getByRole('button', { name: editLabel }))
+  return screen.getByRole('textbox', { name: editLabel }) as HTMLInputElement
 }
 
 describe('CrawlerCrewStep', () => {
-  it('renders exactly the 10 crewed base bays (expansion bays excluded)', () => {
+  it('renders exactly the 10 crewed base bays as roster rows (expansion bays excluded)', () => {
     const bays = crewedBays()
     expect(bays.length).toBe(10)
     const { container } = render(
       <CrawlerCrewStep bays={bays} selectedType={undefined} crew={{}} onChange={() => {}} />
     )
     for (const bay of bays) {
-      expect(byId(container, `crew-${bay.id}-name`)).toBeTruthy()
+      expect(container.textContent).toContain((bay as { name: string }).name)
     }
-    // No expansion bay (e.g. VR Tubes) has a crew section.
+    // No expansion bay (e.g. VR Tubes) has a crew row.
     expect(container.textContent).not.toContain('VR Tubes')
   })
 
-  it('renders Name/Description/Keepsake/Motto for a standard bay NPC', () => {
-    const bays = crewedBays()
-    const command = must(bays.find((b) => b.name === 'Command Bay'))
-    const { container } = render(
-      <CrawlerCrewStep bays={bays} selectedType={undefined} crew={{}} onChange={() => {}} />
+  it('an expanded standard bay exposes Name/Background/Keepsake/Motto IdentityFields', () => {
+    render(
+      <CrawlerCrewStep
+        bays={[bayByName('Command Bay')]}
+        selectedType={undefined}
+        crew={{}}
+        onChange={() => {}}
+      />
     )
-    expect(byId(container, `crew-${command.id}-name`)).toBeTruthy()
-    expect(byId(container, `crew-${command.id}-description`)).toBeTruthy()
-    expect(byId(container, `crew-${command.id}-keepsake`)).toBeTruthy()
-    expect(byId(container, `crew-${command.id}-motto`)).toBeTruthy()
+    // Collapsed: no fields yet.
+    expect(screen.queryByRole('button', { name: /keepsake/i })).toBeNull()
+
+    expandRow('Command Bay')
+    expect(screen.getByRole('button', { name: /name$/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /background/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /keepsake/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /motto/i })).toBeTruthy()
   })
 
-  it('includes the selected type’s special NPC with its full field set', () => {
+  it('the selected type’s special NPC HEADS the roster with its full field set', () => {
     const battle = must(SalvageUnionReference.Crawlers.find((c) => c.name === 'Battle'))
     const { container } = render(
       <CrawlerCrewStep bays={crewedBays()} selectedType={battle} crew={{}} onChange={() => {}} />
     )
-    expect(byId(container, `crew-${battle.id}-name`)).toBeTruthy()
-    expect(byId(container, `crew-${battle.id}-keepsake`)).toBeTruthy()
-    expect(byId(container, `crew-${battle.id}-motto`)).toBeTruthy()
+    const text = container.textContent ?? ''
+    // The type row renders before the first bay row.
+    expect(text.indexOf('Battle')).toBeLessThan(text.indexOf('Command Bay'))
+
+    expandRow('Battle')
+    expect(screen.getByRole('button', { name: /grizzled veteran keepsake/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /grizzled veteran motto/i })).toBeTruthy()
   })
 
-  it('Augmented edge: A.I. NPC shows Name/Description only (no Keepsake/Motto)', () => {
+  it('Augmented edge: A.I. NPC shows Name/Background only (no Keepsake/Motto)', () => {
     const augmented = must(SalvageUnionReference.Crawlers.find((c) => c.name === 'Augmented'))
-    const { container } = render(
-      <CrawlerCrewStep bays={crewedBays()} selectedType={augmented} crew={{}} onChange={() => {}} />
-    )
-    expect(byId(container, `crew-${augmented.id}-name`)).toBeTruthy()
-    expect(byId(container, `crew-${augmented.id}-description`)).toBeTruthy()
-    expect(container.querySelector(`#crew-${augmented.id}-keepsake`)).toBeNull()
-    expect(container.querySelector(`#crew-${augmented.id}-motto`)).toBeNull()
+    render(<CrawlerCrewStep bays={[]} selectedType={augmented} crew={{}} onChange={() => {}} />)
+    expandRow('Augmented')
+    expect(screen.getByRole('button', { name: /union crawler a\.i\. name/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /union crawler a\.i\. background/i })).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /keepsake/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /motto/i })).toBeNull()
   })
 
   it('edits a bay NPC field through onChange (merging crew state)', () => {
-    const bays = crewedBays()
-    const command = must(bays.find((b) => b.name === 'Command Bay'))
     const onChange = mock((patch: { crew?: Record<string, CrewNpcForm> }) => patch)
-    const { container } = render(
-      <CrawlerCrewStep bays={bays} selectedType={undefined} crew={{}} onChange={onChange} />
+    const command = bayByName('Command Bay')
+    render(
+      <CrawlerCrewStep bays={[command]} selectedType={undefined} crew={{}} onChange={onChange} />
     )
-    fireEvent.change(byId(container, `crew-${command.id}-name`), {
-      target: { value: 'Maddox' },
-    })
+    expandRow('Command Bay')
+    const input = openField('Edit princeps name')
+    fireEvent.change(input, { target: { value: 'Maddox' } })
+    fireEvent.blur(input, { target: { value: 'Maddox' } })
     expect(onChange).toHaveBeenCalledWith({
-      crew: { [command.id]: { name: 'Maddox' } },
+      crew: { [(command as { id: string }).id]: { name: 'Maddox' } },
     })
   })
 
-  it('renders existing crew values', () => {
-    const bays = crewedBays()
-    const command = must(bays.find((b) => b.name === 'Command Bay'))
+  it('renders existing crew values in the expanded row', () => {
+    const command = bayByName('Command Bay')
     const crew: Record<string, CrewNpcForm> = {
-      [command.id]: { name: 'Maddox', motto: 'Hold the line' },
+      [(command as { id: string }).id]: { name: 'Maddox', motto: 'Hold the line' },
     }
-    const { container } = render(
+    render(
       <CrawlerCrewStep
-        bays={bays}
+        bays={[command]}
         selectedType={undefined as unknown as SURefCrawler | undefined}
         crew={crew}
         onChange={() => {}}
       />
     )
-    expect((byId(container, `crew-${command.id}-name`) as HTMLInputElement).value).toBe('Maddox')
-    expect((byId(container, `crew-${command.id}-motto`) as HTMLInputElement).value).toBe(
+    expandRow('Command Bay')
+    expect(screen.getByRole('button', { name: 'Edit princeps name' }).textContent).toContain(
+      'Maddox'
+    )
+    expect(screen.getByRole('button', { name: 'Edit princeps motto' }).textContent).toContain(
       'Hold the line'
     )
   })

--- a/apps/in-the-union-now/src/components/crawler/crawlerRollTables.ts
+++ b/apps/in-the-union-now/src/components/crawler/crawlerRollTables.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure helper for rolling on the Crawler Name Table (Union Crawler step 5,
+ * Core Book p.212: "The Crawler Names Table can be found on p.226").
+ * Isolated from React so it can be tested without a DOM — the crawler
+ * counterpart of mechRollTables.
+ */
+
+import { roll } from '@randsum/roller'
+import { SalvageUnionReference, rollOnTable } from 'salvageunion-reference'
+import type { SURefRollTable } from 'salvageunion-reference'
+
+const CRAWLER_NAME_TABLE = 'Crawler Name'
+
+/** Dependency interface for roll table lookup — injectable for testing. */
+export type CrawlerRollTableDeps = {
+  findTable: (name: string) => (SURefRollTable & { schemaName: string }) | undefined
+  rollD20: () => number
+}
+
+const defaultDeps: CrawlerRollTableDeps = {
+  findTable: (name) => SalvageUnionReference.RollTables.find((t) => t.name === name),
+  rollD20: () => roll('1d20').total,
+}
+
+/**
+ * Rolls a d20 on the Crawler Name Table and returns the result string.
+ * Returns null when the table cannot be found or the roll fails — the roll
+ * is an assist, never a commitment (the result stays editable).
+ */
+export function rollCrawlerName(deps: CrawlerRollTableDeps = defaultDeps): string | null {
+  const table = deps.findTable(CRAWLER_NAME_TABLE)
+  if (!table) return null
+  const outcome = rollOnTable(table.table, deps.rollD20)
+  if (!outcome.success) return null
+  return outcome.label ? `${outcome.label}: ${outcome.value}` : outcome.value
+}

--- a/apps/in-the-union-now/src/lib/db/__tests__/crawler-battle-sp.test.ts
+++ b/apps/in-the-union-now/src/lib/db/__tests__/crawler-battle-sp.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for the v8 crawler max-SP rewrite (Battle bonus: stored → derived).
+ *
+ * Pure-rewrite semantics are pinned via `normalizeCrawlerMaxSpRecord`
+ * (mirroring mech-refs-to-slugs.test.ts), then the full through-the-opener
+ * path is exercised against a seeded v7 fixture database — proving a
+ * pre-existing Battle crawler heals to bare-store + read-bonus with NO double
+ * +5, and a non-Battle crawler is untouched.
+ *
+ * fake-indexeddb/auto is preloaded via bunfig.toml. Isolation: a dedicated
+ * fixture database name, destroyed before/after — the shared app db is never
+ * touched here.
+ */
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+
+import { SalvageUnionReference } from 'salvageunion-reference'
+import { crawlerMaxSP } from 'salvageunion-reference/rules'
+import { CrawlerSchema } from '../../schemas/crawler'
+import { DB_VERSION, openItunDatabase } from '../index'
+import { normalizeCrawlerMaxSpRecord } from '../migrations/8-crawler-battle-sp-to-derived'
+import { STORE_NAMES } from '../stores'
+
+const NOW = '2026-01-01T00:00:00.000Z'
+
+/** The Battle type's real SRD id (the migration's frozen snapshot of it). */
+const BATTLE_ID = '3d1d9f79-9c56-43fa-a4c9-6dfe10b9aac9'
+const ENGINEERING_ID = '4e317382-046b-4a35-bce8-065c6d659a7b'
+
+beforeAll(async () => {
+  // The derived-read assertions resolve the type's mutations + the TL base.
+  await SalvageUnionReference.preload(['crawlers', 'crawler-tech-levels'])
+})
+
+// ---------------------------------------------------------------------------
+// Pure rewrite semantics
+// ---------------------------------------------------------------------------
+
+describe('normalizeCrawlerMaxSpRecord (v8 Battle-bonus heal)', () => {
+  test('a Battle crawler with the hand-set +5 sheds it (key removed at 0)', () => {
+    const next = normalizeCrawlerMaxSpRecord({ type: BATTLE_ID, maxSpModifier: 5 })
+    expect(next).not.toBeNull()
+    expect('maxSpModifier' in (next as Record<string, unknown>)).toBe(false)
+  })
+
+  test('matches the Battle type stored by NAME too (id-or-name refs)', () => {
+    const next = normalizeCrawlerMaxSpRecord({ type: 'Battle', maxSpModifier: 5 })
+    expect(next).not.toBeNull()
+    expect('maxSpModifier' in (next as Record<string, unknown>)).toBe(false)
+  })
+
+  test('a hand-edit beyond the bonus survives (7 → 2: previous max preserved)', () => {
+    const next = normalizeCrawlerMaxSpRecord({ type: BATTLE_ID, maxSpModifier: 7 })
+    expect(next).toMatchObject({ maxSpModifier: 2 })
+  })
+
+  test('a STALE Battle crawler (no modifier) is a no-op — it heals at read', () => {
+    expect(normalizeCrawlerMaxSpRecord({ type: BATTLE_ID })).toBeNull()
+    expect(normalizeCrawlerMaxSpRecord({ type: BATTLE_ID, maxSpModifier: 0 })).toBeNull()
+    // A partial modifier below the bonus is treated as stale, not double-set.
+    expect(normalizeCrawlerMaxSpRecord({ type: BATTLE_ID, maxSpModifier: 3 })).toBeNull()
+  })
+
+  test('non-Battle and untyped crawlers are untouched', () => {
+    expect(normalizeCrawlerMaxSpRecord({ type: ENGINEERING_ID, maxSpModifier: 5 })).toBeNull()
+    expect(normalizeCrawlerMaxSpRecord({ maxSpModifier: 5 })).toBeNull()
+    expect(normalizeCrawlerMaxSpRecord({ type: 'Engineering', maxSpModifier: 5 })).toBeNull()
+  })
+
+  test('preserves unrelated fields verbatim on rewrite', () => {
+    const next = normalizeCrawlerMaxSpRecord({
+      id: 'c-1',
+      type: BATTLE_ID,
+      maxSpModifier: 5,
+      currentSP: 25,
+      systems: ['w-1'],
+    })
+    expect(next).toMatchObject({ id: 'c-1', type: BATTLE_ID, currentSP: 25, systems: ['w-1'] })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Through the opener: seeded v7 fixture → DB_VERSION
+// ---------------------------------------------------------------------------
+
+/** Delete a dedicated fixture database (never blocks — no other file opens it). */
+async function destroyDatabase(name: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(name)
+    req.onsuccess = () => resolve()
+    req.onerror = () => reject(req.error)
+    req.onblocked = () => reject(new Error(`deleteDatabase(${name}) blocked`))
+  })
+}
+
+/**
+ * Seed a raw fixture database at v7 — every object store already exists at
+ * that version (v1 core set, v2 mechPatterns, v5 encounterNpcs), so this
+ * fixture isolates the v8 record rewrite from store creation.
+ */
+async function seedV7Database(name: string, crawlers: unknown[]): Promise<void> {
+  const { openDB } = await import('idb')
+  const db = await openDB(name, 7, {
+    upgrade(db) {
+      for (const storeName of Object.values(STORE_NAMES)) {
+        if (!db.objectStoreNames.contains(storeName)) {
+          db.createObjectStore(storeName, { keyPath: 'id' })
+        }
+      }
+    },
+  })
+  for (const value of crawlers) {
+    await db.put(STORE_NAMES.crawlers, value)
+  }
+  db.close()
+}
+
+describe('migration ladder: v7 crawler fixture → DB_VERSION (v8 heal)', () => {
+  const TEST_DB = 'itun-crawler-battle-sp-test'
+
+  beforeEach(async () => {
+    await destroyDatabase(TEST_DB)
+  })
+  afterEach(async () => {
+    await destroyDatabase(TEST_DB)
+  })
+
+  const battleHandSet = {
+    id: 'crawler-battle-1',
+    schemaVersion: 1,
+    name: 'War Wagon',
+    techLevel: 'tech-1',
+    type: BATTLE_ID,
+    systems: [],
+    maxSpModifier: 5, // the old hand-set convention
+    currentSP: 25, // at full under the old derivation (20 + 5)
+    createdAt: NOW,
+    updatedAt: NOW,
+  }
+
+  const battleStale = {
+    id: 'crawler-battle-2',
+    schemaVersion: 1,
+    name: 'Late Bloomer',
+    techLevel: 'tech-1',
+    type: BATTLE_ID,
+    systems: [],
+    // No maxSpModifier — the +5 was never applied (stale record).
+    currentSP: 20,
+    createdAt: NOW,
+    updatedAt: NOW,
+  }
+
+  const engineering = {
+    id: 'crawler-eng-1',
+    schemaVersion: 1,
+    name: 'Tinker Town',
+    techLevel: 'tech-1',
+    type: ENGINEERING_ID,
+    systems: [],
+    maxSpModifier: 5, // a genuine hand-edit on a non-Battle type
+    currentSP: 25,
+    createdAt: NOW,
+    updatedAt: NOW,
+  }
+
+  test('Battle heals to bare-store + read-bonus (no double +5); non-Battle untouched', async () => {
+    await seedV7Database(TEST_DB, [battleHandSet, battleStale, engineering])
+
+    const db = await openItunDatabase(TEST_DB)
+    try {
+      expect(db.version).toBe(DB_VERSION)
+
+      // Hand-set Battle: modifier shed; derived max is EXACTLY the previous
+      // 25 (base 20 + read-bonus 5) — not 30 (the double-count failure mode).
+      const healed = CrawlerSchema.parse(await db.get(STORE_NAMES.crawlers, 'crawler-battle-1'))
+      expect(healed.maxSpModifier).toBeUndefined()
+      expect(crawlerMaxSP(healed)).toBe(25)
+      expect(healed.currentSP).toBe(25) // still at full — no clamp needed
+
+      // Stale Battle: record untouched; the read path now grants the +5.
+      const stale = CrawlerSchema.parse(await db.get(STORE_NAMES.crawlers, 'crawler-battle-2'))
+      expect(stale.maxSpModifier).toBeUndefined()
+      expect(crawlerMaxSP(stale)).toBe(25)
+
+      // Non-Battle: hand-edit preserved verbatim; no type bonus at read.
+      const eng = CrawlerSchema.parse(await db.get(STORE_NAMES.crawlers, 'crawler-eng-1'))
+      expect(eng.maxSpModifier).toBe(5)
+      expect(crawlerMaxSP(eng)).toBe(25)
+    } finally {
+      db.close()
+    }
+  })
+})

--- a/apps/in-the-union-now/src/lib/db/index.ts
+++ b/apps/in-the-union-now/src/lib/db/index.ts
@@ -43,9 +43,11 @@ import { STORE_NAMES } from './stores'
 /**
  * Current IndexedDB schema version. Bump together with a migrations/ entry.
  * (v7 is a version-only bump — it once carried an eager Starter Set seed, now
- * replaced by on-demand seeding in lib/starterSet/seedStarterSet.ts.)
+ * replaced by on-demand seeding in lib/starterSet/seedStarterSet.ts. v8 heals
+ * Battle crawlers whose maxSpModifier hand-carried the type's +5 — the bonus
+ * is now derived at read from the type's mutations.)
  */
-export const DB_VERSION = 7
+export const DB_VERSION = 8
 
 const DB_NAME = 'itun-v1'
 

--- a/apps/in-the-union-now/src/lib/db/migrations/8-crawler-battle-sp-to-derived.ts
+++ b/apps/in-the-union-now/src/lib/db/migrations/8-crawler-battle-sp-to-derived.ts
@@ -1,0 +1,74 @@
+/**
+ * v8 — crawler max SP goes derived-at-read (wizard-refresh Phase 5): the
+ * chosen crawler TYPE's `max_sp_bonus` mutations (Battle +5) now apply inside
+ * `crawlerMaxSP` at READ, so the stored record keeps the BARE tech-level
+ * value and a type swap re-derives correctly in both directions.
+ *
+ * Before this, the Battle bonus was documented as hand-set into
+ * `maxSpModifier` ("the Battle Crawler type's +5 Max SP lives here"). A
+ * Battle crawler whose modifier still carries that hand-set bonus would now
+ * DOUBLE-COUNT it (read-bonus + stored bonus), so this one-shot rewrite heals
+ * Battle-typed records:
+ *
+ *   - `maxSpModifier >= 5`: the hand-set bonus is (contained in) the
+ *     modifier — subtract exactly 5. This preserves the record's previous
+ *     derived max to the point (old: base + mod; new: base + 5 + (mod − 5)),
+ *     so nothing double-counts and hand-edits beyond the bonus survive.
+ *     A resulting 0 removes the key (absent reads as 0).
+ *   - `maxSpModifier` absent, 0, or < 5: the bonus was never (fully) applied
+ *     — the record was STALE. Leave it untouched; the read path now grants
+ *     the +5 the type always conferred (max SP rises, never falls, so no
+ *     currentSP clamp is needed).
+ *   - Non-Battle crawlers (and untyped/legacy records): untouched — no other
+ *     type carries a `max_sp_bonus` mutation.
+ *
+ * The Battle type is matched by its SRD id OR name (stored `type` refs
+ * resolve id-or-name, like bay refs). Both values are FROZEN SNAPSHOTS here,
+ * not reference-data lookups: a migration may only await IndexedDB operations
+ * on its versionchange transaction (awaiting a reference preload would let
+ * the transaction auto-commit mid-migration), and a shipped migration must
+ * describe the data as it was at ship time regardless of later catalog edits.
+ *
+ * IMPORTANT: this function runs inside the versionchange transaction. Only
+ * IndexedDB operations on `tx` may be awaited.
+ */
+
+import type { UpgradeTransaction } from './index'
+import { STORE_NAMES } from '../stores'
+
+/** The Battle crawler type's SRD id + name at ship time (frozen snapshot). */
+const BATTLE_TYPE_REFS: readonly string[] = ['3d1d9f79-9c56-43fa-a4c9-6dfe10b9aac9', 'Battle']
+
+/** The Battle type's `max_sp_bonus` mutation value at ship time. */
+const BATTLE_MAX_SP_BONUS = 5
+
+/** Rewrite one crawler record; returns null when unchanged. */
+export function normalizeCrawlerMaxSpRecord(
+  raw: Record<string, unknown>
+): Record<string, unknown> | null {
+  if (typeof raw.type !== 'string' || !BATTLE_TYPE_REFS.includes(raw.type)) return null
+  const modifier = raw.maxSpModifier
+  if (typeof modifier !== 'number' || modifier < BATTLE_MAX_SP_BONUS) return null
+
+  const next = { ...raw }
+  const healed = modifier - BATTLE_MAX_SP_BONUS
+  if (healed === 0) {
+    delete next.maxSpModifier
+  } else {
+    next.maxSpModifier = healed
+  }
+  return next
+}
+
+export async function migrate(tx: UpgradeTransaction): Promise<void> {
+  if (!tx.db.objectStoreNames.contains(STORE_NAMES.crawlers)) return
+  let cursor = await tx.objectStore(STORE_NAMES.crawlers).openCursor()
+  while (cursor) {
+    const raw = cursor.value as unknown
+    if (typeof raw === 'object' && raw !== null) {
+      const next = normalizeCrawlerMaxSpRecord(raw as Record<string, unknown>)
+      if (next) await cursor.update(next)
+    }
+    cursor = await cursor.continue()
+  }
+}

--- a/apps/in-the-union-now/src/lib/db/migrations/index.ts
+++ b/apps/in-the-union-now/src/lib/db/migrations/index.ts
@@ -22,6 +22,7 @@ import type { IDBPDatabase, IDBPTransaction, StoreNames } from 'idb'
 import { migrate as migrate3CargoToCargoLots } from './3-cargo-to-cargo-lots'
 import { migrate as migrate4RemovePilotRollResults } from './4-remove-pilot-roll-results'
 import { migrate as migrate6MechRefsToSlugs } from './6-mech-refs-to-slugs'
+import { migrate as migrate8CrawlerBattleSpToDerived } from './8-crawler-battle-sp-to-derived'
 
 /** The untyped versionchange transaction handed to the idb upgrade callback. */
 export type UpgradeTransaction = IDBPTransaction<
@@ -59,6 +60,12 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
     toVersion: 6,
     description: 'mech-refs-to-slugs',
     migrate: (tx) => migrate6MechRefsToSlugs(tx),
+  },
+  // v7 was a version-only bump (see ../index.ts) — no record rewrite.
+  {
+    toVersion: 8,
+    description: 'crawler-battle-sp-to-derived',
+    migrate: (tx) => migrate8CrawlerBattleSpToDerived(tx),
   },
   // NOTE: the built-in Starter Set is NOT seeded by a migration. It is spawned
   // on-demand into each browser the first time the user opens the Starter Set

--- a/apps/in-the-union-now/src/lib/rules/__tests__/creation.test.ts
+++ b/apps/in-the-union-now/src/lib/rules/__tests__/creation.test.ts
@@ -8,9 +8,13 @@
 
 import { beforeAll, describe, expect, it } from 'bun:test'
 import { SalvageUnionReference } from 'salvageunion-reference'
+import { isWeaponSystem } from 'salvageunion-reference/rules'
 import {
+  clampCrawlerCreationDraft,
   clampMechCreationDraft,
   clampPilotCreationDraft,
+  crawlerCreationStepGate,
+  crawlerWeaponSlotsFor,
   mechCreationBudgetFor,
   mechCreationStepGate,
   pilotCreationStepGate,
@@ -19,6 +23,8 @@ import type { PilotWizardFormState } from '../../wizard/pilotFormState'
 import { EMPTY_PILOT_FORM_STATE } from '../../wizard/pilotFormState'
 import type { MechWizardFormState } from '../../wizard/mechFormState'
 import { EMPTY_MECH_FORM_STATE } from '../../wizard/mechFormState'
+import type { CrawlerWizardFormState } from '../../wizard/crawlerFormState'
+import { EMPTY_CRAWLER_FORM_STATE } from '../../wizard/crawlerFormState'
 
 beforeAll(async () => {
   await SalvageUnionReference.preload([
@@ -28,6 +34,8 @@ beforeAll(async () => {
     'chassis',
     'systems',
     'modules',
+    'crawlers',
+    'actions',
   ])
 })
 
@@ -394,5 +402,158 @@ describe('clampMechCreationDraft (knapsack, not truncation)', () => {
     })
     expect(result.form.cargoLots).toEqual([])
     expect(result.removed).toContain('starting cargo')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Crawler (Union Crawler pp.212–213 — wizard-refresh Phase 5)
+// ---------------------------------------------------------------------------
+
+function crawlerForm(overrides: Partial<CrawlerWizardFormState> = {}): CrawlerWizardFormState {
+  return { ...EMPTY_CRAWLER_FORM_STATE, ...overrides }
+}
+
+function typeIdOf(name: string): string {
+  const type = SalvageUnionReference.Crawlers.find((c) => c.name === name)
+  if (!type) throw new Error(`crawler type "${name}" not found`)
+  return type.id
+}
+
+function weaponIdAtTL(tl: number): string {
+  const found = SalvageUnionReference.Systems.find(
+    (s) => typeof s.techLevel === 'number' && s.techLevel === tl && isWeaponSystem(s)
+  )
+  if (!found) throw new Error(`no weapons system at TL ${tl}`)
+  return found.id
+}
+
+function secondWeaponIdAtTL(tl: number): string {
+  const found = SalvageUnionReference.Systems.findAll(
+    (s) => typeof s.techLevel === 'number' && s.techLevel === tl && isWeaponSystem(s)
+  )[1]
+  if (!found) throw new Error(`no second weapons system at TL ${tl}`)
+  return found.id
+}
+
+function nonWeaponIdAtTL(tl: number): string {
+  const found = SalvageUnionReference.Systems.find(
+    (s) => typeof s.techLevel === 'number' && s.techLevel === tl && !isWeaponSystem(s)
+  )
+  if (!found) throw new Error(`no non-weapon system at TL ${tl}`)
+  return found.id
+}
+
+describe('crawlerWeaponSlotsFor (mutations-derived, never string-matched)', () => {
+  it('Battle mounts 2; every other type (and no type) mounts 1', () => {
+    expect(crawlerWeaponSlotsFor(typeIdOf('Battle'))).toBe(2)
+    expect(crawlerWeaponSlotsFor(typeIdOf('Engineering'))).toBe(1)
+    expect(crawlerWeaponSlotsFor(null)).toBe(1)
+    // Stored refs resolve id-or-name (bay-ref tolerance).
+    expect(crawlerWeaponSlotsFor('Battle')).toBe(2)
+  })
+})
+
+describe('crawlerCreationStepGate', () => {
+  it('type: blocked until a resolvable type is chosen', () => {
+    expect(crawlerCreationStepGate('type', crawlerForm()).ok).toBe(false)
+    expect(crawlerCreationStepGate('type', crawlerForm({ type: 'nonsense' })).ok).toBe(false)
+    expect(crawlerCreationStepGate('type', crawlerForm({ type: typeIdOf('Battle') })).ok).toBe(true)
+  })
+
+  it('stats and crew never block', () => {
+    expect(crawlerCreationStepGate('stats', crawlerForm()).ok).toBe(true)
+    expect(crawlerCreationStepGate('crew', crawlerForm()).ok).toBe(true)
+  })
+
+  it('weapons: minimum 1 Tech-1 weapon, capped at the type slots', () => {
+    const battle = typeIdOf('Battle')
+    const zero = crawlerCreationStepGate('weapons', crawlerForm({ type: battle }))
+    expect(zero.ok).toBe(false)
+    expect(zero.reason).toContain('at least one')
+
+    const w1 = weaponIdAtTL(1)
+    const w2 = secondWeaponIdAtTL(1)
+    expect(
+      crawlerCreationStepGate('weapons', crawlerForm({ type: battle, systems: [w1] })).ok
+    ).toBe(true)
+    expect(
+      crawlerCreationStepGate('weapons', crawlerForm({ type: battle, systems: [w1, w2] })).ok
+    ).toBe(true)
+
+    // Over the Engineering (1-slot) cap — blocked with the excess named.
+    const over = crawlerCreationStepGate(
+      'weapons',
+      crawlerForm({ type: typeIdOf('Engineering'), systems: [w1, w2] })
+    )
+    expect(over.ok).toBe(false)
+    expect(over.reason).toContain('mounts 1')
+  })
+
+  it('weapons: a non-Tech-1 weapon or a non-weapon system is illegal', () => {
+    const battle = typeIdOf('Battle')
+    const tl2 = crawlerCreationStepGate(
+      'weapons',
+      crawlerForm({ type: battle, systems: [weaponIdAtTL(2)] })
+    )
+    expect(tl2.ok).toBe(false)
+    expect(tl2.reason).toContain('Tech 1')
+
+    const nonWeapon = crawlerCreationStepGate(
+      'weapons',
+      crawlerForm({ type: battle, systems: [nonWeaponIdAtTL(1)] })
+    )
+    expect(nonWeapon.ok).toBe(false)
+  })
+
+  it('identity requires a non-empty name; review re-checks everything', () => {
+    expect(crawlerCreationStepGate('identity', crawlerForm()).ok).toBe(false)
+    expect(crawlerCreationStepGate('identity', crawlerForm({ name: 'Tin Lizzy' })).ok).toBe(true)
+
+    const complete = crawlerForm({
+      name: 'Tin Lizzy',
+      type: typeIdOf('Battle'),
+      systems: [weaponIdAtTL(1)],
+    })
+    expect(crawlerCreationStepGate('review', complete).ok).toBe(true)
+    expect(crawlerCreationStepGate('review', { ...complete, systems: [] }).ok).toBe(false)
+    expect(crawlerCreationStepGate('review', { ...complete, type: null }).ok).toBe(false)
+    expect(crawlerCreationStepGate('review', { ...complete, name: ' ' }).ok).toBe(false)
+  })
+})
+
+describe('clampCrawlerCreationDraft', () => {
+  it('returns the same form when nothing violates', () => {
+    const form = crawlerForm({
+      name: 'Tin Lizzy',
+      type: typeIdOf('Battle'),
+      systems: [weaponIdAtTL(1)],
+    })
+    const { form: clamped, removed } = clampCrawlerCreationDraft(form)
+    expect(removed).toEqual([])
+    expect(clamped).toBe(form)
+  })
+
+  it('drops an unresolvable type (and its crew entry)', () => {
+    const form = crawlerForm({
+      type: 'no-such-type',
+      crew: { 'no-such-type': { name: 'Ghost' } },
+    })
+    const { form: clamped, removed } = clampCrawlerCreationDraft(form)
+    expect(clamped.type).toBeNull()
+    expect(clamped.crew['no-such-type']).toBeUndefined()
+    expect(removed.length).toBe(1)
+  })
+
+  it('drops illegal systems, then clamps weapons NEWEST-first to the type slots', () => {
+    const w1 = weaponIdAtTL(1)
+    const w2 = secondWeaponIdAtTL(1)
+    const form = crawlerForm({
+      type: typeIdOf('Engineering'), // 1 slot
+      systems: [nonWeaponIdAtTL(1), weaponIdAtTL(2), w1, w2],
+    })
+    const { form: clamped, removed } = clampCrawlerCreationDraft(form)
+    // Illegal entries (non-weapon, TL2) dropped; then w2 (newest) clamped.
+    expect(clamped.systems).toEqual([w1])
+    expect(removed.length).toBe(3)
   })
 })

--- a/apps/in-the-union-now/src/lib/rules/creation.ts
+++ b/apps/in-the-union-now/src/lib/rules/creation.ts
@@ -1,6 +1,6 @@
 /**
- * Pilot + mech creation step gates (wizard-refresh Phases 3–4, plan §5.1
- * app half).
+ * Pilot + mech + crawler creation step gates (wizard-refresh Phases 3–5,
+ * plan §5.1 app half).
  *
  * THIN ADAPTER only: destructures wizard form state into neutral inputs
  * (resolved reference records narrowed to primitives + counts) and calls the
@@ -14,17 +14,21 @@
  */
 
 import { SalvageUnionReference } from 'salvageunion-reference'
-import type { SURefAbility, SURefClass, SURefEquipment } from 'salvageunion-reference'
+import type { SURefAbility, SURefClass, SURefEquipment, SURefSystem } from 'salvageunion-reference'
 import {
   computeMechCapacity,
+  crawlerWeaponSlots,
+  isCrawlerWeaponPickComplete,
   isLegalCreationAbility,
   isLegalCreationChassis,
   isLegalCreationClass,
+  isLegalCreationCrawlerWeapon,
   isLegalCreationEquipment,
   isLegalCreationModule,
   isLegalCreationSystem,
   isPilotAbilityPickComplete,
   isPilotEquipmentPickComplete,
+  isWeaponSystem,
   mechCreationBudget,
   PILOT_CREATION_ABILITY_PICKS,
   PILOT_CREATION_EQUIPMENT_PICKS,
@@ -33,7 +37,8 @@ import {
   resolveModuleRef,
   resolveSystemRef,
 } from 'salvageunion-reference/rules'
-import type { MechCreationBudget } from 'salvageunion-reference/rules'
+import type { CrawlerMutationInput, MechCreationBudget } from 'salvageunion-reference/rules'
+import type { CrawlerWizardFormState } from '../wizard/crawlerFormState'
 import type { MechWizardFormState } from '../wizard/mechFormState'
 import type { PilotWizardFormState } from '../wizard/pilotFormState'
 
@@ -474,4 +479,163 @@ export function clampMechCreationDraft(form: MechWizardFormState): MechDraftClam
 
   if (removed.length === 0) return { form, removed }
   return { form: { ...form, chassisName, patternName, systems, modules, cargoLots }, removed }
+}
+
+// ---------------------------------------------------------------------------
+// Union Crawler (pp.212–213 — wizard-refresh Phase 5)
+// ---------------------------------------------------------------------------
+
+/** Book-order crawler wizard step ids (Union Crawler pp.212–213 + Review). */
+export type CrawlerWizardStepId = 'type' | 'stats' | 'weapons' | 'crew' | 'identity' | 'review'
+
+/**
+ * Narrow a stored crawler-type ref (SRD id OR name, the bay-ref tolerance) to
+ * the neutral `mutations` rows the package calculators read. Null/unknown
+ * refs narrow to `undefined` — no mutations, the base rules.
+ */
+function crawlerTypeMutationsOf(
+  typeRef: string | null
+): readonly CrawlerMutationInput[] | undefined {
+  if (typeRef === null || typeRef === '') return undefined
+  const type = SalvageUnionReference.Crawlers.find((c) => c.id === typeRef || c.name === typeRef)
+  return type?.mutations
+}
+
+/**
+ * Armament-Bay weapon slots for the chosen type — read from the type's STORED
+ * `mutations` field via the package calculator (Battle = 2), never an
+ * action-name string match. The same number drives the SelCard cap, the
+ * WEAPONS tracker, the re-clamp on a type change, and the Review gate.
+ */
+export function crawlerWeaponSlotsFor(typeRef: string | null): number {
+  return crawlerWeaponSlots(crawlerTypeMutationsOf(typeRef))
+}
+
+function findCrawlerWeapon(ref: string): SURefSystem | null {
+  return resolveSystemRef(ref)
+}
+
+/** A creation-legal Armament-Bay mount: a resolvable Tech 1 WEAPONS system. */
+function isLegalCrawlerWeaponRef(ref: string): boolean {
+  const system = findCrawlerWeapon(ref)
+  return system !== null && isWeaponSystem(system) && isLegalCreationCrawlerWeapon(system.techLevel)
+}
+
+/** Resolve a stored crawler-type ref (id or name) against the SRD catalog. */
+function crawlerTypeResolves(typeRef: string | null): boolean {
+  if (typeRef === null || typeRef === '') return false
+  return (
+    SalvageUnionReference.Crawlers.find((c) => c.id === typeRef || c.name === typeRef) !== undefined
+  )
+}
+
+function crawlerTypeGate(form: CrawlerWizardFormState): StepGateResult {
+  if (!crawlerTypeResolves(form.type)) {
+    return { ok: false, reason: 'Choose your Crawler type to continue' }
+  }
+  return OK
+}
+
+function crawlerWeaponsGate(form: CrawlerWizardFormState): StepGateResult {
+  if (!isCrawlerWeaponPickComplete(form.systems.length)) {
+    return { ok: false, reason: 'Mount at least one Weapons System to continue' }
+  }
+  if (!form.systems.every(isLegalCrawlerWeaponRef)) {
+    return { ok: false, reason: 'Only Tech 1 Weapons Systems are legal at creation' }
+  }
+  const slots = crawlerWeaponSlotsFor(form.type)
+  if (form.systems.length > slots) {
+    const excess = form.systems.length - slots
+    return {
+      ok: false,
+      reason: `Remove ${excess} Weapons System${excess === 1 ? '' : 's'} — this type mounts ${slots}`,
+    }
+  }
+  return OK
+}
+
+function crawlerNameGate(form: CrawlerWizardFormState): StepGateResult {
+  if (form.name.trim() === '') {
+    return { ok: false, reason: 'Name your Crawler to continue' }
+  }
+  return OK
+}
+
+/**
+ * Next-gating for the crawler CREATE flow (guided mode is HARD — plan §5.3).
+ * The Statistics briefing and the optional Crew step never block; the type
+ * pick, the minimum-1 Tech-1 weapon mount (capped at the type's slots), and
+ * the name are required; Review re-checks everything.
+ */
+export function crawlerCreationStepGate(
+  step: CrawlerWizardStepId,
+  form: CrawlerWizardFormState
+): StepGateResult {
+  switch (step) {
+    case 'stats':
+    case 'crew':
+      return OK // display-only / optional flavor — Next always enabled
+    case 'type':
+      return crawlerTypeGate(form)
+    case 'weapons':
+      return crawlerWeaponsGate(form)
+    case 'identity':
+      return crawlerNameGate(form)
+    case 'review': {
+      for (const gate of [crawlerTypeGate, crawlerWeaponsGate, crawlerNameGate]) {
+        const result = gate(form)
+        if (!result.ok) return result
+      }
+      return OK
+    }
+  }
+}
+
+/** Result of the deterministic crawler draft clamp (plan §5.3). */
+export type CrawlerDraftClampResult = {
+  form: CrawlerWizardFormState
+  /** Human-readable names of everything removed (for the restore toast). */
+  removed: string[]
+}
+
+function crawlerWeaponName(ref: string): string {
+  return findCrawlerWeapon(ref)?.name ?? ref
+}
+
+/**
+ * Deterministic clamp for a restored crawler create-mode draft (plan §5.3):
+ * a draft written before the hard-enforcement regime may violate the creation
+ * rules. Resolution order —
+ *   - an unresolvable type ref is cleared (its crew entry with it),
+ *   - non-weapon / non-Tech-1 / unresolvable systems are dropped,
+ *   - then the weapons are clamped NEWEST-first down to the type's
+ *     Armament-Bay slots (mutations-derived; 1, Battle 2).
+ * The caller shows one toast itemizing `removed`.
+ */
+export function clampCrawlerCreationDraft(form: CrawlerWizardFormState): CrawlerDraftClampResult {
+  const removed: string[] = []
+  let type = form.type
+  let crew = form.crew
+  let systems = [...form.systems]
+
+  if (type !== null && !crawlerTypeResolves(type)) {
+    removed.push(`type pick (${type})`)
+    crew = { ...crew }
+    delete crew[type]
+    type = null
+  }
+
+  const legal = systems.filter(isLegalCrawlerWeaponRef)
+  removed.push(...systems.filter((ref) => !legal.includes(ref)).map(crawlerWeaponName))
+  systems = legal
+
+  const slots = crawlerWeaponSlotsFor(type)
+  while (systems.length > slots) {
+    const dropped = systems.pop()
+    if (dropped === undefined) break
+    removed.push(crawlerWeaponName(dropped))
+  }
+
+  if (removed.length === 0) return { form, removed }
+  return { form: { ...form, type, crew, systems }, removed }
 }

--- a/apps/in-the-union-now/src/lib/rules/derivedStats.ts
+++ b/apps/in-the-union-now/src/lib/rules/derivedStats.ts
@@ -23,6 +23,7 @@ export {
   clampMechCurrentStats,
   unifiedMechConditions,
   crawlerMaxSP,
+  crawlerMaxSPParts,
   clampCrawlerCurrentStats,
 } from 'salvageunion-reference/rules'
-export type { ChassisStats } from 'salvageunion-reference/rules'
+export type { ChassisStats, CrawlerMaxSPParts } from 'salvageunion-reference/rules'

--- a/apps/in-the-union-now/src/routes/crawlers/new.tsx
+++ b/apps/in-the-union-now/src/routes/crawlers/new.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { SalvageUnionReference } from 'salvageunion-reference'
 
 import { CrawlerBuilder } from '../../components/crawler/CrawlerBuilder'
 import { NewEntityScreen } from '../../components/wizard/NewEntityScreen'
@@ -10,6 +11,24 @@ export const Route = createFileRoute('/crawlers/new')({
   validateSearch: (search: Record<string, unknown>): { mode: CreateMode } => ({
     mode: parseCreateMode(search.mode),
   }),
+  loader: async () => {
+    // Preload game data needed by the wizard before rendering (parity with
+    // pilots/mechs — plan §4.3): crawlers for the type cards + mutations
+    // budgets, crawler-tech-levels for the Statistics step + SP derivation,
+    // systems/actions/traits for the weapons entity cards + isWeaponSystem,
+    // crawler-bays for the seeded set + Crew roster, roll-tables for the
+    // Crawler Name d20 assist.
+    await SalvageUnionReference.preload([
+      'crawlers',
+      'crawler-tech-levels',
+      'systems',
+      'crawler-bays',
+      'actions',
+      'traits',
+      'roll-tables',
+    ])
+    return null
+  },
   component: CrawlersNewPage,
 })
 

--- a/packages/salvageunion-reference/lib/rules/creation.test.ts
+++ b/packages/salvageunion-reference/lib/rules/creation.test.ts
@@ -11,12 +11,18 @@ import { beforeAll, describe, expect, it } from 'bun:test'
 import { SalvageUnionReference } from '../index.js'
 import type { SURefAbility, SURefChassis, SURefClass, SURefEquipment } from '../schemas/index.js'
 import {
+  CRAWLER_CREATION_MIN_WEAPONS,
+  CRAWLER_CREATION_TECH_LEVEL,
   MECH_CREATION_SCRAP_CAP,
   PILOT_CREATION_ABILITY_PICKS,
   PILOT_CREATION_EQUIPMENT_PICKS,
+  crawlerMaxSpBonus,
+  crawlerWeaponSlots,
+  isCrawlerWeaponPickComplete,
   isLegalCreationAbility,
   isLegalCreationChassis,
   isLegalCreationClass,
+  isLegalCreationCrawlerWeapon,
   isLegalCreationEquipment,
   isLegalCreationModule,
   isLegalCreationSystem,
@@ -267,5 +273,63 @@ describe('mechCreationBudget (20 Tech 1 Scrap, on scrapCostFor)', () => {
     expect(budget.spent).toBe(25)
     expect(budget.remaining).toBe(-5)
     expect(budget.perItemAffordable(1)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Union Crawler (Core Book pp.212–213 — wizard-refresh Phase 5)
+// ---------------------------------------------------------------------------
+
+describe('isLegalCreationCrawlerWeapon (Tech 1 only, p.213)', () => {
+  it('creation is fixed at Tech Level 1', () => {
+    expect(CRAWLER_CREATION_TECH_LEVEL).toBe(1)
+    expect(isLegalCreationCrawlerWeapon(1)).toBe(true)
+    for (const tl of [2, 3, 4, 5, 6]) expect(isLegalCreationCrawlerWeapon(tl)).toBe(false)
+  })
+
+  it("the 'B'/'N' expansion tiers are never legal", () => {
+    expect(isLegalCreationCrawlerWeapon('B')).toBe(false)
+    expect(isLegalCreationCrawlerWeapon('N')).toBe(false)
+  })
+})
+
+describe('crawlerWeaponSlots / crawlerMaxSpBonus (stored mutations, never string-matched)', () => {
+  it('base is 1 Armament-Bay slot with no mutations', () => {
+    expect(crawlerWeaponSlots(undefined)).toBe(1)
+    expect(crawlerWeaponSlots([])).toBe(1)
+  })
+
+  it('the REAL Battle type mutations yield 2 slots and +5 max SP', () => {
+    const battle = SalvageUnionReference.Crawlers.find((c) => c.name === 'Battle')
+    expect(battle?.mutations).toBeDefined()
+    expect(crawlerWeaponSlots(battle?.mutations)).toBe(2)
+    expect(crawlerMaxSpBonus(battle?.mutations)).toBe(5)
+  })
+
+  it('every non-Battle type has no mutations — 1 slot, +0 SP', () => {
+    const others = SalvageUnionReference.Crawlers.all().filter((c) => c.name !== 'Battle')
+    expect(others.length).toBeGreaterThan(0)
+    for (const type of others) {
+      expect(crawlerWeaponSlots(type.mutations)).toBe(1)
+      expect(crawlerMaxSpBonus(type.mutations)).toBe(0)
+    }
+  })
+
+  it('unrelated mutation rows contribute nothing to either total', () => {
+    const rows = [
+      { type: 'weapon_slots', value: 1 },
+      { type: 'max_sp_bonus', value: 5 },
+    ]
+    expect(crawlerWeaponSlots(rows.filter((m) => m.type !== 'weapon_slots'))).toBe(1)
+    expect(crawlerMaxSpBonus(rows.filter((m) => m.type !== 'max_sp_bonus'))).toBe(0)
+  })
+})
+
+describe('crawler weapon pick minimum (minimum 1 to advance, p.213)', () => {
+  it('zero weapons is incomplete; 1+ satisfies', () => {
+    expect(CRAWLER_CREATION_MIN_WEAPONS).toBe(1)
+    expect(isCrawlerWeaponPickComplete(0)).toBe(false)
+    expect(isCrawlerWeaponPickComplete(1)).toBe(true)
+    expect(isCrawlerWeaponPickComplete(2)).toBe(true)
   })
 })

--- a/packages/salvageunion-reference/lib/rules/creation.ts
+++ b/packages/salvageunion-reference/lib/rules/creation.ts
@@ -1,6 +1,7 @@
 /**
  * Creation-legality predicates and pick budgets (Pilot Bay pp.18–19 +
- * Mech Workshop pp.94–95 — wizard-refresh plan §5.1).
+ * Mech Workshop pp.94–95 + Union Crawler pp.212–213 — wizard-refresh
+ * plan §5.1).
  *
  * Pure predicates over NEUTRAL structural inputs only — the exact primitive
  * values a rule reads (numbers, arrays, strings) with REQUIRED fields — in
@@ -204,4 +205,73 @@ export function mechCreationBudget(input: MechCreationBudgetInput): MechCreation
     remaining,
     perItemAffordable: (sv: number) => sv <= remaining,
   }
+}
+
+// ---------------------------------------------------------------------------
+// Union Crawler (Core Book pp.212–213 — wizard-refresh Phase 5)
+// ---------------------------------------------------------------------------
+
+/**
+ * A new Union Crawler's Tech Level is fixed ("A Tech 1 starting Union Crawler
+ * is about the size of a small village", p.213 — creation always starts at
+ * Tech Level 1, a Hamlet Crawler).
+ */
+export const CRAWLER_CREATION_TECH_LEVEL = 1
+
+/**
+ * A legal creation crawler weapon is a Tech 1 Weapons System ("To start, this
+ * can be any Tech 1 Weapons System of the players' choice", p.213 — creation
+ * is stricter than the in-play `TL ≤ crawler TL` rule). Takes the primitive
+ * the rule reads — the system record's `techLevel` (numeric tiers, or the
+ * 'B'/'N' expansion tiers, which are never 1). The caller separately filters
+ * to WEAPONS systems (`isWeaponSystem`) — the Armament Bay holds nothing else.
+ */
+export function isLegalCreationCrawlerWeapon(techLevel: number | string): boolean {
+  return techLevel === CRAWLER_CREATION_TECH_LEVEL
+}
+
+/**
+ * The neutral mutation line a crawler type's stored `mutations` rows carry —
+ * the exact values these rules read (a discriminator string + a number), NOT
+ * the whole SURef crawler record. A consumer narrows its resolved type record
+ * to `mutations` at the call site.
+ */
+export type CrawlerMutationInput = { type: string; value: number }
+
+/**
+ * Armament-Bay weapon slots for a crawler type: base 1 ("A Union Crawler can
+ * mount a single Weapons System in its Armament Bay", p.213) plus any
+ * `weapon_slots` mutations — the STORED data flag on the type record (the
+ * Battle Crawler's "Improved Armour and Armaments" grants +1, p.216). Never
+ * derived from action-name string matching.
+ */
+export function crawlerWeaponSlots(mutations: readonly CrawlerMutationInput[] | undefined): number {
+  const bonus = (mutations ?? [])
+    .filter((m) => m.type === 'weapon_slots')
+    .reduce((sum, m) => sum + m.value, 0)
+  return 1 + bonus
+}
+
+/**
+ * Max-SP bonus for a crawler type: the sum of its stored `max_sp_bonus`
+ * mutations (the Battle Crawler's +5 Max SP, p.216). Applied AT READ by
+ * `crawlerMaxSP` — the stored crawler record keeps the BARE tech-level value,
+ * so type swaps re-derive correctly in both directions.
+ */
+export function crawlerMaxSpBonus(mutations: readonly CrawlerMutationInput[] | undefined): number {
+  return (mutations ?? [])
+    .filter((m) => m.type === 'max_sp_bonus')
+    .reduce((sum, m) => sum + m.value, 0)
+}
+
+/**
+ * Minimum Armament-Bay weapons at creation: the book's step 3 mounts one
+ * ("Choose your Weapons System … A Union Crawler can mount a single Weapons
+ * System in its Armament Bay", p.213) — a guided crawler never ships unarmed.
+ */
+export const CRAWLER_CREATION_MIN_WEAPONS = 1
+
+/** Whether the creation weapon pick satisfies the minimum-1 mount (p.213). */
+export function isCrawlerWeaponPickComplete(selectedCount: number): boolean {
+  return selectedCount >= CRAWLER_CREATION_MIN_WEAPONS
 }

--- a/packages/salvageunion-reference/lib/rules/derivedStats.test.ts
+++ b/packages/salvageunion-reference/lib/rules/derivedStats.test.ts
@@ -17,6 +17,7 @@ import {
   clampMechCurrentStats,
   clampPilotCurrentStats,
   crawlerMaxSP,
+  crawlerMaxSPParts,
   injuryMaxHpPenalty,
   installedStatBonus,
   isPilotDead,
@@ -31,7 +32,13 @@ import {
 import type { ChassisStats } from './derivedStats.js'
 
 beforeAll(async () => {
-  await SalvageUnionReference.preload(['crawler-tech-levels', 'chassis', 'systems', 'modules'])
+  await SalvageUnionReference.preload([
+    'crawler-tech-levels',
+    'crawlers',
+    'chassis',
+    'systems',
+    'modules',
+  ])
 })
 
 // ---------------------------------------------------------------------------
@@ -249,9 +256,38 @@ describe('crawler derivation', () => {
     expect(crawlerMaxSP({ techLevel: 'tech-3' })).toBe(tl3?.structurePoints ?? -1)
   })
 
-  it('Battle Crawler +5 lives in maxSpModifier', () => {
+  it('maxSpModifier is a pure hand-edit bonus on top of the base', () => {
     const base = crawlerMaxSP({ techLevel: 'tech-1' })
     expect(crawlerMaxSP({ techLevel: 'tech-1', maxSpModifier: 5 })).toBe(base + 5)
+  })
+
+  it('the Battle type’s +5 applies AT READ from its stored max_sp_bonus mutation', () => {
+    const battle = SalvageUnionReference.Crawlers.find((c) => c.name === 'Battle')
+    expect(battle).toBeDefined()
+    const base = crawlerMaxSP({ techLevel: 'tech-1' })
+    // By id AND by name (stored type refs resolve id-or-name, like bay refs).
+    expect(crawlerMaxSP({ techLevel: 'tech-1', type: battle?.id })).toBe(base + 5)
+    expect(crawlerMaxSP({ techLevel: 'tech-1', type: 'Battle' })).toBe(base + 5)
+    // A type swap re-derives in BOTH directions — no stored residue.
+    expect(crawlerMaxSP({ techLevel: 'tech-1', type: 'Engineering' })).toBe(base)
+  })
+
+  it('type bonus stacks with the hand-edit modifier, decomposed by crawlerMaxSPParts', () => {
+    const battle = SalvageUnionReference.Crawlers.find((c) => c.name === 'Battle')
+    const parts = crawlerMaxSPParts({
+      techLevel: 'tech-1',
+      type: battle?.id,
+      maxSpModifier: 2,
+    })
+    expect(parts.base).toBe(20)
+    expect(parts.typeBonus).toBe(5)
+    expect(parts.modifier).toBe(2)
+    expect(parts.total).toBe(27)
+  })
+
+  it('an unresolvable type ref contributes no bonus', () => {
+    const base = crawlerMaxSP({ techLevel: 'tech-1' })
+    expect(crawlerMaxSP({ techLevel: 'tech-1', type: 'no-such-type' })).toBe(base)
   })
 
   it('unresolvable techLevel slug yields the modifier alone (≥ 0)', () => {

--- a/packages/salvageunion-reference/lib/rules/derivedStats.ts
+++ b/packages/salvageunion-reference/lib/rules/derivedStats.ts
@@ -9,8 +9,9 @@
  *   Pilot:   maxHP = 10 + maxHpModifier − Σ(minor injury: 1, major: 2)
  *            maxAP = 5 + maxApModifier
  *   Mech:    max{SP,EP,Heat,Cargo} = chassis stat + max*Modifier
- *   Crawler: maxSP = tech-level structurePoints (ORM) + maxSpModifier
- *            (Battle Crawler +5 is hand-set into maxSpModifier)
+ *   Crawler: maxSP = tech-level structurePoints (ORM) + the chosen TYPE's
+ *            `max_sp_bonus` mutations (Battle +5, applied at read —
+ *            wizard-refresh Phase 5) + maxSpModifier (a pure hand-edit)
  *
  * All functions are pure — no side effects, no async, no React. Parameter
  * types are small structural shapes (not full persisted records) — a
@@ -19,6 +20,7 @@
  */
 
 import { SalvageUnionReference } from '../index.js'
+import { crawlerMaxSpBonus } from './creation.js'
 import { resolveChassisRef, resolveInstalledRef } from './resolveRefs.js'
 
 // ---------------------------------------------------------------------------
@@ -249,7 +251,17 @@ export function unifiedMechConditions(mech: {
 // Crawler
 // ---------------------------------------------------------------------------
 
-type CrawlerDerivationInput = { techLevel: string; maxSpModifier?: number }
+type CrawlerDerivationInput = {
+  techLevel: string
+  /**
+   * Chosen crawler-type ref (SRD id OR name) — the type's stored
+   * `max_sp_bonus` mutations (Battle +5) apply AT READ, so the record keeps
+   * the BARE tech-level value and type swaps re-derive in both directions
+   * (wizard-refresh Phase 5). Absent/unresolvable = no type bonus.
+   */
+  type?: string
+  maxSpModifier?: number
+}
 
 /**
  * Parse a crawler techLevel slug (e.g. "tech-3") to its numeric level (3).
@@ -271,20 +283,57 @@ function parseCrawlerTechLevel(techLevel: string): number | undefined {
 }
 
 /**
- * Derived crawler max SP: the tech level's structurePoints from the reference
- * ORM (20/25/30/35/40/50 for TL 1–6) plus the hand-edited maxSpModifier
- * (Battle Crawler +5). Returns the modifier alone (≥0) when the techLevel
- * slug cannot be resolved — and the caller should surface that as a data
- * problem rather than rendering a silent 0-pip track.
+ * The type's stored `max_sp_bonus` mutations, resolved by id-or-name (the
+ * same tolerance as bay refs). Salvage-tolerant: a missing `crawlers` catalog
+ * (not yet preloaded) or an unresolvable ref contributes 0 rather than
+ * throwing.
  */
-export function crawlerMaxSP(crawler: CrawlerDerivationInput): number {
+function crawlerTypeMaxSpBonus(typeRef: string | undefined): number {
+  if (!typeRef) return 0
+  try {
+    const type = SalvageUnionReference.Crawlers.find((c) => c.id === typeRef || c.name === typeRef)
+    return crawlerMaxSpBonus(type?.mutations)
+  } catch {
+    return 0
+  }
+}
+
+/** The additive parts of a crawler's derived max SP (and their total). */
+export type CrawlerMaxSPParts = {
+  /** The tech level's structurePoints (20/25/30/35/40/50 for TL 1–6). */
+  base: number
+  /** The chosen type's `max_sp_bonus` mutations, applied at read (Battle +5). */
+  typeBonus: number
+  /** The hand-edited maxSpModifier (a pure player-edit field). */
+  modifier: number
+  /** base + typeBonus + modifier, floored at 0. */
+  total: number
+}
+
+/**
+ * Derived crawler max SP, decomposed: the tech level's structurePoints from
+ * the reference ORM, plus the chosen TYPE's stored `max_sp_bonus` mutations
+ * applied AT READ (Battle Crawler +5 — the record stores the BARE tech-level
+ * value, so type swaps re-derive correctly both ways), plus the hand-edited
+ * maxSpModifier. Base resolves to 0 when the techLevel slug cannot be parsed
+ * — the caller should surface that as a data problem rather than rendering a
+ * silent 0-pip track.
+ */
+export function crawlerMaxSPParts(crawler: CrawlerDerivationInput): CrawlerMaxSPParts {
   const tl = parseCrawlerTechLevel(crawler.techLevel)
   const base =
     tl === undefined
       ? 0
       : (SalvageUnionReference.CrawlerTechLevels.find((t) => t.techLevel === tl)?.structurePoints ??
         0)
-  return Math.max(0, base + (crawler.maxSpModifier ?? 0))
+  const typeBonus = crawlerTypeMaxSpBonus(crawler.type)
+  const modifier = crawler.maxSpModifier ?? 0
+  return { base, typeBonus, modifier, total: Math.max(0, base + typeBonus + modifier) }
+}
+
+/** Derived crawler max SP — `crawlerMaxSPParts(crawler).total`. */
+export function crawlerMaxSP(crawler: CrawlerDerivationInput): number {
+  return crawlerMaxSPParts(crawler).total
 }
 
 /**

--- a/packages/salvageunion-reference/lib/rules/index.ts
+++ b/packages/salvageunion-reference/lib/rules/index.ts
@@ -19,6 +19,8 @@ export {
   PILOT_CREATION_ABILITY_PICKS,
   PILOT_CREATION_EQUIPMENT_PICKS,
   MECH_CREATION_SCRAP_CAP,
+  CRAWLER_CREATION_TECH_LEVEL,
+  CRAWLER_CREATION_MIN_WEAPONS,
   isLegalCreationClass,
   isLegalCreationAbility,
   legalCreationAbilities,
@@ -26,9 +28,13 @@ export {
   isLegalCreationChassis,
   isLegalCreationSystem,
   isLegalCreationModule,
+  isLegalCreationCrawlerWeapon,
   isLegalStartingPattern,
   legalStartingPatterns,
   mechCreationBudget,
+  crawlerWeaponSlots,
+  crawlerMaxSpBonus,
+  isCrawlerWeaponPickComplete,
   pilotAbilityPicksRemaining,
   pilotEquipmentPicksRemaining,
   isPilotAbilityPickComplete,
@@ -39,6 +45,7 @@ export type {
   CreationAbilityInput,
   CreationEquipmentInput,
   CreationPatternInput,
+  CrawlerMutationInput,
   MechCreationBudget,
   MechCreationBudgetInput,
   MechCreationLoadoutEntry,
@@ -109,9 +116,10 @@ export {
   clampMechCurrentStats,
   unifiedMechConditions,
   crawlerMaxSP,
+  crawlerMaxSPParts,
   clampCrawlerCurrentStats,
 } from './derivedStats.js'
-export type { ChassisStats } from './derivedStats.js'
+export type { ChassisStats, CrawlerMaxSPParts } from './derivedStats.js'
 export {
   MEDIATOR_TABLE_NAMES,
   MEDIATOR_TABLE_LABEL,


### PR DESCRIPTION
Phase 5 of the ITUN create-wizard refresh: restructures the **Union Crawler** create wizard to the Core Book's own step order (pp.212–213) and enforces its creation rules HARD in guided mode — mirroring the pilot (Phase 3) and mech (Phase 4) wizards, reusing the same `WizShell` + `RuleBrief` + `SelCard` + split `creation.ts` pattern.

## The 5-step restructure (+ Review)
1. **Choose a Crawler Type** — the 5 types as radio `SelCard`s; the type's stored `mutations` (`weapon_slots` / `max_sp_bonus`) re-derive downstream budgets. Changing type re-clamps step 3's weapons (drops excess with a toast). Augmented shows the A.I. + an instructional **"+1 Training Point, Augment tree only"** callout — TEXT ONLY, no cross-pilot write (ADR-007). Step 1's RuleBrief carries the advisory prelude (a gentle count of existing pilots/mechs in this workspace; never blocks).
2. **Note your Statistics** — display-only; Tech Level **fixed at 1** (no input); **`upgradePool` input removed** (fixed at 0); all bays Intact.
3. **Arm the Armament Bay** — Tech-1 weapon systems only; **minimum 1 to advance**; `maxSelectable` read from the type's `mutations` (Battle = 2), clamped.
4. **Name your Crew** — the 10 base bays auto-seed (not choosable/removable); expansion-tagged bays never appear; each NPC HP fixed by data; flavor optional; the type's special NPC heads the list.
5. **Name your Crawler** — name required; **`scrapPool` relocated here** as an explicit optional numeric input (the banked-scrap landing spot) with a RuleBrief line; description here.
- **Review** — recaps type/ability/weapon(s)/stats/scrapPool/crew; `CrawlerSchema.safeParse`; Augmented re-surfaces the +1 TP reminder.

Each step gets a RuleBrief with the actual pp.212–213 copy + citation.

## maxSP derived-at-read + healing migration (correctness-critical)
- `crawlerMaxSP` now applies the chosen **type's `max_sp_bonus` mutations at READ** (Battle +5). The record stores only the **bare tech-level value**, so a type swap re-derives correctly in **both directions**. `crawlerMaxSPParts` exposes the base/typeBonus/modifier breakdown for the Statistics readout (`20 + 5 type bonus = 25`).
- **Migration v8** (`8-crawler-battle-sp-to-derived.ts`) **heals existing data**: a Battle crawler whose `maxSpModifier` hand-carried the +5 sheds exactly 5 (no double-count; hand-edits beyond the bonus survive; a resulting 0 removes the key). A **stale** Battle record (no/partial modifier) is left untouched and gains the +5 at read (max SP rises, never falls — no `currentSP` clamp needed). **Non-Battle crawlers are untouched.** Tests prove every case, through the opener from a seeded v7 fixture.

## Other required changes
- **Mutations-driven weapon cap** — replaces the `"Improved Armour and Armaments"` action-name string match in `CrawlerBuilder`.
- **Route-loader fix** — added the missing loader to `crawlers/new.tsx` (parity with pilots/mechs: preloads crawlers/tech-levels/systems/bays/actions/traits/roll-tables).
- **Crew roster restyle** to the poster idiom (entity-card rows expanding to IdentityFields).
- **Enforcement split**: package `creation.ts` gains `isLegalCreationCrawlerWeapon`, `crawlerWeaponSlots`, `crawlerMaxSpBonus`, `isCrawlerWeaponPickComplete` — all pure over **NEUTRAL inputs** (mutation rows `{type, value}`, `techLevel` primitives, counts). The app adapter narrows resolved records and owns `crawlerCreationStepGate` + `clampCrawlerCreationDraft`.
- **Edit mode stays SOFT** (§5.2): Statistics step hidden, budgets undefined, TL filter lifted, gates relaxed to presence checks, `SoftWarningBanner` + advisory over-capacity warnings remain. Create flow removes the banner entirely.

## Design (Mockup Screen 03) + entity-card confirmation
- Crawler tinted step card = **peach** (`--tone-card` for `.sheet--crawler`, `#EC9C67`, dark ink) under the **magenta** "Union Crawler" band — the existing Phase-2 theming, now opted-in via `tintedStepCard`.
- **Confirmed:** crawler **types**, **weapon systems**, and bay/type **NPCs** all render as the SRD `ReferenceEntityDisplay` card (types + weapons inside `SelCard` → Sel ring; types use radio mode). Flavor/name fields use `IdentityField`.

## Verification — all green
- `bun run typecheck` — 0 errors (all 4 workspaces)
- `bunx @typescript/native-preview --noEmit -p apps/in-the-union-now/tsconfig.json` — **0 errors**
- `bun --filter salvageunion-reference test` — 876 pass
- `bun --filter in-the-union-now test` — 1142 pass (incl. 7 migration tests + rewritten CrawlerBuilder/CrawlerCrewStep suites)
- `bun run build:package` — no schema drift
- `bun run format` — clean
- `bun run check:all` — exit 0 (lint, format, typecheck, test, validate, knip, audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuNKAVLVSumokSeATao282
