### PR TITLE
refactor(suref-react): consolidate atom internals (type dedup, shared interaction, Stamp reuse)

### DIFF
--- a/apps/in-the-union-now/src/components/shared/EntitySearcher.tsx
+++ b/apps/in-the-union-now/src/components/shared/EntitySearcher.tsx
@@ -359,7 +359,7 @@ export function EntitySearcher({
                     onToggle?.(isSelected ? (matchedRef(item) ?? idOf(item)) : idOf(item))
                   }
                   entityProps={
-                    isSelected ? { footActions: <Tag label={`${chosenLabel} ✓`} /> } : undefined
+                    isSelected ? { footActions: <Tag>{`${chosenLabel} ✓`}</Tag> } : undefined
                   }
                 />
               )

--- a/apps/in-the-union-now/src/components/sheet/PilotSheetItems.tsx
+++ b/apps/in-the-union-now/src/components/sheet/PilotSheetItems.tsx
@@ -84,7 +84,7 @@ export function PilotAbilityItem({
   const footMeta: CardFootMeta[] = [{ label: 'AP Cost', value: apCost ?? '—' }]
   const footActions = readOnly ? (
     used ? (
-      <Tag label="Used" />
+      <Tag>Used</Tag>
     ) : undefined
   ) : (
     <>

--- a/apps/in-the-union-now/src/components/sheet/ShareSnapshotScreen.tsx
+++ b/apps/in-the-union-now/src/components/sheet/ShareSnapshotScreen.tsx
@@ -583,7 +583,7 @@ function SnapshotPreviewCard({ kind, entity }: SnapshotPreviewCardProps) {
             readOnly
           />
           {states.length > 0 && (
-            <StatDisplay pips label="Bays" name="Condition" unit="Bays" states={states} />
+            <StatDisplay label="Bays" name="Condition" unit="Bays" states={states} />
           )}
         </>
       }

--- a/packages/suref-react/src/components/chrome/Field.tsx
+++ b/packages/suref-react/src/components/chrome/Field.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from 'react'
 import type { ComponentPropsWithoutRef, ReactNode } from 'react'
 import { cn } from '../../utils/cn'
-import { Text } from '../base/Text'
+import { Stamp } from './Stamp'
 
 type FieldProps = {
   label: ReactNode
@@ -26,14 +26,14 @@ export function Field({ label, required = false, htmlFor, children, className }:
         htmlFor={htmlFor}
         className="absolute left-2 top-0 z-10 flex w-fit -translate-y-1/2 items-center"
       >
-        <Text variant="pseudoheader" as="span" className="text-badge">
+        <Stamp size="sm">
           {label}
           {required && (
             <span aria-hidden="true" className="ml-0.5">
               *
             </span>
           )}
-        </Text>
+        </Stamp>
       </label>
       {children}
     </div>

--- a/packages/suref-react/src/components/chrome/OptRow.tsx
+++ b/packages/suref-react/src/components/chrome/OptRow.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { cn } from '../../utils/cn'
+import { FOCUS_RING } from './interaction'
 
 type OptRowProps = {
   name: string
@@ -24,7 +25,8 @@ export function OptRow({ name, desc, active = false, onClick, img, className }: 
       onClick={onClick}
       aria-current={active || undefined}
       className={cn(
-        'mb-2 flex w-full cursor-pointer items-center gap-3 rounded-card border-chrome border-ink px-3 py-[11px] text-left transition-colors duration-[120ms] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-rust/25',
+        'mb-2 flex w-full cursor-pointer items-center gap-3 rounded-card border-chrome border-ink px-3 py-[11px] text-left transition-colors duration-[120ms]',
+        FOCUS_RING,
         active ? 'bg-paper shadow-[inset_3px_0_0_var(--color-rust)]' : 'bg-transparent',
         className
       )}

--- a/packages/suref-react/src/components/chrome/PickCard.tsx
+++ b/packages/suref-react/src/components/chrome/PickCard.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { cn } from '../../utils/cn'
+import { FOCUS_RING, SELECTION_RING, activateOnKey } from './interaction'
 
 type PickCardProps = {
   /** Card title (cond 700 22px uppercase) */
@@ -38,21 +39,15 @@ export function PickCard({
       tabIndex={interactive ? 0 : undefined}
       aria-pressed={interactive ? selected : undefined}
       onClick={onSelect}
-      onKeyDown={
-        interactive
-          ? (e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault()
-                onSelect()
-              }
-            }
-          : undefined
-      }
+      onKeyDown={interactive ? activateOnKey(onSelect) : undefined}
       className={cn(
         'flex flex-col overflow-hidden rounded-panel border-chrome border-ink bg-paper transition-all duration-[120ms]',
         interactive &&
-          'cursor-pointer hover:-translate-y-0.5 hover:shadow-[0_6px_22px_rgba(34,30,23,0.14)] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-rust/25',
-        selected && 'shadow-[0_0_0_3px_var(--color-rust)]',
+          cn(
+            'cursor-pointer hover:-translate-y-0.5 hover:shadow-[0_6px_22px_rgba(34,30,23,0.14)]',
+            FOCUS_RING
+          ),
+        selected && SELECTION_RING,
         className
       )}
     >

--- a/packages/suref-react/src/components/chrome/Pill.tsx
+++ b/packages/suref-react/src/components/chrome/Pill.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from 'react'
-import { Badge } from './Badge'
+import { Badge, type BadgeTone } from './Badge'
 
-export type PillTone = 'pilot' | 'mech' | 'crawler' | 'ok' | 'warn' | 'bad'
+/** A Pill's tone is exactly the Badge tone set (a Pill is a Badge preset). */
+export type PillTone = BadgeTone
 
 type PillProps = {
   children: ReactNode

--- a/packages/suref-react/src/components/chrome/Sel.tsx
+++ b/packages/suref-react/src/components/chrome/Sel.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { cn } from '../../utils/cn'
+import { FOCUS_RING, SELECTION_RING, activateOnKey } from './interaction'
 
 type SelProps = {
   /** Whether the selection ring is on */
@@ -43,21 +44,11 @@ export function Sel({
       aria-checked={interactive && radio ? selected : undefined}
       aria-label={interactive ? ariaLabel : undefined}
       onClick={onToggle}
-      onKeyDown={
-        interactive
-          ? (e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault()
-                onToggle()
-              }
-            }
-          : undefined
-      }
+      onKeyDown={interactive ? activateOnKey(onToggle) : undefined}
       className={cn(
         'rounded-panel',
-        interactive &&
-          'cursor-pointer focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-rust/25',
-        selected && 'shadow-[0_0_0_3px_var(--color-rust)]',
+        interactive && cn('cursor-pointer', FOCUS_RING),
+        selected && SELECTION_RING,
         className
       )}
     >

--- a/packages/suref-react/src/components/chrome/Slab.tsx
+++ b/packages/suref-react/src/components/chrome/Slab.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { cn } from '../../utils/cn'
+import { POSTER_STAMP } from './Stamp'
 
 type SlabProps = {
   /** Section label, e.g. 'Systems' */
@@ -34,7 +35,9 @@ export function Slab({ label, count, actions, className, variant = 'dashed' }: S
   return (
     <div className={cn('mb-3.5 flex items-center gap-3', className)}>
       {isSolid ? (
-        <span className="box-decoration-clone inline shrink-0 bg-ink px-2 pb-[3px] pt-[2px] font-cond text-sm font-bold uppercase leading-relaxed tracking-[0.09em] text-paper">
+        <span
+          className={cn(POSTER_STAMP, 'shrink-0 px-2 pb-[3px] pt-[2px] text-sm leading-relaxed')}
+        >
           {label}
         </span>
       ) : (

--- a/packages/suref-react/src/components/chrome/SmallButtons.tsx
+++ b/packages/suref-react/src/components/chrome/SmallButtons.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react'
 import type { ComponentPropsWithoutRef } from 'react'
 import { cn } from '../../utils/cn'
+import { DISABLED, FOCUS_RING } from './interaction'
 
 type StepBtnProps = ComponentPropsWithoutRef<'button'>
 
@@ -20,7 +21,9 @@ export const StepBtn = forwardRef<HTMLButtonElement, StepBtnProps>(function Step
       ref={ref}
       type={type}
       className={cn(
-        'inline-flex h-6 w-6 min-h-11 min-w-11 cursor-pointer items-center justify-center rounded-card border-chrome border-ink bg-paper font-body text-lede font-bold leading-none text-ink hover:bg-[var(--ground,var(--color-wk-bg-2))] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-rust/25 disabled:pointer-events-none disabled:opacity-40 sm:min-h-0 sm:min-w-0',
+        'inline-flex h-6 w-6 min-h-11 min-w-11 cursor-pointer items-center justify-center rounded-card border-chrome border-ink bg-paper font-body text-lede font-bold leading-none text-ink hover:bg-[var(--ground,var(--color-wk-bg-2))] sm:min-h-0 sm:min-w-0',
+        FOCUS_RING,
+        DISABLED,
         className
       )}
       {...props}
@@ -43,7 +46,9 @@ export const MiniBtn = forwardRef<HTMLButtonElement, MiniBtnProps>(function Mini
       ref={ref}
       type={type}
       className={cn(
-        'inline-flex cursor-pointer items-center gap-1 rounded-badge border-chrome border-ink bg-paper px-2 py-[3px] font-cond text-label-lg font-semibold uppercase leading-none text-ink hover:bg-[var(--ground,var(--color-wk-bg-2))] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-rust/25 disabled:pointer-events-none disabled:opacity-40',
+        'inline-flex cursor-pointer items-center gap-1 rounded-badge border-chrome border-ink bg-paper px-2 py-[3px] font-cond text-label-lg font-semibold uppercase leading-none text-ink hover:bg-[var(--ground,var(--color-wk-bg-2))]',
+        FOCUS_RING,
+        DISABLED,
         className
       )}
       {...props}

--- a/packages/suref-react/src/components/chrome/Stamp.tsx
+++ b/packages/suref-react/src/components/chrome/Stamp.tsx
@@ -38,6 +38,20 @@ const SURFACE: Record<StampSurface, string> = {
 }
 
 /**
+ * The poster wrapping-stamp shape (clean-pilot.html `.sect`/`.stamp`) — the
+ * multi-line ink label whose background is cloned across each wrapped line
+ * (`box-decoration-clone inline`), with the wider poster tracking (`0.09em`).
+ *
+ * Distinct from the {@link Stamp} atom, which is a single-line `inline-block`
+ * chip locked to `line-height: 1` and `tracking-caps-tight`. Compose this with
+ * the per-site padding / leading / text-size (the shapes differ slightly). Used
+ * by `Slab`'s solid variant and `VitalGauge`'s label, so the poster ink-label
+ * lives in one place instead of being re-inlined.
+ */
+export const POSTER_STAMP =
+  'box-decoration-clone inline bg-ink text-paper font-cond font-bold uppercase tracking-[0.09em]'
+
+/**
  * Stamp — the one ink label/header atom (ruleset §5, atom 1; §0 "stamps label").
  *
  * Ink block, white text, condensed-bold uppercase, tracking `0.04em`

--- a/packages/suref-react/src/components/chrome/StatusBadge.tsx
+++ b/packages/suref-react/src/components/chrome/StatusBadge.tsx
@@ -1,7 +1,8 @@
 import { Badge, type BadgeTone } from './Badge'
+import type { EntityStatus } from '../shared/entityStatus'
 
 /** Per-item condition vocabulary (rules: Intact / Damaged / Destroyed). */
-export type EntityStatus = 'intact' | 'damaged' | 'destroyed'
+export type { EntityStatus }
 
 /** The domain vocabulary maps onto the shared badge tones — one rendering. */
 const STATUS_STYLES: Record<EntityStatus, { label: string; tone: BadgeTone }> = {

--- a/packages/suref-react/src/components/chrome/Tag.tsx
+++ b/packages/suref-react/src/components/chrome/Tag.tsx
@@ -2,8 +2,9 @@ import type { ReactNode } from 'react'
 import { Badge } from './Badge'
 
 type TagProps = {
-  /** Stamped chip text, e.g. "RANGE" */
-  label: ReactNode
+  /** Stamped chip content, e.g. "RANGE" (a single label — the Badge family
+   * all take content via `children`). */
+  children: ReactNode
   /** Inverted ghost chip (paper bg, ink text, inset ring) for keyword /
    * action-economy tags (TURN ACTION, PASSIVE, BALLISTIC…) */
   ghost?: boolean
@@ -17,10 +18,10 @@ type TagProps = {
  * Split label/value content is a Stat: render it with
  * `StatDisplay orientation="horizontal"`.
  */
-export function Tag({ label, ghost = false, className }: TagProps) {
+export function Tag({ children, ghost = false, className }: TagProps) {
   return (
     <Badge surface={ghost ? 'ghost' : 'solid'} className={className}>
-      {label}
+      {children}
     </Badge>
   )
 }

--- a/packages/suref-react/src/components/chrome/TreeSep.tsx
+++ b/packages/suref-react/src/components/chrome/TreeSep.tsx
@@ -20,8 +20,8 @@ export function TreeSep({ name, suffix = 'Tree', className }: TreeSepProps) {
     // biome-ignore lint/a11y/useSemanticElements: the divider must wrap the flanking rules and tree-name tags, which a void <hr> cannot contain
     <div className={cn('flex items-center gap-2', className)} role="separator">
       <span aria-hidden="true" className="h-[1.5px] flex-1 bg-[rgba(128,128,128,0.45)]" />
-      <Tag label={name} />
-      <Tag label={suffix} ghost />
+      <Tag>{name}</Tag>
+      <Tag ghost>{suffix}</Tag>
       <span aria-hidden="true" className="h-[1.5px] flex-1 bg-[rgba(128,128,128,0.45)]" />
     </div>
   )

--- a/packages/suref-react/src/components/chrome/__tests__/Tag.test.tsx
+++ b/packages/suref-react/src/components/chrome/__tests__/Tag.test.tsx
@@ -8,13 +8,13 @@ afterEach(cleanup)
 // render it with StatDisplay orientation="horizontal" (see StatDisplay tests).
 describe('Tag', () => {
   test('renders an ink-on-paper stamped chip by default', () => {
-    const { container } = render(<Tag label="Turn Action" />)
+    const { container } = render(<Tag>Turn Action</Tag>)
     expect(screen.getByText('Turn Action')).toBeTruthy()
     expect(container.firstElementChild?.className).toContain('bg-ink')
   })
 
   test('ghost inverts the chip (paper bg, ink text)', () => {
-    const { container } = render(<Tag label="Passive" ghost />)
+    const { container } = render(<Tag ghost>Passive</Tag>)
     expect(screen.getByText('Passive')).toBeTruthy()
     expect(container.firstElementChild?.className).toContain('bg-paper')
   })

--- a/packages/suref-react/src/components/chrome/__tests__/chrome.test.tsx
+++ b/packages/suref-react/src/components/chrome/__tests__/chrome.test.tsx
@@ -21,8 +21,8 @@ describe('Field / Input', () => {
       </Field>
     )
     expect(screen.getByLabelText(/Name/)).toBeTruthy()
-    // The required mark rides inside the ink stamp (white on ink), not a rust glyph.
-    expect(screen.getByText('*').closest('.bg-su-black')).not.toBeNull()
+    // The required mark rides inside the ink Stamp (white on ink), not a rust glyph.
+    expect(screen.getByText('*').closest('.bg-ink')).not.toBeNull()
   })
 
   test('input carries the rust focus ring classes', () => {

--- a/packages/suref-react/src/components/chrome/__tests__/followups.test.tsx
+++ b/packages/suref-react/src/components/chrome/__tests__/followups.test.tsx
@@ -31,7 +31,7 @@ describe('Badge (unified) + presets', () => {
   })
 
   test('Tag/Pill/Chip presets still render their signature fills', () => {
-    render(<Tag label="Armour" />)
+    render(<Tag>Armour</Tag>)
     expect(screen.getByText('Armour').className).toContain('bg-ink')
     cleanup()
     render(<Pill tone="mech">Mule</Pill>)

--- a/packages/suref-react/src/components/chrome/btnVariants.ts
+++ b/packages/suref-react/src/components/chrome/btnVariants.ts
@@ -1,4 +1,5 @@
 import { cva } from 'class-variance-authority'
+import { DISABLED, FOCUS_RING } from './interaction'
 
 /**
  * The `.btn` cva recipe (design-spec §2.4), exported for non-button elements
@@ -7,7 +8,7 @@ import { cva } from 'class-variance-authority'
  * (react-refresh).
  */
 export const btnVariants = cva(
-  'inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-card border-chrome font-body font-medium tracking-[0.01em] transition-colors duration-[120ms] focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-rust/25 disabled:pointer-events-none disabled:opacity-40',
+  `inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-card border-chrome font-body font-medium tracking-[0.01em] transition-colors duration-[120ms] ${FOCUS_RING} ${DISABLED}`,
   {
     variants: {
       variant: {

--- a/packages/suref-react/src/components/chrome/interaction.ts
+++ b/packages/suref-react/src/components/chrome/interaction.ts
@@ -1,0 +1,32 @@
+import type { KeyboardEvent } from 'react'
+
+/**
+ * Shared interaction primitives for the chrome atoms — one source of truth for
+ * the focus ring, disabled treatment, selection ring, and keyboard activation
+ * that Btn / StepBtn / MiniBtn / OptRow / Sel / PickCard would otherwise each
+ * re-inline.
+ */
+
+/** The canonical rust focus ring (design-spec §2.4). */
+export const FOCUS_RING =
+  'focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-rust/25'
+
+/** The canonical disabled treatment (opacity + no pointer events). */
+export const DISABLED = 'disabled:pointer-events-none disabled:opacity-40'
+
+/** Non-layout-shifting 3px rust selection ring (design-spec §2.8). */
+export const SELECTION_RING = 'shadow-[0_0_0_3px_var(--color-rust)]'
+
+/**
+ * Enter/Space → activate, matching native button semantics on a `div` wrapper
+ * that carries `role="button"`/`"radio"`. Returns a handler that no-ops when
+ * `onActivate` is absent, so callers can pass an optional toggle directly.
+ */
+export function activateOnKey(onActivate?: () => void) {
+  return (e: KeyboardEvent) => {
+    if (onActivate && (e.key === 'Enter' || e.key === ' ')) {
+      e.preventDefault()
+      onActivate()
+    }
+  }
+}

--- a/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/components/ReferenceEntityDisplayContent.tsx
+++ b/packages/suref-react/src/components/referenceEntity/ReferenceEntityDisplay/components/ReferenceEntityDisplayContent.tsx
@@ -477,9 +477,7 @@ export function ReferenceEntityDisplayContent({
   // Trailing type-label tag (design-spec §2.1), appended last to the header
   // data row.
   const typeLabelNode =
-    showTypeLabel || typeLabel != null ? (
-      <Tag label={typeLabel ?? getDisplayName(schemaName)} />
-    ) : null
+    showTypeLabel || typeLabel != null ? <Tag>{typeLabel ?? getDisplayName(schemaName)}</Tag> : null
 
   const headerContent = (
     <CardHeader

--- a/packages/suref-react/src/components/shared/SlotGrid.tsx
+++ b/packages/suref-react/src/components/shared/SlotGrid.tsx
@@ -28,7 +28,7 @@ type SlotGridProps = {
  * `SlotGrid` measures fungible _quantity that has addresses_ — it never merges
  * with a scalar Gauge or a StatDisplay (ruleset §6, must-NOT-merge).
  *
- * Cells lay out on the shared pip-row split (ruleset §4.5): ≤5 per row,
+ * Cells lay out on the shared pip-row split (ruleset §4.5): ≤6 per row,
  * bottom-heavy, centred — the same rhythm as the gauge / statblock tracks.
  */
 export function SlotGrid({ used, cap, scale = 'pip', label, className }: SlotGridProps) {

--- a/packages/suref-react/src/components/shared/StatDisplay.tsx
+++ b/packages/suref-react/src/components/shared/StatDisplay.tsx
@@ -6,6 +6,7 @@ import { StepBtn } from '../chrome/SmallButtons'
 import { statBlockRowStarts, pipClickValue, trackSegmentState } from '../stat/pipRows'
 import { heatDangerFrom, heatLevel } from '../stat/heatLevel'
 import { ConditionSwatch } from '../stat/ConditionSwatch'
+import type { EntityStatus } from './entityStatus'
 
 /**
  * The single canonical stat/value primitive (canonical primitive language §2).
@@ -27,7 +28,7 @@ import { ConditionSwatch } from '../stat/ConditionSwatch'
 /** Pip / fill semantics: hp red, ap/ep rust, heat warn, cargo bronze, cw crawler pink, sp/default ink. */
 export type StatTone = 'hp' | 'ap' | 'ep' | 'sp' | 'heat' | 'cargo' | 'cw' | 'default'
 /** Tri-state tally entry for the `states[]` mode (crawler bays). */
-export type StatState = 'intact' | 'damaged' | 'destroyed'
+export type StatState = EntityStatus
 
 const PIP_FILL: Record<StatTone, string> = {
   hp: 'border-status-bad bg-status-bad',

--- a/packages/suref-react/src/components/shared/StatDisplay.tsx
+++ b/packages/suref-react/src/components/shared/StatDisplay.tsx
@@ -41,149 +41,171 @@ const PIP_FILL: Record<StatTone, string> = {
   default: 'border-ink bg-ink',
 }
 
-type StatDisplayProps = {
-  /** Header code / label ('HP', 'STRUCTURE', 'Range', or a numeric tier). */
-  label: string | number
-  value?: number | string
-  /** Track maximum (framed tracker) or the /max shown beside the value. */
-  max?: number
-  /** Minimum for edit-mode steppers (box). */
-  min?: number
-  /** Bottom pseudoheader stamp (box anatomy). */
-  bottomLabel?: string
-  /** Muted right-side header name (framed tracker). */
-  name?: string
-  /** Black footer unit bar (framed tracker), e.g. 'POINTS'. */
-  unit?: string
+type StatValue = number | string
 
-  /** 'horizontal' selects the [label | value] anatomy; default 'vertical'. */
-  orientation?: 'vertical' | 'horizontal'
-  /** true selects the framed pip-track (pips) tracker anatomy. */
-  pips?: boolean
-  /** 'edit' adds steppers (box + tracker). */
-  mode?: 'read' | 'edit'
-  /** lg (sheet hero) or sm (rail / NPC / spec strip) — framed tracker. */
-  size?: 'lg' | 'sm'
-  /** Pip fill semantics (framed tracker). */
-  tone?: StatTone
-  /** Tri-state tally mode (crawler bays) — replaces the numeric track. */
-  states?: StatState[]
-
-  inverse?: boolean
-  compact?: boolean
-  /** Horizontal anatomy only: extra-small (text-label / 10px) — the seam-tag size. */
-  xs?: boolean
-
-  /** Uncontrolled initial value (framed tracker self-managed state). */
-  init?: number
-  onChange?: (value: number) => void
-  /** Force editability on/off (framed tracker); derived otherwise. */
-  editable?: boolean
-  /** Set false to suppress the pip track even with a max (framed tracker). */
-  showPips?: boolean
-  /** Click handler per states[] pip (framed tracker). */
-  onBay?: (index: number) => void
-
-  onClick?: () => void
-  hoverText?: string
-  flash?: boolean
-  disabled?: boolean
-  isOverMax?: boolean
-
-  /** [box] Value-box fill / value-text colour overrides (Tailwind classes). */
-  bg?: string
-  valueColor?: string
-  /**
-   * Border colour override. **Anatomy-dependent value format:** in the [box]
-   * anatomy it is a Tailwind class (default `border-su-black`); in the
-   * [horizontal] anatomy it is a raw CSS colour applied as inline `style`.
-   */
-  borderColor?: string
-  /** [horizontal] Label-cell background / text colour overrides (raw CSS colours). */
-  bgColor?: string
-  textColor?: string
-  /** [horizontal] inline-flex (default) vs flex. */
-  inline?: boolean
-  labelId?: string
-  ariaLabel?: string
-  className?: string
-}
-
-/*
- * Per-anatomy prop groups. `StatDisplayProps` stays one flat bag for
- * backward-compatible call sites, but the four anatomies are mutually
- * exclusive and each reads only a SUBSET of it. These `Pick`s are the
- * authoritative "which props co-apply" answer — each sub-renderer is typed to
- * exactly its group, so e.g. the [horizontal] `bgColor`/`textColor` and the
- * [box] `bg`/`valueColor` colour overrides never coexist in one signature.
+/**
+ * StatDisplay is a discriminated union over its four mutually-exclusive
+ * anatomies. The discriminants are `orientation` / `pips` / `states`:
+ *
+ *   { orientation: 'horizontal' }             -> HorizontalValue (label|value)
+ *   { orientation: 'horizontal', pips: true } -> InlineChip (label·pips·value)
+ *   { pips: true } | { states }               -> FramedTracker (vertical)
+ *   (default)                                 -> ValueBox (centred box)
+ *
+ * Every prop is scoped to the anatomy that reads it. `Exact<>` (below) then
+ * forbids every OTHER anatomy's props with `?: never`, so mixing anatomies —
+ * e.g. a `[box]` `bg` on an `orientation="horizontal"` call — is a compile
+ * error, not a silently-ignored prop. (A plain union can't do this: TS treats
+ * a prop as "excess" only when it appears in NO member, so `bg` would slip
+ * through on the horizontal member.)
  */
 
-/** [horizontal] `orientation="horizontal"` without `pips` — the former ValueDisplay. */
-type HorizontalValueProps = Pick<
-  StatDisplayProps,
-  | 'label'
-  | 'value'
-  | 'compact'
-  | 'xs'
-  | 'inverse'
-  | 'inline'
-  | 'bgColor'
-  | 'textColor'
-  | 'borderColor'
->
-
-/** [inline-chip] `orientation="horizontal"` with `pips` — the former MiniStat. */
-type InlineChipProps = Pick<StatDisplayProps, 'label' | 'value' | 'max' | 'tone' | 'className'>
-
-/** [tracker] `pips` or `states` (vertical) — the former StatBlock. */
-type FramedTrackerProps = Pick<
-  StatDisplayProps,
-  | 'label'
-  | 'name'
-  | 'unit'
-  | 'tone'
-  | 'size'
-  | 'max'
-  | 'value'
-  | 'init'
-  | 'onChange'
-  | 'editable'
-  | 'mode'
-  | 'showPips'
-  | 'states'
-  | 'onBay'
-  | 'className'
->
-
-/** [box] the default centred value box; `mode="edit"` adds steppers (former StatControl). */
-type ValueBoxProps = Pick<
-  StatDisplayProps,
+/** Every prop name any anatomy accepts — the domain `Exact<>` closes over. */
+type StatPropKey =
   | 'label'
   | 'value'
   | 'max'
   | 'min'
   | 'bottomLabel'
-  | 'labelId'
-  | 'disabled'
-  | 'onClick'
-  | 'onChange'
+  | 'name'
+  | 'unit'
+  | 'orientation'
+  | 'pips'
   | 'mode'
+  | 'size'
+  | 'tone'
+  | 'states'
+  | 'inverse'
+  | 'compact'
+  | 'xs'
+  | 'init'
+  | 'onChange'
+  | 'editable'
+  | 'showPips'
+  | 'onBay'
+  | 'onClick'
+  | 'hoverText'
+  | 'flash'
+  | 'disabled'
+  | 'isOverMax'
   | 'bg'
   | 'valueColor'
   | 'borderColor'
+  | 'bgColor'
+  | 'textColor'
+  | 'inline'
+  | 'labelId'
   | 'ariaLabel'
-  | 'compact'
-  | 'flash'
-  | 'inverse'
-  | 'isOverMax'
-  | 'hoverText'
->
+  | 'className'
+
+/** `T`, plus every stat prop NOT in `T` forbidden (`?: never`) — the exclusion
+ * that makes the anatomies genuinely non-overlapping at the type level. */
+type Exact<T extends Partial<Record<StatPropKey, unknown>>> = T &
+  Partial<Record<Exclude<StatPropKey, keyof T>, never>>
+
+/** [horizontal] `orientation="horizontal"` without `pips` — the former ValueDisplay. */
+type HorizontalValueProps = Exact<{
+  /** Header code / label ('HP', 'Range', or a numeric tier). */
+  label: StatValue
+  orientation: 'horizontal'
+  pips?: false
+  value?: StatValue
+  compact?: boolean
+  /** Extra-small (text-label / 10px) — the seam-tag size. */
+  xs?: boolean
+  inverse?: boolean
+  /** inline-flex (default) vs flex. */
+  inline?: boolean
+  /** Label-cell background / text colour overrides (raw CSS colours). */
+  bgColor?: string
+  textColor?: string
+  /** Outer border colour — a raw CSS colour applied as inline `style`. */
+  borderColor?: string
+  className?: string
+}>
+
+/** [inline-chip] `orientation="horizontal"` with `pips` — the former MiniStat. */
+type InlineChipProps = Exact<{
+  label: StatValue
+  orientation: 'horizontal'
+  pips: true
+  value?: StatValue
+  max?: number
+  tone?: StatTone
+  className?: string
+}>
+
+/** Fields shared by both framed-tracker discriminants. */
+type FramedTrackerBase = {
+  label: StatValue
+  orientation?: 'vertical'
+  value?: StatValue
+  /** Muted right-side header name. */
+  name?: string
+  /** Black footer unit bar, e.g. 'POINTS'. */
+  unit?: string
+  tone?: StatTone
+  /** lg (sheet hero) or sm (rail / NPC / spec strip). */
+  size?: 'lg' | 'sm'
+  max?: number
+  /** Uncontrolled initial value (self-managed state). */
+  init?: number
+  onChange?: (value: number) => void
+  /** Force editability on/off; derived otherwise. */
+  editable?: boolean
+  mode?: 'read' | 'edit'
+  /** Set false to suppress the pip track even with a max. */
+  showPips?: boolean
+  /** Click handler per states[] pip. */
+  onBay?: (index: number) => void
+  className?: string
+}
+
+/** [tracker] numeric pip track (vertical). */
+type TrackerPipsProps = Exact<FramedTrackerBase & { pips: true; states?: undefined }>
+/** [tracker] tri-state bay tally (vertical) — replaces the numeric track. */
+type TrackerStatesProps = Exact<FramedTrackerBase & { pips?: false; states: StatState[] }>
+type FramedTrackerProps = TrackerPipsProps | TrackerStatesProps
+
+/** [box] the default centred value box; `mode="edit"` adds steppers (former StatControl). */
+type ValueBoxProps = Exact<{
+  label: StatValue
+  orientation?: 'vertical'
+  pips?: false
+  states?: undefined
+  value?: StatValue
+  max?: number
+  /** Minimum for edit-mode steppers. */
+  min?: number
+  /** Bottom pseudoheader stamp. */
+  bottomLabel?: string
+  labelId?: string
+  disabled?: boolean
+  onClick?: () => void
+  onChange?: (value: number) => void
+  mode?: 'read' | 'edit'
+  /** Value-box fill / value-text colour overrides (Tailwind classes). */
+  bg?: string
+  valueColor?: string
+  /** Border colour — a Tailwind class (default `border-su-black`). */
+  borderColor?: string
+  ariaLabel?: string
+  compact?: boolean
+  flash?: boolean
+  inverse?: boolean
+  isOverMax?: boolean
+  hoverText?: string
+  className?: string
+}>
+
+type StatDisplayProps = HorizontalValueProps | InlineChipProps | FramedTrackerProps | ValueBoxProps
 
 export function StatDisplay(props: StatDisplayProps) {
   if (props.orientation === 'horizontal') {
     return props.pips ? <InlineChip {...props} /> : <HorizontalValue {...props} />
   }
-  if (props.pips || props.states !== undefined) return <FramedTracker {...props} />
+  if (props.pips) return <FramedTracker {...props} />
+  if (props.states !== undefined) return <FramedTracker {...props} />
   return <ValueBox {...props} />
 }
 
@@ -201,6 +223,7 @@ function HorizontalValue({
   bgColor,
   textColor,
   borderColor,
+  className,
 }: HorizontalValueProps) {
   const fontSize = xs ? 'text-label' : compact ? 'text-xs' : 'text-sm'
   const fontWeight = xs ? 'font-bold' : compact ? 'font-normal' : 'font-semibold'
@@ -212,7 +235,8 @@ function HorizontalValue({
       className={cn(
         'shrink-0 grow-0 cursor-default whitespace-nowrap border border-su-black',
         inline ? 'inline-flex' : 'flex',
-        'w-fit'
+        'w-fit',
+        className
       )}
       style={borderColor ? { borderColor } : undefined}
     >
@@ -566,6 +590,7 @@ function ValueBox({
   inverse = false,
   isOverMax = false,
   hoverText,
+  className,
 }: ValueBoxProps) {
   const [isFlashing, setIsFlashing] = useState(false)
 
@@ -636,7 +661,8 @@ function ValueBox({
       className={cn(
         'flex flex-col items-center gap-0 overflow-visible',
         compact ? 'min-w-8' : 'w-12',
-        disabledClass
+        disabledClass,
+        className
       )}
       aria-label={combinedAriaLabel}
     >

--- a/packages/suref-react/src/components/shared/StatDisplay.tsx
+++ b/packages/suref-react/src/components/shared/StatDisplay.tsx
@@ -90,19 +90,94 @@ type StatDisplayProps = {
   disabled?: boolean
   isOverMax?: boolean
 
-  /** Value-box colour overrides. */
+  /** [box] Value-box fill / value-text colour overrides (Tailwind classes). */
   bg?: string
   valueColor?: string
+  /**
+   * Border colour override. **Anatomy-dependent value format:** in the [box]
+   * anatomy it is a Tailwind class (default `border-su-black`); in the
+   * [horizontal] anatomy it is a raw CSS colour applied as inline `style`.
+   */
   borderColor?: string
-  /** Horizontal-anatomy colour overrides. */
+  /** [horizontal] Label-cell background / text colour overrides (raw CSS colours). */
   bgColor?: string
   textColor?: string
-  /** Horizontal anatomy: inline-flex (default) vs flex. */
+  /** [horizontal] inline-flex (default) vs flex. */
   inline?: boolean
   labelId?: string
   ariaLabel?: string
   className?: string
 }
+
+/*
+ * Per-anatomy prop groups. `StatDisplayProps` stays one flat bag for
+ * backward-compatible call sites, but the four anatomies are mutually
+ * exclusive and each reads only a SUBSET of it. These `Pick`s are the
+ * authoritative "which props co-apply" answer — each sub-renderer is typed to
+ * exactly its group, so e.g. the [horizontal] `bgColor`/`textColor` and the
+ * [box] `bg`/`valueColor` colour overrides never coexist in one signature.
+ */
+
+/** [horizontal] `orientation="horizontal"` without `pips` — the former ValueDisplay. */
+type HorizontalValueProps = Pick<
+  StatDisplayProps,
+  | 'label'
+  | 'value'
+  | 'compact'
+  | 'xs'
+  | 'inverse'
+  | 'inline'
+  | 'bgColor'
+  | 'textColor'
+  | 'borderColor'
+>
+
+/** [inline-chip] `orientation="horizontal"` with `pips` — the former MiniStat. */
+type InlineChipProps = Pick<StatDisplayProps, 'label' | 'value' | 'max' | 'tone' | 'className'>
+
+/** [tracker] `pips` or `states` (vertical) — the former StatBlock. */
+type FramedTrackerProps = Pick<
+  StatDisplayProps,
+  | 'label'
+  | 'name'
+  | 'unit'
+  | 'tone'
+  | 'size'
+  | 'max'
+  | 'value'
+  | 'init'
+  | 'onChange'
+  | 'editable'
+  | 'mode'
+  | 'showPips'
+  | 'states'
+  | 'onBay'
+  | 'className'
+>
+
+/** [box] the default centred value box; `mode="edit"` adds steppers (former StatControl). */
+type ValueBoxProps = Pick<
+  StatDisplayProps,
+  | 'label'
+  | 'value'
+  | 'max'
+  | 'min'
+  | 'bottomLabel'
+  | 'labelId'
+  | 'disabled'
+  | 'onClick'
+  | 'onChange'
+  | 'mode'
+  | 'bg'
+  | 'valueColor'
+  | 'borderColor'
+  | 'ariaLabel'
+  | 'compact'
+  | 'flash'
+  | 'inverse'
+  | 'isOverMax'
+  | 'hoverText'
+>
 
 export function StatDisplay(props: StatDisplayProps) {
   if (props.orientation === 'horizontal') {
@@ -126,7 +201,7 @@ function HorizontalValue({
   bgColor,
   textColor,
   borderColor,
-}: StatDisplayProps) {
+}: HorizontalValueProps) {
   const fontSize = xs ? 'text-label' : compact ? 'text-xs' : 'text-sm'
   const fontWeight = xs ? 'font-bold' : compact ? 'font-normal' : 'font-semibold'
   const mainVariant = inverse ? 'pseudoheaderInverse' : 'pseudoheader'
@@ -164,7 +239,7 @@ function HorizontalValue({
  * ------------------------------------------------------------------ */
 const CHIP_PIP_MAX = 12
 
-function InlineChip({ label, value, max, tone = 'default', className }: StatDisplayProps) {
+function InlineChip({ label, value, max, tone = 'default', className }: InlineChipProps) {
   const v = typeof value === 'number' ? value : Number(value)
   // Over-capacity honesty: the derived mech Hold (cargo tone) can exceed its
   // soft cap — show the true value + red over-pips rather than clamping to a lie.
@@ -252,7 +327,7 @@ function FramedTracker({
   states,
   onBay,
   className,
-}: StatDisplayProps) {
+}: FramedTrackerProps) {
   const isControlled = valueProp !== undefined
   const numericProp = typeof valueProp === 'number' ? valueProp : undefined
   const [internal, setInternal] = useState(init ?? max ?? 0)
@@ -491,7 +566,7 @@ function ValueBox({
   inverse = false,
   isOverMax = false,
   hoverText,
-}: StatDisplayProps) {
+}: ValueBoxProps) {
   const [isFlashing, setIsFlashing] = useState(false)
 
   const combinedAriaLabel = ariaLabel || (bottomLabel ? `${label} ${bottomLabel}` : String(label))

--- a/packages/suref-react/src/components/shared/__tests__/StatDisplayTracker.test.tsx
+++ b/packages/suref-react/src/components/shared/__tests__/StatDisplayTracker.test.tsx
@@ -159,14 +159,14 @@ describe('StatDisplay (tracker) — states[] tally mode (crawler bays)', () => {
   ] as const
 
   test('renders one pip per bay with state titles', () => {
-    render(<StatDisplay pips label="BAYS" states={[...states]} />)
+    render(<StatDisplay label="BAYS" states={[...states]} />)
     expect(screen.getByTitle('Bay 1 · intact')).toBeTruthy()
     expect(screen.getByTitle('Bay 9 · damaged')).toBeTruthy()
     expect(screen.getByTitle('Bay 10 · damaged')).toBeTruthy()
   })
 
   test('tallies counts per present state', () => {
-    render(<StatDisplay pips label="BAYS" states={[...states]} />)
+    render(<StatDisplay label="BAYS" states={[...states]} />)
     expect(screen.getByText('8')).toBeTruthy()
     expect(screen.getByText('intact')).toBeTruthy()
     expect(screen.getByText('2')).toBeTruthy()
@@ -177,13 +177,13 @@ describe('StatDisplay (tracker) — states[] tally mode (crawler bays)', () => {
 
   test('onBay makes pips clickable with the bay index', () => {
     const onBay = mock((i: number) => i)
-    render(<StatDisplay pips label="BAYS" states={[...states]} onBay={onBay} />)
+    render(<StatDisplay label="BAYS" states={[...states]} onBay={onBay} />)
     fireEvent.click(screen.getByTitle('Bay 9 · damaged'))
     expect(onBay).toHaveBeenLastCalledWith(8)
   })
 
   test('states mode renders no steppers or numeric value row', () => {
-    render(<StatDisplay pips label="BAYS" states={[...states]} />)
+    render(<StatDisplay label="BAYS" states={[...states]} />)
     expect(screen.queryByLabelText('Increase BAYS')).toBeNull()
   })
 })

--- a/packages/suref-react/src/components/shared/entityStatus.ts
+++ b/packages/suref-react/src/components/shared/entityStatus.ts
@@ -1,0 +1,8 @@
+/**
+ * Canonical per-entity condition vocabulary (rules: Intact / Damaged /
+ * Destroyed) — one source of truth for the tri-state status shared across the
+ * atom set. `StatusBadge` (`EntityStatus`), `ConditionSwatch`
+ * (`ConditionSwatchState`), and `StatDisplay`'s tally mode (`StatState`) all
+ * alias this so the vocabulary can never drift between them.
+ */
+export type EntityStatus = 'intact' | 'damaged' | 'destroyed'

--- a/packages/suref-react/src/components/stat/ConditionSwatch.tsx
+++ b/packages/suref-react/src/components/stat/ConditionSwatch.tsx
@@ -1,7 +1,9 @@
 import type { HTMLAttributes } from 'react'
 import { cn } from '../../utils/cn'
+import type { EntityStatus } from '../shared/entityStatus'
 
-export type ConditionSwatchState = 'intact' | 'damaged' | 'destroyed'
+/** Tri-state swatch vocabulary — the shared entity condition set. */
+export type ConditionSwatchState = EntityStatus
 
 type ConditionSwatchProps = {
   state: ConditionSwatchState

--- a/packages/suref-react/src/components/stat/VitalGauge.tsx
+++ b/packages/suref-react/src/components/stat/VitalGauge.tsx
@@ -236,7 +236,7 @@ export function VitalGauge({
         </span>
       </div>
 
-      {/* Segmented track — balanced rows, max 5 per row (the pip-row split /
+      {/* Segmented track — balanced rows, max 6 per row (the pip-row split /
           "looping chips" rule; shared with the StatDisplay tracker). */}
       <div className={cn('flex flex-col', isDense ? 'gap-[3px]' : 'gap-1')}>
         {statBlockRowStarts(segCount).map((segRow) => (

--- a/packages/suref-react/src/components/stat/VitalGauge.tsx
+++ b/packages/suref-react/src/components/stat/VitalGauge.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import type { KeyboardEvent } from 'react'
 
 import { cn } from '../../utils/cn'
+import { POSTER_STAMP } from '../chrome/Stamp'
 import { pipClickValue, statBlockRowStarts, trackSegmentState } from './pipRows'
 
 export type VitalGaugeProps = {
@@ -39,10 +40,6 @@ export type VitalGaugeProps = {
   danger?: number
   className?: string
 }
-
-/** Black inline stamp label, cloned across wraps (design-spec `.stamp`). */
-const STAMP =
-  'box-decoration-clone inline bg-ink px-[0.5em] pb-[0.16em] pt-[0.1em] font-cond font-bold uppercase leading-[1.5] tracking-[0.09em] text-paper'
 
 /**
  * VitalGauge (poster design-spec `.gauge`): a horizontal full-width segmented
@@ -160,7 +157,14 @@ export function VitalGauge({
       {/* Label stamp + big numeral */}
       <div className="mb-2 flex items-baseline justify-between gap-2.5">
         <span className="flex min-w-0 items-baseline gap-1.5">
-          <span className={cn(STAMP, 'text-caption')}>{label}</span>
+          <span
+            className={cn(
+              POSTER_STAMP,
+              'px-[0.5em] pb-[0.16em] pt-[0.1em] text-caption leading-[1.5]'
+            )}
+          >
+            {label}
+          </span>
           {subLabel && (
             <span className="truncate font-cond text-label uppercase leading-none tracking-caps text-wk-muted">
               {subLabel}

--- a/packages/suref-react/src/stories/RenderingMatrix.stories.tsx
+++ b/packages/suref-react/src/stories/RenderingMatrix.stories.tsx
@@ -96,7 +96,7 @@ const rows: MatrixRow[] = [
     when: 'cite',
     use: 'Tag (= Badge solid)',
     rule: 'A single stamped keyword.',
-    example: <Tag label={traitLabel} />,
+    example: <Tag>{traitLabel}</Tag>,
   },
   {
     role: 'Condition',

--- a/packages/suref-react/src/stories/primitives/Badges.stories.tsx
+++ b/packages/suref-react/src/stories/primitives/Badges.stories.tsx
@@ -129,14 +129,16 @@ export const Tags: Story = () => (
     <ClusterLabel>Keyword (stamped ink chip)</ClusterLabel>
     <Row>
       {keywordTags.map((keyword) => (
-        <Tag key={keyword} label={keyword} />
+        <Tag key={keyword}>{keyword}</Tag>
       ))}
     </Row>
 
     <ClusterLabel>Ghost (inverted paper chip, inset ring)</ClusterLabel>
     <Row>
       {economyTags.map((economy) => (
-        <Tag key={economy} label={economy} ghost />
+        <Tag key={economy} ghost>
+          {economy}
+        </Tag>
       ))}
     </Row>
   </div>

--- a/packages/suref-react/src/stories/primitives/Layout.stories.tsx
+++ b/packages/suref-react/src/stories/primitives/Layout.stories.tsx
@@ -69,7 +69,7 @@ export const Filters: Story = () => (
   <div className="flex max-w-2xl flex-col gap-4 bg-paper p-4">
     <FilterRow label="Traits">
       {traits.map((t) => (
-        <Tag key={t} label={t} />
+        <Tag key={t}>{t}</Tag>
       ))}
     </FilterRow>
   </div>


### PR DESCRIPTION
Final-review follow-ups on the already-transitioned (non-legacy) Ladle atoms. **Stacked on `worktree-entity-card-capture`** — every change targets code that lives on that branch (Badge/Stamp/StatDisplay), so this PR bases on it, not `main`.

## Type dedup / prop clarity
- **Tri-state union has one home.** `EntityStatus` (`shared/entityStatus.ts`) is now the single `'intact' | 'damaged' | 'destroyed'` source; `ConditionSwatchState` and `StatState` alias it so the vocabulary can't drift.
- **`PillTone` aliases `BadgeTone`** (was a verbatim duplicate of the same 6-tone set).
- **`Tag` takes `children`** instead of `label`, matching the rest of the Badge family. Updated all call sites + stories/tests.

## Streamlined internals
- **`chrome/interaction.ts`** — single source of truth for `FOCUS_RING`, `DISABLED`, `SELECTION_RING`, and an `activateOnKey` Enter/Space handler. Btn/StepBtn/MiniBtn/OptRow/Sel/PickCard consume these; Sel/PickCard drop their copy-pasted keyboard handler + selection ring.
- **`Field` renders the `Stamp` atom** instead of a hand-rolled `Text pseudoheader` label (fixes the `su-black`→`ink` token drift — visually identical since `--color-ink` is `var(--color-su-black)`).
- **`POSTER_STAMP`** — Slab's solid variant and VitalGauge's label both hand-rolled the poster wrapping ink-stamp (`box-decoration-clone`, 0.09em tracking, deliberately *not* the single-line `Stamp` atom). Deduped into a shared class constant on Stamp.tsx — same emitted class set.

## StatDisplay — hard discriminated union
- **`StatDisplayProps` is now a real discriminated union** over the four anatomies (HorizontalValue, InlineChip, FramedTracker `pips | states`, ValueBox), keyed on `orientation`/`pips`/`states`. Each member is wrapped in an `Exact<>` helper that sets every *other* anatomy's props to `?: never`, so **mixing anatomies is a compile error** — e.g. a `[box]` `bg` on an `orientation="horizontal"` call no longer silently no-ops, it fails to typecheck. (A plain union can't do this: TS only flags a prop as excess when it's in *no* member, so `bg` would slip through on the box member.) The `borderColor` overload — a raw CSS colour in the horizontal anatomy vs a Tailwind class in the box — is now scoped and documented per anatomy.
- **Fallout across all 120 call sites was tiny**: the only breakages were calls passing `pips` *and* `states` together (a contradiction — `states` alone selects the tally tracker). Dropped the redundant `pips` in the 5 tracker tests + ShareSnapshotScreen; runtime identical.
- Also wires `className` through the horizontal and box anatomies (the flat type accepted it but silently dropped it) — now honoured on all four; render/snapshot tests unchanged.

## Docs
- **pip-row per-row count** — `SlotGrid`/`VitalGauge` comments said "≤5 per row"; the shared split is **6**. Corrected both.

## Verification
- `typecheck` — 0 errors (suref-react, suref-web, ITUN, discord-bot); cross-anatomy misuse now fails to compile (verified with a throwaway probe).
- Tests — suref-react 414, ITUN 1321, suref-web 989, all pass.
- `lint` clean (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015f4mzBKT8fT7Q7aeqvU9oy
