### PR TITLE
feat(itun): Play Cockpit Phase 6 — downtime

### DIFF
--- a/apps/in-the-union-now/src/components/play/ActiveItemBand.tsx
+++ b/apps/in-the-union-now/src/components/play/ActiveItemBand.tsx
@@ -19,6 +19,7 @@ import { useState } from 'react'
 import type { ReactNode } from 'react'
 
 import {
+  crawlerMaxSP,
   mechMaxCargo,
   mechMaxEP,
   mechMaxHeat,
@@ -30,6 +31,7 @@ import { defaultRoll } from '../../lib/rules/heatCheck'
 import { describePushOutcome } from '../../lib/rules/coreMechanic'
 import { resolveChassisRef } from '../../lib/rules/resolveRefs'
 import type { CriticalDamageEffect, CriticalInjuryEffect } from '../../lib/rules/takeDamage'
+import type { Crawler } from '../../lib/schemas/crawler'
 import { totalLotUnits } from '../../lib/schemas/cargoLot'
 import type { Mech } from '../../lib/schemas/mech'
 import type { Pilot } from '../../lib/schemas/pilot'
@@ -59,17 +61,23 @@ export type PlayStore = Pick<EntityState, 'get' | 'update'>
 type ActiveItemBandProps = {
   mech: Mech
   pilot: Pilot | null
+  /** The linked crawler — the Active Item while in Downtime (Phase 6). */
+  crawler?: Crawler | null
   /** Injectable store (defaults to the live entity store). */
   store?: PlayStore
 }
 
-export function ActiveItemBand({ mech, pilot, store }: ActiveItemBandProps) {
+export function ActiveItemBand({ mech, pilot, crawler, store }: ActiveItemBandProps) {
   const mount = usePlayStateStore((s) => s.mount)
   const setMount = usePlayStateStore((s) => s.setMount)
+  const leaveDowntime = usePlayStateStore((s) => s.leaveDowntime)
   // Unconditional hook; the prop wins when a stub is injected (tests / harness).
   const liveStore = useEntityStore()
   const s: PlayStore = store ?? liveStore
 
+  if (mount === 'downtime' && crawler) {
+    return <CrawlerBand crawler={crawler} onLeave={leaveDowntime} />
+  }
   if (mount === 'pilot' && pilot) {
     return <PilotBand pilot={pilot} store={s} onBoard={() => setMount('mech')} />
   }
@@ -80,6 +88,45 @@ export function ActiveItemBand({ mech, pilot, store }: ActiveItemBandProps) {
       hasPilot={pilot !== null}
       onDismount={() => setMount('pilot')}
     />
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Crawler band (Downtime — read-only: the crawler's Structure + Leave control)
+// ---------------------------------------------------------------------------
+
+function CrawlerBand({ crawler, onLeave }: { crawler: Crawler; onLeave: () => void }) {
+  const maxSP = crawlerMaxSP(crawler)
+  const sp = Math.min(crawler.currentSP ?? maxSP, maxSP)
+  return (
+    <div className="pc-band" data-fam="crawler">
+      <div className="pc-band-id">
+        <span className="pc-stamp" style={{ background: 'var(--pc-crawler-deep)' }}>
+          Downtime · {crawler.name}
+        </span>
+      </div>
+      <div className="pc-bays">
+        <div className="pc-bay">
+          <span className="pc-bay-lab">Crawler</span>
+          <div className="pc-bay-gauges">
+            <CockpitGauge label="SP" value={sp} max={maxSP} tone="crawler" />
+          </div>
+        </div>
+        <div className="pc-bay">
+          <span className="pc-bay-lab">Downtime</span>
+          <div className="pc-btn-grid">
+            <button
+              type="button"
+              className="pc-btn pc-btn-wide"
+              onClick={onLeave}
+              title="Return to the previous mount"
+            >
+              ◄ Leave Downtime
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/apps/in-the-union-now/src/components/play/DisplayView.tsx
+++ b/apps/in-the-union-now/src/components/play/DisplayView.tsx
@@ -18,6 +18,7 @@ import { resolveChassisRef } from '../../lib/rules/resolveRefs'
 import type { Crawler } from '../../lib/schemas/crawler'
 import type { Mech } from '../../lib/schemas/mech'
 import type { Pilot } from '../../lib/schemas/pilot'
+import { usePlayStateStore } from '../../stores/playStateStore'
 import { ActionsDeck } from './ActionsDeck'
 import type { DialItem } from './dialItems'
 
@@ -37,6 +38,7 @@ function EntityCard({ data, note }: { data: SURefEntity | null; note: string }) 
 }
 
 export function DisplayView({ focus, mech, pilot, crawler }: DisplayViewProps) {
+  const enterDowntime = usePlayStateStore((s) => s.enterDowntime)
   if (!focus) return <div className="pc-display-note">Nothing selected.</div>
 
   if (focus.statless) {
@@ -88,8 +90,16 @@ export function DisplayView({ focus, mech, pilot, crawler }: DisplayViewProps) {
   }
   if (focus.key.startsWith('crawler:') && crawler) {
     return (
-      <div className="pc-display-note">
-        Crawler · {crawler.name} — bay reference lands in a later phase.
+      <div className="pc-display-scroll">
+        <div className="pc-crawler-focus">
+          <p className="pc-crawler-focus-name">Crawler · {crawler.name}</p>
+          <p className="pc-crawler-focus-note">
+            Back at the Union Crawler — run the post-/pre-session Downtime loop.
+          </p>
+          <button type="button" className="pc-deck-btn" onClick={enterDowntime}>
+            Enter Downtime ▶
+          </button>
+        </div>
       </div>
     )
   }

--- a/apps/in-the-union-now/src/components/play/DowntimeWizard.tsx
+++ b/apps/in-the-union-now/src/components/play/DowntimeWizard.tsx
@@ -1,0 +1,196 @@
+/**
+ * DowntimeWizard — the guided Union Crawler Downtime loop, shown on the ONE
+ * light display surface while the cockpit is in the `'downtime'` mount state
+ * (plan §5.5, §9.6). Crawler-dominant: pink chrome, the crawler is the Active
+ * Item, and this wizard walks the 10-step Post-/Pre-Session procedure.
+ *
+ * The 10 steps are NOT hard-coded — they are driven from the real "Crawler
+ * Downtime" Guide in the reference ORM (`SalvageUnionReference.Guides`, faithful
+ * SRD p.227-228), one step at a time. Each step's descriptive content renders
+ * through the reused `BlockContentRendererView` (the same content renderer the
+ * reference site uses) so it matches the book verbatim. Step *gating* is layered
+ * on top from the pure rules modules (`downtime.ts` bay gates, `crawlerEconomy.ts`
+ * upkeep/trading) as READ-ONLY readouts, and the relevant SRD roll tables
+ * (Crawler Deterioration / Trading Bay) render via the reused `RollTable`.
+ *
+ * Read-mostly (ADR-007 + the phase brief): the wizard shows what each step
+ * *would* do and defers the destructive economy writes (upkeep spend, restore,
+ * crafting) to the live sheet — those `downtime.ts` / `crawlerEconomy.ts` patch
+ * fns are not applied from here. Navigation (prev/next) and the per-step "Mark
+ * Complete" toggle are ephemeral, held in `playStateStore`.
+ */
+
+import { SalvageUnionReference } from 'salvageunion-reference'
+import type { SURefObjectGuideStep, SURefObjectTable } from 'salvageunion-reference'
+import { BlockContentRendererView, RollTable } from 'suref-react'
+
+import { bayGate, UPKEEP_SCRAP } from '../../lib/rules/crawlerEconomy'
+import { mechBayStatus, medBayStatus } from '../../lib/rules/downtime'
+import type { Crawler } from '../../lib/schemas/crawler'
+import { usePlayStateStore } from '../../stores/playStateStore'
+
+/** The guideType that identifies the Union Crawler Downtime procedure. */
+const DOWNTIME_GUIDE_TYPE = 'downtime'
+
+/** Fallback pink when the guide carries no `guideColor` (crawler ontology). */
+const CRAWLER_PINK = '#7e2a5b'
+
+/**
+ * SRD roll tables associated with a Downtime step (keyed by the guide step's
+ * name). The guide content describes the roll but does not link the table
+ * entity, so this presentation glue resolves it for the reused RollTable.
+ */
+const STEP_ROLL_TABLE: Record<string, string> = {
+  'Upkeep & Upgrade': 'Crawler Deterioration',
+  Trade: 'Trading Bay',
+}
+
+type DowntimeWizardProps = {
+  crawler: Crawler | null
+}
+
+/** Read-only gate readout for the steps whose effects the rules modules gate. */
+function StepGate({ step, crawler }: { step: SURefObjectGuideStep; crawler: Crawler }) {
+  if (step.name === 'Restore your Mech & Pilot') {
+    const mechBay = mechBayStatus(crawler)
+    const medBay = medBayStatus(crawler)
+    return (
+      <ul className="pc-dt-gate">
+        <li>
+          Mech Bay:{' '}
+          {mechBay.operational
+            ? 'operational — SP/EP/Heat restore, damaged items repair'
+            : 'blocked — no restore or repair this Downtime'}
+        </li>
+        <li>
+          Med Bay:{' '}
+          {medBay.operational
+            ? `operational — HP heals${medBay.healsMajor ? ', Minor + Major Injuries heal' : medBay.healsMinor ? ', Minor Injuries heal' : ''}`
+            : 'blocked — no HP or injury healing (AP still rests to full)'}
+        </li>
+      </ul>
+    )
+  }
+  if (step.name === 'Upkeep & Upgrade') {
+    return (
+      <ul className="pc-dt-gate">
+        <li>Upkeep is {UPKEEP_SCRAP}× the crawler's Tech Level in Scrap this Downtime.</li>
+        <li>Unpaid Upkeep forces a roll on the Crawler Deterioration table (below).</li>
+      </ul>
+    )
+  }
+  if (step.name === 'Trade') {
+    const trading = bayGate(crawler, 'Trading Bay')
+    return (
+      <ul className="pc-dt-gate">
+        <li>
+          Trading Bay:{' '}
+          {trading.operational
+            ? 'operational — roll availability, then trade Scrap at fixed rates'
+            : trading.present
+              ? 'damaged — Scrap trading and the availability roll are blocked'
+              : 'not installed — no Trading Bay availability this Downtime'}
+        </li>
+      </ul>
+    )
+  }
+  return null
+}
+
+export function DowntimeWizard({ crawler }: DowntimeWizardProps) {
+  const dtStep = usePlayStateStore((s) => s.dtStep)
+  const setDtStep = usePlayStateStore((s) => s.setDtStep)
+  const dtDone = usePlayStateStore((s) => s.dtDone)
+  const toggleDtDone = usePlayStateStore((s) => s.toggleDtDone)
+
+  const guide = SalvageUnionReference.Guides.find((g) => g.guideType === DOWNTIME_GUIDE_TYPE)
+  const steps = guide?.steps ?? []
+  if (steps.length === 0) {
+    return <div className="pc-display-note">Downtime procedure not in the reference set.</div>
+  }
+
+  const idx = Math.min(Math.max(dtStep, 0), steps.length - 1)
+  const step = steps[idx]
+  if (!step) {
+    return <div className="pc-display-note">Downtime procedure not in the reference set.</div>
+  }
+
+  // Phase = the most recent section label at or before the current step (the
+  // guide sets `section` only on the first step of each phase).
+  let phase = 'Downtime'
+  for (let i = 0; i <= idx; i++) {
+    const sec = steps[i]?.section
+    if (sec) phase = sec
+  }
+
+  const done = dtDone[idx] ?? false
+  const headerBg = guide?.guideColor ?? CRAWLER_PINK
+  const tableName = STEP_ROLL_TABLE[step.name]
+  const table = tableName
+    ? (SalvageUnionReference.RollTables.find((t) => t.name === tableName) as
+        | SURefObjectTable
+        | undefined)
+    : undefined
+
+  return (
+    <div className="pc-display-scroll">
+      <div className="pc-dt">
+        <div className="pc-dt-head">
+          <span className="pc-dt-phase" style={{ background: headerBg }}>
+            {phase}
+          </span>
+          <span className="pc-dt-count">
+            Step {idx + 1} / {steps.length}
+          </span>
+        </div>
+
+        <h3 className="pc-dt-step-name" style={{ borderColor: headerBg }}>
+          {step.name}
+        </h3>
+        {step.content && step.content.length > 0 && (
+          <BlockContentRendererView content={step.content} headerBg={headerBg} />
+        )}
+
+        {crawler && <StepGate step={step} crawler={crawler} />}
+
+        {table && (
+          <div className="pc-dt-table">
+            <RollTable table={table} tableName={tableName} compact showCommand />
+          </div>
+        )}
+
+        <p className="pc-dt-note">
+          Guidance only — Downtime economy writes (Upkeep, Restore, Crafting) are applied on the
+          live sheet.
+        </p>
+
+        <div className="pc-dt-controls">
+          <button
+            type="button"
+            className="pc-deck-btn"
+            onClick={() => setDtStep(idx - 1)}
+            disabled={idx === 0}
+          >
+            ‹ Prev
+          </button>
+          <button
+            type="button"
+            className={done ? 'pc-deck-btn pc-dt-btn-done' : 'pc-deck-btn'}
+            onClick={() => toggleDtDone(idx)}
+            aria-pressed={done}
+          >
+            {done ? '✓ Complete' : 'Mark Complete'}
+          </button>
+          <button
+            type="button"
+            className="pc-deck-btn"
+            onClick={() => setDtStep(idx + 1)}
+            disabled={idx === steps.length - 1}
+          >
+            Next ›
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/play/PlayCockpit.tsx
+++ b/apps/in-the-union-now/src/components/play/PlayCockpit.tsx
@@ -19,6 +19,7 @@ import { CockpitCanvas } from './CockpitCanvas'
 import { Dial } from './Dial'
 import { dialItems } from './dialItems'
 import { DisplayView } from './DisplayView'
+import { DowntimeWizard } from './DowntimeWizard'
 import { RailBar } from './RailBar'
 
 export function PlayCockpit({ id }: { id: string }) {
@@ -26,6 +27,7 @@ export function PlayCockpit({ id }: { id: string }) {
   // The active-row entity drives the whole-canvas tint (proposed ADR-018).
   const mount = usePlayStateStore((s) => s.mount)
   const wheel = usePlayStateStore((s) => s.wheel)
+  const leaveDowntime = usePlayStateStore((s) => s.leaveDowntime)
   const mech = storeState.get('mech', id)
 
   if (!mech) {
@@ -62,24 +64,42 @@ export function PlayCockpit({ id }: { id: string }) {
   })
   const pilot = composition.pilot
   const crawler = composition.crawler
+  const isDowntime = mount === 'downtime'
   const onFoot = mount === 'pilot' && pilot !== null
-  const railTitle = onFoot && pilot ? `Pilot · ${pilot.name}` : `Mech · ${mech.name}`
+  // Downtime is crawler-dominant: rail, stamp, and Active Item all follow the
+  // crawler ontology (pink); otherwise the boarded mech / pilot on foot.
+  const fam = isDowntime ? 'crawler' : onFoot ? 'pilot' : 'mech'
+  const railTitle = isDowntime
+    ? crawler
+      ? `Downtime · ${crawler.name}`
+      : 'Downtime'
+    : onFoot && pilot
+      ? `Pilot · ${pilot.name}`
+      : `Mech · ${mech.name}`
 
   // The Dial holds the non-active entities + statless views; the item in the
   // active slot is the display's focus (focus→display sync; content is Phase 4).
-  const items = dialItems({ mount: onFoot ? 'pilot' : 'mech', mech, pilot, crawler })
+  const items = dialItems({ mount, mech, pilot, crawler })
   const focus =
     items.length > 0 ? items[((wheel % items.length) + items.length) % items.length] : undefined
 
   return (
     <CockpitCanvas>
       <div className="pc-grid" data-mount={mount}>
-        <RailBar title={railTitle} fam={onFoot ? 'pilot' : 'mech'} />
+        <RailBar
+          title={railTitle}
+          fam={fam}
+          onLeaveDowntime={isDowntime ? leaveDowntime : undefined}
+        />
         <div className="pc-primary">
-          <ActiveItemBand mech={mech} pilot={pilot} store={storeState} />
+          <ActiveItemBand mech={mech} pilot={pilot} crawler={crawler} store={storeState} />
         </div>
         <div className="pc-display pc-display-light">
-          <DisplayView focus={focus} mech={mech} pilot={pilot} crawler={crawler} />
+          {isDowntime ? (
+            <DowntimeWizard crawler={crawler} />
+          ) : (
+            <DisplayView focus={focus} mech={mech} pilot={pilot} crawler={crawler} />
+          )}
         </div>
         <div className="pc-wheel">
           <Dial items={items} />

--- a/apps/in-the-union-now/src/components/play/RailBar.tsx
+++ b/apps/in-the-union-now/src/components/play/RailBar.tsx
@@ -16,7 +16,14 @@ const STAMP_BG: Record<RailFam, string> = {
   crawler: 'var(--pc-crawler-deep)',
 }
 
-export function RailBar({ title, fam = 'mech' }: { title: string; fam?: RailFam }) {
+type RailBarProps = {
+  title: string
+  fam?: RailFam
+  /** When set, the rail's right action becomes "Leave Downtime" (Phase 6). */
+  onLeaveDowntime?: () => void
+}
+
+export function RailBar({ title, fam = 'mech', onLeaveDowntime }: RailBarProps) {
   return (
     <div className="pc-rail">
       <AppLink href="/" className="pc-railbtn">
@@ -26,9 +33,20 @@ export function RailBar({ title, fam = 'mech' }: { title: string; fam?: RailFam 
         {title}
       </span>
       <span className="flex-1" />
-      <button type="button" className="pc-railbtn" title="Rules & sources — planned" disabled>
-        ⚙ Settings
-      </button>
+      {onLeaveDowntime ? (
+        <button
+          type="button"
+          className="pc-railbtn"
+          title="Return to the previous mount"
+          onClick={onLeaveDowntime}
+        >
+          ◄ Leave Downtime
+        </button>
+      ) : (
+        <button type="button" className="pc-railbtn" title="Rules & sources — planned" disabled>
+          ⚙ Settings
+        </button>
+      )}
     </div>
   )
 }

--- a/apps/in-the-union-now/src/components/play/__tests__/DowntimeWizard.test.tsx
+++ b/apps/in-the-union-now/src/components/play/__tests__/DowntimeWizard.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Tests for DowntimeWizard — the guided Downtime loop on the light display.
+ *
+ * Verifies the wizard is driven from the real "Crawler Downtime" Guide in the
+ * reference ORM (not a hard-coded array): it renders the current step's name +
+ * phase, advances with Next/Prev, and the ephemeral "Mark Complete" toggle
+ * flips through playStateStore. Reference content needs the ORM, so
+ * preload('all') runs once.
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import { fireEvent, render } from '@testing-library/react'
+import { EntityHrefProvider } from 'suref-react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import type { Crawler } from '../../../lib/schemas/crawler'
+import { usePlayStateStore } from '../../../stores/playStateStore'
+import { DowntimeWizard } from '../DowntimeWizard'
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+beforeEach(() => {
+  usePlayStateStore.setState({
+    mount: 'downtime',
+    wheel: 0,
+    priorMount: 'mech',
+    dtStep: 0,
+    dtDone: {},
+  })
+})
+
+const crawler = { id: 'c1', name: 'Hauler', techLevel: '3', crawlerBays: [] } as unknown as Crawler
+
+function renderWizard() {
+  return render(
+    <EntityHrefProvider value={() => undefined}>
+      <DowntimeWizard crawler={crawler} />
+    </EntityHrefProvider>
+  )
+}
+
+describe('DowntimeWizard', () => {
+  test('drives the first step from the reference guide (name + phase)', () => {
+    const { container } = renderWizard()
+    expect(container.querySelector('.pc-dt')).toBeTruthy()
+    // Step 1 of the SRD procedure is "Tally Salvage" in the Post-Session phase.
+    expect(container.textContent).toContain('Tally Salvage')
+    expect(container.querySelector('.pc-dt-phase')?.textContent).toBe('Post-Session')
+    expect(container.querySelector('.pc-dt-count')?.textContent).toContain('Step 1 /')
+  })
+
+  test('Next advances the step; Prev is disabled on the first step', () => {
+    const { container, getByText } = renderWizard()
+    const prev = getByText('‹ Prev') as HTMLButtonElement
+    expect(prev.disabled).toBe(true)
+    fireEvent.click(getByText('Next ›'))
+    expect(usePlayStateStore.getState().dtStep).toBe(1)
+    expect(container.querySelector('.pc-dt-count')?.textContent).toContain('Step 2 /')
+  })
+
+  test('Mark Complete toggles the ephemeral per-step flag', () => {
+    const { getByText } = renderWizard()
+    fireEvent.click(getByText('Mark Complete'))
+    expect(usePlayStateStore.getState().dtDone[0]).toBe(true)
+    // Re-render reflects the completed label.
+    expect(getByText('✓ Complete')).toBeTruthy()
+  })
+
+  test('Trade step renders its reused RollTable (Trading Bay)', () => {
+    // Find the Trade step index from the guide and jump to it.
+    const guide = SalvageUnionReference.Guides.find((g) => g.guideType === 'downtime')
+    const idx = (guide?.steps ?? []).findIndex((s) => s.name === 'Trade')
+    expect(idx).toBeGreaterThan(-1)
+    usePlayStateStore.setState({ dtStep: idx })
+    const { container } = renderWizard()
+    expect(container.textContent).toContain('Trade')
+    expect(container.querySelector('.pc-dt-table table')).toBeTruthy()
+  })
+})

--- a/apps/in-the-union-now/src/components/play/dialItems.ts
+++ b/apps/in-the-union-now/src/components/play/dialItems.ts
@@ -101,10 +101,11 @@ export function dialItems(args: {
   const items: DialItem[] = [
     { key: 'actions', statless: true, label: 'Actions', sublabel: 'full action deck' },
   ]
-  // The counterpart entity — the one NOT in the active row.
+  // The counterpart entities — everything NOT in the active row. In Downtime
+  // the crawler is active, so the dial carries the mech + pilot instead.
   if (mount !== 'mech') items.push(mechItem(mech))
-  if (mount === 'mech' && pilot) items.push(pilotItem(pilot))
-  if (crawler) items.push(crawlerItem(crawler))
+  if (mount !== 'pilot' && pilot) items.push(pilotItem(pilot))
+  if (mount !== 'downtime' && crawler) items.push(crawlerItem(crawler))
   items.push({ key: 'tables', statless: true, label: 'Tables', sublabel: 'roll on any table' })
   items.push({ key: 'srd', statless: true, label: 'SRD Explorer', sublabel: 'reference browser' })
   return items

--- a/apps/in-the-union-now/src/components/play/play.css
+++ b/apps/in-the-union-now/src/components/play/play.css
@@ -494,6 +494,113 @@
   color: #6c6153;
 }
 
+/* ---- Crawler focus → Enter Downtime (light display, Phase 6) ---- */
+.pc-crawler-focus {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  height: 100%;
+  text-align: center;
+  padding: 24px 16px;
+}
+.pc-crawler-focus-name {
+  margin: 0;
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 18px;
+  color: #282019;
+}
+.pc-crawler-focus-note {
+  margin: 0;
+  font-family: 'Barlow', sans-serif;
+  font-size: 13px;
+  line-height: 1.4;
+  color: #6c6153;
+  max-width: 40ch;
+}
+.pc-crawler-focus .pc-deck-btn {
+  flex: 0 0 auto;
+  min-width: 200px;
+  background: var(--pc-crawler-deep);
+}
+
+/* ---- Downtime wizard (light display, Phase 6) ---- */
+.pc-dt {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.pc-dt-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.pc-dt-phase {
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 12px;
+  color: #fff;
+  padding: 4px 9px 5px;
+  border-radius: 2px;
+}
+.pc-dt-count {
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  color: #6c6153;
+}
+.pc-dt-step-name {
+  margin: 0;
+  padding: 0 0 4px;
+  border-bottom: 2.5px solid #7e2a5b;
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  font-size: 20px;
+  line-height: 1.1;
+  color: #282019;
+}
+.pc-dt-gate {
+  margin: 0;
+  padding: 10px 12px 10px 28px;
+  border: 1.5px solid rgba(40, 32, 25, 0.18);
+  border-radius: 4px;
+  background: #fff;
+  font-family: 'Barlow', sans-serif;
+  font-size: 13px;
+  line-height: 1.4;
+  color: #282019;
+}
+.pc-dt-gate li + li {
+  margin-top: 4px;
+}
+.pc-dt-table {
+  margin-top: 2px;
+}
+.pc-dt-note {
+  margin: 0;
+  font-family: 'Barlow', sans-serif;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #6c6153;
+}
+.pc-dt-controls {
+  display: flex;
+  gap: 8px;
+}
+.pc-dt-btn-done {
+  background: var(--pc-mech-deep);
+}
+
 /* ---- CockpitGauge: bespoke dark segmented instrument bar ---- */
 .pc-gauge {
   display: flex;

--- a/apps/in-the-union-now/src/stores/__tests__/playStateStore.test.ts
+++ b/apps/in-the-union-now/src/stores/__tests__/playStateStore.test.ts
@@ -11,13 +11,20 @@ import { usePlayStateStore } from '../playStateStore'
 
 describe('playStateStore', () => {
   beforeEach(() => {
-    usePlayStateStore.setState({ mount: 'mech', wheel: 0 })
+    usePlayStateStore.setState({
+      mount: 'mech',
+      wheel: 0,
+      priorMount: null,
+      dtStep: 0,
+      dtDone: {},
+    })
   })
 
   test('defaults to the boarded mech, dial at 0', () => {
     const s = usePlayStateStore.getState()
     expect(s.mount).toBe('mech')
     expect(s.wheel).toBe(0)
+    expect(s.priorMount).toBeNull()
   })
 
   test('setMount switches the active-row entity', () => {
@@ -30,5 +37,47 @@ describe('playStateStore', () => {
   test('setWheel moves the dial index', () => {
     usePlayStateStore.getState().setWheel(3)
     expect(usePlayStateStore.getState().wheel).toBe(3)
+  })
+
+  test('enterDowntime remembers the prior mount and resets the wizard', () => {
+    usePlayStateStore.setState({ mount: 'pilot', dtStep: 4, dtDone: { 0: true } })
+    usePlayStateStore.getState().enterDowntime()
+    const s = usePlayStateStore.getState()
+    expect(s.mount).toBe('downtime')
+    expect(s.priorMount).toBe('pilot')
+    expect(s.dtStep).toBe(0)
+    expect(s.dtDone).toEqual({})
+  })
+
+  test('enterDowntime while already in Downtime is a no-op (keeps priorMount)', () => {
+    usePlayStateStore.setState({ mount: 'downtime', priorMount: 'mech' })
+    usePlayStateStore.getState().enterDowntime()
+    const s = usePlayStateStore.getState()
+    expect(s.mount).toBe('downtime')
+    expect(s.priorMount).toBe('mech')
+  })
+
+  test('leaveDowntime restores the mount active when entered', () => {
+    usePlayStateStore.getState().setMount('pilot')
+    usePlayStateStore.getState().enterDowntime()
+    usePlayStateStore.getState().leaveDowntime()
+    const s = usePlayStateStore.getState()
+    expect(s.mount).toBe('pilot')
+    expect(s.priorMount).toBeNull()
+  })
+
+  test('leaveDowntime falls back to mech when no prior mount is set', () => {
+    usePlayStateStore.setState({ mount: 'downtime', priorMount: null })
+    usePlayStateStore.getState().leaveDowntime()
+    expect(usePlayStateStore.getState().mount).toBe('mech')
+  })
+
+  test('setDtStep + toggleDtDone drive the ephemeral wizard cursor', () => {
+    usePlayStateStore.getState().setDtStep(2)
+    expect(usePlayStateStore.getState().dtStep).toBe(2)
+    usePlayStateStore.getState().toggleDtDone(2)
+    expect(usePlayStateStore.getState().dtDone[2]).toBe(true)
+    usePlayStateStore.getState().toggleDtDone(2)
+    expect(usePlayStateStore.getState().dtDone[2]).toBe(false)
   })
 })

--- a/apps/in-the-union-now/src/stores/playStateStore.ts
+++ b/apps/in-the-union-now/src/stores/playStateStore.ts
@@ -10,6 +10,12 @@
  *
  * Phase 1 (read-only shell) tracks only the mount state and dial index; later
  * phases extend it (range band, push-armed, overlays, dial config, etc.).
+ *
+ * Phase 6 (Downtime) adds the crawler-dominant `'downtime'` mode: entering it
+ * remembers the prior mount (`priorMount`) so Leave restores it, and it carries
+ * the guided Downtime wizard's ephemeral progress (`dtStep` + the per-step
+ * `dtDone` "Mark Complete" toggles). None of this is persisted — Downtime
+ * *effects* land on the entity sheets, but the wizard's cursor is play-state.
  */
 
 import { create } from 'zustand'
@@ -22,13 +28,37 @@ type PlayState = {
   mount: MountState
   /** Selected index on the rotary Dial. */
   wheel: number
+  /** The mount to restore when leaving Downtime (null when not in Downtime). */
+  priorMount: MountState | null
+  /** Current step index in the Downtime wizard (0-based). */
+  dtStep: number
+  /** Per-step "Mark Complete" toggles, keyed by step index (ephemeral). */
+  dtDone: Record<number, boolean>
   setMount: (mount: MountState) => void
   setWheel: (wheel: number) => void
+  /** Enter Downtime, remembering the current mount to restore on Leave. */
+  enterDowntime: () => void
+  /** Leave Downtime, restoring the mount active when it was entered. */
+  leaveDowntime: () => void
+  /** Move the Downtime wizard to a step index. */
+  setDtStep: (step: number) => void
+  /** Toggle the "Mark Complete" flag for a Downtime step index. */
+  toggleDtDone: (step: number) => void
 }
 
 export const usePlayStateStore = create<PlayState>((set) => ({
   mount: 'mech',
   wheel: 0,
+  priorMount: null,
+  dtStep: 0,
+  dtDone: {},
   setMount: (mount) => set({ mount }),
   setWheel: (wheel) => set({ wheel }),
+  enterDowntime: () =>
+    set((s) =>
+      s.mount === 'downtime' ? s : { mount: 'downtime', priorMount: s.mount, dtStep: 0, dtDone: {} }
+    ),
+  leaveDowntime: () => set((s) => ({ mount: s.priorMount ?? 'mech', priorMount: null })),
+  setDtStep: (step) => set({ dtStep: step }),
+  toggleDtDone: (step) => set((s) => ({ dtDone: { ...s.dtDone, [step]: !s.dtDone[step] } })),
 }))


### PR DESCRIPTION
## What
Phase 6 ([plan §9.6, §5.5](https://github.com/SalvageUnion-io/SU-SRD/pull/423)). **Stacked on #430.** Adds Downtime as the crawler-dominant third mount state.

- **`playStateStore`** gains `priorMount` + `enter/leaveDowntime` (restores the prior mount) and an ephemeral wizard cursor (`dtStep`/`dtDone`).
- **Enter Downtime** from the crawler's dial focus; rail + a new read-only `CrawlerBand` + wizard chrome all follow the crawler-pink ontology; Leave Downtime on rail + band.
- **`DowntimeWizard`** on the light display, driven from the real **"Crawler Downtime" Guide** in the reference ORM (10 steps, not hard-coded) via reused `BlockContentRendererView`, with prev/next, an ephemeral Mark-Complete, read-only bay-gate readouts from `downtime.ts`/`crawlerEconomy.ts`, and per-step SRD roll tables via reused `RollTable`.

## Verify
typecheck ✓ · 100 play/store tests + full ITUN suite green · lint ✓ · pre-push guards ✓

## Notes
Read-mostly per ADR-007: destructive economy writes (upkeep spend, restore, crafting) are deferred to the live sheet with an on-screen note. Step nav via wizard buttons (dial kept intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNeL9Bxgw2HRKJpSimK1Wm