### PR TITLE
feat(itun): Play Cockpit Phase 3 — rotary Dial + focus→display sync

### DIFF
--- a/apps/in-the-union-now/src/components/play/Dial.tsx
+++ b/apps/in-the-union-now/src/components/play/Dial.tsx
@@ -1,0 +1,158 @@
+/**
+ * Dial — the rotary selector column. The active item sits in a wide slot (it
+ * overhangs the column and, in Phase 4, drives the main display); the rest ride
+ * a track below, right-aligned and smaller. Advance with ▲▼, click a track item
+ * to jump, or drag the column; each step plays a short directional roll.
+ *
+ * Statful cells (entities) show a stamp + compact gauges; statless cells
+ * (Actions / Tables / SRD) show a big centered title — no stats.
+ *
+ * Phase 3: selection + focus. The store's `wheel` index is the single source of
+ * truth; PlayCockpit reads it to drive the display (focus→display sync).
+ */
+
+import { useRef, useState, type PointerEvent } from 'react'
+
+import { usePlayStateStore } from '../../stores/playStateStore'
+import { CockpitGauge } from './CockpitGauge'
+import type { DialItem } from './dialItems'
+
+const DRAG_STEP = 30
+
+function DialCell({
+  item,
+  active,
+  onClick,
+}: {
+  item: DialItem
+  active?: boolean
+  onClick?: () => void
+}) {
+  const cls = `pc-cell${active ? ' pc-cell-active' : ''}${item.statless ? ' statless' : ''}`
+  const inner = item.statless ? (
+    <>
+      <span className="pc-cell-title">{item.label}</span>
+      <span className="pc-cell-sub">{item.sublabel}</span>
+    </>
+  ) : (
+    <>
+      <span className={`pc-cell-lab ${item.tone}`}>{item.label}</span>
+      <div className="pc-cell-gauges">
+        {item.gauges.map((g) => (
+          <CockpitGauge
+            key={g.label}
+            label={g.label}
+            value={g.value}
+            max={g.max}
+            tone={g.tone}
+            danger={g.danger}
+          />
+        ))}
+      </div>
+    </>
+  )
+  if (onClick) {
+    return (
+      <button type="button" className={cls} onClick={onClick} aria-label={item.label}>
+        {inner}
+      </button>
+    )
+  }
+  return <div className={cls}>{inner}</div>
+}
+
+export function Dial({ items }: { items: DialItem[] }) {
+  const wheel = usePlayStateStore((s) => s.wheel)
+  const setWheel = usePlayStateStore((s) => s.setWheel)
+  const [anim, setAnim] = useState<{ dir: 'fwd' | 'back'; key: number }>({ dir: 'fwd', key: 0 })
+
+  const n = items.length
+  const active = n > 0 ? ((wheel % n) + n) % n : 0
+
+  const go = (next: number, dir: 'fwd' | 'back') => {
+    setWheel(next)
+    setAnim((a) => ({ dir, key: a.key + 1 }))
+  }
+  const step = (d: number) => {
+    if (n === 0) return
+    // Read the live wheel so multiple steps within one drag event accumulate.
+    go(usePlayStateStore.getState().wheel + d, d > 0 ? 'fwd' : 'back')
+  }
+  const jump = (idx: number) => {
+    if (idx === active || n === 0) return
+    const forward = (((idx - active) % n) + n) % n
+    go(idx, forward <= n / 2 ? 'fwd' : 'back')
+  }
+
+  const drag = useRef<{ last: number; acc: number } | null>(null)
+  const onPointerDown = (e: PointerEvent) => {
+    drag.current = { last: e.clientY, acc: 0 }
+    e.currentTarget.setPointerCapture(e.pointerId)
+  }
+  const onPointerMove = (e: PointerEvent) => {
+    const d = drag.current
+    if (!d) return
+    d.acc += e.clientY - d.last
+    d.last = e.clientY
+    while (d.acc >= DRAG_STEP) {
+      d.acc -= DRAG_STEP
+      step(-1)
+    }
+    while (d.acc <= -DRAG_STEP) {
+      d.acc += DRAG_STEP
+      step(1)
+    }
+  }
+  const endDrag = (e: PointerEvent) => {
+    drag.current = null
+    if (e.currentTarget.hasPointerCapture?.(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId)
+    }
+  }
+
+  const activeItem = items[active]
+  if (!activeItem) return <div className="pc-wheel-col" />
+
+  const trackIdx: number[] = []
+  for (let k = 1; k < n; k++) trackIdx.push((active + k) % n)
+
+  return (
+    <div
+      className="pc-wheel-col"
+      role="listbox"
+      aria-label="Dial"
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+    >
+      <div className={`pc-wheel-slot anim-${anim.dir}`} key={anim.key}>
+        <DialCell item={activeItem} active />
+      </div>
+      <div className="pc-wheel-track">
+        {trackIdx.map((idx) => {
+          const it = items[idx]
+          return it ? <DialCell key={it.key} item={it} onClick={() => jump(idx)} /> : null
+        })}
+      </div>
+      <div className="pc-wheel-ctl">
+        <button
+          type="button"
+          className="pc-wheel-btn"
+          onClick={() => step(-1)}
+          aria-label="Dial up"
+        >
+          ▲
+        </button>
+        <button
+          type="button"
+          className="pc-wheel-btn"
+          onClick={() => step(1)}
+          aria-label="Dial down"
+        >
+          ▼
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/play/PlayCockpit.tsx
+++ b/apps/in-the-union-now/src/components/play/PlayCockpit.tsx
@@ -16,12 +16,15 @@ import { resolveSheetComposition } from '../sheet/composition'
 import type { EntityLookup } from '../sheet/composition'
 import { ActiveItemBand } from './ActiveItemBand'
 import { CockpitCanvas } from './CockpitCanvas'
+import { Dial } from './Dial'
+import { dialItems } from './dialItems'
 import { RailBar } from './RailBar'
 
 export function PlayCockpit({ id }: { id: string }) {
   const storeState = useEntityStore()
   // The active-row entity drives the whole-canvas tint (proposed ADR-018).
   const mount = usePlayStateStore((s) => s.mount)
+  const wheel = usePlayStateStore((s) => s.wheel)
   const mech = storeState.get('mech', id)
 
   if (!mech) {
@@ -57,8 +60,15 @@ export function PlayCockpit({ id }: { id: string }) {
     store: lookup,
   })
   const pilot = composition.pilot
+  const crawler = composition.crawler
   const onFoot = mount === 'pilot' && pilot !== null
   const railTitle = onFoot && pilot ? `Pilot · ${pilot.name}` : `Mech · ${mech.name}`
+
+  // The Dial holds the non-active entities + statless views; the item in the
+  // active slot is the display's focus (focus→display sync; content is Phase 4).
+  const items = dialItems({ mount: onFoot ? 'pilot' : 'mech', mech, pilot, crawler })
+  const focus =
+    items.length > 0 ? items[((wheel % items.length) + items.length) % items.length] : undefined
 
   return (
     <CockpitCanvas>
@@ -68,10 +78,14 @@ export function PlayCockpit({ id }: { id: string }) {
           <ActiveItemBand mech={mech} pilot={pilot} />
         </div>
         <div className="pc-display">
-          <div className="pc-fill">Main display — SRD reference &amp; actions (Phase 4)</div>
+          <div className="pc-fill">
+            Showing · {focus?.label ?? '—'}
+            <br />
+            Main display — SRD reference &amp; actions (Phase 4)
+          </div>
         </div>
         <div className="pc-wheel">
-          <div className="pc-placeholder">Dial (Phase 3)</div>
+          <Dial items={items} />
         </div>
       </div>
     </CockpitCanvas>

--- a/apps/in-the-union-now/src/components/play/__tests__/Dial.test.tsx
+++ b/apps/in-the-union-now/src/components/play/__tests__/Dial.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Tests for the rotary Dial — ▲▼ stepping, wrap, and click-to-jump, all
+ * reflected in the active slot. Uses plain item fixtures (no ORM needed).
+ */
+
+import { beforeEach, describe, expect, test } from 'bun:test'
+import { fireEvent, render } from '@testing-library/react'
+
+import { usePlayStateStore } from '../../../stores/playStateStore'
+import { Dial } from '../Dial'
+import type { DialItem } from '../dialItems'
+
+const items: DialItem[] = [
+  { key: 'actions', statless: true, label: 'Actions', sublabel: 'deck' },
+  {
+    key: 'pilot',
+    statless: false,
+    label: 'Pilot · Vesh',
+    tone: 'pilot',
+    gauges: [{ label: 'HP', value: 8, max: 10, tone: 'pilot' }],
+  },
+  { key: 'tables', statless: true, label: 'Tables', sublabel: 'roll' },
+]
+
+describe('Dial', () => {
+  beforeEach(() => {
+    usePlayStateStore.setState({ mount: 'mech', wheel: 0 })
+  })
+
+  test('active slot starts on the first item', () => {
+    const { container } = render(<Dial items={items} />)
+    expect(container.querySelector('.pc-cell-active')?.textContent).toContain('Actions')
+  })
+
+  test('▼ advances, ▲ goes back', () => {
+    const { container, getByLabelText } = render(<Dial items={items} />)
+    const slot = () => container.querySelector('.pc-cell-active')?.textContent ?? ''
+    fireEvent.click(getByLabelText('Dial down'))
+    expect(slot()).toContain('Pilot · Vesh')
+    fireEvent.click(getByLabelText('Dial up'))
+    expect(slot()).toContain('Actions')
+  })
+
+  test('▲ from the first item wraps to the last', () => {
+    const { container, getByLabelText } = render(<Dial items={items} />)
+    fireEvent.click(getByLabelText('Dial up'))
+    expect(container.querySelector('.pc-cell-active')?.textContent).toContain('Tables')
+  })
+
+  test('clicking a track item jumps the active slot to it', () => {
+    const { container, getByRole } = render(<Dial items={items} />)
+    fireEvent.click(getByRole('button', { name: 'Tables' }))
+    expect(container.querySelector('.pc-cell-active')?.textContent).toContain('Tables')
+  })
+})

--- a/apps/in-the-union-now/src/components/play/__tests__/dialItems.test.ts
+++ b/apps/in-the-union-now/src/components/play/__tests__/dialItems.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Unit tests for dialItems — the Dial's item list from the entity graph.
+ */
+
+import { beforeAll, describe, expect, test } from 'bun:test'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import type { Crawler } from '../../../lib/schemas/crawler'
+import type { Mech } from '../../../lib/schemas/mech'
+import type { Pilot } from '../../../lib/schemas/pilot'
+import { dialItems } from '../dialItems'
+
+const mech = {
+  id: 'm1',
+  name: 'Iron Mongrel',
+  chassisRef: 'x',
+  systems: [],
+  modules: [],
+} as unknown as Mech
+const pilot = { id: 'p1', name: 'Vesh', abilities: [], conditions: [] } as unknown as Pilot
+const crawler = { id: 'c1', name: 'Union Hauler', techLevel: '3' } as unknown as Crawler
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+describe('dialItems', () => {
+  test('boarded: Actions, the counterpart pilot, crawler, Tables, SRD', () => {
+    const items = dialItems({ mount: 'mech', mech, pilot, crawler })
+    expect(items.map((i) => i.label)).toEqual([
+      'Actions',
+      'Pilot · Vesh',
+      'Crawler · Union Hauler',
+      'Tables',
+      'SRD Explorer',
+    ])
+    expect(items[0]?.statless).toBe(true)
+  })
+
+  test('on foot: the counterpart is the mech', () => {
+    const items = dialItems({ mount: 'pilot', mech, pilot, crawler })
+    expect(items.map((i) => i.label)).toContain('Mech · Iron Mongrel')
+    expect(items.map((i) => i.label)).not.toContain('Pilot · Vesh')
+  })
+
+  test('omits the crawler when none is linked', () => {
+    const items = dialItems({ mount: 'mech', mech, pilot, crawler: null })
+    expect(items.some((i) => i.label.startsWith('Crawler'))).toBe(false)
+  })
+
+  test('statless views carry no gauges', () => {
+    const items = dialItems({ mount: 'mech', mech, pilot: null, crawler: null })
+    const actions = items.find((i) => i.label === 'Actions')
+    expect(actions?.statless).toBe(true)
+  })
+})

--- a/apps/in-the-union-now/src/components/play/dialItems.ts
+++ b/apps/in-the-union-now/src/components/play/dialItems.ts
@@ -1,0 +1,111 @@
+/**
+ * dialItems — builds the rotary Dial's item list from the real entity graph.
+ *
+ * The Dial holds everything that ISN'T the active-row entity: the counterpart
+ * entity (pilot when boarded / mech on foot), the linked crawler, plus the
+ * always-present statless views (Actions / Tables / SRD). Whatever sits in the
+ * active dial slot drives the main display (focus→display sync, Phase 4).
+ *
+ * Statful items carry compact gauges (derived from the same rules helpers the
+ * Active Item uses); statless items are a big centered title — no stats.
+ */
+
+import {
+  crawlerMaxSP,
+  mechMaxHeat,
+  mechMaxSP,
+  pilotMaxAP,
+  pilotMaxHP,
+} from '../../lib/rules/derivedStats'
+import { resolveChassisRef } from '../../lib/rules/resolveRefs'
+import type { Crawler } from '../../lib/schemas/crawler'
+import type { Mech } from '../../lib/schemas/mech'
+import type { Pilot } from '../../lib/schemas/pilot'
+import type { MountState } from '../../stores/playStateStore'
+import type { GaugeTone } from './CockpitGauge'
+
+export type DialGauge = {
+  label: string
+  value: number
+  max: number
+  tone: GaugeTone
+  danger?: number
+}
+
+export type DialItem =
+  | { key: string; statless: true; label: string; sublabel: string }
+  | { key: string; statless: false; label: string; tone: GaugeTone; gauges: DialGauge[] }
+
+function pilotItem(pilot: Pilot): DialItem {
+  const maxHP = Math.max(0, pilotMaxHP(pilot))
+  const maxAP = Math.max(0, pilotMaxAP(pilot))
+  return {
+    key: `pilot:${pilot.id}`,
+    statless: false,
+    label: `Pilot · ${pilot.name}`,
+    tone: 'pilot',
+    gauges: [
+      { label: 'HP', value: Math.min(pilot.currentHP ?? maxHP, maxHP), max: maxHP, tone: 'pilot' },
+      { label: 'AP', value: Math.min(pilot.currentAP ?? maxAP, maxAP), max: maxAP, tone: 'pilot' },
+    ],
+  }
+}
+
+function mechItem(mech: Mech): DialItem {
+  const chassis = resolveChassisRef(mech.chassisRef)
+  const maxSP = mechMaxSP(mech, chassis)
+  const maxHeat = mechMaxHeat(mech, chassis)
+  return {
+    key: `mech:${mech.id}`,
+    statless: false,
+    label: `Mech · ${mech.name}`,
+    tone: 'mech',
+    gauges: [
+      { label: 'SP', value: Math.min(mech.currentSP ?? maxSP, maxSP), max: maxSP, tone: 'mech' },
+      {
+        label: 'Heat',
+        value: Math.min(mech.currentHeat ?? maxHeat, maxHeat),
+        max: maxHeat,
+        tone: 'mech',
+        danger: Math.max(0, maxHeat - 2),
+      },
+    ],
+  }
+}
+
+function crawlerItem(crawler: Crawler): DialItem {
+  const maxSP = crawlerMaxSP(crawler)
+  return {
+    key: `crawler:${crawler.id}`,
+    statless: false,
+    label: `Crawler · ${crawler.name}`,
+    tone: 'crawler',
+    gauges: [
+      {
+        label: 'SP',
+        value: Math.min(crawler.currentSP ?? maxSP, maxSP),
+        max: maxSP,
+        tone: 'crawler',
+      },
+    ],
+  }
+}
+
+export function dialItems(args: {
+  mount: MountState
+  mech: Mech
+  pilot: Pilot | null
+  crawler: Crawler | null
+}): DialItem[] {
+  const { mount, mech, pilot, crawler } = args
+  const items: DialItem[] = [
+    { key: 'actions', statless: true, label: 'Actions', sublabel: 'full action deck' },
+  ]
+  // The counterpart entity — the one NOT in the active row.
+  if (mount !== 'mech') items.push(mechItem(mech))
+  if (mount === 'mech' && pilot) items.push(pilotItem(pilot))
+  if (crawler) items.push(crawlerItem(crawler))
+  items.push({ key: 'tables', statless: true, label: 'Tables', sublabel: 'roll on any table' })
+  items.push({ key: 'srd', statless: true, label: 'SRD Explorer', sublabel: 'reference browser' })
+  return items
+}

--- a/apps/in-the-union-now/src/components/play/play.css
+++ b/apps/in-the-union-now/src/components/play/play.css
@@ -289,6 +289,170 @@
   color: var(--pc-text);
 }
 
+/* ---- Rotary Dial ---- */
+.pc-wheel-col {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  height: 100%;
+  overflow: visible;
+  touch-action: none;
+  cursor: grab;
+}
+.pc-wheel-col:active {
+  cursor: grabbing;
+}
+.pc-wheel-slot {
+  height: 168px;
+  flex: 0 0 auto;
+  display: flex;
+  justify-content: flex-end;
+  overflow: visible;
+}
+.pc-wheel-track {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-end;
+  overflow: hidden;
+  padding: 2px 0;
+}
+.pc-cell {
+  box-sizing: border-box;
+  border: 1.5px solid var(--pc-line);
+  border-radius: 5px;
+  background: color-mix(in oklab, var(--pc-panel) 80%, #000);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  padding: 9px 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: left;
+  color: var(--pc-text);
+  width: 84%;
+  flex: 0 0 auto;
+}
+.pc-cell-active {
+  width: 420px;
+  height: 100%;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.3);
+  padding: 12px 16px;
+  justify-content: flex-start;
+}
+.pc-cell.statless {
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+.pc-cell-lab {
+  align-self: flex-start;
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  font-size: 12px;
+  line-height: 1;
+  padding: 4px 7px 5px;
+  border-radius: 2px;
+  color: #fff;
+}
+.pc-cell-lab.mech {
+  background: var(--pc-mech-deep);
+}
+.pc-cell-lab.pilot {
+  background: var(--pc-pilot-deep);
+}
+.pc-cell-lab.crawler {
+  background: var(--pc-crawler-deep);
+}
+.pc-cell-gauges {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.pc-cell-active .pc-cell-gauges {
+  margin-top: 8px;
+}
+.pc-cell-title {
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  font-size: 18px;
+  line-height: 1;
+  color: var(--pc-text);
+}
+.pc-cell-active.statless .pc-cell-title {
+  font-size: 30px;
+}
+.pc-cell-sub {
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 10px;
+  color: var(--pc-muted);
+}
+.pc-wheel-ctl {
+  display: flex;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+.pc-wheel-btn {
+  flex: 1;
+  height: 26px;
+  border: 1.5px solid var(--pc-line);
+  border-radius: 3px;
+  background: color-mix(in oklab, var(--pc-panel) 60%, #000);
+  color: var(--pc-text);
+  cursor: pointer;
+  font-size: 12px;
+}
+.pc-wheel-btn:hover {
+  border-color: var(--pc-muted);
+}
+.pc-wheel-slot.anim-fwd .pc-cell {
+  animation: pcRollFwd 0.2s cubic-bezier(0.25, 0.8, 0.3, 1.1);
+}
+.pc-wheel-slot.anim-back .pc-cell {
+  animation: pcRollBack 0.2s cubic-bezier(0.25, 0.8, 0.3, 1.1);
+}
+@keyframes pcRollFwd {
+  0% {
+    transform: translateY(42px);
+    opacity: 0.15;
+  }
+  70% {
+    transform: translateY(-4px);
+    opacity: 1;
+  }
+  100% {
+    transform: none;
+  }
+}
+@keyframes pcRollBack {
+  0% {
+    transform: translateY(-42px);
+    opacity: 0.15;
+  }
+  70% {
+    transform: translateY(4px);
+    opacity: 1;
+  }
+  100% {
+    transform: none;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .pc-wheel-slot.anim-fwd .pc-cell,
+  .pc-wheel-slot.anim-back .pc-cell {
+    animation: none;
+  }
+}
+
 /* Below the scale floor (phones / heavy zoom) the fixed canvas is abandoned. */
 .pc-reflow {
   max-width: 340px;


### PR DESCRIPTION
## What

Phase 3 of the Play Cockpit ([plan §9.3](https://github.com/SalvageUnion-io/SU-SRD/pull/423)). **Stacked on #425** (base = `worktree-play-cockpit-phase2`). Adds the rotary **Dial** selector; the active dial item is the display's focus (real display content is Phase 4).

## Changes

- **`dialItems`** — builds the Dial list from the real entity graph: the counterpart entity (pilot when boarded / mech on foot), the linked crawler (via `resolveSheetComposition`), plus statless **Actions / Tables / SRD** views. Statful items carry compact gauges from the same `derivedStats` helpers.
- **`Dial`** — active slot (wide overhang) + right-aligned track + ▲▼. Advance via ▲▼, **click a track item to jump**, or **drag** the column (pointer capture, 30px detent); each step plays a short **directional roll** (reduced-motion aware). Statful cells = stamp + `CockpitGauge`s; statless = big centered title.
- **focus→display sync** — selection is `playStateStore.wheel` (single source of truth); `PlayCockpit` reads it to show the focused item in the display (`Showing · …`, real content Phase 4).

## Verification

- `bun run typecheck` clean (all packages); ITUN suite **1140 pass / 0 fail** (new: `dialItems` model + `Dial` step/wrap/jump)
- `biome lint` clean; pre-push validate/knip/typecheck/test all green

## Not in this phase

The main display's real content — `ReferenceEntityDisplay` / `ActionCard` / `RollTable` (Phase 4); actions & rules (Phase 5); downtime (Phase 6); dial config + storage (Phase 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNeL9Bxgw2HRKJpSimK1Wm