### PR TITLE
Fix catalog tiles: gradients silently dropped by background-color

### DIFF
--- a/packages/component-lib/src/components/shared/CatalogTile.tsx
+++ b/packages/component-lib/src/components/shared/CatalogTile.tsx
@@ -25,14 +25,18 @@ type CatalogTileProps = {
   LinkComponent?: React.ElementType
 }
 
+// `--catalog-bg` may be a colour OR a gradient (tech-level ramps, the ability
+// tier ramp), so this must be the `background` shorthand — `bg-[…]` compiles to
+// `background-color`, which silently drops a `linear-gradient()` and left those
+// tiles unfilled with unreadable paper text on the pale page ground.
 const TILE =
-  'flex min-h-[54px] flex-col items-center justify-center rounded-[3px] border-[1.5px] border-ink bg-[var(--catalog-bg)] px-[15px] py-[13px] text-paper no-underline transition-[box-shadow,transform] duration-[120ms] hover:-translate-y-0.5 hover:shadow-[0_5px_18px_rgba(34,30,23,0.18)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-su-orange'
+  'flex min-h-[54px] flex-col items-center justify-center rounded-card border-chrome border-ink [background:var(--catalog-bg)] px-[15px] py-[13px] text-paper no-underline transition-[box-shadow,transform] duration-[120ms] hover:-translate-y-0.5 hover:shadow-[0_5px_18px_rgba(34,30,23,0.18)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-su-orange'
 
 const NAME =
   'font-cond text-[16px] font-semibold uppercase leading-[1.2] tracking-[0.02em] text-paper [text-shadow:0_1px_2px_rgba(0,0,0,0.75)]'
 
 const NAME_LABEL =
-  'inline-block rounded-[2px] bg-[var(--catalog-label)] px-[10px] py-0.5 [text-shadow:none]'
+  'inline-block rounded-badge bg-[var(--catalog-label)] px-[10px] py-0.5 [text-shadow:none]'
 
 export function CatalogTile({
   href,

--- a/packages/component-lib/src/components/shared/NavDrawer.tsx
+++ b/packages/component-lib/src/components/shared/NavDrawer.tsx
@@ -64,7 +64,9 @@ type NavDrawerProps = {
 
 // Full-width catalog tile (former `.catalog-item`, compact drawer variant).
 const TILE =
-  'block w-full rounded-card border-chrome border-ink bg-[var(--catalog-bg)] px-[15px] py-[13px] text-center text-sm text-paper no-underline transition-[box-shadow,transform] duration-[120ms] hover:-translate-y-0.5 hover:shadow-[0_5px_18px_rgba(34,30,23,0.18)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-su-orange'
+  // `background` shorthand, not `bg-[…]`/`background-color` — `--catalog-bg` may
+  // be a gradient (see CatalogTile), which background-color silently drops.
+  'block w-full rounded-card border-chrome border-ink [background:var(--catalog-bg)] px-[15px] py-[13px] text-center text-sm text-paper no-underline transition-[box-shadow,transform] duration-[120ms] hover:-translate-y-0.5 hover:shadow-[0_5px_18px_rgba(34,30,23,0.18)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-su-orange'
 
 const TILE_LABEL = 'inline-block rounded-badge bg-[var(--catalog-label)] px-[10px] py-0.5'
 


### PR DESCRIPTION
The catalog grid was rendering **three** treatments where there should be one — filled tiles, pale tiles with a colour chip, and (worst) **CLASSES / ABILITIES as white text on the pale page ground, effectively invisible**.

**Cause:** `getCatalogBg` returns either a solid colour *or* a gradient — the tech-level ramp (systems, modules, equipment, drones, vehicles), the tier ramp (abilities), and the core/hybrid split (classes). `CatalogTile` applied it with `bg-[var(--catalog-bg)]`, which Tailwind compiles to **`background-color`** — and `background-color` silently drops a `linear-gradient()`.

So every gradient-backed tile rendered unfilled while keeping its hardcoded `text-paper`. The gear schemas stayed readable only by accident, because they also set a `catalogLabel` chip; `classes` and `abilities` have no chip entry, so they vanished.

**Fix:** use the `background` shorthand. `NavDrawer` had the identical bug, so the mobile drawer was broken the same way — fixed there too.

Also swapped this file's `rounded-[3px]` / `border-[1.5px]` / `rounded-[2px]` for `rounded-card` / `border-chrome` / `rounded-badge` — identical computed values; this component was the audit's named example of bypassing the radius/border vocabulary.

Verified in the emitted CSS: `background-color:var(--catalog-bg)` is gone (0), `background:var(--catalog-bg)` present. Green: typecheck · tests · lint · knip · srd build.

Follow-up worth noting: `apps/srd/src/lib/catalogColors.ts` hand-rolls a schema→colour map that duplicates (and can drift from) the canonical `SCHEMA_DOMAIN` in component-lib — a "single source of truth" violation for a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jp2XjTMVQ3ak7BixETJnEU