### PR TITLE
feat(itun): mandatory current-workspace model — Default workspace, no "All Builds"

### DIFF
--- a/apps/in-the-union-now/src/components/encounter/EncounterScreen.tsx
+++ b/apps/in-the-union-now/src/components/encounter/EncounterScreen.tsx
@@ -11,14 +11,16 @@
  *      condition ticks, per-NPC Mediator rolls, and Remove.
  *
  * Local-first: instances persist to IndexedDB via encounterStore and are
- * workspace-scoped through the same WorkspaceSwitcher the dashboard uses
- * (null = All Builds). New instances are stamped with the active workspace.
+ * workspace-scoped through the same WorkspaceSwitcher the roster uses. There is
+ * always a current workspace (no cross-workspace "All Builds"), so every new
+ * instance is stamped with it.
  */
 
 import { useState } from 'react'
 import { Users } from 'lucide-react'
 import { Empty } from 'suref-react'
 
+import { setActiveWorkspaceId, useActiveWorkspaceId } from '../../hooks/queries'
 import { useHydrateOnMount } from '../../hooks/queries/useHydrateEntities'
 import type { Roll } from '../../lib/rules/heatCheck'
 import type { FindRollTable } from '../../lib/rules/mediatorTables'
@@ -64,8 +66,8 @@ export function EncounterScreen({
   findTable,
 }: EncounterScreenProps) {
   const storeState = store()
-  /** null = "All Builds" — same semantics as the dashboard filter. */
-  const [activeWorkspaceId, setActiveWorkspaceId] = useState<string | null>(null)
+  /** The current workspace (global, persisted) — always a concrete id. */
+  const activeWorkspaceId = useActiveWorkspaceId()
   /** Whole-group roll result — page state, not persisted (per-NPC rolls are). */
   const [groupResult, setGroupResult] = useState<MediatorRollResult | null>(null)
 
@@ -95,7 +97,7 @@ export function EncounterScreen({
     }
     await storeState.create({
       schemaVersion: 1,
-      ...(activeWorkspaceId !== null ? { workspaceId: activeWorkspaceId } : {}),
+      workspaceId: activeWorkspaceId,
       refSchema: candidate.schema,
       refSlug: candidate.slug,
       refName: candidate.name,

--- a/apps/in-the-union-now/src/components/roster/Roster.tsx
+++ b/apps/in-the-union-now/src/components/roster/Roster.tsx
@@ -24,6 +24,8 @@ import { SalvageUnionReference } from 'salvageunion-reference'
 import { Btn, btnVariants, Empty } from 'suref-react'
 
 import {
+  setActiveWorkspaceId,
+  useActiveWorkspaceId,
   useCrawlers,
   useHydrateEntities,
   useMechs,
@@ -34,6 +36,7 @@ import type { SoftLink } from '../../lib/schemas/softLink'
 import { resolveClassName } from '../../lib/classRef'
 import { cn } from '../../lib/utils'
 import type { EntityType } from '../../stores/entityStore'
+import { DEFAULT_WORKSPACE_ID } from '../../lib/defaultWorkspace'
 import { ensureStarterSetSeeded } from '../../lib/starterSet/seedStarterSet'
 import { STARTER_WORKSPACE_ID } from '../../lib/starterSet/starterSet'
 import { useEntityStore } from '../../stores/entityStore'
@@ -111,8 +114,8 @@ const SEGMENTS: ReadonlyArray<{ kind: SegmentKind; label: string }> = [
 
 export function Roster() {
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null)
-  /** null = "All Builds" (show all), string = filter by workspace id */
-  const [activeWorkspaceId, setActiveWorkspaceId] = useState<string | null>(null)
+  /** The current workspace (global, persisted) — always a concrete id. */
+  const activeWorkspaceId = useActiveWorkspaceId()
   /** Mobile-endpoint segmented switch (design §3.7) — which column shows ≤ md */
   const [activeSegment, setActiveSegment] = useState<SegmentKind>('pilot')
 
@@ -125,26 +128,6 @@ export function Roster() {
   const allMechs = useMechs()
   const allCrawlers = useCrawlers()
   const softLinks: SoftLink[] = useSoftLinkList()
-
-  // The built-in Starter Set workspace is seeded into every install but must
-  // stay hidden from the default experience: it never counts toward first-run
-  // and never shows in "All Builds". It surfaces only when explicitly selected
-  // in the Workspace switcher. `isOwn` = "the user's own build, not seeded".
-  const isOwn = <T extends { workspaceId?: string }>(e: T) => e.workspaceId !== STARTER_WORKSPACE_ID
-
-  /**
-   * First-run: a brand-new user with ZERO builds of their OWN, viewing "All
-   * Builds". Measured against the UNFILTERED totals minus the seeded Starter
-   * Set so it means "no data of your own", not "this workspace is empty". The
-   * `activeWorkspaceId === null` guard is load-bearing: once the user selects a
-   * workspace (e.g. "Starter Set") the grid must render so its seeded roster
-   * shows — otherwise the welcome screen would swallow the selection.
-   */
-  const isFirstRun =
-    activeWorkspaceId === null &&
-    allPilots.filter(isOwn).length === 0 &&
-    allMechs.filter(isOwn).length === 0 &&
-    allCrawlers.filter(isOwn).length === 0
 
   // Name lookups for '↳ Name' cross-links — built from the UNFILTERED lists so
   // links resolve across workspace boundaries.
@@ -172,27 +155,30 @@ export function Roster() {
     )
   }
 
-  // Filter by active workspace. "All Builds" (null) shows every entity EXCEPT
-  // the seeded Starter Set — that workspace is reachable only by selecting it.
-  const pilots =
-    activeWorkspaceId === null
-      ? allPilots.filter(isOwn)
-      : allPilots.filter((p) => p.workspaceId === activeWorkspaceId)
-  const mechs =
-    activeWorkspaceId === null
-      ? allMechs.filter(isOwn)
-      : allMechs.filter((m) => m.workspaceId === activeWorkspaceId)
-  const crawlers =
-    activeWorkspaceId === null
-      ? allCrawlers.filter(isOwn)
-      : allCrawlers.filter((c) => c.workspaceId === activeWorkspaceId)
+  // Filter to the current workspace — the only view now (no cross-workspace
+  // "All Builds"). Everything created here is stamped with this workspace.
+  const pilots = allPilots.filter((p) => p.workspaceId === activeWorkspaceId)
+  const mechs = allMechs.filter((m) => m.workspaceId === activeWorkspaceId)
+  const crawlers = allCrawlers.filter((c) => c.workspaceId === activeWorkspaceId)
+
+  /**
+   * First-run welcome: only for a brand-new user sitting in an empty DEFAULT
+   * workspace. Any other empty workspace (a fresh campaign the user made, or the
+   * un-summoned Starter Set) falls through to the normal grid with its per-column
+   * "create" empty states — the big welcome would misfire there.
+   */
+  const isFirstRun =
+    activeWorkspaceId === DEFAULT_WORKSPACE_ID &&
+    pilots.length === 0 &&
+    mechs.length === 0 &&
+    crawlers.length === 0
 
   /**
    * Workspace select. Opening the built-in Starter Set spawns it into this
    * browser on first visit (idempotent), then switches to it — the roster is
    * never seeded until the user asks for it here.
    */
-  async function handleSelectWorkspace(id: string | null) {
+  async function handleSelectWorkspace(id: string) {
     if (id === STARTER_WORKSPACE_ID) await ensureStarterSetSeeded()
     setActiveWorkspaceId(id)
   }
@@ -223,8 +209,9 @@ export function Roster() {
             <ExportAllButton />
             <ImportButton />
             {/* Launch the Dashboard for a chosen pilot/mech/crawler crew
-                (design-spec §8). Shown once at least one mech exists to run. */}
-            {allMechs.length > 0 && <DashboardChooser activeWorkspaceId={activeWorkspaceId} />}
+                (design-spec §8). Shown once the CURRENT workspace has a mech to
+                run — the chooser only offers this workspace's assets. */}
+            {mechs.length > 0 && <DashboardChooser activeWorkspaceId={activeWorkspaceId} />}
           </div>
           <WorkspaceSwitcher
             activeWorkspaceId={activeWorkspaceId}

--- a/apps/in-the-union-now/src/components/workspace/WorkspaceList.tsx
+++ b/apps/in-the-union-now/src/components/workspace/WorkspaceList.tsx
@@ -19,7 +19,9 @@ import { useState } from 'react'
 import { Btn, Input, ModalShell } from 'suref-react'
 
 import { useWorkspaceActions, useWorkspaces } from '../../hooks/queries'
+import { DEFAULT_WORKSPACE_ID } from '../../lib/defaultWorkspace'
 import type { Workspace } from '../../lib/schemas/workspace'
+import { getActiveWorkspaceId, setActiveWorkspaceId } from '../../stores/activeWorkspaceStore'
 
 // ---------------------------------------------------------------------------
 // Injectable store type (for dep-injection in tests)
@@ -136,7 +138,14 @@ function WorkspaceListInner({ onClose, store }: WorkspaceListInnerProps) {
   }
 
   async function handleDelete(id: string) {
+    // The Default workspace is the mandatory fallback — never deletable.
+    if (id === DEFAULT_WORKSPACE_ID) return
     await activeStore.delete(id)
+    // Deleting the current workspace strands the view (members cascade to
+    // Default) — follow them back to Default so the selection stays valid.
+    if (getActiveWorkspaceId() === id) {
+      setActiveWorkspaceId(DEFAULT_WORKSPACE_ID)
+    }
     // If editing this row, cancel the edit
     if (editingId === id) {
       cancelEditing()
@@ -223,15 +232,19 @@ function WorkspaceListInner({ onClose, store }: WorkspaceListInnerProps) {
                     >
                       Rename
                     </Btn>
-                    <Btn
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => void handleDelete(ws.id)}
-                      aria-label={`Delete workspace ${ws.name}`}
-                      className="text-danger hover:text-danger"
-                    >
-                      Delete
-                    </Btn>
+                    {/* The Default workspace is the mandatory fallback — it can
+                        be renamed but never deleted. */}
+                    {ws.id !== DEFAULT_WORKSPACE_ID && (
+                      <Btn
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => void handleDelete(ws.id)}
+                        aria-label={`Delete workspace ${ws.name}`}
+                        className="text-danger hover:text-danger"
+                      >
+                        Delete
+                      </Btn>
+                    )}
                   </>
                 )}
               </li>

--- a/apps/in-the-union-now/src/components/workspace/WorkspaceSwitcher.tsx
+++ b/apps/in-the-union-now/src/components/workspace/WorkspaceSwitcher.tsx
@@ -1,14 +1,17 @@
 /**
- * WorkspaceSwitcher — Dashboard header control.
+ * WorkspaceSwitcher — Roster / Encounter header control.
  *
  * Renders a <select> with:
- *   - "All Builds" option (value = "__all__") — shows all unassigned entities
- *   - One option per workspace
+ *   - One option per real workspace
+ *   - A synthetic "Default workspace" option (fallback until the v10 migration's
+ *     record is hydrated) — the current-workspace model always has a current
+ *     workspace, so there is no "All Builds" entry any more
+ *   - A synthetic "Starter Set" option (until it is spawned into this browser)
  *   - "Manage workspaces…" option (value = "__manage__") — opens WorkspaceList modal
  *
  * Props:
- *   activeWorkspaceId — currently selected workspace id, or null for "All Builds"
- *   onSelect          — called when a workspace (or "__all__") is selected
+ *   activeWorkspaceId — currently selected workspace id (always concrete)
+ *   onSelect          — called when a workspace is selected
  *   store             — injectable store slice for testability
  *
  * WorkspaceList modal is managed internally via local state.
@@ -17,6 +20,7 @@
 import { useState } from 'react'
 
 import { useWorkspaceActions, useWorkspaces } from '../../hooks/queries'
+import { DEFAULT_WORKSPACE_ID, DEFAULT_WORKSPACE_NAME } from '../../lib/defaultWorkspace'
 import type { Workspace } from '../../lib/schemas/workspace'
 import { STARTER_WORKSPACE_ID } from '../../lib/starterSet/starterSet'
 import { WorkspaceList } from './WorkspaceList'
@@ -34,8 +38,6 @@ export type WorkspaceSwitcherStore = WorkspaceListStore & {
 // Constants
 // ---------------------------------------------------------------------------
 
-// biome-ignore lint/style/useComponentExportOnlyModules: sentinel option value consumers must compare against, colocated with the switcher by design
-export const ALL_BUILDS_VALUE = '__all__'
 const MANAGE_VALUE = '__manage__'
 
 // ---------------------------------------------------------------------------
@@ -43,8 +45,8 @@ const MANAGE_VALUE = '__manage__'
 // ---------------------------------------------------------------------------
 
 type WorkspaceSwitcherProps = {
-  activeWorkspaceId: string | null
-  onSelect: (workspaceId: string | null) => void
+  activeWorkspaceId: string
+  onSelect: (workspaceId: string) => void
   /** Inject to avoid Zustand global in tests. */
   store?: WorkspaceSwitcherStore
 }
@@ -65,7 +67,7 @@ export function WorkspaceSwitcher({ activeWorkspaceId, onSelect, store }: Worksp
 
   const [manageOpen, setManageOpen] = useState(false)
 
-  const selectValue = activeWorkspaceId ?? ALL_BUILDS_VALUE
+  const selectValue = activeWorkspaceId
 
   function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
     const val = e.target.value
@@ -73,7 +75,7 @@ export function WorkspaceSwitcher({ activeWorkspaceId, onSelect, store }: Worksp
       setManageOpen(true)
       return
     }
-    onSelect(val === ALL_BUILDS_VALUE ? null : val)
+    onSelect(val)
   }
 
   return (
@@ -94,7 +96,13 @@ export function WorkspaceSwitcher({ activeWorkspaceId, onSelect, store }: Worksp
             className="w-[200px] min-h-11 cursor-pointer appearance-none rounded-[3px] border-chrome border-ink bg-paper py-2 pl-3 pr-8 font-body text-sm text-ink focus:outline-none focus:ring-[3px] focus:ring-rust/[0.22] sm:min-h-9"
             aria-label="Select workspace"
           >
-            <option value={ALL_BUILDS_VALUE}>All Builds</option>
+            {/* The built-in Default workspace always exists (created by the v10
+                migration). Surface it synthetically if the migration's record
+                hasn't hydrated into the store yet, so the current selection is
+                never an option-less value. */}
+            {!activeStore.workspaces.some((ws) => ws.id === DEFAULT_WORKSPACE_ID) && (
+              <option value={DEFAULT_WORKSPACE_ID}>{DEFAULT_WORKSPACE_NAME}</option>
+            )}
             {activeStore.workspaces.map((ws) => (
               <option key={ws.id} value={ws.id}>
                 {ws.name}

--- a/apps/in-the-union-now/src/components/workspace/__tests__/WorkspaceSwitcher.test.tsx
+++ b/apps/in-the-union-now/src/components/workspace/__tests__/WorkspaceSwitcher.test.tsx
@@ -8,9 +8,10 @@
 import { describe, expect, mock, test } from 'bun:test'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 
+import { DEFAULT_WORKSPACE_ID } from '../../../lib/defaultWorkspace'
 import type { Workspace } from '../../../lib/schemas/workspace'
 import type { WorkspaceSwitcherStore } from '../WorkspaceSwitcher'
-import { WorkspaceSwitcher, ALL_BUILDS_VALUE } from '../WorkspaceSwitcher'
+import { WorkspaceSwitcher } from '../WorkspaceSwitcher'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -42,14 +43,29 @@ function makeStore(workspaces: Workspace[] = []): WorkspaceSwitcherStore {
 
 describe('WorkspaceSwitcher — render', () => {
   test('renders the workspace select', () => {
-    render(<WorkspaceSwitcher activeWorkspaceId={null} onSelect={() => {}} store={makeStore()} />)
+    render(
+      <WorkspaceSwitcher
+        activeWorkspaceId={DEFAULT_WORKSPACE_ID}
+        onSelect={() => {}}
+        store={makeStore()}
+      />
+    )
     expect(screen.getByRole('combobox', { name: /select workspace/i })).toBeTruthy()
   })
 
-  test('"All Builds" is the default option when activeWorkspaceId is null', () => {
-    render(<WorkspaceSwitcher activeWorkspaceId={null} onSelect={() => {}} store={makeStore()} />)
+  test('there is no "All Builds" option — a synthetic Default workspace is offered instead', () => {
+    render(
+      <WorkspaceSwitcher
+        activeWorkspaceId={DEFAULT_WORKSPACE_ID}
+        onSelect={() => {}}
+        store={makeStore()}
+      />
+    )
+    expect(screen.queryByRole('option', { name: /all builds/i })).toBeNull()
     const select = screen.getByRole('combobox') as HTMLSelectElement
-    expect(select.value).toBe(ALL_BUILDS_VALUE)
+    // Falls back to the synthetic Default option when the store has no record yet.
+    expect(select.value).toBe(DEFAULT_WORKSPACE_ID)
+    expect(screen.getByRole('option', { name: /default workspace/i })).toBeTruthy()
   })
 
   test('workspace options are rendered', () => {
@@ -57,7 +73,7 @@ describe('WorkspaceSwitcher — render', () => {
     const ws2 = makeWorkspace('ws-2', 'Beta')
     render(
       <WorkspaceSwitcher
-        activeWorkspaceId={null}
+        activeWorkspaceId="ws-1"
         onSelect={() => {}}
         store={makeStore([ws1, ws2])}
       />
@@ -79,11 +95,15 @@ describe('WorkspaceSwitcher — render', () => {
 describe('WorkspaceSwitcher — selection', () => {
   test('selecting a workspace calls onSelect with that workspace id', async () => {
     const ws = makeWorkspace('ws-1', 'Campaign')
-    const onSelect = mock((id: string | null) => {
+    const onSelect = mock((id: string) => {
       void id
     })
     render(
-      <WorkspaceSwitcher activeWorkspaceId={null} onSelect={onSelect} store={makeStore([ws])} />
+      <WorkspaceSwitcher
+        activeWorkspaceId={DEFAULT_WORKSPACE_ID}
+        onSelect={onSelect}
+        store={makeStore([ws])}
+      />
     )
 
     await act(async () => {
@@ -94,25 +114,14 @@ describe('WorkspaceSwitcher — selection', () => {
     expect(onSelect.mock.calls[0]?.[0]).toBe('ws-1')
   })
 
-  test('selecting "All Builds" calls onSelect with null', async () => {
-    const ws = makeWorkspace('ws-1', 'Campaign')
-    const onSelect = mock((id: string | null) => {
-      void id
-    })
-    render(
-      <WorkspaceSwitcher activeWorkspaceId="ws-1" onSelect={onSelect} store={makeStore([ws])} />
-    )
-
-    await act(async () => {
-      fireEvent.change(screen.getByRole('combobox'), { target: { value: ALL_BUILDS_VALUE } })
-    })
-
-    expect(onSelect).toHaveBeenCalledTimes(1)
-    expect(onSelect.mock.calls[0]?.[0]).toBeNull()
-  })
-
   test('selecting "Manage workspaces…" opens WorkspaceList modal', async () => {
-    render(<WorkspaceSwitcher activeWorkspaceId={null} onSelect={() => {}} store={makeStore()} />)
+    render(
+      <WorkspaceSwitcher
+        activeWorkspaceId={DEFAULT_WORKSPACE_ID}
+        onSelect={() => {}}
+        store={makeStore()}
+      />
+    )
 
     await act(async () => {
       fireEvent.change(screen.getByRole('combobox'), { target: { value: '__manage__' } })
@@ -122,10 +131,16 @@ describe('WorkspaceSwitcher — selection', () => {
   })
 
   test('selecting "Manage workspaces…" does not call onSelect', async () => {
-    const onSelect = mock((id: string | null) => {
+    const onSelect = mock((id: string) => {
       void id
     })
-    render(<WorkspaceSwitcher activeWorkspaceId={null} onSelect={onSelect} store={makeStore()} />)
+    render(
+      <WorkspaceSwitcher
+        activeWorkspaceId={DEFAULT_WORKSPACE_ID}
+        onSelect={onSelect}
+        store={makeStore()}
+      />
+    )
 
     await act(async () => {
       fireEvent.change(screen.getByRole('combobox'), { target: { value: '__manage__' } })

--- a/apps/in-the-union-now/src/hooks/queries/index.ts
+++ b/apps/in-the-union-now/src/hooks/queries/index.ts
@@ -17,6 +17,12 @@ export {
   useSoftLinkList,
 } from './entities'
 
-export { useWorkspace, useWorkspaceActions, useWorkspaces } from './workspaces'
+export {
+  setActiveWorkspaceId,
+  useActiveWorkspaceId,
+  useWorkspace,
+  useWorkspaceActions,
+  useWorkspaces,
+} from './workspaces'
 
 export { useHydrateEntities } from './useHydrateEntities'

--- a/apps/in-the-union-now/src/hooks/queries/workspaces.ts
+++ b/apps/in-the-union-now/src/hooks/queries/workspaces.ts
@@ -2,16 +2,23 @@
  * Query hooks over workspaceStore (design review T-7).
  *
  * Same contract as ./entities: typed reactive reads with the store's lazy
- * auto-hydration semantics. There is deliberately NO `useActiveWorkspace`
- * hook — the "active workspace" is page-local UI state (Dashboard and
- * EncounterScreen each keep their own `activeWorkspaceId` useState filter),
- * not store state.
+ * auto-hydration semantics.
+ *
+ * The "current workspace" is now GLOBAL, persisted state (activeWorkspaceStore),
+ * re-exported here as `useActiveWorkspaceId` — it was previously a page-local
+ * `useState` on each surface, but the mandatory current-workspace model (no
+ * cross-workspace "All Builds" view) needs one shared, reload-surviving current
+ * workspace that create sites and the Dashboard chooser can also read.
  */
 
 import { useShallow } from 'zustand/react/shallow'
 
+import { useActiveWorkspaceId } from '../../stores/activeWorkspaceStore'
 import type { Workspace } from '../../lib/schemas/workspace'
 import { useWorkspaceStore } from '../../stores/workspaceStore'
+
+export { useActiveWorkspaceId }
+export { setActiveWorkspaceId } from '../../stores/activeWorkspaceStore'
 
 /** Full workspaceStore state+actions shape (what selectors receive). */
 type WorkspaceStoreState = ReturnType<typeof useWorkspaceStore.getState>

--- a/apps/in-the-union-now/src/lib/db/__tests__/migrations.test.ts
+++ b/apps/in-the-union-now/src/lib/db/__tests__/migrations.test.ts
@@ -17,6 +17,7 @@
  */
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
+import { DEFAULT_WORKSPACE_ID, DEFAULT_WORKSPACE_NAME } from '../../defaultWorkspace'
 import { MechPatternSchema } from '../../schemas/pattern'
 import { MechSchema } from '../../schemas/mech'
 import { PilotSchema } from '../../schemas/pilot'
@@ -352,6 +353,69 @@ describe('salvage read path', () => {
       const raw = await db.get(STORE_NAMES.pilots, 'pilot-heal')
       expect('fieldFromTheFuture' in (raw as Record<string, unknown>)).toBe(false)
       expect((raw as Record<string, unknown>).motto).toBe('Healed.')
+    } finally {
+      db.close()
+    }
+  })
+})
+
+describe('v10 — Default workspace seed + backfill', () => {
+  beforeEach(async () => {
+    await destroyTestDatabase()
+  })
+
+  afterEach(async () => {
+    await destroyTestDatabase()
+  })
+
+  test('creates the Default workspace and backfills only unassigned builds', async () => {
+    // Two builds with NO workspaceId (should be backfilled) and one already
+    // assigned to another workspace (must be left untouched).
+    const unassignedMech = { ...v2Mech, id: 'mech-unassigned' }
+    const unassignedPilot = { ...v2Pilot, id: 'pilot-unassigned' }
+    const assignedPilot = {
+      ...v2Pilot,
+      id: 'pilot-assigned',
+      workspaceId: 'starter-set-workspace',
+    }
+    await seedV2Database([
+      { store: STORE_NAMES.mechs, value: unassignedMech },
+      { store: STORE_NAMES.pilots, value: unassignedPilot },
+      { store: STORE_NAMES.pilots, value: assignedPilot },
+    ])
+
+    const db = await openItunDatabase(TEST_DB_NAME)
+    try {
+      expect(db.version).toBe(DB_VERSION)
+
+      // The Default workspace record now exists.
+      const ws = (await db.get(STORE_NAMES.workspaces, DEFAULT_WORKSPACE_ID)) as
+        | { id: string; name: string }
+        | undefined
+      expect(ws?.id).toBe(DEFAULT_WORKSPACE_ID)
+      expect(ws?.name).toBe(DEFAULT_WORKSPACE_NAME)
+
+      // Unassigned builds were moved into Default (and still strict-parse).
+      const mech = MechSchema.parse(await db.get(STORE_NAMES.mechs, 'mech-unassigned'))
+      expect(mech.workspaceId).toBe(DEFAULT_WORKSPACE_ID)
+      const pilot = PilotSchema.parse(await db.get(STORE_NAMES.pilots, 'pilot-unassigned'))
+      expect(pilot.workspaceId).toBe(DEFAULT_WORKSPACE_ID)
+
+      // A build already in another workspace is untouched.
+      const kept = PilotSchema.parse(await db.get(STORE_NAMES.pilots, 'pilot-assigned'))
+      expect(kept.workspaceId).toBe('starter-set-workspace')
+    } finally {
+      db.close()
+    }
+  })
+
+  test('a fresh database opens with the Default workspace already present', async () => {
+    const db = await openItunDatabase(TEST_DB_NAME)
+    try {
+      const ws = (await db.get(STORE_NAMES.workspaces, DEFAULT_WORKSPACE_ID)) as
+        | { id: string }
+        | undefined
+      expect(ws?.id).toBe(DEFAULT_WORKSPACE_ID)
     } finally {
       db.close()
     }

--- a/apps/in-the-union-now/src/lib/db/index.ts
+++ b/apps/in-the-union-now/src/lib/db/index.ts
@@ -47,9 +47,13 @@ import { STORE_NAMES } from './stores'
  * replaced by on-demand seeding in lib/starterSet/seedStarterSet.ts. v8 heals
  * Battle crawlers whose maxSpModifier hand-carried the type's +5 — the bonus
  * is now derived at read from the type's mutations. v9 creates the append-only
- * `changeLog` (provenance) store — creation only, no record rewrite; ADR-022.)
+ * `changeLog` (provenance) store — creation only, no record rewrite; ADR-022.
+ * v10 creates the mandatory built-in Default workspace and backfills every
+ * unassigned pilot/mech/crawler/encounterNpc into it — the current-workspace
+ * model replaces the old cross-workspace "All Builds" view; see
+ * lib/defaultWorkspace.ts.)
  */
-export const DB_VERSION = 9
+export const DB_VERSION = 10
 
 const DB_NAME = 'itun-v1'
 

--- a/apps/in-the-union-now/src/lib/db/migrations/10-workspace-default-backfill.ts
+++ b/apps/in-the-union-now/src/lib/db/migrations/10-workspace-default-backfill.ts
@@ -1,0 +1,58 @@
+/**
+ * v10 — mandatory current-workspace model.
+ *
+ * Workspaces became the organizing primitive: there is no cross-workspace
+ * "All Builds" view any more, so every build must live in a workspace and the
+ * app always lands in a built-in "Default workspace" (see lib/defaultWorkspace).
+ *
+ * This one-shot migration makes that true for existing data AND fresh installs
+ * (idb runs it for both 9 → 10 and 0 → 10):
+ *   1. Create the Default workspace record if it isn't already present.
+ *   2. Backfill `workspaceId = DEFAULT_WORKSPACE_ID` onto every pilot / mech /
+ *      crawler / encounterNpc that has none, so nothing that used to show under
+ *      "All Builds" disappears. Records that already carry a `workspaceId`
+ *      (Starter Set members, imports) are left untouched.
+ *
+ * IMPORTANT: this runs inside the versionchange transaction. Only IndexedDB
+ * operations on `tx` may be awaited — no reference-data reads (they would let
+ * the transaction auto-commit mid-migration). The Default workspace record is a
+ * static JS constant, not a reference lookup, so importing it is safe.
+ */
+
+import { DEFAULT_WORKSPACE, DEFAULT_WORKSPACE_ID } from '../../defaultWorkspace'
+import { STORE_NAMES } from '../stores'
+import type { UpgradeTransaction } from './index'
+
+/** Object stores whose records get the Default-workspace backfill. */
+const BACKFILL_STORES: readonly string[] = [
+  STORE_NAMES.pilots,
+  STORE_NAMES.mechs,
+  STORE_NAMES.crawlers,
+  STORE_NAMES.encounterNpcs,
+]
+
+export async function migrate(tx: UpgradeTransaction): Promise<void> {
+  // 1. Ensure the Default workspace exists (idempotent — skip if present).
+  if (tx.db.objectStoreNames.contains(STORE_NAMES.workspaces)) {
+    const workspaces = tx.objectStore(STORE_NAMES.workspaces)
+    const existing = await workspaces.get(DEFAULT_WORKSPACE_ID)
+    if (!existing) await workspaces.put(DEFAULT_WORKSPACE)
+  }
+
+  // 2. Backfill unassigned records into the Default workspace.
+  for (const storeName of BACKFILL_STORES) {
+    if (!tx.db.objectStoreNames.contains(storeName)) continue
+    let cursor = await tx.objectStore(storeName).openCursor()
+    while (cursor) {
+      const raw = cursor.value as unknown
+      if (typeof raw === 'object' && raw !== null) {
+        const rec = raw as Record<string, unknown>
+        // == null catches both an absent and an explicitly-null workspaceId.
+        if (rec.workspaceId == null) {
+          await cursor.update({ ...rec, workspaceId: DEFAULT_WORKSPACE_ID })
+        }
+      }
+      cursor = await cursor.continue()
+    }
+  }
+}

--- a/apps/in-the-union-now/src/lib/db/migrations/index.ts
+++ b/apps/in-the-union-now/src/lib/db/migrations/index.ts
@@ -23,6 +23,7 @@ import { migrate as migrate3CargoToCargoLots } from './3-cargo-to-cargo-lots'
 import { migrate as migrate4RemovePilotRollResults } from './4-remove-pilot-roll-results'
 import { migrate as migrate6MechRefsToSlugs } from './6-mech-refs-to-slugs'
 import { migrate as migrate8CrawlerBattleSpToDerived } from './8-crawler-battle-sp-to-derived'
+import { migrate as migrate10WorkspaceDefaultBackfill } from './10-workspace-default-backfill'
 
 /** The untyped versionchange transaction handed to the idb upgrade callback. */
 export type UpgradeTransaction = IDBPTransaction<
@@ -67,9 +68,17 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
     description: 'crawler-battle-sp-to-derived',
     migrate: (tx) => migrate8CrawlerBattleSpToDerived(tx),
   },
+  // v9 was store creation only (changeLog) — no record rewrite.
+  {
+    toVersion: 10,
+    description: 'workspace-default-backfill',
+    migrate: (tx) => migrate10WorkspaceDefaultBackfill(tx),
+  },
   // NOTE: the built-in Starter Set is NOT seeded by a migration. It is spawned
   // on-demand into each browser the first time the user opens the Starter Set
-  // workspace — see lib/starterSet/seedStarterSet.ts.
+  // workspace — see lib/starterSet/seedStarterSet.ts. The built-in DEFAULT
+  // workspace, by contrast, IS created (and backfilled) by the v10 migration
+  // above — it is mandatory, not on-demand.
 ]
 
 /**

--- a/apps/in-the-union-now/src/lib/defaultWorkspace.ts
+++ b/apps/in-the-union-now/src/lib/defaultWorkspace.ts
@@ -1,0 +1,32 @@
+/**
+ * The built-in "Default workspace" — the workspace every install starts in.
+ *
+ * Unlike the on-demand Starter Set (lib/starterSet/), the Default workspace is
+ * MANDATORY and always present: workspaces are the organizing primitive (there
+ * is no cross-workspace "All Builds" view), so there must always be a current
+ * workspace to land in and to stamp new builds with. It is created — and every
+ * pre-existing unassigned build is backfilled into it — by the v10 DB migration
+ * (db/migrations/10-workspace-default-backfill.ts), which runs on both fresh
+ * installs (0 → 10) and upgrades (9 → 10). It carries NO seeded entities.
+ *
+ * The id/createdAt are FIXED constants (like the Starter Set) so the migration
+ * is idempotent and the record never sorts ahead of the user's own builds.
+ */
+
+import type { Workspace } from './schemas/workspace'
+
+/** Deterministic id of the built-in Default workspace. */
+export const DEFAULT_WORKSPACE_ID = 'default-workspace'
+
+/** User-facing name of the built-in Default workspace. */
+export const DEFAULT_WORKSPACE_NAME = 'Default workspace'
+
+/** Fixed creation timestamp (see file header — determinism). */
+const DEFAULT_WORKSPACE_TS = '2020-01-01T00:00:00.000Z'
+
+export const DEFAULT_WORKSPACE: Workspace = {
+  id: DEFAULT_WORKSPACE_ID,
+  schemaVersion: 1,
+  name: DEFAULT_WORKSPACE_NAME,
+  createdAt: DEFAULT_WORKSPACE_TS,
+}

--- a/apps/in-the-union-now/src/stores/__tests__/activeWorkspaceStore.test.ts
+++ b/apps/in-the-union-now/src/stores/__tests__/activeWorkspaceStore.test.ts
@@ -1,0 +1,41 @@
+/**
+ * activeWorkspaceStore unit tests.
+ *
+ * Covers the current-workspace defaults, localStorage persistence, and the
+ * React/non-React accessors. localStorage is provided by the happy-dom preload.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import { DEFAULT_WORKSPACE_ID } from '../../lib/defaultWorkspace'
+import {
+  getActiveWorkspaceId,
+  setActiveWorkspaceId,
+  useActiveWorkspaceStore,
+} from '../activeWorkspaceStore'
+
+afterEach(() => {
+  // Reset back to the built-in default so tests don't leak selection state.
+  setActiveWorkspaceId(DEFAULT_WORKSPACE_ID)
+})
+
+describe('activeWorkspaceStore', () => {
+  test('defaults to the Default workspace', () => {
+    expect(getActiveWorkspaceId()).toBe(DEFAULT_WORKSPACE_ID)
+    expect(useActiveWorkspaceStore.getState().activeWorkspaceId).toBe(DEFAULT_WORKSPACE_ID)
+  })
+
+  test('setActiveWorkspaceId updates state and persists to localStorage', () => {
+    setActiveWorkspaceId('ws-campaign')
+    expect(getActiveWorkspaceId()).toBe('ws-campaign')
+    expect(useActiveWorkspaceStore.getState().activeWorkspaceId).toBe('ws-campaign')
+    expect(localStorage.getItem('itun.activeWorkspaceId')).toBe('ws-campaign')
+  })
+
+  test('switching back to Default persists too', () => {
+    setActiveWorkspaceId('ws-other')
+    setActiveWorkspaceId(DEFAULT_WORKSPACE_ID)
+    expect(getActiveWorkspaceId()).toBe(DEFAULT_WORKSPACE_ID)
+    expect(localStorage.getItem('itun.activeWorkspaceId')).toBe(DEFAULT_WORKSPACE_ID)
+  })
+})

--- a/apps/in-the-union-now/src/stores/__tests__/workspaceStore.test.ts
+++ b/apps/in-the-union-now/src/stores/__tests__/workspaceStore.test.ts
@@ -8,6 +8,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
+import { DEFAULT_WORKSPACE_ID } from '../../lib/defaultWorkspace'
 import { _clearAllStores, _resetDbSingleton } from '../../lib/db/index'
 import { useEntityStore } from '../entityStore'
 import { useWorkspaceStore } from '../workspaceStore'
@@ -100,7 +101,7 @@ describe('workspaceStore — delete', () => {
     expect(fetched).toBeNull()
   })
 
-  test('delete workspace CASCADES — members return to the unassigned pool (plan 2.7)', async () => {
+  test('delete workspace CASCADES — members reassign to the Default workspace', async () => {
     // Create workspace and assign a pilot
     const ws = await useWorkspaceStore.getState().create({ name: 'Campaign' })
     await useEntityStore.getState().hydrate('pilot')
@@ -114,14 +115,25 @@ describe('workspaceStore — delete', () => {
     // Delete workspace
     await useWorkspaceStore.getState().delete(ws.id)
 
-    // Entity still exists but its workspaceId was cleared by the cascade
+    // Entity still exists and was reassigned to the Default workspace by the
+    // cascade — mandatory current-workspace model has no "unassigned pool".
     const member = useEntityStore.getState().get('pilot', pilot.id)
     expect(member).not.toBeNull()
-    expect(member?.workspaceId).toBeUndefined()
+    expect(member?.workspaceId).toBe(DEFAULT_WORKSPACE_ID)
 
-    // It returns to the unassigned pool — never invisible
-    const unassigned = useWorkspaceStore.getState().listUnassigned('pilot')
-    expect(unassigned.find((p) => p.id === pilot.id)).toBeDefined()
+    // It now shows under the Default workspace — never invisible.
+    const inDefault = useWorkspaceStore.getState().listForWorkspace(DEFAULT_WORKSPACE_ID, 'pilot')
+    expect(inDefault.find((p) => p.id === pilot.id)).toBeDefined()
+  })
+
+  test('the Default workspace cannot be deleted', async () => {
+    let message = ''
+    try {
+      await useWorkspaceStore.getState().delete(DEFAULT_WORKSPACE_ID)
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err)
+    }
+    expect(message).toMatch(/cannot be deleted/i)
   })
 
   test('listUnassigned treats an unknown workspaceId as unassigned (dashboard fallback)', async () => {

--- a/apps/in-the-union-now/src/stores/activeWorkspaceStore.ts
+++ b/apps/in-the-union-now/src/stores/activeWorkspaceStore.ts
@@ -1,0 +1,71 @@
+/**
+ * activeWorkspaceStore — the app's single "current workspace".
+ *
+ * Workspaces are the organizing primitive (there is no cross-workspace "All
+ * Builds" view), so there is always exactly one current workspace. It defaults
+ * to the built-in Default workspace (lib/defaultWorkspace) and is persisted to
+ * localStorage so it survives reloads and navigation — unlike the old
+ * page-local `useState` selector each surface used to keep.
+ *
+ * The current workspace drives three things:
+ *   - which builds the Roster / Encounter tray show,
+ *   - which workspace a brand-new build is stamped with (entityStore.create),
+ *   - which assets the Dashboard launch chooser offers.
+ *
+ * Deliberately dumb: it holds a raw id. Guaranteeing that id points at a real
+ * workspace is the caller's job — the v10 migration guarantees the Default
+ * workspace always exists, and the workspace-delete flow resets the current
+ * workspace back to Default when the active one is removed.
+ */
+
+import { create } from 'zustand'
+
+import { DEFAULT_WORKSPACE_ID } from '../lib/defaultWorkspace'
+
+const STORAGE_KEY = 'itun.activeWorkspaceId'
+
+function readPersisted(): string {
+  try {
+    if (typeof localStorage === 'undefined') return DEFAULT_WORKSPACE_ID
+    return localStorage.getItem(STORAGE_KEY) ?? DEFAULT_WORKSPACE_ID
+  } catch {
+    return DEFAULT_WORKSPACE_ID
+  }
+}
+
+function writePersisted(id: string): void {
+  try {
+    if (typeof localStorage === 'undefined') return
+    localStorage.setItem(STORAGE_KEY, id)
+  } catch {
+    // best-effort — a private-mode localStorage throw must not break selection
+  }
+}
+
+type ActiveWorkspaceState = {
+  activeWorkspaceId: string
+  setActiveWorkspaceId: (id: string) => void
+}
+
+export const useActiveWorkspaceStore = create<ActiveWorkspaceState>((set) => ({
+  activeWorkspaceId: readPersisted(),
+  setActiveWorkspaceId(id) {
+    writePersisted(id)
+    set({ activeWorkspaceId: id })
+  },
+}))
+
+/** Reactive read of the current workspace id. */
+export function useActiveWorkspaceId(): string {
+  return useActiveWorkspaceStore((s) => s.activeWorkspaceId)
+}
+
+/** Non-React read of the current workspace id (e.g. from entityStore.create). */
+export function getActiveWorkspaceId(): string {
+  return useActiveWorkspaceStore.getState().activeWorkspaceId
+}
+
+/** Non-React setter for the current workspace id. */
+export function setActiveWorkspaceId(id: string): void {
+  useActiveWorkspaceStore.getState().setActiveWorkspaceId(id)
+}

--- a/apps/in-the-union-now/src/stores/entityStore.ts
+++ b/apps/in-the-union-now/src/stores/entityStore.ts
@@ -27,6 +27,7 @@
 
 import { create } from 'zustand'
 
+import { getActiveWorkspaceId } from './activeWorkspaceStore'
 import { recordDataWrite } from '../lib/backupNudge'
 import { publishStoreChange, subscribeStoreChanges } from '../lib/db/broadcast'
 import * as db from '../lib/db/index'
@@ -268,6 +269,20 @@ function afterWrite(type: EntityType): void {
   recordDataWrite()
 }
 
+/**
+ * Stamp a brand-new build with the current workspace so it belongs somewhere
+ * (mandatory current-workspace model — there is no unassigned pool any more).
+ * Applies to pilots/mechs/crawlers only; SoftLinks carry no workspace, and an
+ * input that already sets `workspaceId` (imports, explicit assignment) is left
+ * untouched so it isn't clobbered.
+ */
+function withActiveWorkspace<T extends EntityType>(type: T, input: CreateInput<T>): CreateInput<T> {
+  if (type === 'softLink') return input
+  const rec = input as { workspaceId?: string }
+  if (rec.workspaceId != null) return input
+  return { ...input, workspaceId: getActiveWorkspaceId() } as CreateInput<T>
+}
+
 export const useEntityStore = create<EntityState>((set, get) => ({
   pilots: [],
   mechs: [],
@@ -317,7 +332,7 @@ export const useEntityStore = create<EntityState>((set, get) => ({
 
   async create<T extends EntityType>(type: T, input: CreateInput<T>): Promise<EntityForType<T>> {
     const key = storeKeyFor(type)
-    const record = await dbStoreFor(type).create(input)
+    const record = await dbStoreFor(type).create(withActiveWorkspace(type, input))
     set((state) => ({
       [key]: [record, ...(state[key] as EntityForType<T>[])],
     }))

--- a/apps/in-the-union-now/src/stores/index.ts
+++ b/apps/in-the-union-now/src/stores/index.ts
@@ -3,6 +3,13 @@ export type { EntityType } from './entityStore'
 
 export { useWorkspaceStore } from './workspaceStore'
 
+export {
+  getActiveWorkspaceId,
+  setActiveWorkspaceId,
+  useActiveWorkspaceId,
+  useActiveWorkspaceStore,
+} from './activeWorkspaceStore'
+
 export { useEncounterStore } from './encounterStore'
 export type { EncounterNpcCreateInput } from './encounterStore'
 

--- a/apps/in-the-union-now/src/stores/workspaceStore.ts
+++ b/apps/in-the-union-now/src/stores/workspaceStore.ts
@@ -14,16 +14,19 @@
  * accessors for one-shot reads or derive-at-call-time patterns.
  *
  * Delete workspace semantics (plan 2.7, gap 9): deleting a workspace CASCADES
- * — every member entity's `workspaceId` is cleared first, so members return
- * to the unassigned pool instead of becoming invisible (assigned to a
- * workspace that no longer exists). As a second line of defence,
- * listUnassigned() also treats entities whose workspaceId points at an
- * unknown workspace as unassigned (records written before the cascade
- * existed, or imported from another browser).
+ * — every member entity is REASSIGNED to the built-in Default workspace first,
+ * so members stay visible instead of vanishing. (Before the mandatory
+ * current-workspace model this cleared `workspaceId` to return members to an
+ * "unassigned pool"; there is no such pool now — there is no cross-workspace
+ * "All Builds" view — so an unassigned build would be invisible. Reassigning to
+ * Default keeps it reachable.) The Default workspace itself cannot be deleted
+ * (guarded in the UI). listUnassigned() still treats entities whose workspaceId
+ * points at an unknown workspace as unassigned, as a salvage fallback.
  */
 
 import { create } from 'zustand'
 
+import { DEFAULT_WORKSPACE_ID } from '../lib/defaultWorkspace'
 import * as db from '../lib/db/index'
 import { STORE_NAMES } from '../lib/db/stores'
 import type { Workspace } from '../lib/schemas/workspace'
@@ -49,8 +52,8 @@ type WorkspaceState = HydratedCollectionSlice<'workspaces', Workspace> &
     rename: (id: string, name: string) => Promise<Workspace>
 
     /**
-     * Deletes the workspace record AND clears workspaceId on every member
-     * entity (cascade) so members return to the unassigned pool.
+     * Deletes the workspace record AND reassigns every member entity to the
+     * built-in Default workspace (cascade) so members stay visible.
      */
     delete: (id: string) => Promise<void>
 
@@ -103,8 +106,15 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
     },
 
     async delete(id) {
-      // Cascade FIRST: clear workspaceId on every member so nothing is left
-      // pointing at a workspace that no longer exists (plan 2.7, gap 9).
+      // The built-in Default workspace is the cascade target and the mandatory
+      // fallback — it must never be deleted (the UI also guards this).
+      if (id === DEFAULT_WORKSPACE_ID) {
+        throw new Error('The Default workspace cannot be deleted.')
+      }
+      // Cascade FIRST: reassign every member to the Default workspace so nothing
+      // is left pointing at a workspace that no longer exists — and nothing
+      // becomes invisible now that there is no cross-workspace view (plan 2.7,
+      // gap 9; mandatory current-workspace model).
       const entityStore = useEntityStore.getState()
       for (const type of ASSIGNABLE_TYPES) {
         await entityStore.hydrate(type)
@@ -115,7 +125,7 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => {
         ).filter((e) => e.workspaceId === id)
         for (const member of members) {
           await entityStore.update(type, member.id, {
-            workspaceId: undefined,
+            workspaceId: DEFAULT_WORKSPACE_ID,
           } as Partial<EntityForType<typeof type>>)
         }
       }


### PR DESCRIPTION
## What & why

ITUN treated workspaces as an *opt-in grouping over an unassigned pool*: new builds were created with no `workspaceId`, the Roster/Encounter surfaces defaulted to a cross-workspace **"All Builds"** view, and the active workspace was page-local `useState` reset on every navigation.

This PR inverts that into a **mandatory current-workspace model**:

- On load you land in a seeded **"Default workspace"** — empty on a fresh install.
- There is **no "All Builds"** option.
- Builds you create belong to the **current** workspace.
- Launching a **Dashboard** only offers assets from the current workspace.

## How

- **`lib/defaultWorkspace.ts`** — fixed id `default-workspace`.
- **v10 DB migration** (`10-workspace-default-backfill.ts`, `DB_VERSION` 9→10) — creates the Default workspace and backfills every unassigned pilot/mech/crawler/encounterNpc into it. Runs for fresh installs (`0→10`) and upgrades (`9→10`), so **nothing that used to show under "All Builds" disappears**. Records already in a workspace (Starter Set, imports) are untouched.
- **`activeWorkspaceStore`** — one global, localStorage-persisted current workspace (re-exported as `useActiveWorkspaceId`), replacing the per-surface `useState`. Reverses the old "deliberately NO `useActiveWorkspace`" note.
- **`entityStore.create`** stamps new pilot/mech/crawler builds with the current workspace (single chokepoint; `softLink` and explicit-`workspaceId` imports left alone).
- **WorkspaceSwitcher** drops the "All Builds" option (synthetic Default fallback until the migration record hydrates); **Roster** + **Encounter** read the global current workspace; Roster's first-run welcome now gates on an empty **Default** workspace.
- **Deleting a workspace** reassigns its members to Default (never orphaned) and resets the current workspace to Default; the **Default workspace itself cannot be deleted** (store guard + hidden UI action).
- The pre-existing `DashboardChooser` workspace scoping (#438) is fed the concrete current workspace, and its Roster launch button gates on the current workspace's mechs.

## Tests

- New: `activeWorkspaceStore` unit test; v10 migration test (Default seeded, unassigned backfilled, already-assigned untouched, fresh DB has Default).
- Updated: `WorkspaceSwitcher` test (no "All Builds", synthetic Default); `workspaceStore` delete-cascade test now asserts reassign-to-Default + a Default-undeletable case.
- `bun --filter in-the-union-now test` → **1242 pass / 0 fail**; typecheck, lint, format, knip, validate:all all green.

## Notes / edge cases

- Import round-trips workspaces; `mergeImport` skips re-creating a workspace whose fixed id already exists, so an imported Default-workspace merges into the local Default (no duplicate). Legacy/orphaned imports (no resolvable `workspaceId`) now land in the current workspace instead of becoming invisible.
- Extends the workspace/roster decisions around ADR-021; worth a short ADR follow-up but the change is self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2wmDEjYcSgvifh9tj6S5A