### PR TITLE
Fix srd build-skip guard cancelling every deploy

### DIFF
--- a/apps/srd/netlify.toml
+++ b/apps/srd/netlify.toml
@@ -37,7 +37,14 @@
   #                                  every post-#318 main deploy cancelled with
   #                                  "no content change", freezing the site.
   #   - unreachable in the (shallow) clone → can't diff it reliably.
-  ignore = 'if [ -z "$CACHED_COMMIT_REF" ] || [ "$CACHED_COMMIT_REF" = "$COMMIT_REF" ] || ! git cat-file -e "$CACHED_COMMIT_REF^{commit}" 2>/dev/null; then exit 1; fi; git diff --quiet "$CACHED_COMMIT_REF" "$COMMIT_REF" -- apps/srd packages/component-lib packages/salvageunion-reference bun.lock package.json bunfig.toml tsconfig.json'
+  # Pathspecs are `:/`-anchored (repo root) because this site's base directory is
+  # `apps/srd`, so the ignore command runs with that as cwd — plain `apps/srd …`
+  # pathspecs resolved to `apps/srd/apps/srd` and matched nothing, so `git diff
+  # --quiet` exited 0 and Netlify cancelled EVERY build ("no content change").
+  # That stayed hidden while no deploy had ever succeeded (an unreachable
+  # CACHED_COMMIT_REF hits the force-build guard below); the moment one landed,
+  # the guard started cancelling real changes.
+  ignore = 'if [ -z "$CACHED_COMMIT_REF" ] || [ "$CACHED_COMMIT_REF" = "$COMMIT_REF" ] || ! git cat-file -e "$CACHED_COMMIT_REF^{commit}" 2>/dev/null; then exit 1; fi; git diff --quiet "$CACHED_COMMIT_REF" "$COMMIT_REF" -- :/apps/srd :/packages/component-lib :/packages/salvageunion-reference :/bun.lock :/package.json :/bunfig.toml :/tsconfig.json'
 
 [build.environment]
   BUN_VERSION = "1.3.14" # keep in sync with .bun-version (checked by tools/check-bun-version.ts)


### PR DESCRIPTION
The first successful srd deploy in months immediately caused the **next** one to be cancelled — `Canceled build due to no content change` — despite component-lib having changed.

**Cause:** this site's base directory is `apps/srd`, so the `ignore` command runs with that as cwd, and **git pathspecs are cwd-relative**. `-- apps/srd packages/component-lib …` resolved to `apps/srd/apps/srd`, `apps/srd/packages/…`, matched nothing, so `git diff --quiet` exited **0** — which is precisely the "nothing changed, cancel" signal.

**Why it stayed hidden:** with no successful deploy there's no reachable `CACHED_COMMIT_REF`, so the leading safety clause force-builds and the diff never ran. The moment a deploy landed, the guard started cancelling real changes.

**Fix:** anchor each pathspec with git's `:/` repo-root prefix. Verified from `cwd=apps/srd` against a diff touching only `packages/component-lib`:

| pathspec form | exit | Netlify |
|---|---|---|
| `-- apps/srd packages/…` | 0 | cancels |
| `-- :/apps/srd :/packages/…` | 1 | builds |

ITUN's netlify.toml uses the same plain pathspecs but is **unaffected** — its site's base is the repo root, so they already resolve correctly. Don't "fix" it to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jp2XjTMVQ3ak7BixETJnEU