### PR TITLE
build(deps): upgrade to TypeScript 7 (+ @randsum/roller 4) — supersedes #444

### DIFF
--- a/apps/discord-bot/package.json
+++ b/apps/discord-bot/package.json
@@ -21,7 +21,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@randsum/roller": "^2.0.0",
+    "@randsum/roller": "^4.0.0",
     "@sentry/node": "10.65.0",
     "discord.js": "^14.26.5",
     "salvageunion-reference": "workspace:*"

--- a/apps/in-the-union-now/package.json
+++ b/apps/in-the-union-now/package.json
@@ -21,7 +21,7 @@
     "@fontsource/barlow": "5.2.8",
     "@fontsource/barlow-semi-condensed": "5.2.7",
     "@netlify/blobs": "^10.7.9",
-    "@randsum/roller": "^2.0.0",
+    "@randsum/roller": "^4.0.0",
     "@sentry/browser": "10.65.0",
     "@sentry/node": "10.65.0",
     "@tanstack/react-query": "^5.101.2",

--- a/apps/in-the-union-now/src/components/crawler/__tests__/CrawlerBuilder.test.tsx
+++ b/apps/in-the-union-now/src/components/crawler/__tests__/CrawlerBuilder.test.tsx
@@ -514,8 +514,11 @@ describe('CrawlerBuilder — edit mode', () => {
       expect(bay?.npcCurrentHP).toBe(1)
       expect(bay?.condition).toBe('damaged')
       expect(c.crawlerBays?.length).toBe(must(crawler.crawlerBays).length)
+      // Assert inside waitFor: the wizard persists to the store before invoking
+      // onComplete in a later microtask, so a bare assertion here races under
+      // heavy parallel load.
+      expect(onComplete).toHaveBeenCalledWith(crawler.id)
     })
-    expect(onComplete).toHaveBeenCalledWith(crawler.id)
   }, 30000)
 
   it('edit lifts the Tech-1 filter (all-TL weapons offered) and the hard cap', async () => {

--- a/apps/in-the-union-now/src/components/mech/__tests__/MechWizard.test.tsx
+++ b/apps/in-the-union-now/src/components/mech/__tests__/MechWizard.test.tsx
@@ -424,8 +424,11 @@ describe('MechWizard — edit mode (soft regime)', () => {
       expect(m.currentSP).toBe(5)
       expect(m.conditions).toEqual(['Vulnerable'])
       expect(m.systemConditions).toEqual({ 'cargo-pod': 'damaged' })
+      // Assert inside waitFor: the wizard persists to the store before invoking
+      // onComplete in a later microtask, so a bare assertion here races under
+      // heavy parallel load.
+      expect(onComplete).toHaveBeenCalledWith(mech.id)
     })
-    expect(onComplete).toHaveBeenCalledWith(mech.id)
   }, 45000)
 
   it('over-slot installs warn but never block in edit mode', async () => {

--- a/apps/in-the-union-now/src/components/pilot/__tests__/PilotWizard.test.tsx
+++ b/apps/in-the-union-now/src/components/pilot/__tests__/PilotWizard.test.tsx
@@ -418,8 +418,11 @@ describe('PilotWizard — edit mode', () => {
       // Live-play state untouched by the wizard patch.
       expect(p.currentHP).toBe(pilot.currentHP)
       expect(p.callsign).toBe('Sparks')
+      // Assert inside waitFor: the wizard persists to the store before invoking
+      // onComplete in a later microtask, so a bare assertion here races under
+      // heavy parallel load.
+      expect(onComplete).toHaveBeenCalledWith(pilot.id)
     })
-    expect(onComplete).toHaveBeenCalledWith(pilot.id)
   }, 30000)
 
   it('offers Advanced/Hybrid specialisation classes in edit mode', async () => {

--- a/apps/suref-web/package.json
+++ b/apps/suref-web/package.json
@@ -40,6 +40,7 @@
     "@playwright/test": "1.61.1",
     "@vite-pwa/astro": "1.2.0",
     "playwright": "1.61.1",
-    "sharp": "0.35.3"
+    "sharp": "0.35.3",
+    "typescript": "6.0.3"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -22,14 +22,15 @@
         "puppeteer-core": "25.3.0",
         "sharp": "0.35.3",
         "tailwindcss": "4.3.2",
-        "typescript": "6.0.3",
+        "typescript": "7.0.2",
+        "typescript-classic": "npm:typescript@6.0.3",
       },
     },
     "apps/discord-bot": {
       "name": "@suref/discord-bot",
       "version": "0.0.1",
       "dependencies": {
-        "@randsum/roller": "^2.0.0",
+        "@randsum/roller": "^4.0.0",
         "@sentry/node": "10.65.0",
         "discord.js": "^14.26.5",
         "salvageunion-reference": "workspace:*",
@@ -43,7 +44,7 @@
         "@fontsource/barlow": "5.2.8",
         "@fontsource/barlow-semi-condensed": "5.2.7",
         "@netlify/blobs": "^10.7.9",
-        "@randsum/roller": "^2.0.0",
+        "@randsum/roller": "^4.0.0",
         "@sentry/browser": "10.65.0",
         "@sentry/node": "10.65.0",
         "@tanstack/react-query": "^5.101.2",
@@ -100,6 +101,7 @@
         "@vite-pwa/astro": "1.2.0",
         "playwright": "1.61.1",
         "sharp": "0.35.3",
+        "typescript": "6.0.3",
       },
     },
     "packages/salvageunion-reference": {
@@ -116,7 +118,7 @@
       "devDependencies": {
         "@base-ui/react": "1.6.0",
         "@ladle/react": "^5.1.1",
-        "@randsum/roller": "^2.0.0",
+        "@randsum/roller": "^4.0.0",
         "@vitejs/plugin-react": "^6.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -130,7 +132,7 @@
       },
       "peerDependencies": {
         "@base-ui/react": "^1.2.0",
-        "@randsum/roller": "^2.0.0",
+        "@randsum/roller": "^4.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.18.0",
@@ -141,6 +143,9 @@
         "tailwind-merge": "^3.0.2",
       },
     },
+  },
+  "patchedDependencies": {
+    "@ladle/react@5.1.1": "patches/@ladle%2Freact@5.1.1.patch",
   },
   "overrides": {
     "undici": "6.27.0",
@@ -750,7 +755,7 @@
 
     "@puppeteer/browsers": ["@puppeteer/browsers@3.0.6", "", { "dependencies": { "modern-tar": "^0.7.6", "yargs": "^18.0.0" }, "peerDependencies": { "proxy-agent": ">=8.0.1", "yauzl": "^2.10.0 || ^3.4.0" }, "optionalPeers": ["proxy-agent", "yauzl"], "bin": { "browsers": "lib/main-cli.js" } }, "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA=="],
 
-    "@randsum/roller": ["@randsum/roller@2.0.0", "", {}, "sha512-dM+fEfVFMzPB+XI95Klm6u+WW32SW3Ds7TxwTX2cBLZdsL3sVS1M7WOGiYnxB/lUCvsRbdUNimmW1Aal1Illhw=="],
+    "@randsum/roller": ["@randsum/roller@4.0.0", "", {}, "sha512-3TMPTMcrFujndyQzeX59hUClYlChj887SPB2/uiHzeY4HcYvSSzfcu4PWKm925O8cQ+A2r/eQ9TCJNyDvkqoUQ=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.4", "", { "os": "android", "cpu": "arm64" }, "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw=="],
 
@@ -1057,6 +1062,46 @@
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
 
@@ -2400,9 +2445,11 @@
 
     "typesafe-path": ["typesafe-path@0.2.2", "", {}, "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA=="],
 
-    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "typescript-auto-import-cache": ["typescript-auto-import-cache@0.3.6", "", { "dependencies": { "semver": "^7.3.8" } }, "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ=="],
+
+    "typescript-classic": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
 
@@ -2779,6 +2826,8 @@
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "suref-web/typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "puppeteer-core": "25.3.0",
     "sharp": "0.35.3",
     "tailwindcss": "4.3.2",
-    "typescript": "6.0.3"
+    "typescript": "7.0.2",
+    "typescript-classic": "npm:typescript@6.0.3"
   },
   "scripts": {
     "prepare": "[ -z \"$CI\" ] && [ -d .git ] && bunx lefthook install || true",
@@ -87,5 +88,8 @@
     "ladle": "bun --filter suref-react ladle",
     "ladle:web": "bun --filter suref-web ladle",
     "ladle:itun": "bun --filter in-the-union-now ladle"
+  },
+  "patchedDependencies": {
+    "@ladle/react@5.1.1": "patches/@ladle%2Freact@5.1.1.patch"
   }
 }

--- a/packages/suref-react/package.json
+++ b/packages/suref-react/package.json
@@ -21,7 +21,7 @@
   },
   "peerDependencies": {
     "@base-ui/react": "^1.2.0",
-    "@randsum/roller": "^2.0.0",
+    "@randsum/roller": "^4.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.18.0",
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@base-ui/react": "1.6.0",
     "@ladle/react": "^5.1.1",
-    "@randsum/roller": "^2.0.0",
+    "@randsum/roller": "^4.0.0",
     "@vitejs/plugin-react": "^6.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/patches/@ladle%2Freact@5.1.1.patch
+++ b/patches/@ladle%2Freact@5.1.1.patch
@@ -1,0 +1,9 @@
+diff --git a/typings-for-build/app/src/ui.tsx b/typings-for-build/app/src/ui.tsx
+index 21e819893e3fd88850885baafff352ad9a2b11a1..bd831f04ba2ecf7720f76e2705ee8b554b7ff4eb 100644
+--- a/typings-for-build/app/src/ui.tsx
++++ b/typings-for-build/app/src/ui.tsx
+@@ -1,3 +1,4 @@
++// @ts-nocheck -- vendored Ladle build artifact; TS7 moved JSX error attribution off its existing @ts-ignore lines. We only consume the `Story` type from the package barrel.
+ import * as React from "react";
+ import { DialogOverlay, DialogContent } from "./dialog";
+ import { Close } from "./icons";

--- a/tools/check-architecture.ts
+++ b/tools/check-architecture.ts
@@ -57,7 +57,13 @@
 import { readFileSync } from 'node:fs'
 import { dirname, join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import ts from 'typescript'
+// `typescript-classic` is an npm alias for typescript@6 (see root package.json).
+// TypeScript 7's package no longer exposes the classic compiler API this tool
+// walks (`ts.createSourceFile`, `ts.ScriptTarget`, `ts.isFunctionDeclaration`,
+// `ts.forEachChild`, …) — they are all undefined on the TS7 default export — so
+// this AST-walking tool stays on the TS6 API until it's migrated. The rest of
+// the monorepo type-checks on TS7.
+import ts from 'typescript-classic'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 


### PR DESCRIPTION
## Why

Lands the working, green version of Dependabot **#444** (major-updates), whose bare manifest bumps failed CI. Bumps `typescript` **6.0.3 → 7.0.2** across the monorepo and `@randsum/roller` **^2 → ^4**.

TypeScript 7's package drops the classic compiler JS API (`ts.sys`, `ts.ScriptTarget`, `ts.createSourceFile`, `findConfigFile`, …). Three consumers broke; each is fixed here.

## Fixes required by TS7

1. **Ladle** — `@ladle/react@5.1.1` (already latest) ships a vendored `typings-for-build/app/src/ui.tsx`; TS7 moved JSX error attribution to the attribute line, so Ladle's existing `//@ts-ignore`s no longer cover it. Its `.d.ts` type entry re-exports that `.tsx` (`export * as ui from "./src/ui"`), so `skipLibCheck` can't skip it. Patched via `bun patch` with a top-of-file `@ts-nocheck` (we only consume the `Story` type from the barrel). CI-durable through `patchedDependencies`.
2. **`astro check`** (suref-web) embeds the classic TS API and crashes under TS7 (`ts.sys` undefined in `getTsconfig`). No TS7-compatible Astro release exists yet, so **suref-web pins its own `typescript@6.0.3`** — full `.astro` coverage (17 pages) stays green. Revert the pin once Astro supports TS7.
3. **`tools/check-architecture.ts`** walks the AST via the classic API. It now imports the TS6 API through a **`typescript-classic`** npm alias (`npm:typescript@6.0.3`) until migrated.

## Verification

- `bun run check:all` **green** — schemas, lint, format, typecheck (all 4 packages), full test suite (**0 fail**), `validate:all`, knip, audit.
- `bun install --frozen-lockfile` passes (CI parity).
- `@randsum/roller` 4.0 is runtime-safe: discord-bot **63/0**, ITUN **1237/0**.

## Notes

- Closes out the last blocked Dependabot PR — **#444 will be closed as superseded** by this.
- Two temporary TS6 footholds (suref-web pin, `typescript-classic` alias) are the only non-TS7 remnants, both documented inline and both removable once the ecosystem (Astro's language server) ships TS7 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Q81quGqHT5AJ9zxVjtkcD