### PR TITLE
fix(component-lib): render Upkeep, Upgrade and Population on crawler tech levels

### DIFF
--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -57,6 +57,7 @@ import { buildReferenceEntityStats } from '../referenceEntityStatsConfig'
 import { CatalogChoiceListing } from './CatalogChoiceListing'
 import { anchorBonusMarker, anchorChoiceMarkers } from './choiceAnchoring'
 import type { AnchoredContentBlock } from './choiceAnchoring'
+import { crawlerPopulationRange } from './crawlerPopulationRange'
 import { firstParagraphText } from './firstParagraphText'
 import { EntityCardHeader } from './EntityCardHeader'
 import { EntityCardIdentityFooter } from './EntityCardIdentityFooter'
@@ -1007,10 +1008,21 @@ function ReferenceEntityCardInner({
   const classRequirementCells: EntityCardSubHeaderCell[] = classRequirement
     ? [{ key: 'class-requires', label: 'Requires', value: classRequirement }]
     : []
+  // A Union Crawler TECH LEVEL is a table row in the book (p.218), and the
+  // population band is the one fact on that row which is not a number the header
+  // can hold: it is a RANGE, so it rides the facet line while Structure Points /
+  // Upkeep / Upgrade sit in the header's stat cluster. `populationMax: 0` is the
+  // dataset's "unbounded" marker for the top tier, which the book prints open-
+  // ended ("25,000+"). Without this the entire crawler-tech-levels catalog
+  // rendered as bare name + TL cards.
+  const populationRange = crawlerPopulationRange(entity)
+  const populationCells: EntityCardSubHeaderCell[] = populationRange
+    ? [{ key: 'population', label: 'Population', value: populationRange }]
+    : []
   const baseCells: EntityCardSubHeaderCell[] =
     isAction && action
       ? actionCells(action)
-      : [...classRequirementCells, ...foldedActionCells, ...dedupedEntityCells]
+      : [...populationCells, ...classRequirementCells, ...foldedActionCells, ...dedupedEntityCells]
   // dvSourceContent — the content whose `datavalues` block (Damage/Range) feeds
   // the resolver's base stats (a self-action's content for a self-action entity).
   const entityContentForDv = 'content' in entity ? entity.content : undefined

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/crawlerTechLevel.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/crawlerTechLevel.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * A Union Crawler TECH LEVEL is a table row in the book (p.218) with no prose at
+ * all: its whole content is Structure Points, Upkeep, Upgrade and a population
+ * band. Four of those six fields reached no renderer, so every card in the
+ * schema — catalog tile AND full page — showed nothing but a name, a TL and an
+ * SP. These tests pin each field to a surface so that cannot silently return.
+ */
+import { beforeAll, describe, expect, test, afterEach } from 'bun:test'
+import { cleanup, render } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+import { ReferenceEntityCard } from '../ReferenceEntityCard'
+import { crawlerPopulationRange } from '../crawlerPopulationRange'
+
+const tier = (name: string) => {
+  const found = SalvageUnionReference.CrawlerTechLevels.all().find((t) => t.name === name)
+  if (!found) throw new Error(`${name} fixture missing`)
+  return found
+}
+
+/** Rendered text, whitespace-collapsed, for substring assertions. */
+const textOf = (node: Parameters<typeof render>[0]) =>
+  (render(node).container.textContent ?? '').replace(/\s+/g, ' ')
+
+afterEach(cleanup)
+
+describe('crawler tech level card', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  test('the CATALOG tile carries every stored field', () => {
+    const text = textOf(
+      <ReferenceEntityCard data={tier('Hamlet Crawler')} size="medium" extent="catalog" />
+    )
+    expect(text).toContain('Hamlet Crawler')
+    expect(text).toContain('TL')
+    expect(text).toContain('SP')
+    expect(text).toContain('Upkeep')
+    expect(text).toContain('Upgrade')
+    expect(text).toContain('Population 100–500')
+  })
+
+  test('the FULL card carries them with the long stat labels', () => {
+    const text = textOf(<ReferenceEntityCard data={tier('Town Crawler')} size="large" />)
+    expect(text).toContain('Upkeep')
+    expect(text).toContain('Upgrade')
+    expect(text).toContain('Cost')
+    expect(text).toContain('Population 2,000–5,000')
+  })
+
+  test('the MAXIMUM tier states no upgrade cost and an open-ended population', () => {
+    // Megacity is the top of the table: `upgradeCost` is null in the data
+    // because there is no next tier to buy, and `populationMax` is the
+    // dataset's 0 "unbounded" marker.
+    const text = textOf(
+      <ReferenceEntityCard data={tier('Megacity Crawler')} size="medium" extent="catalog" />
+    )
+    expect(text).toContain('Upkeep')
+    expect(text).not.toContain('Upgrade')
+    expect(text).toContain('Population 25,000+')
+  })
+
+  test('every tier in the schema renders more than its bare name', () => {
+    for (const t of SalvageUnionReference.CrawlerTechLevels.all()) {
+      const text = textOf(<ReferenceEntityCard data={t} size="medium" extent="catalog" />)
+      expect(text).toContain('Upkeep')
+      expect(text).toContain('Population')
+      cleanup()
+    }
+  })
+})
+
+describe('crawlerPopulationRange', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  test('formats a bounded band with an en dash and grouped thousands', () => {
+    expect(crawlerPopulationRange(tier('City Crawler'))).toBe('5,000–15,000')
+  })
+
+  test('formats the unbounded top tier open-ended', () => {
+    expect(crawlerPopulationRange(tier('Megacity Crawler'))).toBe('25,000+')
+  })
+
+  test('returns undefined for an entity that has no population band', () => {
+    const mule = SalvageUnionReference.Chassis.all().find((c) => c.name === 'Mule')
+    if (!mule) throw new Error('Mule fixture missing')
+    expect(crawlerPopulationRange(mule)).toBeUndefined()
+  })
+})

--- a/packages/component-lib/src/components/referenceEntity/card/crawlerPopulationRange.ts
+++ b/packages/component-lib/src/components/referenceEntity/card/crawlerPopulationRange.ts
@@ -1,0 +1,30 @@
+import type { SURefMetaEntity } from 'salvageunion-reference'
+
+/**
+ * `Intl` instance built once, pinned to `en-US`. The dataset and the rulebook
+ * are English, and the card is server-rendered by srd's static build — a
+ * locale-sensitive format would make the built HTML depend on the build
+ * machine's locale.
+ */
+const GROUPED = new Intl.NumberFormat('en-US')
+
+/**
+ * The population band a Union Crawler tech level covers, formatted the way the
+ * book's tech-level table prints it (Workshop Manual p.218).
+ *
+ * `populationMax: 0` is the dataset's "unbounded" marker — only the Megacity
+ * Crawler carries it, and the book states that tier open-ended, so it formats as
+ * `25,000+` rather than as a range ending at zero.
+ *
+ * Returns `undefined` for every entity that is not a crawler tech level, so the
+ * caller can spread the result into a cell list unconditionally. The check is on
+ * the DATA SHAPE, not the schema name, per the display-system rule.
+ */
+export function crawlerPopulationRange(entity: SURefMetaEntity): string | undefined {
+  if (!('populationMin' in entity) || typeof entity.populationMin !== 'number') return undefined
+  const min = entity.populationMin
+  const max =
+    'populationMax' in entity && typeof entity.populationMax === 'number' ? entity.populationMax : 0
+  // En dash, the range separator the book uses — not a hyphen.
+  return max > 0 ? `${GROUPED.format(min)}–${GROUPED.format(max)}` : `${GROUPED.format(min)}+`
+}

--- a/packages/component-lib/src/components/referenceEntity/referenceEntityStatsConfig.ts
+++ b/packages/component-lib/src/components/referenceEntity/referenceEntityStatsConfig.ts
@@ -14,6 +14,8 @@ import {
   getModuleSlots,
   getCargoCapacity,
   getHitPoints,
+  getUpkeepCost,
+  getUpgradeCost,
 } from 'salvageunion-reference'
 import type { StatItem } from '../shared/statsBarTypes'
 
@@ -123,6 +125,26 @@ const ENTITY_STATS_CONFIG: StatConfig[] = [
     tooltip:
       'Your Mech generates Heat when you activate some Systems and Modules or when you Push your reactor, its Heat Capacity represents its ability to operate under these conditions. If you reach your Heat Capacity your reactor will be at risk of overloading, with potentially catastrophic results.',
     primary: true,
+  },
+  // UNION CRAWLER economy. The book (p.218) states these two alongside Structure
+  // Points as the statistics a Crawler derives from its Tech Level — "Your
+  // Crawler has a set of statistics based on its Tech Level. This includes its
+  // Structure Points, Upkeep, and Upgrade cost." Only `crawler-tech-levels`
+  // carries these fields, so no other card gains a stat; without them a crawler
+  // tech level rendered with nothing but its name, TL and SP.
+  {
+    getter: getUpkeepCost,
+    normalLabel: 'Upkeep',
+    normalBottomLabel: 'Cost',
+    tooltip:
+      "Upkeep Cost is the Scrap of the Union Crawler's own Tech Level you must pay each Downtime to keep it running. Pay it in full and the same amount goes into your Upgrade Pool; fail to pay and the Crawler deteriorates.",
+  },
+  {
+    getter: getUpgradeCost,
+    normalLabel: 'Upgrade',
+    normalBottomLabel: 'Cost',
+    tooltip:
+      'Upgrade Cost is the Upgrade Pool total that unlocks the next Tech Level. The pool fills from the Upkeep you pay (and any extra Scrap you add during Downtime); the upgrade itself then takes one week. The maximum tech level has no upgrade cost, so it shows none.',
   },
 ]
 

--- a/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
+++ b/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
@@ -9121,6 +9121,22 @@ export declare function getModuleSlots(entity: SURefMetaEntity): number | undefi
  */
 export declare function getCargoCapacity(entity: SURefMetaEntity): number | undefined;
 /**
+ * Extract a Union Crawler tech level's Upkeep Cost — the Scrap (of the Crawler's
+ * own Tech Level) it costs to keep running through a Downtime.
+ * @param entity - The entity to extract from
+ * @returns The upkeep cost or undefined
+ */
+export declare function getUpkeepCost(entity: SURefMetaEntity): number | undefined;
+/**
+ * Extract a Union Crawler tech level's Upgrade Cost — the Upgrade Pool total
+ * that unlocks the next Tech Level. `null` in the data at the MAXIMUM tier
+ * (there is nothing to upgrade to), which reads back as `undefined` here so the
+ * stat simply does not render.
+ * @param entity - The entity to extract from
+ * @returns The upgrade cost, or undefined at the maximum tech level
+ */
+export declare function getUpgradeCost(entity: SURefMetaEntity): number | undefined;
+/**
  * Extract hit points from an entity
  * Used for NPCs, Creatures, Squads, and Meld
  * @param entity - The entity to extract from

--- a/packages/salvageunion-reference/lib/utilities.test.ts
+++ b/packages/salvageunion-reference/lib/utilities.test.ts
@@ -24,6 +24,8 @@ import {
   getModuleSlots,
   getCargoCapacity,
   getHitPoints,
+  getUpkeepCost,
+  getUpgradeCost,
   getAssetUrl,
   getPatterns,
   normalizePatternName,
@@ -621,6 +623,33 @@ describe('Property Extractors', () => {
       const chassis = defined(getReference().Chassis.all()[0])
       const hitPoints = getHitPoints(chassis)
       expect(hitPoints).toBeUndefined()
+    })
+  })
+
+  describe('getUpkeepCost / getUpgradeCost', () => {
+    const tier = (techLevel: number) =>
+      defined(getReference().CrawlerTechLevels.find((t) => t.techLevel === techLevel))
+
+    it('should extract both costs from a crawler tech level', () => {
+      const hamlet = tier(1)
+      expect(getUpkeepCost(hamlet)).toBe(hamlet.upkeepCost)
+      expect(getUpgradeCost(hamlet)).toBe(hamlet.upgradeCost as number)
+    })
+
+    it('should return undefined for the null upgrade cost at the maximum tier', () => {
+      // TL6 (Megacity) is the top of the table — `upgradeCost` is null in the
+      // data because there is no next tier, and the stat must simply not render.
+      const megacity = tier(6)
+      expect(megacity.upgradeCost).toBeNull()
+      expect(getUpgradeCost(megacity)).toBeUndefined()
+      // Upkeep is still owed at the top tier.
+      expect(getUpkeepCost(megacity)).toBe(megacity.upkeepCost)
+    })
+
+    it('should return undefined for entities that carry neither cost', () => {
+      const chassis = defined(getReference().Chassis.all()[0])
+      expect(getUpkeepCost(chassis)).toBeUndefined()
+      expect(getUpgradeCost(chassis)).toBeUndefined()
     })
   })
 

--- a/packages/salvageunion-reference/lib/utilities.ts
+++ b/packages/salvageunion-reference/lib/utilities.ts
@@ -323,6 +323,32 @@ export function getCargoCapacity(entity: SURefMetaEntity): number | undefined {
 }
 
 /**
+ * Extract a Union Crawler tech level's Upkeep Cost — the Scrap (of the Crawler's
+ * own Tech Level) it costs to keep running through a Downtime.
+ * @param entity - The entity to extract from
+ * @returns The upkeep cost or undefined
+ */
+export function getUpkeepCost(entity: SURefMetaEntity): number | undefined {
+  return 'upkeepCost' in entity && typeof entity.upkeepCost === 'number'
+    ? entity.upkeepCost
+    : undefined
+}
+
+/**
+ * Extract a Union Crawler tech level's Upgrade Cost — the Upgrade Pool total
+ * that unlocks the next Tech Level. `null` in the data at the MAXIMUM tier
+ * (there is nothing to upgrade to), which reads back as `undefined` here so the
+ * stat simply does not render.
+ * @param entity - The entity to extract from
+ * @returns The upgrade cost, or undefined at the maximum tech level
+ */
+export function getUpgradeCost(entity: SURefMetaEntity): number | undefined {
+  return 'upgradeCost' in entity && typeof entity.upgradeCost === 'number'
+    ? entity.upgradeCost
+    : undefined
+}
+
+/**
  * Extract hit points from an entity
  * Used for NPCs, Creatures, Squads, and Meld
  * @param entity - The entity to extract from


### PR DESCRIPTION
## The bug

Crawler tech levels rendered with no content — in the catalog grid *and* on the item page. All six cards showed nothing but a name, a `TL` badge and an `SP` badge.

A Union Crawler tech level is a table row in the book (Workshop Manual p.218) with no prose at all. Its entire content is six stored fields, and **four of them reached no renderer**:

| field | before | after |
|---|---|---|
| `techLevel` | ✅ header `TL` | ✅ |
| `structurePoints` | ✅ header `SP` | ✅ |
| `upkeepCost` | ❌ nothing | ✅ header `Upkeep / Cost` |
| `upgradeCost` | ❌ nothing | ✅ header `Upgrade / Cost` |
| `populationMin` | ❌ nothing | ✅ facet line |
| `populationMax` | ❌ nothing | ✅ facet line |

## The fix

**Upkeep and Upgrade join the header stat cluster.** The book names them alongside Structure Points as the statistics a Crawler derives from its Tech Level — *"Your Crawler has a set of statistics based on its Tech Level. This includes its Structure Points, Upkeep, and Upgrade cost."* Two new getters (`getUpkeepCost` / `getUpgradeCost`) plus two `ENTITY_STATS_CONFIG` entries, each with a tooltip drawn from the Downtime rules.

**Population rides the sub-header facet line**, because it is a range rather than a number — `Population 100–500`, en dash and grouped thousands, the way the book's table prints it.

**Edge case — the maximum tier.** Megacity Crawler has `upgradeCost: null` (there is no next tier to buy) and `populationMax: 0` (the dataset's unbounded marker). It renders no Upgrade stat at all and reads its population open-ended as `25,000+`.

Rendered result, all six tiers:

```
[catalog] Hamlet Crawler    | TL 1 | SP 20 | Upkeep 5 | Upgrade 30 | Population 100–500
[catalog] Village Crawler   | TL 2 | SP 25 | Upkeep 5 | Upgrade 30 | Population 500–2,000
[catalog] Town Crawler      | TL 3 | SP 30 | Upkeep 5 | Upgrade 30 | Population 2,000–5,000
[catalog] City Crawler      | TL 4 | SP 35 | Upkeep 5 | Upgrade 30 | Population 5,000–15,000
[catalog] Metropolis Crawler| TL 5 | SP 40 | Upkeep 5 | Upgrade 30 | Population 15,000–25,000
[catalog] Megacity Crawler  | TL 6 | SP 50 | Upkeep 5 |            | Population 25,000+
```

## Verification

`ENTITY_STATS_CONFIG` is global, so the risk is a stat leaking onto unrelated cards. I SSR-rendered **every entity in every schema at both `catalog` and `full` extent**, before and after: exactly **12 of 3129** card renders changed — the 6 tech levels × 2 extents — and nothing else moved. (Only `crawler-tech-levels` carries `upkeepCost` / `upgradeCost` / `populationMin`.)

- `bun run check:all` green (lint, format, typecheck, all workspace tests, validate, knip, audit, tokens, styling)
- New tests: `crawlerTechLevel.test.tsx` (card, both extents, max-tier edge case, all six tiers) and getter coverage in `utilities.test.ts`

## Noted, not fixed

The card **body** band is still empty for these entities — there is genuinely no prose in the data to put there, so it renders as a ~40px paper gap between the facet line and the footer. That is pre-existing generic behaviour affecting ~90 entities across 10 schemas (`ability-tree-requirements` and `catalog-categories` are also 100% empty-bodied). Collapsing an empty body band would be a one-line generic change, but it moves rendering well outside this report — happy to do it as a follow-up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013rS3bYaJ4HXsCRrGRn2VhX