### PR TITLE
Fix HP/SP/EP header acronyms, get CI coverage green, finish NEW* rename

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -1,7 +1,7 @@
 {
-  "packages/salvageunion-reference": 84,
-  "packages/component-lib": 69,
-  "apps/srd": 72,
-  "apps/itun": 82,
-  "apps/discord-bot": 68
+  "packages/salvageunion-reference": 89,
+  "packages/component-lib": 71,
+  "apps/srd": 95,
+  "apps/itun": 90,
+  "apps/discord-bot": 92
 }

--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -62,7 +62,6 @@ import { EntityCardSubHeader } from './EntityCardSubHeader'
 import type { EntityCardSubHeaderCell } from './EntityCardSubHeader'
 import { resolveFoldedAction } from './resolveFoldedAction'
 import {
-  abbreviateStat,
   ghostActionTone,
   resolveAxisMarkers,
   resolveCardTone,
@@ -736,7 +735,7 @@ function ReferenceEntityCardInner({
     isAction || isPatternListing
       ? []
       : buildReferenceEntityStats(entity, {
-          compact: false,
+          compact,
           primaryOnly: !!primaryStatsOnly || size === 'listing',
           schemaName: schemaName as SURefEnumSchemaName,
           techLevel,
@@ -770,7 +769,7 @@ function ReferenceEntityCardInner({
     // ATOM MODEL: compact = horizontal cells + SHORTFORM labels (SP, TL, Cargo, …).
     // Non-compact = the vertical value box with FULL two-line labels — the
     // slotsRequired stat reads "Slots" / "Required".
-    ...(compact ? rawHeaderStats.map(abbreviateStat) : rawHeaderStats),
+    ...rawHeaderStats,
   ]
 
   const costSource = action ?? foldedActionFields

--- a/packages/component-lib/src/components/referenceEntity/card/entityCardTone.ts
+++ b/packages/component-lib/src/components/referenceEntity/card/entityCardTone.ts
@@ -170,7 +170,7 @@ export function titleSizeClass(depth: number): string {
   return TITLE_SIZE_LADDER[index] ?? 'text-badge'
 }
 
-export type NEWEyebrow = { type: string }
+export type Eyebrow = { type: string }
 
 /**
  * Eyebrow = the schema TYPE stamp only (e.g. "Ability", "System"). The
@@ -178,14 +178,14 @@ export type NEWEyebrow = { type: string }
  * in this Stamp — it rides the header's top-border seam instead, via
  * {@link resolveAxisMarker}.
  */
-export function resolveEyebrow(schemaName: SURefEnumSchemaName | 'actions'): NEWEyebrow {
+export function resolveEyebrow(schemaName: SURefEnumSchemaName | 'actions'): Eyebrow {
   if (schemaName === 'actions') return { type: 'Action' }
   // The crawler CLASS type reads "Crawler Type" (not just "Crawler").
   if (schemaName === 'crawlers') return { type: 'Crawler Type' }
   return { type: getDisplayName(schemaName) }
 }
 
-export type NEWAxisMarker = { label: string; value?: string }
+export type AxisMarker = { label: string; value?: string }
 
 /**
  * The categorical classification axis (Ability Tree · Level, Tech Level) — the
@@ -203,7 +203,7 @@ export type NEWAxisMarker = { label: string; value?: string }
  * Numeric vitals (SP/EP/Heat/Structure) stay in the header's top-right stat
  * cluster; only this classification axis lives in the seam.
  */
-export function resolveAxisMarkers(entity: SURefMetaEntity): NEWAxisMarker[] {
+export function resolveAxisMarkers(entity: SURefMetaEntity): AxisMarker[] {
   // Only ABILITY classification lives in the seam (Ability Tree · Level, folded
   // into ONE pill). TECH LEVEL moved to the header's top-right stat cluster.
   if (isAbility(entity)) {

--- a/packages/component-lib/src/components/referenceEntity/card/entityCardTone.ts
+++ b/packages/component-lib/src/components/referenceEntity/card/entityCardTone.ts
@@ -1,6 +1,5 @@
 import type { SURefEnumSchemaName, SURefMetaEntity } from 'salvageunion-reference'
 import { getDisplayName, getTechLevel, getTechLevelNumber, isAbility } from 'salvageunion-reference'
-import type { StatItem } from '../../shared/statsBarTypes'
 import { TECH_LEVEL_BG } from '../../shared/techLevelStyles'
 import { borderColorFromHeaderBg, calculateBackgroundColor } from '../referenceEntityHelpers'
 import type { CardDomain } from './EntityCardIdentityFooter'
@@ -215,16 +214,4 @@ export function resolveAxisMarkers(entity: SURefMetaEntity): NEWAxisMarker[] {
     return []
   }
   return []
-}
-
-/**
- * Header stat-box label abbreviations (L1 mockup): the top-right stat cluster
- * uses short glyphs, not full names. Applied to a StatItem's `label`, with the
- * `bottomLabel` cleared so the box shows just the short label + value.
- */
-/** Compact a header stat to its TOP label only — the whole first word (Structure
- * Points → Structure, Energy Points → Energy, Salvage Value → Salvage, System
- * Slots → System, Bio SV → Bio, …); the bottom label is dropped. */
-export function abbreviateStat(stat: StatItem): StatItem {
-  return stat.bottomLabel !== undefined ? { ...stat, bottomLabel: undefined } : stat
 }

--- a/packages/component-lib/src/components/referenceEntity/card/resolveNestedEntities.ts
+++ b/packages/component-lib/src/components/referenceEntity/card/resolveNestedEntities.ts
@@ -12,7 +12,7 @@ type EmbeddedNpc = { name?: unknown; position?: unknown }
 
 /** A labelled group of nested entities — rendered as a `Slab` separator + a
  * grid of depth+1 cards. */
-export type NEWNestedGroup = {
+export type NestedGroup = {
   label: string
   entities: SURefEntity[]
 }
@@ -33,7 +33,7 @@ export type NEWNestedGroup = {
  * De-duplicated globally by `schemaName:id` (patterns reuse systems across
  * loadouts). Actions are NOT here — they render as their own rust cards.
  */
-export function resolveNestedEntities(entity: SURefMetaEntity): NEWNestedGroup[] {
+export function resolveNestedEntities(entity: SURefMetaEntity): NestedGroup[] {
   const groups = new Map<string, SURefEntity[]>()
   const seen = new Set<string>()
 
@@ -102,7 +102,7 @@ export function resolveNestedEntities(entity: SURefMetaEntity): NEWNestedGroup[]
  * entities and de-duplicated. Rendered as `Slab`-separated masonry groups of
  * compact cards under the pattern (with the chassis name as a seam stampseal).
  */
-export function resolvePatternGroups(pattern: SURefObjectPattern): NEWNestedGroup[] {
+export function resolvePatternGroups(pattern: SURefObjectPattern): NestedGroup[] {
   const groups = new Map<string, SURefEntity[]>()
   const seen = new Set<string>()
 
@@ -143,7 +143,7 @@ export function resolvePatternGroups(pattern: SURefObjectPattern): NEWNestedGrou
 
 /** A drone plus its resolved systems/modules loadout — rendered as a compact
  * drone card with listing rows for its systems + modules. */
-export type NEWDroneLoadout = {
+export type DroneLoadout = {
   drone: SURefEntity
   systems: SURefEntity[]
   modules: SURefEntity[]
@@ -153,7 +153,7 @@ function resolveLoadout(
   drone: SURefEntity,
   systemNames: string[],
   moduleNames: string[]
-): NEWDroneLoadout {
+): DroneLoadout {
   const systems = systemNames.flatMap((name) => {
     const found = SalvageUnionReference.findIn('systems', (s) => s.name === name)
     return found ? [found as SURefEntity] : []
@@ -167,7 +167,7 @@ function resolveLoadout(
 
 /** The drone a CHASSIS controls — named by a chassis ability's `drone` field;
  * its systems/modules come from the drone entity's own loadout. */
-export function resolveChassisDrone(entity: SURefMetaEntity): NEWDroneLoadout | undefined {
+export function resolveChassisDrone(entity: SURefMetaEntity): DroneLoadout | undefined {
   const abilities = getChassisAbilities(entity) ?? []
   const droneName = abilities
     .map((ability) => (ability as { drone?: unknown }).drone)
@@ -185,7 +185,7 @@ export function resolveChassisDrone(entity: SURefMetaEntity): NEWDroneLoadout | 
 }
 
 /** The drone a PATTERN specifies — named + loadout come from `pattern.drones[0]`. */
-export function resolvePatternDrone(pattern: SURefObjectPattern): NEWDroneLoadout | undefined {
+export function resolvePatternDrone(pattern: SURefObjectPattern): DroneLoadout | undefined {
   const config = pattern.drones?.[0]
   if (!config) return undefined
   const drone = SalvageUnionReference.findIn('drones', (d) => d.name === config.name)

--- a/tools/coverage-report.ts
+++ b/tools/coverage-report.ts
@@ -29,7 +29,7 @@ import {
   copyFileSync,
   appendFileSync,
 } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
@@ -57,11 +57,32 @@ const WORKSPACES = [
   'apps/discord-bot',
 ]
 
-function parseLcov(path: string): { linesFound: number; linesHit: number } {
+/**
+ * Sum a workspace's line coverage from its lcov, counting ONLY files that belong
+ * to that workspace.
+ *
+ * A test run pulls in source from other workspaces (e.g. srd's `preload-reference`
+ * loads `salvageunion-reference`), and Bun reports coverage for every file it
+ * loaded. Summing all records therefore charged one workspace for another's
+ * uncovered lines — srd read 44.8% because it was being measured mostly on
+ * reference-package files its own tests never exercise. Each `SF:` record is
+ * resolved against the lcov's directory and skipped unless it sits inside the
+ * workspace being measured, so the ratchet tracks each workspace's own code.
+ */
+function parseLcov(path: string, workspaceRoot: string): { linesFound: number; linesHit: number } {
   const contents = readFileSync(path, 'utf-8')
+  const lcovDir = dirname(path)
   let linesFound = 0
   let linesHit = 0
+  let include = false
   for (const line of contents.split('\n')) {
+    if (line.startsWith('SF:')) {
+      const file = line.slice(3).trim()
+      const abs = isAbsolute(file) ? file : resolve(lcovDir, file)
+      include = !relative(workspaceRoot, abs).startsWith('..')
+      continue
+    }
+    if (!include) continue
     if (line.startsWith('LF:')) linesFound += Number(line.slice(3))
     if (line.startsWith('LH:')) linesHit += Number(line.slice(3))
   }
@@ -77,7 +98,7 @@ for (const workspace of WORKSPACES) {
     missing.push(workspace)
     continue
   }
-  const { linesFound, linesHit } = parseLcov(lcovPath)
+  const { linesFound, linesHit } = parseLcov(lcovPath, join(root, workspace))
   const pct = linesFound > 0 ? (linesHit / linesFound) * 100 : 0
   results.push({ workspace, lcovPath, linesFound, linesHit, pct })
 }


### PR DESCRIPTION
Three fixes. Green locally: typecheck · full tests · lint · knip · validate.

### 1. Header stats show acronyms (HP/SP/EP), not first words
The compact card header rendered "Structure" / "Hit" / "Energy" instead of **SP / HP / EP**. The config already had the right `compactLabel`s and the card's own comment said the header should read "SP, TL, Cargo, …" — but header stats were built with `compact: false` (so every label came out `normalLabel`) and then run through `abbreviateStat`, which only cleared the *bottom* label. Now built with the card's own `compact` flag; `abbreviateStat` deleted (no-op, not barrel-exported).

### 2. CI coverage green — coverage was measuring the wrong code
The ratchet has failed on 466 since **well before this work** (srd 44.8% vs 72% baseline). srd was never under-tested: `parseLcov` summed every `LF:`/`LH:` record with no path filter, and a test run loads other workspaces' source (srd's `preload-reference` pulls in `salvageunion-reference`) — so srd was graded almost entirely on reference-package files its own tests never exercise.

Each `SF:` record is now resolved and counted only if it's inside the workspace being measured:

| Workspace | Before | After |
|---|---|---|
| apps/srd | 44.8% | **95.9%** |
| apps/itun | 80.4% | **91.0%** |
| apps/discord-bot | 72.0% | **92.4%** |

Because the measurement basis changed, the old baselines were stale (srd could regress 24pp and still pass), so each is rebaselined just under its true figure.

### 3. Finish the NEW* rename
#479 claimed these were renamed but the change was lost to a rebase autostash that was later reset. `NEWNestedGroup` / `NEWDroneLoadout` / `NEWEyebrow` / `NEWAxisMarker` are now actually renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jp2XjTMVQ3ak7BixETJnEU