### PR TITLE
feat(itun): fresh dashboard opens in pilot (on-foot) mode

### DIFF
--- a/apps/in-the-union-now/src/stores/__tests__/playStateStore.test.ts
+++ b/apps/in-the-union-now/src/stores/__tests__/playStateStore.test.ts
@@ -12,7 +12,7 @@ import { usePlayStateStore } from '../playStateStore'
 describe('playStateStore', () => {
   beforeEach(() => {
     usePlayStateStore.setState({
-      mount: 'mech',
+      mount: 'pilot',
       wheel: 0,
       priorMount: null,
       dtStep: 0,
@@ -20,9 +20,9 @@ describe('playStateStore', () => {
     })
   })
 
-  test('defaults to the boarded mech, dial at 0', () => {
+  test('defaults to the on-foot pilot, dial at 0', () => {
     const s = usePlayStateStore.getState()
-    expect(s.mount).toBe('mech')
+    expect(s.mount).toBe('pilot')
     expect(s.wheel).toBe(0)
     expect(s.priorMount).toBeNull()
   })

--- a/apps/in-the-union-now/src/stores/playStateStore.ts
+++ b/apps/in-the-union-now/src/stores/playStateStore.ts
@@ -24,7 +24,8 @@ import { create } from 'zustand'
 export type MountState = 'mech' | 'pilot' | 'downtime'
 
 type PlayState = {
-  /** Active-row entity. Defaults to the boarded mech. */
+  /** Active-row entity. Defaults to the on-foot pilot (a fresh dashboard opens
+   *  in pilot mode, not boarded). */
   mount: MountState
   /** Selected index on the rotary Dial. */
   wheel: number
@@ -47,7 +48,7 @@ type PlayState = {
 }
 
 export const usePlayStateStore = create<PlayState>((set) => ({
-  mount: 'mech',
+  mount: 'pilot',
   wheel: 0,
   priorMount: null,
   dtStep: 0,


### PR DESCRIPTION
## Why
A newly-opened Dashboard (play surface) was starting **boarded** (in the mech). It should open in **pilot / on-foot** mode.

## What
Flip the play-state store's initial `mount` from `'mech'` → `'pilot'` (`src/stores/playStateStore.ts`). The mount state is an ephemeral module-level singleton (deliberately not persisted), so this line is the sole fresh-open default. Updated the doc comment and the store's default-assertion test.

The `leaveDowntime` `priorMount ?? 'mech'` fallback is left as-is — it only applies on an unreachable-in-practice restore path (entering downtime always stashes `priorMount`), not the fresh-open default.

`bun --filter in-the-union-now typecheck` + full test suite (1229) green; other dashboard tests set `mount` explicitly and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpvQgrCbuqbUuRytUXETJ9