### PR TITLE
fix(itun): close Eldridge Coast sheet-render gaps

### DIFF
--- a/apps/in-the-union-now/src/components/roster/Roster.tsx
+++ b/apps/in-the-union-now/src/components/roster/Roster.tsx
@@ -20,7 +20,7 @@
 import { Fragment, useState } from 'react'
 import type { ReactNode } from 'react'
 import { Bot, UserRound, Warehouse } from 'lucide-react'
-import { SalvageUnionReference } from 'salvageunion-reference'
+import { resolveChassisRef } from '../../lib/rules/resolveRefs'
 import { Btn, btnVariants, Empty } from 'suref-react'
 
 import {
@@ -58,12 +58,12 @@ import { EntityListItem } from './EntityListItem'
 
 /** Roster row meta segment for a mech: "Chassis · TL n". */
 function mechChassisMeta(chassisRef: string): string | undefined {
+  // resolveChassisRef is slug/name/id tolerant; stored refs are slugs, so a
+  // name-only match here would fall through to the raw slug for every mech. Wrap
+  // in try/catch: resolveChassisRef throws when the Chassis model isn't preloaded
+  // (some test/snapshot contexts) — fall back to the raw ref rather than crash.
   try {
-    const all = SalvageUnionReference.Chassis.all() as ReadonlyArray<{
-      name: string
-      techLevel?: number
-    }>
-    const c = all.find((x) => x.name === chassisRef)
+    const c = resolveChassisRef(chassisRef) as { name: string; techLevel?: number } | null
     if (!c) return chassisRef || undefined
     return c.techLevel != null ? `${c.name} · TL ${c.techLevel}` : c.name
   } catch {

--- a/apps/in-the-union-now/src/lib/eldridgeCoast/__tests__/eldridgeCoast.test.ts
+++ b/apps/in-the-union-now/src/lib/eldridgeCoast/__tests__/eldridgeCoast.test.ts
@@ -97,10 +97,20 @@ describe('Eldridge Coast seed — schema validity', () => {
     }
   })
 
-  test('every pilot, mech, and crawler carry seeded flavor text', () => {
+  test('every entity carries seeded flavor text in fields the sheet renders', () => {
+    // Pilots render `description` (Bio) + `background`; mechs render `quirk` +
+    // `appearance` (NOT `description`, which is deprecated/suppressed); crawlers
+    // render `description`.
     for (const p of ELDRIDGE_PILOTS) expect(p.description?.length ?? 0).toBeGreaterThan(0)
-    for (const m of ELDRIDGE_MECHS) expect(m.description?.length ?? 0).toBeGreaterThan(0)
+    for (const m of ELDRIDGE_MECHS) {
+      expect(m.quirk?.length ?? 0).toBeGreaterThan(0)
+      expect(m.appearance?.length ?? 0).toBeGreaterThan(0)
+    }
     for (const c of ELDRIDGE_CRAWLERS) expect(c.description?.length ?? 0).toBeGreaterThan(0)
+  })
+
+  test('mechs do not write the deprecated (unrendered) description field', () => {
+    for (const m of ELDRIDGE_MECHS) expect(m.description).toBeUndefined()
   })
 
   test('ids are unique across the whole seed', () => {
@@ -140,6 +150,21 @@ describe('Eldridge Coast seed — reference refs resolve (drift guard)', () => {
         expect(resolveChassisRef(m.chassisRef)).toBeFalsy()
       } else {
         expect(resolveChassisRef(m.chassisRef)).toBeTruthy()
+      }
+    }
+  })
+
+  test('crawler mounted weapons resolve via the crawler sheet id/name path', () => {
+    // The crawler sheet's resolveCrawlerSystem matches by `id` OR `name` only
+    // (NOT slug), so a slug-stored weapon would render as a raw chit. Guard the
+    // exact matching the UI uses.
+    const systems = SalvageUnionReference.Systems.all() as ReadonlyArray<{
+      id: string
+      name: string
+    }>
+    for (const c of ELDRIDGE_CRAWLERS) {
+      for (const s of c.systems) {
+        expect(systems.some((sys) => sys.id === s || sys.name === s)).toBe(true)
       }
     }
   })

--- a/apps/in-the-union-now/src/lib/eldridgeCoast/eldridgeCoast.ts
+++ b/apps/in-the-union-now/src/lib/eldridgeCoast/eldridgeCoast.ts
@@ -32,9 +32,12 @@
  *     canonical bays exist), so that crew is folded into the crawler
  *     `description` rather than a `crawlerBays[]` entry.
  *   - Crawler type-abilities (All Terrain Locomotion / Improved Trading Bay)
- *     and mech cargo notes are captured in free-text where no structured field
- *     exists; the crawlers' mounted weapons (Mechapult, CACB Laser) are
- *     canonical Systems and resolve normally.
+ *     and mech cargo/ownership notes are captured in mech `appearance` / `quirk`
+ *     (the mech `description` field is deprecated and NOT rendered by the sheet,
+ *     so it is left unset — unlike pilot `description`, which renders as the
+ *     Bio). The crawlers' mounted weapons (Mechapult, CACB Laser) are stored by
+ *     NAME as canonical Systems so the crawler sheet's id/name resolver renders
+ *     them as full weapon cards.
  *   - Pilot real names that the sheet left blank/unknown fall back to the
  *     callsign (Roach-Boy); the pilots' sheet HP/AP maxima above the 10/5 base
  *     are encoded via `maxHpModifier` / `maxApModifier`.
@@ -323,7 +326,7 @@ export const ELDRIDGE_PILOTS: readonly Pilot[] = [
 /** Build a mech record with the shared, always-present defaults. */
 function mech(
   fields: Pick<Mech, 'id' | 'name' | 'chassisRef' | 'patternName' | 'systems' | 'modules'> &
-    Partial<Pick<Mech, 'quirk' | 'appearance' | 'description' | 'systemConditions'>>
+    Partial<Pick<Mech, 'quirk' | 'appearance' | 'systemConditions'>>
 ): Mech {
   return {
     schemaVersion: 1,
@@ -364,9 +367,8 @@ export const ELDRIDGE_MECHS: readonly Mech[] = [
     ],
     modules: ['metal-detector', 'comms-module'],
     quirk: 'constantly leaks coolant',
-    appearance: 'Overgrown with plants and vines.',
-    description:
-      'Integrated Colossal Cargo Bay (default Cargo Cap. 30). Carries: melee armament, ejection system, "Panda sneeze".',
+    appearance:
+      'Overgrown with plants and vines. Cargo: melee armament, ejection system, "Panda sneeze".',
   }),
   mech({
     id: MECH_CUSTOS,
@@ -376,8 +378,8 @@ export const ELDRIDGE_MECHS: readonly Mech[] = [
     systems: ['nanofibre-net-launcher', '50-cal-machine-gun'],
     modules: ['hacking-repeater-node', 'damage-assessor', 'comms-module'],
     quirk: 'Occasionally sparks electricity.',
-    appearance: "'Steampunk', whirring gears, bronze parts.",
-    description: 'Survey Drone (Tech 4) with an Integrated Hover Locomotion System.',
+    appearance:
+      "'Steampunk', whirring gears, bronze parts. A Tech 4 Survey Drone with an Integrated Hover Locomotion System.",
   }),
   mech({
     id: MECH_DAMNATIO,
@@ -387,9 +389,8 @@ export const ELDRIDGE_MECHS: readonly Mech[] = [
     systems: ['rail-rifle', 'locomotion-system', 'ejection-system', 'high-gain-antenna'],
     modules: ['comms-module', 'survey-scanner', 'ir-night-vision-optics', 'pinpoint-targeter'],
     quirk: 'Unusual cockpit location.',
-    appearance: 'Covered in camo and foliage.',
-    description:
-      "Polycarbonate Stealth Chassis. The main gun cuts through the cockpit, only slightly to the right of the pilot's headrest.",
+    appearance:
+      "Covered in camo and foliage. The main gun cuts through the cockpit, only slightly to the right of the pilot's headrest.",
   }),
   mech({
     id: MECH_INCITATUS,
@@ -404,8 +405,7 @@ export const ELDRIDGE_MECHS: readonly Mech[] = [
     ],
     modules: ['comms-module', 'navigation-module'],
     quirk: 'Secretly emits radio waves.',
-    appearance: 'Industrial and utilitarian.',
-    description: "Caligula's Mecha Companion (Tech 4).",
+    appearance: "Industrial and utilitarian. Caligula's Mecha Companion (Tech 4).",
   }),
   mech({
     id: MECH_NEW_DUKE,
@@ -423,9 +423,7 @@ export const ELDRIDGE_MECHS: readonly Mech[] = [
     ],
     modules: ['adv-weapon-link', 'personal-recreation-device'],
     quirk: 'Novelty Car Horn',
-    appearance: 'Beat up and Orange',
-    description:
-      'Close Range Protocols (+2 SP damage at Close Range). The Armour Plating is destroyed.',
+    appearance: 'Beat up and Orange. Its Armour Plating is destroyed.',
     systemConditions: { 'armour-plating': 'destroyed' },
   }),
   mech({
@@ -437,7 +435,6 @@ export const ELDRIDGE_MECHS: readonly Mech[] = [
     modules: ['zoom-optics', 'comms-module', 'firewall', 'ecm-transmitter'],
     quirk: 'Exterior fluctuates in colour.',
     appearance: 'Industrial and utilitarian.',
-    description: 'Polycarbonate Stealth Chassis.',
   }),
   mech({
     id: MECH_PR1,
@@ -447,8 +444,8 @@ export const ELDRIDGE_MECHS: readonly Mech[] = [
     systems: ['hydraulic-crusher'],
     modules: ['hull-magnetiser', 'self-destruct', 'survey-scanner'],
     quirk: 'Exterior fluctuates in colour.',
-    appearance: 'Industrial and utilitarian.',
-    description: 'Survey Drone with an Integrated Hover Locomotion System.',
+    appearance:
+      'Industrial and utilitarian. A Survey Drone with an Integrated Hover Locomotion System.',
   }),
   mech({
     id: MECH_REK_JET,
@@ -464,8 +461,7 @@ export const ELDRIDGE_MECHS: readonly Mech[] = [
     ],
     modules: ['comms-module'],
     quirk: 'Changes personality frequently',
-    appearance: 'Bobblehead Head',
-    description: "Roach-Boy's Auto-Turret. Carries 2 Tier 3 Scrap; a Pelt cape.",
+    appearance: "Bobblehead Head. Roach-Boy's Auto-Turret. Cargo: 2× Tier 3 Scrap and a Pelt cape.",
   }),
   mech({
     id: MECH_RUST_BUCKET,
@@ -482,9 +478,7 @@ export const ELDRIDGE_MECHS: readonly Mech[] = [
     ],
     modules: ['offensive-protocols', 'comms-module', 'personal-recreation-device'],
     quirk: 'Cockpit has far, far too many buttons.',
-    appearance: 'Looks Like Shit, Runs like Butter',
-    description:
-      'Scrap Plating (counts as 3 Armour Plating Systems, restorable in a T2+ Mech Bay).',
+    appearance: 'Looks Like Shit, Runs like Butter.',
   }),
   mech({
     id: MECH_SOB,
@@ -500,9 +494,7 @@ export const ELDRIDGE_MECHS: readonly Mech[] = [
     ],
     modules: ['comms-module'],
     quirk: 'Mismatched Hardware',
-    appearance: 'Hostile Ladybug',
-    description:
-      'Integrated Advanced Shield Dome (spend X EP as a Turn Action; the Shield Dome has SP equal to EP spent x3).',
+    appearance: 'Hostile Ladybug.',
   }),
 ]
 
@@ -600,7 +592,9 @@ const HAVEN_CRAWLER: Crawler = {
     npcCurrentHP: 4,
     npcDescription: 'Wasteland Explorer. Barber, wise beyond his years. Keepsake: Empty Mug.',
   },
-  systems: ['mechapult'],
+  // Stored by NAME (not slug): the crawler sheet's mounted-weapon resolver
+  // matches by id/name only, so a slug would render as a raw chit.
+  systems: ['Mechapult'],
   crawlerBays: HAVEN_BAY_CREW.map((c) => ({
     bayRef: c.ref,
     npcName: c.npcName,
@@ -627,7 +621,8 @@ const GLADHAND_CRAWLER: Crawler = {
     npcCurrentHP: 4,
     npcDescription: 'Savvy Trader. A corpo trading AI.',
   },
-  systems: ['cacb-laser'],
+  // Stored by NAME (see Haven's note).
+  systems: ['CACB Laser'],
   crawlerBays: GLADHAND_BAY_CREW.map((c) => ({
     bayRef: c.ref,
     npcName: c.npcName,


### PR DESCRIPTION
Follow-up to #461. An audit of what the ITUN pilot/mech/crawler sheets **actually render** (vs. what the seed stored) surfaced three gaps between the data and what a user sees. This closes them.

## Gaps fixed

1. **Crawler mounted weapons rendered as raw slugs.** They were stored as slugs (`mechapult`, `cacb-laser`), but the crawler sheet's `resolveCrawlerSystem` matches by **id/name only** — so Haven's Mechapult and Gladhand's CACB Laser showed as bare slug chits instead of full weapon cards. Now stored by **name** (`Mechapult`, `CACB Laser`), which resolves on both the crawler sheet and the (name-tolerant) mech resolver. *(The slug-based seed test passed because it used the mech resolver, which is slug-aware — a new test now guards the crawler sheet's id/name path.)*

2. **Mech notes were invisible.** The mech `description` field is deprecated and **not rendered** (the sheet shows `quirk` + `appearance`, and editing appearance erases `description`). All ten mechs had notes stranded there. The durable notes (cargo, drone-chassis context, companion ownership) are folded into `appearance`; the redundant chassis-ability text is dropped (the resolved SRD chassis renders its own ability); `description` is left unset. *(Pilot `description` renders as the Bio — those are unchanged and fine.)*

3. **Pre-existing roster bug** *(affects all mechs app-wide, not just this workspace)* — the roster's `mechChassisMeta` resolved chassis by **name** while stored refs are **slugs**, so every mech card showed a raw slug with no "· TL n". Switched to the slug/name/id-tolerant `resolveChassisRef` (try/catch-guarded for unpreloaded contexts). Resolved mechs now show e.g. `Atlas · TL 3`.

## Known, accepted (documented in-file)

- The **4 drone/companion mechs** (Custos, PR-1, Incitatus, Rek Jet) still have a chassis not in the SRD, so their sheet shows an advisory banner + 0 SP/EP/Heat; their systems/modules and the new appearance context render fine. Faking chassis stats would risk double-counting installed bonuses, so this stays as the honest best-effort representation.
- Crawler `scrapPool` isn't shown on the sheet face (only in the economy dialog) — that's the app's existing design, not a seed gap.

## Validation

typecheck (all) ✓ · lint ✓ · format ✓ · knip ✓ · seed test 21/21 ✓ · roster tests 17/17 ✓ · full ITUN suite **1303 pass / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LG8czobAR7o7LTML2f1Tye