### PR TITLE
feat(itun): pilot sheet Launch Dashboard seeds the linked mech + crawler

### DIFF
--- a/apps/in-the-union-now/src/components/dashboard/DashboardChooser.tsx
+++ b/apps/in-the-union-now/src/components/dashboard/DashboardChooser.tsx
@@ -60,9 +60,15 @@ type DashboardChooserProps = {
    * Pre-seed the crew picker from a launching pilot/mech sheet (P4.4): the
    * seeded entity is pre-selected and the picker opens on the first still-empty
    * step. Omit on the Roster chooser (start empty at the pilot step).
+   *
+   * A pilot sheet seeds its whole linked crew — the pilot plus, when present,
+   * its assigned mech and home crawler — so launching from a pilot with a mech
+   * and crawler lands on the ready-to-launch crawler step with all three
+   * pre-selected.
    */
   initialPilotId?: string
   initialMechId?: string
+  initialCrawlerId?: string
   /**
    * Scope the pilot/mech/crawler pickers to the current workspace: a workspace
    * id shows only that workspace's entities. Unset = unscoped (all saved
@@ -99,6 +105,7 @@ export function DashboardChooser({
   onLaunch,
   initialPilotId,
   initialMechId,
+  initialCrawlerId,
   activeWorkspaceId,
   label = 'Launch Dashboard',
   className,
@@ -135,11 +142,14 @@ export function DashboardChooser({
 
   function openDialog() {
     // Pre-seed from a launching sheet (P4.4); open on the first empty step.
+    // The crawler is optional, so it never advances the opening step past the
+    // (still-required) pilot/mech — a fully-seeded crew lands on the crawler
+    // step ready to launch.
     const seedPilot = initialPilotId ?? ''
     const seedMech = initialMechId ?? ''
     setPilotId(seedPilot)
     setMechId(seedMech)
-    setCrawlerId('')
+    setCrawlerId(initialCrawlerId ?? '')
     setStep(seedPilot === '' ? 'pilot' : seedMech === '' ? 'mech' : 'crawler')
     setError(null)
     setOpen(true)

--- a/apps/in-the-union-now/src/components/dashboard/__tests__/DashboardChooser.test.tsx
+++ b/apps/in-the-union-now/src/components/dashboard/__tests__/DashboardChooser.test.tsx
@@ -263,4 +263,56 @@ describe('DashboardChooser — wizard', () => {
       )
     ).toBe(true)
   })
+
+  test('a fully-seeded crew opens on the crawler step with the crawler pre-selected and launches directly', async () => {
+    // Mirrors a pilot Live Sheet whose pilot has a linked mech + crawler: the
+    // chooser is seeded with all three, so it skips straight to the last step
+    // with the crew pre-selected and one Launch click links + launches them.
+    const { pilot, mech, crawler } = await seedCrew()
+    resetEntityStore()
+
+    const result: { id: string | null } = { id: null }
+    await act(async () => {
+      render(
+        <DashboardChooser
+          initialPilotId={pilot.id}
+          initialMechId={mech.id}
+          initialCrawlerId={crawler.id}
+          onLaunch={(id) => {
+            result.id = id
+          }}
+        />
+      )
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Launch the Dashboard' }))
+    })
+    // Lands on the crawler step (its Launch button, not a "Next"), with the
+    // seeded crawler already checked — no clicking through pilot/mech first.
+    await settle(
+      () =>
+        screen.queryByRole('button', { name: 'Launch the Dashboard for the chosen crew' }) !== null
+    )
+    const crawlerRadio = screen.getByRole('radio', { name: /Tenacity/ }) as HTMLInputElement
+    expect(crawlerRadio.checked).toBe(true)
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Launch the Dashboard for the chosen crew' })
+      )
+    })
+    await settle(() => result.id !== null)
+
+    expect(result.id).toBe(mech.id)
+    const links = useEntityStore.getState().softLinks
+    expect(
+      links.some((l) => l.type === 'mech-to-pilot' && l.from.id === mech.id && l.to.id === pilot.id)
+    ).toBe(true)
+    expect(
+      links.some(
+        (l) => l.type === 'pilot-to-crawler' && l.from.id === pilot.id && l.to.id === crawler.id
+      )
+    ).toBe(true)
+  })
 })

--- a/apps/in-the-union-now/src/components/sheet/SheetPilot.tsx
+++ b/apps/in-the-union-now/src/components/sheet/SheetPilot.tsx
@@ -136,7 +136,12 @@ export function SheetPilot({
       actions={
         editable ? (
           <>
-            <DashboardChooser initialPilotId={pilot.id} activeWorkspaceId={pilot.workspaceId} />
+            <DashboardChooser
+              initialPilotId={pilot.id}
+              initialMechId={composition.mech?.id}
+              initialCrawlerId={composition.crawler?.id}
+              activeWorkspaceId={pilot.workspaceId}
+            />
             {actions}
           </>
         ) : (


### PR DESCRIPTION
## What

Launching the Dashboard from a **pilot Live Sheet** now pre-seeds the pilot's linked mech and home crawler as the associated models, instead of opening the chooser blank at the mech step.

## Why

`SheetPilot` already resolves the pilot's assigned mech and home crawler (`composition.mech` / `composition.crawler`) for its Linked Units rail, but passed **neither** to `DashboardChooser` — only `initialPilotId`. So a pilot with a full crew still had to re-pick its mech and crawler by hand before launching.

## Change

- `DashboardChooser` gains an `initialCrawlerId` prop (alongside the existing `initialMechId`) and seeds the crawler in `openDialog`. The crawler is optional, so a fully-seeded crew lands on the ready-to-launch **crawler** step with all three pre-selected.
- `SheetPilot` passes `composition.mech?.id` and `composition.crawler?.id` through. When a pilot has no linked mech/crawler, the values are `undefined` and behavior is unchanged (opens at the mech step).
- Associations remain SoftLink-derived (`mech-to-pilot`, `pilot-to-crawler`) — no new data model; the launch still writes/repairs the links via `ensureDashboardLinks`.

## Tests

Added a `DashboardChooser` test: a fully-seeded crew opens on the crawler step with the crawler radio pre-checked and launches directly with one click, linking the crew. Typecheck, lint, and the dashboard/launch test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JE9hgwF2XKnEmbXjgj8n1b