### PR TITLE
refactor(tokens): resolve every shadow onto the ink ladder, raw-color to zero

### DIFF
--- a/apps/itun/src/components/sheet/LiveSheet.tsx
+++ b/apps/itun/src/components/sheet/LiveSheet.tsx
@@ -160,7 +160,7 @@ export function LiveSheet({
       <header
         className={cn(
           'sticky top-0 z-20 flex min-h-[58px] flex-wrap items-center gap-x-4 gap-y-1 border-b-2 border-ink px-4 py-2 sm:px-[30px]',
-          condensed && 'shadow-[0_2px_0_var(--color-ink),0_14px_20px_-18px_rgba(40,32,25,0.55)]'
+          condensed && 'shadow-[0_2px_0_var(--color-ink),0_14px_20px_-18px_var(--color-ink-50)]'
         )}
         style={{ background: 'var(--ground-2)' }}
       >

--- a/apps/itun/src/components/sheet/SheetRail.tsx
+++ b/apps/itun/src/components/sheet/SheetRail.tsx
@@ -82,7 +82,7 @@ export function RailChip({
       href={href}
       aria-label={`${roleLabel}: ${name} — open sheet`}
       className={cn(
-        'relative flex min-w-0 flex-[1_1_0%] flex-col overflow-hidden rounded-[3px] border-rail no-underline transition-transform duration-[120ms] hover:-translate-y-px hover:shadow-[0_12px_26px_-14px_rgba(40,32,25,0.55)]',
+        'relative flex min-w-0 flex-[1_1_0%] flex-col overflow-hidden rounded-[3px] border-rail no-underline transition-transform duration-[120ms] hover:-translate-y-px hover:shadow-[0_12px_26px_-14px_var(--color-ink-50)]',
         className
       )}
       style={{ background: RAIL_BG[tone], borderColor: RAIL_BG[tone] }}

--- a/apps/itun/src/components/wizard/CreateModeChooser.tsx
+++ b/apps/itun/src/components/wizard/CreateModeChooser.tsx
@@ -64,7 +64,7 @@ export function CreateModeChooser({ kind, onGuided, onBlank }: CreateModeChooser
         className="border-b-4 border-paper/95 px-5 pb-3.5 pt-7 sm:px-7"
         style={{ background: 'var(--tone)' }}
       >
-        <h1 className="m-0 font-cond text-[clamp(34px,5.2vw,54px)] font-bold uppercase leading-[0.98] tracking-[0.5px] text-paper [text-shadow:0_2px_0_rgba(0,0,0,0.22)]">
+        <h1 className="m-0 font-cond text-[clamp(34px,5.2vw,54px)] font-bold uppercase leading-[0.98] tracking-[0.5px] text-paper [text-shadow:0_2px_0_var(--color-ink-20)]">
           New {label}
         </h1>
       </header>

--- a/packages/component-lib/src/components/chrome/ModeDoor.tsx
+++ b/packages/component-lib/src/components/chrome/ModeDoor.tsx
@@ -21,7 +21,7 @@ type ModeDoorProps = {
 const DOOR_BASE =
   'relative min-h-[170px] cursor-pointer rounded-xl p-[22px] pb-5 pl-[26px] text-left transition-transform duration-[120ms] hover:-translate-y-0.5'
 const TAB =
-  'absolute -left-3.5 top-[18px] grid h-12 w-11 place-items-center rounded-[2px] bg-ink font-cond text-[22px] font-bold text-paper shadow-[0_8px_14px_-8px_rgba(0,0,0,0.55)]'
+  'absolute -left-3.5 top-[18px] grid h-12 w-11 place-items-center rounded-[2px] bg-ink font-cond text-[22px] font-bold text-paper shadow-[0_8px_14px_-8px_var(--color-ink-50)]'
 const HEAD =
   'mb-1.5 ml-[34px] block font-cond text-[27px] font-bold uppercase leading-none tracking-caps-tight'
 const BODY = 'ml-[34px] block font-body text-caption leading-[1.55] text-ink'
@@ -29,7 +29,7 @@ const CITE = 'ml-[34px] mt-2.5 block font-body text-[12.5px] font-bold text-ink'
 
 /** guided emphasis: a ground gap, a 3px ink ring, then a soft drop shadow. */
 const GUIDED_HALO =
-  'shadow-[0_0_0_3px_var(--ground),0_0_0_7px_var(--color-ink),0_18px_30px_-14px_rgba(0,0,0,0.5)]'
+  'shadow-[0_0_0_3px_var(--ground),0_0_0_7px_var(--color-ink),0_18px_30px_-14px_var(--color-ink-50)]'
 
 /**
  * ModeDoor — the onboarding "choose how to create" poster card (mockup `.door`,
@@ -60,7 +60,7 @@ export function ModeDoor({
         FOCUS_RING,
         guided
           ? GUIDED_HALO
-          : 'border-entity border-dashed border-ink/55 bg-paper text-ink shadow-[0_14px_26px_-14px_rgba(0,0,0,0.4)]',
+          : 'border-entity border-dashed border-ink/55 bg-paper text-ink shadow-[0_14px_26px_-14px_var(--color-ink-40)]',
         className
       )}
     >
@@ -70,7 +70,7 @@ export function ModeDoor({
       <span
         className={cn(
           HEAD,
-          guided ? 'text-paper [text-shadow:0_1px_0_rgba(0,0,0,0.38)]' : 'text-ink'
+          guided ? 'text-paper [text-shadow:0_1px_0_var(--color-ink-40)]' : 'text-ink'
         )}
       >
         {headline}

--- a/packages/component-lib/src/components/chrome/catalogTile.ts
+++ b/packages/component-lib/src/components/chrome/catalogTile.ts
@@ -33,7 +33,7 @@ import { FOCUS_RING } from './interaction'
 export const CATALOG_TILE_CHROME = cn(
   'rounded-card border-chrome border-ink px-[15px] py-[13px] no-underline',
   'transition-[box-shadow,transform] duration-[120ms]',
-  'hover:-translate-y-0.5 hover:shadow-[0_5px_18px_rgba(34,30,23,0.18)]',
+  'hover:-translate-y-0.5 hover:shadow-[0_5px_18px_var(--color-ink-20)]',
   FOCUS_RING
 )
 

--- a/packages/component-lib/src/components/dashboard/instruments.css
+++ b/packages/component-lib/src/components/dashboard/instruments.css
@@ -552,7 +552,7 @@
   border: var(--bw-chrome) solid color-mix(in srgb, var(--color-ink) 16%, transparent);
   border-radius: var(--radius-panel);
   background: var(--color-paper);
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.06);
+  box-shadow: inset 0 1px 2px var(--color-ink-8);
   cursor: pointer;
   padding: 5px 10px;
   display: flex;
@@ -565,7 +565,7 @@
 .pc-cell-active {
   border-color: color-mix(in srgb, var(--color-ink) 55%, transparent);
   background: var(--color-paper);
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.08);
+  box-shadow: inset 0 1px 3px var(--color-ink-8);
   cursor: default;
 }
 .pc-cell.statless {

--- a/packages/component-lib/src/components/shared/CatalogTile.tsx
+++ b/packages/component-lib/src/components/shared/CatalogTile.tsx
@@ -44,7 +44,7 @@ const TILE_GHOST = 'bg-paper text-ink'
 // their utility form on purpose: the guard reads comments, and a citation of
 // the thing you removed counts as the thing itself.)
 const NAME =
-  'font-cond text-lede font-semibold uppercase leading-[1.2] tracking-caps-tight text-paper [text-shadow:0_1px_2px_rgba(0,0,0,0.75)]'
+  'font-cond text-lede font-semibold uppercase leading-[1.2] tracking-caps-tight text-paper [text-shadow:0_1px_2px_var(--color-ink-75)]'
 
 // Ghost name — cond/bold/uppercase at text-lg with no text-shadow (ink on paper
 // needs none), matching the former `.catalog-item--ghost`.

--- a/packages/component-lib/src/components/shared/EntityRow.tsx
+++ b/packages/component-lib/src/components/shared/EntityRow.tsx
@@ -174,8 +174,8 @@ export function EntityRow(props: EntityRowProps) {
     <div
       className={cn(
         'group relative flex items-stretch overflow-hidden rounded-card border-2 border-ink',
-        'shadow-[0_1px_0_rgba(40,32,25,0.05)] transition-all duration-200',
-        'md:hover:-translate-y-0.5 md:hover:shadow-[0_7px_18px_rgba(40,32,25,0.16)]'
+        'shadow-[0_1px_0_var(--color-ink-8)] transition-all duration-200',
+        'md:hover:-translate-y-0.5 md:hover:shadow-[0_7px_18px_var(--color-ink-20)]'
       )}
       style={frameStyle}
     >

--- a/packages/component-lib/src/components/shared/EntitySearcher.tsx
+++ b/packages/component-lib/src/components/shared/EntitySearcher.tsx
@@ -476,7 +476,7 @@ export function EntitySearcher({
             mode={mode}
             onToggle={onToggle}
             onRemove={onRemove}
-            className="max-h-[45vh] overflow-y-auto shadow-[0_6px_24px_rgba(40,32,25,0.28)]"
+            className="max-h-[45vh] overflow-y-auto shadow-[0_6px_24px_var(--color-ink-30)]"
           />
         </div>
       </div>

--- a/packages/component-lib/src/components/shared/RollTable.tsx
+++ b/packages/component-lib/src/components/shared/RollTable.tsx
@@ -531,7 +531,7 @@ function ColumnsRollTable({
                               'relative text-left text-ink transition-all duration-200',
                               compact ? 'px-2 py-0.5 text-xs' : 'px-3 py-1 text-base',
                               isHighlighted &&
-                                'z-[1] scale-[1.04] cursor-pointer outline-4 outline-ink shadow-[0_14px_40px_rgba(0,0,0,0.85)]'
+                                'z-[1] scale-[1.04] cursor-pointer outline-4 outline-ink shadow-[0_14px_40px_var(--color-ink-85)]'
                             )}
                             onClick={isHighlighted ? handleClear : undefined}
                             onKeyDown={
@@ -724,7 +724,7 @@ function StandardRollTable({
                       'relative flex flex-row flex-wrap border-b border-ink/10 transition-all duration-200',
                       bgColor,
                       isHighlighted &&
-                        'z-[1] scale-[1.04] cursor-pointer shadow-[0_0_0_4px_rgba(0,0,0,0.9),0_14px_40px_rgba(0,0,0,0.85)]',
+                        'z-[1] scale-[1.04] cursor-pointer shadow-[0_0_0_4px_var(--color-ink-85),0_14px_40px_var(--color-ink-85)]',
                       compact ? 'gap-1' : 'gap-2'
                     )}
                     onClick={isHighlighted ? handleClearHighlight : undefined}

--- a/packages/component-lib/src/components/shared/WizShell.tsx
+++ b/packages/component-lib/src/components/shared/WizShell.tsx
@@ -91,7 +91,7 @@ type WizShellProps = {
  */
 export function WizTracker({ label, value }: { label: string; value: ReactNode }) {
   return (
-    <span className="inline-flex items-baseline gap-2 whitespace-nowrap rounded-badge bg-ink px-3 py-1.5 font-cond text-caption font-bold uppercase leading-none tracking-caps text-paper shadow-[inset_0_0_0_1.5px_rgba(255,255,255,0.28)]">
+    <span className="inline-flex items-baseline gap-2 whitespace-nowrap rounded-badge bg-ink px-3 py-1.5 font-cond text-caption font-bold uppercase leading-none tracking-caps text-paper shadow-[inset_0_0_0_1.5px_var(--color-paper-30)]">
       <span>{label}</span>
       <span className="text-lede tracking-caps-tight text-pilot">{value}</span>
     </span>
@@ -221,7 +221,7 @@ export function WizShell({
   // `footerHud` it is MOUNTED at the right of the wide paper footer bar. Its own
   // dark ground keeps the ghost buttons legible in either home.
   const actionPill = (
-    <div className="pointer-events-auto flex w-full flex-col items-stretch gap-2 rounded-2xl bg-ink p-2.5 shadow-[0_16px_28px_-12px_rgba(0,0,0,0.6)] sm:w-auto sm:flex-row sm:items-center sm:gap-3 sm:rounded-full sm:pl-4">
+    <div className="pointer-events-auto flex w-full flex-col items-stretch gap-2 rounded-2xl bg-ink p-2.5 shadow-[0_16px_28px_-12px_var(--color-ink-50)] sm:w-auto sm:flex-row sm:items-center sm:gap-3 sm:rounded-full sm:pl-4">
       {trackers && (
         <div className="flex flex-wrap items-center justify-center gap-2 sm:justify-start">
           {trackers}
@@ -319,7 +319,7 @@ export function WizShell({
         className="border-b-4 border-paper/95 px-5 pb-2.5 pt-5 sm:px-7"
         style={{ background: 'var(--tone)' }}
       >
-        <p className="m-0 font-cond text-[clamp(26px,4vw,40px)] font-bold uppercase leading-[0.98] tracking-normal text-paper [text-shadow:0_2px_0_rgba(0,0,0,0.22)]">
+        <p className="m-0 font-cond text-[clamp(26px,4vw,40px)] font-bold uppercase leading-[0.98] tracking-normal text-paper [text-shadow:0_2px_0_var(--color-ink-20)]">
           {eyebrow}
         </p>
       </header>
@@ -386,7 +386,7 @@ export function WizShell({
                flush ink number tab, white condensed step head. */
             <div className={cn('min-h-0 flex-1 sm:pl-5', contentPad)}>
               <article
-                className="relative rounded-xl px-5 pb-6 pt-5 shadow-[0_14px_26px_-14px_rgba(0,0,0,0.4),inset_0_0_46px_rgba(0,0,0,0.08)] sm:pl-8"
+                className="relative rounded-xl px-5 pb-6 pt-5 shadow-[0_14px_26px_-14px_var(--color-ink-40),inset_0_0_46px_var(--color-ink-8)] sm:pl-8"
                 style={{
                   background: 'var(--tone-card, var(--tone))',
                   // Card ink: rust (mech) needs WHITE body ink for legible
@@ -397,12 +397,12 @@ export function WizShell({
               >
                 <span
                   aria-hidden="true"
-                  className="absolute -left-5 top-6 hidden h-16 w-14 place-items-center rounded-badge bg-ink font-cond text-[38px] font-extrabold leading-none text-paper shadow-[0_8px_14px_-8px_rgba(0,0,0,0.55)] sm:grid"
+                  className="absolute -left-5 top-6 hidden h-16 w-14 place-items-center rounded-badge bg-ink font-cond text-[38px] font-extrabold leading-none text-paper shadow-[0_8px_14px_-8px_var(--color-ink-50)] sm:grid"
                 >
                   {active + 1}
                 </span>
                 <header>
-                  <h1 className="m-0 font-cond text-display font-bold uppercase leading-[1.05] text-paper [text-shadow:0_1px_0_rgba(0,0,0,0.38)]">
+                  <h1 className="m-0 font-cond text-display font-bold uppercase leading-[1.05] text-paper [text-shadow:0_1px_0_var(--color-ink-40)]">
                     <span className="sr-only">
                       Step {active + 1} of {steps.length} ·{' '}
                     </span>
@@ -442,7 +442,7 @@ export function WizShell({
             )}
           >
             {footerHud ? (
-              <div className="pointer-events-auto flex w-full flex-col gap-2.5 rounded-2xl border-chrome border-ink bg-paper p-2.5 shadow-[0_16px_28px_-12px_rgba(0,0,0,0.6)] sm:w-auto sm:max-w-4xl sm:flex-row sm:items-stretch sm:gap-3 sm:pl-3.5">
+              <div className="pointer-events-auto flex w-full flex-col gap-2.5 rounded-2xl border-chrome border-ink bg-paper p-2.5 shadow-[0_16px_28px_-12px_var(--color-ink-50)] sm:w-auto sm:max-w-4xl sm:flex-row sm:items-stretch sm:gap-3 sm:pl-3.5">
                 <div className="flex min-w-0 flex-1 items-center">{footerHud}</div>
                 {actionPill}
               </div>

--- a/packages/component-lib/src/components/sheet/SheetActionsMenu.tsx
+++ b/packages/component-lib/src/components/sheet/SheetActionsMenu.tsx
@@ -50,7 +50,7 @@ export function SheetActionsMenu({ children, className }: SheetActionsMenuProps)
         <div
           role="group"
           aria-label="Sheet actions"
-          className="absolute right-0 top-full z-30 mt-1.5 flex min-w-36 flex-col items-stretch gap-1.5 rounded-panel border-2 border-ink bg-paper p-2 shadow-[0_14px_28px_-14px_rgba(40,32,25,0.55)]"
+          className="absolute right-0 top-full z-30 mt-1.5 flex min-w-36 flex-col items-stretch gap-1.5 rounded-panel border-2 border-ink bg-paper p-2 shadow-[0_14px_28px_-14px_var(--color-ink-50)]"
         >
           {children}
         </div>

--- a/packages/component-lib/src/styles/theme.css
+++ b/packages/component-lib/src/styles/theme.css
@@ -127,11 +127,25 @@
      the shadow family (su-grey/-light/-medium/-dark, su-muted, su-ink-soft,
      su-sand, su-input-bg), which were true neutrals fighting the warm paper.
      Warm ink at opacity reads as the same material at distance. */
+  --color-ink-85: rgb(40 32 25 / 0.85);
   --color-ink-75: rgb(40 32 25 / 0.75);
   --color-ink-50: rgb(40 32 25 / 0.5);
+  --color-ink-40: rgb(40 32 25 / 0.4);
   --color-ink-30: rgb(40 32 25 / 0.3);
+  --color-ink-20: rgb(40 32 25 / 0.2);
   --color-ink-12: rgb(40 32 25 / 0.12);
   --color-ink-8: rgb(40 32 25 / 0.08);
+  /* The -85 / -40 / -20 rungs were added for SHADOWS, which had been authored
+     as raw `rgba()` inside Tailwind arbitrary values and were invisible to the
+     token guard until its `rgb()` arm stopped using `\b` (a boundary that can
+     never fire next to the `_` separator). Those 26 literals used THREE
+     different bases — pure black, `rgb(40,32,25)` (ink), and `rgb(34,30,23)`
+     (an ink that exists nowhere in this file) — across 16 alpha values, for
+     what is a handful of elevations.
+     They all resolve here, to warm ink at opacity, for the reason the note
+     above already gives: a true-neutral shadow fights warm paper. Each new rung
+     covers a real cluster (0.16-0.22, 0.38-0.45, 0.85-0.90) rather than
+     enshrining one call site's number. */
   /* Paper — the ONE light surface (ruleset §4.1). NOT pure white and NOT cream:
      a near-white warm paper. Pure white is retired from the UI — paper is used
      universally (surfaces, value cells, and text on ink). The only remaining
@@ -139,6 +153,11 @@
      The Dashboard cockpit is warm paper too (ruleset §1), so the dark-skin
      exception this note used to carve out no longer exists. */
   --color-paper: rgb(251, 250, 247); /* #fbfaf7 */
+  /* Paper at opacity — the inset bevel highlight on a dark surface. One rung,
+     because there is exactly one such highlight; it was `rgba(255,255,255,0.28)`,
+     a pure white that the paper law (§4.1) retired everywhere the guard could
+     actually see. */
+  --color-paper-30: rgb(251 250 247 / 0.3);
   --color-rust: rgb(168, 82, 34); /* #a85222 — THE single action color */
   /* The one sanctioned cream. The rendering matrix (ruleset §2) specifies the
      RollTable as "banded d20, peach/cream", so cream survives for exactly that

--- a/packages/salvageunion-reference/lib/schemas/entities.ts
+++ b/packages/salvageunion-reference/lib/schemas/entities.ts
@@ -442,7 +442,12 @@ export const GuideSchema = BaseEntitySchema.extend({
   guideColor: z
     .string()
     .regex(/^#[0-9a-fA-F]{6}$/)
-    .default('#000000')
+    // #282019 IS `--color-ink`, spelled as a literal because this validates
+    // DATA, not styling: the field's contract is a 6-digit hex (see the regex
+    // above), so `var(--color-ink)` is not a legal value here. The default was
+    // pure black, which the warm palette retired — and it is load-bearing, not
+    // decorative: 64 of the 79 guides omit `guideColor` and render on it.
+    .default('#282019')
     .describe('Hex color for entity display header/footer'),
   steps: z.array(GuideStepSchema).describe('Ordered sequence of steps'),
   repeatable: z.boolean().optional().describe('Whether this guide can be executed multiple times'),

--- a/packages/salvageunion-reference/schemas/guides.schema.json
+++ b/packages/salvageunion-reference/schemas/guides.schema.json
@@ -238,7 +238,7 @@
         "description": "Category of this guide"
       },
       "guideColor": {
-        "default": "#000000",
+        "default": "#282019",
         "description": "Hex color for entity display header/footer",
         "type": "string",
         "pattern": "^#[0-9a-fA-F]{6}$"

--- a/tools/check-design-tokens.ts
+++ b/tools/check-design-tokens.ts
@@ -215,6 +215,36 @@ const EXEMPTIONS: { file: string; rules: string[]; reason: string }[] = [
       'Ruleset §3.5 THE one-off: the .pilot-panel distressed-metal effect on srd /about is a CSS illustration, ruled a sanctioned one-off. It is the single place smooth shading is allowed, and it is allowed because it is a picture of a rusted plate rather than a UI surface. Not precedent — no second one-off without an explicit ruling. raw-color rides along because it is the SAME illustration: the rust blooms, the steel plate, the rivet heads and the engraved lettering are one picture, and a picture needs more shades than a UI palette has — the rivets alone spend nine greys on lit/worn/green/flush/hole. Tokenising them would add a dozen tokens nothing else could ever reuse. CAVEAT, since a file-level exemption is blunter than the rationale: it also swallows three literals outside the illustration block — the .catalog-item hover box-shadow and .catalog-item__name text-shadow (real shadow debt on an authored surface, still owed a token) and one #fff in the print block. Line-scoping the exemption was considered and rejected as too brittle to survive edits to this file; they are recorded here instead of silently absorbed.',
   },
   {
+    file: 'packages/salvageunion-reference/lib/schemas/entities.ts',
+    rules: ['raw-color'],
+    reason:
+      "A DATA contract, not a styling call site. `guideColor` is an authored per-guide hex whose Zod schema enforces `^#[0-9a-fA-F]{6}$` — `var(--color-ink)` is not a legal value for that field, so its default cannot be a token reference no matter how much we would like it to be. The rule the guard is really enforcing (use OUR palette) is still applied: the default is the canonical ink's own hex, #282019, not the pure black it used to be.",
+  },
+  {
+    file: 'packages/component-lib/src/components/shared/KofiButton.tsx',
+    rules: ['raw-color'],
+    reason:
+      "EXTERNAL BRAND colour, not ours. #72a4f2 is Ko-fi's own blue, the default fill for their button; the widget is recognisable BECAUSE it is that colour, so resolving it to a Salvage Union token would misrepresent someone else's mark. This is the standing rule for third-party marks: a colour we source from an external brand keeps the external value, and anything sourced to OUR design uses the canonical set. Note the prop is caller-overridable, so a consumer that wants a themed button already can.",
+  },
+  {
+    file: 'apps/itun/src/styles/print.css',
+    rules: ['raw-color', 'pure-white'],
+    reason:
+      'PRINT MEDIA. Inside `@media print` the surface is physical paper and the ink is real ink, so #fff / #000 are the correct values rather than the screen palette — warm paper (#fbfaf7) printed as a fill wastes toner and reads grey. theme.css already carves out exactly this exception in its paper note ("the only remaining #ffffff is one scoped exception: the @media print sheet"); this is that exception, in the app that owns the sheet.',
+  },
+  {
+    file: 'apps/itun/src/index.css',
+    rules: ['raw-color', 'pure-white'],
+    reason:
+      'Same print exception as styles/print.css above — the literals here are all inside the print/PDF-export block that forces a true-white ground for the live sheet.',
+  },
+  {
+    file: 'packages/component-lib/src/components/referenceEntity/card/entityCardTone.ts',
+    rules: ['raw-color'],
+    reason:
+      "Self-citation, not a colour: the sole match is a doc comment describing the `hostBase` parameter as accepting a resolvable CSS colour, naming the `rgb()` form it accepts. The rule matches the empty-parens spelling. Rewording the comment to dodge the regex would make the parameter's contract less clear to satisfy a lint — the same trade the raw-color rule already refuses for PR and issue references.",
+  },
+  {
     file: 'apps/srd/src/pages/greembeem.astro',
     rules: ['raw-color'],
     reason:

--- a/tools/design-tokens-baseline.json
+++ b/tools/design-tokens-baseline.json
@@ -1,6 +1,6 @@
 {
   "shadow-tokens": 0,
-  "raw-color": 35,
+  "raw-color": 0,
   "gradient": 0,
   "arbitrary-tracking": 5,
   "arbitrary-border-width": 4,


### PR DESCRIPTION
Clears the shadow debt the tightened rule surfaced. **`raw-color` 35 → 0**, joining `shadow-tokens`, `gradient` and `pure-white` as fully enforced. Total known violations 72 → 37.

## What the shadows actually were

Worse than "untokenised". Twenty-six values used **three different bases for one idea**:

- pure black
- `rgb(40,32,25)` — which *is* `--color-ink`
- `rgb(34,30,23)` — an ink that exists **nowhere** in `theme.css`

…across 16 alpha values. Nobody chose that. It's what copy-paste looks like when the guard can't see the values — which it couldn't, until `\b` stopped being used next to Tailwind's `_` separator.

## The fix: reuse the ladder that was already there

Not a new shadow family — the existing ink alpha ladder (`--color-ink-75/50/30/12/8`), which the guard's **own fix text already prescribes** for greys (*"greys → ink-75/50/30/12/8"*). Three rungs added, each earning its place from a real cluster:

| new rung | covers |
| --- | --- |
| `--color-ink-20` | 0.16 – 0.22 |
| `--color-ink-40` | 0.38 – 0.45 |
| `--color-ink-85` | 0.85 – 0.90 |

Plus `--color-paper-30` for the single inset bevel highlight, which was a pure white the paper law had retired everywhere the guard could see.

Black → warm ink is the reason the ladder's own doc comment already gives: *a true neutral fights warm paper.*

**Geometry is deliberately untouched.** The ten distinct offset/blur/spread combinations are genuine per-surface decisions; flattening them into a fake elevation ladder would have been a real visual change in service of tidiness.

## Verification

All tokens resolve in headless Chrome, and a before/after of eight representative surfaces is **visually indistinguishable** — the alpha snap is at most 0.1 and the hue shift reads as the same material. `bun run check:all` green.

## The remaining literals are correct, and now say so in writing

Per the rule that external marks keep external values and anything sourced to our design uses the canonical set:

- **`KofiButton`** keeps Ko-fi's `#72a4f2`. Another brand's mark isn't ours to resolve to our palette — the widget is recognisable *because* it's that blue. (The prop is caller-overridable anyway.)
- **itun print CSS** keeps `#fff` / `#000`: inside `@media print` the surface is physical paper and the ink is real ink. `theme.css` already carves out this exception; this is the app that owns the sheet.
- **`entityCardTone`** matches on a doc comment naming the `rgb()` form.
- **`guideColor`**'s Zod default is a hex because it validates **data** against `^#[0-9a-fA-F]{6}$` — a token reference is not a legal value there. The palette rule still governs *which* hex, so the default moves from pure black to the canonical ink's own `#282019`. Worth knowing: that default is load-bearing — **64 of the 79 guides omit the field** and render on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbANWHNVEGWBhrC835sqtv