### PR TITLE
docs(itun): Dashboard "Display" functionality completion plan

### DIFF
--- a/docs/architecture/dashboard-display-completion-plan.md
+++ b/docs/architecture/dashboard-display-completion-plan.md
@@ -1,0 +1,190 @@
+# Dashboard "Display" — Completion Plan
+
+> **Status:** Planning / remediation record. Scope is the **Display** surface only
+> (the single light "forward" content cell of the Dashboard). It compares the
+> _intended_ Display against what is _built_ today and lays out a prioritized,
+> independently-shippable path to close the gap.
+>
+> **Authoritative design record:** [`dashboard.md`](dashboard.md) — this plan does
+> not restate the locked layout; it inherits §2.2.D (the Display narrative) and §6
+> (the component tree) as the contract. Read alongside
+> [`display-system.md`](display-system.md) (the `suref-react` render stack the
+> Display reuses), [`combat-loop.md`](combat-loop.md) (the play-state model the
+> resolve flow drives), and ADRs
+> [016](../adrs/ADR-016-dashboard-rotary-dial-instrument-split.md) /
+> [017](../adrs/ADR-017-dashboard-reuse-faithful-srd-display.md) /
+> [007](../adrs/ADR-007-automation-boundary.md).
+
+---
+
+## 1. What "the Display" is (and is not)
+
+Within the Dashboard grid the **Display** is the bottom-left `pc-display` cell — the
+one element that reads "forward" (solid 2.5px border), a **META window that follows
+Dial focus** (focus→display sync). In code it is
+[`DisplayView.tsx`](../../apps/in-the-union-now/src/components/dashboard/DisplayView.tsx)
+(swapped for `DowntimeWizard` while in Downtime).
+
+Note the naming trap flagged in `dashboard.md` §1: `Dashboard.tsx` at route `/` is
+the **Roster**, not this surface. The Display is `DisplayView.tsx`; the play-surface
+root is `Dashboard.tsx` under `components/dashboard/` routed at `/dashboard/$id`.
+
+**Important framing:** the Dashboard's _instruments_ (RailBar, ActiveItemBand with
+its live reactor/damage/critical/meltdown/cargo overlays, Dial, DialConfig,
+DashboardChooser, DowntimeWizard, `dashboardRules` engine) are **largely complete
+and mutation-wired.** The deviation the redesign set out to deliver — the _faithful
+reference document that follows the dial_ — is where the Display has drifted. The
+gaps below are almost entirely in **`DisplayView` content**, not the surrounding HUD.
+
+## 2. Intended Display scope (from `dashboard.md` §2.2.D + §6)
+
+```
+Display (the one "forward" surface)
+├── AtRest (3 content modes):
+│   ├── ActionsDeck   ← default: cross-source action grid (mech AND pilot-on-foot,
+│   │                    source-spined; drone/ally where present)
+│   ├── EntityView    ← real ReferenceEntityDisplay + grouped ReferenceEntityActions
+│   │                    + entity-level footActions (Load Into Mech / Enter Downtime /
+│   │                    Hand re-roll) + live statsOverride
+│   └── TablesRoller  ← RollTable + picker + Roll; [[links]] drill into an entity card
+│                        (the one sanctioned internal scroll)
+├── ResolveMode:
+│   └── ActionResolver ← Activate → Roll → Push → **Apply**
+└── Overlays:
+    ├── StorageOverlay      ← cargo hold manifest + Jettison
+    ├── TablePickerOverlay  ← 5-column grouped picker
+    └── DowntimeWizard      ← 10-step guided sequence (downtime state)
+```
+
+Plus the SRD-Explorer statless focus (a "reference browser") and, per §2.5, the
+three-mode content shift (on-foot parked-mech read-only + **Load CTA in the
+display**; boarded pilot-status demotion; downtime step detail + Mark Complete).
+
+## 3. Built vs. intended — the Display gap table
+
+Verified against the current worktree (branched off PR #437).
+
+| Intended Display piece                                                                                                           | Built today                                                                                                                                                                                 | Status                                                   | Evidence                                                                                                                                                        |
+| -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **EntityView** — `ReferenceEntityDisplay` + grouped `ReferenceEntityActions` + entity-level `footActions` + live `statsOverride` | Bare `ReferenceEntityDisplay` card only (chassis for mech, class for pilot); **crawler renders a plain text note, not a card**; no grouped actions, no `footActions`, no live-stat override | **Incomplete (largest gap)**                             | `DisplayView.tsx:96-132`; zero `footActions`/`footMeta`/`statsOverride`/`ReferenceEntityActions`/`EntityHrefProvider` usage anywhere in `components/dashboard/` |
+| **ActionsDeck** — cross-source (mech + pilot-on-foot + drone/ally), source-spined                                                | Boarded **mech only** (Chassis/Systems/Modules); on-foot focus still calls `ActionsDeck mech={mech}`; no pilot deck, no drone/ally                                                          | **Partial**                                              | `DisplayView.tsx:84-86`, `ActionsDeck.tsx:38-48`, `buildMechActions` is mech-scoped                                                                             |
+| **ActionResolver** — Activate → Roll → Push → **Apply**                                                                          | Activate → Roll → Push; **no Apply step** (roll band shown, not applied)                                                                                                                    | **Partial**                                              | `ActionsDeck.tsx:110-164`; "Apply" exists only in `ActiveItemBand` damage overlays (`:471`, `:640`)                                                             |
+| **TablesRoller / TablePickerOverlay** — RollTable + **5-col grouped picker** + `[[links]]` drill-in                              | `RollTable` + a plain alphabetical `<select>`; no grouped picker; `[[links]]` do not drill in-display                                                                                       | **Partial**                                              | `DisplayView.tsx:49-82`; no `EntityHrefProvider` in-display                                                                                                     |
+| **SRD Explorer** focus — reference browser                                                                                       | Hard placeholder note                                                                                                                                                                       | **Stub / unbuilt**                                       | `DisplayView.tsx:87-92` ("Interactive content lands in a later phase")                                                                                          |
+| **Drone / Ally** entity focuses                                                                                                  | Not built — composition surfaces no drones/allies; Dial builds no drone/ally items                                                                                                          | **Unbuilt**                                              | `composition.ts` has no drone/ally; `dialItems.ts:118-154` builds mech/pilot/crawler only                                                                       |
+| StorageOverlay (cargo + Jettison)                                                                                                | Built (lives in `ActiveItemBand` StorageBay)                                                                                                                                                | **Done** (relocated to the band)                         | `ActiveItemBand.tsx` StorageBay                                                                                                                                 |
+| DowntimeWizard (10-step)                                                                                                         | Built, driven from `SalvageUnionReference.Guides`                                                                                                                                           | **Done** (economy writes deliberately deferred to sheet) | `DowntimeWizard.tsx`                                                                                                                                            |
+
+**Adjacent (not Display content, but affect it):**
+
+- **Settings menu** (RailBar ⚙) — disabled "planned" stub (`RailBar.tsx:46-48`).
+- **Phone reflow** — placeholder message below the scale floor; no `DashboardPhone`
+  (`DashboardCanvas.tsx:50-56`). The Display's mobile variant therefore doesn't exist.
+- **Stale docstrings** — several file headers still say "Phase 1 read-only shell / no
+  mutations yet"; the code is far past that. Cosmetic but misleading.
+
+## 4. Prioritized workstreams
+
+Ordered by user-visible value per unit effort. Each is independently shippable and
+testable; each ends green (`bun --filter in-the-union-now test`, `typecheck`, `lint`).
+
+### W1 — EntityView: make the entity focus a real reference document (highest value)
+
+This is the deviation most responsible for the "incomplete form" feel: focusing a
+mech/pilot/crawler on the dial should show the **faithful SRD card the rest of the
+app shows**, with its grouped actions and entity-level buttons — not a bare chassis
+card and a text note.
+
+- Replace the bare `EntityCard` path with `ReferenceEntityDisplay` driven through its
+  slot props (per `display-system.md` and `dashboard.md` §3.4):
+  - `abilitiesSection` → grouped `ReferenceEntityActions` for the focused entity.
+  - `statsOverride` → live play values (`currentHP/SP/EP/Heat`, AP) so the header
+    reflects table state, not base stats.
+  - `footerOverride` / `afterExtraContent` → entity-level `footActions`:
+    **Load Into Mech** (on-foot parked mech), **Enter Downtime** (crawler),
+    **Hand re-roll** (pilot) — via `DisplayCard.footActions`, not a new renderer
+    (ADR-017; reuse the `Erow`/`ActionCardErow` vocabulary, §3.3).
+- Render the **crawler** focus as its real reference card (currently a text note);
+  keep the Enter Downtime button as a `footAction`.
+- Provide an in-display `EntityHrefProvider` so `[[links]]` drill into the in-display
+  entity view rather than navigating away (the one sanctioned internal scroll).
+- Touches: `DisplayView.tsx` (+ a small `EntityView` extraction), no new schema.
+
+### W2 — ActionResolver: add the Apply step + on-foot pilot deck
+
+- **Apply step** in `ActionsDeck`: after Roll/Push, resolve the outcome into the
+  explicit Apply the spec calls for (Activate → Roll → Push → **Apply**), so a rolled
+  action's effect is committed as one bookkeeping write under the ADR-007 boundary
+  (auto for non-destructive; the destructive branches already route through
+  `ActiveItemBand`'s confirm overlays — reuse, don't duplicate).
+- **On-foot deck:** when `mount === 'pilot'`, the Actions focus must render the
+  **pilot's** abilities/equipment deck (source-spined orange), not the mech's. Add a
+  pilot-sourced `buildActions` sibling to `buildMechActions`; select by mount in
+  `DisplayView`.
+- Touches: `ActionsDeck.tsx`, `dashboardRules.ts` (`buildMechActions` → add a pilot
+  variant), `DisplayView.tsx` dispatch.
+
+### W3 — TablesRoller: grouped picker + link drill-in
+
+- Replace the alphabetical `<select>` with the **5-column grouped picker**
+  (`TablePickerOverlay`), grouping the ~96 `RollTables.all()` by app-side categories
+  (there is no category field in data — categorize app-side, per §5.6).
+- Wire `[[Name]]` links in rendered tables to drill into the in-display entity card
+  (shares the W1 `EntityHrefProvider`).
+- Touches: `DisplayView.tsx` (+ a `TablePickerOverlay` component).
+
+### W4 — SRD Explorer focus (currently a hard stub)
+
+- Replace the placeholder with a real in-display reference browser: a compact,
+  searchable list of SRD entities (reuse `salvageunion-reference` `search()` and the
+  same `ReferenceEntityDisplay` W1 uses) that drills into an entity card in place.
+- Decision to make first: is SRD Explorer worth a full browser, or should it be
+  **folded into W1's EntityView + a search box** (cheaper, one code path)? Recommend
+  the latter unless product wants a standalone browser. See §6.
+- Touches: `DisplayView.tsx` (`srd` focus branch), possibly a small `SrdExplorer`.
+
+### W5 — Adjacent polish (opportunistic, lower priority)
+
+- RailBar **Settings** menu (Rules & Sources / Dashboard settings / Downtime entry) —
+  currently disabled.
+- **Phone reflow** (`DashboardPhone`) so the Display has a mobile form — larger effort;
+  scope separately (it's a layout project, not Display content).
+- Refresh the **stale "Phase 1" docstrings** across `components/dashboard/*` to match
+  the shipped reality.
+- **Drone / Ally** focuses — blocked on composition surfacing drones/allies (local-first
+  data model has no such link today). Treat as its own data-model question, not part of
+  Display completion. See §6.
+
+## 5. Sequencing & verification
+
+- **Suggested order:** W1 → W2 → W3 → W4, then W5 as capacity allows. W1 unblocks W3/W4
+  (shared `EntityHrefProvider` + reference-card path) and delivers the biggest visible
+  jump on its own, so it ships first even if the rest slips.
+- **Per-workstream gate:** `bun --filter in-the-union-now test`, `bun run typecheck`,
+  `bun run lint`. Extend `__tests__/DisplayView.test.tsx` per mode; keep the
+  `e2e/display-verification.e2e.ts` flow green.
+- **ADR-007 assertions:** any new Apply/resolve write must be unit-tested to (a)
+  auto-apply only non-destructive bookkeeping and (b) route destructive outcomes
+  through a confirm/undo — never auto-write a condition (`dashboard.md` §10.1).
+- **Ephemeral/persisted split:** new Display state (focus, resolve step) stays in
+  `playStateStore`/component state, never `entityStore` or snapshots (ADR-019).
+- **Screenshot pass** (outstanding per `dashboard.md` §10.5): once W1 lands, verify
+  light/dark contrast on the reference card in the dark HUD and that grouped actions +
+  footActions fit the display area without breaking the no-scroll contract.
+
+## 6. Open questions for the user
+
+1. **SRD Explorer** — full standalone browser, or fold into W1's EntityView + a search
+   box (recommended, cheaper)?
+2. **Drone / Ally focuses** — the spec lists them, but composition/data model surfaces
+   no drones/allies today. In scope for "done," or explicitly deferred as a data-model
+   change?
+3. **Phone reflow (W5)** — is a mobile Display form part of "done," or is
+   landscape-desktop-only acceptable for now (it's a separate layout effort)?
+4. **Apply semantics (W2)** — should Apply commit rolled action outcomes automatically
+   where non-destructive, or always present an explicit confirm even for
+   non-destructive effects? (Recommend auto for non-destructive per ADR-007.)
+
+```
+
+```

--- a/docs/architecture/dashboard-display-completion-plan.md
+++ b/docs/architecture/dashboard-display-completion-plan.md
@@ -129,97 +129,185 @@ Tables uses a bare `<select>` (`:49-82`), SRD is a placeholder (`:87-92`), and e
 focuses render a bare `ReferenceEntityDisplay` with no `footActions`/`statsOverride`/
 `ReferenceEntityActions`/`EntityHrefProvider` anywhere in `components/dashboard/`.
 
-## 4. Workstreams (Display-focused)
+## 4. Data & reuse foundations (dependencies resolved)
 
-Ordered by user-visible value. Each is independently shippable and gated on
+All §6 open questions from the first draft were investigated against the code. The
+Display is buildable on existing data + shared components; only two controls need
+Dashboard-authored logic, and drone/ally support is out of scope.
+
+### 4.1 Action metadata — all filters/micro-meta are data-backed
+
+The action type is `SURefMetaAction` = `ActionSchema`
+(`packages/salvageunion-reference/lib/schemas/objects.ts:674`). Fields the deck needs:
+
+| Deck feature           | Field / helper                                           | Notes                                                                                                                                               |
+| ---------------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Timing tabs            | **`action.actionType`** (not `timing`)                   | enum `Passive/Free/Reaction/Turn/Short/Long/DownTime`; `getActionTypes()` lists them. "React"→`Reaction`; **bucket or drop** `Short/Long/DownTime`. |
+| Range selector + reach | **`action.range: ('Close'\|'Medium'\|'Long'\|'Far')[]`** | clean enum array — backs C/M/L/F directly; no prose parsing.                                                                                        |
+| Damage micro-meta      | `action.damage {damageType:'HP'\|'SP', amount}`          | already rendered by `ActionCard`.                                                                                                                   |
+| HOT micro-meta         | trait `{type:'hot', amount}`; economy `heat`             | `traits[].type` is lowercase (`'hot'`,`'uses'`).                                                                                                    |
+| Traits micro-meta      | `action.traits: {type, amount?}[]`                       | already rendered.                                                                                                                                   |
+| Source stamp           | group source + `action.actionSource` schema              | CHS/SYS/MOD/ABL/EQP.                                                                                                                                |
+
+`SalvageUnionReference.resolveActions(entity)` preserves all of these (nothing
+stripped). **Caveat:** for systems/modules the deck currently surfaces only the
+**primary action** (first numeric-cost) per item (`dashboardRules.ts:249`); listing
+every action independently would need `buildMechActions` widened (optional — see §7).
+
+### 4.2 Two controls need Dashboard-authored logic (no stored backing)
+
+- **EP/AP cost radio.** `resolveActivationCurrency(actionSource)` is _deterministic_
+  (systems/modules/chassis→EP, else AP); the action's `activationCurrency:'EP or AP'`
+  enum is descriptive text no helper consumes. A genuine EP-vs-AP choice (the
+  pilot-through-mech case) must be authored in the Dashboard, branching on
+  `activationCurrency === 'EP or AP'`.
+- **Hot(X) stepper.** `amount` can be the literal `'X'`; today `itemEconomy` /
+  `chassisActionEconomy` collapse `'X'`→`+1` heat (`traitAmount` returns 0). A real
+  stepper needs Dashboard-local state; the data only marks heat as _variable_, not a
+  value/range. (Uses(X) collapses to 0 the same way.)
+
+### 4.3 Reuse-point API (verified) — prop names are correct verbatim
+
+`ReferenceEntityDisplay` accepts `abilitiesSection`, `statsOverride
+{value, bottomLabel}`, `footerOverride`, `afterExtraContent`, `hide`
+(`ReferenceEntityHideConfig` object), `footActions`, `footMeta`
+(`CardFootMeta = {label, value:ReactNode}`) — all real. Caveats to design around:
+
+- **`abilitiesSection` replaces the _chassis-abilities_ block only**, not the
+  game-rules `Actions` masonry. To keep the built-in actions, don't `hide.actions`;
+  to inject entity-level buttons use `afterExtraContent`/`footerOverride`.
+- **`ReferenceEntityActions` and `displayStateContext` are internal** (not in the
+  `suref-react` barrel) — reach them _through_ `ReferenceEntityDisplay`, don't import
+  internals. Density is a `compact`/`mode` prop, not a context knob.
+- **`RollTable`** is interactive but its Roll button needs **`showCommand` + a truthy
+  `tableName`** (else static grid). Roll math: `rollOnTable`/`resultForTable`
+  (package root).
+- **In-panel `[[links]]`**: wrap the display in `EntityHrefProvider value={builder}`
+  and leave `EntityDetailLinkProvider` at default `false` (in-app modal, not
+  navigate-away); both are public. `useSearchCombobox` is also public (for D4).
+- Economy injection stays the `Erow`/`ActionCardErow` + `footActions`/`footMeta`
+  vocabulary (`ActionCard` itself takes neither — wrap it, per ADR-017).
+
+### 4.4 Tables & SRD data
+
+- **No table category field** — the 5 columns (COMBAT/PILOT/SALVAGE/CRAWLER/DOWNTIME)
+  are an **app-side curated `name→category` map** over `RollTables.all()` (96 tables);
+  `indexable:true` filters to the ~19 headline tables. `source` (book) doesn't map.
+- **SRD Explorer:** all 8 tiles map to accessors — `Chassis/Systems/Modules/`
+  **`Abilities`**`/Equipment/NPCs/CrawlerBays/RollTables`. Reuse `useSearchCombobox`
+  (public) or `search()` (needs ORM `preload()` — the dashboard already preloads);
+  render items via `ReferenceEntityDisplay`. **Preload hazard:** never call accessor
+  `.all()`/query at module scope.
+
+### 4.5 Out of scope (data-model work, not Display completion)
+
+- **Drone / Ally focuses + decks.** No drone/ally entity exists; `SoftLink.type` is
+  only `mech-to-pilot`/`pilot-to-crawler`, `EntityRef.type` only
+  `pilot`/`mech`/`crawler`. Surfacing them = new schema + link kinds + composition
+  extension — a separate project.
+- **Broader HUD chrome, Settings menu, phone reflow** — not Display content.
+
+## 5. Workstreams (Display-focused)
+
+Ordered by value. Each is independently shippable and gated on
 `bun --filter in-the-union-now test`, `typecheck`, `lint`, and the ADR-007 boundary
-tests. Reuse `suref-react` (`ReferenceEntityDisplay` / `ActionCard` / `RollTable`)
-and inject economy via the existing `Erow`/`ActionCardErow` + `DisplayCard.footActions`
-vocabulary (ADR-017) — never a new schema-specific renderer.
+tests.
 
-### D1 — Actions deck: filters, grouping, range, and rich cards (highest value)
+### D5 — EntityView: a real reference document (do first — underpins D1/D4)
 
-- **Timing tabs** `All/Turn/Free/React` and a **grouping toggle** `Timing ⇄ Source`
-  over the existing `buildMechActions` groups; drop the hardcoded group-by-source.
-- **Source-filter tags** per owner (pilot/mech/drone), family-colored.
-- **Range selector** `C/M/L/F` + **reach readout**; dim (not hide) out-of-range,
-  heat-locked (`canActivateAction`), and destroyed actions in place.
-- **`acell` cards** carry a source stamp (CHS/SYS/MOD/ABL/EQP) + micro-meta
-  (range/dmg/HOT/traits) — read from `SURefMetaAction`.
-- **On-foot deck:** when `mount==='pilot'`, render the **pilot's** action deck
-  (add a pilot-sourced `buildActions` sibling), not the mech's.
-- Touches: `ActionsDeck.tsx`, `dashboardRules.ts`, `DisplayView.tsx`.
-- **Data dependency to confirm first:** whether `SURefMetaAction` carries timing
-  group / range / traits fields the tabs+range+micro-meta need (see §6).
+- Drive each entity focus through `ReferenceEntityDisplay`: keep the built-in
+  actions (don't `hide.actions`), feed live **`statsOverride`**
+  (`currentHP/SP/EP/Heat`), and inject entity-level **`footActions`** (Load Into Mech
+  / Enter Downtime / Hand re-roll / "Full sheet →") via `afterExtraContent` /
+  `footerOverride` — not a new renderer.
+- Render the **crawler** focus as its real card (today a text note).
+- Provide an in-panel `EntityHrefProvider` (+ `EntityDetailLinkProvider={false}`) so
+  `[[links]]` drill in place. Touches: `DisplayView.tsx` (+ an `EntityView`).
+
+### D1 — Actions deck: filters, grouping, range, rich cards (highest visible value)
+
+- **Timing tabs** `All/Turn/Free/React` over `action.actionType` (map React→Reaction;
+  bucket Short/Long/DownTime), and a **grouping toggle** `Timing ⇄ Source`; drop the
+  hardcoded group-by-source.
+- **Source-filter tags** per owner, family-colored.
+- **Range selector** `C/M/L/F` + **reach readout** from `action.range`; add ephemeral
+  `range` + `setRange` to `playStateStore` and a pure range-vs-band helper in
+  `dashboardRules`. Dim (not hide) out-of-range, heat-locked (`canActivateAction`),
+  and destroyed actions in place.
+- **`acell` cards**: source stamp + micro-meta (range/dmg/HOT/traits) — reuse
+  `ActionCard`/`DataValueDisplayView` for the tag row.
+- **On-foot deck:** when `mount==='pilot'`, render a `buildPilotActions(pilot)`
+  (mirror `buildMechActions` over `pilot.abilities`/`pilot.equipment` via
+  `resolveActions`/`resolveAbilityApCost`; AP economy) instead of the mech deck.
+- Touches: `ActionsDeck.tsx`, `dashboardRules.ts`, `playStateStore.ts`,
+  `DisplayView.tsx`.
 
 ### D2 — Resolve flow: Apply, cost choice, Hot stepper
 
-- Add the **Apply** step (`Activate → Roll → Push → Apply`) that commits a rolled
-  outcome as one write under the ADR-007 boundary (auto for non-destructive; route
-  destructive branches through the existing `ActiveItemBand` confirm overlays).
-- **Cost — EP or AP** radios for `'EP or AP'` actions (`resolveActivationCurrency`).
-- **Hot(X) stepper** with heat-vs-cap projection; disable when it would exceed cap.
-- `◀ Back` / `Clear`. Touches: `ActionsDeck.tsx`, `dashboardRules.ts`.
+- Add the **Apply** step (`Activate → Roll → Push → Apply`) committing the rolled
+  outcome as one write under ADR-007 (auto for non-destructive; route destructive
+  branches through the existing `ActiveItemBand` confirm overlays).
+- **Cost — EP or AP** radios, authored in the Dashboard for
+  `activationCurrency==='EP or AP'` actions (§4.2).
+- **Hot(X) stepper** with Dashboard-local state + heat-vs-cap projection; disable
+  when it would exceed cap (§4.2). `◀ Back` / `Clear`.
+- Touches: `ActionsDeck.tsx`, `dashboardRules.ts`.
 
 ### D3 — Tables: 5-column category picker + roll history
 
-- Replace the `<select>` with the **5-column grouped picker overlay**
-  (`COMBAT/PILOT/SALVAGE/CRAWLER/DOWNTIME`), categorizing `RollTables.all()`
-  app-side (no category field in data — §5.6 of the spec).
-- Roll result + follow-ups in-panel; **roll history** + Clear. Reuse `RollTable`.
-- Touches: `DisplayView.tsx` (+ a `TablePickerOverlay`).
+- Replace the `<select>` with the **5-column picker overlay**
+  (COMBAT/PILOT/SALVAGE/CRAWLER/DOWNTIME) driven by an **app-side curated
+  name→category map** (§4.4). Roll result + follow-ups in-panel via `RollTable`
+  (`showCommand` + `tableName`); **roll history** + Clear.
+- Touches: `DisplayView.tsx` (+ a `TablePickerOverlay` + the category map).
 
 ### D4 — SRD Explorer (currently a hard stub)
 
-- **Search box** over `salvageunion-reference` `search()`, **8 category tiles**
-  (CHS/SYS/MOD/ABL/EQP/NPC/BAY/TBL), result cards drilling into the real
-  `ReferenceEntityDisplay` in-panel (shares the D5 `EntityHrefProvider`).
+- **Search box** via `useSearchCombobox` / `search()`, **8 category tiles** over the
+  real accessors (§4.4), results drilling into `ReferenceEntityDisplay` in-panel
+  (shares D5's `EntityHrefProvider`). Respect the preload hazard.
 - Touches: `DisplayView.tsx` (`srd` branch) + a small `SrdExplorer`.
-
-### D5 — EntityView: a real reference document
-
-- Drive the entity focus through `ReferenceEntityDisplay` slot props: grouped
-  `ReferenceEntityActions` (`abilitiesSection`), live `statsOverride`
-  (`currentHP/SP/EP/Heat`), and entity-level `footActions` (Load Into Mech / Enter
-  Downtime / Hand re-roll / sheet links) via `DisplayCard.footActions`.
-- Render the **crawler** focus as its real card (currently a text note).
-- Provide an in-display `EntityHrefProvider` so `[[links]]` drill in-panel (the one
-  sanctioned internal scroll). Touches: `DisplayView.tsx` (+ an `EntityView`).
 
 ### D6 — Display visual fidelity (fold into D1–D5, not a separate build)
 
-The mockup's Display treatment: light "workshop-paper" SRD card inset in the dark
-HUD; **source stamps** (Barlow Semi Condensed, uppercase, dark-on-light); **cost
-pennant** for EP/AP; **segmented pip gauges**; roll-band colors
-(`--cascade/--failure/--tough/--success/--nailed`); state overlays as _treatment_
-(heat redline pulse, damaged 45° hatch, destroyed strike-in-place), never a second
-hue. Apply these per-workstream as each control lands, against the existing
-`--color-sheet-*` / `--color-rust` / `--color-roll-*` tokens — not as a separate
-visual pass. (Broader HUD chrome / phone reflow are **out of scope** here.)
+Apply the mockup's Display treatment as each control lands: light "workshop-paper"
+SRD card inset in the dark HUD; **source stamps** (Barlow Semi Condensed, uppercase,
+dark-on-light); **cost pennant** for EP/AP; **segmented pip gauges**; roll-band
+colors (`--color-roll-*`); state overlays as _treatment_ (heat redline pulse,
+damaged 45° hatch, destroyed strike-in-place), never a second hue — against the
+existing `--color-sheet-*` / `--color-rust` / `--color-roll-*` tokens.
 
-## 5. Sequencing & verification
+## 6. Sequencing & verification
 
-- **Order:** D5 → D1 → D2 → D3 → D4. D5 (real reference card + `EntityHrefProvider`)
-  underpins D4 and the `acell` cards, and fixes the most visible "bare card" gap;
-  D1/D2 restore the action instrument; D3/D4 complete Tables and SRD.
-- **Per-workstream gate:** the four checks above + extend
-  `__tests__/DisplayView.test.tsx` per mode and keep
-  `e2e/display-verification.e2e.ts` green.
-- **ADR-007:** new Apply/resolve writes must auto-apply only non-destructive
-  bookkeeping and route destructive outcomes through confirm/undo — unit-tested.
+- **Order:** D5 → D1 → D2 → D3 → D4 (D6 folded in). D5's real card +
+  `EntityHrefProvider` underpin D4 and the `acell` cards and fix the most visible
+  "bare card" gap; D1/D2 restore the action instrument; D3/D4 finish Tables and SRD.
+- **Per-workstream gate:** the checks above + extend `__tests__/DisplayView.test.tsx`
+  per mode; keep `e2e/display-verification.e2e.ts` green.
+- **ADR-007:** new Apply/resolve writes auto-apply only non-destructive bookkeeping
+  and route destructive outcomes through confirm/undo — unit-tested.
 - **Ephemeral split (ADR-019):** filter/grouping/range/resolve state stays in
   component state / `playStateStore`, never `entityStore` or snapshots.
 
-## 6. Open questions / dependencies
+## 7. Decisions & residual product questions
 
-1. **Action metadata (blocks D1).** Do `SURefMetaAction` records carry the **timing
-   group** (Turn/Free/React), **range**, and **traits** the tabs / range selector /
-   micro-meta need? If not, D1's filters degrade to what the data supports — confirm
-   before building.
-2. **Range model.** ITUN has no enemy/GM model (local-first); the mockup's `C/M/L/F`
-   is a self-declared range band. Ship the lightweight declare-a-band version
-   (matches spec §10.5), not target selection?
-3. **SRD Explorer depth (D4).** Full standalone browser, or the search + 8-tile +
-   drill-in the mockup shows (recommended — reuses D5's card path)?
-4. **Apply semantics (D2).** Auto-commit non-destructive rolled outcomes, explicit
-   confirm for destructive (recommended, per ADR-007)?
+Resolved (defaults chosen; flag to change):
+
+- **Range** = lightweight self-declared band (`playStateStore.range`), compared
+  against `action.range`. No enemy/target model (matches local-first).
+- **SRD Explorer** = search + 8 tiles + `ReferenceEntityDisplay` drill-in (reusing
+  `useSearchCombobox`), _not_ a separate standalone browser.
+- **Apply** auto-commits non-destructive rolled outcomes; destructive outcomes route
+  through confirm/undo (ADR-007).
+
+Still worth a product call:
+
+1. **Timing buckets.** How should `Short` / `Long` / `DownTime` action types map onto
+   the mockup's 3-tab `Turn/Free/React` filter — folded into `Turn`, given their own
+   tab, or dropped from the play deck?
+2. **Per-item action granularity.** Keep the current primary-action-per-item deck, or
+   widen `buildMechActions` so every action of a multi-action system is independently
+   listed/filterable (more faithful to the mockup, larger change)?
+3. **Hot(X) / Uses(X) semantics.** For variable-heat actions, is a player-entered X
+   (stepper) the right model, or should the deck just surface "variable" and let the
+   player adjust Heat via the Reactor bay?

--- a/docs/architecture/dashboard-display-completion-plan.md
+++ b/docs/architecture/dashboard-display-completion-plan.md
@@ -1,190 +1,225 @@
 # Dashboard "Display" — Completion Plan
 
-> **Status:** Planning / remediation record. Scope is the **Display** surface only
-> (the single light "forward" content cell of the Dashboard). It compares the
-> _intended_ Display against what is _built_ today and lays out a prioritized,
-> independently-shippable path to close the gap.
+> **Status:** Planning / remediation record. **Scope: the Display (center panel)
+> functionality only** — the context-driven content area that follows dial focus
+> (Actions deck, Resolve flow, Tables, SRD Explorer, Entity view). This is a plan,
+> not an implementation.
 >
-> **Authoritative design record:** [`dashboard.md`](dashboard.md) — this plan does
-> not restate the locked layout; it inherits §2.2.D (the Display narrative) and §6
-> (the component tree) as the contract. Read alongside
-> [`display-system.md`](display-system.md) (the `suref-react` render stack the
-> Display reuses), [`combat-loop.md`](combat-loop.md) (the play-state model the
-> resolve flow drives), and ADRs
-> [016](../adrs/ADR-016-dashboard-rotary-dial-instrument-split.md) /
-> [017](../adrs/ADR-017-dashboard-reuse-faithful-srd-display.md) /
-> [007](../adrs/ADR-007-automation-boundary.md).
+> **Reference artifacts:**
+>
+> - **The mockup** — the "Cockpit" Claude Artifact (the original interactive
+>   prototype; self-titled _"ITUN · Play Cockpit — interactive prototype"_,
+>   grounded at `0897124d`): <https://claude.ai/code/artifact/8b78136d-e7ee-4853-8b03-6812ee649ed0>.
+>   It was authored outside the repo and **never committed** (verified via
+>   `git log --all -S` pickaxe on every mockup identifier), so the artifact is the
+>   only source of truth for the intended Display behavior.
+> - **The prose spec** — [`dashboard.md`](dashboard.md) §2.2.D + §6 (describes the
+>   mockup by function name but does not reproduce its controls in full).
+> - The `suref-react` render stack the Display reuses:
+>   [`display-system.md`](display-system.md); the play-state model the resolve flow
+>   drives: [`combat-loop.md`](combat-loop.md); and ADRs
+>   [016](../adrs/ADR-016-dashboard-rotary-dial-instrument-split.md) /
+>   [017](../adrs/ADR-017-dashboard-reuse-faithful-srd-display.md) /
+>   [007](../adrs/ADR-007-automation-boundary.md).
 
 ---
 
-## 1. What "the Display" is (and is not)
+## 1. What "the Display" is
 
-Within the Dashboard grid the **Display** is the bottom-left `pc-display` cell — the
-one element that reads "forward" (solid 2.5px border), a **META window that follows
-Dial focus** (focus→display sync). In code it is
+The **Display** is the lower-left `pc-display` grid cell — the one "forward"
+surface, a **context window that follows the Dial's focus** (`centerMeta()` in the
+mockup). Selecting a different dial item swaps the whole panel. In code it is
 [`DisplayView.tsx`](../../apps/in-the-union-now/src/components/dashboard/DisplayView.tsx)
-(swapped for `DowntimeWizard` while in Downtime).
+(replaced by `DowntimeWizard` during Downtime), with the Actions mode delegated to
+[`ActionsDeck.tsx`](../../apps/in-the-union-now/src/components/dashboard/ActionsDeck.tsx).
 
-Note the naming trap flagged in `dashboard.md` §1: `Dashboard.tsx` at route `/` is
-the **Roster**, not this surface. The Display is `DisplayView.tsx`; the play-surface
-root is `Dashboard.tsx` under `components/dashboard/` routed at `/dashboard/$id`.
+The Dashboard's _instruments_ (RailBar, ActiveItemBand + its live reactor / damage /
+critical / meltdown / cargo overlays, Dial, DialConfig, DashboardChooser,
+DowntimeWizard, `dashboardRules`) are largely complete. **The drift is in the
+Display's content and controls** — the mockup's center panel is a rich, filterable,
+searchable instrument; the build renders a thin subset. This plan closes that.
 
-**Important framing:** the Dashboard's _instruments_ (RailBar, ActiveItemBand with
-its live reactor/damage/critical/meltdown/cargo overlays, Dial, DialConfig,
-DashboardChooser, DowntimeWizard, `dashboardRules` engine) are **largely complete
-and mutation-wired.** The deviation the redesign set out to deliver — the _faithful
-reference document that follows the dial_ — is where the Display has drifted. The
-gaps below are almost entirely in **`DisplayView` content**, not the surrounding HUD.
+## 2. Intended Display functionality (from the Cockpit mockup)
 
-## 2. Intended Display scope (from `dashboard.md` §2.2.D + §6)
+The mockup's center panel has five modes; the header (`center-title`) maps the dial
+focus to `self→Actions`, `tables→Tables`, `srd→SRD Explorer`, entity→its sheet card.
 
-```
-Display (the one "forward" surface)
-├── AtRest (3 content modes):
-│   ├── ActionsDeck   ← default: cross-source action grid (mech AND pilot-on-foot,
-│   │                    source-spined; drone/ally where present)
-│   ├── EntityView    ← real ReferenceEntityDisplay + grouped ReferenceEntityActions
-│   │                    + entity-level footActions (Load Into Mech / Enter Downtime /
-│   │                    Hand re-roll) + live statsOverride
-│   └── TablesRoller  ← RollTable + picker + Roll; [[links]] drill into an entity card
-│                        (the one sanctioned internal scroll)
-├── ResolveMode:
-│   └── ActionResolver ← Activate → Roll → Push → **Apply**
-└── Overlays:
-    ├── StorageOverlay      ← cargo hold manifest + Jettison
-    ├── TablePickerOverlay  ← 5-column grouped picker
-    └── DowntimeWizard      ← 10-step guided sequence (downtime state)
-```
+### 2.1 Actions deck (default, `self` focus) — a filterable action instrument
 
-Plus the SRD-Explorer statless focus (a "reference browser") and, per §2.5, the
-three-mode content shift (on-foot parked-mech read-only + **Load CTA in the
-display**; boarded pilot-status demotion; downtime step detail + Mark Complete).
+Controls above the `deckgrid`:
 
-## 3. Built vs. intended — the Display gap table
+- **Timing filter tabs** — `All · Turn · Free · React` (filter by an action's timing
+  group).
+- **Source-filter tags** — one button per deck owner (pilot / mech / each drone),
+  family-colored (`fam-pilot`/`fam-mech`/`fam-drone`), _"Filter the deck to
+  '&lt;label&gt;' actions."_
+- **Grouping toggle** — `Timing ⇄ Source` (_"Group by timing" / "Group by source"_).
+- **Range selector** — `C · M · L · F` (Close/Medium/Long/Far) + a **reach readout**
+  (`reachStr()`, e.g. _"7 / 12 in reach"_ — counts in-reach, non-heat-locked,
+  non-destroyed actions).
+- **Deck ⋯ menu** — Open Locker · Filter (source/range) · Grouping · Show passives.
+- **Action cards (`acell`)** — a source stamp (CHS/SYS/MOD/ABL/EQP), name, and
+  micro-meta (range / dmg / HOT / traits). **Out-of-range / overheated / destroyed
+  actions are dimmed and locked in place** (titles _"Out of range / overheat",
+  "Heat-locked"_), never hidden.
 
-Verified against the current worktree (branched off PR #437).
+### 2.2 Resolve flow (loaded action) — `Activate → Roll ⬡ → ⟳ Push → Apply`
 
-| Intended Display piece                                                                                                           | Built today                                                                                                                                                                                 | Status                                                   | Evidence                                                                                                                                                        |
-| -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **EntityView** — `ReferenceEntityDisplay` + grouped `ReferenceEntityActions` + entity-level `footActions` + live `statsOverride` | Bare `ReferenceEntityDisplay` card only (chassis for mech, class for pilot); **crawler renders a plain text note, not a card**; no grouped actions, no `footActions`, no live-stat override | **Incomplete (largest gap)**                             | `DisplayView.tsx:96-132`; zero `footActions`/`footMeta`/`statsOverride`/`ReferenceEntityActions`/`EntityHrefProvider` usage anywhere in `components/dashboard/` |
-| **ActionsDeck** — cross-source (mech + pilot-on-foot + drone/ally), source-spined                                                | Boarded **mech only** (Chassis/Systems/Modules); on-foot focus still calls `ActionsDeck mech={mech}`; no pilot deck, no drone/ally                                                          | **Partial**                                              | `DisplayView.tsx:84-86`, `ActionsDeck.tsx:38-48`, `buildMechActions` is mech-scoped                                                                             |
-| **ActionResolver** — Activate → Roll → Push → **Apply**                                                                          | Activate → Roll → Push; **no Apply step** (roll band shown, not applied)                                                                                                                    | **Partial**                                              | `ActionsDeck.tsx:110-164`; "Apply" exists only in `ActiveItemBand` damage overlays (`:471`, `:640`)                                                             |
-| **TablesRoller / TablePickerOverlay** — RollTable + **5-col grouped picker** + `[[links]]` drill-in                              | `RollTable` + a plain alphabetical `<select>`; no grouped picker; `[[links]]` do not drill in-display                                                                                       | **Partial**                                              | `DisplayView.tsx:49-82`; no `EntityHrefProvider` in-display                                                                                                     |
-| **SRD Explorer** focus — reference browser                                                                                       | Hard placeholder note                                                                                                                                                                       | **Stub / unbuilt**                                       | `DisplayView.tsx:87-92` ("Interactive content lands in a later phase")                                                                                          |
-| **Drone / Ally** entity focuses                                                                                                  | Not built — composition surfaces no drones/allies; Dial builds no drone/ally items                                                                                                          | **Unbuilt**                                              | `composition.ts` has no drone/ally; `dialItems.ts:118-154` builds mech/pilot/crawler only                                                                       |
-| StorageOverlay (cargo + Jettison)                                                                                                | Built (lives in `ActiveItemBand` StorageBay)                                                                                                                                                | **Done** (relocated to the band)                         | `ActiveItemBand.tsx` StorageBay                                                                                                                                 |
-| DowntimeWizard (10-step)                                                                                                         | Built, driven from `SalvageUnionReference.Guides`                                                                                                                                           | **Done** (economy writes deliberately deferred to sheet) | `DowntimeWizard.tsx`                                                                                                                                            |
+- `◀ Back` / `Clear`, then state-dependent buttons: **Activate** (pay cost + Heat,
+  for no-roll actions), **Roll ⬡** (Core Mechanic d20), **⟳ Push** (reroll, +2 Heat,
+  forces a Heat Check — shown only if `heat+2 ≤ cap` and boarded), **Apply**
+  (_"Commit this result"_).
+- **Cost — EP or AP** radios (`2 EP / 2 AP`) when a pilot action fires through the
+  mech.
+- **Hot (X) stepper** (`− value +`) — previews heat cost, projects heat-vs-cap,
+  disables when it would exceed cap.
+- Roll outcomes render the SU bands (Cascade Failure / Failure / Tough Choice /
+  Success / Nailed It) with their band colors.
 
-**Adjacent (not Display content, but affect it):**
+### 2.3 Tables roller
 
-- **Settings menu** (RailBar ⚙) — disabled "planned" stub (`RailBar.tsx:46-48`).
-- **Phone reflow** — placeholder message below the scale floor; no `DashboardPhone`
-  (`DashboardCanvas.tsx:50-56`). The Display's mobile variant therefore doesn't exist.
-- **Stale docstrings** — several file headers still say "Phase 1 read-only shell / no
-  mutations yet"; the code is far past that. Cosmetic but misleading.
+- Mini bar: `▾ <table>` picker + `Roll` (result + follow-ups render in the panel).
+- **Full picker overlay** — a **5-column grid, one column per category:
+  `COMBAT · PILOT · SALVAGE · CRAWLER · DOWNTIME`**, each a stamped column of table
+  buttons.
+- Tables ⋯ menu: Pick a table · Roll settings · Roll history · Clear result.
 
-## 4. Prioritized workstreams
+### 2.4 SRD Explorer (`srd` focus)
 
-Ordered by user-visible value per unit effort. Each is independently shippable and
-testable; each ends green (`bun --filter in-the-union-now test`, `typecheck`, `lint`).
+- **Search box** — _"Search the SRD — chassis, systems, abilities, tables…"_
+- **8 category tiles** — Chassis (CHS) · Systems (SYS) · Modules (MOD) · Pilot
+  Abilities (ABL) · Equipment (EQP) · NPCs (NPC) · Crawler Bays (BAY) · Roll Tables
+  (TBL).
+- Result cards drill into the real `ReferenceEntityDisplay` (the mockup stubs this
+  with _"Full ReferenceEntityDisplay renders here."_).
 
-### W1 — EntityView: make the entity focus a real reference document (highest value)
+### 2.5 Entity view (pilot / mech / crawler / drone / ally focus)
 
-This is the deviation most responsible for the "incomplete form" feel: focusing a
-mech/pilot/crawler on the dial should show the **faithful SRD card the rest of the
-app shows**, with its grouped actions and entity-level buttons — not a bare chassis
-card and a text note.
+- The faithful sheet-style reference card + entity-level buttons (Full sheet → /
+  View mech sheet / Restore Mech & Pilot / Customise / Un-link), with live-play
+  stats.
 
-- Replace the bare `EntityCard` path with `ReferenceEntityDisplay` driven through its
-  slot props (per `display-system.md` and `dashboard.md` §3.4):
-  - `abilitiesSection` → grouped `ReferenceEntityActions` for the focused entity.
-  - `statsOverride` → live play values (`currentHP/SP/EP/Heat`, AP) so the header
-    reflects table state, not base stats.
-  - `footerOverride` / `afterExtraContent` → entity-level `footActions`:
-    **Load Into Mech** (on-foot parked mech), **Enter Downtime** (crawler),
-    **Hand re-roll** (pilot) — via `DisplayCard.footActions`, not a new renderer
-    (ADR-017; reuse the `Erow`/`ActionCardErow` vocabulary, §3.3).
-- Render the **crawler** focus as its real reference card (currently a text note);
-  keep the Enter Downtime button as a `footAction`.
-- Provide an in-display `EntityHrefProvider` so `[[links]]` drill into the in-display
-  entity view rather than navigating away (the one sanctioned internal scroll).
-- Touches: `DisplayView.tsx` (+ a small `EntityView` extraction), no new schema.
+## 3. Built vs. intended — the Display functionality gap
 
-### W2 — ActionResolver: add the Apply step + on-foot pilot deck
+Verified against `DisplayView.tsx` + `ActionsDeck.tsx` in the current worktree.
 
-- **Apply step** in `ActionsDeck`: after Roll/Push, resolve the outcome into the
-  explicit Apply the spec calls for (Activate → Roll → Push → **Apply**), so a rolled
-  action's effect is committed as one bookkeeping write under the ADR-007 boundary
-  (auto for non-destructive; the destructive branches already route through
-  `ActiveItemBand`'s confirm overlays — reuse, don't duplicate).
-- **On-foot deck:** when `mount === 'pilot'`, the Actions focus must render the
-  **pilot's** abilities/equipment deck (source-spined orange), not the mech's. Add a
-  pilot-sourced `buildActions` sibling to `buildMechActions`; select by mount in
-  `DisplayView`.
-- Touches: `ActionsDeck.tsx`, `dashboardRules.ts` (`buildMechActions` → add a pilot
-  variant), `DisplayView.tsx` dispatch.
+| Display capability (mockup)                                                              | Built today                                       | Status                               |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------- | ------------------------------------ |
+| Actions **timing tabs** (All/Turn/Free/React)                                            | —                                                 | **Missing**                          |
+| Actions **source-filter tags**                                                           | —                                                 | **Missing**                          |
+| Actions **grouping toggle** (Timing⇄Source)                                              | Hardcoded group-by-source                         | **Missing (fixed grouping)**         |
+| Actions **range selector + reach readout**                                               | —                                                 | **Missing**                          |
+| `acell` **source stamps + micro-meta** (range/dmg/HOT/traits)                            | Name + EP only                                    | **Partial**                          |
+| Action **dim/lock states** (out-of-range / heat-locked / destroyed)                      | —                                                 | **Missing**                          |
+| Resolve **Apply** step                                                                   | Activate/Roll/Push only                           | **Missing**                          |
+| Resolve **Cost EP/AP** radios                                                            | —                                                 | **Missing**                          |
+| Resolve **Hot(X) stepper** + cap projection                                              | —                                                 | **Missing**                          |
+| Deck ⋯ menu (Locker / Filter / Grouping / Passives)                                      | —                                                 | **Missing**                          |
+| Tables **5-column category picker**                                                      | Plain alphabetical `<select>`                     | **Partial**                          |
+| Tables **roll history / settings / clear**                                               | —                                                 | **Missing**                          |
+| **SRD Explorer** search box                                                              | —                                                 | **Missing (hard stub)**              |
+| **SRD Explorer** 8 category tiles + entity drill-in                                      | Placeholder note                                  | **Missing (hard stub)**              |
+| **EntityView** — grouped `ReferenceEntityActions` + `footActions` + live `statsOverride` | Bare card (chassis/class); crawler is a text note | **Partial (largest structural gap)** |
+| On-foot Actions deck (pilot-sourced)                                                     | Always the boarded mech deck                      | **Missing**                          |
+| `[[links]]` drill into in-display entity card                                            | Navigates away / not wired                        | **Missing**                          |
 
-### W3 — TablesRoller: grouped picker + link drill-in
+Evidence: `ActionsDeck.tsx` contains **no** filter / source / grouping / range /
+cost-choice / Hot-stepper controls (only `Activate`/`Roll`/`Push`); `DisplayView.tsx`
+Tables uses a bare `<select>` (`:49-82`), SRD is a placeholder (`:87-92`), and entity
+focuses render a bare `ReferenceEntityDisplay` with no `footActions`/`statsOverride`/
+`ReferenceEntityActions`/`EntityHrefProvider` anywhere in `components/dashboard/`.
 
-- Replace the alphabetical `<select>` with the **5-column grouped picker**
-  (`TablePickerOverlay`), grouping the ~96 `RollTables.all()` by app-side categories
-  (there is no category field in data — categorize app-side, per §5.6).
-- Wire `[[Name]]` links in rendered tables to drill into the in-display entity card
-  (shares the W1 `EntityHrefProvider`).
-- Touches: `DisplayView.tsx` (+ a `TablePickerOverlay` component).
+## 4. Workstreams (Display-focused)
 
-### W4 — SRD Explorer focus (currently a hard stub)
+Ordered by user-visible value. Each is independently shippable and gated on
+`bun --filter in-the-union-now test`, `typecheck`, `lint`, and the ADR-007 boundary
+tests. Reuse `suref-react` (`ReferenceEntityDisplay` / `ActionCard` / `RollTable`)
+and inject economy via the existing `Erow`/`ActionCardErow` + `DisplayCard.footActions`
+vocabulary (ADR-017) — never a new schema-specific renderer.
 
-- Replace the placeholder with a real in-display reference browser: a compact,
-  searchable list of SRD entities (reuse `salvageunion-reference` `search()` and the
-  same `ReferenceEntityDisplay` W1 uses) that drills into an entity card in place.
-- Decision to make first: is SRD Explorer worth a full browser, or should it be
-  **folded into W1's EntityView + a search box** (cheaper, one code path)? Recommend
-  the latter unless product wants a standalone browser. See §6.
-- Touches: `DisplayView.tsx` (`srd` focus branch), possibly a small `SrdExplorer`.
+### D1 — Actions deck: filters, grouping, range, and rich cards (highest value)
 
-### W5 — Adjacent polish (opportunistic, lower priority)
+- **Timing tabs** `All/Turn/Free/React` and a **grouping toggle** `Timing ⇄ Source`
+  over the existing `buildMechActions` groups; drop the hardcoded group-by-source.
+- **Source-filter tags** per owner (pilot/mech/drone), family-colored.
+- **Range selector** `C/M/L/F` + **reach readout**; dim (not hide) out-of-range,
+  heat-locked (`canActivateAction`), and destroyed actions in place.
+- **`acell` cards** carry a source stamp (CHS/SYS/MOD/ABL/EQP) + micro-meta
+  (range/dmg/HOT/traits) — read from `SURefMetaAction`.
+- **On-foot deck:** when `mount==='pilot'`, render the **pilot's** action deck
+  (add a pilot-sourced `buildActions` sibling), not the mech's.
+- Touches: `ActionsDeck.tsx`, `dashboardRules.ts`, `DisplayView.tsx`.
+- **Data dependency to confirm first:** whether `SURefMetaAction` carries timing
+  group / range / traits fields the tabs+range+micro-meta need (see §6).
 
-- RailBar **Settings** menu (Rules & Sources / Dashboard settings / Downtime entry) —
-  currently disabled.
-- **Phone reflow** (`DashboardPhone`) so the Display has a mobile form — larger effort;
-  scope separately (it's a layout project, not Display content).
-- Refresh the **stale "Phase 1" docstrings** across `components/dashboard/*` to match
-  the shipped reality.
-- **Drone / Ally** focuses — blocked on composition surfacing drones/allies (local-first
-  data model has no such link today). Treat as its own data-model question, not part of
-  Display completion. See §6.
+### D2 — Resolve flow: Apply, cost choice, Hot stepper
+
+- Add the **Apply** step (`Activate → Roll → Push → Apply`) that commits a rolled
+  outcome as one write under the ADR-007 boundary (auto for non-destructive; route
+  destructive branches through the existing `ActiveItemBand` confirm overlays).
+- **Cost — EP or AP** radios for `'EP or AP'` actions (`resolveActivationCurrency`).
+- **Hot(X) stepper** with heat-vs-cap projection; disable when it would exceed cap.
+- `◀ Back` / `Clear`. Touches: `ActionsDeck.tsx`, `dashboardRules.ts`.
+
+### D3 — Tables: 5-column category picker + roll history
+
+- Replace the `<select>` with the **5-column grouped picker overlay**
+  (`COMBAT/PILOT/SALVAGE/CRAWLER/DOWNTIME`), categorizing `RollTables.all()`
+  app-side (no category field in data — §5.6 of the spec).
+- Roll result + follow-ups in-panel; **roll history** + Clear. Reuse `RollTable`.
+- Touches: `DisplayView.tsx` (+ a `TablePickerOverlay`).
+
+### D4 — SRD Explorer (currently a hard stub)
+
+- **Search box** over `salvageunion-reference` `search()`, **8 category tiles**
+  (CHS/SYS/MOD/ABL/EQP/NPC/BAY/TBL), result cards drilling into the real
+  `ReferenceEntityDisplay` in-panel (shares the D5 `EntityHrefProvider`).
+- Touches: `DisplayView.tsx` (`srd` branch) + a small `SrdExplorer`.
+
+### D5 — EntityView: a real reference document
+
+- Drive the entity focus through `ReferenceEntityDisplay` slot props: grouped
+  `ReferenceEntityActions` (`abilitiesSection`), live `statsOverride`
+  (`currentHP/SP/EP/Heat`), and entity-level `footActions` (Load Into Mech / Enter
+  Downtime / Hand re-roll / sheet links) via `DisplayCard.footActions`.
+- Render the **crawler** focus as its real card (currently a text note).
+- Provide an in-display `EntityHrefProvider` so `[[links]]` drill in-panel (the one
+  sanctioned internal scroll). Touches: `DisplayView.tsx` (+ an `EntityView`).
+
+### D6 — Display visual fidelity (fold into D1–D5, not a separate build)
+
+The mockup's Display treatment: light "workshop-paper" SRD card inset in the dark
+HUD; **source stamps** (Barlow Semi Condensed, uppercase, dark-on-light); **cost
+pennant** for EP/AP; **segmented pip gauges**; roll-band colors
+(`--cascade/--failure/--tough/--success/--nailed`); state overlays as _treatment_
+(heat redline pulse, damaged 45° hatch, destroyed strike-in-place), never a second
+hue. Apply these per-workstream as each control lands, against the existing
+`--color-sheet-*` / `--color-rust` / `--color-roll-*` tokens — not as a separate
+visual pass. (Broader HUD chrome / phone reflow are **out of scope** here.)
 
 ## 5. Sequencing & verification
 
-- **Suggested order:** W1 → W2 → W3 → W4, then W5 as capacity allows. W1 unblocks W3/W4
-  (shared `EntityHrefProvider` + reference-card path) and delivers the biggest visible
-  jump on its own, so it ships first even if the rest slips.
-- **Per-workstream gate:** `bun --filter in-the-union-now test`, `bun run typecheck`,
-  `bun run lint`. Extend `__tests__/DisplayView.test.tsx` per mode; keep the
-  `e2e/display-verification.e2e.ts` flow green.
-- **ADR-007 assertions:** any new Apply/resolve write must be unit-tested to (a)
-  auto-apply only non-destructive bookkeeping and (b) route destructive outcomes
-  through a confirm/undo — never auto-write a condition (`dashboard.md` §10.1).
-- **Ephemeral/persisted split:** new Display state (focus, resolve step) stays in
-  `playStateStore`/component state, never `entityStore` or snapshots (ADR-019).
-- **Screenshot pass** (outstanding per `dashboard.md` §10.5): once W1 lands, verify
-  light/dark contrast on the reference card in the dark HUD and that grouped actions +
-  footActions fit the display area without breaking the no-scroll contract.
+- **Order:** D5 → D1 → D2 → D3 → D4. D5 (real reference card + `EntityHrefProvider`)
+  underpins D4 and the `acell` cards, and fixes the most visible "bare card" gap;
+  D1/D2 restore the action instrument; D3/D4 complete Tables and SRD.
+- **Per-workstream gate:** the four checks above + extend
+  `__tests__/DisplayView.test.tsx` per mode and keep
+  `e2e/display-verification.e2e.ts` green.
+- **ADR-007:** new Apply/resolve writes must auto-apply only non-destructive
+  bookkeeping and route destructive outcomes through confirm/undo — unit-tested.
+- **Ephemeral split (ADR-019):** filter/grouping/range/resolve state stays in
+  component state / `playStateStore`, never `entityStore` or snapshots.
 
-## 6. Open questions for the user
+## 6. Open questions / dependencies
 
-1. **SRD Explorer** — full standalone browser, or fold into W1's EntityView + a search
-   box (recommended, cheaper)?
-2. **Drone / Ally focuses** — the spec lists them, but composition/data model surfaces
-   no drones/allies today. In scope for "done," or explicitly deferred as a data-model
-   change?
-3. **Phone reflow (W5)** — is a mobile Display form part of "done," or is
-   landscape-desktop-only acceptable for now (it's a separate layout effort)?
-4. **Apply semantics (W2)** — should Apply commit rolled action outcomes automatically
-   where non-destructive, or always present an explicit confirm even for
-   non-destructive effects? (Recommend auto for non-destructive per ADR-007.)
-
-```
-
-```
+1. **Action metadata (blocks D1).** Do `SURefMetaAction` records carry the **timing
+   group** (Turn/Free/React), **range**, and **traits** the tabs / range selector /
+   micro-meta need? If not, D1's filters degrade to what the data supports — confirm
+   before building.
+2. **Range model.** ITUN has no enemy/GM model (local-first); the mockup's `C/M/L/F`
+   is a self-declared range band. Ship the lightweight declare-a-band version
+   (matches spec §10.5), not target selection?
+3. **SRD Explorer depth (D4).** Full standalone browser, or the search + 8-tile +
+   drill-in the mockup shows (recommended — reuses D5's card path)?
+4. **Apply semantics (D2).** Auto-commit non-destructive rolled outcomes, explicit
+   confirm for destructive (recommended, per ADR-007)?

--- a/docs/architecture/dashboard-display-completion-plan.md
+++ b/docs/architecture/dashboard-display-completion-plan.md
@@ -150,9 +150,9 @@ The action type is `SURefMetaAction` = `ActionSchema`
 | Source stamp           | group source + `action.actionSource` schema              | CHS/SYS/MOD/ABL/EQP.                                                                                                                                |
 
 `SalvageUnionReference.resolveActions(entity)` preserves all of these (nothing
-stripped). **Caveat:** for systems/modules the deck currently surfaces only the
-**primary action** (first numeric-cost) per item (`dashboardRules.ts:249`); listing
-every action independently would need `buildMechActions` widened (optional — see §7).
+stripped). **Decided (§7):** the deck **lists every action** — a multi-action
+system/module surfaces each action as its own card, so `buildMechActions` must be
+widened beyond today's primary-action-per-item (`dashboardRules.ts:249`).
 
 ### 4.2 Two controls need Dashboard-authored logic (no stored backing)
 
@@ -226,9 +226,11 @@ tests.
 
 ### D1 — Actions deck: filters, grouping, range, rich cards (highest visible value)
 
-- **Timing tabs** `All/Turn/Free/React` over `action.actionType` (map React→Reaction;
-  bucket Short/Long/DownTime), and a **grouping toggle** `Timing ⇄ Source`; drop the
+- **Timing tabs** — one tab per `actionType`: `All/Turn/Short/Long/Free/React`
+  (React→Reaction; §7) — and a **grouping toggle** `Timing ⇄ Source`; drop the
   hardcoded group-by-source.
+- **List every action** per item (widen `buildMechActions`; §4.1), each an
+  independently filterable card.
 - **Source-filter tags** per owner, family-colored.
 - **Range selector** `C/M/L/F` + **reach readout** from `action.range`; add ephemeral
   `range` + `setRange` to `playStateStore` and a pure range-vs-band helper in
@@ -289,25 +291,18 @@ existing `--color-sheet-*` / `--color-rust` / `--color-roll-*` tokens.
 - **Ephemeral split (ADR-019):** filter/grouping/range/resolve state stays in
   component state / `playStateStore`, never `entityStore` or snapshots.
 
-## 7. Decisions & residual product questions
+## 7. Decisions (all settled)
 
-Resolved (defaults chosen; flag to change):
-
+- **Timing tabs** = **one tab per `actionType`** — `All · Turn · Short · Long · Free ·
+React` (React→`Reaction`). No bucketing; each type is its own tab.
+- **Deck granularity** = **list every action** — a multi-action system/module surfaces
+  each action as its own filterable card (`buildMechActions` widened beyond the
+  primary action; §4.1).
+- **Hot(X) / Uses(X)** = **player-entered stepper** — a `− X +` control with a live
+  heat-vs-cap projection; Dashboard-local state (§4.2).
 - **Range** = lightweight self-declared band (`playStateStore.range`), compared
   against `action.range`. No enemy/target model (matches local-first).
 - **SRD Explorer** = search + 8 tiles + `ReferenceEntityDisplay` drill-in (reusing
   `useSearchCombobox`), _not_ a separate standalone browser.
 - **Apply** auto-commits non-destructive rolled outcomes; destructive outcomes route
   through confirm/undo (ADR-007).
-
-Still worth a product call:
-
-1. **Timing buckets.** How should `Short` / `Long` / `DownTime` action types map onto
-   the mockup's 3-tab `Turn/Free/React` filter — folded into `Turn`, given their own
-   tab, or dropped from the play deck?
-2. **Per-item action granularity.** Keep the current primary-action-per-item deck, or
-   widen `buildMechActions` so every action of a multi-action system is independently
-   listed/filterable (more faithful to the mockup, larger change)?
-3. **Hot(X) / Uses(X) semantics.** For variable-heat actions, is a player-entered X
-   (stepper) the right model, or should the deck just surface "variable" and let the
-   player adjust Heat via the Reactor bay?


### PR DESCRIPTION
## What

A planning/remediation doc for the Dashboard **Display (center panel) functionality** at `docs/architecture/dashboard-display-completion-plan.md`. No code changes.

## Reference

The original comprehensive mockup was the **"Cockpit" Claude Artifact** (self-titled _"ITUN · Play Cockpit — interactive prototype"_), authored outside the repo and **never committed** (verified via `git log --all -S` pickaxe on every mockup identifier). The artifact — not `dashboard.md`, which only names its functions — is the source of truth for intended Display behavior.

## Key finding

The Dashboard **instruments** (RailBar, ActiveItemBand + live reactor/damage/critical/meltdown/cargo overlays, Dial, DialConfig, DashboardChooser, DowntimeWizard, rules engine) are largely complete. The drift is in the **Display's content and controls** — the mockup's center panel is a rich filterable/searchable instrument; the build renders a thin subset:

| Display capability (mockup) | Status |
| --- | --- |
| Actions **timing tabs** (All/Turn/Free/React) | Missing |
| Actions **source-filter tags** | Missing |
| Actions **grouping toggle** (Timing⇄Source) | Missing (fixed group-by-source) |
| Actions **range selector + reach readout** | Missing |
| `acell` **source stamps + micro-meta + dim/lock states** | Partial |
| Resolve **Apply** step / **EP-AP cost radios** / **Hot(X) stepper** | Missing |
| Tables **5-column category picker** + roll history | Partial (plain `<select>`) |
| **SRD Explorer** search + 8 category tiles + drill-in | Missing (hard stub) |
| **EntityView** grouped actions + footActions + live stats | Partial (bare card; crawler is a text note) |
| On-foot (pilot-sourced) Actions deck | Missing (always mech deck) |

## Plan

Display-scoped workstreams **D1–D6** (D5 EntityView first — underpins the rest and fixes the most visible "bare card" gap → D1 action-deck controls → D2 resolve flow → D3 tables → D4 SRD). Each independently shippable, gated on typecheck/test/lint + ADR-007 boundary tests. Visual fidelity folded per-workstream. Four open questions at the end (notably: does `SURefMetaAction` carry timing/range/traits fields for the D1 filters?).

> Requested to branch off #437, but the plan is code-independent of #437 (analyzes `DisplayView.tsx`, which #437 doesn't touch); the behind-main push guard blocks stacked pushes, so it's rebased onto fresh `main`. Retarget to #437's branch to stack it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AH4NrMzgaQPbghfNqjxJJQ