### PR TITLE
refactor(tokens): clear the last 9, every token rule now at zero

### DIFF
--- a/apps/itun/src/components/sheet/ChangeLogDrawer.tsx
+++ b/apps/itun/src/components/sheet/ChangeLogDrawer.tsx
@@ -103,7 +103,7 @@ export function ChangeLogDrawer({
                     >
                       {kind.label}
                     </span>
-                    <span className="font-cond text-sm font-bold uppercase tracking-[0.02em] text-ink">
+                    <span className="font-cond text-sm font-bold uppercase tracking-caps-tight text-ink">
                       {entry.field}
                     </span>
                     <time

--- a/apps/itun/src/components/sheet/SheetRail.tsx
+++ b/apps/itun/src/components/sheet/SheetRail.tsx
@@ -125,7 +125,7 @@ export function RailChip({
       {/* paper BODY (poster `.rail-body`): an ink left rule + inline numeric
           text stats — never VitalGauges or StatBlocks here. */}
       {stats && (
-        <span className="mx-2.5 mb-2.5 border-l-[3px] border-ink bg-paper px-2.5 py-2 font-cond text-note font-semibold uppercase leading-snug tracking-caps text-ink/70 [&_b]:font-bold [&_b]:text-ink">
+        <span className="mx-2.5 mb-2.5 border-l-entity border-ink bg-paper px-2.5 py-2 font-cond text-note font-semibold uppercase leading-snug tracking-caps text-ink/70 [&_b]:font-bold [&_b]:text-ink">
           {stats}
         </span>
       )}

--- a/apps/itun/src/components/wizard/CreateModeChooser.tsx
+++ b/apps/itun/src/components/wizard/CreateModeChooser.tsx
@@ -64,7 +64,7 @@ export function CreateModeChooser({ kind, onGuided, onBlank }: CreateModeChooser
         className="border-b-4 border-paper/95 px-5 pb-3.5 pt-7 sm:px-7"
         style={{ background: 'var(--tone)' }}
       >
-        <h1 className="m-0 font-cond text-[clamp(34px,5.2vw,54px)] font-bold uppercase leading-[0.98] tracking-[0.5px] text-paper [text-shadow:0_2px_0_var(--color-ink-20)]">
+        <h1 className="m-0 font-cond text-[clamp(34px,5.2vw,54px)] font-bold uppercase leading-[0.98] tracking-caps-tight text-paper [text-shadow:0_2px_0_var(--color-ink-20)]">
           New {label}
         </h1>
       </header>

--- a/packages/component-lib/src/changelog/Changelog.tsx
+++ b/packages/component-lib/src/changelog/Changelog.tsx
@@ -33,7 +33,7 @@ export function Changelog({ entries, className }: ChangelogProps) {
         <li key={`${entry.area}-${entry.date}-${entry.version ?? entry.title ?? index}`}>
           <Panel className="p-4">
             <div className="mb-2 flex flex-wrap items-baseline gap-x-3 gap-y-1">
-              <h3 className="font-cond text-lg font-bold uppercase leading-tight tracking-[0.02em] text-ink">
+              <h3 className="font-cond text-lg font-bold uppercase leading-tight tracking-caps-tight text-ink">
                 {entryHeadline(entry)}
               </h3>
               <Badge surface="outline" className="shrink-0">

--- a/packages/component-lib/src/components/shared/AppBar.tsx
+++ b/packages/component-lib/src/components/shared/AppBar.tsx
@@ -64,7 +64,7 @@ const NAV_LINK_ACTIVE = 'text-paper'
 const BUY_BUTTON =
   'inline-flex shrink-0 items-center rounded-md border border-rust bg-rust px-4 py-1.5 font-cond text-caption font-medium uppercase tracking-caps-snug text-paper no-underline transition-colors'
 
-const BREADCRUMB_TEXT = 'font-cond text-xs uppercase tracking-[0.14em] text-ink-2'
+const BREADCRUMB_TEXT = 'font-cond text-xs uppercase tracking-caps-wide text-ink-2'
 
 export function AppBar({
   wordmark,
@@ -106,7 +106,7 @@ export function AppBar({
             className="block size-12 shrink-0 rounded-xl sm:size-16"
           />
           <span className="flex min-w-0 flex-col">
-            <span className="font-cond text-display font-bold leading-[0.98] tracking-[0.005em] text-paper sm:text-display-lg">
+            <span className="font-cond text-display font-bold leading-[0.98] tracking-normal text-paper sm:text-display-lg">
               {wordmark}
               {wordmarkAccent && <span className="text-rust">{wordmarkAccent}</span>}
               {badge && (

--- a/packages/component-lib/src/components/shared/SheetSectionCard.tsx
+++ b/packages/component-lib/src/components/shared/SheetSectionCard.tsx
@@ -88,7 +88,7 @@ export function SheetSectionCard({
       <div className="flex flex-1 flex-col bg-[var(--tone)] px-3">
         <div
           className={cn(
-            'flex-1 border-l-[3px] border-[var(--tone-deep)] bg-paper px-3.5 py-3',
+            'flex-1 border-l-entity border-[var(--tone-deep)] bg-paper px-3.5 py-3',
             bodyClassName
           )}
         >

--- a/packages/component-lib/src/styles/theme.css
+++ b/packages/component-lib/src/styles/theme.css
@@ -314,6 +314,14 @@
 @utility border-b-entity {
   border-bottom-width: var(--bw-entity);
 }
+/* The LEFT entity edge — the accent spine on a sheet-section card and the
+   live-sheet rail callout. Both had been writing the pixel by hand, for the
+   ordinary reason: this utility did not exist, so the vocabulary had no word
+   for the thing they were drawing. Adding it is the whole fix; neither call
+   site changes weight. */
+@utility border-l-entity {
+  border-left-width: var(--bw-entity);
+}
 
 /* Per-sheet one-variable theming (design-spec §1.4): each sheet class sets its
    tone pair and derives the two ground colors via OKLCH relative color.

--- a/tools/check-design-tokens.ts
+++ b/tools/check-design-tokens.ts
@@ -109,29 +109,27 @@ const RULES: Rule[] = [
   {
     id: 'arbitrary-tracking',
     rule: 'ruleset §4.2 — the tracking ladder is tokens only',
-    // NOTE — canon and code disagree here, and the code is what ships.
-    // ruleset §4.2 declares THREE tokens (--tracking-label 0.04em,
-    // --tracking-display 0.01em, --tracking-eyebrow 0.22em) and says the wide
-    // HUD values "conform down to 0.04em". theme.css actually ships FIVE:
-    // caps-tight 0.04 / caps-snug 0.06 / caps 0.08 / caps-wide 0.12 / eyebrow
-    // 0.22 — `--tracking-label` and `--tracking-display` do not exist. This fix
-    // text names the tokens that REALLY resolve, so it can't send anyone to a
-    // non-existent utility. Reconciling the two (collapsing the ladder to 0.04
-    // or amending the ruleset) is a separate, visual-delta decision.
+    // (This note used to say canon and code DISAGREED — that ruleset §4.2
+    // declared a three-token set while theme.css shipped five, leaving a
+    // reconciliation open. That is stale and was actively misleading: §4.2 has
+    // since been rewritten to describe the five rungs theme.css really ships,
+    // and it RATIFIES them — "ratified as-is rather than re-lettering every
+    // label in the app". There is no open decision. Five rungs are canon; the
+    // three-token set never existed as tokens.)
     fix: 'Use the shipped ladder: tracking-caps-tight (0.04em, the canonical label/stamp tracking) / -caps-snug / -caps / -caps-wide / tracking-eyebrow (0.22em, brand caption only).',
     pattern: /tracking-\[[^\]]+\]/g,
   },
   {
     id: 'arbitrary-border-width',
     rule: 'ruleset §4.3 — border weights are tokens, one meaning each',
-    fix: 'Use border-entity (3px) / border-entity-compact (2px) / border-chrome (1.5px) / border (1px hairline).',
+    fix: 'Use border-entity (3px, plus border-b-/border-l- sides) / border-rail (2.5px) / border-2 (2px pill) / border-chrome (1.5px, plus sides) / border (1px hairline).',
     // Only widths — `border-[color:var(--x)]` is a colour, covered by raw-color.
     pattern: /border(?:-[trblxy])?-\[\d*\.?\d+px\]/g,
   },
   {
     id: 'arbitrary-font-size',
     rule: 'ruleset §4.2 — one type scale',
-    fix: 'Use the semantic ladder: text-nano / micro / label / label-lg / badge / note / caption / lede.',
+    fix: 'Use the semantic ladder: text-nano / micro / label / label-lg / badge / note / caption / lede, then the display end — readout (17) / title (22) / display (26) / display-lg (31) / hero (38).',
     pattern: /text-\[\d*\.?\d+(?:px|rem)\]/g,
   },
   {
@@ -213,6 +211,12 @@ const EXEMPTIONS: { file: string; rules: string[]; reason: string }[] = [
     rules: ['gradient', 'raw-color'],
     reason:
       'Ruleset §3.5 THE one-off: the .pilot-panel distressed-metal effect on srd /about is a CSS illustration, ruled a sanctioned one-off. It is the single place smooth shading is allowed, and it is allowed because it is a picture of a rusted plate rather than a UI surface. Not precedent — no second one-off without an explicit ruling. raw-color rides along because it is the SAME illustration: the rust blooms, the steel plate, the rivet heads and the engraved lettering are one picture, and a picture needs more shades than a UI palette has — the rivets alone spend nine greys on lit/worn/green/flush/hole. Tokenising them would add a dozen tokens nothing else could ever reuse. CAVEAT, since a file-level exemption is blunter than the rationale: it also swallows three literals outside the illustration block — the .catalog-item hover box-shadow and .catalog-item__name text-shadow (real shadow debt on an authored surface, still owed a token) and one #fff in the print block. Line-scoping the exemption was considered and rejected as too brittle to survive edits to this file; they are recorded here instead of silently absorbed.',
+  },
+  {
+    file: 'packages/component-lib/src/components/shared/WizShell.tsx',
+    rules: ['arbitrary-border-width'],
+    reason:
+      "Not a border WEIGHT — a shape. The two matches (`border-x-[9px]`, `border-t-[14px]`) sit on an `h-0 w-0` span with `border-x-transparent`: the CSS-triangle idiom, drawing the caret under the wizard step marker. Those numbers are the triangle's half-width and height, so snapping them to the 1.5/2/2.5/3px weight ladder would not tidy a border, it would resize a glyph. The rule is right to look here and wrong about this one.",
   },
   {
     file: 'packages/salvageunion-reference/lib/schemas/entities.ts',
@@ -345,6 +349,22 @@ for (const v of violations) {
  *
  * The rule stands: a stricter rule may rebaseline upward ONCE, in the same
  * commit that tightens it, with the reason written down. Drift may not.
+ *
+ * STATUS: the backlog is GONE. Every rule now sits at 0, so this file has
+ * stopped being a burn-down chart and is purely a regression guard — the next
+ * violation of any rule fails CI outright rather than joining a queue.
+ *
+ * Worth recording WHY it emptied, because "we tidied up" is the wrong lesson.
+ * Almost none of it was carelessness; in every cluster the vocabulary was
+ * missing a word and the call sites had improvised the same one independently:
+ *   - 26 shadow colours -> the ink alpha ladder was missing its -20/-40/-85
+ *     rungs (and the guard could not see the values at all, so nothing ever
+ *     pushed back).
+ *   - 28 font sizes -> the type ladder stopped at 15px and jumped to 26px, so
+ *     ten sizes in between were re-derived by eye, component by component.
+ *   - 2 border widths -> `border-l-entity` did not exist, only `border-b-`.
+ * The lesson that generalises: when a rule shows a CLUSTER rather than a
+ * scatter, suspect the ladder before the authors.
  */
 const BASELINE_PATH = join(import.meta.dir, 'design-tokens-baseline.json')
 

--- a/tools/design-tokens-baseline.json
+++ b/tools/design-tokens-baseline.json
@@ -2,8 +2,8 @@
   "shadow-tokens": 0,
   "raw-color": 0,
   "gradient": 0,
-  "arbitrary-tracking": 5,
-  "arbitrary-border-width": 4,
+  "arbitrary-tracking": 0,
+  "arbitrary-border-width": 0,
   "arbitrary-font-size": 0,
   "pure-white": 0
 }


### PR DESCRIPTION
Finishes the burn-down. **All seven rules sit at 0**, so `design-tokens-baseline.json` stops being a backlog and becomes a pure regression guard — the next violation of any rule fails CI outright instead of joining a queue.

## First, a correction that matters more than the nine fixes

This tool's `arbitrary-tracking` note claimed canon and code disagreed: that ruleset §4.2 declared a **three**-token tracking set while `theme.css` shipped **five**, leaving a reconciliation open.

**That is stale.** §4.2 has since been rewritten to describe the five rungs `theme.css` really ships, and it *ratifies* them, in as many words:

> "That consolidation was never built: those two token names do not exist, and the wide rungs are in deliberate, active use. **Ratified as-is rather than re-lettering every label in the app.**"

There is no open decision — and the stale note was steering readers toward reversing a settled one. It now says so. (I had repeated that stale claim myself in an earlier summary; this is the fix.)

## The nine

- **5 arbitrary tracking values** resolve onto the ratified ladder: `0.02em` → `caps-tight`, `0.14em` → `caps-wide`, `0.5px` → `caps-tight`, and the AppBar wordmark's `0.005em` — tracking by a rounding error — to `tracking-normal`.
- **2 `border-l-[3px]`** become `border-l-entity` — *a utility that did not exist until this commit*. `border-entity` and `border-b-entity` were there; the left edge wasn't, so the two surfaces that wanted it wrote the pixel by hand. Verified in Chrome that the new utility computes to the same 3px, so neither call site changes.
- **2 belong to a CSS triangle** and are exempted, not converted. `border-x-[9px] border-t-[14px]` on an `h-0 w-0` span is the caret under the wizard step marker; those numbers are a glyph's half-width and height. Snapping them to the weight ladder would resize a shape, not tidy a border.

Both `fix:` strings were stale too, and now name rungs that actually exist — the type ladder's display end, and the border sides.

## The lesson, recorded in the ratchet doc

"We tidied up" is the wrong takeaway. Almost none of this backlog was carelessness — in every cluster **the vocabulary was missing a word** and the call sites had independently improvised the same one:

- 26 shadow colours → the ink alpha ladder had no `-20`/`-40`/`-85`
- 28 font sizes → the type ladder jumped 15px straight to 26px
- 2 border widths → `border-l-entity` didn't exist

> When a rule shows a **cluster** rather than a scatter, suspect the ladder before the authors.

`bun run check:all` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbANWHNVEGWBhrC835sqtv