### PR TITLE
refactor(component-lib): build the catalog tile from shared primitives

### DIFF
--- a/packages/component-lib/src/components/chrome/catalogTile.ts
+++ b/packages/component-lib/src/components/chrome/catalogTile.ts
@@ -1,0 +1,49 @@
+import { cn } from '../../utils/cn'
+import { FOCUS_RING } from './interaction'
+
+/**
+ * The catalog-tile treatment — the wayfinding tile shared by the srd landing
+ * grid, the 404 grid (`CatalogTile`) and the mobile nav drawer (`NavDrawer`).
+ *
+ * It lives here, beside `STAMP_SEAM` and `POSTER_STAMP`, for the same reason
+ * they do: it is a treatment used by more than one component, and the two
+ * copies had already drifted apart in the ways duplicated class strings always
+ * do. `NavDrawer` carried a verbatim second copy of the frame AND of the label
+ * chip, so a change to the tile reached the landing page and silently missed
+ * the drawer.
+ *
+ * WHY THE TILE NAME IS NOT A `Badge`. The obvious next step — routing the label
+ * chip through `Badge shape="chip"` — is deliberately NOT taken. Badge's chip is
+ * a fixed-height (22px) `text-badge` (11px) KEYWORD chip; the tile's name is the
+ * tile's entire content at reading scale. Forcing it through Badge would mean
+ * overriding its height, padding, type scale and fill — every part of the
+ * geometry that makes it a Badge — leaving only `rounded-badge` shared. That is
+ * the shape of a primitive being worn as a costume, not reused. Badge is
+ * label-only by design (see its own doc comment); this is a plate around a
+ * heading, which is a different kind, so it keeps its own constant.
+ */
+
+/**
+ * Frame + interaction, minus the fill. `background` shorthand (not `bg-[…]`,
+ * which compiles to `background-color`) because `--catalog-bg` may be a
+ * gradient — the tech-level and ability-tier ramps — and `background-color`
+ * silently drops a `linear-gradient()`, which once left those tiles unfilled
+ * with unreadable paper text on the pale page ground.
+ */
+export const CATALOG_TILE_CHROME = cn(
+  'rounded-card border-chrome border-ink px-[15px] py-[13px] no-underline',
+  'transition-[box-shadow,transform] duration-[120ms]',
+  'hover:-translate-y-0.5 hover:shadow-[0_5px_18px_rgba(34,30,23,0.18)]',
+  FOCUS_RING
+)
+
+/** The coloured fill + paper text (the default, non-ghost tile). */
+export const CATALOG_TILE_FILL = '[background:var(--catalog-bg)] text-paper'
+
+/**
+ * The optional name plate — a `--catalog-label` filled chip around the tile
+ * name. `text-shadow:none` because the plate supplies the contrast the drop
+ * shadow was standing in for.
+ */
+export const CATALOG_TILE_LABEL =
+  'inline-block rounded-badge bg-[var(--catalog-label)] px-[10px] py-0.5 [text-shadow:none]'

--- a/packages/component-lib/src/components/shared/CatalogTile.tsx
+++ b/packages/component-lib/src/components/shared/CatalogTile.tsx
@@ -1,5 +1,6 @@
 import type { CSSVarStyle } from '../../styles/cssVars'
 import { cn } from '../../utils/cn'
+import { CATALOG_TILE_CHROME, CATALOG_TILE_FILL, CATALOG_TILE_LABEL } from '../chrome/catalogTile'
 
 /**
  * CatalogTile — the shared catalog-tile link (canonical; converted from
@@ -9,9 +10,10 @@ import { cn } from '../../utils/cn'
  *
  * The tile fill (and optional label chip fill) are driven by the `catalogBg` /
  * `catalogLabel` colour strings, applied as CSS custom properties so a caller
- * can pass any gradient or token. Styling is self-contained (the former
- * `.catalog-item` global rules, replicated as utilities) so it renders
- * identically in Ladle and in the static site.
+ * can pass any gradient or token. The frame, hover lift, focus ring and name
+ * plate come from `chrome/catalogTile` — shared with `NavDrawer`, which renders
+ * the same tile in its mobile drawer and used to carry a verbatim second copy
+ * of both strings.
  */
 
 type CatalogTileProps = {
@@ -29,27 +31,24 @@ type CatalogTileProps = {
   variant?: 'default' | 'ghost'
 }
 
-// Geometry + interaction shared by both variants. `--catalog-bg` may be a colour
-// OR a gradient (tech-level ramps, the ability tier ramp), so the default fill
-// must use the `background` shorthand — `bg-[…]` compiles to `background-color`,
-// which silently drops a `linear-gradient()` and left those tiles unfilled with
-// unreadable paper text on the pale page ground.
-const TILE_BASE =
-  'flex min-h-[54px] flex-col items-center justify-center rounded-card border-chrome border-ink px-[15px] py-[13px] no-underline transition-[box-shadow,transform] duration-[120ms] hover:-translate-y-0.5 hover:shadow-[0_5px_18px_rgba(34,30,23,0.18)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-pilot'
+/** What the GRID tile adds to the shared chrome. The drawer tile is a
+ *  full-width block instead, which is why this is not in the shared constant. */
+const TILE_LAYOUT = 'flex min-h-[54px] flex-col items-center justify-center'
 
-const TILE_DEFAULT = '[background:var(--catalog-bg)] text-paper'
 const TILE_GHOST = 'bg-paper text-ink'
 
+// Type comes off the ladder: `text-lede` (15px) and `tracking-caps-tight`
+// (0.04em) replace a hand-set 16px size and 0.02em tracking — both arbitrary
+// bracket values of the kind the token guard tracks. The 1px and 0.02em deltas
+// are the price of being on the scale. (Named in prose rather than quoted in
+// their utility form on purpose: the guard reads comments, and a citation of
+// the thing you removed counts as the thing itself.)
 const NAME =
-  'font-cond text-[16px] font-semibold uppercase leading-[1.2] tracking-[0.02em] text-paper [text-shadow:0_1px_2px_rgba(0,0,0,0.75)]'
+  'font-cond text-lede font-semibold uppercase leading-[1.2] tracking-caps-tight text-paper [text-shadow:0_1px_2px_rgba(0,0,0,0.75)]'
 
-const NAME_LABEL =
-  'inline-block rounded-badge bg-[var(--catalog-label)] px-[10px] py-0.5 [text-shadow:none]'
-
-// Ghost name — cond/bold/uppercase at text-lg (1.125rem) with 0.02em tracking
-// and no text-shadow (ink on paper needs none), matching the former
-// `.catalog-item--ghost`.
-const NAME_GHOST = 'font-cond text-lg font-bold uppercase tracking-[0.02em] text-ink'
+// Ghost name — cond/bold/uppercase at text-lg with no text-shadow (ink on paper
+// needs none), matching the former `.catalog-item--ghost`.
+const NAME_GHOST = 'font-cond text-lg font-bold uppercase tracking-caps-tight text-ink'
 
 export function CatalogTile({
   href,
@@ -66,8 +65,14 @@ export function CatalogTile({
   }
 
   return (
-    <a href={href} className={cn(TILE_BASE, isGhost ? TILE_GHOST : TILE_DEFAULT)} style={style}>
-      <span className={isGhost ? NAME_GHOST : cn(NAME, catalogLabel && NAME_LABEL)}>{name}</span>
+    <a
+      href={href}
+      className={cn(CATALOG_TILE_CHROME, TILE_LAYOUT, isGhost ? TILE_GHOST : CATALOG_TILE_FILL)}
+      style={style}
+    >
+      <span className={isGhost ? NAME_GHOST : cn(NAME, catalogLabel && CATALOG_TILE_LABEL)}>
+        {name}
+      </span>
     </a>
   )
 }

--- a/packages/component-lib/src/components/shared/NavDrawer.tsx
+++ b/packages/component-lib/src/components/shared/NavDrawer.tsx
@@ -5,6 +5,8 @@ import { Dialog } from '@base-ui/react/dialog'
 import { Menu, X } from 'lucide-react'
 import { buttonVariants } from '../chrome/buttonVariants'
 import { Badge } from '../chrome/Badge'
+import { CATALOG_TILE_CHROME, CATALOG_TILE_FILL, CATALOG_TILE_LABEL } from '../chrome/catalogTile'
+import { FOCUS_RING } from '../chrome/interaction'
 import { cn } from '../../utils/cn'
 
 /**
@@ -63,12 +65,12 @@ type NavDrawerProps = {
 }
 
 // Full-width catalog tile (former `.catalog-item`, compact drawer variant).
-const TILE =
-  // `background` shorthand, not `bg-[…]`/`background-color` — `--catalog-bg` may
-  // be a gradient (see CatalogTile), which background-color silently drops.
-  'block w-full rounded-card border-chrome border-ink [background:var(--catalog-bg)] px-[15px] py-[13px] text-center text-sm text-paper no-underline transition-[box-shadow,transform] duration-[120ms] hover:-translate-y-0.5 hover:shadow-[0_5px_18px_rgba(34,30,23,0.18)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-pilot'
+// The frame, fill and name plate are the SHARED tile treatment; the drawer only
+// adds its own layout (full-width block, centred, one step down in type). This
+// file used to carry a verbatim copy of both strings, so the two tiles drifted.
+const TILE = cn(CATALOG_TILE_CHROME, CATALOG_TILE_FILL, 'block w-full text-center text-sm')
 
-const TILE_LABEL = 'inline-block rounded-badge bg-[var(--catalog-label)] px-[10px] py-0.5'
+const TILE_LABEL = CATALOG_TILE_LABEL
 
 export function NavDrawer({
   brand,
@@ -90,7 +92,7 @@ export function NavDrawer({
             type="button"
             aria-label="Open menu"
             className={cn(
-              'rounded-md p-2 text-paper transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-pilot',
+              cn('rounded-md p-2 text-paper transition-colors', FOCUS_RING),
               triggerClassName
             )}
           >
@@ -117,7 +119,10 @@ export function NavDrawer({
                 <button
                   type="button"
                   aria-label="Close menu"
-                  className="flex items-center justify-center rounded-md p-1 text-ink/60 transition-colors hover:bg-ink/10 hover:text-ink focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-pilot"
+                  className={cn(
+                    'flex items-center justify-center rounded-md p-1 text-ink/60 transition-colors hover:bg-ink/10 hover:text-ink',
+                    FOCUS_RING
+                  )}
                 >
                   <X size={22} aria-hidden="true" />
                 </button>

--- a/tools/check-design-tokens.ts
+++ b/tools/check-design-tokens.ts
@@ -174,10 +174,10 @@ const EXEMPTIONS: { file: string; rules: string[]; reason: string }[] = [
       'Ladle stories are specimens, not shipped surfaces — the same standing the Foundations catalog pages above already have, extended to the co-located ones so the rule does not depend on which directory a story happens to live in. Their literals are harness scaffolding: the --tone/--ground custom properties the consuming APP supplies at runtime (ModeDoor, VitalGauge), a dark backdrop to prove contrast against, a #ccc outline on a resize container (DashboardGrid/DashboardCanvas), and swatch props fed as data (FilterChip). Nothing here reaches a user, and tokenising a stand-in for app-supplied context would make the story demonstrate something other than what ships. Note the cost, since it is real: stories are where new surfaces get prototyped, so this is the one place drift can incubate un-flagged — a literal that graduates from a story into a component is caught at the component, not here. `gradient` is deliberately NOT on this list: a gradient is banned by §3.5 on shading grounds that a specimen does not escape, and the one sanctioned story gradient (CatalogTile.stories.tsx) is named individually below.',
   },
   {
-    file: 'packages/component-lib/src/components/shared/CatalogTile.tsx',
+    file: 'packages/component-lib/src/components/chrome/catalogTile.ts',
     rules: ['gradient'],
     reason:
-      'Named exemption in ruleset §3.5: the srd catalog tile ramps (--catalog-bg) carry the tech-level and ability-tier ramps on the landing page. The ramp is a wayfinding cue, not decoration.',
+      'Named exemption in ruleset §3.5: the srd catalog tile ramps (--catalog-bg) carry the tech-level and ability-tier ramps on the landing page. The ramp is a wayfinding cue, not decoration. The exemption moved here from shared/CatalogTile.tsx along with the treatment itself: the only match is the doc comment explaining WHY the fill must use the `background` shorthand — it names the `linear-gradient()` that `background-color` silently drops. That comment is the reason the bug stays fixed, so it is not reworded to dodge the regex.',
   },
   {
     file: 'apps/srd/src/lib/catalogColors.ts',

--- a/tools/design-tokens-baseline.json
+++ b/tools/design-tokens-baseline.json
@@ -2,8 +2,8 @@
   "shadow-tokens": 0,
   "raw-color": 11,
   "gradient": 0,
-  "arbitrary-tracking": 7,
+  "arbitrary-tracking": 5,
   "arbitrary-border-width": 4,
-  "arbitrary-font-size": 29,
+  "arbitrary-font-size": 28,
   "pure-white": 0
 }


### PR DESCRIPTION
The srd landing grid, the 404 grid and the mobile nav drawer all render the same wayfinding tile, and two of them hand-rolled it. `NavDrawer` carried a **verbatim second copy** of both the frame string and the label chip, so a change to the tile reached the landing page and silently missed the drawer.

## What moved

Extracted into `chrome/catalogTile` — beside `STAMP_SEAM` and `POSTER_STAMP`, which is where a treatment shared by more than one component already lives:

| constant | what it owns |
| --- | --- |
| `CATALOG_TILE_CHROME` | frame, hover lift, focus ring |
| `CATALOG_TILE_FILL` | the `--catalog-bg` fill |
| `CATALOG_TILE_LABEL` | the `--catalog-label` name plate |

Both `CatalogTile` and `NavDrawer` now compose them.

## Drift fixed along the way

- **Focus ring.** The tiles and the drawer's two icon buttons used a bespoke `outline-2 outline-offset-2 outline-pilot` treatment instead of the canonical rust `FOCUS_RING`. That was not duplication — it was a *different-coloured* focus ring from every other interactive atom in the system.
- **Type ladder.** The tile name moves to `text-lede` / `tracking-caps-tight`, dropping two arbitrary bracket values the token guard tracks (`arbitrary-tracking` and `arbitrary-font-size` both ratchet down).
- **Exemption follows its subject.** The `gradient` exemption moves from `shared/CatalogTile.tsx` to `chrome/catalogTile.ts`, tracking the doc comment it actually covers.

The fill stays the `background` shorthand on purpose — `background-color` silently drops the tech-level and ability-tier gradients, a bug this codebase has already had once.

## Why the tile name is not a `Badge`

Deliberately **not** routed through `Badge shape="chip"`. Badge's chip is a fixed-height 22px `text-badge` *keyword* chip; the tile name is the tile's entire content at reading scale. Going through Badge would mean overriding its height, padding, type scale and fill — every part of the geometry that makes it a Badge — leaving only `rounded-badge` genuinely shared. That is a primitive worn as a costume, not reused. The reasoning is recorded in the new module so it is not re-litigated.

## Verification

- `bun run check:all` green (typecheck, lint, format, 3599 tests, validate, knip, tokens, styling).
- Visual before/after rendered from the **real** components in headless Chrome: only delta is the name, 16px → 15px and 0.02em → 0.04em tracking. Gradient fills, label chips and the ghost tile are unchanged.
- Focus ring verified actually painting on the tile (3px rust at 25%).

## Note for reviewers

The bespoke `outline-pilot` focus treatment still exists in ~5 other places (`AppBar`, `AppHeader`, `SearchField`, `Stat`, `SchemaViewerIsland`). Converting those is a broader sweep and is deliberately **not** in this PR.

Separately: the guard's `raw-color` rule never sees `shadow-[..._rgba(...)]`, because Tailwind's `_` separator defeats the `\b` in its regex. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbANWHNVEGWBhrC835sqtv