### PR TITLE
feat(itun): Play Cockpit Phase 7 — dial config, cargo hold, table picker

### DIFF
--- a/apps/in-the-union-now/src/components/play/ActiveItemBand.tsx
+++ b/apps/in-the-union-now/src/components/play/ActiveItemBand.tsx
@@ -32,6 +32,7 @@ import { describePushOutcome } from '../../lib/rules/coreMechanic'
 import { resolveChassisRef } from '../../lib/rules/resolveRefs'
 import type { CriticalDamageEffect, CriticalInjuryEffect } from '../../lib/rules/takeDamage'
 import type { Crawler } from '../../lib/schemas/crawler'
+import type { CargoLot } from '../../lib/schemas/cargoLot'
 import { totalLotUnits } from '../../lib/schemas/cargoLot'
 import type { Mech } from '../../lib/schemas/mech'
 import type { Pilot } from '../../lib/schemas/pilot'
@@ -52,8 +53,6 @@ import {
   pushPatch,
   shutdownTogglePatch,
 } from './playRules'
-
-const PHASE7 = 'Cargo hold overlay lands in a later phase'
 
 /** The store surface the band needs — injectable so tests can assert patches. */
 export type PlayStore = Pick<EntityState, 'get' | 'update'>
@@ -190,7 +189,58 @@ type MechPrompt =
   | { kind: 'dmg' }
   | { kind: 'crit'; effect: CriticalDamageEffect | null; log: string }
   | { kind: 'eject' }
+  | { kind: 'storage' }
   | null
+
+// ---------------------------------------------------------------------------
+// Cargo-hold overlay (Phase 7) — lists the mech's cargo lots with a Jettison
+// affordance. Jettison is irreversible (the cargo is discarded), so per ADR-007
+// it is a player-confirmed explicit button, never silent auto-bookkeeping.
+// ---------------------------------------------------------------------------
+
+function StorageBay({
+  lots,
+  used,
+  cap,
+  onJettison,
+}: {
+  lots: CargoLot[]
+  used: number
+  cap: number
+  onJettison: (lotId: string) => void
+}) {
+  return (
+    <div className="pc-cargo">
+      <p className="pc-cargo-usage">
+        Hold {used}/{cap}
+      </p>
+      {lots.length === 0 ? (
+        <p className="pc-resolve-log">Cargo hold is empty.</p>
+      ) : (
+        <ul className="pc-cargo-list">
+          {lots.map((lot) => (
+            <li key={lot.id} className="pc-cargo-row">
+              <span className="pc-cargo-name">
+                <span className="pc-cargo-code">{lot.code}</span>
+                {lot.name}
+                {lot.kind === 'bulk' && lot.qty !== undefined ? ` ×${lot.qty}` : ''}
+                <span className="pc-cargo-units">{lot.units}u</span>
+              </span>
+              <button
+                type="button"
+                className="pc-btn pc-btn-danger"
+                onClick={() => onJettison(lot.id)}
+                aria-label={`Jettison ${lot.name}`}
+              >
+                Jettison
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
 
 function MechBand({
   mech,
@@ -285,6 +335,13 @@ function MechBand({
     setPrompt(null)
   }
 
+  function jettison(lotId: string) {
+    const m = fresh()
+    void store.update('mech', mech.id, {
+      cargoLots: m.cargoLots.filter((lot) => lot.id !== lotId),
+    })
+  }
+
   return (
     <div className="pc-band" data-fam="mech">
       <div className="pc-band-id">
@@ -356,7 +413,12 @@ function MechBand({
             >
               Take Dmg
             </button>
-            <button type="button" className="pc-btn" disabled title={PHASE7}>
+            <button
+              type="button"
+              className="pc-btn"
+              onClick={() => setPrompt({ kind: 'storage' })}
+              title="Open the cargo hold"
+            >
               Storage
             </button>
           </div>
@@ -419,6 +481,16 @@ function MechBand({
               </div>
             )
           )}
+        </ResolveOverlay>
+      )}
+      {prompt?.kind === 'storage' && (
+        <ResolveOverlay title="Cargo Hold" onClose={() => setPrompt(null)}>
+          <StorageBay
+            lots={fresh().cargoLots}
+            used={totalLotUnits(fresh().cargoLots)}
+            cap={maxCargo}
+            onJettison={jettison}
+          />
         </ResolveOverlay>
       )}
       {prompt?.kind === 'eject' && (

--- a/apps/in-the-union-now/src/components/play/Dial.tsx
+++ b/apps/in-the-union-now/src/components/play/Dial.tsx
@@ -13,8 +13,10 @@
 
 import { useRef, useState, type PointerEvent } from 'react'
 
+import type { CockpitPrefs, DialKind } from '../../lib/schemas/cockpitPrefs'
 import { usePlayStateStore } from '../../stores/playStateStore'
 import { CockpitGauge } from './CockpitGauge'
+import { DialConfig } from './DialConfig'
 import type { DialItem } from './dialItems'
 
 const DRAG_STEP = 30
@@ -61,10 +63,21 @@ function DialCell({
   return <div className={cls}>{inner}</div>
 }
 
-export function Dial({ items }: { items: DialItem[] }) {
+type DialProps = {
+  items: DialItem[]
+  /** Dial-config universe (kinds this cockpit can show); omit to hide the ⚙. */
+  configKinds?: DialKind[]
+  /** Current persisted dial prefs. */
+  prefs?: CockpitPrefs
+  /** Persist updated prefs; when omitted the ⚙ config control is not shown. */
+  onPrefsChange?: (next: CockpitPrefs) => void
+}
+
+export function Dial({ items, configKinds, prefs, onPrefsChange }: DialProps) {
   const wheel = usePlayStateStore((s) => s.wheel)
   const setWheel = usePlayStateStore((s) => s.setWheel)
   const [anim, setAnim] = useState<{ dir: 'fwd' | 'back'; key: number }>({ dir: 'fwd', key: 0 })
+  const [configOpen, setConfigOpen] = useState(false)
 
   const n = items.length
   const active = n > 0 ? ((wheel % n) + n) % n : 0
@@ -116,6 +129,8 @@ export function Dial({ items }: { items: DialItem[] }) {
   const trackIdx: number[] = []
   for (let k = 1; k < n; k++) trackIdx.push((active + k) % n)
 
+  const canConfigure = onPrefsChange !== undefined && configKinds !== undefined
+
   return (
     <div
       className="pc-wheel-col"
@@ -152,7 +167,27 @@ export function Dial({ items }: { items: DialItem[] }) {
         >
           ▼
         </button>
+        {canConfigure && (
+          <button
+            type="button"
+            className="pc-wheel-btn pc-wheel-cfg"
+            onClick={() => setConfigOpen((o) => !o)}
+            aria-label="Configure dial"
+            aria-expanded={configOpen}
+            title="Show / hide and reorder dial items"
+          >
+            ⚙
+          </button>
+        )}
       </div>
+      {canConfigure && configOpen && (
+        <DialConfig
+          kinds={configKinds}
+          prefs={prefs}
+          onChange={onPrefsChange}
+          onClose={() => setConfigOpen(false)}
+        />
+      )}
     </div>
   )
 }

--- a/apps/in-the-union-now/src/components/play/DialConfig.tsx
+++ b/apps/in-the-union-now/src/components/play/DialConfig.tsx
@@ -1,0 +1,110 @@
+/**
+ * DialConfig — the ⚙ overlay that configures the rotary Dial (Play Cockpit
+ * Phase 7, plan §9.7). Show/hide and reorder the dial kinds; "Actions" is
+ * locked visible. Emits a new CockpitPrefs on every change — PlayCockpit
+ * persists it to the owning Workspace record (local-first), so the layout
+ * survives reloads.
+ *
+ * The overlay operates on stable dial KINDS (not per-instance keys), so the
+ * same prefs apply regardless of which mech/pilot/crawler is loaded.
+ */
+
+import type { CockpitPrefs, DialKind } from '../../lib/schemas/cockpitPrefs'
+import { DIAL_KIND_LABELS, LOCKED_DIAL_KIND, orderKinds } from './dialItems'
+
+type DialConfigProps = {
+  /** The dial kinds this cockpit can show, in default order. */
+  kinds: DialKind[]
+  /** Current persisted prefs (undefined → defaults: all visible, default order). */
+  prefs?: CockpitPrefs
+  /** Emit updated prefs (PlayCockpit persists to the workspace). */
+  onChange: (next: CockpitPrefs) => void
+  onClose: () => void
+}
+
+function buildPrefs(order: DialKind[], hidden: Set<DialKind>): CockpitPrefs {
+  return {
+    order,
+    // `actions` is locked visible — never persisted as hidden.
+    hidden: order.filter((k) => k !== LOCKED_DIAL_KIND && hidden.has(k)),
+  }
+}
+
+export function DialConfig({ kinds, prefs, onChange, onClose }: DialConfigProps) {
+  const order = orderKinds(kinds, prefs)
+  const hidden = new Set<DialKind>(prefs?.hidden ?? [])
+
+  const toggleHidden = (kind: DialKind) => {
+    if (kind === LOCKED_DIAL_KIND) return
+    const next = new Set(hidden)
+    if (next.has(kind)) next.delete(kind)
+    else next.add(kind)
+    onChange(buildPrefs(order, next))
+  }
+
+  const move = (index: number, delta: number) => {
+    const target = index + delta
+    if (target < 0 || target >= order.length) return
+    const next = [...order]
+    const a = next[index]
+    const b = next[target]
+    if (!a || !b) return
+    next[index] = b
+    next[target] = a
+    onChange(buildPrefs(next, hidden))
+  }
+
+  return (
+    <div className="pc-dialcfg" role="dialog" aria-label="Configure dial">
+      <div className="pc-dialcfg-head">
+        <span className="pc-dialcfg-title">Configure Dial</span>
+        <button type="button" className="pc-railbtn" onClick={onClose}>
+          Done
+        </button>
+      </div>
+      <ul className="pc-dialcfg-list">
+        {order.map((kind, i) => {
+          const locked = kind === LOCKED_DIAL_KIND
+          const isHidden = hidden.has(kind)
+          return (
+            <li key={kind} className="pc-dialcfg-row">
+              <label className="pc-dialcfg-show">
+                <input
+                  type="checkbox"
+                  checked={locked || !isHidden}
+                  disabled={locked}
+                  onChange={() => toggleHidden(kind)}
+                  aria-label={`Show ${DIAL_KIND_LABELS[kind]}`}
+                />
+                <span className={isHidden ? 'pc-dialcfg-lab hidden' : 'pc-dialcfg-lab'}>
+                  {DIAL_KIND_LABELS[kind]}
+                  {locked ? ' (locked)' : ''}
+                </span>
+              </label>
+              <span className="pc-dialcfg-move">
+                <button
+                  type="button"
+                  className="pc-wheel-btn"
+                  onClick={() => move(i, -1)}
+                  disabled={i === 0}
+                  aria-label={`Move ${DIAL_KIND_LABELS[kind]} up`}
+                >
+                  ▲
+                </button>
+                <button
+                  type="button"
+                  className="pc-wheel-btn"
+                  onClick={() => move(i, 1)}
+                  disabled={i === order.length - 1}
+                  aria-label={`Move ${DIAL_KIND_LABELS[kind]} down`}
+                >
+                  ▼
+                </button>
+              </span>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/play/DisplayView.tsx
+++ b/apps/in-the-union-now/src/components/play/DisplayView.tsx
@@ -10,6 +10,8 @@
  * of the display stays the read-only reference document from Phase 4.
  */
 
+import { useState } from 'react'
+
 import { SalvageUnionReference } from 'salvageunion-reference'
 import type { SURefEntity } from 'salvageunion-reference'
 import { ReferenceEntityDisplay, RollTable } from 'suref-react'
@@ -39,17 +41,40 @@ function EntityCard({ data, note }: { data: SURefEntity | null; note: string }) 
 
 export function DisplayView({ focus, mech, pilot, crawler }: DisplayViewProps) {
   const enterDowntime = usePlayStateStore((s) => s.enterDowntime)
+  // Which roll table the Tables focus shows (ephemeral; defaults to Core Mechanic).
+  const [tableId, setTableId] = useState<string | null>(null)
   if (!focus) return <div className="pc-display-note">Nothing selected.</div>
 
   if (focus.statless) {
     if (focus.key === 'tables') {
-      const table = SalvageUnionReference.RollTables.find((t) => t.name === 'Core Mechanic') as
-        | Parameters<typeof RollTable>[0]['table']
-        | undefined
+      const tables = SalvageUnionReference.RollTables.all() as Array<{ id: string; name: string }>
+      const sorted = [...tables].sort((a, b) => a.name.localeCompare(b.name))
+      const selected =
+        (tableId ? tables.find((t) => t.id === tableId) : undefined) ??
+        tables.find((t) => t.name === 'Core Mechanic') ??
+        sorted[0]
       return (
         <div className="pc-display-scroll">
-          {table ? (
-            <RollTable table={table} tableName="Core Mechanic" />
+          <label className="pc-table-picker">
+            <span className="pc-table-picker-lab">Roll table</span>
+            <select
+              className="pc-table-picker-sel"
+              value={selected?.id ?? ''}
+              onChange={(e) => setTableId(e.target.value)}
+              aria-label="Choose a roll table"
+            >
+              {sorted.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          {selected ? (
+            <RollTable
+              table={selected as unknown as Parameters<typeof RollTable>[0]['table']}
+              tableName={selected.name}
+            />
           ) : (
             <div className="pc-display-note">Roll tables load here.</div>
           )}

--- a/apps/in-the-union-now/src/components/play/PlayCockpit.tsx
+++ b/apps/in-the-union-now/src/components/play/PlayCockpit.tsx
@@ -10,14 +10,19 @@
  * See docs/architecture/play-cockpit.md for the full plan.
  */
 
+import { useCallback, useState } from 'react'
+
+import { useWorkspace } from '../../hooks/queries/workspaces'
+import type { CockpitPrefs } from '../../lib/schemas/cockpitPrefs'
 import { useEntityStore } from '../../stores/entityStore'
 import { usePlayStateStore } from '../../stores/playStateStore'
+import { useWorkspaceStore } from '../../stores/workspaceStore'
 import { resolveSheetComposition } from '../sheet/composition'
 import type { EntityLookup } from '../sheet/composition'
 import { ActiveItemBand } from './ActiveItemBand'
 import { CockpitCanvas } from './CockpitCanvas'
 import { Dial } from './Dial'
-import { dialItems } from './dialItems'
+import { applyDialPrefs, configurableKinds, dialItems } from './dialItems'
 import { DisplayView } from './DisplayView'
 import { DowntimeWizard } from './DowntimeWizard'
 import { RailBar } from './RailBar'
@@ -29,6 +34,24 @@ export function PlayCockpit({ id }: { id: string }) {
   const wheel = usePlayStateStore((s) => s.wheel)
   const leaveDowntime = usePlayStateStore((s) => s.leaveDowntime)
   const mech = storeState.get('mech', id)
+
+  // Persisted dial prefs live on the owning workspace (local-first, Phase 7).
+  // Hooks run unconditionally (before the no-mech early return); when the mech
+  // has no workspace, prefs fall back to session-only React state.
+  const workspaceId = mech?.workspaceId ?? null
+  const workspace = useWorkspace(workspaceId)
+  const [sessionPrefs, setSessionPrefs] = useState<CockpitPrefs | undefined>(undefined)
+  const prefs = workspace?.cockpitPrefs ?? sessionPrefs
+  const setPrefs = useCallback(
+    (next: CockpitPrefs) => {
+      if (workspaceId) {
+        void useWorkspaceStore.getState().update(workspaceId, { cockpitPrefs: next })
+      } else {
+        setSessionPrefs(next)
+      }
+    },
+    [workspaceId]
+  )
 
   if (!mech) {
     return (
@@ -79,7 +102,9 @@ export function PlayCockpit({ id }: { id: string }) {
 
   // The Dial holds the non-active entities + statless views; the item in the
   // active slot is the display's focus (focus→display sync; content is Phase 4).
-  const items = dialItems({ mount, mech, pilot, crawler })
+  // Persisted prefs (show/hide + order) are applied on top of the base list.
+  const items = applyDialPrefs(dialItems({ mount, mech, pilot, crawler }), prefs)
+  const cfgKinds = configurableKinds({ pilot, crawler })
   const focus =
     items.length > 0 ? items[((wheel % items.length) + items.length) % items.length] : undefined
 
@@ -102,7 +127,7 @@ export function PlayCockpit({ id }: { id: string }) {
           )}
         </div>
         <div className="pc-wheel">
-          <Dial items={items} />
+          <Dial items={items} configKinds={cfgKinds} prefs={prefs} onPrefsChange={setPrefs} />
         </div>
       </div>
     </CockpitCanvas>

--- a/apps/in-the-union-now/src/components/play/__tests__/ActiveItemBand.storage.test.tsx
+++ b/apps/in-the-union-now/src/components/play/__tests__/ActiveItemBand.storage.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Tests for the Phase-7 cargo-hold overlay on the mech band: the Storage button
+ * opens a hold listing the mech's cargo lots, and Jettison writes a cargoLots
+ * patch with that lot removed (the explicit player-confirmed discard, ADR-007).
+ */
+
+import { beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import type { CargoLot } from '../../../lib/schemas/cargoLot'
+import type { Mech } from '../../../lib/schemas/mech'
+import { usePlayStateStore } from '../../../stores/playStateStore'
+import { ActiveItemBand } from '../ActiveItemBand'
+import type { PlayStore } from '../ActiveItemBand'
+
+const lotA: CargoLot = {
+  id: 'lot-a',
+  kind: 'unit',
+  name: 'Sealed Crate',
+  cat: 'SEALED',
+  units: 1,
+  code: 'SEA',
+}
+const lotB: CargoLot = {
+  id: 'lot-b',
+  kind: 'bulk',
+  name: 'Tech 3 Scrap',
+  cat: 'SCRAP',
+  tl: 3,
+  qty: 4,
+  units: 4,
+  code: 'SCR-T3',
+}
+
+const mech = {
+  id: 'm1',
+  name: 'Iron Mongrel',
+  chassisRef: 'unknown-chassis',
+  systems: [],
+  modules: [],
+  cargoLots: [lotA, lotB],
+  currentSP: 10,
+  // Deterministic cargo cap (unknown chassis contributes 0): used 5 / cap 6.
+  maxCargoModifier: 6,
+} as unknown as Mech
+
+type Call = { type: string; id: string; patch: Record<string, unknown> }
+
+function stubStore(entities: Mech[]): { store: PlayStore; calls: Call[] } {
+  const calls: Call[] = []
+  const store = {
+    get: (_type: string, id: string) => entities.find((e) => e.id === id) ?? null,
+    update: async (type: string, id: string, patch: Record<string, unknown>) => {
+      calls.push({ type, id, patch })
+      return entities.find((e) => e.id === id)
+    },
+  } as unknown as PlayStore
+  return { store, calls }
+}
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+describe('ActiveItemBand cargo hold', () => {
+  beforeEach(() => {
+    usePlayStateStore.setState({ mount: 'mech', wheel: 0 })
+  })
+
+  test('Storage opens the hold listing the cargo lots', () => {
+    const { store } = stubStore([mech])
+    render(<ActiveItemBand mech={mech} pilot={null} store={store} />)
+    fireEvent.click(screen.getByText('Storage'))
+    expect(screen.getByLabelText('Jettison Sealed Crate')).toBeTruthy()
+    expect(screen.getByLabelText('Jettison Tech 3 Scrap')).toBeTruthy()
+    expect(screen.getByText('Hold 5/6')).toBeTruthy()
+  })
+
+  test('Jettison writes cargoLots without the discarded lot', () => {
+    const { store, calls } = stubStore([mech])
+    render(<ActiveItemBand mech={mech} pilot={null} store={store} />)
+    fireEvent.click(screen.getByText('Storage'))
+    fireEvent.click(screen.getByLabelText('Jettison Sealed Crate'))
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toEqual({ type: 'mech', id: 'm1', patch: { cargoLots: [lotB] } })
+  })
+})

--- a/apps/in-the-union-now/src/components/play/__tests__/Dial.test.tsx
+++ b/apps/in-the-union-now/src/components/play/__tests__/Dial.test.tsx
@@ -11,15 +11,16 @@ import { Dial } from '../Dial'
 import type { DialItem } from '../dialItems'
 
 const items: DialItem[] = [
-  { key: 'actions', statless: true, label: 'Actions', sublabel: 'deck' },
+  { key: 'actions', kind: 'actions', statless: true, label: 'Actions', sublabel: 'deck' },
   {
     key: 'pilot',
+    kind: 'pilot',
     statless: false,
     label: 'Pilot · Vesh',
     tone: 'pilot',
     gauges: [{ label: 'HP', value: 8, max: 10, tone: 'pilot' }],
   },
-  { key: 'tables', statless: true, label: 'Tables', sublabel: 'roll' },
+  { key: 'tables', kind: 'tables', statless: true, label: 'Tables', sublabel: 'roll' },
 ]
 
 describe('Dial', () => {

--- a/apps/in-the-union-now/src/components/play/__tests__/DialConfig.test.tsx
+++ b/apps/in-the-union-now/src/components/play/__tests__/DialConfig.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * Tests for DialConfig — the ⚙ overlay. Verifies toggling visibility and
+ * reordering emit the expected CockpitPrefs, and that Actions is locked.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { fireEvent, render } from '@testing-library/react'
+
+import type { CockpitPrefs, DialKind } from '../../../lib/schemas/cockpitPrefs'
+import { DialConfig } from '../DialConfig'
+
+const KINDS: DialKind[] = ['actions', 'mech', 'pilot', 'tables', 'srd']
+
+function setup(prefs?: CockpitPrefs) {
+  let last: CockpitPrefs | undefined
+  const onChange = (next: CockpitPrefs) => {
+    last = next
+  }
+  const utils = render(
+    <DialConfig kinds={KINDS} prefs={prefs} onChange={onChange} onClose={() => {}} />
+  )
+  return { ...utils, get: () => last }
+}
+
+describe('DialConfig', () => {
+  test('the Actions row checkbox is disabled (locked visible)', () => {
+    const { getByLabelText } = setup()
+    const actions = getByLabelText('Show Actions') as HTMLInputElement
+    expect(actions.disabled).toBe(true)
+    expect(actions.checked).toBe(true)
+  })
+
+  test('unchecking a row emits prefs with that kind hidden', () => {
+    const { getByLabelText, get } = setup()
+    fireEvent.click(getByLabelText('Show Pilot'))
+    expect(get()?.hidden).toEqual(['pilot'])
+  })
+
+  test('re-checking a hidden row removes it from hidden', () => {
+    const { getByLabelText, get } = setup({ hidden: ['pilot'], order: [] })
+    fireEvent.click(getByLabelText('Show Pilot'))
+    expect(get()?.hidden).toEqual([])
+  })
+
+  test('moving a kind up reorders and emits the full order', () => {
+    const { getByLabelText, get } = setup()
+    // Move "Mech" (index 1) up → swaps with Actions.
+    fireEvent.click(getByLabelText('Move Mech up'))
+    expect(get()?.order).toEqual(['mech', 'actions', 'pilot', 'tables', 'srd'])
+  })
+
+  test('moving a kind down reorders and emits the full order', () => {
+    const { getByLabelText, get } = setup()
+    fireEvent.click(getByLabelText('Move Pilot down'))
+    expect(get()?.order).toEqual(['actions', 'mech', 'tables', 'pilot', 'srd'])
+  })
+})

--- a/apps/in-the-union-now/src/components/play/__tests__/DisplayView.test.tsx
+++ b/apps/in-the-union-now/src/components/play/__tests__/DisplayView.test.tsx
@@ -40,6 +40,7 @@ describe('DisplayView', () => {
   test('mech focus → a resolvable chassis renders a reference card', () => {
     const focus: DialItem = {
       key: 'mech:m1',
+      kind: 'mech',
       statless: false,
       label: 'Mech · Rig',
       tone: 'mech',
@@ -54,6 +55,7 @@ describe('DisplayView', () => {
   test('mech focus → an unresolvable chassis falls back to a note, no throw', () => {
     const focus: DialItem = {
       key: 'mech:m1',
+      kind: 'mech',
       statless: false,
       label: 'Mech · Rig',
       tone: 'mech',
@@ -66,7 +68,13 @@ describe('DisplayView', () => {
   })
 
   test('Tables focus → a RollTable renders', () => {
-    const focus: DialItem = { key: 'tables', statless: true, label: 'Tables', sublabel: 'roll' }
+    const focus: DialItem = {
+      key: 'tables',
+      kind: 'tables',
+      statless: true,
+      label: 'Tables',
+      sublabel: 'roll',
+    }
     const { container } = renderDV(focus)
     expect(container.querySelector('.pc-display-scroll')).toBeTruthy()
     // The reused RollTable renders a real table (not the fallback note).
@@ -75,7 +83,13 @@ describe('DisplayView', () => {
   })
 
   test('Actions focus → the interactive ActionsDeck (Phase 5)', () => {
-    const focus: DialItem = { key: 'actions', statless: true, label: 'Actions', sublabel: 'deck' }
+    const focus: DialItem = {
+      key: 'actions',
+      kind: 'actions',
+      statless: true,
+      label: 'Actions',
+      sublabel: 'deck',
+    }
     const { container } = renderDV(focus)
     // The deck renders (list or empty state), never the generic placeholder note.
     expect(container.querySelector('.pc-display-scroll')).toBeTruthy()

--- a/apps/in-the-union-now/src/components/play/__tests__/dialPrefs.test.ts
+++ b/apps/in-the-union-now/src/components/play/__tests__/dialPrefs.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for the Phase 7 dial-preference helpers: applyDialPrefs (hide +
+ * reorder honored, Actions never hidden), orderKinds, and configurableKinds.
+ * These are pure functions — no ORM needed.
+ */
+
+import { describe, expect, test } from 'bun:test'
+
+import type { CockpitPrefs } from '../../../lib/schemas/cockpitPrefs'
+import type { Crawler } from '../../../lib/schemas/crawler'
+import type { Pilot } from '../../../lib/schemas/pilot'
+import { applyDialPrefs, configurableKinds, orderKinds, type DialItem } from '../dialItems'
+
+function items(): DialItem[] {
+  return [
+    { key: 'actions', kind: 'actions', statless: true, label: 'Actions', sublabel: '' },
+    { key: 'mech:m', kind: 'mech', statless: true, label: 'Mech', sublabel: '' },
+    { key: 'pilot:p', kind: 'pilot', statless: true, label: 'Pilot', sublabel: '' },
+    { key: 'tables', kind: 'tables', statless: true, label: 'Tables', sublabel: '' },
+    { key: 'srd', kind: 'srd', statless: true, label: 'SRD', sublabel: '' },
+  ]
+}
+
+describe('applyDialPrefs', () => {
+  test('no prefs → the list is untouched', () => {
+    const out = applyDialPrefs(items(), undefined)
+    expect(out.map((i) => i.kind)).toEqual(['actions', 'mech', 'pilot', 'tables', 'srd'])
+  })
+
+  test('hidden kinds are dropped', () => {
+    const prefs: CockpitPrefs = { hidden: ['pilot', 'srd'], order: [] }
+    const out = applyDialPrefs(items(), prefs)
+    expect(out.map((i) => i.kind)).toEqual(['actions', 'mech', 'tables'])
+  })
+
+  test('Actions is never hidden even if present in `hidden`', () => {
+    const prefs: CockpitPrefs = { hidden: ['actions'], order: [] }
+    const out = applyDialPrefs(items(), prefs)
+    expect(out.some((i) => i.kind === 'actions')).toBe(true)
+  })
+
+  test('order reorders the visible items; unlisted kinds keep default order after', () => {
+    const prefs: CockpitPrefs = { hidden: [], order: ['tables', 'actions'] }
+    const out = applyDialPrefs(items(), prefs)
+    // tables, actions first (stored order); mech, pilot, srd keep default order.
+    expect(out.map((i) => i.kind)).toEqual(['tables', 'actions', 'mech', 'pilot', 'srd'])
+  })
+
+  test('hide + reorder compose', () => {
+    const prefs: CockpitPrefs = { hidden: ['mech'], order: ['srd', 'tables'] }
+    const out = applyDialPrefs(items(), prefs)
+    expect(out.map((i) => i.kind)).toEqual(['srd', 'tables', 'actions', 'pilot'])
+  })
+})
+
+describe('orderKinds', () => {
+  test('applies the stored order, keeping unlisted kinds in default position', () => {
+    const kinds = configurableKinds({
+      pilot: { id: 'p' } as unknown as Pilot,
+      crawler: { id: 'c' } as unknown as Crawler,
+    })
+    const prefs: CockpitPrefs = { hidden: [], order: ['crawler', 'actions'] }
+    expect(orderKinds(kinds, prefs)).toEqual([
+      'crawler',
+      'actions',
+      'mech',
+      'pilot',
+      'tables',
+      'srd',
+    ])
+  })
+})
+
+describe('configurableKinds', () => {
+  test('includes pilot / crawler only when linked', () => {
+    expect(configurableKinds({ pilot: null, crawler: null })).toEqual([
+      'actions',
+      'mech',
+      'tables',
+      'srd',
+    ])
+    expect(configurableKinds({ pilot: { id: 'p' } as unknown as Pilot, crawler: null })).toContain(
+      'pilot'
+    )
+  })
+})

--- a/apps/in-the-union-now/src/components/play/dialItems.ts
+++ b/apps/in-the-union-now/src/components/play/dialItems.ts
@@ -18,6 +18,7 @@ import {
   pilotMaxHP,
 } from '../../lib/rules/derivedStats'
 import { resolveChassisRef } from '../../lib/rules/resolveRefs'
+import type { CockpitPrefs, DialKind } from '../../lib/schemas/cockpitPrefs'
 import type { Crawler } from '../../lib/schemas/crawler'
 import type { Mech } from '../../lib/schemas/mech'
 import type { Pilot } from '../../lib/schemas/pilot'
@@ -33,14 +34,35 @@ export type DialGauge = {
 }
 
 export type DialItem =
-  | { key: string; statless: true; label: string; sublabel: string }
-  | { key: string; statless: false; label: string; tone: GaugeTone; gauges: DialGauge[] }
+  | { key: string; kind: DialKind; statless: true; label: string; sublabel: string }
+  | {
+      key: string
+      kind: DialKind
+      statless: false
+      label: string
+      tone: GaugeTone
+      gauges: DialGauge[]
+    }
+
+/** Human-facing label for each dial kind — used by the dial-config overlay. */
+export const DIAL_KIND_LABELS: Record<DialKind, string> = {
+  actions: 'Actions',
+  mech: 'Mech',
+  pilot: 'Pilot',
+  crawler: 'Crawler',
+  tables: 'Tables',
+  srd: 'SRD Explorer',
+}
+
+/** The kind that can never be hidden (locked visible in the config overlay). */
+export const LOCKED_DIAL_KIND: DialKind = 'actions'
 
 function pilotItem(pilot: Pilot): DialItem {
   const maxHP = Math.max(0, pilotMaxHP(pilot))
   const maxAP = Math.max(0, pilotMaxAP(pilot))
   return {
     key: `pilot:${pilot.id}`,
+    kind: 'pilot',
     statless: false,
     label: `Pilot · ${pilot.name}`,
     tone: 'pilot',
@@ -57,6 +79,7 @@ function mechItem(mech: Mech): DialItem {
   const maxHeat = mechMaxHeat(mech, chassis)
   return {
     key: `mech:${mech.id}`,
+    kind: 'mech',
     statless: false,
     label: `Mech · ${mech.name}`,
     tone: 'mech',
@@ -77,6 +100,7 @@ function crawlerItem(crawler: Crawler): DialItem {
   const maxSP = crawlerMaxSP(crawler)
   return {
     key: `crawler:${crawler.id}`,
+    kind: 'crawler',
     statless: false,
     label: `Crawler · ${crawler.name}`,
     tone: 'crawler',
@@ -99,14 +123,88 @@ export function dialItems(args: {
 }): DialItem[] {
   const { mount, mech, pilot, crawler } = args
   const items: DialItem[] = [
-    { key: 'actions', statless: true, label: 'Actions', sublabel: 'full action deck' },
+    {
+      key: 'actions',
+      kind: 'actions',
+      statless: true,
+      label: 'Actions',
+      sublabel: 'full action deck',
+    },
   ]
   // The counterpart entities — everything NOT in the active row. In Downtime
   // the crawler is active, so the dial carries the mech + pilot instead.
   if (mount !== 'mech') items.push(mechItem(mech))
   if (mount !== 'pilot' && pilot) items.push(pilotItem(pilot))
   if (mount !== 'downtime' && crawler) items.push(crawlerItem(crawler))
-  items.push({ key: 'tables', statless: true, label: 'Tables', sublabel: 'roll on any table' })
-  items.push({ key: 'srd', statless: true, label: 'SRD Explorer', sublabel: 'reference browser' })
+  items.push({
+    key: 'tables',
+    kind: 'tables',
+    statless: true,
+    label: 'Tables',
+    sublabel: 'roll on any table',
+  })
+  items.push({
+    key: 'srd',
+    kind: 'srd',
+    statless: true,
+    label: 'SRD Explorer',
+    sublabel: 'reference browser',
+  })
   return items
+}
+
+/**
+ * The dial kinds a cockpit CAN show given the linked entities, in default order
+ * — the config overlay's universe (independent of the current mount, which
+ * only decides which of these ride the dial vs. sit in the active row).
+ */
+export function configurableKinds(args: {
+  pilot: Pilot | null
+  crawler: Crawler | null
+}): DialKind[] {
+  const kinds: DialKind[] = ['actions', 'mech']
+  if (args.pilot) kinds.push('pilot')
+  if (args.crawler) kinds.push('crawler')
+  kinds.push('tables', 'srd')
+  return kinds
+}
+
+/**
+ * Order a list of dial kinds by a prefs order (unlisted kinds keep their
+ * default relative position, after the ordered ones). Shared by the dial-config
+ * overlay's row layout and mirrored by applyDialPrefs's item ordering.
+ */
+export function orderKinds(kinds: DialKind[], prefs?: CockpitPrefs): DialKind[] {
+  if (!prefs || prefs.order.length === 0) return kinds
+  const rank = (k: DialKind): number => {
+    const i = prefs.order.indexOf(k)
+    return i === -1 ? prefs.order.length : i
+  }
+  return kinds
+    .map((k, i) => ({ k, i }))
+    .sort((a, b) => rank(a.k) - rank(b.k) || a.i - b.i)
+    .map((x) => x.k)
+}
+
+/**
+ * Apply persisted dial prefs to a freshly-built item list: drop hidden kinds
+ * (never `actions`), then reorder by the stored kind order (unlisted kinds keep
+ * their default relative order, after the ordered ones). Pure — the Dial reads
+ * the result; PlayCockpit owns fetching prefs from the workspace.
+ */
+export function applyDialPrefs(items: DialItem[], prefs?: CockpitPrefs): DialItem[] {
+  if (!prefs) return items
+  const hidden = new Set<DialKind>(prefs.hidden.filter((k) => k !== LOCKED_DIAL_KIND))
+  const visible = items.filter((it) => !hidden.has(it.kind))
+  if (prefs.order.length === 0) return visible
+  const rank = (k: DialKind): number => {
+    const i = prefs.order.indexOf(k)
+    return i === -1 ? prefs.order.length : i
+  }
+  // Decorate-sort-undecorate keeps the sort stable across engines: equal ranks
+  // (e.g. two unlisted kinds) preserve their original relative order.
+  return visible
+    .map((it, i) => ({ it, i }))
+    .sort((a, b) => rank(a.it.kind) - rank(b.it.kind) || a.i - b.i)
+    .map((x) => x.it)
 }

--- a/apps/in-the-union-now/src/components/play/play.css
+++ b/apps/in-the-union-now/src/components/play/play.css
@@ -650,6 +650,7 @@
 
 /* ---- Rotary Dial ---- */
 .pc-wheel-col {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -821,4 +822,175 @@
   font-family: 'Barlow', sans-serif;
   font-size: 13px;
   line-height: 1.5;
+}
+
+/* --------------------------------------------------------------------------
+ * Phase 7 — dial config (⚙), cargo-hold overlay, table picker.
+ * ------------------------------------------------------------------------ */
+
+/* The ⚙ gear sits alongside ▲▼ but is intrinsically sized, not stretched. */
+.pc-wheel-btn.pc-wheel-cfg {
+  flex: 0 0 auto;
+  width: 30px;
+}
+
+/* Dial-config overlay — covers the dial column like the resolve overlay. */
+.pc-dialcfg {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 12px 10px;
+  background: color-mix(in oklab, var(--pc-ground) 92%, #000);
+  border: 1.5px solid var(--pc-line-hard);
+  border-radius: 5px;
+  z-index: 3;
+}
+.pc-dialcfg-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.pc-dialcfg-title {
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 11px;
+  color: var(--pc-muted);
+}
+.pc-dialcfg-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow-y: auto;
+}
+.pc-dialcfg-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 8px;
+  border: 1.5px solid var(--pc-line);
+  border-radius: 4px;
+  background: color-mix(in oklab, var(--pc-panel) 70%, #000);
+}
+.pc-dialcfg-show {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  min-width: 0;
+}
+.pc-dialcfg-lab {
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  font-size: 12px;
+  color: var(--pc-text);
+}
+.pc-dialcfg-lab.hidden {
+  color: var(--pc-muted);
+  text-decoration: line-through;
+}
+.pc-dialcfg-move {
+  display: flex;
+  gap: 4px;
+  flex: 0 0 auto;
+}
+.pc-dialcfg-move .pc-wheel-btn {
+  width: 30px;
+  flex: 0 0 auto;
+}
+
+/* Cargo-hold overlay body (inside the mech-band resolve overlay). */
+.pc-cargo {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  min-height: 0;
+}
+.pc-cargo-usage {
+  margin: 0;
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 11px;
+  color: var(--pc-muted);
+  text-align: center;
+}
+.pc-cargo-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow-y: auto;
+}
+.pc-cargo-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 8px;
+  border: 1.5px solid var(--pc-line);
+  border-radius: 4px;
+  background: color-mix(in oklab, var(--pc-panel) 70%, #000);
+}
+.pc-cargo-name {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  font-family: 'Barlow', sans-serif;
+  font-size: 13px;
+  color: var(--pc-text);
+}
+.pc-cargo-code {
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--pc-muted);
+}
+.pc-cargo-units {
+  font-size: 11px;
+  color: var(--pc-muted);
+}
+.pc-cargo-row .pc-btn {
+  width: auto;
+  flex: 0 0 auto;
+  padding: 5px 10px;
+}
+
+/* Roll-table picker above the RollTable in the light display. */
+.pc-table-picker {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.pc-table-picker-lab {
+  font-family: 'Barlow Semi Condensed', 'Barlow', sans-serif;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 11px;
+}
+.pc-table-picker-sel {
+  flex: 1;
+  min-width: 0;
+  padding: 5px 8px;
+  border-radius: 4px;
+  font-family: 'Barlow', sans-serif;
+  font-size: 13px;
 }

--- a/apps/in-the-union-now/src/lib/schemas/cockpitPrefs.ts
+++ b/apps/in-the-union-now/src/lib/schemas/cockpitPrefs.ts
@@ -1,0 +1,32 @@
+import { z } from 'salvageunion-reference/zod'
+
+/**
+ * CockpitPrefs — persisted Play Cockpit ("Pit HUD") dial preferences
+ * (docs/architecture/play-cockpit.md §9.7).
+ *
+ * These are PERSISTED (unlike the ephemeral mount/wheel state in
+ * playStateStore): which dial items the player has hidden and the order they
+ * ride the rotary Dial. They are stored on the owning Workspace record
+ * (local-first, IndexedDB — no backend), so a table's cockpit remembers its
+ * dial layout across sessions.
+ *
+ * Prefs key the STABLE dial "kind" (actions / mech / pilot / crawler / tables /
+ * srd), never a per-instance dial key like `mech:<uuid>` — the entity ids vary
+ * per cockpit, but the kinds are stable, so the same prefs apply regardless of
+ * which mech/pilot/crawler is loaded. `actions` is always visible (locked in the
+ * UI); it is never added to `hidden`, and the apply step ignores it if it were.
+ */
+
+export const DialKindSchema = z.enum(['actions', 'mech', 'pilot', 'crawler', 'tables', 'srd'])
+export type DialKind = z.infer<typeof DialKindSchema>
+
+export const CockpitPrefsSchema = z
+  .object({
+    /** Dial kinds the player has hidden. `actions` is never hidden. */
+    hidden: z.array(DialKindSchema).default([]),
+    /** Dial kinds in the player's chosen order; unlisted kinds keep default order. */
+    order: z.array(DialKindSchema).default([]),
+  })
+  .strict()
+
+export type CockpitPrefs = z.infer<typeof CockpitPrefsSchema>

--- a/apps/in-the-union-now/src/lib/schemas/workspace.ts
+++ b/apps/in-the-union-now/src/lib/schemas/workspace.ts
@@ -1,8 +1,15 @@
 import { z } from 'salvageunion-reference/zod'
 
+import { CockpitPrefsSchema } from './cockpitPrefs'
+
 /**
  * A Workspace groups related entities (pilots, mechs, crawlers) for a
  * single campaign or play session. It has no game-data references of its own.
+ *
+ * `cockpitPrefs` is a purely additive-optional field (Play Cockpit Phase 7):
+ * persisted dial show/hide + order prefs for this table's cockpit. Optional
+ * fields need NO migration — strict Zod parsing tolerates the missing key on
+ * records written before it existed (see src/lib/db/migrations/README.md).
  */
 export const WorkspaceSchema = z
   .object({
@@ -10,6 +17,8 @@ export const WorkspaceSchema = z
     schemaVersion: z.literal(1),
     name: z.string(),
     createdAt: z.string().datetime(),
+    /** Play Cockpit dial preferences (show/hide + order). Absent on older records. */
+    cockpitPrefs: CockpitPrefsSchema.optional(),
   })
   .strict()
 

--- a/apps/in-the-union-now/src/stores/__tests__/workspaceCockpitPrefs.test.ts
+++ b/apps/in-the-union-now/src/stores/__tests__/workspaceCockpitPrefs.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Persistence test for Play Cockpit Phase 7 dial prefs.
+ *
+ * cockpitPrefs is a purely additive-optional field on the Workspace record, so
+ * it needs no migration. This proves it round-trips through IndexedDB: a write
+ * survives a store reset + rehydrate (i.e. a page reload), and older records
+ * without the field still load.
+ *
+ * fake-indexeddb/auto is preloaded via bunfig.toml.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { _clearAllStores, _resetDbSingleton } from '../../lib/db/index'
+import type { CockpitPrefs } from '../../lib/schemas/cockpitPrefs'
+import { useWorkspaceStore } from '../workspaceStore'
+
+function resetStore(): void {
+  useWorkspaceStore.setState({ workspaces: [], hydrated: false })
+}
+
+beforeEach(async () => {
+  _resetDbSingleton()
+  await _clearAllStores()
+  resetStore()
+})
+
+afterEach(async () => {
+  await _clearAllStores()
+  resetStore()
+})
+
+const prefs: CockpitPrefs = { hidden: ['pilot', 'srd'], order: ['tables', 'actions'] }
+
+describe('workspace cockpitPrefs persistence', () => {
+  test('cockpitPrefs written to a workspace survives a reload (reset + rehydrate)', async () => {
+    const ws = await useWorkspaceStore.getState().create({ name: 'Table' })
+    await useWorkspaceStore.getState().update(ws.id, { cockpitPrefs: prefs })
+
+    // Simulate a page reload: drop in-memory state, then hydrate from IndexedDB.
+    resetStore()
+    await useWorkspaceStore.getState().rehydrate()
+
+    const reloaded = useWorkspaceStore.getState().get(ws.id)
+    expect(reloaded?.cockpitPrefs).toEqual(prefs)
+  })
+
+  test('a workspace without cockpitPrefs still loads (older record)', async () => {
+    const ws = await useWorkspaceStore.getState().create({ name: 'Legacy' })
+    resetStore()
+    await useWorkspaceStore.getState().rehydrate()
+
+    const reloaded = useWorkspaceStore.getState().get(ws.id)
+    expect(reloaded).not.toBeNull()
+    expect(reloaded?.cockpitPrefs).toBeUndefined()
+  })
+
+  test('cockpitPrefs can be cleared back to undefined', async () => {
+    const ws = await useWorkspaceStore.getState().create({ name: 'Table' })
+    await useWorkspaceStore.getState().update(ws.id, { cockpitPrefs: prefs })
+    await useWorkspaceStore.getState().update(ws.id, { cockpitPrefs: undefined })
+
+    resetStore()
+    await useWorkspaceStore.getState().rehydrate()
+    expect(useWorkspaceStore.getState().get(ws.id)?.cockpitPrefs).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## What
Phase 7 ([plan §9.7](https://github.com/SalvageUnion-io/SU-SRD/pull/423)). **Stacked on the Phase 6 PR.**

- **Dial ⚙ config** — show/hide + reorder dial items ("Actions" locked visible), persisted to the owning **Workspace** record via a new additive-optional `cockpitPrefs` field (no migration — strict Zod tolerates the missing key; DB_VERSION unchanged), read reactively via `useWorkspace()`.
- **Cargo-hold storage overlay** — the mech Storage button lists `cargoLots` with a player-confirmed Jettison (`store.update('mech', {cargoLots})`, reusing `totalLotUnits` + `mechMaxCargo`).
- **Table picker** — the Tables display focus gets a dropdown over all `RollTables`.

## Verify
typecheck ✓ · 117 play/store tests + full ITUN suite (1195) green · lint ✓ · pre-push guards ✓

## Notes
Prefs key stable dial KINDS (mech-agnostic), shared across a workspace's mechs — a deliberate simplification. A mech with no `workspaceId` falls back to session-only prefs. Jettison is a direct `cargoLots` filter (not a mech↔crawler transfer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNeL9Bxgw2HRKJpSimK1Wm