### PR TITLE
feat(suref-web): drop Previous/Next entity paging nav

### DIFF
--- a/apps/suref-web/src/lib/changelog.ts
+++ b/apps/suref-web/src/lib/changelog.ts
@@ -6,6 +6,13 @@ type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: '2026-07-13',
+    title: 'Simpler entity pages',
+    items: [
+      'Removed the Previous/Next paging links from entity pages — use search or the category listing to move between entities.',
+    ],
+  },
+  {
     date: '2026-07-09',
     title: 'Link to the character builder',
     items: [

--- a/apps/suref-web/src/lib/staticPaths.ts
+++ b/apps/suref-web/src/lib/staticPaths.ts
@@ -23,9 +23,6 @@ export function getSchemaStaticPaths() {
   })
 }
 
-/** A prev/next sibling reference within the same schema listing. */
-type SiblingLink = { slug: string; name: string }
-
 export function getItemStaticPaths() {
   const paths: {
     params: { schemaId: string; itemId: string }
@@ -34,10 +31,6 @@ export function getItemStaticPaths() {
       schema: (typeof catalog.schemas)[number]
       itemName: string
       itemDescription: string
-      /** Previous sibling in this schema's listing order, or null at the start. */
-      prevItem: SiblingLink | null
-      /** Next sibling in this schema's listing order, or null at the end. */
-      nextItem: SiblingLink | null
     }
   }[] = []
 
@@ -49,16 +42,12 @@ export function getItemStaticPaths() {
   for (const schema of catalog.schemas.filter((s) => !s.meta)) {
     try {
       const items = SalvageUnionReference.findAllIn(schema.id as SURefEnumSchemaName, () => true)
-      // Resolve display data once so prev/next can reference sibling slugs/names
-      // from the same ordered list (no wrap-around: ends omit the missing side).
-      const entries = items
-        .filter((item): item is typeof item & { id: string } => 'id' in item && !!item.id)
-        .map((item) => ({ item, displayData: getReferenceEntityData(item) }))
+      const entries = items.filter(
+        (item): item is typeof item & { id: string } => 'id' in item && !!item.id
+      )
 
-      entries.forEach(({ item, displayData }, index) => {
-        const prev = index > 0 ? entries[index - 1] : undefined
-        const next = index < entries.length - 1 ? entries[index + 1] : undefined
-
+      for (const item of entries) {
+        const displayData = getReferenceEntityData(item)
         paths.push({
           params: { schemaId: schema.id, itemId: displayData.slug },
           props: {
@@ -66,11 +55,9 @@ export function getItemStaticPaths() {
             schema,
             itemName: displayData.name,
             itemDescription: displayData.description ?? '',
-            prevItem: prev ? { slug: prev.displayData.slug, name: prev.displayData.name } : null,
-            nextItem: next ? { slug: next.displayData.slug, name: next.displayData.name } : null,
           },
         })
-      })
+      }
     } catch {
       // Skip schemas that can't be loaded
     }

--- a/apps/suref-web/src/pages/schema/[schemaId]/item/[itemId].astro
+++ b/apps/suref-web/src/pages/schema/[schemaId]/item/[itemId].astro
@@ -11,7 +11,7 @@ export function getStaticPaths() {
   return getItemStaticPaths()
 }
 
-const { item, schema, itemName, itemDescription, prevItem, nextItem } = Astro.props
+const { item, schema, itemName, itemDescription } = Astro.props
 const { schemaId, itemId } = Astro.params
 
 const schemaName = schema.displayName || 'Item'
@@ -119,40 +119,4 @@ const ogImage = `/schema/${schemaId}/item/${itemId}.og.png`
         crawlers keep the content. */}
     {staticSummary && <StaticEntityContent summary={staticSummary} />}
   </article>
-
-  {/* Prev/next sibling navigation within the same schema listing. No
-      wrap-around: the first item omits prev, the last omits next. */}
-  {(prevItem || nextItem) && (
-    <nav
-      aria-label={`${schemaName} navigation`}
-      class="mx-auto flex w-full max-w-[1000px] items-stretch justify-between gap-3 px-4 pb-8"
-    >
-      {prevItem ? (
-        <a
-          href={`/schema/${schemaId}/item/${prevItem.slug}/`}
-          rel="prev"
-          aria-label={`Previous: ${prevItem.name}`}
-          class="group flex flex-1 flex-col rounded border border-su-grey-light bg-su-white px-4 py-3 no-underline transition-colors hover:border-su-orange-dark"
-        >
-          <span class="font-mono text-xs uppercase tracking-wide text-su-grey-dark">← Previous</span>
-          <span class="mt-0.5 font-semibold text-su-black group-hover:text-su-orange-dark">{prevItem.name}</span>
-        </a>
-      ) : (
-        <span class="flex-1" aria-hidden="true"></span>
-      )}
-      {nextItem ? (
-        <a
-          href={`/schema/${schemaId}/item/${nextItem.slug}/`}
-          rel="next"
-          aria-label={`Next: ${nextItem.name}`}
-          class="group flex flex-1 flex-col items-end rounded border border-su-grey-light bg-su-white px-4 py-3 text-right no-underline transition-colors hover:border-su-orange-dark"
-        >
-          <span class="font-mono text-xs uppercase tracking-wide text-su-grey-dark">Next →</span>
-          <span class="mt-0.5 font-semibold text-su-black group-hover:text-su-orange-dark">{nextItem.name}</span>
-        </a>
-      ) : (
-        <span class="flex-1" aria-hidden="true"></span>
-      )}
-    </nav>
-  )}
 </BaseLayout>


### PR DESCRIPTION
## What

Removes the Previous/Next sibling navigation buttons from SRD entity pages, per request.

## Changes

- `apps/suref-web/src/pages/schema/[schemaId]/item/[itemId].astro` — deleted the prev/next `<nav>` block and dropped `prevItem`/`nextItem` from the props destructuring.
- `apps/suref-web/src/lib/staticPaths.ts` — removed the sibling computation (`SiblingLink` type, prev/next index math) from `getItemStaticPaths`; item paths now emit just `item`/`schema`/`itemName`/`itemDescription`.
- `apps/suref-web/src/lib/changelog.ts` — added a changelog entry.

Users move between entities via search or the category listing.

## Verification

- `typecheck` (suref-web): 0 errors
- `test` (suref-web): 986 pass, 0 fail
- `lint`: clean (2 pre-existing warnings in an unrelated component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018riDQ4fUfaQ9bk91mABn7R