### PR TITLE
fix(itun): scope Dashboard launch pickers to the chosen workspace

### DIFF
--- a/apps/in-the-union-now/src/components/dashboard/DashboardChooser.tsx
+++ b/apps/in-the-union-now/src/components/dashboard/DashboardChooser.tsx
@@ -37,6 +37,7 @@ import type { Pilot } from '../../lib/schemas/pilot'
 import type { SoftLink } from '../../lib/schemas/softLink'
 import { useEntityStore } from '../../stores/entityStore'
 import { usePatternStore } from '../../stores/patternStore'
+import { STARTER_WORKSPACE_ID } from '../../lib/starterSet/starterSet'
 import { cn } from '../../lib/utils'
 import type { LinkWriteStore } from './dashboardLinks'
 import { ensureDashboardLinks } from './dashboardLinks'
@@ -63,6 +64,15 @@ type DashboardChooserProps = {
    */
   initialPilotId?: string
   initialMechId?: string
+  /**
+   * Scope the pilot/mech/crawler pickers to the Roster's currently-chosen
+   * workspace, mirroring `Roster.tsx`'s own filter: `null` = "All Builds" shows
+   * every owned entity except the seeded Starter Set; a workspace id shows only
+   * that workspace's entities. Unset = unscoped (all saved entities). Stand-in
+   * mech patterns and default-TL crawler tokens carry no workspace, so they are
+   * always offered.
+   */
+  activeWorkspaceId?: string | null
   /** Button label — defaults to "Launch Dashboard". */
   label?: string
   className?: string
@@ -91,6 +101,7 @@ export function DashboardChooser({
   onLaunch,
   initialPilotId,
   initialMechId,
+  activeWorkspaceId,
   label = 'Launch Dashboard',
   className,
 }: DashboardChooserProps) {
@@ -102,10 +113,24 @@ export function DashboardChooser({
   const [pending, setPending] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const pilots: Pilot[] = usePilots()
-  const mechs: Mech[] = useMechs()
-  const crawlers: Crawler[] = useCrawlers()
+  const allPilots: Pilot[] = usePilots()
+  const allMechs: Mech[] = useMechs()
+  const allCrawlers: Crawler[] = useCrawlers()
   const links: SoftLink[] = useSoftLinkList()
+
+  // Scope the pickers to the Roster's chosen workspace, mirroring Roster.tsx's
+  // own filter so the chooser can only launch entities the roster is showing.
+  // Unset activeWorkspaceId (prop omitted) = unscoped; `null` = "All Builds"
+  // (everything except the seeded Starter Set); an id = that workspace only.
+  const inScope = <T extends { workspaceId?: string }>(list: T[]): T[] => {
+    if (activeWorkspaceId === undefined) return list
+    if (activeWorkspaceId === null)
+      return list.filter((e) => e.workspaceId !== STARTER_WORKSPACE_ID)
+    return list.filter((e) => e.workspaceId === activeWorkspaceId)
+  }
+  const pilots = inScope(allPilots)
+  const mechs = inScope(allMechs)
+  const crawlers = inScope(allCrawlers)
   // Saved patterns → stand-in mechs (list() lazily hydrates, mirroring PatternList).
   const patterns: MechPattern[] = usePatternStore((s) => s.mechPatterns)
   usePatternStore.getState().list()

--- a/apps/in-the-union-now/src/components/dashboard/__tests__/DashboardChooser.test.tsx
+++ b/apps/in-the-union-now/src/components/dashboard/__tests__/DashboardChooser.test.tsx
@@ -187,6 +187,26 @@ describe('DashboardChooser — wizard', () => {
     expect(screen.getByRole('radio', { name: /Iron Jaw/ })).toBeTruthy()
   })
 
+  test('scopes the pilot list to the active workspace', async () => {
+    const store = useEntityStore.getState()
+    await Promise.all([store.hydrate('pilot'), store.hydrate('mech'), store.hydrate('crawler')])
+    // Two pilots in two different workspaces; the chooser is scoped to ws-a.
+    await store.create('pilot', { ...basePilotInput, name: 'Alpha Pilot', workspaceId: 'ws-a' })
+    await store.create('pilot', { ...basePilotInput, name: 'Bravo Pilot', workspaceId: 'ws-b' })
+
+    await act(async () => {
+      render(<DashboardChooser activeWorkspaceId="ws-a" />)
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Launch the Dashboard' }))
+    })
+    await settle(() => screen.queryByRole('radio', { name: /Alpha Pilot/ }) !== null)
+
+    // Only the ws-a pilot is offered; the ws-b pilot is filtered out.
+    expect(screen.getByRole('radio', { name: /Alpha Pilot/ })).toBeTruthy()
+    expect(screen.queryByRole('radio', { name: /Bravo Pilot/ })).toBeNull()
+  })
+
   test('launching calls onLaunch with the chosen mech and links the crew', async () => {
     const { pilot, mech, crawler } = await seedCrew()
     resetEntityStore()

--- a/apps/in-the-union-now/src/components/roster/Roster.tsx
+++ b/apps/in-the-union-now/src/components/roster/Roster.tsx
@@ -224,7 +224,7 @@ export function Roster() {
             <ImportButton />
             {/* Launch the Dashboard for a chosen pilot/mech/crawler crew
                 (design-spec §8). Shown once at least one mech exists to run. */}
-            {allMechs.length > 0 && <DashboardChooser />}
+            {allMechs.length > 0 && <DashboardChooser activeWorkspaceId={activeWorkspaceId} />}
           </div>
           <WorkspaceSwitcher
             activeWorkspaceId={activeWorkspaceId}

--- a/apps/in-the-union-now/src/components/sheet/SheetMech.tsx
+++ b/apps/in-the-union-now/src/components/sheet/SheetMech.tsx
@@ -137,7 +137,10 @@ export function SheetMech({
       actions={
         editable ? (
           <>
-            <DashboardChooser initialMechId={mech.id} />
+            <DashboardChooser
+              initialMechId={mech.id}
+              activeWorkspaceId={mech.workspaceId ?? null}
+            />
             {actions}
           </>
         ) : (

--- a/apps/in-the-union-now/src/components/sheet/SheetPilot.tsx
+++ b/apps/in-the-union-now/src/components/sheet/SheetPilot.tsx
@@ -136,7 +136,10 @@ export function SheetPilot({
       actions={
         editable ? (
           <>
-            <DashboardChooser initialPilotId={pilot.id} />
+            <DashboardChooser
+              initialPilotId={pilot.id}
+              activeWorkspaceId={pilot.workspaceId ?? null}
+            />
             {actions}
           </>
         ) : (


### PR DESCRIPTION
## What

When launching the Dashboard, the pilot/mech/crawler pickers now only offer entities from the **currently chosen workspace**, matching the Roster's own workspace filter.

## Why

`DashboardChooser` pulled the unfiltered `usePilots()` / `useMechs()` / `useCrawlers()` lists and mapped them straight into the picker options. Even when the Roster was scoped to one workspace (via the `WorkspaceSwitcher`), the launch wizard still listed entities from **every** workspace — so you could compose a crew across workspace boundaries.

## Change

- Added an optional `activeWorkspaceId` prop to `DashboardChooser` and filter the three saved-entity lists by it, mirroring `Roster.tsx`'s existing filter:
  - `null` = "All Builds" → everything except the seeded Starter Set
  - a workspace id → only that workspace's entities
  - prop unset → unscoped (unchanged behavior for any caller that doesn't pass it)
- `Roster.tsx` passes its `activeWorkspaceId` into the chooser.
- The pilot/mech sheet launch buttons (`SheetPilot` / `SheetMech`) scope to the **seeded entity's own** `workspaceId` — the relevant "chosen workspace" in that context.
- Stand-in mech **patterns** and default-TL **crawler tokens** carry no workspace, so they remain always available (they're templates, not workspace-bound saved items).

## Tests

- Added a `DashboardChooser` test asserting the pilot list is scoped to the active workspace (a `ws-b` pilot is filtered out when scoped to `ws-a`).
- `bun run typecheck` (all packages) clean; full ITUN suite `1230 pass / 0 fail`; lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Q81quGqHT5AJ9zxVjtkcD