### PR TITLE
feat(itun): widen entity picker modal to 80% of viewport

### DIFF
--- a/apps/in-the-union-now/src/components/sheet/MechSheet.tsx
+++ b/apps/in-the-union-now/src/components/sheet/MechSheet.tsx
@@ -646,7 +646,6 @@ export function MechSheet({
         open={picker === 'system'}
         onClose={() => setPicker(null)}
         title="Add Systems"
-        maxWidth="max-w-5xl"
       >
         <EntitySearcher
           schema="systems"
@@ -667,7 +666,6 @@ export function MechSheet({
         open={picker === 'module'}
         onClose={() => setPicker(null)}
         title="Add Modules"
-        maxWidth="max-w-5xl"
       >
         <EntitySearcher
           schema="modules"

--- a/apps/in-the-union-now/src/components/sheet/SheetSection.tsx
+++ b/apps/in-the-union-now/src/components/sheet/SheetSection.tsx
@@ -341,7 +341,7 @@ type SheetPickerModalProps = {
   open: boolean
   onClose: () => void
   title: string
-  /** ModalShell max width; defaults to the wide picker-grid width. */
+  /** ModalShell max width; defaults to 80% of the viewport for the wide picker grid. */
   maxWidth?: string
   /** Confirm/cancel footer for single-select pickers (multi-select omits it). */
   footer?: ReactNode
@@ -358,7 +358,7 @@ export function SheetPickerModal({
   open,
   onClose,
   title,
-  maxWidth = 'max-w-3xl',
+  maxWidth = 'max-w-[80vw]',
   footer,
   children,
 }: SheetPickerModalProps) {


### PR DESCRIPTION
## What

Makes the shared entity picker modal (`SheetPickerModal` — every collection **+ Add** and single-select swap on the live sheets) span **80% of the page**.

- `SheetPickerModal`'s default `maxWidth` goes from `max-w-3xl` → `max-w-[80vw]`.
- Drops the now-redundant `maxWidth="max-w-5xl"` overrides on the mech **Add Systems** / **Add Modules** pickers so they inherit the new default too.

The width is threaded through the shared `ModalShell` (`suref-react`), which interpolates the class onto the centered `Dialog.Popup` — so this single default change covers pilot, mech, and crawler pickers uniformly.

## Verification

- `bun run typecheck:itun` ✅
- `bun --filter in-the-union-now test` — 1237 pass, 0 fail ✅
- `bun run lint` / `format` clean (2 pre-existing `<fieldset>` warnings, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)