### PR TITLE
Move bot Terms/Privacy links from footer to Discord page

### DIFF
--- a/apps/suref-web/src/layouts/BaseLayout.astro
+++ b/apps/suref-web/src/layouts/BaseLayout.astro
@@ -133,13 +133,7 @@ const ogImageUrl = ogImage.startsWith('http') ? ogImage : new URL(ogImage, SITE_
       <main class="flex flex-1 flex-col bg-su-blue-pale" transition:animate="fade">
         <slot />
       </main>
-      <Footer
-        poweredBySalvageUrl="/Powered_by_Salvage_Black.webp"
-        legalLinks={[
-          { label: 'Bot Terms', href: '/bot/terms' },
-          { label: 'Bot Privacy', href: '/bot/privacy' },
-        ]}
-      />
+      <Footer poweredBySalvageUrl="/Powered_by_Salvage_Black.webp" />
     </div>
   </body>
 </html>

--- a/apps/suref-web/src/lib/changelog.ts
+++ b/apps/suref-web/src/lib/changelog.ts
@@ -13,6 +13,13 @@ export const CHANGELOG: ChangelogEntry[] = [
     ],
   },
   {
+    date: '2026-07-13',
+    title: 'Bot Terms & Privacy moved to the Discord page',
+    items: [
+      "The bot's Terms of Service and Privacy Policy links now live at the bottom of the Discord page instead of in the site footer.",
+    ],
+  },
+  {
     date: '2026-07-09',
     title: 'Link to the character builder',
     items: [

--- a/apps/suref-web/src/pages/discord.astro
+++ b/apps/suref-web/src/pages/discord.astro
@@ -175,6 +175,13 @@ const breadcrumbs = [
           class="font-bold text-su-orange-dark hover:underline">Randsum.dev</a
         >.
       </p>
+
+      <!-- Legal -->
+      <p class="text-center text-xs text-su-grey-dark">
+        <a href="/bot/terms" class="underline hover:text-su-orange-dark">Terms of Service</a>
+        <span class="px-1.5 text-su-grey-light">·</span>
+        <a href="/bot/privacy" class="underline hover:text-su-orange-dark">Privacy Policy</a>
+      </p>
     </div>
   </div>
 </BaseLayout>


### PR DESCRIPTION
## What

Moves the bot's **Terms of Service** and **Privacy Policy** links out of the site footer and onto the Discord page, per request.

- `BaseLayout.astro` — drop the `legalLinks` prop from `<Footer>` (footer no longer shows bot legal links site-wide).
- `discord.astro` — add a small legal-links row at the bottom, relabeled **Terms of Service** · **Privacy Policy** (was "Bot Terms" / "Bot Privacy").
- The `/bot/terms` and `/bot/privacy` pages themselves are unchanged.
- Changelog entry added.

The shared `Footer` component keeps its optional `legalLinks` prop (still covered by its test) — only suref-web's usage changed.

## Verification

- `typecheck` (suref-web): 0 errors
- `test` (suref-web): 986 pass / 0 fail
- `lint`: clean (2 pre-existing unrelated warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L26VPbVQ6VUnZhKsST53tS