### PR TITLE
feat(itun): drone/companion equipment hosts an installed loadout (1/2)

### DIFF
--- a/apps/in-the-union-now/src/components/shared/__tests__/useEquipmentLoadout.test.ts
+++ b/apps/in-the-union-now/src/components/shared/__tests__/useEquipmentLoadout.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for useEquipmentLoadout.
+ *
+ * Tests that:
+ * - loadout comes from the `seed` param, falling back to a stable empty loadout
+ * - add/remove persist via store.update, kebab-slugifying the added NAME and
+ *   MERGING pilot.equipmentLoadouts so sibling equipment loadouts aren't clobbered
+ * - handlers read the FRESHEST record (sequential adds accumulate — stale-closure guard)
+ *
+ * Dep-injection only — NO mock.module().
+ */
+
+import '@testing-library/jest-dom'
+import { describe, expect, mock, test } from 'bun:test'
+import { act, renderHook } from '@testing-library/react'
+
+import { useEquipmentLoadout } from '../useEquipmentLoadout'
+import type { Pilot } from '../../../lib/schemas/pilot'
+import type { useEntityStore } from '../../../stores/entityStore'
+
+const PILOT_ID = 'pilot-loadout-1'
+const SLUG = 'survey-drone'
+
+function makePilot(equipmentLoadouts?: Pilot['equipmentLoadouts']): Pilot {
+  return {
+    id: PILOT_ID,
+    schemaVersion: 1,
+    name: 'Test Pilot',
+    callsign: 'Tester',
+    classRef: 'scout',
+    abilities: [],
+    equipment: ['survey-drone', 'mecha-companion'],
+    motto: '',
+    keepsake: '',
+    appearance: '',
+    background: '',
+    conditions: [],
+    equipmentLoadouts,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  }
+}
+
+function makeStore(initial: Pilot) {
+  let current = initial
+  const updateFn = mock(async (_type: string, _id: string, patch: Partial<Pilot>) => {
+    current = { ...current, ...patch }
+    return current
+  })
+  const storeState = {
+    pilots: [current],
+    mechs: [],
+    crawlers: [],
+    softLinks: [],
+    hydrated: { pilots: true, mechs: false, crawlers: false, softLinks: false },
+    hydrate: mock(async () => {}),
+    list: mock(() => [current]),
+    get: mock((_type: string, id: string) => (id === current.id ? current : null)),
+    create: mock(async () => current),
+    update: updateFn,
+    delete: mock(async () => {}),
+  }
+  const store = (() => storeState) as unknown as typeof useEntityStore
+  return { store, updateFn, getCurrent: () => current }
+}
+
+describe('useEquipmentLoadout — seeding', () => {
+  test('seeds an empty loadout (stable ref) when no seed is provided', () => {
+    const { store } = makeStore(makePilot())
+    const { result, rerender } = renderHook(() =>
+      useEquipmentLoadout(PILOT_ID, SLUG, undefined, store)
+    )
+    expect(result.current.loadout).toEqual({ systems: [], modules: [] })
+    const first = result.current.loadout
+    rerender()
+    expect(result.current.loadout).toBe(first)
+  })
+
+  test('returns the seed loadout verbatim', () => {
+    const seed = { systems: ['red-laser'], modules: ['comms-module'] }
+    const { store } = makeStore(makePilot())
+    const { result } = renderHook(() => useEquipmentLoadout(PILOT_ID, SLUG, seed, store))
+    expect(result.current.loadout).toBe(seed)
+  })
+})
+
+describe('useEquipmentLoadout — add/remove persistence', () => {
+  test('addSystem slugifies the name and appends, merging siblings', async () => {
+    const pilot = makePilot({ 'mecha-companion': { systems: ['locomotion-system'], modules: [] } })
+    const { store, updateFn } = makeStore(pilot)
+    const { result } = renderHook(() => useEquipmentLoadout(PILOT_ID, SLUG, undefined, store))
+
+    await act(async () => {
+      result.current.addSystem('Red Laser')
+    })
+
+    expect(updateFn).toHaveBeenCalledWith('pilot', PILOT_ID, {
+      equipmentLoadouts: {
+        'mecha-companion': { systems: ['locomotion-system'], modules: [] },
+        'survey-drone': { systems: ['red-laser'], modules: [] },
+      },
+    })
+  })
+
+  test('addModule appends to modules only', async () => {
+    const { store, updateFn } = makeStore(makePilot())
+    const { result } = renderHook(() => useEquipmentLoadout(PILOT_ID, SLUG, undefined, store))
+    await act(async () => {
+      result.current.addModule('Comms Module')
+    })
+    expect(updateFn).toHaveBeenCalledWith('pilot', PILOT_ID, {
+      equipmentLoadouts: { 'survey-drone': { systems: [], modules: ['comms-module'] } },
+    })
+  })
+
+  test('sequential adds accumulate (freshest-read, no stale-closure clobber)', async () => {
+    const { store, getCurrent } = makeStore(makePilot())
+    const { result } = renderHook(() => useEquipmentLoadout(PILOT_ID, SLUG, undefined, store))
+    await act(async () => {
+      result.current.addSystem('Red Laser')
+    })
+    await act(async () => {
+      result.current.addSystem('Welding Laser')
+    })
+    expect(getCurrent().equipmentLoadouts?.[SLUG]?.systems).toEqual(['red-laser', 'welding-laser'])
+  })
+
+  test('removeSystem filters by index', async () => {
+    const pilot = makePilot({
+      'survey-drone': { systems: ['red-laser', 'welding-laser'], modules: ['comms-module'] },
+    })
+    const { store, updateFn } = makeStore(pilot)
+    const { result } = renderHook(() =>
+      useEquipmentLoadout(PILOT_ID, SLUG, pilot.equipmentLoadouts?.[SLUG], store)
+    )
+    await act(async () => {
+      result.current.removeSystem(0)
+    })
+    expect(updateFn).toHaveBeenCalledWith('pilot', PILOT_ID, {
+      equipmentLoadouts: {
+        'survey-drone': { systems: ['welding-laser'], modules: ['comms-module'] },
+      },
+    })
+  })
+})

--- a/apps/in-the-union-now/src/components/shared/useEquipmentLoadout.ts
+++ b/apps/in-the-union-now/src/components/shared/useEquipmentLoadout.ts
@@ -1,0 +1,104 @@
+/**
+ * useEquipmentLoadout — controlled adapter between a pilot's persisted
+ * per-equipment installed loadout (`pilot.equipmentLoadouts[slug]`) and the
+ * "Add System / Add Module" collection UI (the same EntitySearcher + section
+ * stack mechs use).
+ *
+ * Given the owning pilot + a drone-equipment slug + the persisted seed loadout
+ * (sourced from the canonical pilot prop, so read-only/snapshot rendering does
+ * not depend on the live store), it returns the current loadout plus add/remove
+ * handlers. Adds emit the entity NAME (EntitySearcher's default idOf), which we
+ * kebab-slugify to match the system/module slug convention.
+ *
+ * Write path reads the FRESHEST record from the store at call time (not a
+ * render-time closure) and merges only this slug's entry, mirroring
+ * useEntityChoices.setSelections and MechSheet.addItem/removeItem so rapid edits
+ * to sibling equipment never clobber each other. Dep-injected `store` keeps the
+ * hook unit-testable without module mocking.
+ */
+
+import { useCallback } from 'react'
+
+import { nameToSlug } from 'salvageunion-reference'
+
+import { useEntityStore } from '../../stores/entityStore'
+import type { Pilot } from '../../lib/schemas/pilot'
+
+/** One equipment instance's installed loadout. */
+export type EquipmentLoadout = { systems: string[]; modules: string[] }
+
+/** Stable empty loadout — frozen so a fresh literal never defeats memoisation. */
+const EMPTY_LOADOUT: EquipmentLoadout = Object.freeze({
+  systems: Object.freeze([]) as unknown as string[],
+  modules: Object.freeze([]) as unknown as string[],
+})
+
+type UseEquipmentLoadoutResult = {
+  loadout: EquipmentLoadout
+  addSystem: (name: string) => void
+  removeSystem: (index: number) => void
+  addModule: (name: string) => void
+  removeModule: (index: number) => void
+}
+
+export function useEquipmentLoadout(
+  pilotId: string,
+  slug: string,
+  /** Persisted loadout for this equipment, from the canonical pilot prop. */
+  seed: EquipmentLoadout | undefined,
+  /** Injectable store — defaults to useEntityStore. Pass a stub in tests. */
+  store: typeof useEntityStore = useEntityStore
+): UseEquipmentLoadoutResult {
+  const storeState = store()
+
+  const loadout: EquipmentLoadout = seed ?? EMPTY_LOADOUT
+
+  /** Merge this slug's next loadout into the freshest pilot record. */
+  const write = useCallback(
+    (next: EquipmentLoadout) => {
+      const fresh = storeState.get('pilot', pilotId) as Pilot | undefined
+      const prevAll = fresh?.equipmentLoadouts ?? {}
+      void storeState.update('pilot', pilotId, {
+        equipmentLoadouts: { ...prevAll, [slug]: next },
+      })
+    },
+    [storeState, pilotId, slug]
+  )
+
+  const current = useCallback((): EquipmentLoadout => {
+    const fresh = storeState.get('pilot', pilotId) as Pilot | undefined
+    const entry = fresh?.equipmentLoadouts?.[slug]
+    return { systems: entry?.systems ?? [], modules: entry?.modules ?? [] }
+  }, [storeState, pilotId, slug])
+
+  const addSystem = useCallback(
+    (name: string) => {
+      const c = current()
+      write({ ...c, systems: [...c.systems, nameToSlug(name)] })
+    },
+    [current, write]
+  )
+  const removeSystem = useCallback(
+    (index: number) => {
+      const c = current()
+      write({ ...c, systems: c.systems.filter((_, i) => i !== index) })
+    },
+    [current, write]
+  )
+  const addModule = useCallback(
+    (name: string) => {
+      const c = current()
+      write({ ...c, modules: [...c.modules, nameToSlug(name)] })
+    },
+    [current, write]
+  )
+  const removeModule = useCallback(
+    (index: number) => {
+      const c = current()
+      write({ ...c, modules: c.modules.filter((_, i) => i !== index) })
+    },
+    [current, write]
+  )
+
+  return { loadout, addSystem, removeSystem, addModule, removeModule }
+}

--- a/apps/in-the-union-now/src/components/sheet/PilotEquipmentLoadout.tsx
+++ b/apps/in-the-union-now/src/components/sheet/PilotEquipmentLoadout.tsx
@@ -1,0 +1,202 @@
+/**
+ * PilotEquipmentLoadout — the installed systems/modules loadout for a
+ * drone/companion equipment carried by a pilot (Survey Drone, Mecha Companion,
+ * Auto-Turret). These equipment entities carry their own systemSlots/moduleSlots,
+ * so they host a real loadout the same way a mech does.
+ *
+ * Reuses the exact mech loadout stack — SheetSectionCard + SectionAddButton +
+ * SheetPickerModal + EntitySearcher (mode="count") — writing through
+ * `pilot.equipmentLoadouts[slug]` via useEquipmentLoadout. Installed items render
+ * as compact ReferenceEntityDisplay cards with a remove control; per-item
+ * condition/uses tracking is intentionally deferred for v1 (kept read-only),
+ * unlike a mech's MechItemCard economy.
+ */
+
+import { useState } from 'react'
+
+import type { SURefEntity } from 'salvageunion-reference'
+import { ReferenceEntityDisplay } from 'suref-react'
+
+import type { useEntityStore } from '../../stores/entityStore'
+import { useEquipmentLoadout } from '../shared/useEquipmentLoadout'
+import type { EquipmentLoadout } from '../shared/useEquipmentLoadout'
+import { EntitySearcher } from '../shared/EntitySearcher'
+import { Ecflow, Erow } from './Erow'
+import { resolveModule, resolveSystem } from './mechItemRules'
+import {
+  REMOVABLE_CARD_STYLE,
+  SectionAddButton,
+  SheetPickerModal,
+  cardRemoveControls,
+} from './SheetSection'
+import { SheetSectionCard } from './SheetSectionCard'
+
+const HIDE_CHOICES = { choices: true } as const
+
+/** Read a numeric slot field off the drone-equipment entity, defaulting to 0. */
+function slotMax(equipment: Record<string, unknown>, field: 'systemSlots' | 'moduleSlots'): number {
+  const raw = equipment[field]
+  return typeof raw === 'number' ? raw : 0
+}
+
+/** True when the resolved equipment is a loadout host (carries slot fields). */
+// biome-ignore lint/style/useComponentExportOnlyModules: gate helper colocated with the loadout component it guards
+export function isLoadoutHost(equipment: Record<string, unknown> | null): boolean {
+  return !!equipment && ('systemSlots' in equipment || 'moduleSlots' in equipment)
+}
+
+type Kind = 'system' | 'module'
+
+type PilotEquipmentLoadoutProps = {
+  /** Owning pilot id — the loadout persists under this entity. */
+  pilotId: string
+  /** Equipment slug as stored on the pilot. */
+  slug: string
+  /** Resolved drone-equipment entity (carries systemSlots/moduleSlots + name). */
+  equipment: Record<string, unknown> & { name?: string }
+  /** Persisted loadout for this equipment, from the canonical pilot prop. */
+  seed: EquipmentLoadout | undefined
+  readOnly: boolean
+  /** Injectable store — forwarded to useEquipmentLoadout for tests. */
+  store: typeof useEntityStore
+}
+
+export function PilotEquipmentLoadout({
+  pilotId,
+  slug,
+  equipment,
+  seed,
+  readOnly,
+  store,
+}: PilotEquipmentLoadoutProps) {
+  const [picker, setPicker] = useState<Kind | null>(null)
+  const { loadout, addSystem, removeSystem, addModule, removeModule } = useEquipmentLoadout(
+    pilotId,
+    slug,
+    seed,
+    store
+  )
+
+  const systemMax = slotMax(equipment, 'systemSlots')
+  const moduleMax = slotMax(equipment, 'moduleSlots')
+  const railName = equipment.name ?? 'Companion'
+
+  function renderItems(kind: Kind, slugs: string[], onRemove: (index: number) => void) {
+    if (slugs.length === 0) {
+      return (
+        <p className="font-body text-caption text-wk-muted">
+          {kind === 'system' ? 'No systems installed.' : 'No modules installed.'}
+        </p>
+      )
+    }
+    return (
+      <Ecflow>
+        {slugs.map((itemSlug, index) => {
+          const entity = kind === 'system' ? resolveSystem(itemSlug) : resolveModule(itemSlug)
+          const controls =
+            readOnly || !entity
+              ? undefined
+              : cardRemoveControls({
+                  name: entity.name ?? itemSlug,
+                  onRemove: () => {
+                    onRemove(index)
+                  },
+                })
+          return (
+            // biome-ignore lint/suspicious/noArrayIndexKey: the same slug may be installed more than once; install order is stable
+            <Erow key={`${itemSlug}-${index}`}>
+              {entity ? (
+                <ReferenceEntityDisplay
+                  data={entity as unknown as SURefEntity}
+                  compact
+                  hide={HIDE_CHOICES}
+                  controls={controls}
+                  cardStyle={controls ? REMOVABLE_CARD_STYLE : undefined}
+                />
+              ) : (
+                <div className="flex h-full items-center justify-between gap-2 rounded-[3px] border-chrome border-ink bg-paper px-3 py-2">
+                  <span className="font-body text-sm text-ink">{itemSlug}</span>
+                </div>
+              )}
+            </Erow>
+          )
+        })}
+      </Ecflow>
+    )
+  }
+
+  return (
+    <div className="mt-3 flex flex-col gap-3">
+      {'systemSlots' in equipment && (
+        <SheetSectionCard
+          title="Systems"
+          count={
+            <span className="tabular-nums">
+              {loadout.systems.length}/{systemMax} slots
+            </span>
+          }
+          controls={
+            readOnly ? undefined : (
+              <SectionAddButton label="system" onClick={() => setPicker('system')} />
+            )
+          }
+        >
+          {renderItems('system', loadout.systems, removeSystem)}
+        </SheetSectionCard>
+      )}
+
+      {'moduleSlots' in equipment && (
+        <SheetSectionCard
+          title="Modules"
+          count={
+            <span className="tabular-nums">
+              {loadout.modules.length}/{moduleMax} slots
+            </span>
+          }
+          controls={
+            readOnly ? undefined : (
+              <SectionAddButton label="module" onClick={() => setPicker('module')} />
+            )
+          }
+        >
+          {renderItems('module', loadout.modules, removeModule)}
+        </SheetSectionCard>
+      )}
+
+      <SheetPickerModal
+        open={picker === 'system'}
+        onClose={() => setPicker(null)}
+        title="Add Systems"
+      >
+        <EntitySearcher
+          schema="systems"
+          mode="count"
+          selected={loadout.systems}
+          onAdd={addSystem}
+          onRemove={removeSystem}
+          railName={railName}
+          chosenLabel="Installed"
+          emptyMessage="No systems match those filters."
+          budget={[{ label: 'System Slots', used: loadout.systems.length, max: systemMax }]}
+        />
+      </SheetPickerModal>
+      <SheetPickerModal
+        open={picker === 'module'}
+        onClose={() => setPicker(null)}
+        title="Add Modules"
+      >
+        <EntitySearcher
+          schema="modules"
+          mode="count"
+          selected={loadout.modules}
+          onAdd={addModule}
+          onRemove={removeModule}
+          railName={railName}
+          chosenLabel="Installed"
+          emptyMessage="No modules match those filters."
+          budget={[{ label: 'Module Slots', used: loadout.modules.length, max: moduleMax }]}
+        />
+      </SheetPickerModal>
+    </div>
+  )
+}

--- a/apps/in-the-union-now/src/components/sheet/PilotSheet.tsx
+++ b/apps/in-the-union-now/src/components/sheet/PilotSheet.tsx
@@ -492,6 +492,7 @@ export function PilotSheet({
                   slug={slug}
                   pilotId={pilot.id}
                   seedSelections={pilot.equipmentChoices?.[slug]}
+                  seedLoadout={pilot.equipmentLoadouts?.[slug]}
                   condition={pilot.equipmentConditions?.[slug] ?? 'intact'}
                   usesLeft={pilot.equipmentUses?.[slug]}
                   onConditionChange={(itemSlug, next) => {

--- a/apps/in-the-union-now/src/components/sheet/PilotSheetItems.tsx
+++ b/apps/in-the-union-now/src/components/sheet/PilotSheetItems.tsx
@@ -14,8 +14,11 @@ import type { CardFootMeta, ChoiceSelections, EntityStatus } from 'suref-react'
 import type { ItemCondition } from '../../lib/schemas/mech'
 import type { GenericInventoryEntry } from '../../lib/schemas/pilot'
 import { resolveAbilityApCost } from '../../lib/abilityCost'
+import { matchesRef } from '../../lib/rules/resolveRefs'
 import type { useEntityStore } from '../../stores/entityStore'
 import { useEntityChoices } from '../shared/useEntityChoices'
+import type { EquipmentLoadout } from '../shared/useEquipmentLoadout'
+import { PilotEquipmentLoadout, isLoadoutHost } from './PilotEquipmentLoadout'
 import { CardRemoveButton, REMOVABLE_CARD_STYLE, cardRemoveControls } from './SheetSection'
 import {
   equipmentMaxUses,
@@ -36,7 +39,8 @@ const CONDITION_CYCLE: Record<ItemCondition, ItemCondition> = {
 // biome-ignore lint/style/useComponentExportOnlyModules: shared control helpers, colocated by design (audit items 24/19)
 export function resolveAbility(slug: string): SURefAbility | null {
   const all = SalvageUnionReference.Abilities.all() as ReadonlyArray<SURefAbility>
-  return all.find((a) => a.id === slug || a.name === slug) ?? null
+  // Slug-tolerant (matchesRef): seeded pilots store kebab ability slugs.
+  return all.find((a) => matchesRef(a, slug)) ?? null
 }
 
 // ---------------------------------------------------------------------------
@@ -142,6 +146,12 @@ type PilotEquipmentItemProps = {
    * pilot prop so read-only/snapshot rendering does not depend on the store.
    */
   seedSelections: ChoiceSelections | undefined
+  /**
+   * Persisted installed loadout for drone/companion equipment (Survey Drone,
+   * Mecha Companion, Auto-Turret), sourced from the canonical pilot prop.
+   * Undefined for normal gear, which never renders a loadout section.
+   */
+  seedLoadout: EquipmentLoadout | undefined
   condition: ItemCondition
   /** Uses remaining for this item; undefined = full (rules A14). */
   usesLeft: number | undefined
@@ -172,6 +182,7 @@ export function PilotEquipmentItem({
   slug,
   pilotId,
   seedSelections,
+  seedLoadout,
   condition,
   usesLeft,
   onConditionChange,
@@ -252,26 +263,43 @@ export function PilotEquipmentItem({
   const controls =
     !readOnly && onRemove ? cardRemoveControls({ name: equipment.name, onRemove }) : undefined
 
+  const equipmentRecord = equipment as unknown as Record<string, unknown> & { name?: string }
+
   return (
-    <ReferenceEntityDisplay
-      data={equipment as unknown as SURefEntity}
-      compact
-      selections={selections}
-      onSelectionChange={readOnly ? undefined : setSelections}
-      scalingParent={scalingParent}
-      status={condition as EntityStatus}
-      onStatusClick={
-        readOnly
-          ? undefined
-          : () => {
-              onConditionChange(slug, CONDITION_CYCLE[condition])
-            }
-      }
-      footMeta={footMeta}
-      footActions={footActions}
-      controls={controls}
-      cardStyle={controls ? REMOVABLE_CARD_STYLE : undefined}
-    />
+    <>
+      <ReferenceEntityDisplay
+        data={equipment as unknown as SURefEntity}
+        compact
+        selections={selections}
+        onSelectionChange={readOnly ? undefined : setSelections}
+        scalingParent={scalingParent}
+        status={condition as EntityStatus}
+        onStatusClick={
+          readOnly
+            ? undefined
+            : () => {
+                onConditionChange(slug, CONDITION_CYCLE[condition])
+              }
+        }
+        footMeta={footMeta}
+        footActions={footActions}
+        controls={controls}
+        cardStyle={controls ? REMOVABLE_CARD_STYLE : undefined}
+      />
+      {/* Drone/companion equipment (Survey Drone, Mecha Companion, Auto-Turret)
+          carries its own systemSlots/moduleSlots, so it hosts a real installed
+          loadout edited with the same picker mechs use. */}
+      {isLoadoutHost(equipmentRecord) && (
+        <PilotEquipmentLoadout
+          pilotId={pilotId}
+          slug={slug}
+          equipment={equipmentRecord}
+          seed={seedLoadout}
+          readOnly={readOnly}
+          store={store}
+        />
+      )}
+    </>
   )
 }
 

--- a/apps/in-the-union-now/src/components/sheet/__tests__/PilotEquipmentLoadout.test.tsx
+++ b/apps/in-the-union-now/src/components/sheet/__tests__/PilotEquipmentLoadout.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * PilotEquipmentLoadout — drone/companion installed-loadout section tests.
+ *
+ * Asserts that:
+ *   1. Systems + Modules sections render the seeded installed items (resolved
+ *      to their reference names) and the used/max slot counts.
+ *   2. Editable mode exposes the "Add system"/"Add module" affordances and
+ *      opening one shows the picker; readOnly hides them.
+ *   3. isLoadoutHost gates on the slot-carrying data shape.
+ *
+ * Store-injection seam; NO mock.module().
+ */
+
+import { afterEach, beforeAll, describe, expect, mock, test } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import { PilotEquipmentLoadout, isLoadoutHost } from '../PilotEquipmentLoadout'
+import type { Pilot } from '../../../lib/schemas/pilot'
+import type { useEntityStore } from '../../../stores/entityStore'
+
+// Installed system/module cards resolve via reference + nest trait/keyword
+// lookups, so preload 'all'.
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+const PILOT_ID = 'pilot-loadout-cmp'
+// A drone-equipment-shaped record: only name + slot fields are read.
+const SURVEY_DRONE = { name: 'Survey Drone', systemSlots: 3, moduleSlots: 1 }
+const SEED = { systems: ['red-laser'], modules: ['comms-module'] }
+
+function makeStore(): typeof useEntityStore {
+  const current = { id: PILOT_ID } as unknown as Pilot
+  const storeState = {
+    pilots: [current],
+    mechs: [],
+    crawlers: [],
+    softLinks: [],
+    hydrated: { pilots: true, mechs: false, crawlers: false, softLinks: false },
+    hydrate: mock(async () => {}),
+    list: mock(() => [current]),
+    get: mock(() => current),
+    create: mock(async () => current),
+    update: mock(async () => current),
+    delete: mock(async () => {}),
+  }
+  return (() => storeState) as unknown as typeof useEntityStore
+}
+
+describe('isLoadoutHost', () => {
+  test('true for slot-carrying equipment, false otherwise', () => {
+    expect(isLoadoutHost({ systemSlots: 3 })).toBe(true)
+    expect(isLoadoutHost({ moduleSlots: 1 })).toBe(true)
+    expect(isLoadoutHost({ name: 'First Aid Kit' })).toBe(false)
+    expect(isLoadoutHost(null)).toBe(false)
+  })
+})
+
+describe('PilotEquipmentLoadout — render', () => {
+  test('renders installed systems/modules + slot counts, and the add affordances', () => {
+    render(
+      <PilotEquipmentLoadout
+        pilotId={PILOT_ID}
+        slug="survey-drone"
+        equipment={SURVEY_DRONE}
+        seed={SEED}
+        readOnly={false}
+        store={makeStore()}
+      />
+    )
+    // Section headings.
+    expect(screen.getByText('Systems')).toBeTruthy()
+    expect(screen.getByText('Modules')).toBeTruthy()
+    // Installed items resolved to names.
+    expect(screen.getByText('Red Laser')).toBeTruthy()
+    expect(screen.getByText('Comms Module')).toBeTruthy()
+    // Used/max slot counts.
+    expect(screen.getByText('1/3 slots')).toBeTruthy()
+    expect(screen.getByText('1/1 slots')).toBeTruthy()
+    // Editable add affordances.
+    expect(screen.getByLabelText('Add system')).toBeTruthy()
+    expect(screen.getByLabelText('Add module')).toBeTruthy()
+  })
+
+  test('empty loadout shows the empty copy', () => {
+    render(
+      <PilotEquipmentLoadout
+        pilotId={PILOT_ID}
+        slug="survey-drone"
+        equipment={SURVEY_DRONE}
+        seed={undefined}
+        readOnly={false}
+        store={makeStore()}
+      />
+    )
+    expect(screen.getByText('No systems installed.')).toBeTruthy()
+    expect(screen.getByText('No modules installed.')).toBeTruthy()
+    expect(screen.getByText('0/3 slots')).toBeTruthy()
+  })
+
+  test('readOnly hides the add affordances', () => {
+    render(
+      <PilotEquipmentLoadout
+        pilotId={PILOT_ID}
+        slug="survey-drone"
+        equipment={SURVEY_DRONE}
+        seed={SEED}
+        readOnly={true}
+        store={makeStore()}
+      />
+    )
+    expect(screen.queryByLabelText('Add system')).toBeNull()
+    expect(screen.queryByLabelText('Add module')).toBeNull()
+  })
+})

--- a/apps/in-the-union-now/src/components/sheet/__tests__/pilotInventory.test.ts
+++ b/apps/in-the-union-now/src/components/sheet/__tests__/pilotInventory.test.ts
@@ -29,6 +29,26 @@ function inventory(
   return { equipment, genericInventory }
 }
 
+describe('resolveEquipment — slug tolerance', () => {
+  // Seeded pilots store kebab slugs; resolveEquipment must be slug-tolerant
+  // (matchesRef), not id/name-only — else every seed slug renders as a raw chit.
+  test('resolves a kebab slug to the same entity as its display name', () => {
+    const byName = resolveEquipment('Remote Mine')
+    const bySlug = resolveEquipment('remote-mine')
+    expect(byName).not.toBeNull()
+    expect(bySlug).not.toBeNull()
+    expect(bySlug?.id).toBe(byName?.id as string)
+  })
+
+  test('resolves the drone-equipment slug (survey-drone)', () => {
+    expect(resolveEquipment('survey-drone')?.name).toBe('Survey Drone')
+  })
+
+  test('unknown slug returns null', () => {
+    expect(resolveEquipment('not-a-real-thing')).toBeNull()
+  })
+})
+
 describe('equipmentSlotCost', () => {
   test('standard equipment costs 1 slot', () => {
     expect(equipmentSlotCost(resolveEquipment('Rifle'))).toBe(1)

--- a/apps/in-the-union-now/src/components/sheet/pilotInventory.ts
+++ b/apps/in-the-union-now/src/components/sheet/pilotInventory.ts
@@ -20,11 +20,17 @@ import type { SURefEquipment, SURefMetaEntity } from 'salvageunion-reference'
 
 import type { GenericInventoryEntry, Pilot } from '../../lib/schemas/pilot'
 import { PILOT_BASE_INVENTORY_SLOTS } from '../../lib/rules/derivedStats'
+import { matchesRef } from '../../lib/rules/resolveRefs'
 
-/** Resolve an equipment slug (id or name) against the reference data. */
+/**
+ * Resolve an equipment ref (slug, name, or id) against the reference data.
+ * Seeded records store kebab slugs (e.g. `remote-mine`, `survey-drone`), so the
+ * match must be slug-tolerant via `matchesRef` — an id/name-only match silently
+ * fails every slug and renders the item as a raw-slug chit.
+ */
 export function resolveEquipment(slug: string): SURefEquipment | null {
   const all = SalvageUnionReference.Equipment.all() as ReadonlyArray<SURefEquipment>
-  return all.find((e) => e.id === slug || e.name === slug) ?? null
+  return all.find((e) => matchesRef(e, slug)) ?? null
 }
 
 /**

--- a/apps/in-the-union-now/src/lib/schemas/pilot.ts
+++ b/apps/in-the-union-now/src/lib/schemas/pilot.ts
@@ -142,6 +142,28 @@ export const PilotSchema = z
      */
     equipmentChoices: z.record(z.string(), ChoiceSelectionsSchema).optional(),
     /**
+     * Per-equipment installed loadout for drone/companion equipment that carries
+     * its own systemSlots/moduleSlots (Survey Drone, Mecha Companion,
+     * Auto-Turret). Keyed by equipment slug → the systems/modules installed on
+     * that instance; refs are system/module slugs (same convention as
+     * mech.systems/modules). Edited through the same "Add System/Module" picker
+     * mechs use. Additive-optional — absent reads as no loadout; no DB migration
+     * needed (same tactic as equipmentChoices/equipmentConditions). Keyed by slug
+     * so two of the same drone slug on one pilot would share an entry — an
+     * accepted limitation identical to equipmentChoices.
+     */
+    equipmentLoadouts: z
+      .record(
+        z.string(),
+        z
+          .object({
+            systems: z.array(z.string()).default([]),
+            modules: z.array(z.string()).default([]),
+          })
+          .strict()
+      )
+      .optional(),
+    /**
      * Manual fallback for the pilot's effective Crawler Tech Level (1–6), used
      * to scale choice caps (e.g. the Custom Sniper Rifle's Modification choice,
      * "at each Tech Level you may select an additional Modification"). Only used

--- a/docs/adrs/ADR-023-drone-equipment-installed-loadout.md
+++ b/docs/adrs/ADR-023-drone-equipment-installed-loadout.md
@@ -1,0 +1,68 @@
+# ADR-023: Drone/Companion Equipment Hosts an Installed Systems/Modules Loadout
+
+## Status
+
+Accepted.
+
+## Context
+
+Some Salvage Union pilot abilities (Mecha Companion, Survey Drone, Auto-Turret)
+`grants` a same-named **equipment** entity that is drone-chassis-like: it carries
+its own `structurePoints` / `energyPoints` / `heatCapacity` / `systemSlots` /
+`moduleSlots` / `bonusPerTechLevel`. In play these companions are built up with
+Systems and Modules, exactly like a mech — but ITUN modeled them either as
+standalone mechs (unresolved "chassis", 0 base stats) or as plain pilot equipment
+with no place to record an installed loadout.
+
+The reference `choices` mechanism ([ADR-010](ADR-010-srd-choices-ephemeral-vs-persisted.md))
+resolves only stat-modifying effects and free text, so it cannot represent a
+browsable, per-owner list of installed Systems/Modules rendered as cards. Building
+that into the shared choice layer would be a large change to `suref-react`.
+
+## Decision
+
+A pilot's granted drone/companion equipment carries a **real installed loadout**
+stored per equipment instance on the owning pilot, edited through the **same
+"Add System / Add Module" collection UX** mechs and the crawler Armament Bay
+already use — not the choice mechanism.
+
+- **Persistence (ITUN):** a new additive-optional `Pilot.equipmentLoadouts`
+  field — `Record<equipmentSlug, { systems: string[]; modules: string[] }>` —
+  mirroring the existing `equipmentChoices` / `equipmentConditions` per-slug maps.
+  Absent reads as no loadout; no DB migration; it rides through snapshots with the
+  pilot. Keyed by slug, so two of the same drone slug on one pilot share an entry —
+  an accepted limitation identical to `equipmentChoices`.
+- **Identity stays on `equipmentChoices`.** Name / Appearance / A.I. Personality
+  remain free-text choices on the equipment; the loadout store is purely
+  `{ systems, modules }`.
+- **Rendering (ITUN-local, no `suref-react` change):** a `PilotEquipmentLoadout`
+  section reuses `SheetSectionCard` + `SheetPickerModal` + `EntitySearcher`
+  (`mode="count"`) + a `useEquipmentLoadout` hook (analogue of `useEntityChoices`).
+  It mounts on the equipment card when the resolved entity is a loadout host
+  (data-shape check: `systemSlots`/`moduleSlots` present), so normal gear never
+  shows it. Because nothing is added to `suref-react`, there is no generated-schema
+  drift and no suref-web / discord-bot blast radius.
+- **Slot budget is soft** ([ADR-007](ADR-007-automation-boundary.md)): the picker
+  shows `used/max` from the equipment's own slot fields but never blocks — the
+  Live Sheet is a Free-Edit surface ([ADR-021](ADR-021-itun-surface-taxonomy.md)).
+- **Prerequisite fix:** `resolveEquipment` / `resolveAbility` matched by id/name
+  only, so every seeded kebab slug (`survey-drone`, `remote-mine`, …) rendered as a
+  raw chit. Both now use the slug-tolerant `matchesRef`, so seeded equipment and
+  abilities resolve to full cards (the drone card must resolve to host a loadout).
+
+Per-instance condition/uses tracking for installed drone systems/modules is
+deferred (v1 renders them read-only) to keep scope tight.
+
+## Consequences
+
+- Companions become correctly-modeled granted equipment with their real
+  loadouts, proper drone stats, and no "unknown chassis" artifact; they leave the
+  mech roster.
+- One new persistence field and two small ITUN modules (`useEquipmentLoadout`,
+  `PilotEquipmentLoadout`); the reference data change is minimal (a `Name` choice
+  added to Survey Drone for naming parity).
+- Fixing the equipment/ability resolvers is a strict, visible improvement across
+  all seeds (Starter Set included): seeded gear and abilities now render as cards.
+- The slug-keyed loadout map cannot distinguish two identical drone slugs on one
+  pilot — accepted, matching `equipmentChoices`; revisit with instance ids if a
+  build ever needs it.


### PR DESCRIPTION
First of two PRs adding **drone/companion loadouts** (ADR-023). This one lands the reusable capability + a latent-bug fix; the follow-up converts the Eldridge Coast seed.

## Why

Salvage Union companions (Mecha Companion, Survey Drone, Auto-Turret) are ability-**granted equipment** that carry their own `systemSlots`/`moduleSlots` — they're built up with Systems/Modules like a mech. ITUN had no way to record that loadout. This adds it, reusing the exact "Add System/Module" picker mechs already use — **no `suref-react` change**, so no generated-schema drift and no suref-web/discord-bot blast radius.

## What

- **`Pilot.equipmentLoadouts`** — additive-optional `Record<equipmentSlug, {systems, modules}>`, mirroring `equipmentChoices`. No DB migration; rides through snapshots.
- **`useEquipmentLoadout`** hook (analogue of `useEntityChoices`) + **`PilotEquipmentLoadout`** section that reuses `SheetSectionCard` + `SheetPickerModal` + `EntitySearcher` + compact item cards. Mounts on the equipment card when the resolved entity is a loadout host (data-shape: `systemSlots`/`moduleSlots` present), so normal gear never shows it. Soft slot budget (ADR-007); per-item condition/uses deferred for v1.
- **Prerequisite bug fix:** `resolveEquipment` / `resolveAbility` matched by id/name only, so every seeded **kebab slug** (`survey-drone`, `remote-mine`, …) rendered as a raw-slug chit — the pilot-side twin of the crawler-weapon/roster-chassis resolver bugs already fixed. Both now use the slug-tolerant `matchesRef`, so seeded pilot equipment/abilities (Starter Set **and** Eldridge Coast) now resolve to full cards. A visible, strict improvement.
- **ADR-023** records the design.

## Tests

New: `useEquipmentLoadout` write-through (add/remove/slugify/merge), `PilotEquipmentLoadout` render + gate + readOnly, `resolveEquipment` slug tolerance. Full suite **1312 pass / 0 fail**; `check:all` green (validate, doc-drift, knip, audit).

## Next

PR 2/2: add a `Name` choice to Survey Drone in the reference data, and convert the Eldridge Coast seed's four drone-mechs into pilot-equipment grants carrying these loadouts (removing the standalone mechs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LG8czobAR7o7LTML2f1Tye