### PR TITLE
fix(entity-card): one tree stamp per ability card, not two

### DIFF
--- a/apps/itun/src/components/sheet/PilotSheetItems.tsx
+++ b/apps/itun/src/components/sheet/PilotSheetItems.tsx
@@ -117,7 +117,6 @@ export function PilotAbilityItem({
     <ReferenceEntityCard
       data={ability}
       size="medium"
-      label={ability.tree}
       hide={HIDE_CHOICES}
       footMeta={footMeta}
       controls={controls.length > 0 ? controls : undefined}

--- a/apps/srd/src/components/islands/ReferenceEntityIsland.tsx
+++ b/apps/srd/src/components/islands/ReferenceEntityIsland.tsx
@@ -1,6 +1,5 @@
 import { Suspense, useEffect, useMemo } from 'react'
 import type { SURefEntity } from 'salvageunion-reference'
-import { isAbility } from 'salvageunion-reference'
 import {
   ReferenceEntityCard,
   Skeleton,
@@ -74,7 +73,6 @@ export function ReferenceEntityIsland({
                   afterExtraContent={
                     classEntity ? <ClassAbilityTree classEntity={classEntity} /> : undefined
                   }
-                  label={isAbility(item) && item.tree ? `${item.tree} tree` : undefined}
                 />
               </EntityDetailLinkProvider>
             </EntityHrefProvider>

--- a/apps/srd/src/components/islands/SchemaViewerIsland.tsx
+++ b/apps/srd/src/components/islands/SchemaViewerIsland.tsx
@@ -340,28 +340,23 @@ export function SchemaViewerIsland({
               <EntityHrefProvider value={srdEntityHref}>
                 <EntityDetailLinkProvider value={true}>
                   <MasonryColumns>
-                    {filteredData.map((item: SURefEntity) => {
-                      const treeValue = schemaId === 'abilities' ? getTree(item) : undefined
-                      const tree = typeof treeValue === 'string' ? treeValue : undefined
-                      return (
-                        <a
-                          key={item.id}
-                          href={`/schema/${schemaId}/item/${getEntitySlug(item)}/`}
-                          aria-label={item.name}
-                          className="relative block"
-                        >
-                          <Suspense fallback={<Skeleton mode="card" compact />}>
-                            <ReferenceEntityCard
-                              data={item}
-                              size="medium"
-                              extent="catalog"
-                              label={tree}
-                              cardClickable
-                            />
-                          </Suspense>
-                        </a>
-                      )
-                    })}
+                    {filteredData.map((item: SURefEntity) => (
+                      <a
+                        key={item.id}
+                        href={`/schema/${schemaId}/item/${getEntitySlug(item)}/`}
+                        aria-label={item.name}
+                        className="relative block"
+                      >
+                        <Suspense fallback={<Skeleton mode="card" compact />}>
+                          <ReferenceEntityCard
+                            data={item}
+                            size="medium"
+                            extent="catalog"
+                            cardClickable
+                          />
+                        </Suspense>
+                      </a>
+                    ))}
                   </MasonryColumns>
                 </EntityDetailLinkProvider>
               </EntityHrefProvider>

--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -220,8 +220,6 @@ export type ReferenceEntityCardProps = {
   footMeta?: CardFootMeta[]
   /** Overrides the header's top-right flavor slot. */
   rightContent?: ReactNode
-  /** Callout stamp above the frame. */
-  label?: string
   className?: string
   /** Extra className on the card root (legacy `cardStyle`, e.g. the
    * removable-card treatment). `className` alone covers the same case. */
@@ -376,7 +374,6 @@ function ReferenceEntityCardInner({
   footerOverride,
   footMeta,
   rightContent: rightContentProp,
-  label,
   className,
   cardStyle,
   titleAs,
@@ -809,14 +806,16 @@ function ReferenceEntityCardInner({
     onClick: onStatusClick,
     subject: entityName,
   })
-  // Label callout — a stamp straddling the top-left frame.
-  const labelCallout = label ? (
-    <div className={cn('absolute left-3 z-30', compact ? 'top-0 -translate-y-1/2' : '-mt-2')}>
-      <Badge shape="stamp" size="mini">
-        {label}
-      </Badge>
-    </div>
-  ) : null
+  // (There was a `label` CALLOUT here — a second mini stamp at `left-3 z-30`,
+  // straddling the same top-left corner as the seam at `left-[15px] z-10`. It
+  // is deleted, not merely unused. Every one of its four call sites passed the
+  // ability's TREE, which the seam pill already states with the level
+  // (`[Forging | 1]`), so the callout painted OVER the pill: same corner, higher
+  // z-index, a different vertical offset (`-mt-2` vs `-translate-y-1/2`), which
+  // left just a sliver of the pill's white level cell poking above a stamp
+  // reading "FORGING TREE". The level — the fact the callout did not carry —
+  // was the part hidden. Keeping the prop around would leave a loaded gun: it
+  // has no non-duplicating use, and passing it re-creates the collision.)
   // Selection seal — an `ok`-tone "chosen" stamp riding the top-right frame when
   // selected (the picker-cell affordance formerly overlaid by SelCard).
   const selectionSealNode =
@@ -949,7 +948,6 @@ function ReferenceEntityCardInner({
     return (
       <div className={outerClassName} {...outerInteraction}>
         {seam}
-        {labelCallout}
         {topRightRail}
         <div
           className="flex flex-1 flex-col overflow-hidden rounded-card bg-paper"
@@ -1533,7 +1531,6 @@ function ReferenceEntityCardInner({
   return (
     <div className={outerClassName} {...outerInteraction}>
       {seam}
-      {labelCallout}
       {topRightRail}
       <div
         className="flex flex-1 flex-col overflow-hidden rounded-card bg-paper"

--- a/packages/component-lib/src/components/referenceEntity/useDetailModal.tsx
+++ b/packages/component-lib/src/components/referenceEntity/useDetailModal.tsx
@@ -12,7 +12,6 @@ import type { StatItem } from '../shared/statsBarTypes'
 
 type UseDetailModalOptions = {
   children?: ReactNode
-  label?: string
   /** Controls to render in the modal's entity header */
   modalControls?: ReferenceEntityControl[]
   /** Generic override props */
@@ -97,11 +96,6 @@ export function useDetailModal(
                   disabled={false}
                   hide={options?.hide}
                   controls={options?.modalControls}
-                  label={
-                    schemaName === 'abilities' && 'tree' in data && data.tree
-                      ? `${data.tree} Tree`
-                      : options?.label
-                  }
                   titleOverride={options?.titleOverride}
                   subtitleExtra={options?.subtitleExtra}
                   statsOverride={options?.statsOverride}

--- a/packages/component-lib/src/components/wizard/ClassAbilityStep.tsx
+++ b/packages/component-lib/src/components/wizard/ClassAbilityStep.tsx
@@ -115,13 +115,13 @@ export function ClassAbilityStep({
       selected={selectedAbilities.includes(ability.id)}
       selectionRole="toggle"
       cardClickLabel={ability.name}
-      label={ability.tree}
       onCardClick={() => onSelectAbility(ability.id)}
       hide={{ actions: true, choices: true }}
     />
   )
 
-  // Create mode: the class's legal Level-1 pool, flat, tree label on the card.
+  // Create mode: the class's legal Level-1 pool, flat. The card names its own
+  // tree in the seam pill (`[Forging | 1]`), so the pool needs no extra label.
   const legalPool = legalCreationAbilities(allAbilities, selectedClass?.coreTrees).sort((a, b) =>
     a.tree.localeCompare(b.tree)
   )


### PR DESCRIPTION
Closes the double-stamp reported on the ability card.

## The bug

An ability card carried its classification **twice, in the same corner**:

| element | position | content |
| --- | --- | --- |
| seam pill | `left-[15px] z-10` | `[Forging \| 1]` — tree **and level** |
| `label` callout | `left-3 z-30` | `FORGING TREE` — tree only |

Same corner, higher z-index, and a *different* vertical offset (`-mt-2` vs `-translate-y-1/2`). So the callout painted over the pill and left only a sliver of the pill's white level cell poking above — which read as a blank white box.

The **level** was the casualty: the one fact the callout did not carry is the one the collision hid.

## The fix

Every consumer of `label` passed an ability tree, so all five duplicated the pill and all five are removed:

- srd ability item page (`ReferenceEntityIsland`)
- srd catalog tile (`SchemaViewerIsland`)
- itun pilot sheet (`PilotSheetItems`)
- wizard ability picker (`ClassAbilityStep`)
- the shared detail modal (`useDetailModal`) — which also carried an unused `options.label` escape hatch that no caller set

With no consumers left, the `label` prop and its `labelCallout` are **deleted** rather than left dangling. The prop had no non-duplicating use, and passing it would re-create the collision. A comment records the reasoning where the callout used to be so it doesn't come back.

## Verification

Rendered all four surfaces in headless Chrome: **zero callouts**, and the seam pill still reads `[Forging | 1]` on every one — the tree name is lost nowhere, and the level is now visible.

`bun run check:all` green (typecheck, lint, format, tests, validate, knip, tokens, styling).

Typecheck earned its keep here: it caught the fifth consumer (`useDetailModal`) that the initial grep sweep missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbANWHNVEGWBhrC835sqtv