### PR TITLE
fix(component-lib): restore stat hover tooltips; changelog entries use Card

### DIFF
--- a/packages/component-lib/src/changelog/Changelog.test.tsx
+++ b/packages/component-lib/src/changelog/Changelog.test.tsx
@@ -28,6 +28,20 @@ describe('Changelog', () => {
     expect(screen.getByText('Fixed a typo')).toBeTruthy()
   })
 
+  test('each entry is a Card, not a bespoke panel', () => {
+    // The listing composes the shared card shell, so it inherits the card
+    // language (seam stamp, frame weight, header band) instead of restating it.
+    const entries: ChangelogEntry[] = [
+      { date: '2026-07-20', version: '1.2.3', area: 'Data', items: ['Added a chassis'] },
+    ]
+    const { container } = render(<Changelog entries={entries} />)
+    const frame = container.querySelector('li > div')
+    expect(frame?.className).toContain('rounded-card')
+    // Card draws its frame as longhand inline style off the border glossary;
+    // `chrome` is the sub-panel weight this listing asks for.
+    expect(frame?.getAttribute('style')).toContain('var(--bw-chrome)')
+  })
+
   test('uses the title as the headline for historical (unversioned) entries', () => {
     const entries: ChangelogEntry[] = [
       { date: '2026-07-14', title: 'Support on Ko-fi', area: 'Site', items: ['Added a link'] },

--- a/packages/component-lib/src/changelog/Changelog.tsx
+++ b/packages/component-lib/src/changelog/Changelog.tsx
@@ -1,5 +1,4 @@
-import { Badge } from '../components/chrome/Badge'
-import { Panel } from '../components/chrome/Panel'
+import { Card } from '../components/shared/Card'
 import { cn } from '../utils/cn'
 import type { ChangelogEntry } from './parseChangelog'
 
@@ -14,9 +13,23 @@ function entryHeadline(entry: ChangelogEntry): string {
 }
 
 /**
- * Presentational, data-source-agnostic changelog renderer. Each entry is a
- * paper panel with a headline (version or title), a muted date, an area badge,
- * and a semantic bullet list. Shared by both sites so they render identically.
+ * Presentational, data-source-agnostic changelog renderer. Shared by both sites
+ * so they render identically.
+ *
+ * Each entry is a **`Card`** — the generic four-band container — not a bespoke
+ * listing. It previously hand-assembled a `Panel` around its own header row
+ * (heading + `Badge` + `<time>`), which is the exact shape Card already models:
+ * the area is the card's SEAM stamp (`label`), the version/title is the header
+ * band, and the bullets are the body. Rebuilding that by hand meant the
+ * changelog drifted from every other listing surface in the apps — its frame
+ * weight, radius, seam placement and header padding were all set independently
+ * of the card language rather than inherited from it.
+ *
+ * The rungs it picks: `size="medium"` (this is a LIST of entries, so it takes
+ * the listing density, not the dominant solo scale), `frame="chrome"` for the
+ * 1.5px sub-panel weight the changelog has always had, and no `headerBg` — the
+ * band stays on paper, so an entry reads as the quiet, chrome-level listing it
+ * is rather than a toned entity card.
  */
 export function Changelog({ entries, className }: ChangelogProps) {
   if (entries.length === 0) {
@@ -31,21 +44,26 @@ export function Changelog({ entries, className }: ChangelogProps) {
     <ol className={cn('flex list-none flex-col gap-4', className)}>
       {entries.map((entry, index) => (
         <li key={`${entry.area}-${entry.date}-${entry.version ?? entry.title ?? index}`}>
-          <Panel className="p-4">
-            <div className="mb-2 flex flex-wrap items-baseline gap-x-3 gap-y-1">
-              <h3 className="font-cond text-lg font-bold uppercase leading-tight tracking-caps-tight text-ink">
-                {entryHeadline(entry)}
-              </h3>
-              <Badge surface="outline" className="shrink-0">
-                {entry.area}
-              </Badge>
-              <time
-                dateTime={entry.date}
-                className="ml-auto font-body text-xs text-wk-muted tabular-nums"
-              >
-                {entry.date}
-              </time>
-            </div>
+          <Card
+            label={entry.area}
+            size="medium"
+            frame="chrome"
+            borderColor="var(--color-ink)"
+            bodyPadding="px-4 pb-3 pt-1"
+            headerContent={
+              <>
+                <h3 className="font-cond text-lg font-bold uppercase leading-tight tracking-caps-tight text-ink">
+                  {entryHeadline(entry)}
+                </h3>
+                <time
+                  dateTime={entry.date}
+                  className="ml-auto font-body text-xs text-wk-muted tabular-nums"
+                >
+                  {entry.date}
+                </time>
+              </>
+            }
+          >
             {entry.items.length > 0 && (
               <ul className="ml-4 list-disc space-y-1 font-body text-sm text-ink-2 marker:text-wk-muted">
                 {entry.items.map((item) => (
@@ -53,7 +71,7 @@ export function Changelog({ entries, className }: ChangelogProps) {
                 ))}
               </ul>
             )}
-          </Panel>
+          </Card>
         </li>
       ))}
     </ol>

--- a/packages/component-lib/src/components/referenceEntity/EntityTooltip.tsx
+++ b/packages/component-lib/src/components/referenceEntity/EntityTooltip.tsx
@@ -32,7 +32,16 @@ type EntityTooltipProps = EntityTooltipBase &
  * EntityTooltip already had.
  */
 function resolveIdByName(schemaName: SURefEnumSchemaName, name: string): string | undefined {
-  const entity = SalvageUnionReference.findIn(schemaName, (e) => 'name' in e && e.name === name)
+  // Case-INSENSITIVE, like every other name→entity lookup in the library
+  // (`parseTraitReferences`, `Stat`'s `entityTooltip`). Callers address entities
+  // with the name as it reads on the surface — a capitalised trait type
+  // ("Explosive") against a stored name that may be cased differently — and an
+  // exact match silently dropped the hovercard on exactly those.
+  const target = name.toLowerCase()
+  const entity = SalvageUnionReference.findIn(
+    schemaName,
+    (e) => 'name' in e && String(e.name).toLowerCase() === target
+  )
   return entity?.id
 }
 

--- a/packages/component-lib/src/components/referenceEntity/card/EntityCardStatBox.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/EntityCardStatBox.tsx
@@ -43,6 +43,7 @@ export function EntityCardStatBox({ stats, compact = false }: EntityCardStatBoxP
           onChange={stat.onChange}
           mode={stat.onChange ? editMode : 'read'}
           max={stat.outOfMax}
+          hoverText={stat.hoverText}
         />
       )
     }
@@ -59,6 +60,7 @@ export function EntityCardStatBox({ stats, compact = false }: EntityCardStatBoxP
         state={stat.state}
         mode={editMode}
         onChange={stat.onChange}
+        hoverText={stat.hoverText}
       />
     ) : (
       <Stat

--- a/packages/component-lib/src/components/referenceEntity/card/EntityCardSubHeader.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/EntityCardSubHeader.tsx
@@ -1,5 +1,8 @@
+import { Fragment } from 'react'
 import type { ReactNode } from 'react'
+import type { SURefEnumSchemaName } from 'salvageunion-reference'
 import { cn } from '../../../utils/cn'
+import { EntityTooltip } from '../EntityTooltip'
 
 /** One sub-header cell — a horizontal Stat `[label | value]` (value
  * optional for label-only keywords, e.g. "Immobile"). The MODIFIED-STATS language
@@ -13,6 +16,13 @@ export type EntityCardSubHeaderCell = {
   borderColor?: string
   /** Raw CSS colour for the label fill — marks an added/modified trait. */
   labelBg?: string
+  /**
+   * The rules entity this cell NAMES — a trait ("Explosive"), a keyword. When
+   * set, the segment summons that entity's hovercard on hover, the same as an
+   * in-prose `[[trait]]` reference does. Unresolvable refs render as plain text,
+   * so a cell never loses its reading to a missing entity.
+   */
+  entityRef?: { schemaName: SURefEnumSchemaName; name: string }
 }
 
 type EntityCardSubHeaderProps = {
@@ -91,7 +101,27 @@ export function EntityCardSubHeader({
     if (isTrait || isNumeric) return `${cell.label} (${cell.value})`
     return `${cell.label} ${cell.value}`
   }
-  const parts = cells.map(cellToText)
+  // Each cell is still ONE segment of the book's trait line, but a segment that
+  // NAMES a rules entity keeps that entity's hovercard — the affordance the
+  // per-cell stamps used to carry, and that an in-prose `[[trait]]` reference
+  // still carries. Flattening the row to a single string had silently dropped
+  // it, so a card's own traits were the one place the glossary was unreachable.
+  const parts = cells.map((cell) => {
+    const text = cellToText(cell)
+    if (!cell.entityRef) return { key: cell.key, node: text as ReactNode }
+    return {
+      key: cell.key,
+      node: (
+        <EntityTooltip
+          schemaName={cell.entityRef.schemaName}
+          entityName={cell.entityRef.name}
+          openDelay={300}
+        >
+          <span className="cursor-help">{text}</span>
+        </EntityTooltip>
+      ) as ReactNode,
+    }
+  })
 
   return (
     <div
@@ -116,7 +146,12 @@ export function EntityCardSubHeader({
             compact ? 'text-xs' : 'text-sm'
           )}
         >
-          {parts.join(' // ')}
+          {parts.map((part, i) => (
+            <Fragment key={part.key}>
+              {i > 0 && ' // '}
+              {part.node}
+            </Fragment>
+          ))}
         </span>
       )}
     </div>

--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -262,6 +262,9 @@ function traitCells(traits: SURefObjectTrait[]): EntityCardSubHeaderCell[] {
     key: `trait-${trait.type}`,
     label: capitalize(trait.type),
     value: trait.amount != null ? String(trait.amount) : undefined,
+    // The trait line is a glossary of named rules — each name summons its own
+    // entry, the same as an in-prose `[[trait]]` reference.
+    entityRef: { schemaName: 'traits' as const, name: trait.type },
   }))
 }
 
@@ -1064,10 +1067,20 @@ function ReferenceEntityCardInner({
           : { value: d.value, scaled: false }
       const val = fmtDv({ value: scaled.value, unit: d.unit })
       const changed = baseDvMap.get(String(d.label).toLowerCase()) !== val || scaled.scaled
+      // A datavalue that IS a named rules term (`type: "trait" | "keyword"`)
+      // keeps its glossary hovercard — the legacy sub-header resolved exactly
+      // these two types against the traits / keywords schemas.
+      const refSchema =
+        d.type === 'trait'
+          ? ('traits' as const)
+          : d.type === 'keyword'
+            ? ('keywords' as const)
+            : undefined
       return {
         key: `dv-${d.label}`,
         label: String(d.label),
         value: val,
+        ...(refSchema ? { entityRef: { schemaName: refSchema, name: String(d.label) } } : {}),
         ...(changed ? { borderColor: MODIFIED } : {}),
       }
     })

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/statTooltips.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/statTooltips.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * The card's HOVER EXPLANATIONS — the glossary reachable from a stat.
+ *
+ * Two affordances regressed when the card was unified, in the two places a card
+ * states a rules term:
+ *
+ * - the SUB-HEADER trait line, which was flattened from per-trait cells to one
+ *   joined string, taking every trait's hovercard with it (the same hovercard an
+ *   in-prose `[[trait]]` reference still summons);
+ * - the HEADER stat cluster in its COMPACT anatomy, where the `hoverText` the
+ *   stat config supplies for every stat was dropped — so a stat explained itself
+ *   on a large card and went silent on a listing or nested one.
+ *
+ * Both are asserted through the trigger attribute base-ui stamps on whatever it
+ * arms, since the popup itself only mounts on hover.
+ */
+import { beforeAll, describe, expect, test, afterEach } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+import { ReferenceEntityCard } from '../ReferenceEntityCard'
+import { InsideTooltipContext } from '../../../ui/insideTooltipContext'
+
+const TRIGGER = '[data-base-ui-tooltip-trigger]'
+
+const action = (name: string) => {
+  const found = SalvageUnionReference.Actions.all().find((a) => a.name === name)
+  if (!found) throw new Error(`${name} action fixture missing`)
+  return found
+}
+
+const mule = () => {
+  const found = SalvageUnionReference.Chassis.all().find((c) => c.name === 'Mule')
+  if (!found) throw new Error('Mule fixture missing')
+  return found
+}
+
+/** The element whose whole text IS `text` — the segment/label, not its ancestors. */
+const leafWithText = (text: string) =>
+  screen.getAllByText((_, el) => el?.textContent === text).at(-1)
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+afterEach(cleanup)
+
+describe('sub-header trait line', () => {
+  test('each trait segment arms its own hovercard', () => {
+    render(<ReferenceEntityCard data={action('Beta Fission Gun')} />)
+    for (const segment of ['Burn (2)', 'Explosive (2)', 'Heavy', 'Uses (3)']) {
+      expect(leafWithText(segment)?.closest(TRIGGER)).toBeTruthy()
+    }
+  })
+
+  test('arming the segments does not change what the line reads', () => {
+    // The trait line is book-fidelity text, not a row of stamps — restoring the
+    // hovercards must leave the " // " reading byte-identical.
+    const { container } = render(<ReferenceEntityCard data={action('Beta Fission Gun')} />)
+    const text = (container.textContent ?? '').replace(/\s+/g, ' ')
+    expect(text).toContain('Burn (2) // Explosive (2) // Heavy // Uses (3)')
+  })
+
+  test('a segment naming no known entity stays plain text', () => {
+    // An action's classification and its measured cells lead the line and are
+    // not glossary terms — they must stay bare text nodes, not armed spans.
+    const { container } = render(<ReferenceEntityCard data={action('Beta Fission Gun')} />)
+    const armed = [...container.querySelectorAll(TRIGGER)].map((el) => el.textContent)
+    expect(armed).not.toContain('Turn Action')
+    expect(armed).not.toContain('Range: Medium')
+  })
+
+  test('inside a hovercard the line is inert — no nested hovercards', () => {
+    const { container } = render(
+      <InsideTooltipContext.Provider value={true}>
+        <ReferenceEntityCard data={action('Beta Fission Gun')} size="medium" extent="catalog" />
+      </InsideTooltipContext.Provider>
+    )
+    expect(container.querySelector(TRIGGER)).toBeNull()
+  })
+})
+
+describe('header stat cluster', () => {
+  test('a COMPACT card explains its stats', () => {
+    // The regression: `hoverText` reached the value box but never the compact
+    // horizontal cell, so every listing and nested card lost its glossary.
+    render(<ReferenceEntityCard data={mule()} size="medium" />)
+    expect(leafWithText('SP')?.closest(TRIGGER)).toBeTruthy()
+    expect(leafWithText('EP')?.closest(TRIGGER)).toBeTruthy()
+  })
+
+  test('a FULL card still explains its stats', () => {
+    render(<ReferenceEntityCard data={mule()} size="large" />)
+    expect(leafWithText('Structure')?.closest(TRIGGER)).toBeTruthy()
+  })
+})

--- a/packages/component-lib/src/components/shared/Stat.tsx
+++ b/packages/component-lib/src/components/shared/Stat.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
+import type { ReactElement } from 'react'
 import { SalvageUnionReference, EntitySchemaNames } from 'salvageunion-reference'
 import type { EntitySchemaName, SURefEnumSchemaName } from 'salvageunion-reference'
 import { cn } from '../../utils/cn'
@@ -183,6 +184,10 @@ type HorizontalValueProps = Exact<{
   /** When set, wrap the cell in the entity/keyword hover-tooltip (resolves
    * `label` within `schemaName`); unresolved refs render plain (no tooltip). */
   entityTooltip?: { schemaName: SURefEnumSchemaName; label: StatValue }
+  /** Plain-text hover explanation (the stat's glossary line). Same contract as
+   * the value box's `hoverText` — a compact header cell states the SAME stat as
+   * the full box, so it must be able to explain itself too. */
+  hoverText?: string
   className?: string
 }>
 
@@ -289,6 +294,7 @@ function HorizontalValue({
   min = 0,
   step = 1,
   stepperLabel,
+  hoverText,
   className,
 }: HorizontalValueProps) {
   const fontSize = size === 'mini' ? 'text-label' : size === 'compact' ? 'text-xs' : 'text-sm'
@@ -300,6 +306,13 @@ function HorizontalValue({
   // ring would double it, so both halves suppress it with `ring-0`.
   const plate = 'ring-0 leading-none'
 
+  // The hover explanation rides the OUTERMOST node of whichever anatomy we
+  // return, so it works on the bare cell, the running-text finish and the
+  // cell+stepper cluster alike. `Tooltip` is already inert inside a hovercard
+  // (InsideTooltipContext), so nested cards need no extra suppression here.
+  const withHover = (node: ReactElement) =>
+    hoverText ? <Tooltip content={hoverText}>{node}</Tooltip> : node
+
   // PLAIN material — running text (`SP 9/13`). No plate, no border, no radius;
   // an inert inline `<span>` so it neither breaks the line's flow nor changes
   // how the surrounding sentence wraps. The reading (value AND `/max`) is one
@@ -310,7 +323,7 @@ function HorizontalValue({
   // a cell with an edge, not to a word in a sentence, so `mode="edit"` has no
   // plain rendering (use the plate material when the stat is editable).
   if (surface === 'plain') {
-    return (
+    return withHover(
       <span className={className}>
         {label}
         {value !== undefined && (
@@ -390,7 +403,7 @@ function HorizontalValue({
   // right. Read-only (no edit / no onChange) returns the bare cell, unchanged.
   const numericValue = typeof value === 'number' ? value : Number(value)
   const canEdit = mode === 'edit' && onChange !== undefined && Number.isFinite(numericValue)
-  if (!canEdit) return cell
+  if (!canEdit) return withHover(cell)
 
   const atMin = numericValue <= min
   const atMax = max !== undefined && numericValue >= max
@@ -403,7 +416,7 @@ function HorizontalValue({
     'flex min-h-11 items-center justify-center rounded-badge border border-ink font-body font-bold leading-none transition-colors sm:min-h-0'
 
   const stepName = stepperLabel ?? label
-  return (
+  return withHover(
     <span className="inline-flex w-fit items-stretch gap-0.5">
       {cell}
       <button


### PR DESCRIPTION
## Hover tooltips on stats (the reported regression)

Two hover affordances were lost when the card was unified, in the two places a card states a rules term.

**Sub-header trait line.** It was flattened from per-trait cells to one joined string, taking every trait's hovercard with it — so a card's own traits were the one place the glossary was unreachable, while an in-prose `[[trait]]` reference still summoned it. Cells now carry an optional `entityRef`; each segment naming a rules entity (a trait, or a `trait`/`keyword` datavalue — exactly the two types the legacy sub-header resolved) arms that entity's hovercard. The `" // "` reading is byte-identical; segments naming nothing known stay bare text nodes.

**Header stat cluster.** `hoverText` reached the vertical value box but not the compact horizontal cell, and not the editable box — so a stat explained itself on a large card and went silent on every listing or nested one. `Stat`'s horizontal anatomy gains `hoverText`, applied to whichever node it returns (bare cell, running-text finish, cell+stepper), and `EntityCardStatBox` passes it in all three branches.

Also: `EntityTooltip`'s name→entity lookup is now case-**insensitive**, matching every other such lookup in the library. Trait names are stored lowercase while the surface capitalises them, so an exact match dropped the hovercard on exactly the callers that address by name.

Tooltips inside a hovercard stay inert — both primitives already gate on `InsideTooltipContext`, now asserted.

## Changelog entries render through `Card`

A changelog entry hand-assembled a `Panel` around its own header row (heading + `Badge` + `<time>`) — the exact shape `Card` already models. Rebuilding it by hand meant the changelog drifted from every other listing surface: frame weight, radius, seam placement and header padding were all set independently of the card language. Now: area → the card's seam stamp (`label`), version/title → the header band, bullets → the body, at `size="medium"` (a list, so listing density), `frame="chrome"` (the 1.5px sub-panel weight it always had), no `headerBg` (stays on paper).

## Verification

`bun run check:all` green — lint, format, typecheck (all 4 workspaces), 434 component-lib tests, validate, knip, audit, token + styling checks. New regression tests: `card/__tests__/statTooltips.test.tsx` (both affordances + the inert-inside-a-hovercard law + the unchanged trait-line reading) and a `Changelog` test asserting the entry is a Card frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019QCTK84eojKbNRYTQptgmw