### PR TITLE
Drop the dead onToneText field from DomainTone

### DIFF
--- a/packages/component-lib/src/components/referenceEntity/card/entityCardTone.ts
+++ b/packages/component-lib/src/components/referenceEntity/card/entityCardTone.ts
@@ -55,22 +55,6 @@ export type DomainTone = {
   domain: CardDomain
   bg: string | undefined
   bgColor: string | undefined
-  /** Tailwind text-colour class (`text-ink` / `text-paper`) that reads against
-   * this tone — for the title text sitting directly on the header band. */
-  onToneText: string
-}
-
-/**
- * Paper text on DARK grounds, ink text on the light warm/blue tones. Derived
- * from the resolved bg TOKEN, not the domain — so tier-coloured abilities (brick
- * Core, pink Legendary) get the right contrast even though their domain is
- * `pilot`. Dark: brick / rust / pink / ink / tl-3..6. Light: orange / green /
- * tl-1 / tl-2 / Bio / Nanite.
- */
-function resolveOnToneText(bg: string | undefined): string {
-  const s = bg ?? ''
-  if (/su-brick|su-rust|su-pink|su-orange-dark|ink-2|ink\b|tl-[3-6]/.test(s)) return 'text-paper'
-  return 'text-ink'
 }
 
 /**
@@ -97,7 +81,7 @@ export function resolveDomainTone(
           : techLevel === 'B'
             ? 'bg-tl-b'
             : 'bg-tl-n'
-      return { domain, bg, bgColor: undefined, onToneText: resolveOnToneText(bg) }
+      return { domain, bg, bgColor: undefined }
     }
   }
 
@@ -108,7 +92,7 @@ export function resolveDomainTone(
     entity,
     TECH_LEVEL_BG
   )
-  return { domain, bg, bgColor: undefined, onToneText: resolveOnToneText(bg) }
+  return { domain, bg, bgColor: undefined }
 }
 
 /**
@@ -142,7 +126,7 @@ export function resolveCardTone(
   entity: SURefMetaEntity
 ): DomainTone {
   if (schemaName === 'actions') {
-    return { domain: 'action', bg: undefined, bgColor: undefined, onToneText: 'text-ink' }
+    return { domain: 'action', bg: undefined, bgColor: undefined }
   }
   return resolveDomainTone(schemaName, entity)
 }


### PR DESCRIPTION
`DomainTone.onToneText` was computed on every tone resolution (with a `resolveOnToneText` helper maintained alongside it) but **never read anywhere in the repo**. The card's on-band contrast actually flows through its own `onBandText` — which is what #488 wired into the sub-header.

Removing it leaves one contrast rule instead of a live one and a plausible-looking dead one sitting next to it, ready to be picked up by mistake.

Green: typecheck (4 workspaces) · full tests · lint · knip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jp2XjTMVQ3ak7BixETJnEU