### PR TITLE
Retire the --font-mono alias: two faces, no aliases

### DIFF
--- a/apps/itun/src/components/shared/AppHeader.tsx
+++ b/apps/itun/src/components/shared/AppHeader.tsx
@@ -16,7 +16,7 @@ import { AppBar, type AppBarNavItem, NavDrawer, type NavDrawerItem } from 'compo
 // SRD search-field treatment, matching the shared SearchField chrome exactly so
 // the trigger button reads as the same search bar.
 const SEARCH_BOX =
-  'flex shrink-0 cursor-pointer items-center gap-2 rounded border border-ink bg-paper px-3 py-[7px] font-mono text-[13px] text-ink-2 transition-colors hover:border-su-orange-dark focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-su-orange lg:w-64'
+  'flex shrink-0 cursor-pointer items-center gap-2 rounded border border-ink bg-paper px-3 py-[7px] font-body text-[13px] text-ink-2 transition-colors hover:border-su-orange-dark focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-su-orange lg:w-64'
 
 // Small "Alpha" pills — same rust treatment as the brand "Beta" badge.
 const DESKTOP_ALPHA = (

--- a/apps/itun/src/components/sheet/ConditionsEditor.tsx
+++ b/apps/itun/src/components/sheet/ConditionsEditor.tsx
@@ -108,7 +108,7 @@ export function ConditionsEditor({
   return (
     <div className="flex min-h-12 flex-wrap items-center gap-1.5 rounded border-chrome border-ink bg-su-paper p-2.5">
       {conditions.length === 0 && !adding && (
-        <span className="font-mono text-xs text-wk-muted">None</span>
+        <span className="font-body text-xs text-wk-muted">None</span>
       )}
 
       {conditions.map((condition, index) =>

--- a/apps/itun/src/components/sheet/InlineEditField.tsx
+++ b/apps/itun/src/components/sheet/InlineEditField.tsx
@@ -123,7 +123,7 @@ export function InlineEditField({
               }
         }
         className={cn(
-          'inline-flex items-center justify-center min-h-11 sm:min-h-9 font-mono text-lg font-bold text-ink',
+          'inline-flex items-center justify-center min-h-11 sm:min-h-9 font-body text-lg font-bold text-ink',
           !readOnly &&
             'cursor-pointer rounded px-1 hover:bg-su-paper focus:outline-none focus:ring-2 focus:ring-su-orange',
           className
@@ -163,7 +163,7 @@ export function InlineEditField({
           }
         }}
         className={cn(
-          'w-16 rounded border-chrome bg-su-paper px-1 py-0.5 text-center font-mono text-lg font-bold text-ink focus:outline-none focus:ring-2 focus:ring-su-orange',
+          'w-16 rounded border-chrome bg-su-paper px-1 py-0.5 text-center font-body text-lg font-bold text-ink focus:outline-none focus:ring-2 focus:ring-su-orange',
           error ? 'border-danger focus:ring-danger' : 'border-ink',
           inputClassName
         )}

--- a/apps/itun/src/components/sheet/InlineEditTextArea.tsx
+++ b/apps/itun/src/components/sheet/InlineEditTextArea.tsx
@@ -75,7 +75,7 @@ export function InlineEditTextArea({
               }
         }
         className={cn(
-          'block min-h-9 whitespace-pre-wrap rounded px-1.5 py-1 font-mono text-sm',
+          'block min-h-9 whitespace-pre-wrap rounded px-1.5 py-1 font-body text-sm',
           hasValue ? 'text-ink' : 'text-wk-muted italic',
           !readOnly &&
             'cursor-pointer hover:bg-su-paper focus:outline-none focus:ring-2 focus:ring-su-orange'
@@ -105,7 +105,7 @@ export function InlineEditTextArea({
           cancel()
         }
       }}
-      className="w-full rounded border-chrome border-ink bg-su-paper px-1.5 py-1 font-mono text-sm text-ink focus:outline-none focus:ring-2 focus:ring-su-orange"
+      className="w-full rounded border-chrome border-ink bg-su-paper px-1.5 py-1 font-body text-sm text-ink focus:outline-none focus:ring-2 focus:ring-su-orange"
     />
   )
 }

--- a/apps/itun/src/components/sheet/NpcFactsEditor.tsx
+++ b/apps/itun/src/components/sheet/NpcFactsEditor.tsx
@@ -66,7 +66,7 @@ export function NpcFactsEditor({
   return (
     <div className="flex min-h-10 flex-wrap items-center gap-1.5 rounded border-chrome border-ink bg-su-paper p-2">
       {facts.length === 0 && !adding && (
-        <span className="font-mono text-xs text-wk-muted">No facts yet</span>
+        <span className="font-body text-xs text-wk-muted">No facts yet</span>
       )}
 
       {facts.map((fact, index) =>

--- a/apps/itun/src/components/sheet/ShareSnapshotScreen.tsx
+++ b/apps/itun/src/components/sheet/ShareSnapshotScreen.tsx
@@ -354,7 +354,7 @@ export function ShareSnapshotScreen({
               <ul className="m-0 flex list-none flex-col gap-2 p-0">
                 {links.map((link) => (
                   <li key={link.id} className="flex items-center gap-2">
-                    <code className="min-w-0 flex-1 truncate font-mono text-xs text-ink">
+                    <code className="min-w-0 flex-1 truncate font-body text-xs text-ink">
                       /s/{link.id}
                     </code>
                     <Button

--- a/apps/itun/src/components/sheet/SnapshotSheet.tsx
+++ b/apps/itun/src/components/sheet/SnapshotSheet.tsx
@@ -148,7 +148,7 @@ export function SnapshotSheet({ snapshot }: SnapshotSheetProps) {
           may have been published by a newer or older version.
         </p>
         {!result.ok && (
-          <p className="text-wk-muted mb-4 break-words font-mono text-xs">{result.reason}</p>
+          <p className="text-wk-muted mb-4 break-words font-body text-xs">{result.reason}</p>
         )}
         <AppLink href="/" className="text-sm underline">
           &larr; Back to Roster

--- a/apps/itun/src/index.css
+++ b/apps/itun/src/index.css
@@ -98,7 +98,7 @@ body {
    */
   background-color: var(--color-su-blue-pale);
   color: var(--color-ink);
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/apps/srd/src/components/islands/MobileNavIsland.tsx
+++ b/apps/srd/src/components/islands/MobileNavIsland.tsx
@@ -22,7 +22,7 @@ type MobileNavIslandProps = {
 
 const SRD_BRAND = (
   <a href="/">
-    <span className="inline-flex shrink-0 cursor-pointer border border-ink font-mono text-xl font-bold uppercase leading-none tracking-tight">
+    <span className="inline-flex shrink-0 cursor-pointer border border-ink font-cond text-xl font-bold uppercase leading-none tracking-tight">
       <span className="bg-ink px-1 py-0.5 text-paper">Salvage Union</span>
       <span className="bg-paper px-1 py-0.5 text-ink">SRD</span>
     </span>

--- a/apps/srd/src/components/islands/MobileSearchIsland.tsx
+++ b/apps/srd/src/components/islands/MobileSearchIsland.tsx
@@ -45,7 +45,7 @@ export function MobileSearchIsland() {
         <Dialog.Backdrop className="fixed inset-0 z-50 bg-ink/50" />
         <Dialog.Popup className="fixed inset-x-0 top-0 z-50 flex flex-col gap-3 bg-paper p-4 shadow-lg data-[open]:animate-slide-in-right data-[closed]:animate-slide-out-right">
           <div className="flex items-center justify-between">
-            <Dialog.Title className="font-mono text-sm font-bold uppercase text-ink">
+            <Dialog.Title className="font-cond text-sm font-bold uppercase text-ink">
               Search
             </Dialog.Title>
             <Dialog.Close

--- a/apps/srd/src/components/islands/SchemaViewerIsland.tsx
+++ b/apps/srd/src/components/islands/SchemaViewerIsland.tsx
@@ -218,7 +218,7 @@ export function SchemaViewerIsland({
                           onChange={(e) => setNameFilter(e.target.value)}
                           placeholder="Filter by name…"
                           aria-label="Filter items by name"
-                          className="w-full rounded-card border border-ink bg-paper px-2 py-1 font-mono text-caption md:w-64"
+                          className="w-full rounded-card border border-ink bg-paper px-2 py-1 font-body text-caption md:w-64"
                         />
                       </FilterRow>
                     </div>
@@ -305,7 +305,7 @@ export function SchemaViewerIsland({
                   <button
                     type="button"
                     onClick={clearFilters}
-                    className="cursor-pointer rounded-card px-2 py-0.5 font-mono text-xs font-semibold uppercase transition-colors bg-wk-faint text-ink hover:bg-wk-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-su-orange"
+                    className="cursor-pointer rounded-card px-2 py-0.5 font-cond text-xs font-semibold uppercase transition-colors bg-wk-faint text-ink hover:bg-wk-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-su-orange"
                   >
                     Clear filters
                   </button>

--- a/apps/srd/src/components/islands/SearchResultsIsland.tsx
+++ b/apps/srd/src/components/islands/SearchResultsIsland.tsx
@@ -154,7 +154,7 @@ function SearchResults({ query, index }: { query: string; index: CompactSearchEn
               className="flex items-center justify-between gap-3 px-4 py-3 no-underline transition-colors hover:bg-su-blue-pale"
             >
               <span className="font-medium text-ink">{result.entityName}</span>
-              <span className="shrink-0 font-mono text-xs uppercase tracking-wide text-ink-2">
+              <span className="shrink-0 font-cond text-xs uppercase tracking-wide text-ink-2">
                 {schemaLabel(result)}
               </span>
             </a>

--- a/apps/srd/src/pages/about.astro
+++ b/apps/srd/src/pages/about.astro
@@ -54,7 +54,7 @@ const structuredData = {
 
         <div class="relative z-[1] flex flex-col gap-3">
           <!-- Inspiration text -->
-          <div class="engraved-text text-center font-mono text-sm font-medium uppercase tracking-caps-snug leading-relaxed">
+          <div class="engraved-text text-center font-cond text-sm font-medium uppercase tracking-caps-snug leading-relaxed">
             <p>Inspired by the pilots of</p>
             <p class="font-bold text-lg">#812 Haven</p>
             <p>of</p>
@@ -70,21 +70,21 @@ const structuredData = {
             {pilots.map((name, i) => (
               <>
                 {i > 0 && <span class="engraved-text text-base">&ensp;&ensp;</span>}
-                <span class="engraved-text font-mono text-xl font-bold uppercase">{name}</span>
+                <span class="engraved-text font-cond text-xl font-bold uppercase">{name}</span>
               </>
             ))}
           </div>
 
           <hr class="metal-separator" />
 
-          <p class="engraved-text text-center font-mono text-sm font-medium uppercase tracking-caps-snug">
+          <p class="engraved-text text-center font-cond text-sm font-medium uppercase tracking-caps-snug">
             And union crawlers everywhere
           </p>
 
           <hr class="metal-separator" />
 
           <!-- Friends text -->
-          <p class="engraved-text text-center font-mono text-lg font-bold uppercase tracking-caps-snug">
+          <p class="engraved-text text-center font-cond text-lg font-bold uppercase tracking-caps-snug">
             "We get by with a little help from our friends"
           </p>
         </div>

--- a/apps/srd/src/pages/api.astro
+++ b/apps/srd/src/pages/api.astro
@@ -62,8 +62,8 @@ const baseUrl = SITE_URL
         <!-- Schema data array -->
         <div class="rounded-panel border-2 border-wk-faint bg-paper">
           <div class="border-b-2 border-wk-faint px-5 py-3">
-            <p class="font-mono text-sm font-bold uppercase tracking-wide text-ink-2">GET</p>
-            <p class="mt-1 font-mono text-base font-bold">
+            <p class="font-cond text-sm font-bold uppercase tracking-wide text-ink-2">GET</p>
+            <p class="mt-1 font-body text-base font-bold">
               /schema/<span class="text-su-orange-dark">{'{schemaId}'}</span>.json
             </p>
           </div>
@@ -96,8 +96,8 @@ const baseUrl = SITE_URL
         <!-- JSON Schema definition -->
         <div class="rounded-panel border-2 border-wk-faint bg-paper">
           <div class="border-b-2 border-wk-faint px-5 py-3">
-            <p class="font-mono text-sm font-bold uppercase tracking-wide text-ink-2">GET</p>
-            <p class="mt-1 font-mono text-base font-bold">
+            <p class="font-cond text-sm font-bold uppercase tracking-wide text-ink-2">GET</p>
+            <p class="mt-1 font-body text-base font-bold">
               /schema/<span class="text-su-orange-dark">{'{schemaId}'}</span>.schema.json
             </p>
           </div>
@@ -132,8 +132,8 @@ const baseUrl = SITE_URL
         <!-- Individual entity -->
         <div class="rounded-panel border-2 border-wk-faint bg-paper">
           <div class="border-b-2 border-wk-faint px-5 py-3">
-            <p class="font-mono text-sm font-bold uppercase tracking-wide text-ink-2">GET</p>
-            <p class="mt-1 font-mono text-base font-bold">
+            <p class="font-cond text-sm font-bold uppercase tracking-wide text-ink-2">GET</p>
+            <p class="mt-1 font-body text-base font-bold">
               /schema/<span class="text-su-orange-dark">{'{schemaId}'}</span>/item/<span class="text-su-orange-dark">{'{itemId}'}</span>.json
             </p>
           </div>
@@ -185,10 +185,10 @@ console.log(chassis[0].name) // "Iron Mongrel"`}</code></pre>
           <table class="w-full text-sm">
             <thead>
               <tr class="border-b-2 border-wk-faint bg-ink text-paper">
-                <th class="px-4 py-2 text-left font-mono text-xs font-bold uppercase tracking-wide">Schema ID</th>
-                <th class="px-4 py-2 text-left font-mono text-xs font-bold uppercase tracking-wide">Name</th>
-                <th class="px-4 py-2 text-left font-mono text-xs font-bold uppercase tracking-wide hidden sm:table-cell">Description</th>
-                <th class="px-4 py-2 text-right font-mono text-xs font-bold uppercase tracking-wide">Items</th>
+                <th class="px-4 py-2 text-left font-cond text-xs font-bold uppercase tracking-wide">Schema ID</th>
+                <th class="px-4 py-2 text-left font-cond text-xs font-bold uppercase tracking-wide">Name</th>
+                <th class="px-4 py-2 text-left font-cond text-xs font-bold uppercase tracking-wide hidden sm:table-cell">Description</th>
+                <th class="px-4 py-2 text-right font-cond text-xs font-bold uppercase tracking-wide">Items</th>
               </tr>
             </thead>
             <tbody>
@@ -197,14 +197,14 @@ console.log(chassis[0].name) // "Iron Mongrel"`}</code></pre>
                   <td class="px-4 py-2">
                     <a
                       href={`/schema/${schema.id}/`}
-                      class="font-mono text-xs font-bold text-su-orange-dark hover:underline"
+                      class="font-body text-xs font-bold text-su-orange-dark hover:underline"
                     >
                       {schema.id}
                     </a>
                   </td>
                   <td class="px-4 py-2 font-medium">{schema.displayNamePlural}</td>
                   <td class="px-4 py-2 text-ink-2 hidden sm:table-cell">{schema.description}</td>
-                  <td class="px-4 py-2 text-right font-mono">{schema.itemCount}</td>
+                  <td class="px-4 py-2 text-right font-body">{schema.itemCount}</td>
                 </tr>
               ))}
             </tbody>

--- a/apps/srd/src/pages/discord.astro
+++ b/apps/srd/src/pages/discord.astro
@@ -70,7 +70,7 @@ const breadcrumbs = [
 
         <div class="rounded-panel border-2 border-wk-faint bg-paper">
           <div class="border-b-2 border-wk-faint px-5 py-3">
-            <p class="mt-1 font-mono text-base font-bold">
+            <p class="mt-1 font-body text-base font-bold">
               /su roll <span class="text-su-orange-dark">[table]</span>
             </p>
           </div>
@@ -106,14 +106,14 @@ const breadcrumbs = [
 
         <div class="rounded-panel border-2 border-wk-faint bg-paper">
           <div class="border-b-2 border-wk-faint px-5 py-3">
-            <p class="mt-1 font-mono text-base font-bold">
+            <p class="mt-1 font-body text-base font-bold">
               /su lookup <span class="text-su-orange-dark">entity</span>
             </p>
           </div>
           <div class="flex flex-col gap-3 px-5 py-4 text-sm leading-relaxed">
             <p>
               Looks up any entity in the reference — the same search as this site&rsquo;s
-              <kbd class="rounded-card border border-wk-faint bg-su-blue-pale px-1.5 py-0.5 font-mono text-xs"
+              <kbd class="rounded-card border border-wk-faint bg-su-blue-pale px-1.5 py-0.5 font-body text-xs"
                 >Cmd&nbsp;K</kbd
               > box. Autocomplete searches as you type (multi-word queries and small typos are fine);
               the reply shows the entity&rsquo;s key stats and links to its full page here.

--- a/apps/srd/src/styles/global.css
+++ b/apps/srd/src/styles/global.css
@@ -326,7 +326,7 @@
 body {
   background-color: var(--background);
   color: var(--foreground);
-  font-family: var(--font-mono);
+  font-family: var(--font-body);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/packages/component-lib/src/components/base/Text.tsx
+++ b/packages/component-lib/src/components/base/Text.tsx
@@ -5,7 +5,7 @@ import { cn } from '../../utils/cn'
 const textVariants = cva('', {
   variants: {
     variant: {
-      default: 'font-mono text-[var(--foreground)]',
+      default: 'font-body text-[var(--foreground)]',
       pseudoheader:
         'block w-fit self-start bg-ink text-paper px-1 py-0.5 font-cond font-bold uppercase leading-tight tracking-caps-tight',
       pseudoheaderInverse:

--- a/packages/component-lib/src/components/chrome/Callout.stories.tsx
+++ b/packages/component-lib/src/components/chrome/Callout.stories.tsx
@@ -42,7 +42,7 @@ const Body = ({ children }: { children: string }) => (
 export const Default: Story = () => (
   <div className="flex max-w-xl flex-col gap-6">
     <div className="flex flex-col gap-1.5">
-      <p className="font-mono text-xs text-wk-muted">Body-only bullets (mech accent)</p>
+      <p className="font-body text-xs text-wk-muted">Body-only bullets (mech accent)</p>
       {settlements.map((b, i) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: static SRD list, order-stable
         <Callout key={i} accent={MECH}>
@@ -53,7 +53,7 @@ export const Default: Story = () => (
 
     {labelled && (
       <div className="flex flex-col gap-1.5">
-        <p className="font-mono text-xs text-wk-muted">Labelled (crawler accent + tint)</p>
+        <p className="font-body text-xs text-wk-muted">Labelled (crawler accent + tint)</p>
         <Callout
           label={String(labelled.label)}
           accent={CRAWLER}
@@ -65,7 +65,7 @@ export const Default: Story = () => (
     )}
 
     <div className="flex flex-col gap-1.5">
-      <p className="font-mono text-xs text-wk-muted">When Damaged (status-bad accent)</p>
+      <p className="font-body text-xs text-wk-muted">When Damaged (status-bad accent)</p>
       <Callout
         label="When Damaged"
         accent={DAMAGED}
@@ -76,7 +76,7 @@ export const Default: Story = () => (
     </div>
 
     <div className="flex flex-col gap-1.5">
-      <p className="font-mono text-xs text-wk-muted">Compact</p>
+      <p className="font-body text-xs text-wk-muted">Compact</p>
       <Callout compact accent={MECH}>
         <Body>
           {String(settlements[0]?.value ?? 'Corporate Arcos typically have a Tech Level of 5-6.')}

--- a/packages/component-lib/src/components/chrome/InlineRef.stories.tsx
+++ b/packages/component-lib/src/components/chrome/InlineRef.stories.tsx
@@ -20,7 +20,7 @@ const systemHref = `/systems/${systemSlug}`
 /** Resolved vs unresolved references, in prose and standalone — on one page. */
 export const Default: Story = () => (
   <div className="flex flex-col gap-5 bg-paper p-5 text-ink">
-    <p className="max-w-2xl font-mono text-xs leading-relaxed text-ink-2">
+    <p className="max-w-2xl font-body text-xs leading-relaxed text-ink-2">
       An in-prose entity reference: resolved (rust border, a real keyboard-reachable link) or
       unresolved (ink dashed border, inert — only summons a tooltip).
     </p>
@@ -38,11 +38,11 @@ export const Default: Story = () => (
         <InlineRef resolved href={systemHref} title={systemName}>
           {systemName}
         </InlineRef>
-        <code className="font-mono text-nano text-ink-2">resolved</code>
+        <code className="font-body text-nano text-ink-2">resolved</code>
       </div>
       <div className="flex flex-col gap-1.5">
         <InlineRef title="No such entity">Phantom System</InlineRef>
-        <code className="font-mono text-nano text-ink-2">unresolved</code>
+        <code className="font-body text-nano text-ink-2">unresolved</code>
       </div>
     </div>
   </div>

--- a/packages/component-lib/src/components/referenceEntity/Content.stories.tsx
+++ b/packages/component-lib/src/components/referenceEntity/Content.stories.tsx
@@ -34,7 +34,7 @@ function Row({
   return (
     <div className="flex flex-col gap-1.5">
       <div className={`${width} bg-paper p-3`}>{children}</div>
-      <code className="font-mono text-nano text-ink-2">{label}</code>
+      <code className="font-body text-nano text-ink-2">{label}</code>
     </div>
   )
 }
@@ -42,7 +42,7 @@ function Row({
 /** Every content-block type — headings, paragraphs, list-items, hints, labels. */
 export const Default: Story = () => (
   <div className="flex flex-col gap-6 bg-paper p-5 text-ink">
-    <p className="max-w-2xl font-mono text-xs leading-relaxed text-ink-2">
+    <p className="max-w-2xl font-body text-xs leading-relaxed text-ink-2">
       Renders a content-block array: headings, paragraphs, list-items, hints, and EFFECT/ON-CRITICAL
       labels. compact tightens spacing.
     </p>

--- a/packages/component-lib/src/components/referenceEntity/EntityTooltip.stories.tsx
+++ b/packages/component-lib/src/components/referenceEntity/EntityTooltip.stories.tsx
@@ -15,7 +15,7 @@ const trait = SalvageUnionReference.Traits.all()[0]
 /** Entity hovercards over different triggers — pseudoheader, a stat, a trait. */
 export const Default: Story = () => (
   <div className="flex flex-col gap-6 bg-paper p-8 text-ink">
-    <p className="max-w-2xl font-mono text-xs leading-relaxed text-ink-2">
+    <p className="max-w-2xl font-body text-xs leading-relaxed text-ink-2">
       Wrap any trigger to summon a dense entity hovercard (schemaName + entityId). Hover each below.
     </p>
     <div className="flex flex-wrap items-start gap-8">

--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityActions.stories.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityActions.stories.tsx
@@ -108,12 +108,12 @@ const RULES = [
 function HeaderNote(): ReactNode {
   return (
     <div className="flex flex-col gap-1 border-b-2 border-ink pb-3">
-      <code className="font-mono text-caption font-bold text-ink">
+      <code className="font-body text-caption font-bold text-ink">
         Actions = the card in action mode; these are the rendering rules.
       </code>
       <ul className="flex flex-col gap-0.5">
         {RULES.map((rule) => (
-          <li key={rule} className="font-mono text-nano text-ink-2">
+          <li key={rule} className="font-body text-nano text-ink-2">
             · {rule}
           </li>
         ))}
@@ -126,7 +126,7 @@ function HeaderNote(): ReactNode {
 function ActionSpecCard({ spec }: { spec: ActionSpec }): ReactNode {
   return (
     <div className="flex flex-col gap-1.5">
-      <code className="font-mono text-nano text-ink-2">{spec.parentLabel}</code>
+      <code className="font-body text-nano text-ink-2">{spec.parentLabel}</code>
       <ReferenceEntityCard
         data={spec.action as unknown as SURefEntity}
         hostTone={parentToneBase(spec.parent)}
@@ -177,12 +177,12 @@ export const Spec: Story = () => (
  */
 export const Badge: Story = () => (
   <div className="flex flex-col items-start gap-3 bg-paper p-4">
-    <code className="font-mono text-caption font-bold text-ink">
+    <code className="font-body text-caption font-bold text-ink">
       Action badge = name · Cost · type · Damage · range (name always leads)
     </code>
     {SPECS.map((spec) => (
       <div key={spec.parentLabel} className="flex flex-col items-start gap-1.5">
-        <code className="font-mono text-nano text-ink-2">{spec.parentLabel}</code>
+        <code className="font-body text-nano text-ink-2">{spec.parentLabel}</code>
         <ReferenceEntityCard
           data={spec.action as unknown as SURefEntity}
           hostTone={parentToneBase(spec.parent)}

--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.stories.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.stories.tsx
@@ -118,7 +118,7 @@ export const Catalog: Story = () => (
  */
 export const PatternCard: Story = () => (
   <div className="flex flex-col gap-4 bg-paper p-4">
-    <code className="font-mono text-nano text-ink-2">
+    <code className="font-body text-nano text-ink-2">
       {chassis.name} · {surveyorPattern.name}
     </code>
     <ReferenceEntityCard data={chassis} pattern={surveyorPattern} />

--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityWriteLayer.stories.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityWriteLayer.stories.tsx
@@ -58,11 +58,11 @@ function TwoUp({ readOnly, editable }: { readOnly: ReactNode; editable: ReactNod
   return (
     <div className="flex flex-col gap-6 bg-paper p-4">
       <div className="flex flex-col gap-1.5">
-        <code className="font-mono text-nano text-ink-2">read-only</code>
+        <code className="font-body text-nano text-ink-2">read-only</code>
         {readOnly}
       </div>
       <div className="flex flex-col gap-1.5">
-        <code className="font-mono text-nano text-ink-2">editable</code>
+        <code className="font-body text-nano text-ink-2">editable</code>
         {editable}
       </div>
     </div>

--- a/packages/component-lib/src/components/referenceEntity/choiceCard/ChoiceGroups.stories.tsx
+++ b/packages/component-lib/src/components/referenceEntity/choiceCard/ChoiceGroups.stories.tsx
@@ -48,7 +48,7 @@ function Row({
   return (
     <div className="flex flex-col gap-1.5">
       <div className={width}>{children}</div>
-      <code className="font-mono text-nano text-ink-2">{label}</code>
+      <code className="font-body text-nano text-ink-2">{label}</code>
     </div>
   )
 }
@@ -56,7 +56,7 @@ function Row({
 /** Each choice type × its states — exclusive, multi-select (capped), free-text. */
 export const Types: Story = () => (
   <div className="flex flex-col gap-6 bg-paper p-5 text-ink">
-    <p className="max-w-2xl font-mono text-xs leading-relaxed text-ink-2">
+    <p className="max-w-2xl font-body text-xs leading-relaxed text-ink-2">
       Exclusive (single-select), multi-select (with a scalesWithField cap counter), and free-text
       choices — unselected vs a pre-seeded controlled selection.
     </p>
@@ -100,7 +100,7 @@ export const Types: Story = () => (
 /** All choice types together on one granted card — full and compact. */
 export const Composed: Story = () => (
   <div className="flex flex-col gap-6 bg-paper p-5 text-ink">
-    <p className="max-w-2xl font-mono text-xs leading-relaxed text-ink-2">
+    <p className="max-w-2xl font-body text-xs leading-relaxed text-ink-2">
       Multiple choices as they render on a real granted-equipment card; compact tightens for
       listings.
     </p>

--- a/packages/component-lib/src/components/referenceEntity/choiceCard/ChoiceGroups.tsx
+++ b/packages/component-lib/src/components/referenceEntity/choiceCard/ChoiceGroups.tsx
@@ -263,7 +263,7 @@ function ChoiceOptionGroup({
   const options = getChoiceCardOptions(choice)
   return (
     <div style={toneVar}>
-      {counter && !readOnly && <div className="mb-1 font-mono text-nano text-ink-2">{counter}</div>}
+      {counter && !readOnly && <div className="mb-1 font-body text-nano text-ink-2">{counter}</div>}
       <div className={cn('gap-1.5', compact ? 'columns-1' : 'columns-1 sm:columns-2')}>
         {options.map((option) => (
           <div key={option.value} className="mb-1.5 break-inside-avoid pt-2.5">

--- a/packages/component-lib/src/components/shared/ActivationCostBox.stories.tsx
+++ b/packages/component-lib/src/components/shared/ActivationCostBox.stories.tsx
@@ -19,7 +19,7 @@ function Cell({ label, children }: { label: string; children: ReactNode }) {
 
 /** Every currency × cost at a glance — the AP / EP / Variable activation costs. */
 export const Default: Story = () => (
-  <div className="flex flex-col gap-4 bg-paper p-5 font-mono text-ink">
+  <div className="flex flex-col gap-4 bg-paper p-5 font-body text-ink">
     <p className="max-w-2xl text-xs leading-relaxed text-ink-2">
       The activation-cost pennant. currency is AP or EP; a non-numeric cost (Variable) renders as X.
       compact tightens it for rails and listings.

--- a/packages/component-lib/src/components/shared/CardImage.tsx
+++ b/packages/component-lib/src/components/shared/CardImage.tsx
@@ -19,9 +19,9 @@ type CardImageProps = {
 }
 
 const TAG_SM =
-  'inline-flex items-center gap-1 border border-ink bg-paper px-1 py-0 font-mono text-xs font-bold uppercase leading-none text-ink transition-opacity hover:opacity-80'
+  'inline-flex items-center gap-1 border border-ink bg-paper px-1 py-0 font-cond text-xs font-bold uppercase leading-none text-ink transition-opacity hover:opacity-80'
 const TAG_SM_DANGER =
-  'inline-flex items-center gap-1 border border-ink bg-su-rust px-1 py-0 font-mono text-xs font-bold uppercase leading-none text-paper transition-opacity hover:opacity-80'
+  'inline-flex items-center gap-1 border border-ink bg-su-rust px-1 py-0 font-cond text-xs font-bold uppercase leading-none text-paper transition-opacity hover:opacity-80'
 
 export function CardImage({ url, alt, compact, editable, width, height }: CardImageProps) {
   const [showImage, setShowImage] = useState(true)

--- a/packages/component-lib/src/components/shared/ControlButtons.tsx
+++ b/packages/component-lib/src/components/shared/ControlButtons.tsx
@@ -77,7 +77,7 @@ function ControlButton({
       <a
         href={control.href}
         aria-label={control.ariaLabel}
-        className="inline-flex shrink-0 items-center whitespace-nowrap rounded-card border border-ink bg-paper px-2 py-1 font-mono text-xs font-bold uppercase tracking-tight text-ink no-underline transition-colors hover:bg-ink hover:text-paper"
+        className="inline-flex shrink-0 items-center whitespace-nowrap rounded-card border border-ink bg-paper px-2 py-1 font-cond text-xs font-bold uppercase tracking-tight text-ink no-underline transition-colors hover:bg-ink hover:text-paper"
       >
         {control.label ?? control.ariaLabel}
       </a>
@@ -89,7 +89,7 @@ function ControlButton({
   const onClick = control.onClick ?? (() => {})
 
   const segmentClasses = cn(
-    'px-1 font-mono font-bold uppercase tracking-tight',
+    'px-1 font-cond font-bold uppercase tracking-tight',
     compact ? 'text-label' : 'text-xs'
   )
 

--- a/packages/component-lib/src/components/shared/DisplayCard.stories.tsx
+++ b/packages/component-lib/src/components/shared/DisplayCard.stories.tsx
@@ -47,7 +47,7 @@ const genericFootMeta: CardFootMeta[] = [
 
 function Gallery({ rule, children }: { rule: string; children: ReactNode }) {
   return (
-    <div className="flex flex-col gap-4 bg-paper p-5 font-mono text-ink">
+    <div className="flex flex-col gap-4 bg-paper p-5 font-body text-ink">
       <p className="max-w-2xl text-xs leading-relaxed text-ink-2">{rule}</p>
       <div className="flex flex-wrap items-start gap-6">{children}</div>
     </div>

--- a/packages/component-lib/src/components/shared/DisplayCard.tsx
+++ b/packages/component-lib/src/components/shared/DisplayCard.tsx
@@ -437,7 +437,7 @@ export function DisplayCard({
               const afterTabs = tabs.filter((t) => !t.before)
 
               const tabBaseClass =
-                'min-w-0 basis-1/3 grow shrink-0 md:basis-0 md:shrink cursor-pointer px-3 py-1.5 font-mono text-xs font-bold uppercase tracking-wide transition-colors'
+                'min-w-0 basis-1/3 grow shrink-0 md:basis-0 md:shrink cursor-pointer px-3 py-1.5 font-cond text-xs font-bold uppercase tracking-wide transition-colors'
 
               const renderTabButton = (tab: DisplayCardTab) => {
                 const isActive = resolvedTabKey === tab.key

--- a/packages/component-lib/src/components/shared/EntityGrid.stories.tsx
+++ b/packages/component-lib/src/components/shared/EntityGrid.stories.tsx
@@ -30,7 +30,7 @@ const body = (
 
 function Gallery({ rule, children }: { rule: string; children: ReactNode }) {
   return (
-    <div className="flex flex-col gap-5 bg-paper p-5 font-mono text-ink">
+    <div className="flex flex-col gap-5 bg-paper p-5 font-body text-ink">
       <p className="max-w-2xl text-xs leading-relaxed text-ink-2">{rule}</p>
       {children}
     </div>

--- a/packages/component-lib/src/components/shared/FilterChip.tsx
+++ b/packages/component-lib/src/components/shared/FilterChip.tsx
@@ -15,7 +15,7 @@ export function FilterChip({ label, active, onClick, colorClass, swatchStyle }: 
   // On the shared chrome token system (ink / paper / rust), matching
   // Button / Sel / StepButton — active = ink fill, inactive = paper.
   const base =
-    'cursor-pointer rounded-badge px-2 py-0.5 font-mono text-xs font-semibold uppercase transition-colors'
+    'cursor-pointer rounded-badge px-2 py-0.5 font-cond text-xs font-semibold uppercase transition-colors'
 
   // When a swatch is shown, use tlchip layout: flex row, font-cond label, bordered swatch
   const swatchBase =

--- a/packages/component-lib/src/components/shared/FilterRow.tsx
+++ b/packages/component-lib/src/components/shared/FilterRow.tsx
@@ -9,7 +9,7 @@ type FilterRowProps = {
 export function FilterRow({ label, children, gap = 'gap-1' }: FilterRowProps) {
   return (
     <div className="flex flex-col items-center gap-1 sm:flex-row sm:items-center">
-      <span className="font-mono text-label font-bold uppercase tracking-caps-snug text-ink/40 sm:w-[4.5rem] sm:shrink-0 sm:text-right">
+      <span className="font-cond text-label font-bold uppercase tracking-caps-snug text-ink/40 sm:w-[4.5rem] sm:shrink-0 sm:text-right">
         {label}
       </span>
       <div className={`flex flex-wrap justify-center ${gap} sm:justify-start`}>{children}</div>

--- a/packages/component-lib/src/components/shared/Inset.stories.tsx
+++ b/packages/component-lib/src/components/shared/Inset.stories.tsx
@@ -20,7 +20,7 @@ const crawlerName = SalvageUnionReference.Crawlers.all()[0]?.name ?? 'Union Craw
 // Inset the way ITUN actually mounts it — inside a parent card's expand slot.
 function Stage({ rule, children }: { rule: string; children: ReactNode }) {
   return (
-    <div className="flex flex-col gap-4 bg-wk-bg p-5 font-mono text-ink">
+    <div className="flex flex-col gap-4 bg-wk-bg p-5 font-body text-ink">
       <p className="max-w-2xl text-xs leading-relaxed text-ink-2">{rule}</p>
       <div className="max-w-md">{children}</div>
     </div>

--- a/packages/component-lib/src/components/shared/ModalShell.stories.tsx
+++ b/packages/component-lib/src/components/shared/ModalShell.stories.tsx
@@ -34,7 +34,7 @@ function Trigger({ headerBg, label }: { headerBg?: string; label: string }) {
           </Text>
         </div>
       </ModalShell>
-      <code className="font-mono text-nano text-ink-2">
+      <code className="font-body text-nano text-ink-2">
         {headerBg ? headerBg : 'default header'}
       </code>
     </div>
@@ -44,7 +44,7 @@ function Trigger({ headerBg, label }: { headerBg?: string; label: string }) {
 /** The dialog shell — default vs rust header. Click a trigger; Esc / backdrop / × close it. */
 export const Default: Story = () => (
   <div className="flex flex-col gap-4 bg-paper p-5 text-ink">
-    <p className="max-w-2xl font-mono text-xs leading-relaxed text-ink-2">
+    <p className="max-w-2xl font-body text-xs leading-relaxed text-ink-2">
       A centered dialog on the DisplayCard shell. headerBg tones the header (bg-su-rust uses the
       light close button). Modals overlay, so open one to see it.
     </p>

--- a/packages/component-lib/src/components/shared/NavDrawer.stories.tsx
+++ b/packages/component-lib/src/components/shared/NavDrawer.stories.tsx
@@ -8,7 +8,7 @@ export default {
 }
 
 const SrdBrand = () => (
-  <span className="inline-flex shrink-0 border border-ink font-mono text-xl font-bold uppercase leading-none tracking-tight">
+  <span className="inline-flex shrink-0 border border-ink font-cond text-xl font-bold uppercase leading-none tracking-tight">
     <span className="bg-ink px-1 py-0.5 text-paper">Salvage Union</span>
     <span className="bg-paper px-1 py-0.5 text-ink">SRD</span>
   </span>

--- a/packages/component-lib/src/components/shared/NavDrawer.tsx
+++ b/packages/component-lib/src/components/shared/NavDrawer.tsx
@@ -133,7 +133,7 @@ export function NavDrawer({
             {categories?.map((cat) => (
               <div key={cat.label} className="mb-2 flex flex-col gap-2">
                 <div className="flex items-center gap-3">
-                  <span className="bg-ink px-1 font-mono font-bold uppercase leading-none tracking-tight text-paper">
+                  <span className="bg-ink px-1 font-cond font-bold uppercase leading-none tracking-tight text-paper">
                     {cat.label}
                   </span>
                 </div>

--- a/packages/component-lib/src/components/shared/RollTable.stories.tsx
+++ b/packages/component-lib/src/components/shared/RollTable.stories.tsx
@@ -25,7 +25,7 @@ function Row({
   return (
     <div className="flex flex-col gap-1.5">
       <div className={width}>{children}</div>
-      <code className="font-mono text-nano text-ink-2">{label}</code>
+      <code className="font-body text-nano text-ink-2">{label}</code>
     </div>
   )
 }
@@ -34,7 +34,7 @@ function Row({
 export const Default: Story = () =>
   table ? (
     <div className="flex flex-col gap-6 bg-paper p-5 text-ink">
-      <p className="max-w-2xl font-mono text-xs leading-relaxed text-ink-2">
+      <p className="max-w-2xl font-body text-xs leading-relaxed text-ink-2">
         The banded d20 roll table. showCommand adds the rust Roll control + command name; compact
         tightens for rails/tooltips; disabled suppresses the Roll action (Reference surface).
       </p>

--- a/packages/component-lib/src/components/shared/SearchField.tsx
+++ b/packages/component-lib/src/components/shared/SearchField.tsx
@@ -30,7 +30,7 @@ export const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(functi
   return (
     <div
       className={cn(
-        'flex items-center gap-2 rounded border border-ink bg-paper px-3 py-[7px] font-mono text-[13px] text-ink-2 focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-su-orange',
+        'flex items-center gap-2 rounded border border-ink bg-paper px-3 py-[7px] font-body text-[13px] text-ink-2 focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-su-orange',
         containerClassName
       )}
     >

--- a/packages/component-lib/src/components/shared/Sheet.stories.tsx
+++ b/packages/component-lib/src/components/shared/Sheet.stories.tsx
@@ -18,7 +18,7 @@ const tl = chassis?.techLevel ?? 1
 
 /** The label-over-value sheet field, across its prop variants. */
 export const Fields: Story = () => (
-  <div className="flex flex-col gap-4 bg-paper p-5 font-mono text-ink">
+  <div className="flex flex-col gap-4 bg-paper p-5 font-body text-ink">
     <p className="max-w-2xl text-xs leading-relaxed text-ink-2">
       A labelled sheet field (label + value, or label + children). compact tightens spacing;
       labelColor overrides the label ink.

--- a/packages/component-lib/src/components/shared/Stat.stories.tsx
+++ b/packages/component-lib/src/components/shared/Stat.stories.tsx
@@ -37,7 +37,7 @@ function Cell({ label, children }: { label: string; children: ReactNode }) {
 
 function Gallery({ rule, children }: { rule: string; children: ReactNode }) {
   return (
-    <div className="flex flex-col gap-4 bg-paper p-5 font-mono text-ink">
+    <div className="flex flex-col gap-4 bg-paper p-5 font-body text-ink">
       <p className="max-w-2xl text-xs leading-relaxed text-ink-2">{rule}</p>
       <div className="flex flex-wrap items-start gap-x-6 gap-y-5">{children}</div>
     </div>

--- a/packages/component-lib/src/components/shared/Stat.tsx
+++ b/packages/component-lib/src/components/shared/Stat.tsx
@@ -281,7 +281,7 @@ function HorizontalValue({
   const btnResting = inverse ? 'border-paper bg-ink text-paper' : 'border-ink bg-paper text-ink'
   const btnHover = inverse ? 'hover:bg-paper hover:text-ink' : 'hover:bg-ink hover:text-paper'
   const btnBase =
-    'flex min-h-11 items-center justify-center rounded-badge border border-ink font-mono font-bold leading-none transition-colors sm:min-h-0'
+    'flex min-h-11 items-center justify-center rounded-badge border border-ink font-body font-bold leading-none transition-colors sm:min-h-0'
 
   return (
     <span className="inline-flex w-fit items-stretch gap-0.5">
@@ -534,7 +534,7 @@ function ValueBox({
               onChange?.(max !== undefined ? Math.min(max, numericValue + 1) : numericValue + 1)
             }
             disabled={!!atMax}
-            className={`flex min-h-11 min-w-11 items-center justify-center rounded-badge border-chrome font-mono font-bold leading-none transition-colors sm:min-h-0 sm:min-w-0 ${btnSize} ${btnResting} ${
+            className={`flex min-h-11 min-w-11 items-center justify-center rounded-badge border-chrome font-body font-bold leading-none transition-colors sm:min-h-0 sm:min-w-0 ${btnSize} ${btnResting} ${
               atMax ? 'cursor-not-allowed opacity-30' : `cursor-pointer ${btnHover}`
             }`}
           >
@@ -545,7 +545,7 @@ function ValueBox({
             aria-label={`Decrease ${label}`}
             onClick={() => onChange?.(Math.max(min, numericValue - 1))}
             disabled={atMin}
-            className={`flex min-h-11 min-w-11 items-center justify-center rounded-badge border-chrome font-mono font-bold leading-none transition-colors sm:min-h-0 sm:min-w-0 ${btnSize} ${btnResting} ${
+            className={`flex min-h-11 min-w-11 items-center justify-center rounded-badge border-chrome font-body font-bold leading-none transition-colors sm:min-h-0 sm:min-w-0 ${btnSize} ${btnResting} ${
               atMin ? 'cursor-not-allowed opacity-30' : `cursor-pointer ${btnHover}`
             }`}
           >

--- a/packages/component-lib/src/components/shared/StaticEntityContent.tsx
+++ b/packages/component-lib/src/components/shared/StaticEntityContent.tsx
@@ -33,7 +33,7 @@ export function StaticEntityContent({ summary, resolveTraitHref }: StaticEntityC
         <dl className="mb-3 grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
           {summary.stats.map(({ label, value }) => (
             <Fragment key={label}>
-              <dt className="font-mono font-bold uppercase">{label}</dt>
+              <dt className="font-cond font-bold uppercase">{label}</dt>
               <dd>{value}</dd>
             </Fragment>
           ))}
@@ -50,7 +50,7 @@ export function StaticEntityContent({ summary, resolveTraitHref }: StaticEntityC
 
       {summary.traits.length > 0 && (
         <p className="mb-3">
-          <span className="font-mono font-bold uppercase">Traits:</span>{' '}
+          <span className="font-cond font-bold uppercase">Traits:</span>{' '}
           {summary.traits.map((t, i) => {
             const href = resolveTraitHref?.(t) ?? null
             return (

--- a/packages/component-lib/src/components/shared/__tests__/FilterRow.test.tsx
+++ b/packages/component-lib/src/components/shared/__tests__/FilterRow.test.tsx
@@ -53,7 +53,9 @@ describe('FilterRow', () => {
     )
     const label = container.querySelector('span')
     expect(label).toBeTruthy()
-    expect(label?.className).toContain('font-mono')
+    // An uppercase caps label rides the CONDENSED face (font-cond), not the
+    // body face — it used to sit on the retired `font-mono` alias.
+    expect(label?.className).toContain('font-cond')
     expect(label?.className).toContain('uppercase')
   })
 })

--- a/packages/component-lib/src/components/skeleton/CardSkeleton.stories.tsx
+++ b/packages/component-lib/src/components/skeleton/CardSkeleton.stories.tsx
@@ -9,17 +9,17 @@ export default {
 /** The card loading placeholder — full, compact, and a stacked list. */
 export const Default: Story = () => (
   <div className="flex flex-col gap-6 bg-paper p-5 text-ink">
-    <p className="max-w-2xl font-mono text-xs leading-relaxed text-ink-2">
+    <p className="max-w-2xl font-body text-xs leading-relaxed text-ink-2">
       The reference-entity card skeleton, shown at full and compact density and as a loading list.
     </p>
     <div className="flex flex-wrap items-start gap-6">
       <div className="flex w-[380px] flex-col gap-1.5">
         <CardSkeleton />
-        <code className="font-mono text-nano text-ink-2">default</code>
+        <code className="font-body text-nano text-ink-2">default</code>
       </div>
       <div className="flex w-[300px] flex-col gap-1.5">
         <CardSkeleton compact />
-        <code className="font-mono text-nano text-ink-2">compact</code>
+        <code className="font-body text-nano text-ink-2">compact</code>
       </div>
       <div className="flex w-[380px] flex-col gap-1.5">
         <div className="flex flex-col gap-3">
@@ -27,7 +27,7 @@ export const Default: Story = () => (
           <CardSkeleton />
           <CardSkeleton />
         </div>
-        <code className="font-mono text-nano text-ink-2">list</code>
+        <code className="font-body text-nano text-ink-2">list</code>
       </div>
     </div>
   </div>

--- a/packages/component-lib/src/components/stat/VitalGauge.stories.tsx
+++ b/packages/component-lib/src/components/stat/VitalGauge.stories.tsx
@@ -29,7 +29,7 @@ function Row({ label, skin, children }: { label: string; skin: string; children:
 
 /** Every VitalGauge variant on one page — read-only through overridden-max. */
 export const Default: Story = () => (
-  <div className="flex flex-col gap-5 bg-paper p-5 font-mono text-ink">
+  <div className="flex flex-col gap-5 bg-paper p-5 font-body text-ink">
     <p className="max-w-2xl text-xs leading-relaxed text-ink-2">
       The segmented current/max gauge. readOnly is a static read-out; onChange makes segments
       click-to-set; dense auto-engages at max ≥ 12; danger redlines from a segment index; caption /
@@ -89,7 +89,7 @@ export const Default: Story = () => (
  *  `surface="sheet"` (light, default) and `surface="instrument"` (dark ground):
  *  the same primitive the dashboard now renders in place of its bespoke gauge. */
 export const Compact: Story = () => (
-  <div className="flex flex-col gap-5 bg-paper p-5 font-mono text-ink">
+  <div className="flex flex-col gap-5 bg-paper p-5 font-body text-ink">
     <p className="max-w-2xl text-xs leading-relaxed text-ink-2">
       The single-row compact gauge: label, one segment row, and value/max on one line — no big
       numeral, caption, or multi-row split. Filled segments use the sheet's <code>--tone</code>, and

--- a/packages/component-lib/src/components/ui/toaster.tsx
+++ b/packages/component-lib/src/components/ui/toaster.tsx
@@ -11,7 +11,7 @@ export function Toaster() {
           background: 'rgb(40, 32, 25)',
           border: '1px solid rgb(80, 80, 80)',
           color: 'rgb(255, 255, 255)',
-          fontFamily: "var(--font-mono, 'Barlow', system-ui, sans-serif)",
+          fontFamily: "var(--font-body, 'Barlow', system-ui, sans-serif)",
           fontSize: '0.8125rem',
         },
         classNames: {

--- a/packages/component-lib/src/components/ui/tooltip.stories.tsx
+++ b/packages/component-lib/src/components/ui/tooltip.stories.tsx
@@ -11,7 +11,7 @@ const trigger = 'rounded-card bg-ink px-4 py-2 font-cond uppercase tracking-caps
 /** Sides, rich content, and delay — every Tooltip mode on one page (hover each). */
 export const Default: Story = () => (
   <div className="flex flex-col gap-6 bg-paper p-8 text-ink">
-    <p className="max-w-2xl font-mono text-xs leading-relaxed text-ink-2">
+    <p className="max-w-2xl font-body text-xs leading-relaxed text-ink-2">
       Hover a trigger. side positions the tip (top / right / bottom / left); content accepts rich
       nodes; delayDuration tunes the open delay.
     </p>

--- a/packages/component-lib/src/stories/RenderingMatrix.stories.tsx
+++ b/packages/component-lib/src/stories/RenderingMatrix.stories.tsx
@@ -144,7 +144,7 @@ const rows: MatrixRow[] = [
 ]
 
 export const Default: Story = () => (
-  <div className="bg-paper p-6 font-mono text-ink">
+  <div className="bg-paper p-6 font-body text-ink">
     <Badge shape="stamp" size="lg" as="span">
       Rendering Matrix
     </Badge>

--- a/packages/component-lib/src/stories/Typography.stories.tsx
+++ b/packages/component-lib/src/stories/Typography.stories.tsx
@@ -76,25 +76,19 @@ const SCALE: { cls: string; token: string; px: string; use: string }[] = [
   },
 ]
 
-/** The three families (theme.css `--font-*`). */
+/** The two faces (theme.css `--font-*`). */
 const FONTS: { cls: string; token: string; name: string; use: string }[] = [
   {
     cls: 'font-body',
     token: '--font-body',
     name: 'Barlow',
-    use: 'body copy, values, default running text (the preferred alias)',
+    use: 'body copy, values, default running text',
   },
   {
     cls: 'font-cond',
     token: '--font-cond',
     name: 'Barlow Semi Condensed',
     use: 'stamps, labels, titles, tabs — all-caps chrome',
-  },
-  {
-    cls: 'font-mono',
-    token: '--font-mono',
-    name: 'Barlow (legacy alias — NOT monospace)',
-    use: 'existing usage only; new code uses font-body',
   },
 ]
 
@@ -218,11 +212,11 @@ export const Scale: Story = () => (
   </Section>
 )
 
-/** The three font families. */
+/** The two font families. */
 export const Fonts: Story = () => (
   <Section
     title="Font families"
-    blurb="Two faces: Barlow (body/values) and Barlow Semi Condensed (all-caps chrome). font-mono is a legacy alias for Barlow — it is NOT monospaced; new code uses font-body."
+    blurb="Two faces, no aliases: Barlow (body/values) and Barlow Semi Condensed (all-caps chrome)."
   >
     {FONTS.map((f) => (
       <Row

--- a/packages/component-lib/src/styles/theme.css
+++ b/packages/component-lib/src/styles/theme.css
@@ -4,9 +4,10 @@
  */
 @theme {
   /* === Typography === */
-  --font-mono: 'Barlow', system-ui, -apple-system, sans-serif;
-  /* Preferred alias for Barlow (it is NOT a monospace — design-spec §1.2).
-     New code should use `font-body`; `--font-mono` stays for existing usage. */
+  /* TWO faces, no aliases: Barlow for body/values, Barlow Semi Condensed for
+     all-caps chrome. (`--font-mono` was a legacy alias for Barlow — misleadingly
+     named, since it is NOT a monospace — and is now retired; every reference
+     moved to `font-body` or, for caps labels, `font-cond`.) */
   --font-body: 'Barlow', system-ui, -apple-system, sans-serif;
   --font-cond: 'Barlow Semi Condensed', 'Barlow', system-ui, -apple-system, sans-serif;
 


### PR DESCRIPTION
`--font-mono` was a legacy alias for Barlow — misleadingly named, since it is **not** a monospace — and the theme itself said new code should use `font-body`. It still had **~98 references**, including the ones setting the *default* body text (`Text`'s default variant, both apps' `body {}`, the toaster).

Migrated every reference **by role**, then deleted the token:

| Role | → | Count |
|---|---|---|
| all-caps chrome (uppercase / caps-tracked) | `font-cond` | 26 |
| everything else | `font-body` | 72 |

The body moves are **visually identical** (both tokens resolve to Barlow). The 26 caps labels genuinely change face — that's the point: they're the "labels on the wrong face" the audit called out, now on the condensed face that exists for exactly that job.

Classification is line-local and deliberately biased safe: anything not clearly uppercase went to `font-body`, which preserves today's appearance. So the failure mode is "a label stays as-is", never "body text gets condensed".

Also: dropped the retired alias from the `Foundations/Typography` specimen (two faces now, not three) and updated the `FilterRow` assertion, which pinned that label to the body face — the component correctly renders `font-cond`.

Green: typecheck (4 workspaces) · full tests · lint · knip · srd build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jp2XjTMVQ3ak7BixETJnEU