### PR TITLE
refactor(focus): one focus vocabulary across component-lib, srd and itun

### DIFF
--- a/apps/itun/src/components/mech/LoadoutPanel.tsx
+++ b/apps/itun/src/components/mech/LoadoutPanel.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties } from 'react'
 import { SalvageUnionReference } from 'salvageunion-reference'
-import { Glyph, VitalGauge } from 'component-lib'
+import { FOCUS_RING, Glyph, VitalGauge } from 'component-lib'
 import { cn } from '../../lib/utils'
 import { matchesRef } from '../../lib/rules/resolveRefs'
 
@@ -126,7 +126,7 @@ export function LoadoutPanel({
                   type="button"
                   onClick={() => onRemove(index)}
                   aria-label={`Remove ${itemName}`}
-                  className="flex size-5 shrink-0 items-center justify-center rounded-sm text-xs text-ink transition-colors hover:bg-ink hover:text-paper focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink"
+                  className={`flex size-5 shrink-0 items-center justify-center rounded-sm text-xs text-ink transition-colors hover:bg-ink hover:text-paper ${FOCUS_RING}`}
                 >
                   <Glyph name="x" />
                 </button>

--- a/apps/itun/src/components/shared/GlobalSearch.tsx
+++ b/apps/itun/src/components/shared/GlobalSearch.tsx
@@ -20,7 +20,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { SURefEntity } from 'salvageunion-reference'
-import { ModalShell, useDetailModal, useSearchCombobox } from 'component-lib'
+import { INPUT_FOCUS, ModalShell, useDetailModal, useSearchCombobox } from 'component-lib'
 import type { SearchComboboxResult } from 'component-lib'
 
 import { deepLinkToSchema } from '../../lib/srd-deep-link'
@@ -108,7 +108,7 @@ export function GlobalSearch({ open, onOpenChange }: GlobalSearchProps) {
             role="combobox"
             aria-expanded={hasSearched && results.length > 0}
             aria-controls={listboxId}
-            className="w-full rounded-[3px] border-chrome border-ink bg-paper px-3 py-2 font-body text-sm text-ink placeholder:text-wk-muted focus:outline-2 focus:outline-offset-2 focus:outline-rust"
+            className={`w-full rounded-[3px] border-chrome border-ink bg-paper px-3 py-2 font-body text-sm text-ink placeholder:text-wk-muted ${INPUT_FOCUS}`}
           />
 
           {hasSearched &&

--- a/apps/srd/src/components/islands/SchemaViewerIsland.tsx
+++ b/apps/srd/src/components/islands/SchemaViewerIsland.tsx
@@ -11,6 +11,7 @@ import {
   techLevelLabel,
   EntityHrefProvider,
   EntityDetailLinkProvider,
+  FOCUS_RING,
 } from 'component-lib'
 import { GameDataGate, type SchemaList } from '../../lib/useGameData'
 import { srdEntityHref } from '../../lib/entityHref'
@@ -330,7 +331,7 @@ export function SchemaViewerIsland({
                   <button
                     type="button"
                     onClick={clearFilters}
-                    className="cursor-pointer rounded-card px-2 py-0.5 font-cond text-xs font-semibold uppercase transition-colors bg-wk-faint text-ink hover:bg-wk-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-pilot"
+                    className={`cursor-pointer rounded-card px-2 py-0.5 font-cond text-xs font-semibold uppercase transition-colors bg-wk-faint text-ink hover:bg-wk-muted ${FOCUS_RING}`}
                   >
                     Clear filters
                   </button>

--- a/packages/component-lib/src/components/chrome/Conditions.tsx
+++ b/packages/component-lib/src/components/chrome/Conditions.tsx
@@ -1,4 +1,5 @@
 import { cn } from '../../utils/cn'
+import { FOCUS_RING } from './interaction'
 import { Badge } from './Badge'
 
 type ConditionChipProps = {
@@ -40,7 +41,7 @@ export function ConditionChip({
       type="button"
       onClick={onClick}
       aria-pressed={active}
-      className="cursor-pointer uppercase focus-visible:outline-none"
+      className={cn('cursor-pointer rounded-badge uppercase', FOCUS_RING)}
     >
       {label}
     </button>

--- a/packages/component-lib/src/components/chrome/InlineEditField.tsx
+++ b/packages/component-lib/src/components/chrome/InlineEditField.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react'
 import { cn } from '../../utils/cn'
+import { INPUT_FOCUS } from './interaction'
 import { Input, Textarea } from './Field'
 import { FieldError } from './FieldError'
 
@@ -145,10 +146,7 @@ export function InlineEditField({
           bordered && 'w-full rounded-card px-3',
           !hasValue && 'font-normal text-wk-muted',
           !readOnly &&
-            cn(
-              'cursor-pointer hover:bg-wk-bg-2 focus:outline-none focus:ring-[3px] focus:ring-rust/25',
-              !bordered && 'rounded-card px-1'
-            )
+            cn('cursor-pointer hover:bg-wk-bg-2', INPUT_FOCUS, !bordered && 'rounded-card px-1')
         )}
       >
         {hasValue ? value : (placeholder ?? '—')}

--- a/packages/component-lib/src/components/chrome/interaction.ts
+++ b/packages/component-lib/src/components/chrome/interaction.ts
@@ -16,6 +16,35 @@ export const FOCUS_RING =
  */
 export const INPUT_FOCUS = 'focus:outline-none focus:ring-[3px] focus:ring-rust/25'
 
+/**
+ * The same rust ring again, raised by a focusable DESCENDANT — the search-field
+ * shape, where the bordered shell is the thing that should look focused but the
+ * `<input>` inside is what actually takes focus. The inner control carries
+ * `focus:outline-none` itself, so this is ring-only: there is no outline on the
+ * shell to suppress, and pretending otherwise would imply the shell is
+ * focusable when it is not.
+ *
+ * This third rung exists because both search shells had already invented it —
+ * one as a pilot OUTLINE, one as the rust ring inline — which is the usual
+ * signal that the vocabulary was missing a word, not that the surfaces were
+ * special.
+ */
+export const FOCUS_WITHIN = 'focus-within:ring-[3px] focus-within:ring-rust/25'
+
+/**
+ * The ON-TONE rung: an ink ring with a paper offset, for a focusable surface
+ * whose own background is an arbitrary ENTITY TONE rather than paper — a
+ * clickable entity card can be pale pilot or near-black `tl-6`, and the 25%-alpha
+ * rust ring simply disappears against the dark end of that ramp.
+ *
+ * This is a real exception, not drift, so it is named instead of inlined: the
+ * ring is the accessibility affordance, and a rung that vanishes on a legal
+ * background is not one. Reach for it ONLY when the background is caller-supplied
+ * tone; everything sitting on paper uses `FOCUS_RING`.
+ */
+export const FOCUS_RING_ON_TONE =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink focus-visible:ring-offset-2 focus-visible:ring-offset-paper'
+
 /** The canonical disabled treatment (opacity + no pointer events). */
 export const DISABLED = 'disabled:pointer-events-none disabled:opacity-40'
 

--- a/packages/component-lib/src/components/referenceEntity/choiceCard/ChoiceGroups.tsx
+++ b/packages/component-lib/src/components/referenceEntity/choiceCard/ChoiceGroups.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from 'react'
 import type { SURefObjectChoice } from 'salvageunion-reference'
 import { SalvageUnionReference } from 'salvageunion-reference'
 import { cn } from '../../../utils/cn'
+import { INPUT_FOCUS } from '../../chrome/interaction'
 import { useParseTraitReferences } from '../../../utils/parseTraitReferences'
 import { Badge } from '../../chrome/Badge'
 import { RollTable } from '../../shared/RollTable'
@@ -140,8 +141,7 @@ function StampsealField({
   multiline?: boolean
   onChange: (value: string) => void
 }): ReactNode {
-  const fieldClass =
-    'peer w-full rounded border border-ink/20 bg-paper px-2 pt-3.5 pb-1 font-body text-xs text-ink focus:border-rust focus:outline-none'
+  const fieldClass = `peer w-full rounded border border-ink/20 bg-paper px-2 pt-3.5 pb-1 font-body text-xs text-ink focus:border-rust ${INPUT_FOCUS}`
   const badge = (
     // A single space placeholder makes `:placeholder-shown` track "is empty".
     <span

--- a/packages/component-lib/src/components/shared/AppBar.tsx
+++ b/packages/component-lib/src/components/shared/AppBar.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'react'
 import type { ElementType, ReactNode } from 'react'
 import { cn } from '../../utils/cn'
+import { FOCUS_RING } from '../chrome/interaction'
 
 /**
  * AppBar — the shared masthead both SU surfaces are built from (the internal
@@ -56,8 +57,7 @@ type AppBarProps = {
   breadcrumbDescription?: string
 }
 
-const NAV_LINK =
-  'inline-flex shrink-0 items-center font-cond text-lede font-semibold uppercase tracking-caps-tight text-paper/60 no-underline transition-colors hover:text-paper focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-pilot'
+const NAV_LINK = `inline-flex shrink-0 items-center font-cond text-lede font-semibold uppercase tracking-caps-tight text-paper/60 no-underline transition-colors hover:text-paper ${FOCUS_RING}`
 
 const NAV_LINK_ACTIVE = 'text-paper'
 

--- a/packages/component-lib/src/components/shared/AppHeader.tsx
+++ b/packages/component-lib/src/components/shared/AppHeader.tsx
@@ -1,5 +1,6 @@
 import type { ElementType } from 'react'
 import { Badge } from '../chrome/Badge'
+import { FOCUS_RING } from '../chrome/interaction'
 import { Search } from 'lucide-react'
 import { AppBar } from './AppBar'
 import type { AppBarNavItem } from './AppBar'
@@ -19,8 +20,7 @@ import type { NavDrawerItem } from './NavDrawer'
 
 // SRD search-field treatment, matching the shared SearchField chrome exactly so
 // the trigger button reads as the same search bar.
-const SEARCH_BOX =
-  'flex shrink-0 cursor-pointer items-center gap-2 rounded border border-ink bg-paper px-3 py-[7px] font-body text-caption text-ink-2 transition-colors hover:border-rust focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-pilot lg:w-64'
+const SEARCH_BOX = `flex shrink-0 cursor-pointer items-center gap-2 rounded border border-ink bg-paper px-3 py-[7px] font-body text-caption text-ink-2 transition-colors hover:border-rust ${FOCUS_RING} lg:w-64`
 
 // Small "Alpha" pills — the shared stamp atom rather than two hand-rolled
 // spans that differed only in size (px-1/text-label vs px-1.5/text-badge).

--- a/packages/component-lib/src/components/shared/Card.tsx
+++ b/packages/component-lib/src/components/shared/Card.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import type { CSSProperties, KeyboardEvent, ReactNode } from 'react'
 import { cn } from '../../utils/cn'
+import { FOCUS_RING_ON_TONE } from '../chrome/interaction'
 import { CardControlRail } from './CardControlRail'
 import { Stat } from './Stat'
 import type { StatItem } from './statsBarTypes'
@@ -239,11 +240,10 @@ export function Card({
         'relative flex shrink-0 flex-col overflow-visible rounded-card',
         cardStyle?.className || 'shadow-lg',
         disabled && 'opacity-50',
-        // Focus ring for button mode: uses a dark inner ring + white outer offset
-        // so the outline stays visible on both light backgrounds (e.g., bg-paper)
-        // and dark tech-level backgrounds (e.g., tl-5/tl-6).
-        resolvedCardClick &&
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink focus-visible:ring-offset-2 focus-visible:ring-offset-paper',
+        // Button mode focuses ON TONE — a card's own background may be any
+        // entity tone, including the near-black end of the tech-level ramp,
+        // where the 25%-alpha rust ring disappears. See FOCUS_RING_ON_TONE.
+        resolvedCardClick && FOCUS_RING_ON_TONE,
         isCardHoverable &&
           'cursor-pointer transition-all duration-200 md:hover:z-10 md:hover:-translate-y-0.5 md:hover:scale-[1.02]'
       )}

--- a/packages/component-lib/src/components/shared/EntitySearcher.tsx
+++ b/packages/component-lib/src/components/shared/EntitySearcher.tsx
@@ -26,6 +26,7 @@ import type {
 } from 'salvageunion-reference'
 import { matchesRef, type TechLevel } from 'salvageunion-reference/rules'
 import { cn } from '../../utils/cn'
+import { FOCUS_WITHIN } from '../chrome/interaction'
 import { Badge } from '../chrome/Badge'
 import { Panel } from '../chrome/Panel'
 import { Button } from '../chrome/Button'
@@ -263,7 +264,12 @@ export function EntitySearcher({
 
   // ---- Sub-parts of the searcher Card ----
   const searchInput = (
-    <label className="flex w-full items-center gap-2 rounded-card border-chrome border-ink bg-paper px-3 py-2 focus-within:ring-[3px] focus-within:ring-rust/25">
+    <label
+      className={cn(
+        'flex w-full items-center gap-2 rounded-card border-chrome border-ink bg-paper px-3 py-2',
+        FOCUS_WITHIN
+      )}
+    >
       <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" className="opacity-70">
         <circle cx="7" cy="7" r="5" fill="none" stroke="currentColor" strokeWidth="2" />
         <line x1="11" y1="11" x2="15" y2="15" stroke="currentColor" strokeWidth="2" />

--- a/packages/component-lib/src/components/shared/SearchField.tsx
+++ b/packages/component-lib/src/components/shared/SearchField.tsx
@@ -2,6 +2,7 @@ import { forwardRef } from 'react'
 import type { InputHTMLAttributes } from 'react'
 import { Search } from 'lucide-react'
 import { cn } from '../../utils/cn'
+import { FOCUS_WITHIN } from '../chrome/interaction'
 
 /**
  * SearchField — the shared search box (canonical; hoisted from the SRD search
@@ -30,7 +31,8 @@ export const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(functi
   return (
     <div
       className={cn(
-        'flex items-center gap-2 rounded border border-ink bg-paper px-3 py-[7px] font-body text-caption text-ink-2 focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-pilot',
+        'flex items-center gap-2 rounded border border-ink bg-paper px-3 py-[7px] font-body text-caption text-ink-2',
+        FOCUS_WITHIN,
         containerClassName
       )}
     >

--- a/packages/component-lib/src/components/shared/SheetSection.tsx
+++ b/packages/component-lib/src/components/shared/SheetSection.tsx
@@ -29,6 +29,7 @@ import { ModalShell } from './ModalShell'
 import { EDIT_CUE_CLASS } from './editLanguage'
 
 import { cn } from '../../utils/cn'
+import { FOCUS_RING } from '../chrome/interaction'
 
 // ---------------------------------------------------------------------------
 // HButton — the container-header control button (design `.hbtn`, clean-edit.html
@@ -41,8 +42,7 @@ import { cn } from '../../utils/cn'
 
 type HButtonVariant = 'edit' | 'done' | 'add'
 
-const HBTN_BASE =
-  'inline-flex cursor-pointer items-center gap-1.5 rounded-card border-2 px-3 font-cond text-label-lg font-bold uppercase leading-none tracking-caps-wide whitespace-nowrap transition-colors min-h-11 sm:min-h-8 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-rust/25 print:hidden'
+const HBTN_BASE = `inline-flex cursor-pointer items-center gap-1.5 rounded-card border-2 px-3 font-cond text-label-lg font-bold uppercase leading-none tracking-caps-wide whitespace-nowrap transition-colors min-h-11 sm:min-h-8 ${FOCUS_RING} print:hidden`
 
 const HBTN_VARIANT: Record<HButtonVariant, string> = {
   edit: 'border-ink bg-paper text-ink hover:bg-ink hover:text-paper',

--- a/packages/component-lib/src/components/shared/Stat.tsx
+++ b/packages/component-lib/src/components/shared/Stat.tsx
@@ -5,6 +5,7 @@ import { cn } from '../../utils/cn'
 import type { SizeRung } from '../../styles/sizing'
 import { Badge } from '../chrome/Badge'
 import type { StampSurface } from '../chrome/Badge'
+import { FOCUS_RING } from '../chrome/interaction'
 import { Tooltip } from '../ui/tooltip'
 import { EntityTooltip } from '../referenceEntity/EntityTooltip'
 import type { EntityStatus } from './entityStatus'
@@ -595,9 +596,7 @@ function ValueBox({
             trueBg,
             trueBorderColor,
             size === 'mini' ? 'border' : 'border-chrome',
-            disabled
-              ? 'pointer-events-none'
-              : 'cursor-pointer hover:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-pilot',
+            disabled ? 'pointer-events-none' : cn('cursor-pointer hover:opacity-80', FOCUS_RING),
             isFlashing && 'animate-[growShrink_3s_ease-out] motion-reduce:animate-none'
           )}
           aria-label={combinedAriaLabel}

--- a/packages/component-lib/src/components/sheet/ConditionsEditor.tsx
+++ b/packages/component-lib/src/components/sheet/ConditionsEditor.tsx
@@ -19,6 +19,8 @@
 import { useRef, useState } from 'react'
 
 import { Conditions } from '../chrome/Conditions'
+import { INPUT_FOCUS } from '../chrome/interaction'
+import { cn } from '../../utils/cn'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -112,7 +114,10 @@ export function ConditionsEditor({
           onBlur={() => {
             void commitAdd()
           }}
-          className="w-28 rounded-badge border border-ink bg-paper px-1.5 py-0.5 font-cond text-badge uppercase tracking-caps text-ink focus:outline-none focus:ring-1 focus:ring-rust/25"
+          className={cn(
+            'w-28 rounded-badge border border-ink bg-paper px-1.5 py-0.5 font-cond text-badge uppercase tracking-caps text-ink',
+            INPUT_FOCUS
+          )}
         />
       )}
     </div>

--- a/packages/component-lib/src/components/sheet/NpcFactsEditor.tsx
+++ b/packages/component-lib/src/components/sheet/NpcFactsEditor.tsx
@@ -14,6 +14,7 @@
 import { useRef, useState } from 'react'
 
 import { cn } from '../../utils/cn'
+import { INPUT_FOCUS } from '../chrome/interaction'
 
 type NpcFactsEditorProps = {
   facts: ReadonlyArray<string>
@@ -121,7 +122,10 @@ export function NpcFactsEditor({
             onBlur={() => {
               void commitAdd()
             }}
-            className="w-40 rounded-badge border border-ink bg-paper px-1.5 py-0.5 font-cond text-badge tracking-caps-tight text-ink focus:outline-none focus:ring-1 focus:ring-rust/25"
+            className={cn(
+              'w-40 rounded-badge border border-ink bg-paper px-1.5 py-0.5 font-cond text-badge tracking-caps-tight text-ink',
+              INPUT_FOCUS
+            )}
           />
         ) : (
           <button

--- a/packages/component-lib/src/components/sheet/SheetHero.tsx
+++ b/packages/component-lib/src/components/sheet/SheetHero.tsx
@@ -25,6 +25,7 @@ import { Badge } from '../chrome/Badge'
 import { Stat } from '../shared/Stat'
 
 import { cn } from '../../utils/cn'
+import { FOCUS_RING } from '../chrome/interaction'
 
 type HeroIdentityLine = {
   label: string
@@ -176,7 +177,10 @@ export function ChassisStats({ items, className }: ChassisStatsProps) {
             aria-label={item.actionLabel ?? item.code}
             title={item.actionLabel}
             onClick={item.onClick}
-            className="cursor-pointer rounded-card text-left transition-transform duration-[120ms] hover:-translate-y-px focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-rust/25"
+            className={cn(
+              'cursor-pointer rounded-card text-left transition-transform duration-[120ms] hover:-translate-y-px',
+              FOCUS_RING
+            )}
           >
             {block}
           </button>

--- a/packages/component-lib/src/components/wizard/MechInstallStep.stories.tsx
+++ b/packages/component-lib/src/components/wizard/MechInstallStep.stories.tsx
@@ -1,6 +1,7 @@
 import type { Story } from '@ladle/react'
 import { useMemo, useState } from 'react'
 import type { CSSVarStyle } from '../../styles/cssVars'
+import { FOCUS_RING } from '../chrome/interaction'
 import { SalvageUnionReference } from 'salvageunion-reference'
 import type { SURefModule, SURefSystem } from 'salvageunion-reference'
 import { matchesRef } from 'salvageunion-reference/rules'
@@ -118,7 +119,7 @@ function LegacyLoadoutPanel({
                   type="button"
                   onClick={() => onRemove(index)}
                   aria-label={`Remove ${itemName}`}
-                  className="flex size-5 shrink-0 items-center justify-center rounded-sm text-xs text-ink transition-colors hover:bg-ink hover:text-paper focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink"
+                  className={`flex size-5 shrink-0 items-center justify-center rounded-sm text-xs text-ink transition-colors hover:bg-ink hover:text-paper ${FOCUS_RING}`}
                 >
                   ✕
                 </button>

--- a/packages/component-lib/src/index.ts
+++ b/packages/component-lib/src/index.ts
@@ -75,6 +75,20 @@ export { Badge } from './components/chrome/Badge'
 export type { BadgeTone } from './components/chrome/Badge'
 export { Button } from './components/chrome/Button'
 export { buttonVariants } from './components/chrome/buttonVariants'
+/**
+ * The focus vocabulary. Exported because the APPS need it, not only the lib:
+ * srd and itun each had their own hand-rolled focus treatment (a pilot outline,
+ * a rust outline) purely because the canonical rungs stopped at the package
+ * boundary. A design system the consuming apps cannot import is one they will
+ * re-invent.
+ */
+export {
+  FOCUS_RING,
+  FOCUS_RING_ON_TONE,
+  FOCUS_WITHIN,
+  INPUT_FOCUS,
+  DISABLED,
+} from './components/chrome/interaction'
 // EmptyState — dashed stamp-headline empty slot (ruleset §"Empty state")
 export { EmptyState } from './components/chrome/EmptyState'
 // FieldError — the one single-message validation line (role="alert", danger tone)

--- a/tools/check-design-tokens.ts
+++ b/tools/check-design-tokens.ts
@@ -79,8 +79,19 @@ const RULES: Rule[] = [
     // 3. `(?<!&)` excludes a `#` preceded by `&` — an HTML numeric character
     //    entity like `&#8599;` (↗) or `&#9670;` (◆) in JSX. A 4-digit entity is
     //    a valid hex *length*, so only the lookbehind can tell it from a colour.
+    //
+    // 4. The `rgb()` arm uses `(?<![a-zA-Z0-9])` where it used to use `\b`. This
+    //    is not a cosmetic tidy: `_` is a WORD character, so `\b` never fired
+    //    inside a Tailwind arbitrary value, where `_` is the space separator.
+    //    Every `shadow-[0_5px_18px_rgba(...)]` in the codebase — the hover lifts
+    //    on the catalog tile, the entity row, the wizard door — was invisible to
+    //    this rule, which is the exact place raw colour is most likely to hide,
+    //    since there is no shadow token ladder to reach for instead. The new
+    //    lookbehind still refuses a letter or digit before `rgb`, so an
+    //    identifier ending in it (`srgb(`) is not a false positive, while `_`,
+    //    `(`, space and line-start all correctly count as a boundary.
     pattern:
-      /(?<!&)#(?!\d{1,3}\b)(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})\b|\brgba?\([^)]*\)/g,
+      /(?<!&)#(?!\d{1,3}\b)(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})\b|(?<![a-zA-Z0-9])rgba?\([^)]*\)/g,
   },
   {
     id: 'gradient',
@@ -287,6 +298,23 @@ for (const v of violations) {
  * enforced today.
  *
  * Rebaseline (only ever downward) with: bun run check:tokens --update-baseline
+ *
+ * ONE SANCTIONED EXCEPTION to "only ever downward", recorded because a silent
+ * upward bump is exactly what this ratchet exists to prevent: when a rule is
+ * made STRICTER, its count rises without anyone having written a new violation.
+ * That happened once, to `raw-color` (11 -> 35), when its `rgb()` arm stopped
+ * using `\b` — a boundary that could never fire inside a Tailwind arbitrary
+ * value, because `_` is a word character. The 24 newly-counted literals are all
+ * pre-existing `shadow-[..._rgba(...)]` / `[text-shadow:..._rgba(...)]` values
+ * that had been present and uncounted; not one of them is new drift.
+ *
+ * They are baselined rather than fixed because there is no shadow/scrim token
+ * ladder to convert them to — inventing one is a design decision with real
+ * visual consequences across the wizard doors, roll tables and hover lifts, not
+ * a lint cleanup. The debt is now VISIBLE and frozen, which is the point.
+ *
+ * The rule stands: a stricter rule may rebaseline upward ONCE, in the same
+ * commit that tightens it, with the reason written down. Drift may not.
  */
 const BASELINE_PATH = join(import.meta.dir, 'design-tokens-baseline.json')
 

--- a/tools/design-tokens-baseline.json
+++ b/tools/design-tokens-baseline.json
@@ -1,6 +1,6 @@
 {
   "shadow-tokens": 0,
-  "raw-color": 11,
+  "raw-color": 35,
   "gradient": 0,
   "arbitrary-tracking": 5,
   "arbitrary-border-width": 4,


### PR DESCRIPTION
Two asks, one branch: switch everything to the canonical focus ring, and tighten the token guard — with srd and itun on the **same** style system.

## Why the apps had their own rings

The canonical rust ring lived in `chrome/interaction` but was **never exported from the package barrel**, so neither app could reach it. Both invented their own: srd a pilot `outline`, itun a rust `outline`, neither matching the ring every `Button` already used. A design system the consuming apps cannot import is one they will re-invent. The constants are now barrel-exported and both apps consume them.

## Four named rungs, sixteen call sites

| rung | when |
| --- | --- |
| `FOCUS_RING` | keyboard focus on paper — the default |
| `INPUT_FOCUS` | same ring on plain `focus:`, for editable controls |
| `FOCUS_WITHIN` *(new)* | the search-shell shape: shell shows the ring, inner `<input>` takes focus |
| `FOCUS_RING_ON_TONE` *(new)* | ink ring + paper offset, for a surface whose background is a caller-supplied entity tone |

Both new rungs are **discoveries, not inventions**. Both search shells had independently invented focus-within (one as a pilot outline, one as the rust ring inline) — the usual sign the vocabulary was missing a word. And `Card` already had the on-tone ring inline with a written rationale that turns out to be correct: the 25%-alpha rust ring disappears against the near-black end of the tech-level ramp. Naming it makes it part of the system and marks it as the narrow exception rather than drift.

## Two bugs fell out

- **`Conditions`' clickable chip set `focus-visible:outline-none` with no replacement** — it removed the focus indicator and put nothing back. That's an accessibility defect, not a style choice.
- Two sheet inputs rang at `ring-1` instead of the canonical 3px.

Deliberately **not** converted: a search shell's inner input keeps `focus:outline-none` (the shell carries the ring), and `InlineEditField`'s `ERROR_SKIN` keeps its `status-bad` recolour — the same ring in an error state, not a competing treatment.

## Tightening `raw-color`

The rule's `rgb()` arm used `\b`, which **can never fire inside a Tailwind arbitrary value**, because `_` is a word character. Every `shadow-[0_5px_18px_rgba(...)]` in the repo was invisible to it — precisely where raw colour is most likely to hide, since there is no shadow token ladder to reach for instead. Now `(?<![a-zA-Z0-9])`, which still rejects `srgb(` but treats `_`, `(`, space and line-start as boundaries.

That surfaced **24 pre-existing literals (11 → 35)**. Read the number carefully: this is a *detection* change, not new drift — not one of those 24 is newly written.

They are **baselined rather than fixed** because converting them needs a shadow/scrim token ladder that does not exist, and inventing one is a design decision with real visual consequences across the wizard doors, roll tables and hover lifts. The debt is now visible and frozen. The ratchet doc records this as the one sanctioned upward rebaseline: **a stricter rule may rebaseline upward once, in the commit that tightens it, with the reason written down. Drift may not.**

## Verification

`bun run check:all` green, and all pre-push gates passed. All four rungs verified painting in headless Chrome, including the on-tone rung staying legible on a `tl-6` card where the rust ring would not be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbANWHNVEGWBhrC835sqtv