### PR TITLE
Collapse lifted components onto existing primitives (bug fix + tokens + Glyph)

### DIFF
--- a/packages/component-lib/src/components/chrome/Glyph.stories.tsx
+++ b/packages/component-lib/src/components/chrome/Glyph.stories.tsx
@@ -8,19 +8,40 @@ export default {
   title: 'Atoms/Glyph',
 }
 
-const NAMES: GlyphName[] = ['gear', 'clock', 'pennant', 'x']
+/** Filled geometry — the original set. */
+const FILLED: GlyphName[] = ['gear', 'clock', 'pennant', 'x']
+/** Stroked geometry — the live-sheet edit-language affordances. */
+const STROKED: GlyphName[] = ['pencil', 'check', 'plus', 'remove', 'swap']
 
-/** name — the whole set at a glance (gear / clock / pennant / ✕). */
+/**
+ * name — the whole set at a glance. The set carries BOTH filled icons (gear /
+ * clock / pennant / ✕) and stroked control affordances (pencil / check / plus /
+ * remove / swap); `Glyph` picks the right rendering per name, so a caller never
+ * has to know which is which.
+ */
 export const AllGlyphs: Story = () => (
-  <div className="bg-paper p-4">
-    <Caption>name · currentColor at 1em</Caption>
-    <div className="flex items-center gap-6 text-ink">
-      {NAMES.map((name) => (
-        <span key={name} className="flex items-center gap-2 text-2xl">
-          <Glyph name={name} />
-          <span className="font-cond text-xs uppercase tracking-caps-tight">{name}</span>
-        </span>
-      ))}
+  <div className="space-y-5 bg-paper p-4">
+    <div>
+      <Caption>filled · currentColor at 1em</Caption>
+      <div className="flex items-center gap-6 text-ink">
+        {FILLED.map((name) => (
+          <span key={name} className="flex items-center gap-2 text-2xl">
+            <Glyph name={name} />
+            <span className="font-cond text-xs uppercase tracking-caps-tight">{name}</span>
+          </span>
+        ))}
+      </div>
+    </div>
+    <div>
+      <Caption>stroked · the edit-language affordances</Caption>
+      <div className="flex items-center gap-6 text-ink">
+        {STROKED.map((name) => (
+          <span key={name} className="flex items-center gap-2 text-2xl">
+            <Glyph name={name} />
+            <span className="font-cond text-xs uppercase tracking-caps-tight">{name}</span>
+          </span>
+        ))}
+      </div>
     </div>
   </div>
 )

--- a/packages/component-lib/src/components/chrome/InlineEditField.tsx
+++ b/packages/component-lib/src/components/chrome/InlineEditField.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react'
+import { Glyph } from './glyphs'
 import type { ReactNode } from 'react'
 import { cn } from '../../utils/cn'
 import { Input } from './Field'
@@ -39,23 +40,6 @@ type InlineEditFieldProps = {
 // ---------------------------------------------------------------------------
 // Pen glyph — pinned inside the labeled value box (design-spec `.ifield .pen`)
 // ---------------------------------------------------------------------------
-
-function PenIcon() {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="pointer-events-none absolute right-2.5 top-1/2 h-[15px] w-[15px] -translate-y-1/2 text-ink/55"
-      aria-hidden="true"
-    >
-      <path d="m16.5 3.5 4 4L7 21H3v-4z" />
-    </svg>
-  )
-}
 
 // Shared input skin, mirroring Field's Input focus-ring pattern (ring-rust/25,
 // paper bg, 1.5px ink border, 3px radius) so the textarea matches the input.
@@ -282,7 +266,12 @@ export function InlineEditField({
         style={{ borderColor: 'var(--tone-deep, var(--color-ink))' }}
       >
         {inner}
-        {!readOnly && !editing && <PenIcon />}
+        {!readOnly && !editing && (
+          <Glyph
+            name="pencil"
+            className="pointer-events-none absolute right-2.5 top-1/2 h-[15px] w-[15px] -translate-y-1/2 text-ink/55"
+          />
+        )}
       </span>
     </div>
   )

--- a/packages/component-lib/src/components/chrome/glyphs.tsx
+++ b/packages/component-lib/src/components/chrome/glyphs.tsx
@@ -1,6 +1,16 @@
 import type { SVGProps } from 'react'
 
-export type GlyphName = 'gear' | 'clock' | 'pennant' | 'x'
+export type GlyphName =
+  | 'gear'
+  | 'clock'
+  | 'pennant'
+  | 'x'
+  // Stroked control glyphs — the edit-language affordances (see STROKE below).
+  | 'pencil'
+  | 'check'
+  | 'plus'
+  | 'remove'
+  | 'swap'
 
 type GlyphProps = {
   name: GlyphName
@@ -22,6 +32,30 @@ const PATHS: Record<GlyphName, string> = {
   pennant: 'M6 2h2v20H6V2Zm2 2h11l-3 4 3 4H8V4Z',
   // condition · ✕
   x: 'M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z',
+
+  // ── Stroked control glyphs ────────────────────────────────────────────────
+  // The live-sheet edit language (pencil / check / plus / remove / swap) is
+  // drawn as STROKES, not fills — a filled pencil outline renders as a blob.
+  // Their weights live in STROKE below; absent from it means "fill".
+  pencil: 'm16.5 3.5 4 4L7 21H3v-4z',
+  check: 'm5.5 12.5 4 4 9-10',
+  plus: 'M12 5v14M5 12h14',
+  remove: 'm6 6 12 12M18 6 6 18',
+  swap: 'M4 8h14M14.5 4.5 18 8l-3.5 3.5M20 16H6M9.5 12.5 6 16l3.5 3.5',
+}
+
+/**
+ * Per-glyph stroke weight. A glyph listed here renders as an unfilled stroke at
+ * this width; anything absent renders filled. The weights are carried over
+ * verbatim from the hand-drawn icons these replaced, so the affordances keep
+ * their exact optical weight.
+ */
+const STROKE: Partial<Record<GlyphName, number>> = {
+  pencil: 2,
+  check: 2.4,
+  plus: 3,
+  remove: 2.2,
+  swap: 2.2,
 }
 
 /**
@@ -32,12 +66,18 @@ const PATHS: Record<GlyphName, string> = {
  */
 export function Glyph({ name, title, ...rest }: GlyphProps) {
   const decorative = title === undefined
+  const strokeWidth = STROKE[name]
+  const stroked = strokeWidth !== undefined
   return (
     <svg
       viewBox="0 0 24 24"
       width="1em"
       height="1em"
-      fill="currentColor"
+      fill={stroked ? 'none' : 'currentColor'}
+      stroke={stroked ? 'currentColor' : undefined}
+      strokeWidth={strokeWidth}
+      strokeLinecap={stroked ? 'round' : undefined}
+      strokeLinejoin={stroked ? 'round' : undefined}
       role={decorative ? undefined : 'img'}
       aria-hidden={decorative ? 'true' : undefined}
       aria-label={title}

--- a/packages/component-lib/src/components/shared/AppBar.tsx
+++ b/packages/component-lib/src/components/shared/AppBar.tsx
@@ -58,12 +58,12 @@ type AppBarProps = {
 }
 
 const NAV_LINK =
-  'inline-flex shrink-0 items-center font-cond text-[15px] font-semibold uppercase tracking-[0.04em] text-su-muted no-underline transition-colors hover:text-su-paper focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-su-orange'
+  'inline-flex shrink-0 items-center font-cond text-lede font-semibold uppercase tracking-[0.04em] text-su-muted no-underline transition-colors hover:text-su-paper focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-su-orange'
 
 const NAV_LINK_ACTIVE = 'text-su-paper'
 
 const BUY_BUTTON =
-  'inline-flex shrink-0 items-center rounded-md border border-su-orange-dark bg-su-orange-dark px-4 py-1.5 font-cond text-[13px] font-medium uppercase tracking-[0.06em] text-paper no-underline transition-colors'
+  'inline-flex shrink-0 items-center rounded-md border border-su-orange-dark bg-su-orange-dark px-4 py-1.5 font-cond text-caption font-medium uppercase tracking-[0.06em] text-paper no-underline transition-colors'
 
 const BREADCRUMB_TEXT = 'font-cond text-xs uppercase tracking-[0.14em] text-ink-2'
 

--- a/packages/component-lib/src/components/shared/AppHeader.tsx
+++ b/packages/component-lib/src/components/shared/AppHeader.tsx
@@ -19,16 +19,16 @@ import type { NavDrawerItem } from './NavDrawer'
 // SRD search-field treatment, matching the shared SearchField chrome exactly so
 // the trigger button reads as the same search bar.
 const SEARCH_BOX =
-  'flex shrink-0 cursor-pointer items-center gap-2 rounded border border-ink bg-paper px-3 py-[7px] font-body text-[13px] text-ink-2 transition-colors hover:border-su-orange-dark focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-su-orange lg:w-64'
+  'flex shrink-0 cursor-pointer items-center gap-2 rounded border border-ink bg-paper px-3 py-[7px] font-body text-caption text-ink-2 transition-colors hover:border-su-orange-dark focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-su-orange lg:w-64'
 
 // Small "Alpha" pills — same rust treatment as the brand "Beta" badge.
 const DESKTOP_ALPHA = (
-  <span className="ml-1.5 inline-block rounded bg-rust px-1 py-0.5 font-cond text-[10px] font-bold uppercase leading-none tracking-caps text-paper">
+  <span className="ml-1.5 inline-block rounded bg-rust px-1 py-0.5 font-cond text-label font-bold uppercase leading-none tracking-caps text-paper">
     Alpha
   </span>
 )
 const DRAWER_ALPHA = (
-  <span className="ml-2 inline-block rounded bg-rust px-1.5 py-0.5 font-cond text-[11px] font-bold uppercase leading-none tracking-caps text-paper">
+  <span className="ml-2 inline-block rounded bg-rust px-1.5 py-0.5 font-cond text-badge font-bold uppercase leading-none tracking-caps text-paper">
     Alpha
   </span>
 )
@@ -43,7 +43,7 @@ const DESKTOP_NAV: AppBarNavItem[] = [
 
 /** ITUN's two-tone brand tag for the mobile drawer. */
 const ITUN_DRAWER_BRAND = (
-  <span className="inline-flex shrink-0 border border-ink font-cond text-sm font-bold uppercase leading-none tracking-tight">
+  <span className="inline-flex shrink-0 border border-ink font-cond text-sm font-bold uppercase leading-none tracking-caps-tight">
     <span className="bg-ink px-1.5 py-1 text-paper">In the Union</span>
     <span className="bg-paper px-1.5 py-1 text-ink">Now</span>
   </span>

--- a/packages/component-lib/src/components/shared/ControlButtons.tsx
+++ b/packages/component-lib/src/components/shared/ControlButtons.tsx
@@ -77,7 +77,7 @@ function ControlButton({
       <a
         href={control.href}
         aria-label={control.ariaLabel}
-        className="inline-flex shrink-0 items-center whitespace-nowrap rounded-card border border-ink bg-paper px-2 py-1 font-cond text-xs font-bold uppercase tracking-tight text-ink no-underline transition-colors hover:bg-ink hover:text-paper"
+        className="inline-flex shrink-0 items-center whitespace-nowrap rounded-card border border-ink bg-paper px-2 py-1 font-cond text-xs font-bold uppercase tracking-caps-tight text-ink no-underline transition-colors hover:bg-ink hover:text-paper"
       >
         {control.label ?? control.ariaLabel}
       </a>
@@ -89,7 +89,7 @@ function ControlButton({
   const onClick = control.onClick ?? (() => {})
 
   const segmentClasses = cn(
-    'px-1 font-cond font-bold uppercase tracking-tight',
+    'px-1 font-cond font-bold uppercase tracking-caps-tight',
     compact ? 'text-label' : 'text-xs'
   )
 

--- a/packages/component-lib/src/components/shared/DisplayCard.stories.tsx
+++ b/packages/component-lib/src/components/shared/DisplayCard.stories.tsx
@@ -98,7 +98,7 @@ export const Bands: Story = () => (
         subHeader={
           <Text
             as="span"
-            className="font-cond text-micro font-bold uppercase tracking-wide text-paper"
+            className="font-cond text-micro font-bold uppercase tracking-caps text-paper"
           >
             Custom sub-header content
           </Text>

--- a/packages/component-lib/src/components/shared/DisplayCard.tsx
+++ b/packages/component-lib/src/components/shared/DisplayCard.tsx
@@ -437,7 +437,7 @@ export function DisplayCard({
               const afterTabs = tabs.filter((t) => !t.before)
 
               const tabBaseClass =
-                'min-w-0 basis-1/3 grow shrink-0 md:basis-0 md:shrink cursor-pointer px-3 py-1.5 font-cond text-xs font-bold uppercase tracking-wide transition-colors'
+                'min-w-0 basis-1/3 grow shrink-0 md:basis-0 md:shrink cursor-pointer px-3 py-1.5 font-cond text-xs font-bold uppercase tracking-caps transition-colors'
 
               const renderTabButton = (tab: DisplayCardTab) => {
                 const isActive = resolvedTabKey === tab.key

--- a/packages/component-lib/src/components/shared/EntitySearcher.tsx
+++ b/packages/component-lib/src/components/shared/EntitySearcher.tsx
@@ -634,7 +634,7 @@ function BudgetTrack({
   const fill = tone === 'ap' ? 'border-rust bg-rust' : 'border-ink bg-ink'
   return (
     <div>
-      <p className="font-cond text-badge font-bold uppercase tracking-widest text-ink">
+      <p className="font-cond text-badge font-bold uppercase tracking-caps-wide text-ink">
         {label} ·{' '}
         <span className={cn('font-body text-xs font-bold', isOver && 'text-status-bad')}>
           {value} / {max}
@@ -657,7 +657,7 @@ function BudgetTrack({
                     key={i}
                     data-pip={on ? 'on' : 'off'}
                     className={cn(
-                      'h-[13px] w-[13px] rounded-[2px] border-chrome',
+                      'h-[13px] w-[13px] rounded-badge border-chrome',
                       on
                         ? over
                           ? 'border-status-bad bg-status-bad'

--- a/packages/component-lib/src/components/shared/NavDrawer.stories.tsx
+++ b/packages/component-lib/src/components/shared/NavDrawer.stories.tsx
@@ -8,7 +8,7 @@ export default {
 }
 
 const SrdBrand = () => (
-  <span className="inline-flex shrink-0 border border-ink font-cond text-xl font-bold uppercase leading-none tracking-tight">
+  <span className="inline-flex shrink-0 border border-ink font-cond text-xl font-bold uppercase leading-none tracking-caps-tight">
     <span className="bg-ink px-1 py-0.5 text-paper">Salvage Union</span>
     <span className="bg-paper px-1 py-0.5 text-ink">SRD</span>
   </span>

--- a/packages/component-lib/src/components/shared/NavDrawer.tsx
+++ b/packages/component-lib/src/components/shared/NavDrawer.tsx
@@ -133,7 +133,7 @@ export function NavDrawer({
             {categories?.map((cat) => (
               <div key={cat.label} className="mb-2 flex flex-col gap-2">
                 <div className="flex items-center gap-3">
-                  <span className="bg-ink px-1 font-cond font-bold uppercase leading-none tracking-tight text-paper">
+                  <span className="bg-ink px-1 font-cond font-bold uppercase leading-none tracking-caps-tight text-paper">
                     {cat.label}
                   </span>
                 </div>

--- a/packages/component-lib/src/components/shared/OffRulesEscape.tsx
+++ b/packages/component-lib/src/components/shared/OffRulesEscape.tsx
@@ -16,7 +16,7 @@ export function OffRulesEscape({ onEscape }: OffRulesEscapeProps) {
     <button
       type="button"
       onClick={onEscape}
-      className="cursor-pointer whitespace-nowrap font-cond text-[11px] font-semibold uppercase tracking-caps text-paper/70 underline decoration-dotted underline-offset-2 hover:text-paper"
+      className="cursor-pointer whitespace-nowrap font-cond text-badge font-semibold uppercase tracking-caps text-paper/70 underline decoration-dotted underline-offset-2 hover:text-paper"
     >
       Off-rules build? Build it on the Live Sheet →
     </button>

--- a/packages/component-lib/src/components/shared/RosterSkeleton.tsx
+++ b/packages/component-lib/src/components/shared/RosterSkeleton.tsx
@@ -13,7 +13,7 @@ import { cn } from '../../utils/cn'
 function SkeletonRow() {
   return (
     <li className="list-none">
-      <div className="rounded-[3px] border-chrome border-ink/15 bg-paper px-3 py-2.5">
+      <div className="rounded-card border-chrome border-ink/15 bg-paper px-3 py-2.5">
         <div className="h-4 w-2/5 rounded bg-ink/10" />
         <div className="mt-2 h-3 w-3/5 rounded bg-ink/5" />
       </div>
@@ -26,7 +26,7 @@ function SkeletonColumn({ hiddenOnMobile = false }: { hiddenOnMobile?: boolean }
     <section aria-hidden="true" className={cn(hiddenOnMobile && 'hidden md:block')}>
       <div className="mb-3 flex items-center justify-between">
         <div className="h-5 w-24 rounded bg-rust/25" />
-        <div className="h-7 w-28 rounded-[3px] border-chrome border-ink/10 bg-paper" />
+        <div className="h-7 w-28 rounded-card border-chrome border-ink/10 bg-paper" />
       </div>
       <ul className="flex flex-col gap-2.5">
         <SkeletonRow />

--- a/packages/component-lib/src/components/shared/SearchField.tsx
+++ b/packages/component-lib/src/components/shared/SearchField.tsx
@@ -30,7 +30,7 @@ export const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(functi
   return (
     <div
       className={cn(
-        'flex items-center gap-2 rounded border border-ink bg-paper px-3 py-[7px] font-body text-[13px] text-ink-2 focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-su-orange',
+        'flex items-center gap-2 rounded border border-ink bg-paper px-3 py-[7px] font-body text-caption text-ink-2 focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-su-orange',
         containerClassName
       )}
     >

--- a/packages/component-lib/src/components/shared/SelectorDialog.tsx
+++ b/packages/component-lib/src/components/shared/SelectorDialog.tsx
@@ -72,7 +72,7 @@ export function SelectorDialog({
             {options.map((option) => (
               <label
                 key={option.id}
-                className="flex cursor-pointer items-center gap-2 rounded-[3px] border-chrome border-ink bg-paper p-2 hover:bg-wk-bg-2"
+                className="flex cursor-pointer items-center gap-2 rounded-card border-chrome border-ink bg-paper p-2 hover:bg-wk-bg-2"
               >
                 <input
                   type="radio"

--- a/packages/component-lib/src/components/shared/SheetSection.tsx
+++ b/packages/component-lib/src/components/shared/SheetSection.tsx
@@ -149,7 +149,7 @@ function SwapIcon({ className }: { className?: string }) {
 type HButtonVariant = 'edit' | 'done' | 'add'
 
 const HBTN_BASE =
-  'inline-flex cursor-pointer items-center gap-1.5 rounded-[3px] border-2 px-3 font-cond text-label-lg font-bold uppercase leading-none tracking-caps-wide whitespace-nowrap transition-colors min-h-11 sm:min-h-8 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-rust/25 print:hidden'
+  'inline-flex cursor-pointer items-center gap-1.5 rounded-card border-2 px-3 font-cond text-label-lg font-bold uppercase leading-none tracking-caps-wide whitespace-nowrap transition-colors min-h-11 sm:min-h-8 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-rust/25 print:hidden'
 
 const HBTN_VARIANT: Record<HButtonVariant, string> = {
   edit: 'border-ink bg-paper text-ink hover:bg-ink hover:text-paper',

--- a/packages/component-lib/src/components/shared/SheetSection.tsx
+++ b/packages/component-lib/src/components/shared/SheetSection.tsx
@@ -24,6 +24,7 @@ import {
   isValidElement,
 } from 'react'
 import { Button } from '../chrome/Button'
+import { Glyph } from '../chrome/glyphs'
 import { ModalShell } from './ModalShell'
 import type { ReferenceEntityControl } from '../referenceEntity/ReferenceEntityDisplay/referenceEntityControlTypes'
 
@@ -54,88 +55,17 @@ export const REMOVABLE_CARD_STYLE: { className: string } = {
 // a className so it can size to its host button (design `.hbtn svg` / `.ctl svg`).
 // ---------------------------------------------------------------------------
 
-function PencilIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="m16.5 3.5 4 4L7 21H3v-4z" />
-    </svg>
-  )
-}
-
-function CheckIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2.4}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="m5.5 12.5 4 4 9-10" />
-    </svg>
-  )
-}
-
-function PlusIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={3}
-      strokeLinecap="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M12 5v14M5 12h14" />
-    </svg>
-  )
-}
-
-function RemoveIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2.2}
-      strokeLinecap="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="m6 6 12 12M18 6 6 18" />
-    </svg>
-  )
-}
-
-function SwapIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2.2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M4 8h14M14.5 4.5 18 8l-3.5 3.5M20 16H6M9.5 12.5 6 16l3.5 3.5" />
-    </svg>
-  )
-}
+/**
+ * The edit-language affordances now come from the shared {@link Glyph} set —
+ * these thin adapters exist only because `cardRemoveControls` takes a component
+ * reference rather than a glyph name.
+ */
+const SwapGlyph = ({ className }: { className?: string }) => (
+  <Glyph name="swap" className={className} />
+)
+const RemoveGlyph = ({ className }: { className?: string }) => (
+  <Glyph name="remove" className={className} />
+)
 
 // ---------------------------------------------------------------------------
 // HButton — the container-header control button (design `.hbtn`, clean-edit.html
@@ -245,7 +175,11 @@ export function SectionEditButton({
       onClick={onToggle}
       className={className}
     >
-      {editing ? <CheckIcon className="h-3.5 w-3.5" /> : <PencilIcon className="h-3.5 w-3.5" />}
+      {editing ? (
+        <Glyph name="check" className="h-3.5 w-3.5" />
+      ) : (
+        <Glyph name="pencil" className="h-3.5 w-3.5" />
+      )}
       {editing ? 'Done' : 'Edit'}
     </HButton>
   )
@@ -276,7 +210,7 @@ export function SectionAddButton({ label, onClick, className }: SectionAddButton
       className={className}
     >
       <span className="flex h-4 w-4 items-center justify-center rounded-full border-2 border-current">
-        <PlusIcon className="h-2 w-2" />
+        <Glyph name="plus" className="h-2 w-2" />
       </span>
       Add {label}
     </HButton>
@@ -314,9 +248,14 @@ export function cardRemoveControls({
 }: CardControlOptions): ReferenceEntityControl[] {
   const controls: ReferenceEntityControl[] = []
   if (onSwap) {
-    controls.push({ key: 'swap', ariaLabel: `Swap ${name}`, icon: SwapIcon, onClick: onSwap })
+    controls.push({ key: 'swap', ariaLabel: `Swap ${name}`, icon: SwapGlyph, onClick: onSwap })
   }
-  controls.push({ key: 'remove', ariaLabel: `Remove ${name}`, icon: RemoveIcon, onClick: onRemove })
+  controls.push({
+    key: 'remove',
+    ariaLabel: `Remove ${name}`,
+    icon: RemoveGlyph,
+    onClick: onRemove,
+  })
   return controls
 }
 

--- a/packages/component-lib/src/components/shared/SheetSectionCard.tsx
+++ b/packages/component-lib/src/components/shared/SheetSectionCard.tsx
@@ -77,7 +77,7 @@ export function SheetSectionCard({
       }
       footerContent={
         source ? (
-          <span className="min-w-0 truncate font-cond text-[10px] font-semibold uppercase leading-none tracking-caps text-ink/85">
+          <span className="min-w-0 truncate font-cond text-label font-semibold uppercase leading-none tracking-caps text-ink/85">
             {source}
           </span>
         ) : undefined

--- a/packages/component-lib/src/components/shared/StaticEntityContent.tsx
+++ b/packages/component-lib/src/components/shared/StaticEntityContent.tsx
@@ -25,7 +25,9 @@ export function StaticEntityContent({ summary, resolveTraitHref }: StaticEntityC
     <div data-static-fallback className="mx-auto w-full max-w-6xl px-4 text-sm text-ink">
       {/* SSR / no-JS heading. JS users get this whole block stripped by BaseLayout
           and the hydrated island supplies the real <h1>, so they never double up. */}
-      <h1 className="mb-3 font-cond text-2xl font-bold uppercase tracking-tight">{summary.name}</h1>
+      <h1 className="mb-3 font-cond text-2xl font-bold uppercase tracking-caps-tight">
+        {summary.name}
+      </h1>
 
       {summary.description && <p className="mb-3 italic">{summary.description}</p>}
 

--- a/packages/component-lib/src/components/shared/WizShell.tsx
+++ b/packages/component-lib/src/components/shared/WizShell.tsx
@@ -145,7 +145,7 @@ function RailStep({
       <span
         className={cn(
           'hidden font-cond font-bold uppercase leading-[1.15] tracking-caps-snug text-ink min-[721px]:block',
-          active ? 'text-caption' : 'text-[11.5px]',
+          active ? 'text-caption' : 'text-note',
           done && !active && 'opacity-80',
           !done && !active && 'opacity-[0.66]'
         )}

--- a/packages/component-lib/src/components/sheet/ConditionToggle.tsx
+++ b/packages/component-lib/src/components/sheet/ConditionToggle.tsx
@@ -67,7 +67,7 @@ export function ConditionToggle({
     : `Condition: ${LABELS[value]}`
 
   const badgeClass = cn(
-    'inline-flex select-none items-center rounded border-2 px-2 py-0.5 font-cond text-xs font-bold uppercase tracking-wide',
+    'inline-flex select-none items-center rounded border-2 px-2 py-0.5 font-cond text-xs font-bold uppercase tracking-caps',
     STYLES[value],
     className
   )

--- a/packages/component-lib/src/components/sheet/ConditionsEditor.tsx
+++ b/packages/component-lib/src/components/sheet/ConditionsEditor.tsx
@@ -98,12 +98,12 @@ export function ConditionsEditor({
     await onChange(conditions.filter((_, i) => i !== index))
   }
 
-  // Poster `.cond` chip shape: 2px border, rounded-[2px], min-h-8, a leading
+  // Poster `.cond` chip shape: 2px border, rounded-badge, min-h-8, a leading
   // dot, cond-caps text. Present conditions always render the `.cond.on`
   // fill (ink or warn-tone) + accent/ink dot; the "+ Add" affordance below
   // uses the unset shape (solid ink-35 border, no dashed rule).
   const chipBase =
-    'inline-flex min-h-8 items-center gap-1.5 rounded-[2px] border-2 px-2.5 py-1.5 font-cond text-[10.5px] font-bold uppercase leading-none tracking-caps'
+    'inline-flex min-h-8 items-center gap-1.5 rounded-badge border-2 px-2.5 py-1.5 font-cond text-label-lg font-bold uppercase leading-none tracking-caps'
 
   return (
     <div className="flex min-h-12 flex-wrap items-center gap-1.5 rounded border-chrome border-ink bg-su-paper p-2.5">
@@ -141,7 +141,7 @@ export function ConditionsEditor({
               onClick={() => {
                 void removeAt(index)
               }}
-              className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-[1px] leading-none hover:bg-paper/20"
+              className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-pip leading-none hover:bg-paper/20"
             >
               <span aria-hidden className="text-[12px]">
                 ×
@@ -171,7 +171,7 @@ export function ConditionsEditor({
             onBlur={() => {
               void commitAdd()
             }}
-            className="w-28 rounded-[2px] border border-ink bg-paper px-1.5 py-0.5 font-cond text-badge uppercase tracking-caps text-ink focus:outline-none focus:ring-1 focus:ring-su-orange"
+            className="w-28 rounded-badge border border-ink bg-paper px-1.5 py-0.5 font-cond text-badge uppercase tracking-caps text-ink focus:outline-none focus:ring-1 focus:ring-su-orange"
           />
         ) : (
           <button

--- a/packages/component-lib/src/components/sheet/CrawlerEcon.tsx
+++ b/packages/component-lib/src/components/sheet/CrawlerEcon.tsx
@@ -51,10 +51,10 @@ export function CrawlerEconFrame({ gauge, items, className }: CrawlerEconFramePr
   return (
     <aside
       aria-label="Crawler economy"
-      className={cn('flex flex-col gap-3 rounded-[3px] border-entity p-3', className)}
+      className={cn('flex flex-col gap-3 rounded-card border-entity p-3', className)}
       style={{ borderColor: 'var(--tone)', background: 'var(--tone)' }}
     >
-      <div className="rounded-[3px] bg-paper px-3 py-2.5">{gauge}</div>
+      <div className="rounded-card bg-paper px-3 py-2.5">{gauge}</div>
       {items.length > 0 && (
         <div className="grid grid-cols-[repeat(auto-fit,minmax(92px,1fr))] gap-2.5">
           {items.map((item) => (
@@ -71,7 +71,7 @@ function EconLoz({ item }: { item: EconLozItem }) {
   const body = (
     <>
       <span
-        className="font-cond text-[10px] font-bold uppercase tracking-caps"
+        className="font-cond text-label font-bold uppercase tracking-caps"
         style={{ color: 'var(--tone-deep)' }}
       >
         {item.label}
@@ -80,13 +80,13 @@ function EconLoz({ item }: { item: EconLozItem }) {
         {item.value}
         {item.max !== undefined && (
           <>
-            <i className="px-0.5 not-italic text-[15px] text-ink/55">/</i>
-            <span className="text-[15px] text-ink/70">{item.max}</span>
+            <i className="px-0.5 not-italic text-lede text-ink/55">/</i>
+            <span className="text-lede text-ink/70">{item.max}</span>
           </>
         )}
       </div>
       {item.caption && (
-        <span className="font-cond text-[8px] font-semibold uppercase tracking-[0.16em] text-ink/55">
+        <span className="font-cond text-nano font-semibold uppercase tracking-[0.16em] text-ink/55">
           {item.caption}
         </span>
       )}
@@ -95,7 +95,7 @@ function EconLoz({ item }: { item: EconLozItem }) {
   )
 
   const frameClass =
-    'flex min-h-[64px] flex-col items-center justify-center gap-0.5 rounded-[3px] border-2 border-ink bg-paper px-1.5 py-2 text-center'
+    'flex min-h-[64px] flex-col items-center justify-center gap-0.5 rounded-card border-2 border-ink bg-paper px-1.5 py-2 text-center'
 
   if (!item.action) {
     return <div className={frameClass}>{body}</div>

--- a/packages/component-lib/src/components/sheet/IdentityField.tsx
+++ b/packages/component-lib/src/components/sheet/IdentityField.tsx
@@ -18,6 +18,7 @@
  */
 
 import type { ReactNode } from 'react'
+import { Glyph } from '../chrome/glyphs'
 import { InlineEditField } from '../chrome/InlineEditField'
 
 import { cn } from '../../utils/cn'
@@ -59,22 +60,6 @@ const EDIT_VALUE_BOX_CLASS =
   'relative flex min-h-[44px] items-center rounded-card border-2 border-[color:var(--tone-deep,var(--color-ink))] bg-paper px-3 py-2 pr-9 font-body text-sm text-ink'
 
 /** Pen icon pinned right inside an editing `.ifield` box (design-spec `.ifield .pen`). */
-function PenIcon() {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className="pointer-events-none absolute right-[10px] top-1/2 h-[15px] w-[15px] -translate-y-1/2 text-ink/55"
-      aria-hidden="true"
-    >
-      <path d="m16.5 3.5 4 4L7 21H3v-4z" />
-    </svg>
-  )
-}
 
 export function IdentityField({
   label,
@@ -112,7 +97,10 @@ export function IdentityField({
           )}
         >
           <span className="min-w-0 flex-1 truncate">{value || placeholder}</span>
-          <PenIcon />
+          <Glyph
+            name="pencil"
+            className="pointer-events-none absolute right-[10px] top-1/2 h-[15px] w-[15px] -translate-y-1/2 text-ink/55"
+          />
         </button>
       </div>
     )

--- a/packages/component-lib/src/components/sheet/NpcFactsEditor.tsx
+++ b/packages/component-lib/src/components/sheet/NpcFactsEditor.tsx
@@ -61,7 +61,7 @@ export function NpcFactsEditor({
   }
 
   const chipBase =
-    'inline-flex items-center gap-1 rounded-[2px] px-2 py-0.5 font-cond text-badge font-semibold tracking-[.03em]'
+    'inline-flex items-center gap-1 rounded-badge px-2 py-0.5 font-cond text-badge font-semibold tracking-[.03em]'
 
   return (
     <div className="flex min-h-10 flex-wrap items-center gap-1.5 rounded border-chrome border-ink bg-su-paper p-2">
@@ -91,7 +91,7 @@ export function NpcFactsEditor({
               onClick={() => {
                 void removeAt(index)
               }}
-              className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-[1px] leading-none hover:bg-ink/10"
+              className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-pip leading-none hover:bg-ink/10"
             >
               <span aria-hidden className="text-[12px]">
                 ×
@@ -121,7 +121,7 @@ export function NpcFactsEditor({
             onBlur={() => {
               void commitAdd()
             }}
-            className="w-40 rounded-[2px] border border-ink bg-paper px-1.5 py-0.5 font-cond text-badge tracking-[.03em] text-ink focus:outline-none focus:ring-1 focus:ring-su-orange"
+            className="w-40 rounded-badge border border-ink bg-paper px-1.5 py-0.5 font-cond text-badge tracking-[.03em] text-ink focus:outline-none focus:ring-1 focus:ring-su-orange"
           />
         ) : (
           <button

--- a/packages/component-lib/src/components/sheet/NpcInset.tsx
+++ b/packages/component-lib/src/components/sheet/NpcInset.tsx
@@ -71,7 +71,7 @@ export function NpcInset({
         headerContent={
           <>
             <div className="flex min-w-0 flex-wrap items-center gap-2">
-              <span className="rounded-[1px] bg-crawler px-1.5 pb-px pt-[2px] font-cond text-nano font-bold uppercase leading-none tracking-caps-wide text-paper">
+              <span className="rounded-pip bg-crawler px-1.5 pb-px pt-[2px] font-cond text-nano font-bold uppercase leading-none tracking-caps-wide text-paper">
                 Crew
               </span>
               <span className="min-w-0 font-cond text-lede font-bold uppercase leading-none text-paper">
@@ -110,7 +110,7 @@ export function NpcInset({
 
           <dl className="m-0 min-w-0 flex-1 space-y-1.5">
             <div className="flex items-baseline gap-1.5">
-              <dt className="shrink-0 font-cond text-micro font-bold uppercase leading-none tracking-widest text-ink">
+              <dt className="shrink-0 font-cond text-micro font-bold uppercase leading-none tracking-caps-wide text-ink">
                 Keepsake
               </dt>
               <dd className="m-0 min-w-0 font-body text-note leading-snug text-ink-2">
@@ -127,7 +127,7 @@ export function NpcInset({
               </dd>
             </div>
             <div className="flex items-baseline gap-1.5">
-              <dt className="shrink-0 font-cond text-micro font-bold uppercase leading-none tracking-widest text-ink">
+              <dt className="shrink-0 font-cond text-micro font-bold uppercase leading-none tracking-caps-wide text-ink">
                 Motto
               </dt>
               <dd className="m-0 min-w-0 font-body text-note leading-snug text-ink-2">
@@ -144,7 +144,7 @@ export function NpcInset({
               </dd>
             </div>
             <div className="flex items-baseline gap-1.5">
-              <dt className="shrink-0 font-cond text-micro font-bold uppercase leading-none tracking-widest text-ink">
+              <dt className="shrink-0 font-cond text-micro font-bold uppercase leading-none tracking-caps-wide text-ink">
                 Detail
               </dt>
               <dd className="m-0 min-w-0 flex-1 font-body text-note leading-snug text-ink-2">
@@ -162,7 +162,7 @@ export function NpcInset({
             </div>
             {(editable || facts.length > 0) && (
               <div className="flex items-baseline gap-1.5">
-                <dt className="shrink-0 font-cond text-micro font-bold uppercase leading-none tracking-widest text-ink">
+                <dt className="shrink-0 font-cond text-micro font-bold uppercase leading-none tracking-caps-wide text-ink">
                   Facts
                 </dt>
                 <dd className="m-0 min-w-0 flex-1">

--- a/packages/component-lib/src/components/sheet/SheetActionsMenu.tsx
+++ b/packages/component-lib/src/components/sheet/SheetActionsMenu.tsx
@@ -50,7 +50,7 @@ export function SheetActionsMenu({ children, className }: SheetActionsMenuProps)
         <div
           role="group"
           aria-label="Sheet actions"
-          className="absolute right-0 top-full z-30 mt-1.5 flex min-w-36 flex-col items-stretch gap-1.5 rounded-[6px] border-2 border-ink bg-paper p-2 shadow-[0_14px_28px_-14px_rgba(40,32,25,0.55)]"
+          className="absolute right-0 top-full z-30 mt-1.5 flex min-w-36 flex-col items-stretch gap-1.5 rounded-panel border-2 border-ink bg-paper p-2 shadow-[0_14px_28px_-14px_rgba(40,32,25,0.55)]"
         >
           {children}
         </div>

--- a/packages/component-lib/src/components/sheet/SheetHero.tsx
+++ b/packages/component-lib/src/components/sheet/SheetHero.tsx
@@ -76,7 +76,7 @@ export function SheetHero({
     <section
       ref={heroRef}
       aria-label={`${name} sheet header`}
-      className={cn('relative overflow-hidden rounded-[3px] border-entity border-ink', className)}
+      className={cn('relative overflow-hidden rounded-card border-entity border-ink', className)}
       style={{ background: 'var(--tone)' }}
     >
       {/* Category tab — rides the top border like .ec__cat (StampSeam) */}
@@ -199,7 +199,7 @@ export function ChassisStats({ items, className }: ChassisStatsProps) {
             aria-label={item.actionLabel ?? item.code}
             title={item.actionLabel}
             onClick={item.onClick}
-            className="cursor-pointer rounded-[3px] text-left transition-transform duration-[120ms] hover:-translate-y-px focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-rust/[0.22]"
+            className="cursor-pointer rounded-card text-left transition-transform duration-[120ms] hover:-translate-y-px focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-rust/[0.22]"
           >
             {block}
           </button>

--- a/packages/component-lib/src/components/sheet/SheetSkeleton.tsx
+++ b/packages/component-lib/src/components/sheet/SheetSkeleton.tsx
@@ -17,8 +17,8 @@ function SkeletonSlab() {
         <div className="h-0.5 flex-1 rounded bg-ink/10" />
       </div>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        <div className="h-20 rounded-[6px] border-chrome border-ink/15 bg-paper" />
-        <div className="h-20 rounded-[6px] border-chrome border-ink/15 bg-paper" />
+        <div className="h-20 rounded-panel border-chrome border-ink/15 bg-paper" />
+        <div className="h-20 rounded-panel border-chrome border-ink/15 bg-paper" />
       </div>
     </div>
   )
@@ -31,14 +31,14 @@ export function SheetSkeleton() {
       <div className="flex min-h-[58px] items-center gap-4 border-b-2 border-ink/20 px-4 py-2 sm:px-[30px]">
         <div className="h-4 w-24 rounded bg-ink/15" />
         <div className="ml-auto flex items-center gap-2.5">
-          <div className="h-7 w-16 rounded-[3px] border-chrome border-ink/10 bg-paper" />
-          <div className="h-7 w-16 rounded-[3px] border-chrome border-ink/10 bg-paper" />
+          <div className="h-7 w-16 rounded-card border-chrome border-ink/10 bg-paper" />
+          <div className="h-7 w-16 rounded-card border-chrome border-ink/10 bg-paper" />
         </div>
       </div>
 
       {/* Hero band placeholder */}
       <div className="px-4 pb-1.5 pt-4 sm:px-[30px] sm:pt-[22px]">
-        <div className="rounded-[6px] border-entity border-ink/20 bg-paper p-5 sm:p-6">
+        <div className="rounded-panel border-entity border-ink/20 bg-paper p-5 sm:p-6">
           <div className="h-8 w-1/2 rounded bg-ink/15 sm:w-2/5" />
           <div className="mt-3 h-4 w-1/3 rounded bg-ink/10" />
           <div className="mt-6 flex flex-wrap gap-3">

--- a/packages/component-lib/src/components/sheet/SnapshotQr.tsx
+++ b/packages/component-lib/src/components/sheet/SnapshotQr.tsx
@@ -37,7 +37,7 @@ export function SnapshotQr({ url }: SnapshotQrProps) {
     return (
       <div
         aria-hidden="true"
-        className="h-[84px] w-[84px] shrink-0 animate-pulse rounded-[3px] border-chrome border-ink bg-paper"
+        className="h-[84px] w-[84px] shrink-0 animate-pulse rounded-card border-chrome border-ink bg-paper"
       />
     )
   }
@@ -47,7 +47,7 @@ export function SnapshotQr({ url }: SnapshotQrProps) {
       role="img"
       aria-label="QR code linking to this snapshot"
       data-testid="snapshot-qr"
-      className="h-[84px] w-[84px] shrink-0 rounded-[3px] border-chrome border-ink bg-paper p-1 [&>svg]:h-full [&>svg]:w-full"
+      className="h-[84px] w-[84px] shrink-0 rounded-card border-chrome border-ink bg-paper p-1 [&>svg]:h-full [&>svg]:w-full"
       // Trusted markup: generated locally by the qrcode encoder from module
       // geometry — the URL is encoded as QR modules, never interpolated as HTML.
       // biome-ignore lint/security/noDangerouslySetInnerHtml: SVG string is produced locally by the qrcode encoder from module geometry; no user-controlled HTML can reach it

--- a/packages/component-lib/src/components/sheet/sheetChrome.ts
+++ b/packages/component-lib/src/components/sheet/sheetChrome.ts
@@ -10,4 +10,4 @@
  * "⋯" overflow trigger so the bar's two icon buttons can never drift apart.
  */
 export const SHEET_ICONBTN_CLASS =
-  'flex size-[38px] shrink-0 items-center justify-center rounded-[3px] border-chrome border-ink bg-paper text-ink transition-colors duration-[120ms] hover:bg-wk-bg-2 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-rust/25'
+  'flex size-[38px] shrink-0 items-center justify-center rounded-card border-chrome border-ink bg-paper text-ink transition-colors duration-[120ms] hover:bg-wk-bg-2 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-rust/25'

--- a/packages/component-lib/src/components/wizard/MechFlavorStep.tsx
+++ b/packages/component-lib/src/components/wizard/MechFlavorStep.tsx
@@ -1,6 +1,6 @@
 import { Button } from '../chrome/Button'
 import { IdentityField } from '../sheet/IdentityField'
-import type { MechRollField, MechRollTableDeps } from 'component-lib'
+import type { MechRollField, MechRollTableDeps } from './mechRollTables'
 import { rollForMechField } from './mechRollTables'
 
 type MechFlavorStepProps = {

--- a/packages/component-lib/src/components/wizard/NewEntityScreen.stories.tsx
+++ b/packages/component-lib/src/components/wizard/NewEntityScreen.stories.tsx
@@ -111,7 +111,7 @@ function CreateModeChooser({
         {kind === 'mech' && (
           <a
             href="/mechs/patterns"
-            className="mx-auto mt-6 block w-fit max-w-[92%] rounded-[2px] bg-ink px-4 py-2 text-center font-cond text-[11px] font-bold uppercase leading-relaxed tracking-widest text-paper no-underline hover:bg-ink/85"
+            className="mx-auto mt-6 block w-fit max-w-[92%] rounded-badge bg-ink px-4 py-2 text-center font-cond text-badge font-bold uppercase leading-relaxed tracking-caps-wide text-paper no-underline hover:bg-ink/85"
           >
             A third door in the Blank family —{' '}
             <span className="text-su-orange">Instantiate from Pattern</span> · stamp a saved


### PR DESCRIPTION
First pass of collapsing the 35 newly-lifted components onto primitives the design system already provides. A deep scan estimates **~700–900 removable lines** across the set; this lands the bug and the two cleanest mechanical wins.

### 1. A real bug — self-referential barrel import
`MechFlavorStep` imported its own package **by name** — `from 'component-lib'` — *inside* component-lib, resolving through the barrel back into the same package. Circular-import hazard and a latent build break. Now imports `./mechRollTables` directly. No others exist.

### 2. Token sweep — 58 arbitrary values
`rounded-[1|2|3|6px]` → `rounded-pip|badge|card|panel` (28) · `text-[8…15px]` → the `--text-*` ladder (15) · `tracking-tight|wide|widest` → the `tracking-caps-*` ladder (15).

**The tracking moves are not value-preserving**, so each was checked individually: all 15 sites carry `uppercase` in the same class string, which is exactly where the caps ladder applies. `tracking-tight` → `tracking-caps-tight` flips the sign (−0.025em → +0.04em) and that **is** the fix — negative tracking on uppercase condensed type was a defect.

Deliberately untouched: display sizes (`text-[22px]`–`text-[38px]`) sit above the ladder's top step with nothing to map onto, and `text-[12px]` / `rounded-[4|5px]` fall between steps. Forcing those would invent design decisions.

### 3. Seven hand-drawn icons → `Glyph`
The pencil path `m16.5 3.5 4 4L7 21H3v-4z` was drawn **three times**, and SheetSection re-drew an ✕ `Glyph` already owned.

`Glyph` couldn't just absorb them — its existing four are **filled**, all five affordances are **stroked**; dropping stroke paths into a filled renderer turns a pencil outline into a blob. So `Glyph` gained a per-name `STROKE` table: listed ⇒ unfilled at that width, absent ⇒ filled. Weights carried over verbatim (2 / 2.4 / 3 / 2.2 / 2.2) so each keeps its optical weight. Story updated to show both families.

Two thin adapters remain in SheetSection only because `cardRemoveControls` takes a component reference rather than a glyph name.

### Still to come
The largest single win is `ConditionsEditor` and `NpcFactsEditor` being **the same component with different labels** (~110 duplicated lines), which both also re-implement `chrome/Conditions`. That one is deliberately held back — #501/#502 are actively reshaping `Conditions`/`ConditionChip`, and folding onto a moving primitive mid-flight would conflict.

Green: typecheck (4 workspaces) · full suite · lint · knip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jp2XjTMVQ3ak7BixETJnEU