### PR TITLE
feat(itun): Play Cockpit Phase 4 — real SRD display

### DIFF
--- a/apps/in-the-union-now/src/components/play/DisplayView.tsx
+++ b/apps/in-the-union-now/src/components/play/DisplayView.tsx
@@ -1,0 +1,95 @@
+/**
+ * DisplayView — the cockpit's main display: the ONE surface that reads
+ * "forward". It renders the faithful light SRD reference document for whatever
+ * the Dial is focused on (focus→display sync), reusing suref-react's
+ * ReferenceEntityDisplay / ReferenceEntityActions / RollTable verbatim — the
+ * same components the live sheet and reference site show (proposed ADR-017).
+ *
+ * Phase 4 scope: render real reference content per focus (entity card + its
+ * actions, or a roll table, or the SRD/Actions landing). Read-only — activating
+ * actions, rolling into state, and the resolve flow are Phase 5.
+ */
+
+import { SalvageUnionReference } from 'salvageunion-reference'
+import type { SURefEntity } from 'salvageunion-reference'
+import { ReferenceEntityDisplay, RollTable } from 'suref-react'
+
+import { resolveChassisRef } from '../../lib/rules/resolveRefs'
+import type { Crawler } from '../../lib/schemas/crawler'
+import type { Mech } from '../../lib/schemas/mech'
+import type { Pilot } from '../../lib/schemas/pilot'
+import type { DialItem } from './dialItems'
+
+const HIDE_CHOICES = { choices: true } as const
+
+type DisplayViewProps = {
+  focus: DialItem | undefined
+  mech: Mech
+  pilot: Pilot | null
+  crawler: Crawler | null
+}
+
+/** A framed reference card, or a graceful fallback when a slug doesn't resolve. */
+function EntityCard({ data, note }: { data: SURefEntity | null; note: string }) {
+  if (!data) return <div className="pc-display-note">{note}</div>
+  return <ReferenceEntityDisplay data={data} hide={HIDE_CHOICES} />
+}
+
+export function DisplayView({ focus, mech, pilot, crawler }: DisplayViewProps) {
+  if (!focus) return <div className="pc-display-note">Nothing selected.</div>
+
+  if (focus.statless) {
+    if (focus.key === 'tables') {
+      const table = SalvageUnionReference.RollTables.find((t) => t.name === 'Core Mechanic') as
+        | Parameters<typeof RollTable>[0]['table']
+        | undefined
+      return (
+        <div className="pc-display-scroll">
+          {table ? (
+            <RollTable table={table} tableName="Core Mechanic" />
+          ) : (
+            <div className="pc-display-note">Roll tables load here.</div>
+          )}
+        </div>
+      )
+    }
+    // Actions deck (Phase 5) and the SRD explorer (later) land here.
+    const label = focus.key === 'actions' ? 'Actions deck' : 'SRD explorer'
+    return (
+      <div className="pc-display-note">
+        {label} — {focus.sublabel}. (Interactive content lands in a later phase.)
+      </div>
+    )
+  }
+
+  // Statful entity focus → its reference card.
+  if (focus.key.startsWith('mech:')) {
+    const chassis = resolveChassisRef(mech.chassisRef) as SURefEntity | null
+    return (
+      <div className="pc-display-scroll">
+        <EntityCard
+          data={chassis}
+          note={`Chassis “${mech.chassisRef}” not in the reference set.`}
+        />
+      </div>
+    )
+  }
+  if (focus.key.startsWith('pilot:') && pilot) {
+    const cls = (SalvageUnionReference.Classes.find((c) => c.id === pilot.classRef) ??
+      null) as SURefEntity | null
+    return (
+      <div className="pc-display-scroll">
+        <EntityCard data={cls} note={`Class “${pilot.classRef}” not in the reference set.`} />
+      </div>
+    )
+  }
+  if (focus.key.startsWith('crawler:') && crawler) {
+    return (
+      <div className="pc-display-note">
+        Crawler · {crawler.name} — bay reference lands in a later phase.
+      </div>
+    )
+  }
+
+  return <div className="pc-display-note">{focus.label}</div>
+}

--- a/apps/in-the-union-now/src/components/play/PlayCockpit.tsx
+++ b/apps/in-the-union-now/src/components/play/PlayCockpit.tsx
@@ -18,6 +18,7 @@ import { ActiveItemBand } from './ActiveItemBand'
 import { CockpitCanvas } from './CockpitCanvas'
 import { Dial } from './Dial'
 import { dialItems } from './dialItems'
+import { DisplayView } from './DisplayView'
 import { RailBar } from './RailBar'
 
 export function PlayCockpit({ id }: { id: string }) {
@@ -77,12 +78,8 @@ export function PlayCockpit({ id }: { id: string }) {
         <div className="pc-primary">
           <ActiveItemBand mech={mech} pilot={pilot} />
         </div>
-        <div className="pc-display">
-          <div className="pc-fill">
-            Showing · {focus?.label ?? '—'}
-            <br />
-            Main display — SRD reference &amp; actions (Phase 4)
-          </div>
+        <div className="pc-display pc-display-light">
+          <DisplayView focus={focus} mech={mech} pilot={pilot} crawler={crawler} />
         </div>
         <div className="pc-wheel">
           <Dial items={items} />

--- a/apps/in-the-union-now/src/components/play/__tests__/DisplayView.test.tsx
+++ b/apps/in-the-union-now/src/components/play/__tests__/DisplayView.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Tests for DisplayView — the cockpit's main display. Verifies each dial-focus
+ * kind renders without throwing and reuses the real reference components:
+ * a resolvable chassis → a ReferenceEntityDisplay card; Tables → a RollTable;
+ * unresolvable slugs → a graceful note (never a crash).
+ *
+ * Reference content needs the ORM, so preload('all') runs once. A real chassis
+ * slug is picked from the loaded set so the card path is genuinely exercised.
+ */
+
+import { beforeAll, describe, expect, test } from 'bun:test'
+import { render } from '@testing-library/react'
+import { EntityHrefProvider } from 'suref-react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import type { Crawler } from '../../../lib/schemas/crawler'
+import type { Mech } from '../../../lib/schemas/mech'
+import { DisplayView } from '../DisplayView'
+import type { DialItem } from '../dialItems'
+
+let chassisSlug = 'iron-mongrel'
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+  const first = SalvageUnionReference.Chassis.all()[0] as { id?: string } | undefined
+  if (first?.id) chassisSlug = first.id
+})
+
+function renderDV(focus: DialItem | undefined, mechChassis = chassisSlug) {
+  const mech = { id: 'm1', name: 'Rig', chassisRef: mechChassis } as unknown as Mech
+  const crawler = { id: 'c1', name: 'Hauler', techLevel: '3' } as unknown as Crawler
+  return render(
+    <EntityHrefProvider value={() => undefined}>
+      <DisplayView focus={focus} mech={mech} pilot={null} crawler={crawler} />
+    </EntityHrefProvider>
+  )
+}
+
+describe('DisplayView', () => {
+  test('mech focus → a resolvable chassis renders a reference card', () => {
+    const focus: DialItem = {
+      key: 'mech:m1',
+      statless: false,
+      label: 'Mech · Rig',
+      tone: 'mech',
+      gauges: [],
+    }
+    const { container } = renderDV(focus)
+    // The reference card renders real content, not the fallback note.
+    expect(container.querySelector('.pc-display-note')).toBeNull()
+    expect(container.querySelector('.pc-display-scroll')).toBeTruthy()
+  })
+
+  test('mech focus → an unresolvable chassis falls back to a note, no throw', () => {
+    const focus: DialItem = {
+      key: 'mech:m1',
+      statless: false,
+      label: 'Mech · Rig',
+      tone: 'mech',
+      gauges: [],
+    }
+    const { container } = renderDV(focus, 'definitely-not-a-chassis')
+    expect(container.querySelector('.pc-display-note')?.textContent).toContain(
+      'not in the reference set'
+    )
+  })
+
+  test('Tables focus → a RollTable renders', () => {
+    const focus: DialItem = { key: 'tables', statless: true, label: 'Tables', sublabel: 'roll' }
+    const { container } = renderDV(focus)
+    expect(container.querySelector('.pc-display-scroll')).toBeTruthy()
+    // The reused RollTable renders a real table (not the fallback note).
+    expect(container.querySelector('table')).toBeTruthy()
+    expect(container.querySelector('.pc-display-note')).toBeNull()
+  })
+
+  test('Actions focus → a placeholder note (Phase 5)', () => {
+    const focus: DialItem = { key: 'actions', statless: true, label: 'Actions', sublabel: 'deck' }
+    const { container } = renderDV(focus)
+    expect(container.querySelector('.pc-display-note')?.textContent).toContain('Actions deck')
+  })
+
+  test('no focus → graceful empty note', () => {
+    const { container } = renderDV(undefined)
+    expect(container.querySelector('.pc-display-note')?.textContent).toContain('Nothing selected')
+  })
+})

--- a/apps/in-the-union-now/src/components/play/play.css
+++ b/apps/in-the-union-now/src/components/play/play.css
@@ -88,6 +88,35 @@
   grid-area: wheel;
 }
 
+/* The display is the ONE surface that reads "forward": a light SRD "paper"
+   document inset in the dark cockpit (the reused ReferenceEntityDisplay /
+   RollTable are light-themed). Its own scroll — the canvas never scrolls. */
+.pc-display-light {
+  background: #f3ede2;
+  color: #282019;
+  overflow: hidden;
+  padding: 0;
+}
+.pc-display-scroll {
+  height: 100%;
+  overflow-y: auto;
+  padding: 12px;
+}
+.pc-display-note {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 16px;
+  text-align: center;
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 12px;
+  color: #6c6153;
+}
+
 /* Phase-1 placeholder for a surface not yet built. */
 .pc-placeholder {
   display: flex;


### PR DESCRIPTION
## What

Phase 4 of the Play Cockpit ([plan §9.4](https://github.com/SalvageUnion-io/SU-SRD/pull/423)). **Stacked on #427** (base = `worktree-play-cockpit-phase3`). Swaps the display placeholder for the **faithful light SRD reference document**, reusing `suref-react` components verbatim (proposed ADR-017). Read-only — the resolve flow is Phase 5.

## Changes

- **`DisplayView`** — renders per dial focus (focus→display sync):
  - Statful entity → its `ReferenceEntityDisplay` card: mech → resolved chassis; pilot → its class; crawler → note (bay ref later). **Unresolvable slugs fall back to a graceful note, never a crash.**
  - Tables → the reused `RollTable` (Core Mechanic).
  - Actions / SRD → placeholder notes (Phase 5 / later).
- The display is the one **"forward"** surface — a light paper document (`.pc-display-light`) with its **own** scroll; the fixed canvas never scrolls.

## Verification

- `bun run typecheck` clean (all packages); ITUN suite **1145 pass / 0 fail** (new: `DisplayView` renders a real card for a resolvable chassis, note-fallback for an unresolvable slug, a `RollTable` for Tables, notes for Actions / empty)
- `biome lint` clean; pre-push validate/knip/typecheck/test all green

## Not in this phase

Actions deck + resolve flow (Activate/Roll/Push/Apply), heat/push/overload, damage→critical (Phase 5); downtime (Phase 6); dial config + storage (Phase 7); launch chooser (Phase 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNeL9Bxgw2HRKJpSimK1Wm