### PR TITLE
fix(suref-web): chassis pattern click opens modal, not a chassis-page reload

### DIFF
--- a/apps/suref-web/src/lib/changelog.ts
+++ b/apps/suref-web/src/lib/changelog.ts
@@ -6,6 +6,13 @@ type ChangelogEntry = {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    date: '2026-07-14',
+    title: 'Chassis patterns open their loadout again',
+    items: [
+      'Clicking a pattern on a chassis page now opens its pattern-specific systems and modules in a modal, instead of re-opening the chassis page in a new tab.',
+    ],
+  },
+  {
     date: '2026-07-13',
     title: 'Filter abilities by tree',
     items: [

--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/ReferenceEntityChassisPatterns.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/ReferenceEntityChassisPatterns.tsx
@@ -56,13 +56,17 @@ function PatternListing({
     abilitiesSection: modalConfig?.abilitiesSection,
     afterExtraContent: modalConfig?.afterExtraContent,
     hide: { patterns: true },
+    // A pattern is a modal-only configured view of the chassis (per-pattern
+    // title, stats, loadout) with no standalone URL — its `data` is the chassis
+    // itself. Force the detail to stay a modal even where the app enables link
+    // mode (suref-web); linking out would just reopen the same chassis page and
+    // drop the pattern-specific view. This must be an explicit option because
+    // the `EntityDetailLinkProvider` below only wraps the returned JSX — this
+    // hook runs above it and would otherwise read the ambient link mode.
+    forceModal: true,
   })
 
-  // A pattern is a modal-only configured view of the chassis (per-pattern title,
-  // stats, loadout) with no standalone URL — its `data` is the chassis itself.
-  // So we force the detail to stay a modal even where the app enables link mode
-  // (suref-web); linking out would just reopen the same chassis page and drop
-  // the pattern-specific view.
+  // The provider keeps nested cards inside the listing/modal from linking out.
   return (
     <EntityDetailLinkProvider value={false}>
       <ReferenceEntityDisplay

--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/useDetailModal.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/useDetailModal.tsx
@@ -24,6 +24,15 @@ type UseDetailModalOptions = {
   afterChoicesContent?: ReactNode
   footerOverride?: ReactNode
   hide?: Partial<ReferenceEntityHideConfig>
+  /**
+   * Force the in-place modal even when the app enables link mode. Used for
+   * views that have no standalone URL (e.g. chassis patterns, whose `data` is
+   * the chassis itself) — linking out would just reopen the same page and drop
+   * the pattern-specific view. The `EntityDetailLinkProvider` can't cover this:
+   * this hook runs in the caller's body, above the provider it wraps its JSX
+   * with, so the hook still reads the ambient link mode.
+   */
+  forceModal?: boolean
 }
 
 export function useDetailModal(
@@ -41,7 +50,7 @@ export function useDetailModal(
   // so it keeps the modal (its href would deep-link out to suref-web).
   const href = useEntityHref(data)
   const linkMode = useEntityDetailLink()
-  const openInNewTab = linkMode && !!href
+  const openInNewTab = !options?.forceModal && linkMode && !!href
 
   const schemaName =
     data && 'schemaName' in data && typeof data.schemaName === 'string'


### PR DESCRIPTION
## Problem

Clicking a **pattern** on a chassis page reloaded/looped the page (opening the chassis's own page again in a new tab) instead of showcasing that pattern's systems and modules.

## Root cause

`PatternListing` (`ReferenceEntityChassisPatterns.tsx`) calls `useDetailModal(chassisEntity, …)` in its component body — **above** the `EntityDetailLinkProvider value={false}` it wraps its returned JSX with. React reads context by tree position, so the hook saw suref-web's ambient link mode (`value={true}` from `ReferenceEntityIsland`) rather than the intended `false`. With the chassis's own href resolving, `openInNewTab` became `true`, so the pattern card's click ran `window.open(chassisHref, '_blank')` and the modal was never rendered.

The `EntityDetailLinkProvider value={false}` wrapper could never fix this — a provider in the returned JSX can't reach a hook that ran in the same component's body. Regression introduced by #332 (which added the `openInNewTab`/link-mode logic).

## Fix

Add an explicit `forceModal` option to `useDetailModal` that overrides link mode, and pass `forceModal: true` from `PatternListing`. Patterns have no standalone URL (their `data` is the chassis itself), so they must always open the in-place modal. The `EntityDetailLinkProvider value={false}` wrapper stays — it still correctly keeps nested cards inside the listing/modal from linking out.

## Verification

- `bun run typecheck` — clean across all packages
- `bun --filter suref-react test` — 399 pass
- `bun --filter suref-web test` — 989 pass
- `bun run lint` / `bun run format` — no changes from this diff

Also added a `/changelog` entry (user-visible bug fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtDCyTHSiMZsgdA34jd8Ee