### PR TITLE
refactor(itun): retire DashboardChooser's dead "All Builds" (null) branch

### DIFF
--- a/apps/in-the-union-now/src/components/dashboard/DashboardChooser.tsx
+++ b/apps/in-the-union-now/src/components/dashboard/DashboardChooser.tsx
@@ -37,7 +37,6 @@ import type { Pilot } from '../../lib/schemas/pilot'
 import type { SoftLink } from '../../lib/schemas/softLink'
 import { useEntityStore } from '../../stores/entityStore'
 import { usePatternStore } from '../../stores/patternStore'
-import { STARTER_WORKSPACE_ID } from '../../lib/starterSet/starterSet'
 import { cn } from '../../lib/utils'
 import type { LinkWriteStore } from './dashboardLinks'
 import { ensureDashboardLinks } from './dashboardLinks'
@@ -65,14 +64,13 @@ type DashboardChooserProps = {
   initialPilotId?: string
   initialMechId?: string
   /**
-   * Scope the pilot/mech/crawler pickers to the Roster's currently-chosen
-   * workspace, mirroring `Roster.tsx`'s own filter: `null` = "All Builds" shows
-   * every owned entity except the seeded Starter Set; a workspace id shows only
-   * that workspace's entities. Unset = unscoped (all saved entities). Stand-in
-   * mech patterns and default-TL crawler tokens carry no workspace, so they are
-   * always offered.
+   * Scope the pilot/mech/crawler pickers to the current workspace: a workspace
+   * id shows only that workspace's entities. Unset = unscoped (all saved
+   * entities) — the tests' default and a safe fallback for an entity with no
+   * workspace. Stand-in mech patterns and default-TL crawler tokens carry no
+   * workspace, so they are always offered.
    */
-  activeWorkspaceId?: string | null
+  activeWorkspaceId?: string
   /** Button label — defaults to "Launch Dashboard". */
   label?: string
   className?: string
@@ -118,14 +116,11 @@ export function DashboardChooser({
   const allCrawlers: Crawler[] = useCrawlers()
   const links: SoftLink[] = useSoftLinkList()
 
-  // Scope the pickers to the Roster's chosen workspace, mirroring Roster.tsx's
-  // own filter so the chooser can only launch entities the roster is showing.
-  // Unset activeWorkspaceId (prop omitted) = unscoped; `null` = "All Builds"
-  // (everything except the seeded Starter Set); an id = that workspace only.
+  // Scope the pickers to the chosen workspace so the chooser can only launch
+  // entities that workspace holds. Prop omitted = unscoped (tests / no-workspace
+  // fallback); an id = that workspace only.
   const inScope = <T extends { workspaceId?: string }>(list: T[]): T[] => {
     if (activeWorkspaceId === undefined) return list
-    if (activeWorkspaceId === null)
-      return list.filter((e) => e.workspaceId !== STARTER_WORKSPACE_ID)
     return list.filter((e) => e.workspaceId === activeWorkspaceId)
   }
   const pilots = inScope(allPilots)

--- a/apps/in-the-union-now/src/components/sheet/SheetMech.tsx
+++ b/apps/in-the-union-now/src/components/sheet/SheetMech.tsx
@@ -137,10 +137,7 @@ export function SheetMech({
       actions={
         editable ? (
           <>
-            <DashboardChooser
-              initialMechId={mech.id}
-              activeWorkspaceId={mech.workspaceId ?? null}
-            />
+            <DashboardChooser initialMechId={mech.id} activeWorkspaceId={mech.workspaceId} />
             {actions}
           </>
         ) : (

--- a/apps/in-the-union-now/src/components/sheet/SheetPilot.tsx
+++ b/apps/in-the-union-now/src/components/sheet/SheetPilot.tsx
@@ -136,10 +136,7 @@ export function SheetPilot({
       actions={
         editable ? (
           <>
-            <DashboardChooser
-              initialPilotId={pilot.id}
-              activeWorkspaceId={pilot.workspaceId ?? null}
-            />
+            <DashboardChooser initialPilotId={pilot.id} activeWorkspaceId={pilot.workspaceId} />
             {actions}
           </>
         ) : (


### PR DESCRIPTION
## Why

#451 made workspaces mandatory (there is always a current workspace; no "All Builds"). That left a loose end in `DashboardChooser` (introduced in #438): its `activeWorkspaceId === null` branch — "show every owned entity except the seeded Starter Set" — is now **unreachable and contradicts the new invariant**:

- The Roster now feeds a **concrete workspace id** (`useActiveWorkspaceId()`), so the `null` branch is dead from the primary caller.
- If it *were* ever hit, it would offer cross-workspace assets, directly violating "there is always a current workspace."

Surfaced by the PR #451 review as the fast-follow it recommended.

## What

- Narrow the prop `activeWorkspaceId?: string | null` → `activeWorkspaceId?: string`.
- Drop the `null` branch in `inScope` and the now-unused `STARTER_WORKSPACE_ID` import.
- Update the two sheet callers (`SheetMech`, `SheetPilot`) from `entity.workspaceId ?? null` → `entity.workspaceId`.
- `undefined` still means **unscoped** — the tests' default and a safe fallback for an entity with no workspace. Refreshed the prop JSDoc + inline comment to match.

No behavioral change on any live path (Roster already passes a concrete id; entities are always workspace-stamped post-#451 migration) — this removes dead, contradictory code.

## Verification

typecheck (all packages) + `DashboardChooser` tests (6/0) + lint + knip green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Q81quGqHT5AJ9zxVjtkcD