### PR TITLE
feat(itun): Play Cockpit Phase 9 — follow-ups (meltdown gate, vent, launch stand-ins)

### DIFF
--- a/apps/in-the-union-now/src/components/play/ActiveItemBand.tsx
+++ b/apps/in-the-union-now/src/components/play/ActiveItemBand.tsx
@@ -185,7 +185,7 @@ function DamageStepper({ amount, setAmount }: { amount: number; setAmount: (n: n
 // ---------------------------------------------------------------------------
 
 type MechPrompt =
-  | { kind: 'reactor'; log: string }
+  | { kind: 'reactor'; log: string; meltdown?: boolean }
   | { kind: 'dmg' }
   | { kind: 'crit'; effect: CriticalDamageEffect | null; log: string }
   | { kind: 'eject' }
@@ -275,32 +275,35 @@ function MechBand({
     const m = fresh()
     const cap = mechMaxHeat(m, chassis)
     const spMax = mechMaxSP(m, chassis)
-    const { patch, effect, nextHeat } = pushPatch({
+    const { patch, effect, nextHeat, meltdown } = pushPatch({
       heat: Math.min(m.currentHeat ?? cap, cap),
       heatCap: cap,
       currentSP: Math.min(m.currentSP ?? spMax, spMax),
       roll: defaultRoll,
     })
     void store.update('mech', mech.id, patch)
-    setPrompt({ kind: 'reactor', log: describePushOutcome(nextHeat, effect) })
+    setPrompt({ kind: 'reactor', log: describePushOutcome(nextHeat, effect), meltdown })
   }
 
   function doHeatCheck() {
     const m = fresh()
     const cap = mechMaxHeat(m, chassis)
     const spMax = mechMaxSP(m, chassis)
-    const { patch, effect } = heatCheckOncePatch({
+    const { patch, effect, meltdown } = heatCheckOncePatch({
       heat: Math.min(m.currentHeat ?? cap, cap),
       currentSP: Math.min(m.currentSP ?? spMax, spMax),
       roll: defaultRoll,
     })
     void store.update('mech', mech.id, patch)
-    setPrompt({ kind: 'reactor', log: describeHeatCheck(effect) })
+    setPrompt({ kind: 'reactor', log: describeHeatCheck(effect), meltdown })
   }
 
   function doVent() {
     void store.update('mech', mech.id, VENT_PATCH)
-    setPrompt({ kind: 'reactor', log: 'Vented — Heat 0, reactor shut down, Vulnerable.' })
+    setPrompt({
+      kind: 'reactor',
+      log: 'Vented — Heat 0, Vulnerable. (Shut down separately if needed.)',
+    })
   }
 
   function doShutdown() {
@@ -451,6 +454,13 @@ function MechBand({
       {prompt?.kind === 'reactor' && (
         <ResolveOverlay title="Reactor" onClose={() => setPrompt(null)}>
           <p className="pc-resolve-log">{prompt.log}</p>
+          {prompt.meltdown && (
+            <div className="pc-resolve-actions">
+              <button type="button" className="pc-btn pc-btn-danger" onClick={confirmDestroyed}>
+                Confirm Meltdown — Mark Mech Destroyed
+              </button>
+            </div>
+          )}
         </ResolveOverlay>
       )}
       {prompt?.kind === 'dmg' && (

--- a/apps/in-the-union-now/src/components/play/CockpitChooser.tsx
+++ b/apps/in-the-union-now/src/components/play/CockpitChooser.tsx
@@ -32,17 +32,29 @@ import { Btn, ModalShell } from 'suref-react'
 import { useCrawlers, useMechs, usePilots, useSoftLinkList } from '../../hooks/queries'
 import type { Crawler } from '../../lib/schemas/crawler'
 import type { Mech } from '../../lib/schemas/mech'
+import type { MechPattern } from '../../lib/schemas/pattern'
 import type { Pilot } from '../../lib/schemas/pilot'
 import type { SoftLink } from '../../lib/schemas/softLink'
 import { useEntityStore } from '../../stores/entityStore'
+import { usePatternStore } from '../../stores/patternStore'
 import { cn } from '../../lib/utils'
 import type { LinkWriteStore } from './cockpitLinks'
 import { ensureCockpitLinks } from './cockpitLinks'
+import {
+  createBaseCrawler,
+  DEFAULT_CRAWLER_TLS,
+  instantiateMechFromPattern,
+  parseSelToken,
+  patternToken,
+  tlCrawlerToken,
+  type LaunchStore,
+} from './cockpitLaunch'
 
 type CockpitChooserProps = {
-  /** Inject to avoid the Zustand global in tests. */
-  store?: LinkWriteStore
-  /** Inject to avoid the router in tests; receives the chosen mech id. */
+  /** Inject to avoid the Zustand global in tests. Needs SoftLink writes (links)
+   *  plus mech/crawler create (stand-in mech / default crawler). */
+  store?: LinkWriteStore & LaunchStore
+  /** Inject to avoid the router in tests; receives the (possibly new) mech id. */
   onLaunch?: (mechId: string) => void
   className?: string
 }
@@ -78,6 +90,9 @@ export function CockpitChooser({ store, onLaunch, className }: CockpitChooserPro
   const mechs: Mech[] = useMechs()
   const crawlers: Crawler[] = useCrawlers()
   const links: SoftLink[] = useSoftLinkList()
+  // Saved patterns → stand-in mechs (list() lazily hydrates, mirroring PatternList).
+  const patterns: MechPattern[] = usePatternStore((s) => s.mechPatterns)
+  usePatternStore.getState().list()
   // useRouter can be probed without a mounted router (warn:false) so tests that
   // omit onLaunch don't throw; production always has the router.
   const router = useRouter({ warn: false })
@@ -126,21 +141,46 @@ export function CockpitChooser({ store, onLaunch, className }: CockpitChooserPro
     setPending(true)
     setError(null)
     try {
-      const writeStore: LinkWriteStore = store ?? useEntityStore.getState()
+      // Cast mirrors Sheet.tsx's EntityLookup: the store's generic create/delete
+      // satisfy this narrowed surface at runtime; TS can't align the generics.
+      const writeStore: LinkWriteStore & LaunchStore =
+        store ?? (useEntityStore.getState() as unknown as LinkWriteStore & LaunchStore)
+
+      // Resolve the mech choice: a pattern token instantiates a stand-in mech
+      // first; a plain id is an existing mech.
+      const mechSel = parseSelToken(mechId)
+      let launchMechId = mechSel.value
+      if (mechSel.kind === 'pattern') {
+        const pattern = patterns.find((p) => p.id === mechSel.value)
+        if (!pattern) throw new Error('That pattern is no longer available.')
+        launchMechId = await instantiateMechFromPattern(writeStore, pattern)
+      }
+
+      // Resolve the crawler choice: a "tl:" token creates a default base crawler;
+      // a plain id is an existing crawler; empty = none.
+      const crawlerSel = crawlerId ? parseSelToken(crawlerId) : null
+      let launchCrawlerId: string | undefined
+      if (crawlerSel) {
+        launchCrawlerId =
+          crawlerSel.kind === 'tl'
+            ? await createBaseCrawler(writeStore, Number(crawlerSel.value))
+            : crawlerSel.value
+      }
+
       await ensureCockpitLinks({
         store: writeStore,
         links,
         pilotId,
-        mechId,
-        crawlerId: crawlerId || undefined,
+        mechId: launchMechId,
+        crawlerId: launchCrawlerId,
       })
       setOpen(false)
       if (onLaunch) {
-        onLaunch(mechId)
+        onLaunch(launchMechId)
       } else if (router) {
-        void router.navigate({ to: '/play/$id', params: { id: mechId } })
+        void router.navigate({ to: '/play/$id', params: { id: launchMechId } })
       } else {
-        window.location.assign(`/play/${mechId}`)
+        window.location.assign(`/play/${launchMechId}`)
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to launch the cockpit.')
@@ -192,14 +232,21 @@ export function CockpitChooser({ store, onLaunch, className }: CockpitChooserPro
           {step === 'mech' && (
             <ChooserList
               name="cockpit-mech"
-              emptyMessage="No mechs yet. Create a mech first."
+              emptyMessage="No mechs or patterns yet. Create a mech or save a pattern first."
               selectedId={mechId}
               onSelect={setMechId}
-              options={mechs.map((m) => ({
-                id: m.id,
-                label: m.name,
-                sublabel: chassisMeta(m.chassisRef),
-              }))}
+              options={[
+                ...mechs.map((m) => ({
+                  id: m.id,
+                  label: m.name,
+                  sublabel: chassisMeta(m.chassisRef),
+                })),
+                ...patterns.map((p) => ({
+                  id: patternToken(p.id),
+                  label: p.name,
+                  sublabel: `Pattern · stand-in${p.chassisRef ? ` · ${chassisMeta(p.chassisRef) ?? ''}` : ''}`,
+                })),
+              ]}
             />
           )}
 
@@ -210,15 +257,22 @@ export function CockpitChooser({ store, onLaunch, className }: CockpitChooserPro
               </p>
               <ChooserList
                 name="cockpit-crawler"
-                emptyMessage="No crawlers yet — you can still launch without one."
+                emptyMessage="No crawlers yet — pick a default base crawler or launch without one."
                 selectedId={crawlerId}
                 onSelect={setCrawlerId}
                 includeNone
-                options={crawlers.map((c) => ({
-                  id: c.id,
-                  label: c.name,
-                  sublabel: c.techLevel ? `TL ${c.techLevel.replace(/[^0-9]/g, '')}` : undefined,
-                }))}
+                options={[
+                  ...crawlers.map((c) => ({
+                    id: c.id,
+                    label: c.name,
+                    sublabel: c.techLevel ? `TL ${c.techLevel.replace(/[^0-9]/g, '')}` : undefined,
+                  })),
+                  ...DEFAULT_CRAWLER_TLS.map((tl) => ({
+                    id: tlCrawlerToken(tl),
+                    label: `Default base crawler`,
+                    sublabel: `New · TL ${tl}`,
+                  })),
+                ]}
               />
             </>
           )}

--- a/apps/in-the-union-now/src/components/play/__tests__/ActiveItemBand.rules.test.tsx
+++ b/apps/in-the-union-now/src/components/play/__tests__/ActiveItemBand.rules.test.tsx
@@ -58,12 +58,12 @@ describe('ActiveItemBand rules buttons', () => {
     usePlayStateStore.setState({ mount: 'mech', wheel: 0 })
   })
 
-  test('Vent writes Heat 0 + shutdown + Vulnerable', () => {
+  test('Vent writes Heat 0 + Vulnerable (no auto-shutdown; Vent ≠ Shutdown, plan §5.1)', () => {
     const { store, calls } = stubStore([mech])
     render(<ActiveItemBand mech={mech} pilot={null} store={store} />)
     fireEvent.click(screen.getByText('Vent'))
     expect(calls).toHaveLength(1)
-    expect(calls[0]?.patch).toEqual({ currentHeat: 0, shutdown: true, vulnerable: true })
+    expect(calls[0]?.patch).toEqual({ currentHeat: 0, vulnerable: true })
   })
 
   test('Shutdn toggles the shutdown flag', () => {

--- a/apps/in-the-union-now/src/components/play/__tests__/cockpitLaunch.test.ts
+++ b/apps/in-the-union-now/src/components/play/__tests__/cockpitLaunch.test.ts
@@ -1,0 +1,90 @@
+/**
+ * cockpitLaunch tests (Play Cockpit Phase 9 follow-ups, plan §8/§10.5).
+ *
+ * Exercises the two previously-deferred chooser create paths against the real
+ * entityStore (fake-indexeddb via bunfig): a stand-in mech from a pattern, and
+ * a default base crawler of a Tech Level. ORM preloaded for chassis/bay lookups.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import { _clearAllStores, _resetDbSingleton } from '../../../lib/db/index'
+import type { MechPattern } from '../../../lib/schemas/pattern'
+import { useEntityStore } from '../../../stores/entityStore'
+import {
+  createBaseCrawler,
+  instantiateMechFromPattern,
+  parseSelToken,
+  patternToken,
+  tlCrawlerToken,
+  type LaunchStore,
+} from '../cockpitLaunch'
+
+const pattern = {
+  id: 'pat-1',
+  schemaVersion: 1,
+  name: 'Iron Frame',
+  chassisRef: 'titan',
+  systems: ['auto-cannon'],
+  modules: [],
+  cargoLots: [],
+} as unknown as MechPattern
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+beforeEach(async () => {
+  _resetDbSingleton()
+  await _clearAllStores()
+  useEntityStore.setState({
+    pilots: [],
+    mechs: [],
+    crawlers: [],
+    softLinks: [],
+    hydrated: { pilots: false, mechs: false, crawlers: false, softLinks: false },
+  })
+  await Promise.all([
+    useEntityStore.getState().hydrate('mech'),
+    useEntityStore.getState().hydrate('crawler'),
+  ])
+})
+
+afterEach(async () => {
+  await _clearAllStores()
+})
+
+const store = () => useEntityStore.getState() as unknown as LaunchStore
+
+describe('selection tokens', () => {
+  test('encode/decode round-trip', () => {
+    expect(parseSelToken(patternToken('pat-1'))).toEqual({ kind: 'pattern', value: 'pat-1' })
+    expect(parseSelToken(tlCrawlerToken(3))).toEqual({ kind: 'tl', value: '3' })
+    expect(parseSelToken('mech-abc')).toEqual({ kind: 'id', value: 'mech-abc' })
+  })
+})
+
+describe('instantiateMechFromPattern', () => {
+  test('creates a stand-in mech seeded from the pattern', async () => {
+    const id = await instantiateMechFromPattern(store(), pattern)
+    const mech = useEntityStore.getState().get('mech', id)
+    expect(mech).toBeTruthy()
+    expect(mech?.name).toBe('Iron Frame (stand-in)')
+    expect(mech?.chassisRef).toBe('titan')
+    expect(mech?.systems).toEqual(['auto-cannon'])
+    expect(mech?.currentHeat).toBe(0)
+  })
+})
+
+describe('createBaseCrawler', () => {
+  test('creates a valid base crawler at the given Tech Level with seeded bays', async () => {
+    const id = await createBaseCrawler(store(), 3)
+    const crawler = useEntityStore.getState().get('crawler', id)
+    expect(crawler).toBeTruthy()
+    expect(crawler?.name).toBe('Base Crawler (TL 3)')
+    expect(crawler?.techLevel).toBe('3')
+    // Official sheets pre-print the base bays.
+    expect(crawler?.crawlerBays?.length ?? 0).toBeGreaterThan(0)
+  })
+})

--- a/apps/in-the-union-now/src/components/play/__tests__/playRules.test.ts
+++ b/apps/in-the-union-now/src/components/play/__tests__/playRules.test.ts
@@ -64,14 +64,31 @@ describe('reactor patches', () => {
     expect(patch.currentSP).toBe(0) // 10 − 20, clamped
   })
 
-  test('heatCheckOncePatch: no +2, persists current Heat', () => {
-    const { patch } = heatCheckOncePatch({ heat: 6, currentSP: 5, roll: seqRoll([20]) })
-    expect(patch.currentHeat).toBe(6)
-    expect(patch.shutdown).toBeUndefined()
+  test('pushPatch: Meltdown (overload roll 1) is player-confirmed, NOT auto-destroyed', () => {
+    // Heat Check d20 = 1 (overload), overload roll = 1 (meltdown).
+    const { patch, meltdown } = pushPatch({
+      heat: 18,
+      heatCap: 20,
+      currentSP: 10,
+      roll: seqRoll([1, 1]),
+    })
+    expect(meltdown).toBe(true)
+    // The destructive flag must NOT auto-apply — the cockpit gates it (ADR-007).
+    expect(patch.destroyed).toBeUndefined()
   })
 
-  test('VENT_PATCH dumps Heat to 0 and shuts down', () => {
-    expect(VENT_PATCH).toEqual({ currentHeat: 0, shutdown: true, vulnerable: true })
+  test('heatCheckOncePatch: no +2, persists current Heat; meltdown gated', () => {
+    const passed = heatCheckOncePatch({ heat: 6, currentSP: 5, roll: seqRoll([20]) })
+    expect(passed.patch.currentHeat).toBe(6)
+    expect(passed.patch.shutdown).toBeUndefined()
+    expect(passed.meltdown).toBe(false)
+    const melt = heatCheckOncePatch({ heat: 20, currentSP: 5, roll: seqRoll([1, 1]) })
+    expect(melt.meltdown).toBe(true)
+    expect(melt.patch.destroyed).toBeUndefined()
+  })
+
+  test('VENT_PATCH dumps Heat to 0 + Vulnerable, no auto-shutdown (Vent ≠ Shutdown, plan §5.1)', () => {
+    expect(VENT_PATCH).toEqual({ currentHeat: 0, vulnerable: true })
   })
 
   test('shutdownTogglePatch flips the flag', () => {

--- a/apps/in-the-union-now/src/components/play/cockpitLaunch.ts
+++ b/apps/in-the-union-now/src/components/play/cockpitLaunch.ts
@@ -1,0 +1,88 @@
+/**
+ * cockpitLaunch — the Play Cockpit launch chooser's entity-creation helpers
+ * (plan §8, §10.5). Split out of CockpitChooser.tsx to keep that module
+ * component-only (Biome Fast-Refresh rule) and to make the create paths
+ * unit-testable behind an injectable store.
+ *
+ * These realize the two deferred chooser options:
+ *   - a STAND-IN mech instantiated from a saved MechPattern (same write path as
+ *     InstantiateFromPattern — seed live stats, fresh cargo-lot ids), and
+ *   - a DEFAULT base crawler of a chosen Tech Level (minimal valid record with
+ *     the official pre-printed base bays and full derived SP).
+ *
+ * Both persist a real record via entityStore.create (reversible — the player
+ * can delete it), never a silent mutation of an existing entity, so they stay
+ * on the right side of the ADR-007 boundary.
+ */
+
+import { findChassisByRef } from '../../lib/rules/derivedStats'
+import { crawlerMaxSP } from '../../lib/rules/derivedStats'
+import type { Crawler } from '../../lib/schemas/crawler'
+import type { Mech } from '../../lib/schemas/mech'
+import type { MechPattern } from '../../lib/schemas/pattern'
+import { seedDefaultCrawlerBays } from '../../lib/wizard/crawlerFormState'
+
+/** Minimal create surface for the launch helpers — injectable for tests. */
+export type LaunchStore = {
+  create: (<T extends 'mech'>(type: T, input: MechCreateInput) => Promise<Mech>) &
+    (<T extends 'crawler'>(type: T, input: CrawlerCreateInput) => Promise<Crawler>)
+}
+
+type MechCreateInput = Omit<Mech, 'id' | 'createdAt' | 'updatedAt'>
+type CrawlerCreateInput = Omit<Crawler, 'id' | 'createdAt' | 'updatedAt'>
+
+/** The Tech Levels a default base crawler can be spun up at. */
+export const DEFAULT_CRAWLER_TLS = [1, 2, 3, 4, 5, 6] as const
+
+/** Selection-token encoders so the chooser's radio list can mix kinds. */
+export const patternToken = (id: string) => `pattern:${id}`
+export const tlCrawlerToken = (tl: number) => `tl:${tl}`
+export const parseSelToken = (token: string): { kind: 'pattern' | 'tl' | 'id'; value: string } => {
+  if (token.startsWith('pattern:')) return { kind: 'pattern', value: token.slice(8) }
+  if (token.startsWith('tl:')) return { kind: 'tl', value: token.slice(3) }
+  return { kind: 'id', value: token }
+}
+
+/**
+ * Instantiate a fresh Mech from a saved pattern — mirrors InstantiateFromPattern:
+ * copy chassis/systems/modules, fresh cargo-lot ids, seed full SP/EP + Heat 0.
+ * Returns the new mech's id.
+ */
+export async function instantiateMechFromPattern(
+  store: LaunchStore,
+  pattern: MechPattern
+): Promise<string> {
+  const chassis = findChassisByRef(pattern.chassisRef)
+  const mech = await store.create('mech', {
+    schemaVersion: 1,
+    name: `${pattern.name} (stand-in)`,
+    chassisRef: pattern.chassisRef,
+    systems: [...pattern.systems],
+    modules: [...pattern.modules],
+    cargoLots: pattern.cargoLots.map((lot) => ({ ...lot, id: crypto.randomUUID() })),
+    conditions: [],
+    currentSP: chassis?.structurePoints,
+    currentEP: chassis?.energyPoints,
+    currentHeat: 0,
+  } as MechCreateInput)
+  return mech.id
+}
+
+/**
+ * Create a default base crawler of the given Tech Level: a minimal valid record
+ * (schemaVersion, name, techLevel, no systems) seeded with the official
+ * pre-printed base bays and full derived SP. Returns the new crawler's id.
+ */
+export async function createBaseCrawler(store: LaunchStore, tl: number): Promise<string> {
+  const techLevel = String(tl)
+  const maxSP = crawlerMaxSP({ techLevel: `tech-${tl}` })
+  const crawler = await store.create('crawler', {
+    schemaVersion: 1,
+    name: `Base Crawler (TL ${tl})`,
+    techLevel,
+    systems: [],
+    crawlerBays: seedDefaultCrawlerBays(),
+    ...(typeof maxSP === 'number' ? { currentSP: maxSP } : {}),
+  } as CrawlerCreateInput)
+  return crawler.id
+}

--- a/apps/in-the-union-now/src/components/play/playRules.ts
+++ b/apps/in-the-union-now/src/components/play/playRules.ts
@@ -44,33 +44,58 @@ import type { MechItem, MechItemEconomy } from '../sheet/mechItemRules'
 // ---------------------------------------------------------------------------
 
 /**
- * Push: +2 Heat then an immediate Heat Check, assembled into one write-through
- * patch via the shared `heatCheckPatch` (the exact path `SheetMech.pushMech`
- * uses). Deterministic bookkeeping auto-applies; a destroyed System/Module
- * (`requiresPlayerChoice` bands) is left for the player to mark on the sheet.
+ * Strip the destructive `destroyed` flag out of a shared `heatCheckPatch`
+ * result. In the sheet, `heatCheckPatch` auto-sets `destroyed` on a Meltdown
+ * (overload roll = 1); the cockpit holds a STRICTER ADR-007 line — a Meltdown's
+ * mech-destruction is a player-confirmed step (like Critical Damage), never
+ * silent bookkeeping. All the non-destructive fields (Heat, shutdown,
+ * vulnerable, SP) still auto-apply; `meltdown` tells the caller to offer the
+ * confirm. The shared `heatCheckPatch` (SheetMech's path) is left untouched.
+ */
+function autoApplyPatch(patch: Partial<Mech>): { patch: Partial<Mech>; meltdown: boolean } {
+  if (!patch.destroyed) return { patch, meltdown: false }
+  const rest = { ...patch }
+  delete rest.destroyed
+  return { patch: rest, meltdown: true }
+}
+
+/**
+ * Push: +2 Heat then an immediate Heat Check. Non-destructive bookkeeping
+ * auto-applies via the shared `heatCheckPatch`; a Meltdown's `destroyed` is
+ * held back (`meltdown: true`) for the caller's player-confirm (ADR-007).
+ * Destroyed System/Module bands are likewise left for the player to mark.
  */
 export function pushPatch(args: { heat: number; heatCap: number; currentSP: number; roll: Roll }): {
   patch: Partial<Mech>
   effect: HeatCheckEffect
   nextHeat: number
+  meltdown: boolean
 } {
   const { nextHeat, effect } = performPush(args)
-  return { patch: heatCheckPatch(effect, nextHeat), effect, nextHeat }
+  const { patch, meltdown } = autoApplyPatch(heatCheckPatch(effect, nextHeat))
+  return { patch, effect, nextHeat, meltdown }
 }
 
-/** A standalone Heat Check at current Heat (no +2). */
+/** A standalone Heat Check at current Heat (no +2). Meltdown is player-confirmed. */
 export function heatCheckOncePatch(args: { heat: number; currentSP: number; roll: Roll }): {
   patch: Partial<Mech>
   effect: HeatCheckEffect
+  meltdown: boolean
 } {
   const effect = performHeatCheck(args)
-  return { patch: heatCheckPatch(effect, args.heat), effect }
+  const { patch, meltdown } = autoApplyPatch(heatCheckPatch(effect, args.heat))
+  return { patch, effect, meltdown }
 }
 
-/** Emergency Vent: dump Heat to 0, mech shuts down and is Vulnerable. */
+/**
+ * Emergency Vent: dump Heat to 0 and become Vulnerable (plan §5.1 — Vent and
+ * Shutdown are distinct Reactor-bay controls: Vent sets Heat→0 + `vulnerable`,
+ * Shutdown toggles the flag). NB the tabletop rule folds a full shutdown into
+ * venting; the cockpit keeps them separate per the plan — hit Shutdown too for
+ * the strict-SRD sequence.
+ */
 export const VENT_PATCH: Partial<Mech> = {
   currentHeat: 0,
-  shutdown: true,
   vulnerable: true,
 }
 


### PR DESCRIPTION
## What
Resolves the review flags raised on the Phase 5 and Phase 8 PRs. **Stacked on #433.**

### P5 — Meltdown is now player-confirmed (strict ADR-007)
`pushPatch` / `heatCheckOncePatch` strip the destructive `destroyed` flag from the auto-apply patch and return `meltdown`; a Meltdown (overload roll = 1) no longer silently destroys the mech via the shared `heatCheckPatch`. The Reactor resolve overlay now shows a **"Confirm Meltdown — Mark Mech Destroyed"** step, mirroring the Critical-Damage confirm. The shared `heatCheckPatch` (SheetMech's path) is left untouched.

### P5 — Vent matches plan §5.1
`VENT_PATCH` = Heat 0 + Vulnerable only; **Vent and Shutdown stay distinct** Reactor controls (dropped the auto-shutdown). Noted the strict-SRD "vent implies shutdown" nuance in-code for a human call.

### P8 — launch stand-ins (plan §8 / §10.5)
New `cockpitLaunch.ts` realizes the two deferred chooser options:
- **Stand-in mech from a saved MechPattern** — same seed path as `InstantiateFromPattern` (chassis/systems/modules copied, fresh cargo-lot ids, full SP/EP + Heat 0).
- **Default base crawler of a chosen Tech Level** — minimal valid record + official pre-printed base bays + derived SP.

The mech step lists patterns (stand-in); the crawler step lists TL defaults; `handleLaunch` decodes the selection tokens, creates the record, then links + launches. Both persist a real, deletable record — no silent entity mutation.

## Verify
typecheck (all pkgs) ✓ · play+stores **126 pass** · full ITUN suite **1224 pass / 0 fail** · lint ✓ · pre-push guards ✓

New tests: playRules meltdown-gate + vent patch; `cockpitLaunch` pattern→mech, TL→crawler, token round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNeL9Bxgw2HRKJpSimK1Wm