### PR TITLE
fix(itun): Roster Launch Dashboard button also enables on saved patterns

### DIFF
--- a/apps/in-the-union-now/src/components/roster/Roster.tsx
+++ b/apps/in-the-union-now/src/components/roster/Roster.tsx
@@ -40,6 +40,7 @@ import { DEFAULT_WORKSPACE_ID } from '../../lib/defaultWorkspace'
 import { ensureStarterSetSeeded } from '../../lib/starterSet/seedStarterSet'
 import { STARTER_WORKSPACE_ID } from '../../lib/starterSet/starterSet'
 import { useEntityStore } from '../../stores/entityStore'
+import { usePatternStore } from '../../stores/patternStore'
 import { ExportAllButton } from '../export/ExportAllButton'
 import { ImportButton } from '../export/ImportButton'
 import { DashboardChooser } from '../dashboard/DashboardChooser'
@@ -128,6 +129,10 @@ export function Roster() {
   const allMechs = useMechs()
   const allCrawlers = useCrawlers()
   const softLinks: SoftLink[] = useSoftLinkList()
+  // Saved patterns are global (not workspace-scoped) — the Dashboard chooser
+  // offers them as stand-in mechs, so their presence also enables a launch.
+  const patterns = usePatternStore((s) => s.mechPatterns)
+  usePatternStore.getState().list()
 
   // Name lookups for '↳ Name' cross-links — built from the UNFILTERED lists so
   // links resolve across workspace boundaries.
@@ -210,8 +215,11 @@ export function Roster() {
             <ImportButton />
             {/* Launch the Dashboard for a chosen pilot/mech/crawler crew
                 (design-spec §8). Shown once the CURRENT workspace has a mech to
-                run — the chooser only offers this workspace's assets. */}
-            {mechs.length > 0 && <DashboardChooser activeWorkspaceId={activeWorkspaceId} />}
+                run, or any saved pattern exists to launch as a stand-in — the
+                chooser scopes saved mechs to this workspace. */}
+            {(mechs.length > 0 || patterns.length > 0) && (
+              <DashboardChooser activeWorkspaceId={activeWorkspaceId} />
+            )}
           </div>
           <WorkspaceSwitcher
             activeWorkspaceId={activeWorkspaceId}


### PR DESCRIPTION
## What & why

Follow-up to #451. During review of that PR I flagged a minor regression it introduced: the Roster **Launch Dashboard** button was gated on `mechs.length > 0` (current-workspace saved mechs only). But `DashboardChooser`'s mech step also offers **saved patterns** as stand-in mechs, and patterns are global (not workspace-scoped). So a workspace with saved patterns but zero saved mechs could no longer launch a Dashboard from the Roster, even though the chooser could.

## Fix

Gate the button on `mechs.length > 0 || patterns.length > 0` (patterns read from `patternStore`, mirroring how `DashboardChooser` sources them). An empty Default workspace with neither still hides the button.

Typecheck + full ITUN suite green (1244 pass / 0 fail).

## Not included (noted from the #451 review, optional future work)

- Persisted current-workspace id isn't revalidated against existing workspaces — a stale id (e.g. after an IndexedDB eviction that spares localStorage) leaves the Roster filtered to a nonexistent workspace with no auto-recovery to Default.
- A dashboard stand-in launched from a sheet whose entity is in a non-current workspace is stamped with the current workspace rather than the entity's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2wmDEjYcSgvifh9tj6S5A