### PR TITLE
Fix srd deploy: publish path must be base-relative

### DIFF
--- a/apps/srd/netlify.toml
+++ b/apps/srd/netlify.toml
@@ -12,7 +12,13 @@
   # deploy reliably exceeded the build limit ("Command did not finish") — every
   # srd deploy was failing. Entity pages now use the site-wide default og:image.
   command = "bun install --frozen-lockfile && PUBLIC_COMMIT_REF=\"$COMMIT_REF\" bun --filter srd build"
-  publish = "apps/srd/dist"
+  # Netlify resolves `publish` RELATIVE TO the site's base directory, which for
+  # this site is `apps/srd` — so this must be base-relative, not root-relative.
+  # It read `apps/srd/dist` and resolved to `apps/srd/apps/srd/dist`, failing
+  # every deploy with "Deploy directory does not exist" (exit code 2) even
+  # though the build itself succeeded. (ITUN's site differs: its base is the
+  # repo root, so its netlify.toml paths are root-relative.)
+  publish = "dist"
   # Skip the build when nothing affecting srd changed since the last
   # published deploy. `git diff --quiet` exits 0 (→ Netlify cancels the build)
   # when none of these paths differ, and 1 (→ build proceeds) when they do.


### PR DESCRIPTION
Second and final blocker on the srd Netlify deploys. From the build log:

```
Deploy directory 'apps/srd/apps/srd/dist' does not exist
  base:    /opt/build/repo/apps/srd
  publish: /opt/build/repo/apps/srd/apps/srd/dist
```

The **build succeeded** — it failed at the deploy step. Netlify resolves `publish` relative to the site's **base directory** (`apps/srd` for this site), so the root-relative `apps/srd/dist` doubled. Set `publish = "dist"`.

ITUN's site is configured differently (base = repo root), which is why its netlify.toml paths are correctly root-relative — worth knowing before "aligning" the two.

This was masked until now: builds were timing out on the og:image screenshot pass (#482), so they never reached the deploy step to surface this.

Verified: build emits `apps/srd/dist/index.html`, which is exactly what `publish = "dist"` resolves to under this base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jp2XjTMVQ3ak7BixETJnEU