### PR TITLE
chore(knip): drop 3 redundant config hints

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@latest/schema.json",
-  "ignoreBinaries": ["lefthook", "netlify"],
+  "ignoreBinaries": ["netlify"],
   "ignoreDependencies": ["tailwindcss"],
   "ignoreExportsUsedInFile": true,
   "workspaces": {
@@ -9,7 +9,7 @@
       "project": ["tools/**/*.ts"]
     },
     "packages/salvageunion-reference": {
-      "entry": ["lib/index.ts", "tools/**/*.ts"],
+      "entry": ["tools/**/*.ts"],
       "project": ["lib/**/*.ts", "tools/**/*.ts"]
     },
     "packages/suref-react": {
@@ -17,8 +17,7 @@
     },
     "apps/suref-web": {
       "entry": ["src/pages/**/*.{astro,ts,tsx}"],
-      "project": ["src/**/*.{ts,tsx,astro}"],
-      "ignoreDependencies": ["sharp"]
+      "project": ["src/**/*.{ts,tsx,astro}"]
     },
     "apps/in-the-union-now": {
       "entry": [


### PR DESCRIPTION
## Summary

knip was emitting 3 non-fatal **configuration hints** (exit 0, but stale entries). This removes them so `knip.json` matches reality. **No code changes** — config only.

| Entry removed | Why it was redundant |
|---|---|
| `ignoreBinaries: ["lefthook", …]` → drop `lefthook` | `lefthook` is a declared devDep, invoked in the root `prepare` script via `bunx lefthook install` — knip resolves it, so ignoring the binary did nothing. (`netlify` stays; still flagged without it.) |
| `packages/salvageunion-reference` `entry: ["lib/index.ts", …]` → drop `lib/index.ts` | Already auto-detected as an entry from the package's `main`/`types`/`exports` (all `./lib/index.ts`). |
| `apps/suref-web` `ignoreDependencies: ["sharp"]` → removed | No longer needed; knip flagged it as redundant. Removing it does **not** produce an "unused dependency" error (verified). |

## Verification

- `bun run knip` → **exit 0, zero configuration hints, zero errors** (was: exit 0, 3 hints).
- `bun run format` → no fixes (json already clean).

Follow-up to the ITUN create-wizard refresh Phase 6 capstone (which itself needed no code changes). Unrelated to the wizard code — purely a knip config tidy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8xqFxRRS8nNCx6JsFhCgo