### PR TITLE
feat(itun): Dashboard Display D5 — real entity reference cards + foot actions

### DIFF
--- a/apps/in-the-union-now/src/components/dashboard/DisplayView.tsx
+++ b/apps/in-the-union-now/src/components/dashboard/DisplayView.tsx
@@ -2,25 +2,32 @@
  * DisplayView — the Dashboard's main display: the ONE surface that reads
  * "forward". It renders the faithful light SRD reference document for whatever
  * the Dial is focused on (focus→display sync), reusing suref-react's
- * ReferenceEntityDisplay / ReferenceEntityActions / RollTable verbatim — the
- * same components the live sheet and reference site show (proposed ADR-017).
+ * ReferenceEntityDisplay / RollTable verbatim — the same components the live
+ * sheet and reference site show (ADR-017).
  *
- * Phase 5 scope: the Dial's "actions" focus now drives the interactive
- * ActionsDeck (activate / roll / push) instead of a placeholder note; the rest
- * of the display stays the read-only reference document from Phase 4.
+ * D5 (this pass): each statful entity focus (mech / pilot / crawler) renders the
+ * entity's real reference card with entity-level `footActions` folded into the
+ * card foot — "Full sheet →" links plus the play verbs (Load Into Mech on foot,
+ * Enter Downtime for the crawler). Live vitals stay in the gauges / dial / Active
+ * Item band (the app has no live-composed entity card, by design — see the
+ * dashboard-display-completion-plan). The crawler focus is now a real reference
+ * card instead of the old text note.
  */
 
+import type { ReactNode } from 'react'
 import { useState } from 'react'
 
 import { SalvageUnionReference } from 'salvageunion-reference'
 import type { SURefEntity } from 'salvageunion-reference'
 import { ReferenceEntityDisplay, RollTable } from 'suref-react'
 
+import { resolveCrawlerType } from '../../lib/crawlerRefs'
 import { resolveChassisRef } from '../../lib/rules/resolveRefs'
 import type { Crawler } from '../../lib/schemas/crawler'
 import type { Mech } from '../../lib/schemas/mech'
 import type { Pilot } from '../../lib/schemas/pilot'
 import { usePlayStateStore } from '../../stores/playStateStore'
+import { AppLink } from '../shared/AppLink'
 import { ActionsDeck } from './ActionsDeck'
 import type { DialItem } from './dialItems'
 
@@ -33,14 +40,34 @@ type DisplayViewProps = {
   crawler: Crawler | null
 }
 
-/** A framed reference card, or a graceful fallback when a slug doesn't resolve. */
-function EntityCard({ data, note }: { data: SURefEntity | null; note: string }) {
-  if (!data) return <div className="pc-display-note">{note}</div>
-  return <ReferenceEntityDisplay data={data} hide={HIDE_CHOICES} />
+/**
+ * A framed reference card with optional entity-level foot actions, or a graceful
+ * fallback (still carrying the foot actions) when a slug doesn't resolve.
+ */
+function EntityCard({
+  data,
+  note,
+  footActions,
+}: {
+  data: SURefEntity | null
+  note: string
+  footActions?: ReactNode
+}) {
+  if (!data) {
+    return (
+      <div className="pc-entity-fallback">
+        <p className="pc-crawler-focus-note">{note}</p>
+        {footActions ? <div className="pc-entity-foot">{footActions}</div> : null}
+      </div>
+    )
+  }
+  return <ReferenceEntityDisplay data={data} hide={HIDE_CHOICES} footActions={footActions} />
 }
 
 export function DisplayView({ focus, mech, pilot, crawler }: DisplayViewProps) {
   const enterDowntime = usePlayStateStore((s) => s.enterDowntime)
+  const mount = usePlayStateStore((s) => s.mount)
+  const setMount = usePlayStateStore((s) => s.setMount)
   // Which roll table the Tables focus shows (ephemeral; defaults to Core Mechanic).
   const [tableId, setTableId] = useState<string | null>(null)
   if (!focus) return <div className="pc-display-note">Nothing selected.</div>
@@ -92,14 +119,27 @@ export function DisplayView({ focus, mech, pilot, crawler }: DisplayViewProps) {
     )
   }
 
-  // Statful entity focus → its reference card.
+  // Statful entity focus → its reference card + entity-level foot actions.
   if (focus.key.startsWith('mech:')) {
     const chassis = resolveChassisRef(mech.chassisRef) as SURefEntity | null
+    const foot = (
+      <>
+        {mount === 'pilot' ? (
+          <button type="button" className="pc-deck-btn" onClick={() => setMount('mech')}>
+            Load Into Mech ▶
+          </button>
+        ) : null}
+        <AppLink href={`/sheet/mech/${mech.id}`} className="pc-deck-btn">
+          Full mech sheet →
+        </AppLink>
+      </>
+    )
     return (
       <div className="pc-display-scroll">
         <EntityCard
           data={chassis}
           note={`Chassis “${mech.chassisRef}” not in the reference set.`}
+          footActions={foot}
         />
       </div>
     )
@@ -107,24 +147,42 @@ export function DisplayView({ focus, mech, pilot, crawler }: DisplayViewProps) {
   if (focus.key.startsWith('pilot:') && pilot) {
     const cls = (SalvageUnionReference.Classes.find((c) => c.id === pilot.classRef) ??
       null) as SURefEntity | null
+    const foot = (
+      <AppLink href={`/sheet/pilot/${pilot.id}`} className="pc-deck-btn">
+        Full pilot sheet →
+      </AppLink>
+    )
     return (
       <div className="pc-display-scroll">
-        <EntityCard data={cls} note={`Class “${pilot.classRef}” not in the reference set.`} />
+        <EntityCard
+          data={cls}
+          note={`Class “${pilot.classRef}” not in the reference set.`}
+          footActions={foot}
+        />
       </div>
     )
   }
   if (focus.key.startsWith('crawler:') && crawler) {
+    const crawlerRef = crawler.type
+      ? (resolveCrawlerType(crawler.type) as unknown as SURefEntity | null)
+      : null
+    const foot = (
+      <>
+        <button type="button" className="pc-deck-btn" onClick={enterDowntime}>
+          Enter Downtime ▶
+        </button>
+        <AppLink href={`/sheet/crawler/${crawler.id}`} className="pc-deck-btn">
+          Full crawler sheet →
+        </AppLink>
+      </>
+    )
     return (
       <div className="pc-display-scroll">
-        <div className="pc-crawler-focus">
-          <p className="pc-crawler-focus-name">Crawler · {crawler.name}</p>
-          <p className="pc-crawler-focus-note">
-            Back at the Union Crawler — run the post-/pre-session Downtime loop.
-          </p>
-          <button type="button" className="pc-deck-btn" onClick={enterDowntime}>
-            Enter Downtime ▶
-          </button>
-        </div>
+        <EntityCard
+          data={crawlerRef}
+          note={`Crawler · ${crawler.name} — back at the Union Crawler for the Downtime loop.`}
+          footActions={foot}
+        />
       </div>
     )
   }

--- a/apps/in-the-union-now/src/components/dashboard/__tests__/DisplayView.test.tsx
+++ b/apps/in-the-union-now/src/components/dashboard/__tests__/DisplayView.test.tsx
@@ -62,9 +62,39 @@ describe('DisplayView', () => {
       gauges: [],
     }
     const { container } = renderDV(focus, 'definitely-not-a-chassis')
-    expect(container.querySelector('.pc-display-note')?.textContent).toContain(
+    expect(container.querySelector('.pc-entity-fallback')?.textContent).toContain(
       'not in the reference set'
     )
+  })
+
+  test('mech focus → foot carries a "Full mech sheet" link (D5)', () => {
+    const focus: DialItem = {
+      key: 'mech:m1',
+      kind: 'mech',
+      statless: false,
+      label: 'Mech · Rig',
+      tone: 'mech',
+      gauges: [],
+    }
+    const { container } = renderDV(focus)
+    expect(container.querySelector('a[href="/sheet/mech/m1"]')).toBeTruthy()
+  })
+
+  test('crawler focus → foot carries Enter Downtime + a crawler sheet link (D5)', () => {
+    const focus: DialItem = {
+      key: 'crawler:c1',
+      kind: 'crawler',
+      statless: false,
+      label: 'Crawler · Hauler',
+      tone: 'crawler',
+      gauges: [],
+    }
+    const { container } = renderDV(focus)
+    expect(container.querySelector('a[href="/sheet/crawler/c1"]')).toBeTruthy()
+    const downtime = [...container.querySelectorAll('button')].some((b) =>
+      b.textContent?.includes('Enter Downtime')
+    )
+    expect(downtime).toBe(true)
   })
 
   test('Tables focus → a RollTable renders', () => {

--- a/apps/in-the-union-now/src/components/dashboard/dashboard.css
+++ b/apps/in-the-union-now/src/components/dashboard/dashboard.css
@@ -531,6 +531,26 @@
   min-width: 200px;
   background: var(--pc-crawler-deep);
 }
+.pc-entity-fallback {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  height: 100%;
+  text-align: center;
+  padding: 24px 16px;
+}
+.pc-entity-foot {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+}
+.pc-entity-foot .pc-deck-btn {
+  flex: 0 0 auto;
+  min-width: 180px;
+}
 
 /* ---- Downtime wizard (light display, Phase 6) ---- */
 .pc-dt {


### PR DESCRIPTION
First implementation slice of the Dashboard **Display** completion plan (PR #446), workstream **D5**.

## What changed

Each statful Display focus now renders the entity's **real reference card** with entity-level `footActions` folded into the card foot (`DisplayView.tsx`):

- **mech** → chassis reference card + `Full mech sheet →` link + `Load Into Mech ▶` (when on foot)
- **pilot** → class reference card + `Full pilot sheet →` link
- **crawler** → the crawler-type reference card (was a bare text note) + `Enter Downtime ▶` + `Full crawler sheet →` link

Reuses `ReferenceEntityDisplay`'s native `footActions` prop and `AppLink` — no new renderer (ADR-017). Adds `.pc-entity-fallback` / `.pc-entity-foot` CSS for the unresolved-slug fallback.

## Scope note (deviation from the plan's original D5 framing)

Investigation found the app has **no live-composed entity card** and `statsOverride` only covers the SV stat — the live sheet draws the player entity as a bespoke poster, not a `ReferenceEntityDisplay`. So live vitals **stay in the gauges / dial / Active Item band** (where they already are) rather than being folded into the reference card. This is documented in the plan §4.3. In-panel `[[links]]` drill-in is **deferred** (the app-wide `EntityHrefProvider` already links to the SRD page); true in-panel drill needs an in-display entity stack — a follow-up.

## Verification

- `bun run typecheck:itun` ✅
- `bun --filter in-the-union-now test` ✅ 1239 pass / 0 fail (+2 new DisplayView tests: mech-sheet-link, crawler foot)
- `biome check` ✅ clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AH4NrMzgaQPbghfNqjxJJQ