### PR TITLE
fix(itun): Dashboard canvas fills available space, scales up past 1.3x

### DIFF
--- a/apps/in-the-union-now/src/components/dashboard/DashboardCanvas.tsx
+++ b/apps/in-the-union-now/src/components/dashboard/DashboardCanvas.tsx
@@ -1,51 +1,78 @@
 /**
  * DashboardCanvas — the fixed 1280×800 design canvas, scaled to fit its host with
  * a single `transform: scale(...)`, letterboxed, never scrolling (proposed
- * ADR-020). Below the clamp floor the fixed canvas is abandoned for a stacked
- * fallback (Phase 1 renders a placeholder message there; the real phone reflow
- * is a later phase).
+ * ADR-020). It scales linearly to fill the available space: the host is sized to
+ * the viewport height below its own top offset (nothing on the ancestor chain
+ * establishes a height, so `h-full` alone would collapse to the canvas's fixed
+ * 800px layout box and leave dead space below), then the canvas grows uniformly
+ * to fill whichever axis binds first. Below the width floor the fixed canvas is
+ * abandoned for a stacked fallback (Phase 1 renders a placeholder message there;
+ * the real phone reflow is a later phase).
  */
 
 import { useEffect, useRef, useState, type ReactNode } from 'react'
 
 const CANVAS_W = 1280
 const CANVAS_H = 800
+// Width floor for the landscape HUD: below this the viewport is treated as the
+// wrong form factor (phone) and the stacked fallback replaces the canvas.
 const MIN_SCALE = 0.62
-const MAX_SCALE = 1.3
+// Uniform upscale cap — generous enough to fill a 4K display's height while
+// still guarding against an absurdly large render on giant panels (beyond which
+// the dark ground letterboxes, preserving the HUD look).
+const MAX_SCALE = 2.6
 
 export function DashboardCanvas({ children }: { children: ReactNode }) {
   const hostRef = useRef<HTMLDivElement>(null)
   const [scale, setScale] = useState(1)
   const [reflow, setReflow] = useState(false)
+  // Explicit viewport-anchored height: the host fills from its top offset down
+  // to the viewport bottom so the scale math sees the true available space (and
+  // the dark ground fills it) rather than the collapsed canvas layout box.
+  const [hostH, setHostH] = useState<number | undefined>(undefined)
 
   useEffect(() => {
     const host = hostRef.current
     if (!host) return
     const compute = () => {
+      const top = host.getBoundingClientRect().top
+      const availH = Math.max(0, window.innerHeight - top)
+      setHostH(availH)
       const w = host.clientWidth
-      const h = host.clientHeight
-      if (!w || !h) return
-      const raw = Math.min(w / CANVAS_W, h / CANVAS_H)
-      setReflow(raw < MIN_SCALE)
-      setScale(Math.max(MIN_SCALE, Math.min(MAX_SCALE, raw)))
+      if (!w || !availH) return
+      const rawW = w / CANVAS_W
+      const rawH = availH / CANVAS_H
+      // Reflow is a "wrong form factor" (phone) signal — keyed to WIDTH only, as
+      // it always effectively was before the host gained a real height. A short
+      // but wide desktop window must NOT trip the phone fallback; it just scales
+      // the HUD down to fit its height.
+      setReflow(rawW < MIN_SCALE)
+      // Uniform scale that fits whichever axis binds first (never clipping),
+      // capped so it can fill space without ballooning on giant panels.
+      setScale(Math.min(MAX_SCALE, Math.min(rawW, rawH)))
     }
     compute()
-    // ResizeObserver is absent in some test/SSR environments — fall back to
-    // a window resize listener so the canvas still sizes (and never throws).
+    // ResizeObserver catches host/layout changes; the window resize listener
+    // catches viewport-height changes (which don't resize the host on their own
+    // once its height is pinned). ResizeObserver is absent in some test/SSR
+    // environments — the listener alone still sizes the canvas there.
+    window.addEventListener('resize', compute)
     if (typeof ResizeObserver === 'undefined') {
-      window.addEventListener('resize', compute)
       return () => window.removeEventListener('resize', compute)
     }
     const ro = new ResizeObserver(compute)
     ro.observe(host)
-    return () => ro.disconnect()
+    return () => {
+      window.removeEventListener('resize', compute)
+      ro.disconnect()
+    }
   }, [])
 
   return (
     <div
       ref={hostRef}
-      className="pc-root flex h-full w-full items-center justify-center overflow-hidden"
-      style={{ background: 'var(--pc-ground)' }}
+      className="pc-root flex w-full items-center justify-center overflow-hidden"
+      style={{ background: 'var(--pc-ground)', height: hostH }}
     >
       {reflow ? (
         <div className="pc-reflow">


### PR DESCRIPTION
## What

The play **Dashboard** left a large empty band below the HUD and never scaled past ~1.0× on desktop — see the reported screenshot. This makes the scale-to-fit canvas fill the available space linearly.

## Why it happened

Two compounding causes in `DashboardCanvas.tsx`:

1. **Collapsed host height.** `transform: scale()` is visual only — it never shrinks the layout box, so `.pc-canvas` always occupies its fixed **1280×800** layout size. Nothing on the ancestor chain (`__root` → fragment → fragment) establishes a height, so `.pc-root`'s `h-full` collapsed to that 800px content box. The scale math measured ~800px of "available" height and the dark ground stopped there, exposing the page background below.
2. **Upscale cap.** `MAX_SCALE = 1.3` capped growth even when the viewport had room.

## Fix

- Size the host **explicitly** to the viewport height below its own measured top offset (`window.innerHeight − rect.top`), re-measured on resize. The dark ground now fills, and the scale math sees the true available height.
- Raise `MAX_SCALE` to **2.6** so the HUD can fill up to a 4K display's height (beyond that the ground letterboxes, preserving the look).
- Scale = `min(MAX_SCALE, min(w/1280, availH/800))` — uniform, fits whichever axis binds first, never clips.
- **Reflow (phone fallback) is now width-only.** Previously the height ratio was always pegged at 1.0 (the collapsed host), so the floor was effectively width-only anyway; feeding real height in would have wrongly tripped the "too small, rotate" message on short-but-wide desktop windows. Keying reflow to width preserves the original phone trigger and lets short desktop windows simply scale down to fit.

## Verification

- `bun --filter in-the-union-now test` → 1237 pass / 0 fail (all 72 dashboard tests green)
- `bun run typecheck` → pass
- `bun run lint` / `format` → clean (only 2 pre-existing unrelated warnings)

Note: this adjusts the fixed-canvas behavior described as proposed ADR-020 (letterboxed, never scrolling) — it stays letterboxed and non-scrolling, but now fills rather than capping at 1.3× / collapsing to 800px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXrZwnHZ17p7KP67khvv5j