### PR TITLE
feat(itun): condition + uses tracking for drone loadout items

### DIFF
--- a/apps/in-the-union-now/src/components/shared/__tests__/useEquipmentLoadout.test.ts
+++ b/apps/in-the-union-now/src/components/shared/__tests__/useEquipmentLoadout.test.ts
@@ -143,3 +143,64 @@ describe('useEquipmentLoadout — add/remove persistence', () => {
     })
   })
 })
+
+describe('useEquipmentLoadout — condition + uses persistence', () => {
+  function seeded() {
+    const pilot = makePilot({
+      'survey-drone': { systems: ['red-laser'], modules: ['comms-module'] },
+    })
+    const { store, updateFn } = makeStore(pilot)
+    const { result } = renderHook(() =>
+      useEquipmentLoadout(PILOT_ID, SLUG, pilot.equipmentLoadouts?.[SLUG], store)
+    )
+    return { store, updateFn, result }
+  }
+
+  test('setCondition writes systemConditions, preserving the installed items', async () => {
+    const { updateFn, result } = seeded()
+    await act(async () => {
+      result.current.setCondition('system', 'red-laser', 'damaged')
+    })
+    expect(updateFn).toHaveBeenCalledWith('pilot', PILOT_ID, {
+      equipmentLoadouts: {
+        'survey-drone': {
+          systems: ['red-laser'],
+          modules: ['comms-module'],
+          systemConditions: { 'red-laser': 'damaged' },
+        },
+      },
+    })
+  })
+
+  test('setCondition writes moduleConditions for modules', async () => {
+    const { updateFn, result } = seeded()
+    await act(async () => {
+      result.current.setCondition('module', 'comms-module', 'destroyed')
+    })
+    expect(updateFn).toHaveBeenCalledWith('pilot', PILOT_ID, {
+      equipmentLoadouts: {
+        'survey-drone': {
+          systems: ['red-laser'],
+          modules: ['comms-module'],
+          moduleConditions: { 'comms-module': 'destroyed' },
+        },
+      },
+    })
+  })
+
+  test('setUses writes itemUses, clamped to ≥ 0', async () => {
+    const { updateFn, result } = seeded()
+    await act(async () => {
+      result.current.setUses('red-laser', -3)
+    })
+    expect(updateFn).toHaveBeenCalledWith('pilot', PILOT_ID, {
+      equipmentLoadouts: {
+        'survey-drone': {
+          systems: ['red-laser'],
+          modules: ['comms-module'],
+          itemUses: { 'red-laser': 0 },
+        },
+      },
+    })
+  })
+})

--- a/apps/in-the-union-now/src/components/shared/useEquipmentLoadout.ts
+++ b/apps/in-the-union-now/src/components/shared/useEquipmentLoadout.ts
@@ -2,19 +2,20 @@
  * useEquipmentLoadout — controlled adapter between a pilot's persisted
  * per-equipment installed loadout (`pilot.equipmentLoadouts[slug]`) and the
  * "Add System / Add Module" collection UI (the same EntitySearcher + section
- * stack mechs use).
+ * stack mechs use), including per-installed-item condition + uses tracking.
  *
  * Given the owning pilot + a drone-equipment slug + the persisted seed loadout
  * (sourced from the canonical pilot prop, so read-only/snapshot rendering does
  * not depend on the live store), it returns the current loadout plus add/remove
- * handlers. Adds emit the entity NAME (EntitySearcher's default idOf), which we
- * kebab-slugify to match the system/module slug convention.
+ * and condition/uses handlers. Adds emit the entity NAME (EntitySearcher's
+ * default idOf), which we kebab-slugify to match the system/module slug
+ * convention.
  *
  * Write path reads the FRESHEST record from the store at call time (not a
  * render-time closure) and merges only this slug's entry, mirroring
- * useEntityChoices.setSelections and MechSheet.addItem/removeItem so rapid edits
- * to sibling equipment never clobber each other. Dep-injected `store` keeps the
- * hook unit-testable without module mocking.
+ * useEntityChoices + MechSheet.addItem/removeItem/setItemCondition/setItemUses so
+ * rapid edits to sibling equipment never clobber each other. Dep-injected `store`
+ * keeps the hook unit-testable without module mocking.
  */
 
 import { useCallback } from 'react'
@@ -23,9 +24,19 @@ import { nameToSlug } from 'salvageunion-reference'
 
 import { useEntityStore } from '../../stores/entityStore'
 import type { Pilot } from '../../lib/schemas/pilot'
+import type { ItemCondition } from '../../lib/schemas/mech'
 
-/** One equipment instance's installed loadout. */
-export type EquipmentLoadout = { systems: string[]; modules: string[] }
+/** One equipment instance's installed loadout + per-item condition/uses. */
+export type EquipmentLoadout = {
+  systems: string[]
+  modules: string[]
+  systemConditions?: Record<string, ItemCondition>
+  moduleConditions?: Record<string, ItemCondition>
+  itemUses?: Record<string, number>
+}
+
+/** Which collection an installed item belongs to. */
+export type LoadoutKind = 'system' | 'module'
 
 /** Stable empty loadout — frozen so a fresh literal never defeats memoisation. */
 const EMPTY_LOADOUT: EquipmentLoadout = Object.freeze({
@@ -39,6 +50,10 @@ type UseEquipmentLoadoutResult = {
   removeSystem: (index: number) => void
   addModule: (name: string) => void
   removeModule: (index: number) => void
+  /** Set one installed item's condition (Intact/Damaged/Destroyed). */
+  setCondition: (kind: LoadoutKind, slug: string, condition: ItemCondition) => void
+  /** Set one installed item's uses-remaining counter (clamped ≥ 0). */
+  setUses: (slug: string, next: number) => void
 }
 
 export function useEquipmentLoadout(
@@ -53,7 +68,20 @@ export function useEquipmentLoadout(
 
   const loadout: EquipmentLoadout = seed ?? EMPTY_LOADOUT
 
-  /** Merge this slug's next loadout into the freshest pilot record. */
+  /** Freshest entry for this equipment slug, read from the store at call time. */
+  const current = useCallback((): EquipmentLoadout => {
+    const fresh = storeState.get('pilot', pilotId) as Pilot | undefined
+    const entry = fresh?.equipmentLoadouts?.[slug]
+    return {
+      systems: entry?.systems ?? [],
+      modules: entry?.modules ?? [],
+      systemConditions: entry?.systemConditions,
+      moduleConditions: entry?.moduleConditions,
+      itemUses: entry?.itemUses,
+    }
+  }, [storeState, pilotId, slug])
+
+  /** Merge this slug's next entry into the freshest pilot record. */
   const write = useCallback(
     (next: EquipmentLoadout) => {
       const fresh = storeState.get('pilot', pilotId) as Pilot | undefined
@@ -64,12 +92,6 @@ export function useEquipmentLoadout(
     },
     [storeState, pilotId, slug]
   )
-
-  const current = useCallback((): EquipmentLoadout => {
-    const fresh = storeState.get('pilot', pilotId) as Pilot | undefined
-    const entry = fresh?.equipmentLoadouts?.[slug]
-    return { systems: entry?.systems ?? [], modules: entry?.modules ?? [] }
-  }, [storeState, pilotId, slug])
 
   const addSystem = useCallback(
     (name: string) => {
@@ -100,5 +122,30 @@ export function useEquipmentLoadout(
     [current, write]
   )
 
-  return { loadout, addSystem, removeSystem, addModule, removeModule }
+  const setCondition = useCallback(
+    (kind: LoadoutKind, itemSlug: string, condition: ItemCondition) => {
+      const c = current()
+      const field = kind === 'system' ? 'systemConditions' : 'moduleConditions'
+      write({ ...c, [field]: { ...(c[field] ?? {}), [itemSlug]: condition } })
+    },
+    [current, write]
+  )
+
+  const setUses = useCallback(
+    (itemSlug: string, next: number) => {
+      const c = current()
+      write({ ...c, itemUses: { ...(c.itemUses ?? {}), [itemSlug]: Math.max(0, next) } })
+    },
+    [current, write]
+  )
+
+  return {
+    loadout,
+    addSystem,
+    removeSystem,
+    addModule,
+    removeModule,
+    setCondition,
+    setUses,
+  }
 }

--- a/apps/in-the-union-now/src/components/sheet/PilotEquipmentLoadout.tsx
+++ b/apps/in-the-union-now/src/components/sheet/PilotEquipmentLoadout.tsx
@@ -5,33 +5,25 @@
  * so they host a real loadout the same way a mech does.
  *
  * Reuses the exact mech loadout stack — SheetSectionCard + SectionAddButton +
- * SheetPickerModal + EntitySearcher (mode="count") — writing through
- * `pilot.equipmentLoadouts[slug]` via useEquipmentLoadout. Installed items render
- * as compact ReferenceEntityDisplay cards with a remove control; per-item
- * condition/uses tracking is intentionally deferred for v1 (kept read-only),
- * unlike a mech's MechItemCard economy.
+ * SheetPickerModal + EntitySearcher (mode="count") for editing, and MechItemCard
+ * for each installed item (status cycle + uses stepper + repair + remove) —
+ * writing through `pilot.equipmentLoadouts[slug]` via useEquipmentLoadout. There
+ * is no crawler scrap pool in this surface, so repair uses the no-deduction path
+ * (scrapPool=null); "using a system" (EP/heat) is a mech-sheet transaction and is
+ * not offered here (uses stay hand-editable via the stepper).
  */
 
 import { useState } from 'react'
 
-import type { SURefEntity } from 'salvageunion-reference'
-import { ReferenceEntityDisplay } from 'suref-react'
-
-import type { useEntityStore } from '../../stores/entityStore'
 import { useEquipmentLoadout } from '../shared/useEquipmentLoadout'
 import type { EquipmentLoadout } from '../shared/useEquipmentLoadout'
+import type { useEntityStore } from '../../stores/entityStore'
 import { EntitySearcher } from '../shared/EntitySearcher'
 import { Ecflow, Erow } from './Erow'
-import { resolveModule, resolveSystem } from './mechItemRules'
-import {
-  REMOVABLE_CARD_STYLE,
-  SectionAddButton,
-  SheetPickerModal,
-  cardRemoveControls,
-} from './SheetSection'
+import { MechItemCard } from './MechItemCard'
+import { cycleCondition, resolveModule, resolveSystem } from './mechItemRules'
+import { SectionAddButton, SheetPickerModal } from './SheetSection'
 import { SheetSectionCard } from './SheetSectionCard'
-
-const HIDE_CHOICES = { choices: true } as const
 
 /** Read a numeric slot field off the drone-equipment entity, defaulting to 0. */
 function slotMax(equipment: Record<string, unknown>, field: 'systemSlots' | 'moduleSlots'): number {
@@ -70,12 +62,8 @@ export function PilotEquipmentLoadout({
   store,
 }: PilotEquipmentLoadoutProps) {
   const [picker, setPicker] = useState<Kind | null>(null)
-  const { loadout, addSystem, removeSystem, addModule, removeModule } = useEquipmentLoadout(
-    pilotId,
-    slug,
-    seed,
-    store
-  )
+  const { loadout, addSystem, removeSystem, addModule, removeModule, setCondition, setUses } =
+    useEquipmentLoadout(pilotId, slug, seed, store)
 
   const systemMax = slotMax(equipment, 'systemSlots')
   const moduleMax = slotMax(equipment, 'moduleSlots')
@@ -89,35 +77,38 @@ export function PilotEquipmentLoadout({
         </p>
       )
     }
+    const conditions = kind === 'system' ? loadout.systemConditions : loadout.moduleConditions
     return (
       <Ecflow>
         {slugs.map((itemSlug, index) => {
-          const entity = kind === 'system' ? resolveSystem(itemSlug) : resolveModule(itemSlug)
-          const controls =
-            readOnly || !entity
-              ? undefined
-              : cardRemoveControls({
-                  name: entity.name ?? itemSlug,
-                  onRemove: () => {
-                    onRemove(index)
-                  },
-                })
+          const condition = conditions?.[itemSlug] ?? 'intact'
           return (
             // biome-ignore lint/suspicious/noArrayIndexKey: the same slug may be installed more than once; install order is stable
             <Erow key={`${itemSlug}-${index}`}>
-              {entity ? (
-                <ReferenceEntityDisplay
-                  data={entity as unknown as SURefEntity}
-                  compact
-                  hide={HIDE_CHOICES}
-                  controls={controls}
-                  cardStyle={controls ? REMOVABLE_CARD_STYLE : undefined}
-                />
-              ) : (
-                <div className="flex h-full items-center justify-between gap-2 rounded-[3px] border-chrome border-ink bg-paper px-3 py-2">
-                  <span className="font-body text-sm text-ink">{itemSlug}</span>
-                </div>
-              )}
+              <MechItemCard
+                slug={itemSlug}
+                entity={kind === 'system' ? resolveSystem(itemSlug) : resolveModule(itemSlug)}
+                condition={condition}
+                usesRemaining={loadout.itemUses?.[itemSlug]}
+                scrapPool={null}
+                readOnly={readOnly}
+                onStatusCycle={() => {
+                  setCondition(kind, itemSlug, cycleCondition(condition))
+                }}
+                onUsesChange={(next) => {
+                  setUses(itemSlug, next)
+                }}
+                onRepair={() => {
+                  setCondition(kind, itemSlug, 'intact')
+                }}
+                onRemove={
+                  readOnly
+                    ? undefined
+                    : () => {
+                        onRemove(index)
+                      }
+                }
+              />
             </Erow>
           )
         })}

--- a/apps/in-the-union-now/src/lib/schemas/pilot.ts
+++ b/apps/in-the-union-now/src/lib/schemas/pilot.ts
@@ -147,7 +147,11 @@ export const PilotSchema = z
      * Auto-Turret). Keyed by equipment slug → the systems/modules installed on
      * that instance; refs are system/module slugs (same convention as
      * mech.systems/modules). Edited through the same "Add System/Module" picker
-     * mechs use. Additive-optional — absent reads as no loadout; no DB migration
+     * mechs use, with the same per-item condition/uses tracking scoped to this
+     * instance: `systemConditions`/`moduleConditions` keyed by the item slug
+     * (Intact/Damaged/Destroyed) and `itemUses` (uses remaining, absent = full)
+     * — the pilot-equipment analogue of mech.systemConditions/moduleConditions/
+     * itemUses. Additive-optional — absent reads as no loadout; no DB migration
      * needed (same tactic as equipmentChoices/equipmentConditions). Keyed by slug
      * so two of the same drone slug on one pilot would share an entry — an
      * accepted limitation identical to equipmentChoices.
@@ -159,6 +163,12 @@ export const PilotSchema = z
           .object({
             systems: z.array(z.string()).default([]),
             modules: z.array(z.string()).default([]),
+            /** Per-installed-system condition (slug → Intact/Damaged/Destroyed). */
+            systemConditions: ItemConditionMapSchema.optional(),
+            /** Per-installed-module condition (slug → Intact/Damaged/Destroyed). */
+            moduleConditions: ItemConditionMapSchema.optional(),
+            /** Uses remaining per installed item slug (absent = full, rules B13). */
+            itemUses: z.record(z.string(), z.number().int().min(0)).optional(),
           })
           .strict()
       )

--- a/docs/adrs/ADR-023-drone-equipment-installed-loadout.md
+++ b/docs/adrs/ADR-023-drone-equipment-installed-loadout.md
@@ -27,21 +27,26 @@ stored per equipment instance on the owning pilot, edited through the **same
 already use — not the choice mechanism.
 
 - **Persistence (ITUN):** a new additive-optional `Pilot.equipmentLoadouts`
-  field — `Record<equipmentSlug, { systems: string[]; modules: string[] }>` —
-  mirroring the existing `equipmentChoices` / `equipmentConditions` per-slug maps.
-  Absent reads as no loadout; no DB migration; it rides through snapshots with the
-  pilot. Keyed by slug, so two of the same drone slug on one pilot share an entry —
-  an accepted limitation identical to `equipmentChoices`.
+  field — `Record<equipmentSlug, { systems, modules, systemConditions?,
+moduleConditions?, itemUses? }>` — mirroring the existing `equipmentChoices` /
+  `equipmentConditions` per-slug maps and the mech's own
+  `systemConditions`/`moduleConditions`/`itemUses`. Each installed item tracks its
+  Intact/Damaged/Destroyed condition and uses-remaining, scoped to that drone
+  instance. Absent reads as no loadout; no DB migration; it rides through
+  snapshots with the pilot. Keyed by slug, so two of the same drone slug on one
+  pilot share an entry — an accepted limitation identical to `equipmentChoices`.
 - **Identity stays on `equipmentChoices`.** Name / Appearance / A.I. Personality
-  remain free-text choices on the equipment; the loadout store is purely
-  `{ systems, modules }`.
+  remain free-text choices on the equipment; the loadout store holds the installed
+  items and their per-item condition/uses, not identity.
 - **Rendering (ITUN-local, no `suref-react` change):** a `PilotEquipmentLoadout`
   section reuses `SheetSectionCard` + `SheetPickerModal` + `EntitySearcher`
-  (`mode="count"`) + a `useEquipmentLoadout` hook (analogue of `useEntityChoices`).
-  It mounts on the equipment card when the resolved entity is a loadout host
-  (data-shape check: `systemSlots`/`moduleSlots` present), so normal gear never
-  shows it. Because nothing is added to `suref-react`, there is no generated-schema
-  drift and no suref-web / discord-bot blast radius.
+  (`mode="count"`) for editing and `MechItemCard` for each installed item (status
+  cycle + uses stepper + repair + remove), all wired through a
+  `useEquipmentLoadout` hook (analogue of `useEntityChoices`). It mounts on the
+  equipment card when the resolved entity is a loadout host (data-shape check:
+  `systemSlots`/`moduleSlots` present), so normal gear never shows it. Because
+  nothing is added to `suref-react`, there is no generated-schema drift and no
+  suref-web / discord-bot blast radius.
 - **Slot budget is soft** ([ADR-007](ADR-007-automation-boundary.md)): the picker
   shows `used/max` from the equipment's own slot fields but never blocks — the
   Live Sheet is a Free-Edit surface ([ADR-021](ADR-021-itun-surface-taxonomy.md)).
@@ -49,9 +54,6 @@ already use — not the choice mechanism.
   only, so every seeded kebab slug (`survey-drone`, `remote-mine`, …) rendered as a
   raw chit. Both now use the slug-tolerant `matchesRef`, so seeded equipment and
   abilities resolve to full cards (the drone card must resolve to host a loadout).
-
-Per-instance condition/uses tracking for installed drone systems/modules is
-deferred (v1 renders them read-only) to keep scope tight.
 
 ## Consequences
 


### PR DESCRIPTION
Follow-up to the drone-loadout work (#463 capability, #464 seed; ADR-023). Adds the deferred piece: each installed system/module on a drone/companion now tracks its **condition and uses**, **persisted in the data** — the pilot-equipment analogue of a mech's `systemConditions`/`moduleConditions`/`itemUses`.

## Changes

- **Pilot schema:** `equipmentLoadouts[slug]` gains optional `systemConditions` / `moduleConditions` / `itemUses` maps (additive, no migration; rides through snapshots).
- **`useEquipmentLoadout`:** exposes `setCondition(kind, slug, condition)` and `setUses(slug, n)`, same freshest-read write-through merge.
- **`PilotEquipmentLoadout`:** each installed item now renders via **`MechItemCard`** (status cycle Intact→Damaged→Destroyed + uses stepper + repair + remove) instead of a read-only card — the same economy a mech's systems/modules get. Repair uses the no-deduction path (no crawler scrap pool on this surface); "use a system" (EP/heat) stays a mech-sheet transaction (uses remain hand-editable via the stepper).
- Tests for `setCondition`/`setUses` persistence; ADR-023 updated.

## Validation

typecheck ✓ · loadout + pilot suite (48 tests) ✓ · `check:all` green (validate, knip, audit). Independent of #464 (disjoint files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LG8czobAR7o7LTML2f1Tye