### PR TITLE
fix(component-lib): parenthesise every trait value; TL / SYS / MODS short forms

### DIFF
--- a/packages/component-lib/src/components/referenceEntity/__tests__/buildReferenceEntityStats.test.ts
+++ b/packages/component-lib/src/components/referenceEntity/__tests__/buildReferenceEntityStats.test.ts
@@ -60,11 +60,15 @@ describe('buildReferenceEntityStats', () => {
     // box read "Structure" / "Energy" before, which is half a label.
     expect(byLabel(stats, 'SP')?.value).toBe('12')
     expect(byLabel(stats, 'EP')?.value).toBe('4')
-    // Stats whose top word already IS the short form keep it.
-    expect(byLabel(stats, 'System')?.value).toBe('16')
-    // …and the bottom label is dropped in both cases.
+    // Slot counts abbreviate too — SYS / MODS. Bare "System" / "Module" was the
+    // same half-a-label problem as "Structure", just less obvious because the
+    // top word happens to be a whole English word.
+    expect(byLabel(stats, 'SYS')?.value).toBe('16')
+    expect(byLabel(stats, 'MODS')?.value).toBe('2')
+    expect(byLabel(stats, 'System')).toBeUndefined()
+    // …and the bottom label is dropped in every case.
     expect(byLabel(stats, 'SP')?.bottomLabel).toBeUndefined()
-    expect(byLabel(stats, 'System')?.bottomLabel).toBeUndefined()
+    expect(byLabel(stats, 'SYS')?.bottomLabel).toBeUndefined()
   })
 
   test('full mode keeps the two-line long form', () => {

--- a/packages/component-lib/src/components/referenceEntity/card/EntityCardSubHeader.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/EntityCardSubHeader.tsx
@@ -72,7 +72,13 @@ export function EntityCardSubHeader({
   //   - a MEASURED cell reads "Range: Close" / "Damage: 4 SP" (colon after the
   //     label). Damage joins Range here because it is the same shape of
   //     statement — a named quantity — and read "Damage 4SP" without one;
-  //   - a NUMERIC value reads "Heat (4)" / "Blast (3)" (value in parens);
+  //   - a TRAIT always parenthesises its value — "Explosive (1)", "Burn (2)",
+  //     "Uses (3)", "Uses (Destroy)". The book prints every qualified trait this
+  //     way, including the non-numeric ones (its own glossary entry reads
+  //     "Uses (X)"), so the parens follow the CELL KIND, not the value's type.
+  //     Keying off "is it a number" left a trait like Uses/Destroy reading
+  //     "USES DESTROY", the one shape the rulebook never uses;
+  //   - any other numeric value still reads "Label (4)";
   //   - everything else (a label-only keyword) is unchanged.
   const COLON_CELLS = new Set(['range', 'damage'])
   const cellToText = (cell: EntityCardSubHeaderCell) => {
@@ -80,8 +86,9 @@ export function EntityCardSubHeader({
     if (COLON_CELLS.has(cell.key) || cell.label === 'Range' || cell.label === 'Damage') {
       return `${cell.label}: ${cell.value}`
     }
+    const isTrait = cell.key.startsWith('trait-')
     const isNumeric = typeof cell.value === 'number' || /^\d+$/.test(String(cell.value))
-    if (isNumeric) return `${cell.label} (${cell.value})`
+    if (isTrait || isNumeric) return `${cell.label} (${cell.value})`
     return `${cell.label} ${cell.value}`
   }
   const parts = cells.map(cellToText)

--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -649,9 +649,11 @@ function ReferenceEntityCardInner({
     !isAction && !isPatternListing && techLevel != null
       ? {
           key: 'tech-level',
-          // Compact (horizontal) renders "Tech"; the full-size vertical value box
-          // renders two-line "Tech" / "Level".
-          label: 'Tech',
+          // Compact (horizontal) renders the SHORT form "TL" — the same
+          // shortLabel treatment SP / EP / SV get, and the abbreviation players
+          // actually use. Bare "Tech" was neither the full name nor the short
+          // one. The full-size vertical value box keeps two-line "Tech" / "Level".
+          label: compact ? 'TL' : 'Tech',
           bottomLabel: compact ? undefined : 'Level',
           value: String(techLevelDisplay),
           // A TL-scalable item shows the EFFECTIVE level; a rust `modified`

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/statVocabulary.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/statVocabulary.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * The card's stat/trait VOCABULARY, checked against how the rulebook prints it.
+ *
+ * - A qualified trait is parenthesised: the book's own lines read
+ *   "Burn (2) // Explosive (2) // Heavy // Uses (3)", and its glossary entry for
+ *   the trait reads "Uses (X)" — so the parens belong to the trait, not to the
+ *   value being a number. A non-numeric amount (Uses/Destroy) used to render
+ *   "USES DESTROY", a shape the book never prints.
+ * - A compact card labels stats with their SHORT forms (TL / SP / EP / SV /
+ *   SYS / MODS); the full card keeps the two-line long form.
+ */
+import { beforeAll, describe, expect, test, afterEach } from 'bun:test'
+import { cleanup, render } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+import { ReferenceEntityCard } from '../ReferenceEntityCard'
+
+const action = (name: string) => {
+  const found = SalvageUnionReference.Actions.all().find((a) => a.name === name)
+  if (!found) throw new Error(`${name} action fixture missing`)
+  return found
+}
+
+const mule = () => {
+  const found = SalvageUnionReference.Chassis.all().find((c) => c.name === 'Mule')
+  if (!found) throw new Error('Mule fixture missing')
+  return found
+}
+
+/** Rendered text, whitespace-collapsed, for substring assertions. */
+const textOf = (node: Parameters<typeof render>[0]) =>
+  (render(node).container.textContent ?? '').replace(/\s+/g, ' ')
+
+afterEach(cleanup)
+
+describe('trait rendering', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  test('a NUMERIC uses amount is parenthesised', () => {
+    const text = textOf(<ReferenceEntityCard data={action('Beta Fission Gun')} />)
+    expect(text).toContain('Uses (3)')
+  })
+
+  test('a NON-NUMERIC uses amount is parenthesised too', () => {
+    const text = textOf(<ReferenceEntityCard data={action('Armour Plating')} />)
+    expect(text).toContain('Uses (Destroy)')
+    // The bare form is exactly what this guards against.
+    expect(text).not.toContain('Uses Destroy')
+  })
+
+  test('the whole trait line matches the book', () => {
+    const text = textOf(<ReferenceEntityCard data={action('Beta Fission Gun')} />)
+    expect(text).toContain('Burn (2) // Explosive (2) // Heavy // Uses (3)')
+  })
+
+  test('a label-only trait takes no parens', () => {
+    const text = textOf(<ReferenceEntityCard data={action('Beta Fission Gun')} />)
+    expect(text).toContain('Heavy //')
+    expect(text).not.toContain('Heavy (')
+  })
+})
+
+describe('stat label short forms', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  test('a compact card uses the abbreviations', () => {
+    const text = textOf(<ReferenceEntityCard data={mule()} size="medium" />)
+    for (const label of ['TL', 'SP', 'EP', 'SV', 'SYS', 'MODS']) {
+      expect(text).toContain(label)
+    }
+  })
+
+  test('a compact card never falls back to the half-form labels', () => {
+    const text = textOf(<ReferenceEntityCard data={mule()} size="medium" />)
+    // "Tech" with no "Level" beside it, and bare "System"/"Module", were the
+    // three labels that read as neither the long nor the short form.
+    expect(text).not.toContain('Tech')
+    expect(text).not.toContain('System 16')
+    expect(text).not.toContain('Module 2')
+  })
+
+  test('a full card keeps the two-line long form', () => {
+    const text = textOf(<ReferenceEntityCard data={mule()} size="large" />)
+    expect(text).toContain('Tech')
+    expect(text).toContain('Level')
+    expect(text).toContain('System')
+    expect(text).toContain('Slots')
+  })
+})

--- a/packages/component-lib/src/components/referenceEntity/referenceEntityStatsConfig.ts
+++ b/packages/component-lib/src/components/referenceEntity/referenceEntityStatsConfig.ts
@@ -97,6 +97,7 @@ const ENTITY_STATS_CONFIG: StatConfig[] = [
     getter: getSystemSlots,
     normalLabel: 'System',
     normalBottomLabel: 'Slots',
+    shortLabel: 'SYS',
     tooltip:
       'Each System has a System Slot value which represents how much space it takes up on a Mech, conversely a Mechs System Slot value represents how many Systems it can mount. This is an abstract value that covers not only size, but energy requirements, ammo storage and a host of other factors.',
   },
@@ -104,6 +105,7 @@ const ENTITY_STATS_CONFIG: StatConfig[] = [
     getter: getModuleSlots,
     normalLabel: 'Module',
     normalBottomLabel: 'Slots',
+    shortLabel: 'MODS',
     tooltip:
       "Each Module has a Module Slot value which represents how much space it takes up on a Mech, conversely a Mech's Module Slot value represents how many Modules it can mount.",
   },


### PR DESCRIPTION
Three rendering corrections in the entity card's stat/trait vocabulary, checked against the rulebook.

## 1. `Uses` (and every trait) parenthesises its value

The sub-header parenthesised a trait's value only when it was a **number**:

```ts
const isNumeric = typeof cell.value === 'number' || /^\d+$/.test(String(cell.value))
if (isNumeric) return `${cell.label} (${cell.value})`
return `${cell.label} ${cell.value}`   // ← "USES DESTROY"
```

So `{ type: 'uses', amount: 'Destroy' }` rendered `USES DESTROY`, a shape the book never prints. The parens belong to the **cell kind**, not to the value's type — the book's own glossary entry for the trait reads `Uses (X)`, with a non-numeric placeholder inside the parens.

Trait cells now always parenthesise. A label-only keyword (`Heavy`) is untouched, and `Range` / `Damage` keep their colon form.

**Checked against the book.** Beta Fission Gun renders:

```
Burn (2) // Explosive (2) // Heavy // Uses (3)
```

— character-for-character the line the Core Book prints for it. Grep of the book text shows every qualified trait in this form: `Uses (1)`, `Uses (3)`, `Uses (30)`, `Explosive (1)`, and the glossary's `Uses (X)`.

Data-wise this affects the 43 actions carrying a `uses` trait; the non-numeric amounts (Armour Plating's `Destroy`) were the broken ones.

## 2 + 3. `TL`, `SYS`, `MODS`

A compact card shows ONE label — the stat's short form. Three stats had no `shortLabel` and fell back to the first word of their name, which is half a label rather than an abbreviation:

| Stat | Compact label before | After |
| --- | --- | --- |
| Tech Level | `Tech` | `TL` |
| System Slots | `System` | `SYS` |
| Module Slots | `Module` | `MODS` |

A compact chassis card now reads `TL 1 · SP 12 · EP 4 · SV 7 · SYS 16 · MODS 2 · Cargo 16 · Heat 6`, consistent with the `SP` / `EP` / `SV` abbreviations already there.

**Full-size cards are unchanged** — they keep the two-line long form (`Tech` / `Level`, `System` / `Slots`), which is what the official character sheets print.

## Notes

`buildReferenceEntityStats.test.ts` asserted the old assumption explicitly — *"Stats whose top word already IS the short form keep it"*, pinning `System` — so that expectation is updated rather than worked around. New `statVocabulary.test.tsx` covers both halves, including that `Uses Destroy` (unparenthesised) never renders.

## Verification

- `bun run check:all` green — lint, format, typecheck, tests, validate, knip, audit, tokens, styling
- Rendered output diffed against the book's printed trait lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZwCo6XFSEuHmxFeTg5Xms