### PR TITLE
feat(itun): Play Cockpit Phase 8 — launch chooser

### DIFF
--- a/apps/in-the-union-now/src/components/dashboard/Dashboard.tsx
+++ b/apps/in-the-union-now/src/components/dashboard/Dashboard.tsx
@@ -39,6 +39,7 @@ import { STARTER_WORKSPACE_ID } from '../../lib/starterSet/starterSet'
 import { useEntityStore } from '../../stores/entityStore'
 import { ExportAllButton } from '../export/ExportAllButton'
 import { ImportButton } from '../export/ImportButton'
+import { CockpitChooser } from '../play/CockpitChooser'
 import { AppLink } from '../shared/AppLink'
 import { WorkspaceSwitcher } from '../workspace/WorkspaceSwitcher'
 import { DashboardSkeleton } from './DashboardSkeleton'
@@ -221,6 +222,9 @@ export function Dashboard() {
           <div className="flex flex-wrap items-start gap-2.5">
             <ExportAllButton />
             <ImportButton />
+            {/* Launch the Play Cockpit for a chosen pilot/mech/crawler crew
+                (design-spec §8). Shown once at least one mech exists to run. */}
+            {allMechs.length > 0 && <CockpitChooser />}
           </div>
           <WorkspaceSwitcher
             activeWorkspaceId={activeWorkspaceId}

--- a/apps/in-the-union-now/src/components/play/CockpitChooser.tsx
+++ b/apps/in-the-union-now/src/components/play/CockpitChooser.tsx
@@ -1,0 +1,314 @@
+/**
+ * CockpitChooser — the launch chooser wizard for the Play Cockpit (plan §8, §9.8).
+ *
+ * A small three-step wizard (pilot → mech → crawler) rendered in a ModalShell.
+ * On confirm it ensures the SoftLinks the cockpit composition needs exist —
+ * `mech-to-pilot` (chosen mech → chosen pilot) and, when a crawler is picked,
+ * `pilot-to-crawler` (chosen pilot → chosen crawler) — then launches
+ * `/play/$id` for the chosen mech.
+ *
+ * SoftLink writes go through the Zustand entityStore (write-through to
+ * IndexedDB), reusing the same `softLink` create/delete the wiring components
+ * (`useSoftLinks` / AssignPilotToMech) use. Creating/repairing links is
+ * reversible bookkeeping and auto-applies (ADR-007); nothing destructive to a
+ * pilot/mech/crawler record happens here.
+ *
+ * Deferred (noted in plan §8, §10.5 "Stand-in mech / default crawler
+ * persistence"): instantiating an ephemeral stand-in mech from a `mechPattern`,
+ * and building a default base crawler from a chosen Tech Level. The chooser
+ * lists only already-saved entities; the crawler step is optional (launch a
+ * mech + pilot without a crawler).
+ *
+ * `store` / `onLaunch` are injectable for tests (dep-injection, no router or
+ * global Zustand mock needed). In production both fall back to the real store
+ * and the TanStack router.
+ */
+
+import { useState } from 'react'
+import { useRouter } from '@tanstack/react-router'
+import { SalvageUnionReference } from 'salvageunion-reference'
+import { Btn, ModalShell } from 'suref-react'
+
+import { useCrawlers, useMechs, usePilots, useSoftLinkList } from '../../hooks/queries'
+import type { Crawler } from '../../lib/schemas/crawler'
+import type { Mech } from '../../lib/schemas/mech'
+import type { Pilot } from '../../lib/schemas/pilot'
+import type { SoftLink } from '../../lib/schemas/softLink'
+import { useEntityStore } from '../../stores/entityStore'
+import { cn } from '../../lib/utils'
+import type { LinkWriteStore } from './cockpitLinks'
+import { ensureCockpitLinks } from './cockpitLinks'
+
+type CockpitChooserProps = {
+  /** Inject to avoid the Zustand global in tests. */
+  store?: LinkWriteStore
+  /** Inject to avoid the router in tests; receives the chosen mech id. */
+  onLaunch?: (mechId: string) => void
+  className?: string
+}
+
+type Step = 'pilot' | 'mech' | 'crawler'
+const STEP_ORDER: readonly Step[] = ['pilot', 'mech', 'crawler']
+
+/** Chassis "TL n" annotation for a mech row, best-effort. */
+function chassisMeta(chassisRef: string): string | undefined {
+  try {
+    const all = SalvageUnionReference.Chassis.all() as ReadonlyArray<{
+      name: string
+      techLevel?: number
+    }>
+    const c = all.find((x) => x.name === chassisRef)
+    if (!c) return chassisRef || undefined
+    return c.techLevel != null ? `${c.name} · TL ${c.techLevel}` : c.name
+  } catch {
+    return chassisRef || undefined
+  }
+}
+
+export function CockpitChooser({ store, onLaunch, className }: CockpitChooserProps) {
+  const [open, setOpen] = useState(false)
+  const [step, setStep] = useState<Step>('pilot')
+  const [pilotId, setPilotId] = useState('')
+  const [mechId, setMechId] = useState('')
+  const [crawlerId, setCrawlerId] = useState('')
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const pilots: Pilot[] = usePilots()
+  const mechs: Mech[] = useMechs()
+  const crawlers: Crawler[] = useCrawlers()
+  const links: SoftLink[] = useSoftLinkList()
+  // useRouter can be probed without a mounted router (warn:false) so tests that
+  // omit onLaunch don't throw; production always has the router.
+  const router = useRouter({ warn: false })
+
+  function openDialog() {
+    setStep('pilot')
+    setPilotId('')
+    setMechId('')
+    setCrawlerId('')
+    setError(null)
+    setOpen(true)
+  }
+
+  function closeDialog() {
+    setOpen(false)
+    setError(null)
+  }
+
+  const stepIndex = STEP_ORDER.indexOf(step)
+
+  function goBack() {
+    setError(null)
+    const prev = STEP_ORDER[stepIndex - 1]
+    if (prev) setStep(prev)
+  }
+
+  function goNext() {
+    if (step === 'pilot' && !pilotId) {
+      setError('Select a pilot to continue.')
+      return
+    }
+    if (step === 'mech' && !mechId) {
+      setError('Select a mech to continue.')
+      return
+    }
+    setError(null)
+    const next = STEP_ORDER[stepIndex + 1]
+    if (next) setStep(next)
+  }
+
+  async function handleLaunch() {
+    if (!pilotId || !mechId) {
+      setError('Pick a pilot and a mech before launching.')
+      return
+    }
+    setPending(true)
+    setError(null)
+    try {
+      const writeStore: LinkWriteStore = store ?? useEntityStore.getState()
+      await ensureCockpitLinks({
+        store: writeStore,
+        links,
+        pilotId,
+        mechId,
+        crawlerId: crawlerId || undefined,
+      })
+      setOpen(false)
+      if (onLaunch) {
+        onLaunch(mechId)
+      } else if (router) {
+        void router.navigate({ to: '/play/$id', params: { id: mechId } })
+      } else {
+        window.location.assign(`/play/${mechId}`)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to launch the cockpit.')
+    } finally {
+      setPending(false)
+    }
+  }
+
+  const stepTitle =
+    step === 'pilot' ? 'Choose a pilot' : step === 'mech' ? 'Choose a mech' : 'Choose a crawler'
+
+  return (
+    <>
+      <Btn
+        size="sm"
+        onClick={openDialog}
+        className={cn(className)}
+        aria-label="Launch the Play Cockpit"
+      >
+        Launch Cockpit
+      </Btn>
+
+      <ModalShell
+        open={open}
+        onOpenChange={(next) => {
+          if (!next) closeDialog()
+        }}
+        title="Launch Cockpit"
+        subtitle={`Step ${stepIndex + 1} of 3 · ${stepTitle}`}
+        headerBg="bg-su-orange"
+        maxWidth="max-w-md"
+        align="center"
+      >
+        <div className="flex flex-col gap-4 bg-paper p-5">
+          {step === 'pilot' && (
+            <ChooserList
+              name="cockpit-pilot"
+              emptyMessage="No pilots yet. Create a pilot first."
+              selectedId={pilotId}
+              onSelect={setPilotId}
+              options={pilots.map((p) => ({
+                id: p.id,
+                label: p.name,
+                sublabel: p.callsign ? `“${p.callsign}”` : undefined,
+              }))}
+            />
+          )}
+
+          {step === 'mech' && (
+            <ChooserList
+              name="cockpit-mech"
+              emptyMessage="No mechs yet. Create a mech first."
+              selectedId={mechId}
+              onSelect={setMechId}
+              options={mechs.map((m) => ({
+                id: m.id,
+                label: m.name,
+                sublabel: chassisMeta(m.chassisRef),
+              }))}
+            />
+          )}
+
+          {step === 'crawler' && (
+            <>
+              <p className="font-body text-xs text-wk-muted">
+                Optional — launch on foot / in the mech without a crawler, or anchor to one.
+              </p>
+              <ChooserList
+                name="cockpit-crawler"
+                emptyMessage="No crawlers yet — you can still launch without one."
+                selectedId={crawlerId}
+                onSelect={setCrawlerId}
+                includeNone
+                options={crawlers.map((c) => ({
+                  id: c.id,
+                  label: c.name,
+                  sublabel: c.techLevel ? `TL ${c.techLevel.replace(/[^0-9]/g, '')}` : undefined,
+                }))}
+              />
+            </>
+          )}
+
+          {error && (
+            <p className="font-body text-sm text-danger" role="alert">
+              {error}
+            </p>
+          )}
+
+          <div className="flex justify-between gap-2">
+            <Btn
+              variant="ghost"
+              size="sm"
+              onClick={stepIndex === 0 ? closeDialog : goBack}
+              disabled={pending}
+            >
+              {stepIndex === 0 ? 'Cancel' : 'Back'}
+            </Btn>
+            {step === 'crawler' ? (
+              <Btn
+                variant="primary"
+                size="sm"
+                onClick={() => void handleLaunch()}
+                disabled={pending}
+                aria-label="Launch the cockpit for the chosen crew"
+              >
+                {pending ? 'Launching…' : 'Launch'}
+              </Btn>
+            ) : (
+              <Btn variant="primary" size="sm" onClick={goNext} disabled={pending}>
+                Next
+              </Btn>
+            )}
+          </div>
+        </div>
+      </ModalShell>
+    </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Radio list (shares the SelectorDialog visual grammar; inlined so the wizard
+// keeps one modal across steps rather than stacking three dialogs).
+// ---------------------------------------------------------------------------
+
+type ChooserOption = { id: string; label: string; sublabel?: string }
+
+function ChooserList({
+  name,
+  options,
+  emptyMessage,
+  selectedId,
+  onSelect,
+  includeNone = false,
+}: {
+  name: string
+  options: ChooserOption[]
+  emptyMessage: string
+  selectedId: string
+  onSelect: (id: string) => void
+  /** Add a leading "None" radio (crawler step). */
+  includeNone?: boolean
+}) {
+  if (options.length === 0 && !includeNone) {
+    return <p className="font-body text-sm text-wk-muted">{emptyMessage}</p>
+  }
+  const rows: ChooserOption[] = includeNone ? [{ id: '', label: 'None' }, ...options] : options
+  return (
+    <div className="space-y-2">
+      {options.length === 0 && <p className="font-body text-sm text-wk-muted">{emptyMessage}</p>}
+      {rows.map((option) => (
+        <label
+          key={option.id || '__none__'}
+          className="flex cursor-pointer items-center gap-2 rounded-[3px] border-chrome border-ink bg-paper p-2 hover:bg-wk-bg-2"
+        >
+          <input
+            type="radio"
+            name={name}
+            value={option.id}
+            checked={selectedId === option.id}
+            onChange={() => onSelect(option.id)}
+            className="accent-rust"
+          />
+          <span className="font-body text-sm font-medium text-ink">{option.label}</span>
+          {option.sublabel && (
+            <span className="font-body text-xs text-wk-muted">{option.sublabel}</span>
+          )}
+        </label>
+      ))}
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/play/__tests__/CockpitChooser.test.tsx
+++ b/apps/in-the-union-now/src/components/play/__tests__/CockpitChooser.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * CockpitChooser tests (Play Cockpit Phase 8, plan §8).
+ *
+ * fake-indexeddb/auto is preloaded via bunfig.toml; the real entityStore is
+ * exercised so link-writes go through the true write-through path. The ORM is
+ * preloaded in beforeAll because the mech step resolves chassis metadata.
+ *
+ * Uses .toBeTruthy() (no jest-dom type augmentation) per the ITUN convention.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import { _clearAllStores, _resetDbSingleton } from '../../../lib/db/index'
+import { useEntityStore } from '../../../stores/entityStore'
+import { CockpitChooser } from '../CockpitChooser'
+import { ensureCockpitLinks } from '../cockpitLinks'
+
+const basePilotInput = {
+  schemaVersion: 1 as const,
+  name: 'Yara Voss',
+  callsign: 'Ghost',
+  classRef: 'scavenger',
+  abilities: [],
+  equipment: [],
+  motto: '',
+  keepsake: '',
+  appearance: '',
+  background: '',
+  conditions: [],
+}
+
+const baseMechInput = {
+  schemaVersion: 1 as const,
+  name: 'Iron Jaw',
+  chassisRef: 'titan',
+  systems: [],
+  modules: [],
+  cargoLots: [],
+  conditions: [],
+}
+
+const baseCrawlerInput = {
+  schemaVersion: 1 as const,
+  name: 'Tenacity',
+  techLevel: '3',
+  systems: [],
+}
+
+function resetEntityStore(): void {
+  useEntityStore.setState({
+    pilots: [],
+    mechs: [],
+    crawlers: [],
+    softLinks: [],
+    hydrated: { pilots: false, mechs: false, crawlers: false, softLinks: false },
+  })
+}
+
+async function settle(done: () => boolean): Promise<void> {
+  for (let i = 0; i < 200 && !done(); i++) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5))
+    })
+  }
+}
+
+/** Seed one crew (pilot + mech + crawler) into the hydrated store. */
+async function seedCrew() {
+  const store = useEntityStore.getState()
+  await Promise.all([
+    store.hydrate('pilot'),
+    store.hydrate('mech'),
+    store.hydrate('crawler'),
+    store.hydrate('softLink'),
+  ])
+  const pilot = await store.create('pilot', basePilotInput)
+  const mech = await store.create('mech', baseMechInput)
+  const crawler = await store.create('crawler', baseCrawlerInput)
+  return { pilot, mech, crawler }
+}
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+beforeEach(async () => {
+  _resetDbSingleton()
+  await _clearAllStores()
+  resetEntityStore()
+})
+
+afterEach(async () => {
+  await _clearAllStores()
+  act(() => {
+    resetEntityStore()
+  })
+})
+
+describe('ensureCockpitLinks', () => {
+  test('creates the mech-to-pilot and pilot-to-crawler links', async () => {
+    const { pilot, mech, crawler } = await seedCrew()
+    const store = useEntityStore.getState()
+
+    await ensureCockpitLinks({
+      store,
+      links: store.softLinks,
+      pilotId: pilot.id,
+      mechId: mech.id,
+      crawlerId: crawler.id,
+    })
+
+    const links = useEntityStore.getState().softLinks
+    const mechLink = links.find((l) => l.type === 'mech-to-pilot')
+    const crawlerLink = links.find((l) => l.type === 'pilot-to-crawler')
+    expect(mechLink?.from.id).toBe(mech.id)
+    expect(mechLink?.to.id).toBe(pilot.id)
+    expect(crawlerLink?.from.id).toBe(pilot.id)
+    expect(crawlerLink?.to.id).toBe(crawler.id)
+  })
+
+  test('does not create a crawler link when no crawler is chosen', async () => {
+    const { pilot, mech } = await seedCrew()
+    const store = useEntityStore.getState()
+
+    await ensureCockpitLinks({ store, links: store.softLinks, pilotId: pilot.id, mechId: mech.id })
+
+    const links = useEntityStore.getState().softLinks
+    expect(links.filter((l) => l.type === 'mech-to-pilot').length).toBe(1)
+    expect(links.filter((l) => l.type === 'pilot-to-crawler').length).toBe(0)
+  })
+
+  test('repairs a conflicting mech-to-pilot link rather than duplicating', async () => {
+    const { pilot, mech } = await seedCrew()
+    const store = useEntityStore.getState()
+    // Pre-existing link from the same mech pointing at a stale pilot.
+    await store.create('softLink', {
+      from: { type: 'mech', id: mech.id },
+      to: { type: 'pilot', id: 'stale-pilot' },
+      type: 'mech-to-pilot',
+    })
+
+    await ensureCockpitLinks({
+      store,
+      links: useEntityStore.getState().softLinks,
+      pilotId: pilot.id,
+      mechId: mech.id,
+    })
+
+    const mechLinks = useEntityStore
+      .getState()
+      .softLinks.filter((l) => l.type === 'mech-to-pilot' && l.from.id === mech.id)
+    expect(mechLinks.length).toBe(1)
+    expect(mechLinks[0]?.to.id).toBe(pilot.id)
+  })
+})
+
+describe('CockpitChooser — wizard', () => {
+  test('lists pilots then mechs across the wizard steps', async () => {
+    await seedCrew()
+    resetEntityStore()
+
+    await act(async () => {
+      render(<CockpitChooser />)
+    })
+
+    // Open the chooser.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Launch the Play Cockpit' }))
+    })
+    await settle(() => screen.queryByRole('radio', { name: /Yara Voss/ }) !== null)
+    expect(screen.getByRole('radio', { name: /Yara Voss/ })).toBeTruthy()
+
+    // Pick the pilot, advance to the mech step.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('radio', { name: /Yara Voss/ }))
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    })
+    expect(screen.getByRole('radio', { name: /Iron Jaw/ })).toBeTruthy()
+  })
+
+  test('launching calls onLaunch with the chosen mech and links the crew', async () => {
+    const { pilot, mech, crawler } = await seedCrew()
+    resetEntityStore()
+
+    const result: { id: string | null } = { id: null }
+    await act(async () => {
+      render(
+        <CockpitChooser
+          onLaunch={(id) => {
+            result.id = id
+          }}
+        />
+      )
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Launch the Play Cockpit' }))
+    })
+    await settle(() => screen.queryByRole('radio', { name: /Yara Voss/ }) !== null)
+
+    // Pilot → Next
+    await act(async () => {
+      fireEvent.click(screen.getByRole('radio', { name: /Yara Voss/ }))
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    })
+    // Mech → Next
+    await act(async () => {
+      fireEvent.click(screen.getByRole('radio', { name: /Iron Jaw/ }))
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    })
+    // Crawler → Launch
+    await act(async () => {
+      fireEvent.click(screen.getByRole('radio', { name: /Tenacity/ }))
+    })
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Launch the cockpit for the chosen crew' })
+      )
+    })
+    await settle(() => result.id !== null)
+
+    expect(result.id).toBe(mech.id)
+    const links = useEntityStore.getState().softLinks
+    expect(
+      links.some((l) => l.type === 'mech-to-pilot' && l.from.id === mech.id && l.to.id === pilot.id)
+    ).toBe(true)
+    expect(
+      links.some(
+        (l) => l.type === 'pilot-to-crawler' && l.from.id === pilot.id && l.to.id === crawler.id
+      )
+    ).toBe(true)
+  })
+})

--- a/apps/in-the-union-now/src/components/play/cockpitLinks.ts
+++ b/apps/in-the-union-now/src/components/play/cockpitLinks.ts
@@ -1,0 +1,62 @@
+/**
+ * cockpitLinks — SoftLink helpers for the Play Cockpit launch chooser (plan §8).
+ *
+ * Split out of CockpitChooser.tsx so the component module exports only a
+ * component (Biome's useComponentExportOnlyModules / Fast Refresh rule).
+ */
+
+import type { SoftLink } from '../../lib/schemas/softLink'
+
+/** Minimal SoftLink write surface — injectable for tests. */
+export type LinkWriteStore = {
+  create: (type: 'softLink', input: Omit<SoftLink, 'id' | 'createdAt'>) => Promise<SoftLink>
+  delete: (type: 'softLink', id: string) => Promise<void>
+}
+
+/**
+ * Ensure the SoftLinks the mech-kind composition reads exist, repairing any
+ * conflicting outgoing link on the same source first (mech-to-pilot from the
+ * chosen mech; pilot-to-crawler from the chosen pilot when a crawler is given).
+ *
+ * Reversible bookkeeping — safe to auto-apply (ADR-007). Writes go through the
+ * same `softLink` create/delete the wiring components (useSoftLinks) use.
+ */
+export async function ensureCockpitLinks(args: {
+  store: LinkWriteStore
+  links: SoftLink[]
+  pilotId: string
+  mechId: string
+  crawlerId?: string
+}): Promise<void> {
+  const { store, links, pilotId, mechId, crawlerId } = args
+
+  // mech-to-pilot: exactly one outgoing link from the chosen mech → pilot.
+  const mechLinks = links.filter((l) => l.type === 'mech-to-pilot' && l.from.id === mechId)
+  const keptMech = mechLinks.find((l) => l.to.id === pilotId)
+  for (const l of mechLinks) {
+    if (l.id !== keptMech?.id) await store.delete('softLink', l.id)
+  }
+  if (!keptMech) {
+    await store.create('softLink', {
+      from: { type: 'mech', id: mechId },
+      to: { type: 'pilot', id: pilotId },
+      type: 'mech-to-pilot',
+    })
+  }
+
+  if (!crawlerId) return
+
+  // pilot-to-crawler: exactly one outgoing link from the chosen pilot → crawler.
+  const crawlerLinks = links.filter((l) => l.type === 'pilot-to-crawler' && l.from.id === pilotId)
+  const keptCrawler = crawlerLinks.find((l) => l.to.id === crawlerId)
+  for (const l of crawlerLinks) {
+    if (l.id !== keptCrawler?.id) await store.delete('softLink', l.id)
+  }
+  if (!keptCrawler) {
+    await store.create('softLink', {
+      from: { type: 'pilot', id: pilotId },
+      to: { type: 'crawler', id: crawlerId },
+      type: 'pilot-to-crawler',
+    })
+  }
+}


### PR DESCRIPTION
## What
Phase 8 ([plan §8, §9.8](https://github.com/SalvageUnion-io/SU-SRD/pull/423)). **Stacked on the Phase 7 PR.** The launch flow.

- **`CockpitChooser`** — a three-step `ModalShell` wizard (pilot → mech → optional crawler), surfaced by a **"Launch Cockpit"** button on the Dashboard header (shown once a mech exists).
- On confirm, **`ensureCockpitLinks`** creates the SoftLinks `resolveSheetComposition` reads (mech→pilot, pilot→crawler) via the same `entityStore` softLink create the wiring components use (reversible bookkeeping, ADR-007), then navigates to `/play/$id`.

## Verify
typecheck ✓ · 122 play/store + 17 dashboard tests + full ITUN suite green · lint ✓ · pre-push guards ✓

## Notes
Deferred per plan §8/§10.5 (flagged in code): instantiating an ephemeral stand-in mech from a pattern, and a default base crawler from a Tech Level. The chooser lists only saved entities; the crawler step is optional; only SoftLinks are written on launch (no silent entity creation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNeL9Bxgw2HRKJpSimK1Wm