### PR TITLE
refactor(tokens): complete the type ladder, arbitrary-font-size to zero

### DIFF
--- a/apps/itun/src/components/encounter/EncounterScreen.tsx
+++ b/apps/itun/src/components/encounter/EncounterScreen.tsx
@@ -132,7 +132,7 @@ export function EncounterScreen({
         <div className="flex flex-wrap items-end justify-between gap-4">
           <h1 className="m-0 flex items-center gap-2 font-cond text-xl font-bold uppercase tracking-caps-tight text-ink">
             Encounter Tray
-            <span className="inline-block rounded bg-rust px-1.5 py-0.5 font-cond text-[11px] font-bold uppercase leading-none tracking-caps text-paper">
+            <span className="inline-block rounded bg-rust px-1.5 py-0.5 font-cond text-badge font-bold uppercase leading-none tracking-caps text-paper">
               Alpha
             </span>
           </h1>

--- a/apps/itun/src/components/sheet/ChangeLogDrawer.tsx
+++ b/apps/itun/src/components/sheet/ChangeLogDrawer.tsx
@@ -99,7 +99,7 @@ export function ChangeLogDrawer({
                 >
                   <div className="flex flex-wrap items-center gap-2">
                     <span
-                      className={`rounded-[3px] px-1.5 py-0.5 font-cond text-[11px] font-bold uppercase tracking-caps-tight ${kind.className}`}
+                      className={`rounded-[3px] px-1.5 py-0.5 font-cond text-badge font-bold uppercase tracking-caps-tight ${kind.className}`}
                     >
                       {kind.label}
                     </span>

--- a/apps/itun/src/components/sheet/SheetRail.tsx
+++ b/apps/itun/src/components/sheet/SheetRail.tsx
@@ -125,7 +125,7 @@ export function RailChip({
       {/* paper BODY (poster `.rail-body`): an ink left rule + inline numeric
           text stats — never VitalGauges or StatBlocks here. */}
       {stats && (
-        <span className="mx-2.5 mb-2.5 border-l-[3px] border-ink bg-paper px-2.5 py-2 font-cond text-[12px] font-semibold uppercase leading-snug tracking-caps text-ink/70 [&_b]:font-bold [&_b]:text-ink">
+        <span className="mx-2.5 mb-2.5 border-l-[3px] border-ink bg-paper px-2.5 py-2 font-cond text-note font-semibold uppercase leading-snug tracking-caps text-ink/70 [&_b]:font-bold [&_b]:text-ink">
           {stats}
         </span>
       )}

--- a/apps/itun/src/components/sheet/StorageManifest.tsx
+++ b/apps/itun/src/components/sheet/StorageManifest.tsx
@@ -206,7 +206,7 @@ function CargoLotItem({ lot, side, cargo, linked, readOnly }: CargoLotItemProps)
             title={disabledReason ?? undefined}
             aria-label={`Load ${lot.name}`}
             onClick={handleMove}
-            className="mt-auto self-end rounded-[2px] border-0 px-2 py-0.5 font-cond text-[10px] font-bold uppercase tracking-caps-tight hover:bg-[var(--color-cargo-pale)]"
+            className="mt-auto self-end rounded-[2px] border-0 px-2 py-0.5 font-cond text-label font-bold uppercase tracking-caps-tight hover:bg-[var(--color-cargo-pale)]"
           >
             {label}
           </Button>

--- a/packages/component-lib/src/changelog/Changelog.tsx
+++ b/packages/component-lib/src/changelog/Changelog.tsx
@@ -21,7 +21,7 @@ function entryHeadline(entry: ChangelogEntry): string {
 export function Changelog({ entries, className }: ChangelogProps) {
   if (entries.length === 0) {
     return (
-      <p className={cn('font-body text-[13px] text-wk-muted', className)}>
+      <p className={cn('font-body text-caption text-wk-muted', className)}>
         No changelog entries yet.
       </p>
     )

--- a/packages/component-lib/src/components/chrome/CountStepper.tsx
+++ b/packages/component-lib/src/components/chrome/CountStepper.tsx
@@ -78,7 +78,7 @@ export function CountStepper({
         </Button>
         <span
           aria-hidden="true"
-          className="min-w-[44px] text-center font-cond text-[24px] font-bold tabular-nums text-ink"
+          className="min-w-[44px] text-center font-cond text-title font-bold tabular-nums text-ink"
         >
           {readout}
         </span>
@@ -112,7 +112,7 @@ export function CountStepper({
       <span
         aria-hidden="true"
         className={cn(
-          'grid place-items-center bg-paper font-cond text-[13px] font-bold uppercase leading-none text-ink',
+          'grid place-items-center bg-paper font-cond text-caption font-bold uppercase leading-none text-ink',
           label !== undefined ? 'min-w-[4.5rem] px-1.5 tabular-nums' : 'w-8',
           count === 0 && 'opacity-55'
         )}

--- a/packages/component-lib/src/components/chrome/ModeDoor.tsx
+++ b/packages/component-lib/src/components/chrome/ModeDoor.tsx
@@ -21,11 +21,11 @@ type ModeDoorProps = {
 const DOOR_BASE =
   'relative min-h-[170px] cursor-pointer rounded-xl p-[22px] pb-5 pl-[26px] text-left transition-transform duration-[120ms] hover:-translate-y-0.5'
 const TAB =
-  'absolute -left-3.5 top-[18px] grid h-12 w-11 place-items-center rounded-[2px] bg-ink font-cond text-[22px] font-bold text-paper shadow-[0_8px_14px_-8px_var(--color-ink-50)]'
+  'absolute -left-3.5 top-[18px] grid h-12 w-11 place-items-center rounded-[2px] bg-ink font-cond text-title font-bold text-paper shadow-[0_8px_14px_-8px_var(--color-ink-50)]'
 const HEAD =
-  'mb-1.5 ml-[34px] block font-cond text-[27px] font-bold uppercase leading-none tracking-caps-tight'
+  'mb-1.5 ml-[34px] block font-cond text-display font-bold uppercase leading-none tracking-caps-tight'
 const BODY = 'ml-[34px] block font-body text-caption leading-[1.55] text-ink'
-const CITE = 'ml-[34px] mt-2.5 block font-body text-[12.5px] font-bold text-ink'
+const CITE = 'ml-[34px] mt-2.5 block font-body text-caption font-bold text-ink'
 
 /** guided emphasis: a ground gap, a 3px ink ring, then a soft drop shadow. */
 const GUIDED_HALO =

--- a/packages/component-lib/src/components/shared/AppBar.tsx
+++ b/packages/component-lib/src/components/shared/AppBar.tsx
@@ -106,7 +106,7 @@ export function AppBar({
             className="block size-12 shrink-0 rounded-xl sm:size-16"
           />
           <span className="flex min-w-0 flex-col">
-            <span className="font-cond text-display font-bold leading-[0.98] tracking-[0.005em] text-paper sm:text-[34px]">
+            <span className="font-cond text-display font-bold leading-[0.98] tracking-[0.005em] text-paper sm:text-display-lg">
               {wordmark}
               {wordmarkAccent && <span className="text-rust">{wordmarkAccent}</span>}
               {badge && (

--- a/packages/component-lib/src/components/shared/WizShell.tsx
+++ b/packages/component-lib/src/components/shared/WizShell.tsx
@@ -134,10 +134,10 @@ function RailStep({
           active
             ? 'h-11 w-11 bg-ink text-2xl leading-none text-paper shadow-[0_0_0_4px_var(--tone)] lg:-ml-[5px]'
             : 'h-[34px] w-[34px]',
-          !active && done && 'bg-ink text-[17px] text-pilot',
+          !active && done && 'bg-ink text-readout text-pilot',
           !active &&
             !done &&
-            'bg-paper text-[17px] text-ink shadow-[inset_0_0_0_2.5px_var(--color-ink)]'
+            'bg-paper text-readout text-ink shadow-[inset_0_0_0_2.5px_var(--color-ink)]'
         )}
       >
         {done ? '✓' : index + 1}
@@ -204,7 +204,7 @@ export function WizShell({
     <header>
       <h1 className="m-0">
         {/* Ink-stamp step heading (SheetHero name-chip treatment). */}
-        <span className="inline bg-ink box-decoration-clone px-2 pb-[3px] pt-[2px] font-cond text-[22px] font-bold uppercase leading-[1.35] tracking-normal text-paper">
+        <span className="inline bg-ink box-decoration-clone px-2 pb-[3px] pt-[2px] font-cond text-title font-bold uppercase leading-[1.35] tracking-normal text-paper">
           <span className="text-pilot">
             Step {active + 1} of {steps.length}
           </span>
@@ -397,7 +397,7 @@ export function WizShell({
               >
                 <span
                   aria-hidden="true"
-                  className="absolute -left-5 top-6 hidden h-16 w-14 place-items-center rounded-badge bg-ink font-cond text-[38px] font-extrabold leading-none text-paper shadow-[0_8px_14px_-8px_var(--color-ink-50)] sm:grid"
+                  className="absolute -left-5 top-6 hidden h-16 w-14 place-items-center rounded-badge bg-ink font-cond text-hero font-extrabold leading-none text-paper shadow-[0_8px_14px_-8px_var(--color-ink-50)] sm:grid"
                 >
                   {active + 1}
                 </span>

--- a/packages/component-lib/src/components/sheet/NpcFactsEditor.tsx
+++ b/packages/component-lib/src/components/sheet/NpcFactsEditor.tsx
@@ -94,7 +94,7 @@ export function NpcFactsEditor({
               }}
               className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-pip leading-none hover:bg-ink/10"
             >
-              <span aria-hidden className="text-[12px]">
+              <span aria-hidden className="text-note">
                 ×
               </span>
             </button>

--- a/packages/component-lib/src/components/sheet/SheetHero.tsx
+++ b/packages/component-lib/src/components/sheet/SheetHero.tsx
@@ -85,7 +85,7 @@ export function SheetHero({
             size="full"
             as="h1"
             leading="leading-[1.28]"
-            className="m-0 inline box-decoration-clone py-0 text-[26px] sm:text-[31px]"
+            className="m-0 inline box-decoration-clone py-0 text-display sm:text-display-lg"
           >
             {name}
           </Badge>

--- a/packages/component-lib/src/components/stat/VitalGauge.tsx
+++ b/packages/component-lib/src/components/stat/VitalGauge.tsx
@@ -277,16 +277,12 @@ export function VitalGauge({
             className={cn(
               'font-bold',
               isOver ? 'text-status-bad' : 'text-ink',
-              isDense ? 'text-[28px]' : 'text-[30px]'
+              isDense ? 'text-display' : 'text-display-lg'
             )}
           >
             {shown}
           </b>
-          <i
-            className={cn('px-0.5 not-italic text-ink/55', isDense ? 'text-[16px]' : 'text-[17px]')}
-          >
-            /
-          </i>
+          <i className={cn('px-0.5 not-italic text-readout text-ink/55')}>/</i>
           {editingMax ? (
             <input
               ref={maxInputRef}
@@ -297,8 +293,7 @@ export function VitalGauge({
               onBlur={commitMax}
               aria-label={`Set ${label} max`}
               className={cn(
-                'w-14 rounded-card border border-ink/40 bg-paper px-1 text-center tabular-nums text-ink',
-                isDense ? 'text-[16px]' : 'text-[17px]'
+                'w-14 rounded-card border border-ink/40 bg-paper px-1 text-center text-readout tabular-nums text-ink'
               )}
             />
           ) : editableMax ? (
@@ -307,17 +302,14 @@ export function VitalGauge({
               onClick={beginEditMax}
               aria-label={`Override ${label} max (currently ${max})`}
               className={cn(
-                'cursor-pointer rounded-badge px-0.5 underline decoration-dotted underline-offset-2',
-                isOverridden ? 'text-[var(--tone-deep)]' : 'text-ink/70',
-                isDense ? 'text-[16px]' : 'text-[17px]'
+                'cursor-pointer rounded-badge px-0.5 text-readout underline decoration-dotted underline-offset-2',
+                isOverridden ? 'text-[var(--tone-deep)]' : 'text-ink/70'
               )}
             >
               {max}
             </button>
           ) : (
-            <span className={cn('text-ink/70', isDense ? 'text-[16px]' : 'text-[17px]')}>
-              {max}
-            </span>
+            <span className={cn('text-readout text-ink/70')}>{max}</span>
           )}
           {isOverridden && (
             <sup

--- a/packages/component-lib/src/styles/theme.css
+++ b/packages/component-lib/src/styles/theme.css
@@ -61,6 +61,28 @@
      commission. It caught this doc block on first run.) */
   --text-display: 26px;
 
+  /* …and the note above was right about the CAUSE but only half-fixed it. One
+     display step left a 15px -> 26px canyon, so 28 call sites still had to
+     bracket their own size: 16, 17, 22, 24, 27, 28, 30, 31, 34, 38.
+     Read as a set, those values are already a ~1.2 ratio scale — the drift was
+     people re-deriving the same scale by eye, one component at a time. So the
+     ladder is completed at that ratio rather than invented:
+
+       lede 15 -> readout 17 -> title 22 -> display 26 -> display-lg 31 -> hero 38
+
+     Each rung absorbs a real cluster, so most sites move 0-2px. Two notes on
+     the sites that move furthest, because they are judgement calls, not
+     rounding: the AppBar wordmark's `sm:` step drops 34 -> 31, and VitalGauge's
+     dense/normal numeral pair (28/30) becomes 26/31, which WIDENS the density
+     gap from 2px to 5px — a dense mode should read as denser than a 2px hint.
+     Its supporting `/max` text collapses from a 16/17 pair to one rung: a 1px
+     step is below the resolution any ladder should encode, and density is
+     carried by the numeral beside it. */
+  --text-readout: 17px;
+  --text-title: 22px;
+  --text-display-lg: 31px;
+  --text-hero: 38px;
+
   /* The `su-*` brand family that used to live here is DELETED. It was a shadow
      tokenset: the canonical semantic tokens below were defined as aliases *of*
      it, so the brand names were the real substrate and the semantic layer was a

--- a/tools/design-tokens-baseline.json
+++ b/tools/design-tokens-baseline.json
@@ -4,6 +4,6 @@
   "gradient": 0,
   "arbitrary-tracking": 5,
   "arbitrary-border-width": 4,
-  "arbitrary-font-size": 28,
+  "arbitrary-font-size": 0,
   "pure-white": 0
 }


### PR DESCRIPTION
**`arbitrary-font-size` 28 → 0.** With `raw-color` already cleared, five of seven rules are now fully enforced and the known backlog goes **37 → 9**.

## The token comment already knew

`--text-display`'s own note said it: *"the ladder not having a display step is WHY that drift existed."* It was right about the cause and half-fixed it. One display rung left a **15px → 26px canyon**, so 28 call sites still bracketed their own size: 16, 17, 22, 24, 27, 28, 30, 31, 34, 38.

Read as a *set*, those values are already a ~1.2 ratio scale. The drift wasn't carelessness — it was people re-deriving the same scale by eye, one component at a time. So the ladder is completed at the ratio the code had already converged on, rather than invented:

```
lede 15 → readout 17 → title 22 → display 26 → display-lg 31 → hero 38
```

## What moves

Seven of sixteen mappings are **exact**; the rest are ≤2px. Three are judgement calls rather than rounding, and are recorded in the token comment:

- **AppBar wordmark** `sm:` step drops 34 → 31 (the largest move, −3px).
- **VitalGauge** dense/normal numeral pair 28/30 → 26/31, which **widens** the density gap from 2px to 5px. A dense mode should read as denser than a 2px hint.
- That gauge's supporting `/max` text collapses from a 16/17 dense pair onto **one** rung. A 1px step is below the resolution a ladder should encode, and the numeral beside it already carries the density signal. This turned four `isDense ? a : b` ternaries into dead conditionals with identical branches — they're removed rather than left implying a difference that no longer exists.

## Verification

Every token resolves to its intended size in headless Chrome (`10 11 11.5 13 17 22 26 31 38`), and a before/after of all 16 mappings renders near-identically. `bun run check:all` green.

## Remaining debt

`arbitrary-tracking: 5` and `arbitrary-border-width: 4` — both largely doc-comment self-citations, and the tracking one needs a ruleset-vs-`theme.css` reconciliation (the ruleset declares 3 tracking tokens, the theme ships 5) that is its own visual-delta decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbANWHNVEGWBhrC835sqtv