### PR TITLE
fix(itun): open chassis-pattern detail modal in link mode (suref-web)

### DIFF
--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/__tests__/chassisPatternsLinkMode.test.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/__tests__/chassisPatternsLinkMode.test.tsx
@@ -1,0 +1,60 @@
+import { describe, test, expect, afterEach, mock } from 'bun:test'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+import type { SURefChassis, SURefEntity } from 'salvageunion-reference'
+import { ReferenceEntityChassisPatterns } from '../ReferenceEntityChassisPatterns'
+import { EntityHrefProvider, EntityDetailLinkProvider } from '../entityHrefContext'
+
+/**
+ * Regression: a pattern under a chassis is a modal-only configured view of the
+ * chassis (per-pattern title/stats/loadout) with no standalone URL. Even when
+ * the consuming app enables link mode (suref-web wraps entities in
+ * `EntityDetailLinkProvider value={true}`), clicking a pattern must open the
+ * in-place detail modal — NOT `window.open` the chassis's own show page (which
+ * would drop the pattern-specific view and read as "nothing happened / blink").
+ *
+ * The provider that forces link mode off must wrap the component whose
+ * `useDetailModal` hook reads the context; placing it inside that component's
+ * returned JSX (covering only its children) leaves the hook reading the ambient
+ * `true`, which is the bug this pins.
+ */
+const mule = SalvageUnionReference.Chassis.find((c) => c.name === 'Mule') as SURefChassis
+
+afterEach(() => cleanup())
+
+describe('ReferenceEntityChassisPatterns — link-mode detail', () => {
+  test('fixture has patterns', () => {
+    expect(mule).toBeDefined()
+    expect(mule.patterns.length).toBeGreaterThan(0)
+  })
+
+  test('clicking a pattern in link mode opens the modal, not a new tab', () => {
+    const openSpy = mock(() => null)
+    const originalOpen = window.open
+    window.open = openSpy as unknown as typeof window.open
+
+    try {
+      render(
+        <EntityHrefProvider value={(e) => `/schema/chassis/item/${e.id}`}>
+          <EntityDetailLinkProvider value={true}>
+            <ReferenceEntityChassisPatterns
+              patterns={mule.patterns}
+              chassisEntity={mule as SURefEntity}
+            />
+          </EntityDetailLinkProvider>
+        </EntityHrefProvider>
+      )
+
+      const card = document.querySelector('[role="button"]') as HTMLElement | null
+      expect(card).toBeTruthy()
+      fireEvent.click(card as HTMLElement)
+
+      // The regression: pre-fix this click called window.open (link-out) and
+      // rendered no modal.
+      expect(openSpy).not.toHaveBeenCalled()
+      expect(screen.queryByRole('dialog')).toBeTruthy()
+    } finally {
+      window.open = originalOpen
+    }
+  })
+})


### PR DESCRIPTION
## Problem

On the suref-web reference site, **clicking a pattern under a chassis did nothing — the page just blinked**, and the pattern-specific view never rendered.

## Root cause

A pattern under a chassis is a modal-only configured view of the chassis (per-pattern title / stats / loadout) with no standalone URL. `PatternListing` calls `useDetailModal`, which reads `useEntityDetailLink()` to decide between the in-place modal and linking out.

The `EntityDetailLinkProvider value={false}` intended to force modal mode was placed **inside `PatternListing`'s returned JSX** — so it only wrapped that component's *children*, not its own hook call. The hook therefore read the **ambient** link mode.

suref-web wraps entities in `EntityDetailLinkProvider value={true}`, so `useDetailModal` saw link mode on, resolved the chassis's own href, and the pattern click became `window.open(chassisPage)` while `modal` was `null`. Result: the chassis's own page (re)opened, the pattern view was dropped, and it read as "nothing happened / blink". ITUN (link mode off) was unaffected, which is why this only showed on the reference site.

## Fix

Hoist the `EntityDetailLinkProvider value={false}` into the parent `ReferenceEntityChassisPatterns` so it wraps each `PatternListing` **before** its `useDetailModal` hook runs. The redundant inner provider is removed.

## Test

Adds `chassisPatternsLinkMode.test.tsx`: renders the patterns section inside `EntityDetailLinkProvider value={true}` (simulating suref-web), clicks a pattern, and asserts `window.open` is **not** called and the detail modal opens. Confirmed the test fails against the pre-fix code and passes with the fix.

## Validation

- `bun run typecheck` (all workspaces) ✅
- `bun --filter suref-react test` — 401 pass ✅
- Biome lint clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsbMBTQ5meEKkaJXdY9bTG