### PR TITLE
feat(itun): add "The Eldridge Coast" built-in campaign workspace

### DIFF
--- a/apps/in-the-union-now/src/components/roster/Roster.tsx
+++ b/apps/in-the-union-now/src/components/roster/Roster.tsx
@@ -39,6 +39,8 @@ import type { EntityType } from '../../stores/entityStore'
 import { DEFAULT_WORKSPACE_ID } from '../../lib/defaultWorkspace'
 import { ensureStarterSetSeeded } from '../../lib/starterSet/seedStarterSet'
 import { STARTER_WORKSPACE_ID } from '../../lib/starterSet/starterSet'
+import { ensureEldridgeCoastSeeded } from '../../lib/eldridgeCoast/seedEldridgeCoast'
+import { ELDRIDGE_WORKSPACE_ID } from '../../lib/eldridgeCoast/eldridgeCoast'
 import { useEntityStore } from '../../stores/entityStore'
 import { usePatternStore } from '../../stores/patternStore'
 import { ExportAllButton } from '../export/ExportAllButton'
@@ -179,12 +181,13 @@ export function Roster() {
     crawlers.length === 0
 
   /**
-   * Workspace select. Opening the built-in Starter Set spawns it into this
-   * browser on first visit (idempotent), then switches to it — the roster is
-   * never seeded until the user asks for it here.
+   * Workspace select. Opening a built-in workspace (Starter Set, The Eldridge
+   * Coast) spawns it into this browser on first visit (idempotent), then
+   * switches to it — the roster is never seeded until the user asks for it here.
    */
   async function handleSelectWorkspace(id: string) {
     if (id === STARTER_WORKSPACE_ID) await ensureStarterSetSeeded()
+    if (id === ELDRIDGE_WORKSPACE_ID) await ensureEldridgeCoastSeeded()
     setActiveWorkspaceId(id)
   }
 

--- a/apps/in-the-union-now/src/components/workspace/WorkspaceSwitcher.tsx
+++ b/apps/in-the-union-now/src/components/workspace/WorkspaceSwitcher.tsx
@@ -23,6 +23,7 @@ import { useWorkspaceActions, useWorkspaces } from '../../hooks/queries'
 import { DEFAULT_WORKSPACE_ID, DEFAULT_WORKSPACE_NAME } from '../../lib/defaultWorkspace'
 import type { Workspace } from '../../lib/schemas/workspace'
 import { STARTER_WORKSPACE_ID } from '../../lib/starterSet/starterSet'
+import { ELDRIDGE_WORKSPACE_ID } from '../../lib/eldridgeCoast/eldridgeCoast'
 import { WorkspaceList } from './WorkspaceList'
 import type { WorkspaceListStore } from './WorkspaceList'
 
@@ -113,6 +114,11 @@ export function WorkspaceSwitcher({ activeWorkspaceId, onSelect, store }: Worksp
                 real workspace, so surface it here as a synthetic option. */}
             {!activeStore.workspaces.some((ws) => ws.id === STARTER_WORKSPACE_ID) && (
               <option value={STARTER_WORKSPACE_ID}>Starter Set</option>
+            )}
+            {/* The built-in Eldridge Coast campaign is likewise always
+                selectable; surfaced synthetically until first opened. */}
+            {!activeStore.workspaces.some((ws) => ws.id === ELDRIDGE_WORKSPACE_ID) && (
+              <option value={ELDRIDGE_WORKSPACE_ID}>The Eldridge Coast</option>
             )}
             <option value={MANAGE_VALUE}>Manage workspaces…</option>
           </select>

--- a/apps/in-the-union-now/src/lib/eldridgeCoast/__tests__/eldridgeCoast.test.ts
+++ b/apps/in-the-union-now/src/lib/eldridgeCoast/__tests__/eldridgeCoast.test.ts
@@ -173,9 +173,16 @@ describe('Eldridge Coast seed — soft link integrity', () => {
   const mechIds = new Set(ELDRIDGE_MECHS.map((m) => m.id))
   const crawlerIds = new Set(ELDRIDGE_CRAWLERS.map((c) => c.id))
 
-  test('every pilot crews a crawler, plus the two companion links', () => {
-    // 6 pilot-to-crawler + 2 mech-to-pilot (Incitatus → Cali, Rek Jet → Roach-Boy).
-    expect(ELDRIDGE_SOFT_LINKS).toHaveLength(ELDRIDGE_PILOTS.length + 2)
+  test('every pilot crews a crawler and every mech links to its owning pilot', () => {
+    // 6 pilot-to-crawler + 10 mech-to-pilot (each mech assigned to a pilot).
+    expect(ELDRIDGE_SOFT_LINKS).toHaveLength(ELDRIDGE_PILOTS.length + ELDRIDGE_MECHS.length)
+  })
+
+  test('every mech has exactly one mech-to-pilot link', () => {
+    const linkedMechIds = ELDRIDGE_SOFT_LINKS.filter((l) => l.type === 'mech-to-pilot').map(
+      (l) => l.from.id
+    )
+    expect([...linkedMechIds].sort()).toEqual([...mechIds].sort())
   })
 
   test('every link endpoint references a seeded entity of the right type', () => {

--- a/apps/in-the-union-now/src/lib/eldridgeCoast/__tests__/eldridgeCoast.test.ts
+++ b/apps/in-the-union-now/src/lib/eldridgeCoast/__tests__/eldridgeCoast.test.ts
@@ -1,0 +1,239 @@
+/**
+ * The Eldridge Coast seed guards — the built-in home-campaign workspace.
+ *
+ * Mirrors the Starter Set seed test (../../starterSet/__tests__): the static
+ * rows reference the `salvageunion-reference` dataset by hard-coded slug/id and
+ * are written into IndexedDB by the on-demand seeder, so these tests are the
+ * safety net for both:
+ *   1. Every row strict-parses its Zod schema.
+ *   2. Every reference ref still resolves (a dataset rename fails CI instead of
+ *      silently orphaning a seeded row) — EXCEPT the four intentionally
+ *      home-brew drone/companion "chassis", which are asserted to stay
+ *      unresolved (documented fidelity gap).
+ *   3. The on-demand seeder lands the whole roster and it re-parses.
+ *
+ * fake-indexeddb/auto is preloaded via bunfig.toml; the reference dataset is
+ * preloaded in beforeAll.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+import { SalvageUnionReference, nameToSlug } from 'salvageunion-reference'
+
+import { crawlerMaxSP, pilotMaxAP, pilotMaxHP } from '../../rules/derivedStats'
+import { resolveChassisRef, resolveModuleRef, resolveSystemRef } from '../../rules/resolveRefs'
+import { resolveCrawlerBay, resolveCrawlerType } from '../../crawlerRefs'
+import { CrawlerSchema } from '../../schemas/crawler'
+import { MechSchema } from '../../schemas/mech'
+import { PilotSchema } from '../../schemas/pilot'
+import { SoftLinkSchema } from '../../schemas/softLink'
+import { WorkspaceSchema } from '../../schemas/workspace'
+import {
+  _clearAllStores,
+  _resetDbSingleton,
+  crawlers,
+  mechs,
+  pilots,
+  softLinks,
+  workspaces,
+} from '../../db/index'
+import { useEntityStore } from '../../../stores/entityStore'
+import { useWorkspaceStore } from '../../../stores/workspaceStore'
+import { ensureEldridgeCoastSeeded, isEldridgeCoastSeeded } from '../seedEldridgeCoast'
+import {
+  ELDRIDGE_CRAWLERS,
+  ELDRIDGE_MECHS,
+  ELDRIDGE_PILOTS,
+  ELDRIDGE_SOFT_LINKS,
+  ELDRIDGE_WORKSPACE,
+  ELDRIDGE_WORKSPACE_ID,
+} from '../eldridgeCoast'
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+/** True when some reference entity of `all` slugifies to `slug`. */
+function slugExists(all: ReadonlyArray<{ name: string }>, slug: string): boolean {
+  return all.some((e) => nameToSlug(e.name) === slug)
+}
+
+/**
+ * The four ability-granted drones/companions whose "chassis" is not an SRD
+ * Chassis entry (Survey Drone → Custos & PR-1, Mecha Companion → Incitatus,
+ * Auto-Turret → Rek Jet). Their `chassisRef` is intentionally unresolved — see
+ * the eldridgeCoast.ts fidelity notes. Their Systems/Modules still resolve.
+ */
+const DRONE_MECH_IDS = new Set([
+  'eldridge-mech-custos',
+  'eldridge-mech-incitatus',
+  'eldridge-mech-pr-1',
+  'eldridge-mech-rek-jet',
+])
+
+describe('Eldridge Coast seed — schema validity', () => {
+  test('workspace strict-parses', () => {
+    expect(() => WorkspaceSchema.parse(ELDRIDGE_WORKSPACE)).not.toThrow()
+  })
+
+  test('every pilot strict-parses', () => {
+    for (const p of ELDRIDGE_PILOTS) expect(() => PilotSchema.parse(p)).not.toThrow()
+  })
+
+  test('every mech strict-parses', () => {
+    for (const m of ELDRIDGE_MECHS) expect(() => MechSchema.parse(m)).not.toThrow()
+  })
+
+  test('every crawler strict-parses', () => {
+    for (const c of ELDRIDGE_CRAWLERS) expect(() => CrawlerSchema.parse(c)).not.toThrow()
+  })
+
+  test('every soft link strict-parses', () => {
+    for (const l of ELDRIDGE_SOFT_LINKS) expect(() => SoftLinkSchema.parse(l)).not.toThrow()
+  })
+
+  test('all seeded rows belong to the Eldridge Coast workspace', () => {
+    for (const e of [...ELDRIDGE_PILOTS, ...ELDRIDGE_MECHS, ...ELDRIDGE_CRAWLERS]) {
+      expect(e.workspaceId).toBe(ELDRIDGE_WORKSPACE_ID)
+    }
+  })
+
+  test('every pilot, mech, and crawler carry seeded flavor text', () => {
+    for (const p of ELDRIDGE_PILOTS) expect(p.description?.length ?? 0).toBeGreaterThan(0)
+    for (const m of ELDRIDGE_MECHS) expect(m.description?.length ?? 0).toBeGreaterThan(0)
+    for (const c of ELDRIDGE_CRAWLERS) expect(c.description?.length ?? 0).toBeGreaterThan(0)
+  })
+
+  test('ids are unique across the whole seed', () => {
+    const ids = [
+      ELDRIDGE_WORKSPACE.id,
+      ...ELDRIDGE_PILOTS.map((p) => p.id),
+      ...ELDRIDGE_MECHS.map((m) => m.id),
+      ...ELDRIDGE_CRAWLERS.map((c) => c.id),
+      ...ELDRIDGE_SOFT_LINKS.map((l) => l.id),
+    ]
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+})
+
+describe('Eldridge Coast seed — reference refs resolve (drift guard)', () => {
+  test('pilot class / ability / equipment refs resolve', () => {
+    const classes = SalvageUnionReference.Classes.all()
+    const abilities = SalvageUnionReference.Abilities.all()
+    const equipment = SalvageUnionReference.Equipment.all()
+    for (const p of ELDRIDGE_PILOTS) {
+      expect(slugExists(classes, p.classRef)).toBe(true)
+      for (const a of p.abilities) expect(slugExists(abilities, a)).toBe(true)
+      for (const e of p.equipment) expect(slugExists(equipment, e)).toBe(true)
+    }
+  })
+
+  test('every mech system / module ref resolves', () => {
+    for (const m of ELDRIDGE_MECHS) {
+      for (const s of m.systems) expect(resolveSystemRef(s)).toBeTruthy()
+      for (const mod of m.modules) expect(resolveModuleRef(mod)).toBeTruthy()
+    }
+  })
+
+  test('standard-chassis mechs resolve; the four drone/companion mechs stay unresolved', () => {
+    for (const m of ELDRIDGE_MECHS) {
+      if (DRONE_MECH_IDS.has(m.id)) {
+        expect(resolveChassisRef(m.chassisRef)).toBeFalsy()
+      } else {
+        expect(resolveChassisRef(m.chassisRef)).toBeTruthy()
+      }
+    }
+  })
+
+  test('crawler type, every bay ref, and every crawler system resolve', () => {
+    for (const c of ELDRIDGE_CRAWLERS) {
+      if (c.type) expect(resolveCrawlerType(c.type)).not.toBeNull()
+      for (const bay of c.crawlerBays ?? []) {
+        expect(resolveCrawlerBay(bay.bayRef)).not.toBeNull()
+      }
+      for (const s of c.systems) expect(resolveSystemRef(s)).toBeTruthy()
+    }
+  })
+})
+
+describe('Eldridge Coast seed — derived stats', () => {
+  test('each pilot derives 10 + maxHpModifier HP and 5 + maxApModifier AP', () => {
+    for (const p of ELDRIDGE_PILOTS) {
+      expect(pilotMaxHP(p)).toBe(10 + (p.maxHpModifier ?? 0))
+      expect(pilotMaxAP(p)).toBe(5 + (p.maxApModifier ?? 0))
+    }
+  })
+
+  test('both crawlers derive 35 SP (Tech Level 4 / City)', () => {
+    for (const c of ELDRIDGE_CRAWLERS) expect(crawlerMaxSP(c)).toBe(35)
+  })
+})
+
+describe('Eldridge Coast seed — soft link integrity', () => {
+  const pilotIds = new Set(ELDRIDGE_PILOTS.map((p) => p.id))
+  const mechIds = new Set(ELDRIDGE_MECHS.map((m) => m.id))
+  const crawlerIds = new Set(ELDRIDGE_CRAWLERS.map((c) => c.id))
+
+  test('every pilot crews a crawler, plus the two companion links', () => {
+    // 6 pilot-to-crawler + 2 mech-to-pilot (Incitatus → Cali, Rek Jet → Roach-Boy).
+    expect(ELDRIDGE_SOFT_LINKS).toHaveLength(ELDRIDGE_PILOTS.length + 2)
+  })
+
+  test('every link endpoint references a seeded entity of the right type', () => {
+    for (const l of ELDRIDGE_SOFT_LINKS) {
+      if (l.type === 'mech-to-pilot') {
+        expect(mechIds.has(l.from.id)).toBe(true)
+        expect(pilotIds.has(l.to.id)).toBe(true)
+      } else {
+        expect(pilotIds.has(l.from.id)).toBe(true)
+        expect(crawlerIds.has(l.to.id)).toBe(true)
+      }
+    }
+  })
+})
+
+describe('Eldridge Coast seed — on-demand seeding', () => {
+  beforeEach(async () => {
+    _resetDbSingleton()
+    await _clearAllStores()
+    useEntityStore.setState({
+      pilots: [],
+      mechs: [],
+      crawlers: [],
+      softLinks: [],
+      hydrated: { pilots: false, mechs: false, crawlers: false, softLinks: false },
+    })
+    useWorkspaceStore.setState({ workspaces: [], hydrated: false })
+  })
+
+  afterEach(async () => {
+    await _clearAllStores()
+  })
+
+  test('ensureEldridgeCoastSeeded spawns the full roster on first call, and it parses', async () => {
+    expect(isEldridgeCoastSeeded()).toBe(false)
+    await ensureEldridgeCoastSeeded()
+
+    expect((await workspaces.list()).some((w) => w.id === ELDRIDGE_WORKSPACE_ID)).toBe(true)
+
+    const storedPilots = await pilots.list()
+    const storedMechs = await mechs.list()
+    const storedCrawlers = await crawlers.list()
+    expect(storedPilots).toHaveLength(ELDRIDGE_PILOTS.length)
+    expect(storedMechs).toHaveLength(ELDRIDGE_MECHS.length)
+    expect(storedCrawlers).toHaveLength(ELDRIDGE_CRAWLERS.length)
+    expect(await softLinks.list()).toHaveLength(ELDRIDGE_SOFT_LINKS.length)
+
+    for (const p of storedPilots) expect(() => PilotSchema.parse(p)).not.toThrow()
+    for (const m of storedMechs) expect(() => MechSchema.parse(m)).not.toThrow()
+    for (const c of storedCrawlers) expect(() => CrawlerSchema.parse(c)).not.toThrow()
+    expect(isEldridgeCoastSeeded()).toBe(true)
+  })
+
+  test('is idempotent — a second call never duplicates', async () => {
+    await ensureEldridgeCoastSeeded()
+    await ensureEldridgeCoastSeeded()
+    expect(await workspaces.list()).toHaveLength(1)
+    expect(await pilots.list()).toHaveLength(ELDRIDGE_PILOTS.length)
+    expect(await softLinks.list()).toHaveLength(ELDRIDGE_SOFT_LINKS.length)
+  })
+})

--- a/apps/in-the-union-now/src/lib/eldridgeCoast/eldridgeCoast.ts
+++ b/apps/in-the-union-now/src/lib/eldridgeCoast/eldridgeCoast.ts
@@ -1,0 +1,686 @@
+/**
+ * Built-in "The Eldridge Coast" workspace — a home-campaign roster transcribed
+ * from its Salvage Union character-sheet workbook: six pilots, ten mech /
+ * companion patterns, and two Union Crawlers (Haven and Gladhand) with their
+ * named NPC bay crews.
+ *
+ * Modelled exactly on the Starter Set (lib/starterSet/) — the second built-in,
+ * on-demand-seeded workspace:
+ *   - Every record here is FULLY STATIC plain data — hard-coded reference slugs
+ *     (chassis / systems / modules / class / ability / equipment) and reference
+ *     ids (crawler type + bays). Nothing resolves against `salvageunion-reference`
+ *     at runtime; the seed test asserts each ref still resolves.
+ *   - IDs are DETERMINISTIC (`eldridge-*`) so the on-demand seed is idempotent:
+ *     re-opening the workspace after deleting a single member does not resurrect
+ *     it (the guard is the workspace's existence), and a double-open overwrites
+ *     rather than duplicates.
+ *   - `createdAt`/`updatedAt` are a FIXED constant so these rows never sort
+ *     ahead of the user's own newest-first builds.
+ *   - Everything lives in `ELDRIDGE_WORKSPACE_ID`; it is reachable only by
+ *     selecting it in the Workspace switcher (like the Starter Set).
+ *
+ * Fidelity notes — the workbook mixes canonical SRD content with home-brew.
+ * Best-effort mapping (canonical refs where a name resolves; free-text notes in
+ * `description` / `quirk` / `appearance` / NPC descriptions otherwise):
+ *   - Four "mechs" are ability-granted drones/companions whose "chassis" is not
+ *     in the SRD Chassis dataset (Survey Drone → Custos & PR-1, Mecha Companion
+ *     → Incitatus, Auto-Turret → Rek Jet). Their `chassisRef` is stored as the
+ *     drone/companion slug and renders by name only; derived SP/EP/Heat fall to
+ *     0 (their Systems/Modules still resolve and render). The seed test asserts
+ *     chassis resolution only for the six standard-chassis mechs.
+ *   - The crawlers' home-brew Library / Bar bays are not SRD bays (only the ten
+ *     canonical bays exist), so that crew is folded into the crawler
+ *     `description` rather than a `crawlerBays[]` entry.
+ *   - Crawler type-abilities (All Terrain Locomotion / Improved Trading Bay),
+ *     home-brew crawler weapons carried in `systems[]`, and mech cargo notes are
+ *     captured in free-text where no structured field exists.
+ *   - Pilot real names that the sheet left blank/unknown fall back to the
+ *     callsign (Roach-Boy); the pilots' sheet HP/AP maxima above the 10/5 base
+ *     are encoded via `maxHpModifier` / `maxApModifier`.
+ */
+
+import type { Crawler } from '../schemas/crawler'
+import type { Mech } from '../schemas/mech'
+import type { Pilot } from '../schemas/pilot'
+import type { SoftLink } from '../schemas/softLink'
+import type { Workspace } from '../schemas/workspace'
+
+/** Deterministic id of the built-in Eldridge Coast workspace. */
+export const ELDRIDGE_WORKSPACE_ID = 'eldridge-coast-workspace'
+
+/** Fixed timestamp for every seeded row (see file header — determinism). */
+const SEED_TS = '2020-01-01T00:00:00.000Z'
+
+/** Crawler-type ids (crawler `type` resolves by id/name, not slug). */
+const EXPLORATORY_TYPE_ID = 'd850cd93-f1cc-462b-bfa4-babfb0b2812e'
+const TRADE_CARAVAN_TYPE_ID = '46e44f56-be78-49d8-bfe4-32628ad4b8ef'
+
+/** Base crawler-bay ids (resolve by id/name, not slug). */
+const BAY = {
+  command: '233d7930-1c4d-475d-9ea8-c88a1c70350c',
+  mech: '3234f326-0fae-4ec1-a31e-900be859c156',
+  storage: '4522e605-a384-4c3d-b556-c377e4cc2a97',
+  armament: '6b0e9620-06ed-40ee-9feb-5f635518e48e',
+  crafting: 'e4612293-d3a1-4533-889a-977c92ea1313',
+  trading: '2a4ac355-95fc-451b-8b46-cf8ba5eec31b',
+  med: '0850a891-19e3-4372-af35-0a1679130c8f',
+  pilot: '74904a14-92be-41e0-80d9-63fce02b8851',
+  armoury: '3075663e-0ee6-4e82-8697-4778f303adc7',
+  cantina: '674a412f-486b-4693-b912-1838cc39b77d',
+} as const
+
+// ---------------------------------------------------------------------------
+// Workspace
+// ---------------------------------------------------------------------------
+
+export const ELDRIDGE_WORKSPACE: Workspace = {
+  id: ELDRIDGE_WORKSPACE_ID,
+  schemaVersion: 1,
+  name: 'The Eldridge Coast',
+  createdAt: SEED_TS,
+}
+
+// ---------------------------------------------------------------------------
+// Pilots
+// ---------------------------------------------------------------------------
+
+/** Build a pilot record with the shared, always-present defaults. */
+function pilot(
+  fields: Pick<
+    Pilot,
+    | 'id'
+    | 'name'
+    | 'callsign'
+    | 'classRef'
+    | 'abilities'
+    | 'equipment'
+    | 'motto'
+    | 'keepsake'
+    | 'appearance'
+    | 'background'
+  > &
+    Partial<Pick<Pilot, 'description' | 'maxHpModifier' | 'maxApModifier' | 'trainingPoints'>>
+): Pilot {
+  return {
+    schemaVersion: 1,
+    conditions: [],
+    workspaceId: ELDRIDGE_WORKSPACE_ID,
+    createdAt: SEED_TS,
+    updatedAt: SEED_TS,
+    ...fields,
+  }
+}
+
+const PILOT_CALIGULA = 'eldridge-pilot-caligula'
+const PILOT_NELL = 'eldridge-pilot-nell'
+const PILOT_PARCEL = 'eldridge-pilot-parcel'
+const PILOT_GERSIN = 'eldridge-pilot-gersin'
+const PILOT_ROACH_BOY = 'eldridge-pilot-roach-boy'
+const PILOT_LESTER = 'eldridge-pilot-lester'
+
+export const ELDRIDGE_PILOTS: readonly Pilot[] = [
+  pilot({
+    id: PILOT_CALIGULA,
+    name: 'Caligula',
+    callsign: 'Cali',
+    classRef: 'scout',
+    abilities: [
+      'you-shot-first',
+      'spotter',
+      'custom-sniper-rifle',
+      'gather-intelligence',
+      'tail',
+      'survey-drone',
+      'mecha-companion',
+      'snipe',
+      'infiltration',
+    ],
+    equipment: ['remote-mine', 'portable-comms-unit', 'holofoil-tent', 'handheld-epoxy-canister'],
+    motto: 'Feel the fear and do it anyway.',
+    keepsake: 'Butterfly Earrings',
+    appearance: 'Gaunt, all hair buzzed with the shortest clippers. He/him, age 34.',
+    background: 'Survivor',
+    maxHpModifier: 4,
+    maxApModifier: 2,
+    trainingPoints: 2,
+    description:
+      'Scout who advanced into the Ranger tree. Custom Sniper Rifle (Tech 3): Energy, 5 SP, Range Long, Silent; Mods: High Caliber, Compact, Silenced. Fields a Mecha Companion (Incitatus) and a Survey Drone.',
+  }),
+  pilot({
+    id: PILOT_NELL,
+    name: 'Nell',
+    callsign: 'Nell',
+    classRef: 'hacker',
+    abilities: [
+      'bionic-senses',
+      'bionic-arms',
+      'bionic-legs',
+      'hacking-kit',
+      'system-and-software-hacker',
+      'denial-of-service-attack',
+      'trojan-horse',
+      'counter-hacking',
+      'worm',
+    ],
+    equipment: [
+      'reactive-armour',
+      'fell-rifle',
+      'handheld-epoxy-canister',
+      'disposable-camera',
+      'high-tensile-wire',
+      'portable-comms-unit',
+    ],
+    motto: "I've Got You",
+    keepsake: 'Family Photo',
+    appearance: 'Homebrewed Android. She/her.',
+    background: 'Fugitive Corporate Property',
+    maxHpModifier: 8,
+    maxApModifier: 2,
+    trainingPoints: 1,
+    description:
+      'Hacking Kit loadout: Reactor Overload, Firewall, Sleeping Beauty. Disposable Camera: 24 photos left.',
+  }),
+  pilot({
+    id: PILOT_PARCEL,
+    name: 'Parcel',
+    callsign: 'Parcel',
+    classRef: 'hauler',
+    abilities: [
+      'squeeze-it-in',
+      'expert-salvager',
+      'emergency-salvage-drop',
+      'folk-song',
+      'behemoth',
+      'valiant-speech',
+      'union-representative',
+      'union-call',
+      'recruit',
+    ],
+    equipment: [
+      'rocket-launcher',
+      'salvaging-tools',
+      'reactive-armour',
+      'rigging-jack',
+      'reinforced-polycarbonate-shield',
+      'melee-armament',
+    ],
+    motto: "i'll turn this mech around",
+    keepsake: 'Pinecone',
+    appearance: 'Big burly lumberjacky guy. He/him.',
+    background: 'Born Salvager',
+    trainingPoints: 3,
+    description: 'Hauler who advanced into the Union Rep tree.',
+  }),
+  pilot({
+    id: PILOT_GERSIN,
+    name: 'Gersin',
+    callsign: 'Part',
+    classRef: 'scout',
+    abilities: [
+      'you-shot-first',
+      'spotter',
+      'custom-sniper-rifle',
+      'gather-intelligence',
+      'tail',
+      'survey-drone',
+      'flashback',
+      'camo-suit',
+      'wingsuit',
+    ],
+    equipment: [
+      'reactive-armour',
+      'green-laser-rifle',
+      'portable-comms-unit',
+      'holofoil-tent',
+      'hazard-protection-suit',
+    ],
+    motto: "It's worth a shot.",
+    keepsake: 'Tatterfolk family photo',
+    appearance: 'Wiry. They/them, age 38.',
+    background: 'Corpo Worker',
+    maxHpModifier: 4,
+    maxApModifier: 2,
+    description:
+      'Custom Sniper Rifle (Tech 3): 5 SP dmg, Far Range; Mods: Laser Guidance, Pinpoint Targeter, Rangefinder. Fields a Survey Drone.',
+  }),
+  pilot({
+    id: PILOT_ROACH_BOY,
+    name: 'Roach-Boy',
+    callsign: 'Roach-Boy',
+    classRef: 'engineer',
+    abilities: [
+      'engineering-expertise',
+      'jury-rig',
+      'talk-shop',
+      'mech-gyver',
+      'auto-turret',
+      'mech-acquisition',
+      'field-fabrication',
+      'miniaturised-emp',
+      'chassis-modder',
+    ],
+    equipment: [
+      'portable-comms-unit',
+      'high-tensile-wire',
+      'tranquiliser-rifle',
+      'green-laser-rifle',
+    ],
+    motto: 'It is not a bug, it is a feature.',
+    keepsake: 'Roach Squad Pin',
+    appearance: 'Small and Dirty. He/him.',
+    background: 'Prodigy',
+    maxHpModifier: 4,
+    maxApModifier: 2,
+    trainingPoints: 2,
+    description:
+      'Engineer who advanced into the Fabricator tree; deploys an Auto-Turret (Rek Jet). Real name unknown. Associates: the Roach Scouts; Jan and Wayne (the vent kids); Davey the Hartford; Tiberius (AI bracelet); Roger Belamy. The Evil Roach is in the Abandoned Eldridge Outpost.',
+  }),
+  pilot({
+    id: PILOT_LESTER,
+    name: 'Lester Owens',
+    callsign: 'Stumpy',
+    classRef: 'soldier',
+    abilities: [
+      'charge',
+      'wastelander-rapport',
+      'overpower',
+      'provoke',
+      'duel',
+      'resourceful',
+      'custom-missile-launcher',
+      'glanded-stims',
+      'modular-face-implant',
+      'bionic-endoskeleton',
+    ],
+    equipment: [
+      'improvised-melee-weapon',
+      'first-aid-kit',
+      'shotgun',
+      'portable-arc-welder',
+      'reactive-armour',
+      'rigging-jack',
+    ],
+    motto: 'No job too big.',
+    keepsake: 'Stuffed Toy',
+    appearance: '',
+    background: 'Mercenary',
+    maxHpModifier: 4,
+    maxApModifier: 2,
+    trainingPoints: 1,
+    description: 'Soldier who advanced into the Cyborg tree.',
+  }),
+]
+
+// ---------------------------------------------------------------------------
+// Mechs — the tab name is the pattern name (a chassis + systems + modules
+// combination). Six use standard SRD chassis; four are ability-granted
+// drones/companions whose "chassis" is not in the SRD Chassis dataset (see the
+// file-header fidelity notes) — their SP/EP/Heat derive to 0 but their
+// Systems/Modules still resolve.
+// ---------------------------------------------------------------------------
+
+/** Build a mech record with the shared, always-present defaults. */
+function mech(
+  fields: Pick<Mech, 'id' | 'name' | 'chassisRef' | 'patternName' | 'systems' | 'modules'> &
+    Partial<Pick<Mech, 'quirk' | 'appearance' | 'description' | 'systemConditions'>>
+): Mech {
+  return {
+    schemaVersion: 1,
+    cargoLots: [],
+    conditions: [],
+    workspaceId: ELDRIDGE_WORKSPACE_ID,
+    createdAt: SEED_TS,
+    updatedAt: SEED_TS,
+    ...fields,
+  }
+}
+
+const MECH_GOAT = 'eldridge-mech-goat'
+const MECH_CUSTOS = 'eldridge-mech-custos'
+const MECH_DAMNATIO = 'eldridge-mech-damnatio-memoriae'
+const MECH_INCITATUS = 'eldridge-mech-incitatus'
+const MECH_NEW_DUKE = 'eldridge-mech-new-duke'
+const MECH_PEEKABOO = 'eldridge-mech-peekaboo'
+const MECH_PR1 = 'eldridge-mech-pr-1'
+const MECH_REK_JET = 'eldridge-mech-rek-jet'
+const MECH_RUST_BUCKET = 'eldridge-mech-rust-bucket'
+const MECH_SOB = 'eldridge-mech-son-of-beanstalk'
+
+export const ELDRIDGE_MECHS: readonly Mech[] = [
+  mech({
+    id: MECH_GOAT,
+    name: 'GOAT',
+    chassisRef: 'atlas',
+    patternName: 'GOAT',
+    systems: [
+      'armour-plating',
+      'escape-hatch',
+      'aff-coolant-foam',
+      'prawn-sifter',
+      'locomotion-system',
+      'electro-magnetic-shield-projector',
+      '120mm-cannon',
+    ],
+    modules: ['metal-detector', 'comms-module'],
+    quirk: 'constantly leaks coolant',
+    appearance: 'Overgrown with plants and vines.',
+    description:
+      'Integrated Colossal Cargo Bay (default Cargo Cap. 30). Carries: melee armament, ejection system, "Panda sneeze".',
+  }),
+  mech({
+    id: MECH_CUSTOS,
+    name: 'Custos',
+    chassisRef: 'survey-drone',
+    patternName: 'Custos',
+    systems: ['nanofibre-net-launcher', '50-cal-machine-gun'],
+    modules: ['hacking-repeater-node', 'damage-assessor', 'comms-module'],
+    quirk: 'Occasionally sparks electricity.',
+    appearance: "'Steampunk', whirring gears, bronze parts.",
+    description: 'Survey Drone (Tech 4) with an Integrated Hover Locomotion System.',
+  }),
+  mech({
+    id: MECH_DAMNATIO,
+    name: 'Damnatio Memoriae',
+    chassisRef: 'solo',
+    patternName: 'Damnatio Memoriae',
+    systems: ['rail-rifle', 'locomotion-system', 'ejection-system', 'high-gain-antenna'],
+    modules: ['comms-module', 'survey-scanner', 'ir-night-vision-optics', 'pinpoint-targeter'],
+    quirk: 'Unusual cockpit location.',
+    appearance: 'Covered in camo and foliage.',
+    description:
+      "Polycarbonate Stealth Chassis. The main gun cuts through the cockpit, only slightly to the right of the pilot's headrest.",
+  }),
+  mech({
+    id: MECH_INCITATUS,
+    name: 'Incitatus',
+    chassisRef: 'mecha-companion',
+    patternName: 'Incitatus',
+    systems: [
+      'locomotion-system',
+      'long-barrelled-green-laser',
+      'composite-armour',
+      'tracking-node',
+    ],
+    modules: ['comms-module', 'navigation-module'],
+    quirk: 'Secretly emits radio waves.',
+    appearance: 'Industrial and utilitarian.',
+    description: "Caligula's Mecha Companion (Tech 4).",
+  }),
+  mech({
+    id: MECH_NEW_DUKE,
+    name: 'New Duke',
+    chassisRef: 'brawler',
+    patternName: 'New Duke',
+    systems: [
+      'rigging-arm',
+      'escape-hatch',
+      'mech-melee-armament',
+      'locomotion-system',
+      'needle-missile-pod',
+      'armour-plating',
+      'grappling-harpoon',
+    ],
+    modules: ['adv-weapon-link', 'personal-recreation-device'],
+    quirk: 'Novelty Car Horn',
+    appearance: 'Beat up and Orange',
+    description:
+      'Close Range Protocols (+2 SP damage at Close Range). The Armour Plating is destroyed.',
+    systemConditions: { 'armour-plating': 'destroyed' },
+  }),
+  mech({
+    id: MECH_PEEKABOO,
+    name: 'Peekaboo',
+    chassisRef: 'solo',
+    patternName: 'Peekaboo',
+    systems: ['ejection-system', 'long-barrelled-green-laser', 'hover-locomotion-system'],
+    modules: ['zoom-optics', 'comms-module', 'firewall', 'ecm-transmitter'],
+    quirk: 'Exterior fluctuates in colour.',
+    appearance: 'Industrial and utilitarian.',
+    description: 'Polycarbonate Stealth Chassis.',
+  }),
+  mech({
+    id: MECH_PR1,
+    name: 'PR-1',
+    chassisRef: 'survey-drone',
+    patternName: 'PR-1',
+    systems: ['hydraulic-crusher'],
+    modules: ['hull-magnetiser', 'self-destruct', 'survey-scanner'],
+    quirk: 'Exterior fluctuates in colour.',
+    appearance: 'Industrial and utilitarian.',
+    description: 'Survey Drone with an Integrated Hover Locomotion System.',
+  }),
+  mech({
+    id: MECH_REK_JET,
+    name: 'Rek Jet',
+    chassisRef: 'auto-turret',
+    patternName: 'Rek Jet',
+    systems: [
+      'red-laser',
+      'locomotion-system',
+      'nanofibre-net-launcher',
+      'composite-armour',
+      'welding-laser',
+    ],
+    modules: ['comms-module'],
+    quirk: 'Changes personality frequently',
+    appearance: 'Bobblehead Head',
+    description: "Roach-Boy's Auto-Turret. Carries 2 Tier 3 Scrap; a Pelt cape.",
+  }),
+  mech({
+    id: MECH_RUST_BUCKET,
+    name: 'Rust Bucket',
+    chassisRef: 'goliath',
+    patternName: 'Rust Bucket',
+    systems: [
+      'heavy-duty-mining-rig',
+      'escape-hatch',
+      'spider-locomotion-system',
+      'adv-fabrication-arm',
+      'rigging-arm',
+      'shotgun-pit',
+    ],
+    modules: ['offensive-protocols', 'comms-module', 'personal-recreation-device'],
+    quirk: 'Cockpit has far, far too many buttons.',
+    appearance: 'Looks Like Shit, Runs like Butter',
+    description:
+      'Scrap Plating (counts as 3 Armour Plating Systems, restorable in a T2+ Mech Bay).',
+  }),
+  mech({
+    id: MECH_SOB,
+    name: 'Son of Beanstalk',
+    chassisRef: 'mirrorball',
+    patternName: 'Son of Beanstalk',
+    systems: [
+      'locomotion-system',
+      'escape-hatch',
+      'high-gain-antenna',
+      'capacitance-bank',
+      'electro-magnetic-hardening',
+    ],
+    modules: ['comms-module'],
+    quirk: 'Mismatched Hardware',
+    appearance: 'Hostile Ladybug',
+    description:
+      'Integrated Advanced Shield Dome (spend X EP as a Turn Action; the Shield Dome has SP equal to EP spent x3).',
+  }),
+]
+
+// ---------------------------------------------------------------------------
+// Crawlers — Haven (Exploratory) and Gladhand (Trade Caravan), both Tech 4
+// (City, base SP 35). The home-brew Library / Bar bays are folded into the
+// description (only the ten canonical bays exist as SRD bays).
+// ---------------------------------------------------------------------------
+
+const CRAWLER_HAVEN = 'eldridge-crawler-haven'
+const CRAWLER_GLADHAND = 'eldridge-crawler-gladhand'
+
+type BayCrew = { ref: string; npcName: string; npcDescription?: string }
+
+const HAVEN_BAY_CREW: readonly BayCrew[] = [
+  {
+    ref: BAY.command,
+    npcName: 'Singh',
+    npcDescription:
+      'Princep. Takes his job very seriously, but refuses the hierarchy of his position.',
+  },
+  {
+    ref: BAY.mech,
+    npcName: 'Tommins',
+    npcDescription: 'Greaser. Kind of a stoner. Really, really, *Really* into mechs.',
+  },
+  {
+    ref: BAY.armament,
+    npcName: 'Alvarez',
+    npcDescription:
+      'Gunny. Loud and Fabulous, large and in charge of the Mechapult. Loves the thrill and majesty of explosions.',
+  },
+  { ref: BAY.crafting, npcName: 'Yusef', npcDescription: 'Forger. Former corpo.' },
+  {
+    ref: BAY.trading,
+    npcName: 'Lapp',
+    npcDescription:
+      'Operator. A somewhat unsettling man, though a sharp operator and keen trader. Distaste for organized religion; struggles with memory issues — but never about the deal.',
+  },
+  {
+    ref: BAY.med,
+    npcName: 'Guo',
+    npcDescription:
+      'Doctor. Kind-hearted older gentleman. Optimistic; tries to keep things jovial. Not above a gentle lie for your own good.',
+  },
+  {
+    ref: BAY.pilot,
+    npcName: 'Yancy',
+    npcDescription:
+      'Ace. Broad-shouldered woman, a little intense but excited to train new pilots. Sees mech piloting as an art. Former (illegal) racer.',
+  },
+  {
+    ref: BAY.armoury,
+    npcName: 'Slott',
+    npcDescription:
+      'Quartermaster. A quirky thin man left near-deaf by a life beside powerful weaponry. Lighthearted and goofy; often mistaken for stupid when he is just searching for the right rhyme.',
+  },
+  {
+    ref: BAY.cantina,
+    npcName: 'Hobart',
+    npcDescription:
+      'Chef. An incredibly kind elderly man, though a tyrant once the cooking begins. Keeps an "Eternal Stew" he all but exclusively eats.',
+  },
+  {
+    ref: BAY.storage,
+    npcName: 'Tanner',
+    npcDescription:
+      'Bullwhacker. Incredibly good at the job — maybe too good; occasionally misses the forest for the trees.',
+  },
+]
+
+const GLADHAND_BAY_CREW: readonly BayCrew[] = [
+  { ref: BAY.command, npcName: 'Fawkes', npcDescription: 'Princep.' },
+  { ref: BAY.mech, npcName: 'Quisling', npcDescription: 'Greaser.' },
+  { ref: BAY.armament, npcName: 'Ames', npcDescription: 'Gunny.' },
+  { ref: BAY.crafting, npcName: 'Cariot', npcDescription: 'Forger.' },
+  { ref: BAY.trading, npcName: 'Jingwei', npcDescription: 'Operator. Looks like Santa.' },
+  { ref: BAY.med, npcName: 'Hansenn', npcDescription: 'Doctor.' },
+  { ref: BAY.pilot, npcName: 'Ephi', npcDescription: 'Ace.' },
+  { ref: BAY.armoury, npcName: 'Benedict', npcDescription: 'Quartermaster.' },
+  { ref: BAY.cantina, npcName: 'Brutus', npcDescription: 'Chef.' },
+  { ref: BAY.storage, npcName: 'Tanner', npcDescription: 'Bullwhacker.' },
+]
+
+const HAVEN_CRAWLER: Crawler = {
+  id: CRAWLER_HAVEN,
+  schemaVersion: 1,
+  name: 'Haven',
+  description:
+    'Union Crawler #812. Exploratory, Tech 4 (City). Type ability: All Terrain Locomotion. Also crewed by the home-brew Library (Archivist: Glinda — 74-year-old widower, big Star Trek fan, incense aficionado) and Bar (Bartend: Francis "Frank" Bulwark — does not go by Frank). Notable stores: Bio Scrap Freezer upgrade (40 units), Ejection System, Rolling Thunder Raider Chit, Target Painter, a T4 Mech Reactor Bomb, the Roiling Earth Chit, and a tier-1 GOAT chassis.',
+  techLevel: 'tech-4',
+  type: EXPLORATORY_TYPE_ID,
+  typeNpc: {
+    npcName: 'Rappaport',
+    npcCurrentHP: 4,
+    npcDescription: 'Wasteland Explorer. Barber, wise beyond his years. Keepsake: Empty Mug.',
+  },
+  systems: ['mechapult'],
+  crawlerBays: HAVEN_BAY_CREW.map((c) => ({
+    bayRef: c.ref,
+    npcName: c.npcName,
+    npcCurrentHP: 4,
+    npcDescription: c.npcDescription,
+  })),
+  scrapPool: { tl1: 8, tl3: 2, tl4: 2, tl5: 2, tl6: 1 },
+  upgradePool: 300,
+  workspaceId: ELDRIDGE_WORKSPACE_ID,
+  createdAt: SEED_TS,
+  updatedAt: SEED_TS,
+}
+
+const GLADHAND_CRAWLER: Crawler = {
+  id: CRAWLER_GLADHAND,
+  schemaVersion: 1,
+  name: 'Gladhand',
+  description:
+    'Union Crawler #213. Trade Caravan, Tech 4 (City). Type ability: Improved Trading Bay. Home-brew Library bay is unstaffed and the Bar is offline. Notable stores: Bio Scrap Freezer upgrade (40 units), Ejection System, Rolling Thunder Raider Chit, Target Painter, a T4 Mech Reactor Bomb, a Decommissioned Murmur, and a tier-1 GOAT chassis.',
+  techLevel: 'tech-4',
+  type: TRADE_CARAVAN_TYPE_ID,
+  typeNpc: {
+    npcName: 'Tiberius',
+    npcCurrentHP: 4,
+    npcDescription: 'Savvy Trader. A corpo trading AI.',
+  },
+  systems: ['cacb-laser'],
+  crawlerBays: GLADHAND_BAY_CREW.map((c) => ({
+    bayRef: c.ref,
+    npcName: c.npcName,
+    npcCurrentHP: 4,
+    npcDescription: c.npcDescription,
+  })),
+  scrapPool: { tl1: 9, tl2: 4, tl3: 3, tl4: 2, tl5: 2, tl6: 1 },
+  upgradePool: 5,
+  workspaceId: ELDRIDGE_WORKSPACE_ID,
+  createdAt: SEED_TS,
+  updatedAt: SEED_TS,
+}
+
+export const ELDRIDGE_CRAWLERS: readonly Crawler[] = [HAVEN_CRAWLER, GLADHAND_CRAWLER]
+
+// ---------------------------------------------------------------------------
+// SoftLinks — the workbook does not pair pilots to their piloted mechs, so only
+// the relationships the sheets actually establish are wired:
+//   - all six pilots crew Haven (the Exploratory party crawler; its Storage-bay
+//     note names pilot Parcel). Gladhand is included as a second crawler with
+//     its own NPC crew, no pilots auto-assigned.
+//   - the two ability-granted companions link to their owning pilot: Incitatus
+//     (Mecha Companion) → Caligula, Rek Jet (Auto-Turret) → Roach-Boy.
+// ---------------------------------------------------------------------------
+
+const CREW_PILOT_IDS = [
+  PILOT_CALIGULA,
+  PILOT_NELL,
+  PILOT_PARCEL,
+  PILOT_GERSIN,
+  PILOT_ROACH_BOY,
+  PILOT_LESTER,
+] as const
+
+export const ELDRIDGE_SOFT_LINKS: readonly SoftLink[] = [
+  ...CREW_PILOT_IDS.map((pilotId) => ({
+    id: `eldridge-link-crew-${pilotId}`,
+    from: { type: 'pilot' as const, id: pilotId },
+    to: { type: 'crawler' as const, id: CRAWLER_HAVEN },
+    type: 'pilot-to-crawler' as const,
+    createdAt: SEED_TS,
+  })),
+  {
+    id: `eldridge-link-mech-${PILOT_CALIGULA}`,
+    from: { type: 'mech' as const, id: MECH_INCITATUS },
+    to: { type: 'pilot' as const, id: PILOT_CALIGULA },
+    type: 'mech-to-pilot' as const,
+    createdAt: SEED_TS,
+  },
+  {
+    id: `eldridge-link-mech-${PILOT_ROACH_BOY}`,
+    from: { type: 'mech' as const, id: MECH_REK_JET },
+    to: { type: 'pilot' as const, id: PILOT_ROACH_BOY },
+    type: 'mech-to-pilot' as const,
+    createdAt: SEED_TS,
+  },
+]

--- a/apps/in-the-union-now/src/lib/eldridgeCoast/eldridgeCoast.ts
+++ b/apps/in-the-union-now/src/lib/eldridgeCoast/eldridgeCoast.ts
@@ -31,9 +31,10 @@
  *   - The crawlers' home-brew Library / Bar bays are not SRD bays (only the ten
  *     canonical bays exist), so that crew is folded into the crawler
  *     `description` rather than a `crawlerBays[]` entry.
- *   - Crawler type-abilities (All Terrain Locomotion / Improved Trading Bay),
- *     home-brew crawler weapons carried in `systems[]`, and mech cargo notes are
- *     captured in free-text where no structured field exists.
+ *   - Crawler type-abilities (All Terrain Locomotion / Improved Trading Bay)
+ *     and mech cargo notes are captured in free-text where no structured field
+ *     exists; the crawlers' mounted weapons (Mechapult, CACB Laser) are
+ *     canonical Systems and resolve normally.
  *   - Pilot real names that the sheet left blank/unknown fall back to the
  *     callsign (Roach-Boy); the pilots' sheet HP/AP maxima above the 10/5 base
  *     are encoded via `maxHpModifier` / `maxApModifier`.
@@ -643,13 +644,20 @@ const GLADHAND_CRAWLER: Crawler = {
 export const ELDRIDGE_CRAWLERS: readonly Crawler[] = [HAVEN_CRAWLER, GLADHAND_CRAWLER]
 
 // ---------------------------------------------------------------------------
-// SoftLinks — the workbook does not pair pilots to their piloted mechs, so only
-// the relationships the sheets actually establish are wired:
-//   - all six pilots crew Haven (the Exploratory party crawler; its Storage-bay
-//     note names pilot Parcel). Gladhand is included as a second crawler with
-//     its own NPC crew, no pilots auto-assigned.
-//   - the two ability-granted companions link to their owning pilot: Incitatus
-//     (Mecha Companion) → Caligula, Rek Jet (Auto-Turret) → Roach-Boy.
+// SoftLinks — pilot↔mech assignments (confirmed by the campaign owner) and
+// pilot↔crawler crew membership. Each pilot's main mech and any drone/companion
+// are all `mech-to-pilot` links (the schema's only mech relationship):
+//   - Parcel → GOAT
+//   - Caligula → Damnatio Memoriae (main) + Custos (Survey Drone) + Incitatus
+//     (Mecha Companion)
+//   - Roach-Boy → Rust Bucket (main) + Rek Jet (Auto-Turret)
+//   - Lester 'Stumpy' Owens → New Duke
+//   - Nell → Son of Beanstalk
+//   - Gersin 'Part' → Peekaboo (main) + PR-1 (Survey Drone) — the remaining
+//     builds, mirroring Caligula's stealth-Solo + Survey-Drone loadout.
+// All six pilots crew Haven (the Exploratory party crawler; its Storage-bay note
+// names pilot Parcel). Gladhand is a second crawler with its own NPC crew, no
+// pilots auto-assigned.
 // ---------------------------------------------------------------------------
 
 const CREW_PILOT_IDS = [
@@ -661,6 +669,20 @@ const CREW_PILOT_IDS = [
   PILOT_LESTER,
 ] as const
 
+/** Owning pilot for each mech (main mechs + drones/companions). */
+const MECH_PILOT_LINKS: ReadonlyArray<readonly [string, string]> = [
+  [MECH_GOAT, PILOT_PARCEL],
+  [MECH_DAMNATIO, PILOT_CALIGULA],
+  [MECH_CUSTOS, PILOT_CALIGULA],
+  [MECH_INCITATUS, PILOT_CALIGULA],
+  [MECH_RUST_BUCKET, PILOT_ROACH_BOY],
+  [MECH_REK_JET, PILOT_ROACH_BOY],
+  [MECH_NEW_DUKE, PILOT_LESTER],
+  [MECH_SOB, PILOT_NELL],
+  [MECH_PEEKABOO, PILOT_GERSIN],
+  [MECH_PR1, PILOT_GERSIN],
+]
+
 export const ELDRIDGE_SOFT_LINKS: readonly SoftLink[] = [
   ...CREW_PILOT_IDS.map((pilotId) => ({
     id: `eldridge-link-crew-${pilotId}`,
@@ -669,18 +691,11 @@ export const ELDRIDGE_SOFT_LINKS: readonly SoftLink[] = [
     type: 'pilot-to-crawler' as const,
     createdAt: SEED_TS,
   })),
-  {
-    id: `eldridge-link-mech-${PILOT_CALIGULA}`,
-    from: { type: 'mech' as const, id: MECH_INCITATUS },
-    to: { type: 'pilot' as const, id: PILOT_CALIGULA },
+  ...MECH_PILOT_LINKS.map(([mechId, pilotId]) => ({
+    id: `eldridge-link-mech-${mechId}`,
+    from: { type: 'mech' as const, id: mechId },
+    to: { type: 'pilot' as const, id: pilotId },
     type: 'mech-to-pilot' as const,
     createdAt: SEED_TS,
-  },
-  {
-    id: `eldridge-link-mech-${PILOT_ROACH_BOY}`,
-    from: { type: 'mech' as const, id: MECH_REK_JET },
-    to: { type: 'pilot' as const, id: PILOT_ROACH_BOY },
-    type: 'mech-to-pilot' as const,
-    createdAt: SEED_TS,
-  },
+  })),
 ]

--- a/apps/in-the-union-now/src/lib/eldridgeCoast/seedEldridgeCoast.ts
+++ b/apps/in-the-union-now/src/lib/eldridgeCoast/seedEldridgeCoast.ts
@@ -1,0 +1,69 @@
+/**
+ * On-demand seeding of the built-in "The Eldridge Coast" workspace.
+ *
+ * Mirrors the Starter Set seeder (lib/starterSet/seedStarterSet.ts): the roster
+ * is NOT seeded eagerly (no DB migration). It is spawned into THIS browser's
+ * IndexedDB the first time the user opens the Eldridge Coast workspace — see the
+ * Roster's workspace-select handler. Everything is written in one transaction
+ * from the static records in `./eldridgeCoast`, then the stores rehydrate so the
+ * dashboard renders the roster immediately.
+ *
+ * Idempotent, and it never resurrects deletions: the guard is the workspace's
+ * existence. If the workspace is present the seed is skipped (so deleting an
+ * individual member and re-opening does not bring it back). If the user deletes
+ * the whole workspace, re-opening it spawns a fresh copy.
+ */
+
+import { useEntityStore } from '../../stores/entityStore'
+import { useWorkspaceStore } from '../../stores/workspaceStore'
+import { atomicWrite } from '../db'
+import type { AtomicWriteOp } from '../db'
+import { STORE_NAMES } from '../db/stores'
+import {
+  ELDRIDGE_CRAWLERS,
+  ELDRIDGE_MECHS,
+  ELDRIDGE_PILOTS,
+  ELDRIDGE_SOFT_LINKS,
+  ELDRIDGE_WORKSPACE,
+  ELDRIDGE_WORKSPACE_ID,
+} from './eldridgeCoast'
+
+/** Whether the Eldridge Coast workspace already exists in the in-memory store. */
+export function isEldridgeCoastSeeded(): boolean {
+  return useWorkspaceStore
+    .getState()
+    .list()
+    .some((w) => w.id === ELDRIDGE_WORKSPACE_ID)
+}
+
+/**
+ * Spawn the Eldridge Coast roster into this browser once, on first visit. No-op
+ * if the workspace already exists. Deterministic ids make the single
+ * transaction safe to re-run (a double-click overwrites rather than duplicates).
+ */
+export async function ensureEldridgeCoastSeeded(): Promise<void> {
+  await useWorkspaceStore.getState().hydrate()
+  if (isEldridgeCoastSeeded()) return
+
+  const put = (storeName: string, record: { id: string }): AtomicWriteOp => ({
+    op: 'put',
+    storeName,
+    record,
+  })
+
+  await atomicWrite([
+    put(STORE_NAMES.workspaces, ELDRIDGE_WORKSPACE),
+    ...ELDRIDGE_PILOTS.map((r) => put(STORE_NAMES.pilots, r)),
+    ...ELDRIDGE_MECHS.map((r) => put(STORE_NAMES.mechs, r)),
+    ...ELDRIDGE_CRAWLERS.map((r) => put(STORE_NAMES.crawlers, r)),
+    ...ELDRIDGE_SOFT_LINKS.map((r) => put(STORE_NAMES.softLinks, r)),
+  ])
+
+  // Reflect the newly-written rows in memory so the dashboard renders them.
+  await useWorkspaceStore.getState().rehydrate()
+  await Promise.all(
+    (['pilot', 'mech', 'crawler', 'softLink'] as const).map((t) =>
+      useEntityStore.getState().rehydrate(t)
+    )
+  )
+}


### PR DESCRIPTION
## What

Adds **The Eldridge Coast** as a second built-in, on-demand-seeded ITUN workspace alongside the Starter Set — transcribed from the home-campaign Salvage Union sheet workbook. It appears in the Workspace switcher and spawns into the browser on first open (idempotent, guarded by workspace existence), exactly like the Starter Set.

**Roster (18 entities):**
- **6 pilots** — Caligula (Cali), Nell, Parcel, Gersin (Part), Roach-Boy, Lester Owens (Stumpy)
- **10 mech / companion patterns** — GOAT, Custos, Damnatio Memoriae, Incitatus, New Duke, Peekaboo, PR-1, Rek Jet, Rust Bucket, Son of Beanstalk
- **2 Union Crawlers** — Haven (Exploratory, TL4) and Gladhand (Trade Caravan, TL4), each with named NPC bay crews

**Pilot ↔ mech assignments** (confirmed by the campaign owner):
- Parcel → GOAT
- Caligula → Damnatio Memoriae + Custos (Survey Drone) + Incitatus (Mecha Companion)
- Roach-Boy → Rust Bucket + Rek Jet (Auto-Turret)
- Lester "Stumpy" Owens → New Duke
- Nell → Son of Beanstalk
- Gersin "Part" → Peekaboo + PR-1 (Survey Drone)

All six pilots crew **Haven**; Gladhand is a second crawler with its own NPC crew.

## How

Mirrors `lib/starterSet/` exactly:
- `lib/eldridgeCoast/eldridgeCoast.ts` — fully-static records (hard-coded reference slugs + ids, deterministic `eldridge-*` ids, fixed timestamp).
- `lib/eldridgeCoast/seedEldridgeCoast.ts` — idempotent on-demand seeder.
- `Roster.tsx` seeds on select; `WorkspaceSwitcher.tsx` surfaces it as a synthetic option until first opened.
- `__tests__/eldridgeCoast.test.ts` — schema-validity + ref-resolution drift guard + soft-link integrity + on-demand-seeding coverage (19 tests).

## Fidelity notes (best-effort SRD mapping + free-text for home-brew)

~120 entity references resolved against the SRD dataset. Documented judgment calls:
- **4 "mechs" are ability-granted drones/companions** (Survey Drone → Custos & PR-1; Mecha Companion → Incitatus; Auto-Turret → Rek Jet) whose "chassis" isn't an SRD Chassis. Their `chassisRef` is stored unresolved (renders by name; SP/EP/Heat derive to 0); their systems/modules resolve. The test asserts this gap explicitly.
- **Home-brew Library/Bar crawler bays** aren't SRD bays → folded into the crawler `description`. Crawler mounted weapons (Mechapult, CACB Laser) are canonical Systems and resolve.
- Pilot HP/AP maxima above the 10/5 base encoded via `maxHpModifier`/`maxApModifier`; Roach-Boy's unknown real name falls back to callsign.

## Validation

typecheck ✓ · lint ✓ · format ✓ · knip ✓ · new seed test 19/19 ✓ · full ITUN suite 1300 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LG8czobAR7o7LTML2f1Tye