### PR TITLE
Sub-header follows the same on-band contrast rule as the title

### DIFF
--- a/packages/component-lib/src/components/referenceEntity/card/EntityCardSubHeader.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/EntityCardSubHeader.tsx
@@ -39,6 +39,12 @@ type EntityCardSubHeaderProps = {
    * against the trait cells. Absent ⇒ the band renders its plain packed layout. */
   trailing?: ReactNode
   compact?: boolean
+  /** Foreground for this band — the SAME value the card gives its header title
+   * (`onBandText`). The sub-header rides a darker shade of the same tone, so it
+   * flips to ink exactly when the title does (damaged/destroyed greys, ghosted
+   * action/NPC bands); hardcoding paper left it unreadable on those light
+   * bands. Defaults to paper, the solid-tone case. */
+  onBandText?: string
 }
 
 /**
@@ -58,6 +64,7 @@ export function EntityCardSubHeader({
   group,
   trailing,
   compact = false,
+  onBandText = 'text-paper',
 }: EntityCardSubHeaderProps) {
   const hasGroup = !!group && group.cells.length > 0
   if (!leading && cells.length === 0 && !hasGroup && !trailing) return null
@@ -83,7 +90,8 @@ export function EntityCardSubHeader({
       {parts.length > 0 && (
         <span
           className={cn(
-            'font-cond uppercase leading-snug tracking-caps-tight text-paper',
+            'font-cond uppercase leading-snug tracking-caps-tight',
+            onBandText,
             compact ? 'text-xs' : 'text-sm'
           )}
         >

--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -1798,6 +1798,7 @@ function ReferenceEntityCardInner({
           cells={cells}
           leading={subHeaderLeading}
           compact={compact}
+          onBandText={onBandText}
         />
         <div
           className={cn(


### PR DESCRIPTION
The header title flips to ink whenever its band goes light — a damaged/destroyed grey, or a ghosted action/NPC band — through the single `onBandText` value.

The sub-header rides a **darker shade of that same tone** but hardcoded `text-paper`, so on exactly those light bands it stayed white-on-light and became unreadable.

It now takes the card's own `onBandText`, defaulting to paper (the solid-tone case) so nothing else moves.

Noted while here, not changed: `DomainTone.onToneText` is computed in `resolveDomainTone` but **never consumed** by the card — dead weight worth a separate cleanup.

Green: typecheck (4 workspaces) · full tests · lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jp2XjTMVQ3ak7BixETJnEU