### PR TITLE
feat(component-lib): "Legal Starting Pattern" seam stamp on pattern cards

### DIFF
--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.stories.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.stories.tsx
@@ -95,6 +95,15 @@ const surveyorPattern = pick(
   'Little Sestra pattern'
 )
 
+// The Mule's Hauler — one of the five patterns the book tags `legalStarting`,
+// which stamps "Legal Starting Pattern" on the seam beside the chassis marker.
+const muleChassis = pick(SalvageUnionReference.Chassis.all(), (c) => c.name === 'Mule', 'chassis')
+const haulerPattern = pick(
+  muleChassis.patterns ?? [],
+  (pat) => pat.name === 'Hauler',
+  'Mule legal starting pattern'
+)
+
 const nameOf = (e: SURefEntity): string => e.name
 const idOf = (e: SURefEntity): string => e.id
 
@@ -221,6 +230,14 @@ export const PatternCard: Story = () => (
       {chassis.name} · {surveyorPattern.name}
     </code>
     <ReferenceEntityCard data={chassis} pattern={surveyorPattern} />
+    {/* A `legalStarting`-tagged pattern adds the "Legal Starting Pattern" stamp
+        to the seam, right of the chassis marker — full card and listing row
+        alike (the row is what the chassis page's Patterns list renders). */}
+    <code className="font-body text-nano text-ink-2">
+      {muleChassis.name} · {haulerPattern.name} (legal starting — full + listing)
+    </code>
+    <ReferenceEntityCard data={muleChassis} pattern={haulerPattern} />
+    <ReferenceEntityCard data={muleChassis} pattern={haulerPattern} size="medium" extent="head" />
   </div>
 )
 

--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -29,7 +29,7 @@ import {
   resolveDataValueForTechLevel,
   resolveGrantedEntities,
 } from 'salvageunion-reference'
-import { isSchemaOnlyCatalogChoice } from 'salvageunion-reference/rules'
+import { isLegalStartingPattern, isSchemaOnlyCatalogChoice } from 'salvageunion-reference/rules'
 import { cn } from '../../../utils/cn'
 import type { EntityStatus } from '../../shared/entityStatus'
 import { type CardExtent, type CardSize, resolveCardDisplay } from '../../shared/displayMode'
@@ -579,6 +579,10 @@ function ReferenceEntityCardInner({
         ? [{ label: 'Chassis', value: resolvedChassisName }]
         : []
       : resolveAxisMarkers(entity)
+  // "Legal Starting Pattern" is a STORED data tag on the pattern, set only where
+  // the source book calls it out — never derived from an SV budget (that older
+  // computed version wrongly badged every untagged pattern).
+  const isLegalStartingPatternCard = isPattern && isLegalStartingPattern(pattern.legalStarting)
 
   // The lone non-titanic action that FOLDS into this entity's body: its content
   // goes in the body, and its sub-header STATS (type/range/damage/cost) merge
@@ -625,6 +629,17 @@ function ReferenceEntityCardInner({
           size="mini"
         />
       ))}
+      {/* A pattern the book sanctions as a starting loadout wears a stamp on the
+          seam, RIGHT of the `[Chassis | …]` marker. It rides the seam (not the
+          body) precisely so it survives the LISTING extent — the pattern rows
+          under a chassis render header-only, and that is where a reader picking
+          a starting mech is actually looking. Purely the stored `legalStarting`
+          data tag, never computed from tech level or salvage value. */}
+      {isLegalStartingPatternCard && (
+        <Badge shape="stamp" size="mini" className="whitespace-nowrap">
+          Legal Starting Pattern
+        </Badge>
+      )}
     </div>
   )
 

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/PatternView.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/PatternView.test.tsx
@@ -89,3 +89,40 @@ describe('full pattern view reading order', () => {
     expect(systems).toBeLessThan(modules)
   })
 })
+
+/**
+ * The "Legal Starting Pattern" seam stamp. It rides the seam RIGHT of the
+ * `[Chassis | …]` marker specifically so it survives the LISTING extent — the
+ * pattern rows under a chassis are header-only, and that list is where a reader
+ * choosing a starting mech actually looks. Driven purely by the stored
+ * `legalStarting` data tag; never computed from tech level or salvage value.
+ */
+describe('legal starting pattern seam stamp', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  const patternOf = (name: string): SURefObjectPattern => {
+    const found = mule().patterns?.find((p) => p.name === name)
+    if (!found) throw new Error(`${name} pattern fixture missing`)
+    return found
+  }
+
+  test('the full pattern card stamps a tagged pattern', () => {
+    render(<ReferenceEntityCard data={mule()} pattern={patternOf('Hauler')} />)
+    expect(screen.getAllByText('Legal Starting Pattern').length).toBe(1)
+  })
+
+  test('an untagged pattern carries no stamp', () => {
+    render(<ReferenceEntityCard data={mule()} pattern={patternOf('Crusher')} />)
+    expect(screen.queryByText('Legal Starting Pattern')).toBeNull()
+  })
+
+  test('the chassis pattern LISTING stamps exactly its tagged patterns', () => {
+    const chassis = mule()
+    render(<ReferenceEntityCard data={chassis} />)
+    const tagged = (chassis.patterns ?? []).filter((p) => p.legalStarting === true)
+    expect(tagged.length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Legal Starting Pattern').length).toBe(tagged.length)
+  })
+})


### PR DESCRIPTION
## What

A pattern the book sanctions as a starting loadout now wears a **`LEGAL STARTING PATTERN`** stamp on its card seam, to the right of the `[Chassis | …]` marker.

## Why the seam, not the body

It rides the seam precisely so it survives the **listing** extent (`size="medium" extent="head"`) — the pattern rows under a chassis render header-only, and that list is where a reader choosing a starting mech actually looks. Same stamp shows on the full pattern card.

## Provenance

Driven purely by the stored `legalStarting` data tag (via the package's `isLegalStartingPattern`), never computed from tech level or salvage value — the older computed version wrongly badged every untagged pattern. Five patterns carry the tag today: Mule/Hauler, Mazona/Buzzard, Scrapper/Leaky, Spectrum/Settler, Thresher/Shepherd.

## Not touched

ITUN's mech wizard renders patterns through `useChassisPatternConfig` (no `pattern` prop), so `isPattern` is false there — it keeps its existing subtitle badge and gains no duplicate.

## Verification

- 3 new tests in `PatternView.test.tsx`: stamp on the tagged full card, absent on an untagged one, and exactly one per tagged pattern in the chassis listing.
- `lint` (no new findings), `typecheck`, full `test` (3619 pass / 0 fail), `validate:all`, `knip` — all clean.
- `PatternCard` Ladle story extended with Mule · Hauler in both full and listing form for visual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016r9C8MsMMo74i5XGUDXAAm