### PR TITLE
feat(itun): Play Cockpit Phase 5 — actions & rules

### DIFF
--- a/apps/in-the-union-now/src/components/play/ActionsDeck.tsx
+++ b/apps/in-the-union-now/src/components/play/ActionsDeck.tsx
@@ -1,0 +1,190 @@
+/**
+ * ActionsDeck — the Actions resolve flow, reachable from the Dial's "actions"
+ * focus and rendered on the ONE light display surface (plan §5.2). It lists the
+ * boarded mech's available actions grouped by source (Chassis Ability / Systems
+ * / Modules) via `SalvageUnionReference.resolveActions`, and opens a resolve
+ * panel for the selected one:
+ *
+ *   Activate  → pay EP + Hot Heat, decrement Uses (auto bookkeeping, ADR-007)
+ *   Roll      → the Core Mechanic d20 + its band (component state, never stored)
+ *   Push      → reroll the d20, +2 Heat, forcing a Heat Check on the mech
+ *   Close     → back to the list
+ *
+ * Only Activate and Push mutate, and both are explicit clicks. The selected
+ * action's reference card reuses suref-react's `ActionCard` verbatim — the deck
+ * layers cockpit controls around it, never replaces it.
+ */
+
+import { useState } from 'react'
+import { ActionCard } from 'suref-react'
+
+import { CORE_ROLL_BANDS, describePushOutcome, performCoreRoll } from '../../lib/rules/coreMechanic'
+import type { CoreRollResult } from '../../lib/rules/coreMechanic'
+import { defaultRoll } from '../../lib/rules/heatCheck'
+import { mechMaxHeat } from '../../lib/rules/derivedStats'
+import { resolveChassisRef } from '../../lib/rules/resolveRefs'
+import type { Mech } from '../../lib/schemas/mech'
+import { useEntityStore } from '../../stores/entityStore'
+import type { PlayStore } from './ActiveItemBand'
+import { activationPatch, buildMechActions, pushPatch } from './playRules'
+import type { PlayAction } from './playRules'
+
+type ActionsDeckProps = {
+  mech: Mech
+  /** Injectable store (defaults to the live entity store). */
+  store?: PlayStore
+}
+
+export function ActionsDeck({ mech, store }: ActionsDeckProps) {
+  const liveStore = useEntityStore()
+  const s: PlayStore = store ?? liveStore
+
+  const groups = buildMechActions(mech)
+  const [selectedKey, setSelectedKey] = useState<string | null>(null)
+  const [roll, setRoll] = useState<CoreRollResult | null>(null)
+  const [activated, setActivated] = useState(false)
+  const [pushLog, setPushLog] = useState<string | null>(null)
+
+  const selected = groups.flatMap((g) => g.items).find((a) => a.key === selectedKey) ?? null
+
+  function open(action: PlayAction) {
+    setSelectedKey(action.key)
+    setRoll(null)
+    setActivated(false)
+    setPushLog(null)
+  }
+
+  function close() {
+    setSelectedKey(null)
+    setRoll(null)
+    setActivated(false)
+    setPushLog(null)
+  }
+
+  function activate(action: PlayAction) {
+    const chassis = resolveChassisRef(mech.chassisRef)
+    const fresh = s.get('mech', mech.id) ?? mech
+    const heatCap = mechMaxHeat(fresh, chassis)
+    const patch = activationPatch({
+      slug: action.slug,
+      economy: action.economy,
+      currentEP: fresh.currentEP ?? 0,
+      currentHeat: fresh.currentHeat ?? 0,
+      heatCap,
+      prevUses: fresh.itemUses,
+    })
+    if (Object.keys(patch).length > 0) {
+      void s.update('mech', mech.id, patch)
+    }
+    setActivated(true)
+  }
+
+  function doRoll() {
+    setRoll(performCoreRoll(defaultRoll))
+    setPushLog(null)
+  }
+
+  function doPush() {
+    const chassis = resolveChassisRef(mech.chassisRef)
+    const fresh = s.get('mech', mech.id) ?? mech
+    const cap = mechMaxHeat(fresh, chassis)
+    const { patch, effect, nextHeat } = pushPatch({
+      heat: Math.min(fresh.currentHeat ?? cap, cap),
+      heatCap: cap,
+      currentSP: fresh.currentSP ?? 0,
+      roll: defaultRoll,
+    })
+    void s.update('mech', mech.id, patch)
+    setRoll(performCoreRoll(defaultRoll))
+    setPushLog(describePushOutcome(nextHeat, effect))
+  }
+
+  if (groups.length === 0) {
+    return (
+      <div className="pc-display-scroll">
+        <div className="pc-deck-empty">This mech has no activatable actions.</div>
+      </div>
+    )
+  }
+
+  if (selected) {
+    const eco = selected.economy
+    const cost: string[] = []
+    if (eco.epCost > 0) cost.push(`${eco.epCost} EP`)
+    if (eco.heat > 0) cost.push(`+${eco.heat} Heat`)
+    if (eco.maxUses > 0) cost.push(`Uses ${eco.maxUses}`)
+
+    return (
+      <div className="pc-display-scroll">
+        <div className="pc-deck-panel">
+          <div className="pc-deck-panel-head">
+            <button type="button" className="pc-deck-back" onClick={close}>
+              ‹ All actions
+            </button>
+            <span className="pc-deck-cost">{cost.length > 0 ? cost.join(' · ') : 'No cost'}</span>
+          </div>
+
+          <ActionCard data={selected.action} />
+
+          <div className="pc-deck-controls">
+            <button
+              type="button"
+              className="pc-deck-btn"
+              onClick={() => activate(selected)}
+              disabled={activated}
+            >
+              {activated ? 'Activated' : 'Activate'}
+            </button>
+            <button type="button" className="pc-deck-btn" onClick={doRoll}>
+              Roll
+            </button>
+            <button
+              type="button"
+              className="pc-deck-btn pc-deck-btn-danger"
+              onClick={doPush}
+              disabled={roll === null}
+              title="Reroll the d20, +2 Heat, forcing a Heat Check"
+            >
+              Push
+            </button>
+          </div>
+
+          {roll && (
+            <div className="pc-deck-roll" data-band={roll.band}>
+              <span className="pc-deck-d20">{roll.roll}</span>
+              <div className="pc-deck-band">
+                <strong>{CORE_ROLL_BANDS[roll.band].label}</strong>
+                <span>{CORE_ROLL_BANDS[roll.band].summary}</span>
+              </div>
+            </div>
+          )}
+          {pushLog && <p className="pc-deck-pushlog">{pushLog}</p>}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="pc-display-scroll">
+      <div className="pc-deck">
+        {groups.map((group) => (
+          <section key={group.source} className="pc-deck-group">
+            <h3 className="pc-deck-group-lab">{group.source}</h3>
+            <ul className="pc-deck-list">
+              {group.items.map((action) => (
+                <li key={action.key}>
+                  <button type="button" className="pc-deck-item" onClick={() => open(action)}>
+                    <span className="pc-deck-item-name">{action.name}</span>
+                    {action.economy.epCost > 0 && (
+                      <span className="pc-deck-item-cost">{action.economy.epCost} EP</span>
+                    )}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/play/ActiveItemBand.tsx
+++ b/apps/in-the-union-now/src/components/play/ActiveItemBand.tsx
@@ -4,12 +4,19 @@
  * grid). Dispatches by mount state (playStateStore): the boarded mech, or the
  * pilot on foot.
  *
- * Phase 2 scope: gauges are bound to the real live stats (currentSP/EP/Heat/HP/
- * AP + derived maxima) and are read-only; only the mount transitions
- * (Board / Dismount / Eject) mutate anything. The heat/damage/action buttons
- * are present but disabled — they get wired to the rules engine in Phase 5,
- * under the ADR-007 automation boundary.
+ * Phase 5 scope: the reactor / damage / egress buttons are LIVE, driven through
+ * the pure rules engine (`playRules.ts` → `lib/rules/*`) and written through the
+ * entity store (`update`), under the ADR-007 automation boundary:
+ *   - Auto-apply (single click): Push, Heat Check, Vent, Shutdown toggle, the
+ *     SP/HP value of a self-declared hit.
+ *   - Player-confirmed (explicit extra step): the Critical Damage / Critical
+ *     Injury *roll* when a hit hits 0, marking the mech Destroyed, and Eject.
+ * `Storage` stays inert until the cargo-hold overlay lands (Phase 7). Derived
+ * maxima come from the same `derivedStats` helpers the gauges read.
  */
+
+import { useState } from 'react'
+import type { ReactNode } from 'react'
 
 import {
   mechMaxCargo,
@@ -19,36 +26,133 @@ import {
   pilotMaxAP,
   pilotMaxHP,
 } from '../../lib/rules/derivedStats'
+import { defaultRoll } from '../../lib/rules/heatCheck'
+import { describePushOutcome } from '../../lib/rules/coreMechanic'
 import { resolveChassisRef } from '../../lib/rules/resolveRefs'
+import type { CriticalDamageEffect, CriticalInjuryEffect } from '../../lib/rules/takeDamage'
 import { totalLotUnits } from '../../lib/schemas/cargoLot'
 import type { Mech } from '../../lib/schemas/mech'
 import type { Pilot } from '../../lib/schemas/pilot'
+import { useEntityStore } from '../../stores/entityStore'
+import type { EntityState } from '../../stores/entityStore'
 import { usePlayStateStore } from '../../stores/playStateStore'
 import { CockpitGauge } from './CockpitGauge'
+import {
+  VENT_PATCH,
+  critDamagePatch,
+  critInjuryPatch,
+  describeCritDamage,
+  describeCritInjury,
+  describeHeatCheck,
+  heatCheckOncePatch,
+  mechDamagePatch,
+  pilotDamagePatch,
+  pushPatch,
+  shutdownTogglePatch,
+} from './playRules'
 
-const PHASE5 = 'Wired to the rules engine in a later phase'
+const PHASE7 = 'Cargo hold overlay lands in a later phase'
+
+/** The store surface the band needs — injectable so tests can assert patches. */
+export type PlayStore = Pick<EntityState, 'get' | 'update'>
 
 type ActiveItemBandProps = {
   mech: Mech
   pilot: Pilot | null
+  /** Injectable store (defaults to the live entity store). */
+  store?: PlayStore
 }
 
-export function ActiveItemBand({ mech, pilot }: ActiveItemBandProps) {
+export function ActiveItemBand({ mech, pilot, store }: ActiveItemBandProps) {
   const mount = usePlayStateStore((s) => s.mount)
   const setMount = usePlayStateStore((s) => s.setMount)
+  // Unconditional hook; the prop wins when a stub is injected (tests / harness).
+  const liveStore = useEntityStore()
+  const s: PlayStore = store ?? liveStore
 
   if (mount === 'pilot' && pilot) {
-    return <PilotBand pilot={pilot} onBoard={() => setMount('mech')} />
+    return <PilotBand pilot={pilot} store={s} onBoard={() => setMount('mech')} />
   }
-  return <MechBand mech={mech} hasPilot={pilot !== null} onDismount={() => setMount('pilot')} />
+  return (
+    <MechBand
+      mech={mech}
+      store={s}
+      hasPilot={pilot !== null}
+      onDismount={() => setMount('pilot')}
+    />
+  )
 }
+
+// ---------------------------------------------------------------------------
+// Resolve overlay — a small dark panel over the band for roll readouts and the
+// player-confirmed steps (never auto-destructive).
+// ---------------------------------------------------------------------------
+
+function ResolveOverlay({
+  title,
+  children,
+  onClose,
+}: {
+  title: string
+  children: ReactNode
+  onClose: () => void
+}) {
+  return (
+    <div className="pc-resolve" role="dialog" aria-label={title}>
+      <div className="pc-resolve-head">
+        <span className="pc-resolve-title">{title}</span>
+        <button type="button" className="pc-railbtn" onClick={onClose}>
+          Close
+        </button>
+      </div>
+      <div className="pc-resolve-body">{children}</div>
+    </div>
+  )
+}
+
+function DamageStepper({ amount, setAmount }: { amount: number; setAmount: (n: number) => void }) {
+  return (
+    <div className="pc-step">
+      <button
+        type="button"
+        className="pc-btn"
+        onClick={() => setAmount(Math.max(1, amount - 1))}
+        aria-label="Decrease damage"
+      >
+        −
+      </button>
+      <span className="pc-step-num">{amount}</span>
+      <button
+        type="button"
+        className="pc-btn"
+        onClick={() => setAmount(amount + 1)}
+        aria-label="Increase damage"
+      >
+        +
+      </button>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Mech band
+// ---------------------------------------------------------------------------
+
+type MechPrompt =
+  | { kind: 'reactor'; log: string }
+  | { kind: 'dmg' }
+  | { kind: 'crit'; effect: CriticalDamageEffect | null; log: string }
+  | { kind: 'eject' }
+  | null
 
 function MechBand({
   mech,
+  store,
   hasPilot,
   onDismount,
 }: {
   mech: Mech
+  store: PlayStore
   hasPilot: boolean
   onDismount: () => void
 }) {
@@ -61,6 +165,78 @@ function MechBand({
   const ep = Math.min(mech.currentEP ?? maxEP, maxEP)
   const heat = Math.min(mech.currentHeat ?? maxHeat, maxHeat)
   const cargo = totalLotUnits(mech.cargoLots)
+
+  const [prompt, setPrompt] = useState<MechPrompt>(null)
+  const [dmg, setDmg] = useState(1)
+
+  const fresh = () => store.get('mech', mech.id) ?? mech
+
+  // Quick Ref p.233 — can't Push if +2 Heat would exceed the Heat Cap.
+  const pushLocked = heat + 2 > maxHeat
+
+  function doPush() {
+    const m = fresh()
+    const cap = mechMaxHeat(m, chassis)
+    const spMax = mechMaxSP(m, chassis)
+    const { patch, effect, nextHeat } = pushPatch({
+      heat: Math.min(m.currentHeat ?? cap, cap),
+      heatCap: cap,
+      currentSP: Math.min(m.currentSP ?? spMax, spMax),
+      roll: defaultRoll,
+    })
+    void store.update('mech', mech.id, patch)
+    setPrompt({ kind: 'reactor', log: describePushOutcome(nextHeat, effect) })
+  }
+
+  function doHeatCheck() {
+    const m = fresh()
+    const cap = mechMaxHeat(m, chassis)
+    const spMax = mechMaxSP(m, chassis)
+    const { patch, effect } = heatCheckOncePatch({
+      heat: Math.min(m.currentHeat ?? cap, cap),
+      currentSP: Math.min(m.currentSP ?? spMax, spMax),
+      roll: defaultRoll,
+    })
+    void store.update('mech', mech.id, patch)
+    setPrompt({ kind: 'reactor', log: describeHeatCheck(effect) })
+  }
+
+  function doVent() {
+    void store.update('mech', mech.id, VENT_PATCH)
+    setPrompt({ kind: 'reactor', log: 'Vented — Heat 0, reactor shut down, Vulnerable.' })
+  }
+
+  function doShutdown() {
+    void store.update('mech', mech.id, shutdownTogglePatch(fresh().shutdown))
+  }
+
+  function applyDamage() {
+    const m = fresh()
+    // Damage operates on the stored SP (authoritative); default to max only
+    // when it was never set. The gauge, not this write, clamps for display.
+    const { patch, effect } = mechDamagePatch({
+      currentSP: m.currentSP ?? mechMaxSP(m, chassis),
+      amount: dmg,
+      vulnerable: m.vulnerable ?? false,
+    })
+    void store.update('mech', mech.id, patch)
+    if (effect.criticalDue) {
+      setPrompt({ kind: 'crit', effect: null, log: `−${effect.effectiveDamage} SP → 0.` })
+    } else {
+      setPrompt({ kind: 'reactor', log: `−${effect.effectiveDamage} SP → ${effect.nextSP}.` })
+    }
+  }
+
+  function rollCritical() {
+    const { patch, effect } = critDamagePatch(defaultRoll)
+    void store.update('mech', mech.id, patch)
+    setPrompt({ kind: 'crit', effect, log: describeCritDamage(effect) })
+  }
+
+  function confirmDestroyed() {
+    void store.update('mech', mech.id, { destroyed: true })
+    setPrompt(null)
+  }
 
   return (
     <div className="pc-band" data-fam="mech">
@@ -81,16 +257,36 @@ function MechBand({
             <CockpitGauge label="EP" value={ep} max={maxEP} tone="mech" />
           </div>
           <div className="pc-btn-grid">
-            <button type="button" className="pc-btn pc-btn-danger" disabled title={PHASE5}>
+            <button
+              type="button"
+              className="pc-btn pc-btn-danger"
+              onClick={doPush}
+              disabled={pushLocked}
+              title={
+                pushLocked
+                  ? `Can't Push at Heat ${heat}/${maxHeat} — +2 would exceed the Heat Cap (p.233).`
+                  : '+2 Heat, then a Heat Check'
+              }
+            >
               Push
             </button>
-            <button type="button" className="pc-btn pc-btn-danger" disabled title={PHASE5}>
+            <button
+              type="button"
+              className="pc-btn pc-btn-danger"
+              onClick={doHeatCheck}
+              title="Roll a Heat Check at current Heat"
+            >
               Heat Chk
             </button>
-            <button type="button" className="pc-btn" disabled title={PHASE5}>
+            <button type="button" className="pc-btn" onClick={doVent} title="Vent Heat to 0">
               Vent
             </button>
-            <button type="button" className="pc-btn" disabled title={PHASE5}>
+            <button
+              type="button"
+              className="pc-btn"
+              onClick={doShutdown}
+              title="Toggle reactor shutdown"
+            >
               Shutdn
             </button>
           </div>
@@ -102,10 +298,18 @@ function MechBand({
             <CockpitGauge label="Cargo" value={cargo} max={maxCargo} tone="mech" />
           </div>
           <div className="pc-btn-grid">
-            <button type="button" className="pc-btn" disabled title={PHASE5}>
+            <button
+              type="button"
+              className="pc-btn"
+              onClick={() => {
+                setDmg(1)
+                setPrompt({ kind: 'dmg' })
+              }}
+              title="Take Structure damage"
+            >
               Take Dmg
             </button>
-            <button type="button" className="pc-btn" disabled title={PHASE5}>
+            <button type="button" className="pc-btn" disabled title={PHASE7}>
               Storage
             </button>
           </div>
@@ -125,7 +329,7 @@ function MechBand({
             <button
               type="button"
               className="pc-btn pc-btn-danger"
-              onClick={onDismount}
+              onClick={() => setPrompt({ kind: 'eject' })}
               disabled={!hasPilot}
               title={hasPilot ? 'Emergency exit' : 'No pilot assigned to this mech'}
             >
@@ -134,15 +338,112 @@ function MechBand({
           </div>
         </div>
       </div>
+
+      {prompt?.kind === 'reactor' && (
+        <ResolveOverlay title="Reactor" onClose={() => setPrompt(null)}>
+          <p className="pc-resolve-log">{prompt.log}</p>
+        </ResolveOverlay>
+      )}
+      {prompt?.kind === 'dmg' && (
+        <ResolveOverlay title="Take Structure Damage" onClose={() => setPrompt(null)}>
+          <DamageStepper amount={dmg} setAmount={setDmg} />
+          <div className="pc-resolve-actions">
+            <button type="button" className="pc-btn pc-btn-danger" onClick={applyDamage}>
+              Apply −{dmg} SP
+            </button>
+          </div>
+        </ResolveOverlay>
+      )}
+      {prompt?.kind === 'crit' && (
+        <ResolveOverlay title="Critical Damage" onClose={() => setPrompt(null)}>
+          <p className="pc-resolve-log">{prompt.log}</p>
+          {prompt.effect === null ? (
+            <div className="pc-resolve-actions">
+              <button type="button" className="pc-btn pc-btn-danger" onClick={rollCritical}>
+                Roll Critical Damage
+              </button>
+            </div>
+          ) : (
+            prompt.effect.destroyed && (
+              <div className="pc-resolve-actions">
+                <button type="button" className="pc-btn pc-btn-danger" onClick={confirmDestroyed}>
+                  Mark Mech Destroyed
+                </button>
+              </div>
+            )
+          )}
+        </ResolveOverlay>
+      )}
+      {prompt?.kind === 'eject' && (
+        <ResolveOverlay title="Eject" onClose={() => setPrompt(null)}>
+          <p className="pc-resolve-log">Eject the pilot from the mech?</p>
+          <div className="pc-resolve-actions">
+            <button
+              type="button"
+              className="pc-btn pc-btn-danger"
+              onClick={() => {
+                setPrompt(null)
+                onDismount()
+              }}
+            >
+              Confirm Eject
+            </button>
+          </div>
+        </ResolveOverlay>
+      )}
     </div>
   )
 }
 
-function PilotBand({ pilot, onBoard }: { pilot: Pilot; onBoard: () => void }) {
+// ---------------------------------------------------------------------------
+// Pilot band
+// ---------------------------------------------------------------------------
+
+type PilotPrompt =
+  | { kind: 'log'; log: string }
+  | { kind: 'dmg' }
+  | { kind: 'crit'; effect: CriticalInjuryEffect | null; log: string }
+  | null
+
+function PilotBand({
+  pilot,
+  store,
+  onBoard,
+}: {
+  pilot: Pilot
+  store: PlayStore
+  onBoard: () => void
+}) {
   const maxHP = Math.max(0, pilotMaxHP(pilot))
   const maxAP = Math.max(0, pilotMaxAP(pilot))
   const hp = Math.min(pilot.currentHP ?? maxHP, maxHP)
   const ap = Math.min(pilot.currentAP ?? maxAP, maxAP)
+
+  const [prompt, setPrompt] = useState<PilotPrompt>(null)
+  const [dmg, setDmg] = useState(1)
+
+  const fresh = () => store.get('pilot', pilot.id) ?? pilot
+
+  function applyDamage() {
+    const p = fresh()
+    const { patch, effect } = pilotDamagePatch({
+      currentHP: p.currentHP ?? Math.max(0, pilotMaxHP(p)),
+      amount: dmg,
+      vulnerable: false,
+    })
+    void store.update('pilot', pilot.id, patch)
+    if (effect.criticalDue) {
+      setPrompt({ kind: 'crit', effect: null, log: `−${effect.effectiveDamage} HP → 0.` })
+    } else {
+      setPrompt({ kind: 'log', log: `−${effect.effectiveDamage} HP → ${effect.nextHP}.` })
+    }
+  }
+
+  function rollInjury() {
+    const { patch, effect } = critInjuryPatch(defaultRoll)
+    void store.update('pilot', pilot.id, patch)
+    setPrompt({ kind: 'crit', effect, log: describeCritInjury(effect) })
+  }
 
   return (
     <div className="pc-band" data-fam="pilot">
@@ -159,10 +460,25 @@ function PilotBand({ pilot, onBoard }: { pilot: Pilot; onBoard: () => void }) {
             <CockpitGauge label="AP" value={ap} max={maxAP} tone="pilot" />
           </div>
           <div className="pc-btn-grid">
-            <button type="button" className="pc-btn" disabled title={PHASE5}>
+            <button
+              type="button"
+              className="pc-btn"
+              onClick={() => {
+                setDmg(1)
+                setPrompt({ kind: 'dmg' })
+              }}
+              title="Take HP damage"
+            >
               Take Dmg
             </button>
-            <button type="button" className="pc-btn pc-btn-danger" disabled title={PHASE5}>
+            <button
+              type="button"
+              className="pc-btn pc-btn-danger"
+              onClick={() =>
+                setPrompt({ kind: 'crit', effect: null, log: 'Roll a Critical Injury?' })
+              }
+              title="Roll on the Critical Injury table"
+            >
               Crit Injury
             </button>
           </div>
@@ -181,6 +497,34 @@ function PilotBand({ pilot, onBoard }: { pilot: Pilot; onBoard: () => void }) {
           </div>
         </div>
       </div>
+
+      {prompt?.kind === 'log' && (
+        <ResolveOverlay title="Vitals" onClose={() => setPrompt(null)}>
+          <p className="pc-resolve-log">{prompt.log}</p>
+        </ResolveOverlay>
+      )}
+      {prompt?.kind === 'dmg' && (
+        <ResolveOverlay title="Take Damage" onClose={() => setPrompt(null)}>
+          <DamageStepper amount={dmg} setAmount={setDmg} />
+          <div className="pc-resolve-actions">
+            <button type="button" className="pc-btn pc-btn-danger" onClick={applyDamage}>
+              Apply −{dmg} HP
+            </button>
+          </div>
+        </ResolveOverlay>
+      )}
+      {prompt?.kind === 'crit' && (
+        <ResolveOverlay title="Critical Injury" onClose={() => setPrompt(null)}>
+          <p className="pc-resolve-log">{prompt.log}</p>
+          {prompt.effect === null && (
+            <div className="pc-resolve-actions">
+              <button type="button" className="pc-btn pc-btn-danger" onClick={rollInjury}>
+                Roll Critical Injury
+              </button>
+            </div>
+          )}
+        </ResolveOverlay>
+      )}
     </div>
   )
 }

--- a/apps/in-the-union-now/src/components/play/DisplayView.tsx
+++ b/apps/in-the-union-now/src/components/play/DisplayView.tsx
@@ -5,9 +5,9 @@
  * ReferenceEntityDisplay / ReferenceEntityActions / RollTable verbatim — the
  * same components the live sheet and reference site show (proposed ADR-017).
  *
- * Phase 4 scope: render real reference content per focus (entity card + its
- * actions, or a roll table, or the SRD/Actions landing). Read-only — activating
- * actions, rolling into state, and the resolve flow are Phase 5.
+ * Phase 5 scope: the Dial's "actions" focus now drives the interactive
+ * ActionsDeck (activate / roll / push) instead of a placeholder note; the rest
+ * of the display stays the read-only reference document from Phase 4.
  */
 
 import { SalvageUnionReference } from 'salvageunion-reference'
@@ -18,6 +18,7 @@ import { resolveChassisRef } from '../../lib/rules/resolveRefs'
 import type { Crawler } from '../../lib/schemas/crawler'
 import type { Mech } from '../../lib/schemas/mech'
 import type { Pilot } from '../../lib/schemas/pilot'
+import { ActionsDeck } from './ActionsDeck'
 import type { DialItem } from './dialItems'
 
 const HIDE_CHOICES = { choices: true } as const
@@ -53,11 +54,13 @@ export function DisplayView({ focus, mech, pilot, crawler }: DisplayViewProps) {
         </div>
       )
     }
-    // Actions deck (Phase 5) and the SRD explorer (later) land here.
-    const label = focus.key === 'actions' ? 'Actions deck' : 'SRD explorer'
+    if (focus.key === 'actions') {
+      return <ActionsDeck mech={mech} />
+    }
+    // The SRD explorer lands in a later phase.
     return (
       <div className="pc-display-note">
-        {label} — {focus.sublabel}. (Interactive content lands in a later phase.)
+        SRD explorer — {focus.sublabel}. (Interactive content lands in a later phase.)
       </div>
     )
   }

--- a/apps/in-the-union-now/src/components/play/PlayCockpit.tsx
+++ b/apps/in-the-union-now/src/components/play/PlayCockpit.tsx
@@ -76,7 +76,7 @@ export function PlayCockpit({ id }: { id: string }) {
       <div className="pc-grid" data-mount={mount}>
         <RailBar title={railTitle} fam={onFoot ? 'pilot' : 'mech'} />
         <div className="pc-primary">
-          <ActiveItemBand mech={mech} pilot={pilot} />
+          <ActiveItemBand mech={mech} pilot={pilot} store={storeState} />
         </div>
         <div className="pc-display pc-display-light">
           <DisplayView focus={focus} mech={mech} pilot={pilot} crawler={crawler} />

--- a/apps/in-the-union-now/src/components/play/__tests__/ActionsDeck.test.tsx
+++ b/apps/in-the-union-now/src/components/play/__tests__/ActionsDeck.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Tests for ActionsDeck — the Phase-5 actions resolve flow on the light display.
+ * Verifies the grouped list renders from the real ORM, selecting an action opens
+ * the resolve panel, and Activate writes the EP/uses patch through the store
+ * (asserted via a stub store).
+ *
+ * Reference content needs the ORM, so preload('all') runs once. A system with a
+ * real EP cost is picked from the loaded set so the Activate write is exercised.
+ */
+
+import { beforeAll, describe, expect, test } from 'bun:test'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { EntityHrefProvider } from 'suref-react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import type { Mech } from '../../../lib/schemas/mech'
+import { itemEconomy, resolveSystem } from '../../sheet/mechItemRules'
+import { ActionsDeck } from '../ActionsDeck'
+import type { PlayStore } from '../ActiveItemBand'
+
+type Call = { type: string; id: string; patch: Record<string, unknown> }
+
+function stubStore(mech: Mech): { store: PlayStore; calls: Call[] } {
+  const calls: Call[] = []
+  const store = {
+    get: (_type: string, id: string) => (id === mech.id ? mech : null),
+    update: async (type: string, id: string, patch: Record<string, unknown>) => {
+      calls.push({ type, id, patch })
+      return mech
+    },
+  } as unknown as PlayStore
+  return { store, calls }
+}
+
+let costedSystemId = ''
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+  // A system whose primary action costs EP → Activate produces a currentEP patch.
+  for (const sys of SalvageUnionReference.Systems.all() as Array<{ id?: string }>) {
+    if (!sys.id) continue
+    const resolved = resolveSystem(sys.id)
+    if (resolved && itemEconomy(resolved).epCost > 0) {
+      costedSystemId = sys.id
+      break
+    }
+  }
+})
+
+function makeMech(): Mech {
+  return {
+    id: 'm1',
+    name: 'Rig',
+    chassisRef: 'unknown-chassis',
+    systems: [costedSystemId],
+    modules: [],
+    currentEP: 6,
+    currentHeat: 0,
+  } as unknown as Mech
+}
+
+function renderDeck(mech: Mech, store: PlayStore) {
+  return render(
+    <EntityHrefProvider value={() => undefined}>
+      <ActionsDeck mech={mech} store={store} />
+    </EntityHrefProvider>
+  )
+}
+
+describe('ActionsDeck', () => {
+  test('lists installed systems under a Systems group', () => {
+    expect(costedSystemId).toBeTruthy()
+    const mech = makeMech()
+    const { store } = stubStore(mech)
+    renderDeck(mech, store)
+    expect(screen.getByText('Systems')).toBeTruthy()
+  })
+
+  test('selecting an action opens the resolve panel with Activate', () => {
+    const mech = makeMech()
+    const { store } = stubStore(mech)
+    renderDeck(mech, store)
+    const item = resolveSystem(costedSystemId)
+    fireEvent.click(screen.getByText(item?.name ?? ''))
+    expect(screen.getByText('Activate')).toBeTruthy()
+    expect(screen.getByText('Roll')).toBeTruthy()
+  })
+
+  test('Activate writes the EP-spend patch through the store', () => {
+    const mech = makeMech()
+    const { store, calls } = stubStore(mech)
+    renderDeck(mech, store)
+    const item = resolveSystem(costedSystemId)
+    const economy = item ? itemEconomy(item) : { epCost: 0, heat: 0, maxUses: 0 }
+    fireEvent.click(screen.getByText(item?.name ?? ''))
+    fireEvent.click(screen.getByText('Activate'))
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.type).toBe('mech')
+    expect(calls[0]?.patch.currentEP).toBe(Math.max(0, 6 - economy.epCost))
+  })
+
+  test('Roll shows a Core Mechanic band readout', () => {
+    const mech = makeMech()
+    const { store } = stubStore(mech)
+    const { container } = renderDeck(mech, store)
+    const item = resolveSystem(costedSystemId)
+    fireEvent.click(screen.getByText(item?.name ?? ''))
+    expect(container.querySelector('.pc-deck-roll')).toBeNull()
+    fireEvent.click(screen.getByText('Roll'))
+    expect(container.querySelector('.pc-deck-roll')).toBeTruthy()
+    expect(container.querySelector('.pc-deck-d20')).toBeTruthy()
+  })
+})

--- a/apps/in-the-union-now/src/components/play/__tests__/ActiveItemBand.rules.test.tsx
+++ b/apps/in-the-union-now/src/components/play/__tests__/ActiveItemBand.rules.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Tests for the Phase-5 rules buttons on ActiveItemBand — a stub store captures
+ * every `update(...)` so we can assert the exact patch each handler writes
+ * (deterministic controls only: Vent, Shutdown toggle, and self-declared SP/HP
+ * damage; the d20-driven Push / Heat Check / Critical rolls are exercised in
+ * playRules.test.ts against an injected roller).
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import type { Mech } from '../../../lib/schemas/mech'
+import type { Pilot } from '../../../lib/schemas/pilot'
+import { usePlayStateStore } from '../../../stores/playStateStore'
+import { ActiveItemBand } from '../ActiveItemBand'
+import type { PlayStore } from '../ActiveItemBand'
+
+const mech = {
+  id: 'm1',
+  name: 'Iron Mongrel',
+  chassisRef: 'unknown-chassis',
+  systems: [],
+  modules: [],
+  cargoLots: [],
+  currentSP: 10,
+} as unknown as Mech
+
+const pilot = {
+  id: 'p1',
+  name: 'Vesh',
+  abilities: [],
+  equipment: [],
+  conditions: [],
+  currentHP: 10,
+} as unknown as Pilot
+
+type Call = { type: string; id: string; patch: Record<string, unknown> }
+
+function stubStore(entities: Array<Mech | Pilot>): { store: PlayStore; calls: Call[] } {
+  const calls: Call[] = []
+  const store = {
+    get: (_type: string, id: string) => entities.find((e) => e.id === id) ?? null,
+    update: async (type: string, id: string, patch: Record<string, unknown>) => {
+      calls.push({ type, id, patch })
+      return entities.find((e) => e.id === id)
+    },
+  } as unknown as PlayStore
+  return { store, calls }
+}
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+describe('ActiveItemBand rules buttons', () => {
+  beforeEach(() => {
+    usePlayStateStore.setState({ mount: 'mech', wheel: 0 })
+  })
+
+  test('Vent writes Heat 0 + shutdown + Vulnerable', () => {
+    const { store, calls } = stubStore([mech])
+    render(<ActiveItemBand mech={mech} pilot={null} store={store} />)
+    fireEvent.click(screen.getByText('Vent'))
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.patch).toEqual({ currentHeat: 0, shutdown: true, vulnerable: true })
+  })
+
+  test('Shutdn toggles the shutdown flag', () => {
+    const { store, calls } = stubStore([mech])
+    render(<ActiveItemBand mech={mech} pilot={null} store={store} />)
+    fireEvent.click(screen.getByText('Shutdn'))
+    expect(calls[0]?.patch).toEqual({ shutdown: true })
+  })
+
+  test('Take Dmg applies the entered SP damage', () => {
+    const { store, calls } = stubStore([mech])
+    render(<ActiveItemBand mech={mech} pilot={null} store={store} />)
+    fireEvent.click(screen.getByText('Take Dmg'))
+    // Bump damage 1 → 3, then apply.
+    fireEvent.click(screen.getByLabelText('Increase damage'))
+    fireEvent.click(screen.getByLabelText('Increase damage'))
+    fireEvent.click(screen.getByText('Apply −3 SP'))
+    expect(calls[0]?.patch).toEqual({ currentSP: 7 })
+  })
+
+  test('pilot Take Dmg applies HP damage after Dismount', () => {
+    const { store, calls } = stubStore([mech, pilot])
+    render(<ActiveItemBand mech={mech} pilot={pilot} store={store} />)
+    fireEvent.click(screen.getByText('Dismount'))
+    fireEvent.click(screen.getByText('Take Dmg'))
+    fireEvent.click(screen.getByText('Apply −1 HP'))
+    expect(calls[0]).toEqual({ type: 'pilot', id: 'p1', patch: { currentHP: 9 } })
+  })
+
+  test('Eject requires an explicit confirm (ADR-007)', () => {
+    const { store } = stubStore([mech, pilot])
+    render(<ActiveItemBand mech={mech} pilot={pilot} store={store} />)
+    fireEvent.click(screen.getByText('Eject'))
+    // Still boarded until confirmed.
+    expect(usePlayStateStore.getState().mount).toBe('mech')
+    fireEvent.click(screen.getByText('Confirm Eject'))
+    expect(usePlayStateStore.getState().mount).toBe('pilot')
+  })
+})

--- a/apps/in-the-union-now/src/components/play/__tests__/DisplayView.test.tsx
+++ b/apps/in-the-union-now/src/components/play/__tests__/DisplayView.test.tsx
@@ -74,10 +74,13 @@ describe('DisplayView', () => {
     expect(container.querySelector('.pc-display-note')).toBeNull()
   })
 
-  test('Actions focus → a placeholder note (Phase 5)', () => {
+  test('Actions focus → the interactive ActionsDeck (Phase 5)', () => {
     const focus: DialItem = { key: 'actions', statless: true, label: 'Actions', sublabel: 'deck' }
     const { container } = renderDV(focus)
-    expect(container.querySelector('.pc-display-note')?.textContent).toContain('Actions deck')
+    // The deck renders (list or empty state), never the generic placeholder note.
+    expect(container.querySelector('.pc-display-scroll')).toBeTruthy()
+    expect(container.querySelector('.pc-deck, .pc-deck-empty')).toBeTruthy()
+    expect(container.querySelector('.pc-display-note')).toBeNull()
   })
 
   test('no focus → graceful empty note', () => {

--- a/apps/in-the-union-now/src/components/play/__tests__/playRules.test.ts
+++ b/apps/in-the-union-now/src/components/play/__tests__/playRules.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for playRules — the cockpit's pure patch builders. Each function is
+ * driven with an injected deterministic `Roll` and asserted on the exact
+ * `Partial<Mech>` / `Partial<Pilot>` it produces, so the Phase-5 button/action
+ * handlers can't drift from the rules engine (ADR-006/ADR-007).
+ *
+ * buildMechActions touches the reference ORM, so preload('all') runs once.
+ */
+
+import { beforeAll, describe, expect, test } from 'bun:test'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import type { Roll } from '../../../lib/rules/heatCheck'
+import type { Mech } from '../../../lib/schemas/mech'
+import {
+  VENT_PATCH,
+  activationPatch,
+  buildMechActions,
+  critDamagePatch,
+  critInjuryPatch,
+  heatCheckOncePatch,
+  mechDamagePatch,
+  pilotDamagePatch,
+  pushPatch,
+  shutdownTogglePatch,
+} from '../playRules'
+
+/** A deterministic roller that returns the queued values, then 20. */
+function seqRoll(values: number[]): Roll {
+  let i = 0
+  return () => values[i++] ?? 20
+}
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+describe('reactor patches', () => {
+  test('pushPatch: passed Heat Check adds +2 Heat, no shutdown', () => {
+    // Heat Check d20 = 20 → always a success (no overload).
+    const { patch, nextHeat } = pushPatch({
+      heat: 3,
+      heatCap: 10,
+      currentSP: 8,
+      roll: seqRoll([20]),
+    })
+    expect(nextHeat).toBe(5)
+    expect(patch.currentHeat).toBe(5)
+    expect(patch.shutdown).toBeUndefined()
+  })
+
+  test('pushPatch: overheat overload applies shutdown + Vulnerable + SP damage', () => {
+    // Push to Heat 20 (cap), Heat Check d20 = 1 (overload), overload roll = 15 (overheat).
+    const { patch, nextHeat } = pushPatch({
+      heat: 18,
+      heatCap: 20,
+      currentSP: 10,
+      roll: seqRoll([1, 15]),
+    })
+    expect(nextHeat).toBe(20)
+    expect(patch.currentHeat).toBe(20)
+    expect(patch.shutdown).toBe(true)
+    expect(patch.vulnerable).toBe(true)
+    expect(patch.currentSP).toBe(0) // 10 − 20, clamped
+  })
+
+  test('heatCheckOncePatch: no +2, persists current Heat', () => {
+    const { patch } = heatCheckOncePatch({ heat: 6, currentSP: 5, roll: seqRoll([20]) })
+    expect(patch.currentHeat).toBe(6)
+    expect(patch.shutdown).toBeUndefined()
+  })
+
+  test('VENT_PATCH dumps Heat to 0 and shuts down', () => {
+    expect(VENT_PATCH).toEqual({ currentHeat: 0, shutdown: true, vulnerable: true })
+  })
+
+  test('shutdownTogglePatch flips the flag', () => {
+    expect(shutdownTogglePatch(false)).toEqual({ shutdown: true })
+    expect(shutdownTogglePatch(true)).toEqual({ shutdown: false })
+    expect(shutdownTogglePatch(undefined)).toEqual({ shutdown: true })
+  })
+})
+
+describe('damage patches', () => {
+  test('mechDamagePatch: SP reduced, no critical above 0', () => {
+    const { patch, effect } = mechDamagePatch({ currentSP: 10, amount: 3, vulnerable: false })
+    expect(patch.currentSP).toBe(7)
+    expect(effect.criticalDue).toBe(false)
+  })
+
+  test('mechDamagePatch: reaching 0 SP flags criticalDue', () => {
+    const { patch, effect } = mechDamagePatch({ currentSP: 2, amount: 5, vulnerable: false })
+    expect(patch.currentSP).toBe(0)
+    expect(effect.criticalDue).toBe(true)
+  })
+
+  test('critDamagePatch: miraculous survival auto-sets 1 SP, never Destroyed', () => {
+    const { patch, effect } = critDamagePatch(seqRoll([20]))
+    expect(patch.currentSP).toBe(1)
+    expect(effect.destroyed).toBe(false)
+    expect(patch.destroyed).toBeUndefined()
+  })
+
+  test('critDamagePatch: catastrophic flags destroyed but never auto-writes it', () => {
+    const { patch, effect } = critDamagePatch(seqRoll([1]))
+    expect(effect.destroyed).toBe(true)
+    expect(patch.destroyed).toBeUndefined() // player-confirmed (ADR-007)
+    expect(patch.currentSP).toBeUndefined()
+  })
+
+  test('pilotDamagePatch: HP reduced, 0 HP flags criticalDue', () => {
+    expect(pilotDamagePatch({ currentHP: 5, amount: 2, vulnerable: false }).patch.currentHP).toBe(3)
+    const zero = pilotDamagePatch({ currentHP: 3, amount: 5, vulnerable: false })
+    expect(zero.patch.currentHP).toBe(0)
+    expect(zero.effect.criticalDue).toBe(true)
+  })
+
+  test('critInjuryPatch: miraculous auto-sets 1 HP; fatal writes nothing', () => {
+    expect(critInjuryPatch(seqRoll([20])).patch.currentHP).toBe(1)
+    const fatal = critInjuryPatch(seqRoll([1]))
+    expect(fatal.effect.fatal).toBe(true)
+    expect(fatal.patch.currentHP).toBeUndefined()
+  })
+})
+
+describe('activationPatch', () => {
+  test('spends EP + Hot Heat and ticks Uses down', () => {
+    const patch = activationPatch({
+      slug: 'flak-cannon',
+      economy: { epCost: 2, heat: 1, maxUses: 3 },
+      currentEP: 5,
+      currentHeat: 4,
+      heatCap: 10,
+      prevUses: undefined,
+    })
+    expect(patch.currentEP).toBe(3)
+    expect(patch.currentHeat).toBe(5)
+    expect(patch.itemUses).toEqual({ 'flak-cannon': 2 })
+  })
+
+  test('clamps Heat to the cap and EP at 0', () => {
+    const patch = activationPatch({
+      slug: 'x',
+      economy: { epCost: 9, heat: 5, maxUses: 0 },
+      currentEP: 2,
+      currentHeat: 8,
+      heatCap: 10,
+      prevUses: undefined,
+    })
+    expect(patch.currentEP).toBe(0)
+    expect(patch.currentHeat).toBe(10)
+    expect(patch.itemUses).toBeUndefined()
+  })
+})
+
+describe('buildMechActions', () => {
+  test('groups a chassis with abilities under "Chassis Ability"', () => {
+    // Find a chassis whose resolveActions returns at least one action.
+    const chassis = SalvageUnionReference.Chassis.all().find((c) => {
+      const acts = SalvageUnionReference.resolveActions(c)
+      return acts !== undefined && acts.length > 0
+    }) as { id?: string } | undefined
+    expect(chassis?.id).toBeTruthy()
+
+    const mech = {
+      id: 'm1',
+      name: 'Rig',
+      chassisRef: chassis?.id ?? '',
+      systems: [],
+      modules: [],
+    } as unknown as Mech
+    const groups = buildMechActions(mech)
+    expect(groups.some((g) => g.source === 'Chassis Ability')).toBe(true)
+  })
+
+  test('empty for an unresolvable chassis with no items', () => {
+    const mech = {
+      id: 'm2',
+      name: 'Ghost',
+      chassisRef: 'not-a-real-chassis',
+      systems: [],
+      modules: [],
+    } as unknown as Mech
+    expect(buildMechActions(mech)).toEqual([])
+  })
+})

--- a/apps/in-the-union-now/src/components/play/play.css
+++ b/apps/in-the-union-now/src/components/play/play.css
@@ -271,6 +271,229 @@
   color: #e0917f;
 }
 
+/* ---- Resolve overlay: roll readouts + player-confirmed steps (Phase 5) ---- */
+.pc-band {
+  position: relative;
+}
+.pc-resolve {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 12px 10px;
+  background: color-mix(in oklab, var(--pc-ground) 92%, #000);
+  border: 1.5px solid var(--pc-line-hard);
+  border-radius: 5px;
+  z-index: 2;
+}
+.pc-resolve-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.pc-resolve-title {
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 11px;
+  color: var(--pc-muted);
+}
+.pc-resolve-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1;
+  min-height: 0;
+  justify-content: center;
+}
+.pc-resolve-log {
+  margin: 0;
+  font-family: 'Barlow', sans-serif;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--pc-text);
+  text-align: center;
+}
+.pc-resolve-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+.pc-resolve-actions .pc-btn {
+  width: auto;
+  min-width: 140px;
+  padding: 8px 14px;
+}
+.pc-step {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+.pc-step .pc-btn {
+  width: 34px;
+  padding: 6px 0;
+}
+.pc-step-num {
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  font-size: 24px;
+  min-width: 44px;
+  text-align: center;
+  color: var(--pc-text);
+}
+
+/* ---- Actions deck (light display surface, Phase 5) ---- */
+.pc-deck {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.pc-deck-empty {
+  padding: 12px;
+  font-family: 'Barlow', sans-serif;
+  font-size: 13px;
+  color: #6c6153;
+  text-align: center;
+}
+.pc-deck-group-lab {
+  margin: 0 0 6px;
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 11px;
+  color: #6c6153;
+}
+.pc-deck-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.pc-deck-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 12px;
+  border: 1.5px solid rgba(40, 32, 25, 0.18);
+  border-radius: 4px;
+  background: #fff;
+  color: #282019;
+  cursor: pointer;
+  text-align: left;
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  font-size: 14px;
+}
+.pc-deck-item:hover {
+  border-color: rgba(40, 32, 25, 0.45);
+}
+.pc-deck-item-cost {
+  font-size: 12px;
+  color: #6c6153;
+  white-space: nowrap;
+}
+.pc-deck-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.pc-deck-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.pc-deck-back {
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 12px;
+  color: #6c6153;
+}
+.pc-deck-cost {
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  font-size: 12px;
+  color: #6c6153;
+}
+.pc-deck-controls {
+  display: flex;
+  gap: 8px;
+}
+.pc-deck-btn {
+  flex: 1;
+  padding: 9px 12px;
+  border: 1.5px solid rgba(40, 32, 25, 0.3);
+  border-radius: 4px;
+  background: #282019;
+  color: #f3ede2;
+  cursor: pointer;
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 13px;
+}
+.pc-deck-btn:hover:not(:disabled) {
+  background: #3a2f24;
+}
+.pc-deck-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.pc-deck-btn-danger {
+  background: var(--pc-crawler-deep);
+}
+.pc-deck-roll {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1.5px solid rgba(40, 32, 25, 0.18);
+  border-radius: 4px;
+  background: #fff;
+}
+.pc-deck-d20 {
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  font-size: 34px;
+  line-height: 1;
+  min-width: 48px;
+  text-align: center;
+  color: #282019;
+}
+.pc-deck-band {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-family: 'Barlow', sans-serif;
+  font-size: 13px;
+  color: #282019;
+}
+.pc-deck-pushlog {
+  margin: 0;
+  font-family: 'Barlow', sans-serif;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #6c6153;
+}
+
 /* ---- CockpitGauge: bespoke dark segmented instrument bar ---- */
 .pc-gauge {
   display: flex;

--- a/apps/in-the-union-now/src/components/play/playRules.ts
+++ b/apps/in-the-union-now/src/components/play/playRules.ts
@@ -1,0 +1,309 @@
+/**
+ * playRules — the cockpit's thin, PURE driver over the existing rules engine
+ * (plan §5). Nothing here touches React or the store: every function takes the
+ * live numbers (+ an injectable `Roll`) and returns the `Partial<Mech>` /
+ * `Partial<Pilot>` write-through patch the caller hands to
+ * `storeState.update(...)`, mirroring `MechSheet.activateItem` / `SheetMech`'s
+ * `pushMech`. This keeps the Phase-5 button/action handlers trivially testable
+ * (assert the patch) and keeps the ADR-006 pure-math boundary intact — the math
+ * lives in `lib/rules/*`, this only assembles patches and readouts.
+ *
+ * ADR-007 boundary: non-destructive bookkeeping (Heat/EP/uses/SP/HP deltas,
+ * Vent, Shutdown toggle) is assembled into an auto-apply patch; the destructive
+ * Critical Damage / Critical Injury *rolls* are separate functions the caller
+ * only invokes behind an explicit player confirm, and their destructive
+ * consequences (mech Destroyed, accepted injury, pilot death) are NEVER folded
+ * into the returned patch — they stay explicit player calls at the UI layer.
+ */
+
+import { SalvageUnionReference } from 'salvageunion-reference'
+import type { SURefMetaAction, SURefMetaEntity } from 'salvageunion-reference'
+
+import { resolveChassisRef } from '../../lib/rules/resolveRefs'
+import { clampHeat, heatCheckPatch, performHeatCheck, performPush } from '../../lib/rules/heatCheck'
+import type { HeatCheckEffect, Roll } from '../../lib/rules/heatCheck'
+import {
+  applyMechDamage,
+  applyPilotDamage,
+  performCriticalDamage,
+  performCriticalInjury,
+} from '../../lib/rules/takeDamage'
+import type {
+  CriticalDamageEffect,
+  CriticalInjuryEffect,
+  MechDamageEffect,
+  PilotDamageEffect,
+} from '../../lib/rules/takeDamage'
+import type { Mech } from '../../lib/schemas/mech'
+import type { Pilot } from '../../lib/schemas/pilot'
+import { itemEconomy, resolveModule, resolveSystem } from '../sheet/mechItemRules'
+import type { MechItem, MechItemEconomy } from '../sheet/mechItemRules'
+
+// ---------------------------------------------------------------------------
+// Reactor — Push / Heat Check / Vent / Shutdown (plan §5.1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Push: +2 Heat then an immediate Heat Check, assembled into one write-through
+ * patch via the shared `heatCheckPatch` (the exact path `SheetMech.pushMech`
+ * uses). Deterministic bookkeeping auto-applies; a destroyed System/Module
+ * (`requiresPlayerChoice` bands) is left for the player to mark on the sheet.
+ */
+export function pushPatch(args: { heat: number; heatCap: number; currentSP: number; roll: Roll }): {
+  patch: Partial<Mech>
+  effect: HeatCheckEffect
+  nextHeat: number
+} {
+  const { nextHeat, effect } = performPush(args)
+  return { patch: heatCheckPatch(effect, nextHeat), effect, nextHeat }
+}
+
+/** A standalone Heat Check at current Heat (no +2). */
+export function heatCheckOncePatch(args: { heat: number; currentSP: number; roll: Roll }): {
+  patch: Partial<Mech>
+  effect: HeatCheckEffect
+} {
+  const effect = performHeatCheck(args)
+  return { patch: heatCheckPatch(effect, args.heat), effect }
+}
+
+/** Emergency Vent: dump Heat to 0, mech shuts down and is Vulnerable. */
+export const VENT_PATCH: Partial<Mech> = {
+  currentHeat: 0,
+  shutdown: true,
+  vulnerable: true,
+}
+
+/** Toggle the reactor Shutdown flag (reversible bookkeeping). */
+export function shutdownTogglePatch(shutdown: boolean | undefined): Partial<Mech> {
+  return { shutdown: !(shutdown ?? false) }
+}
+
+/** One-line readout for a resolved Heat Check (Push wording lives in coreMechanic). */
+export function describeHeatCheck(effect: HeatCheckEffect): string {
+  const r = effect.result
+  const head = `Heat Check ${r.heatCheckRoll} vs Heat ${r.heatAtCheck}`
+  if (!r.overloaded) return `${head} — passed (no overload).`
+  const outcome =
+    r.outcome === 'meltdown'
+      ? 'Catastrophic Meltdown — mech DESTROYED.'
+      : r.outcome === 'system-destroyed'
+        ? 'A System is destroyed — mark one on the sheet.'
+        : r.outcome === 'module-destroyed'
+          ? 'A Module is destroyed — mark one on the sheet.'
+          : r.outcome === 'overheat'
+            ? 'Reactor Overheat — shutdown, Vulnerable, SP damage applied.'
+            : 'Safe — no effect.'
+  return `${head} — OVERLOAD. Reactor Overload ${r.overloadRoll}: ${outcome}`
+}
+
+// ---------------------------------------------------------------------------
+// Damage → Critical (plan §5.3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Self-declared SP damage to the boarded mech (SP-listed, 1:1). Auto-applies
+ * the clamped SP; `criticalDue` tells the caller to offer the (player-confirmed)
+ * Critical Damage roll when this hit left the mech at 0 SP.
+ */
+export function mechDamagePatch(args: { currentSP: number; amount: number; vulnerable: boolean }): {
+  patch: Partial<Mech>
+  effect: MechDamageEffect
+} {
+  const effect = applyMechDamage({ ...args, kind: 'sp' })
+  return { patch: { currentSP: effect.nextSP }, effect }
+}
+
+/**
+ * The Critical Damage roll (player-confirmed step). Only the non-destructive
+ * `nextSP` override (Miraculous Survival → 1 SP) crosses into the patch;
+ * `destroyed` / `chassisDamaged` / `requiresPlayerChoice` stay explicit player
+ * calls (ADR-007) and are surfaced as advisory text by the caller.
+ */
+export function critDamagePatch(roll: Roll): {
+  patch: Partial<Mech>
+  effect: CriticalDamageEffect
+} {
+  const effect = performCriticalDamage({ roll })
+  const patch: Partial<Mech> = {}
+  if (effect.nextSP !== null) patch.currentSP = effect.nextSP
+  return { patch, effect }
+}
+
+/** Self-declared HP damage to the on-foot pilot (HP-listed, 1:1). */
+export function pilotDamagePatch(args: {
+  currentHP: number
+  amount: number
+  vulnerable: boolean
+}): { patch: Partial<Pilot>; effect: PilotDamageEffect } {
+  const effect = applyPilotDamage({ ...args, kind: 'hp' })
+  return { patch: { currentHP: effect.nextHP }, effect }
+}
+
+/**
+ * The Critical Injury roll (player-confirmed step). Only the non-destructive
+ * `nextHP` override crosses into the patch; the max-HP-reducing injury,
+ * Unconscious condition, and death stay explicit player calls (ADR-007).
+ */
+export function critInjuryPatch(roll: Roll): {
+  patch: Partial<Pilot>
+  effect: CriticalInjuryEffect
+} {
+  const effect = performCriticalInjury({ roll })
+  const patch: Partial<Pilot> = {}
+  if (effect.nextHP !== null) patch.currentHP = effect.nextHP
+  return { patch, effect }
+}
+
+export function describeCritDamage(effect: CriticalDamageEffect): string {
+  const map: Record<CriticalDamageEffect['result']['outcome'], string> = {
+    catastrophic: 'Catastrophic — mech destroyed (confirm below).',
+    'system-destruction': 'System Destruction — chassis Damaged; mark a System on the sheet.',
+    'module-destruction': 'Module Destruction — chassis Damaged; mark a Module on the sheet.',
+    'core-damage': 'Core Damage — chassis Damaged & inoperable; pilot to 0 HP unless they escape.',
+    'miraculous-survival': 'Miraculous Survival — mech Intact at 1 SP.',
+  }
+  return `Critical Damage ${effect.result.roll}: ${map[effect.result.outcome]}`
+}
+
+export function describeCritInjury(effect: CriticalInjuryEffect): string {
+  const map: Record<CriticalInjuryEffect['result']['outcome'], string> = {
+    fatal: 'Fatal Injury — the pilot dies (confirm on the sheet).',
+    'major-injury': 'Major Injury — −2 max HP until healed + Unconscious.',
+    'minor-injury': 'Minor Injury — −1 max HP until healed + Unconscious.',
+    unconscious: 'Unconscious — stable at 0 HP until they regain ≥1 HP.',
+    'miraculous-survival': 'Miraculous Survival — 1 HP, conscious.',
+  }
+  return `Critical Injury ${effect.result.roll}: ${map[effect.result.outcome]}`
+}
+
+// ---------------------------------------------------------------------------
+// Action activation (plan §5.2)
+// ---------------------------------------------------------------------------
+
+export type PlayActionKind = 'chassis' | 'system' | 'module'
+export type PlayActionSourceLabel = 'Chassis Ability' | 'Systems' | 'Modules'
+
+export type PlayAction = {
+  /** Stable list key. */
+  key: string
+  /** Display name of the ability / item. */
+  name: string
+  kind: PlayActionKind
+  /** The installed item's slug (systems/modules); the chassis ref for chassis. */
+  slug: string
+  /** What one activation costs / produces. */
+  economy: MechItemEconomy
+  /** The primary action, for the reference card + damage/roll detection. */
+  action: SURefMetaAction
+}
+
+export type PlayActionGroup = { source: PlayActionSourceLabel; items: PlayAction[] }
+
+function traitAmount(trait: { amount?: unknown }): number {
+  return typeof trait.amount === 'number' ? trait.amount : 0
+}
+
+/** Per-action economy for a chassis ability (EP from cost, Heat from Hot). */
+function chassisActionEconomy(action: SURefMetaAction): MechItemEconomy {
+  const epCost = typeof action.activationCost === 'number' ? action.activationCost : 0
+  const heat = (action.traits ?? [])
+    .filter((t) => t.type === 'hot')
+    .reduce((sum, t) => sum + Math.max(1, traitAmount(t)), 0)
+  const maxUses = (action.traits ?? [])
+    .filter((t) => t.type === 'uses')
+    .reduce((m, t) => Math.max(m, traitAmount(t)), 0)
+  return { epCost, heat, maxUses }
+}
+
+function itemActions(item: MechItem): SURefMetaAction[] {
+  return SalvageUnionReference.resolveActions(item as unknown as SURefMetaEntity) ?? []
+}
+
+/** The action that drives an item's Use button (first numeric-cost, else first). */
+function primaryAction(actions: SURefMetaAction[]): SURefMetaAction | undefined {
+  return actions.find((a) => typeof a.activationCost === 'number') ?? actions[0]
+}
+
+/**
+ * The boarded mech's available actions, grouped by source (Chassis Ability /
+ * Systems / Modules) via `SalvageUnionReference.resolveActions`. Systems/modules
+ * contribute one entry each (their primary action), matching the sheet's
+ * per-item Use model; the chassis contributes each of its ability actions.
+ */
+export function buildMechActions(mech: Mech): PlayActionGroup[] {
+  const groups: PlayActionGroup[] = []
+
+  const chassis = resolveChassisRef(mech.chassisRef)
+  if (chassis) {
+    const acts = SalvageUnionReference.resolveActions(chassis) ?? []
+    if (acts.length > 0) {
+      groups.push({
+        source: 'Chassis Ability',
+        items: acts.map((action, i) => ({
+          key: `chassis:${action.id ?? i}`,
+          name: action.name,
+          kind: 'chassis',
+          slug: mech.chassisRef,
+          economy: chassisActionEconomy(action),
+          action,
+        })),
+      })
+    }
+  }
+
+  const build = (slugs: string[], kind: 'system' | 'module'): PlayAction[] => {
+    const out: PlayAction[] = []
+    for (const slug of slugs) {
+      const item = kind === 'system' ? resolveSystem(slug) : resolveModule(slug)
+      if (!item) continue
+      const action = primaryAction(itemActions(item))
+      if (!action) continue
+      out.push({
+        key: `${kind}:${slug}`,
+        name: item.name,
+        kind,
+        slug,
+        economy: itemEconomy(item),
+        action,
+      })
+    }
+    return out
+  }
+
+  const systems = build(mech.systems ?? [], 'system')
+  if (systems.length > 0) groups.push({ source: 'Systems', items: systems })
+  const modules = build(mech.modules ?? [], 'module')
+  if (modules.length > 0) groups.push({ source: 'Modules', items: modules })
+
+  return groups
+}
+
+/**
+ * The write-through patch for one activation — spend EP, add Hot Heat (clamped
+ * to cap), tick the Uses counter down. Byte-for-byte the shape
+ * `MechSheet.activateItem` writes, so the cockpit and the sheet can't drift.
+ */
+export function activationPatch(args: {
+  slug: string
+  economy: MechItemEconomy
+  currentEP: number
+  currentHeat: number
+  heatCap: number
+  prevUses: Record<string, number> | undefined
+}): Partial<Mech> {
+  const { slug, economy, currentEP, currentHeat, heatCap, prevUses } = args
+  const patch: Partial<Mech> = {}
+  if (economy.epCost > 0) {
+    patch.currentEP = Math.max(0, currentEP - economy.epCost)
+  }
+  if (economy.heat > 0) {
+    patch.currentHeat = clampHeat(currentHeat + economy.heat, heatCap)
+  }
+  if (economy.maxUses > 0) {
+    const prev = prevUses ?? {}
+    const remaining = Math.min(prev[slug] ?? economy.maxUses, economy.maxUses)
+    patch.itemUses = { ...prev, [slug]: Math.max(0, remaining - 1) }
+  }
+  return patch
+}


### PR DESCRIPTION
## What
Phase 5 of the Play Cockpit ([plan §9.5, §5](https://github.com/SalvageUnion-io/SU-SRD/pull/423)). **Stacked on #428.** Wires the cockpit to the pure rules engine — the first state-mutating phase.

- **`playRules.ts`** — pure patch assembly reusing `performPush`+`heatCheckPatch` (SheetMech's exact path), `performHeatCheck`, `applyMechDamage`/`applyPilotDamage`, `performCriticalDamage`/`performCriticalInjury`, `itemEconomy`, `resolveActions`. No math reinvented.
- **Active Item buttons wired** (write-through `store.update`, ADR-007): mech Push / Heat Check / Vent / Shutdown / Take Dmg auto-apply; **player-confirmed** Critical Damage/Injury, Mark-Destroyed, Eject.
- **`ActionsDeck`** on the light display: actions grouped Chassis/Systems/Modules, Activate → Roll (Core Mechanic) → Push, reusing suref-react `ActionCard`.

## Verify
typecheck (all pkgs) ✓ · full ITUN suite green · lint ✓ · pre-push guards ✓

## Review flags (from the implementing agent)
- Push/Heat-Check write `heatCheckPatch` directly (matching shipped `SheetMech`), so a Meltdown (overload roll = 1) auto-sets `mech.destroyed`. Plan §4.3 lists Meltdown as player-confirm — a stricter gate is a possible follow-up.
- Vent uses `currentHeat 0 + shutdown + vulnerable` (per the phase brief); plan §5.1 prose says Heat 0 + vulnerable only.
- Storage button left disabled (wired in Phase 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNeL9Bxgw2HRKJpSimK1Wm