### PR TITLE
fix(component-lib): render roll tables referenced by name

### DIFF
--- a/apps/srd/src/lib/schemaPreloadDeps.ts
+++ b/apps/srd/src/lib/schemaPreloadDeps.ts
@@ -7,7 +7,7 @@
  * This is deliberately conservative and coarse-grained (per audit advice):
  * cross-schema references in this dataset are pervasive, and a few are
  * unconditional — `ReferenceEntityCard` itself, regardless of the
- * entity's schema, always calls `getTable()` (-> `roll-tables`, for
+ * entity's schema, always calls `resolveCardTable()` (-> `roll-tables`, for
  * `tableName` refs), always renders `RangeValueDisplay` for any `range`
  * DataValue (-> `distances`), and always resolves ability-tree prerequisite
  * text via `resolveClassRequirements` (-> `ability-tree-requirements`).
@@ -27,8 +27,9 @@
  *
  * - ALWAYS_CORE — every `ReferenceEntityCard` render, regardless of
  *   schema, unconditionally touches:
- *   - `roll-tables`: `getTable()` (utilities.ts) checks the entity's own
- *     `tableName` field via a LazyModel `.find()`.
+ *   - `roll-tables`: `resolveCardTable()` (referenceEntity/card/) checks the
+ *     entity's own `tableName` field — and its folded action's — via a
+ *     LazyModel `.find()`.
  *   - `distances`: `RangeValueDisplay` resolves any `range`-type DataValue
  *     via a LazyModel lookup.
  *   - `ability-tree-requirements`: `resolveClassRequirements`

--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -62,6 +62,7 @@ import { EntityCardHeader } from './EntityCardHeader'
 import { EntityCardIdentityFooter } from './EntityCardIdentityFooter'
 import { EntityCardSubHeader } from './EntityCardSubHeader'
 import type { EntityCardSubHeaderCell } from './EntityCardSubHeader'
+import { resolveCardTable } from './resolveCardTable'
 import { resolveFoldedAction } from './resolveFoldedAction'
 import { stripHostParenthetical } from './stripHostParenthetical'
 import {
@@ -1521,7 +1522,17 @@ function ReferenceEntityCardInner({
   // A CATALOG tile and any NESTED card get it `collapsible` (header + Roll
   // button, rows behind a Show toggle) so a 20-row table can't swallow a
   // listing tile; a full card renders the whole table open.
-  const entityTable = 'table' in entity ? entity.table : undefined
+  //
+  // The table may be INLINE (`table`) or BY REFERENCE (`tableName` -> the
+  // `roll-tables` schema), and it may belong to the entity itself or to the
+  // action that FOLDS into it — an ability like "System and Software Hacker"
+  // keeps its d20 outcomes on its self-named action, by name. Reading
+  // `entity.table` alone dropped every one of those tables silently.
+  //
+  // Only the FOLDED action is consulted, never a sibling action: a sibling
+  // renders as its own nested card and resolves its own table there, so
+  // pulling it up here would print it twice.
+  const entityTable = resolveCardTable(entity) ?? resolveCardTable(foldedAction)
   //
   // `showCommand` keeps the header band (and its Roll button) on every rung —
   // the legacy renderer passed it unconditionally, and it is the affordance

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/resolveCardTable.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/resolveCardTable.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Roll-table data reaches the card two ways — INLINE (`table`) and BY
+ * REFERENCE (`tableName` -> the `roll-tables` schema) — and it may sit on the
+ * entity itself or on the action that folds into it. The card used to read
+ * `entity.table` only, so "System and Software Hacker" (and 87 other entities)
+ * rendered their prose with the d20 outcomes silently missing.
+ */
+import { beforeAll, describe, expect, test, afterEach } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+import { SalvageUnionReference, extractVisibleActions } from 'salvageunion-reference'
+import type { SURefEntity } from 'salvageunion-reference'
+import { ReferenceEntityCard } from '../ReferenceEntityCard'
+import { resolveCardTable } from '../resolveCardTable'
+
+const ROLL_BUTTON = 'Roll on this table'
+
+const find = <T extends { name?: string }>(items: readonly T[], name: string): T => {
+  const match = items.find((item) => item.name === name)
+  if (!match) throw new Error(`fixture missing: ${name}`)
+  return match
+}
+
+afterEach(cleanup)
+
+describe('roll tables reach the card by reference, not just inline', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  test("an ability whose self-action names a table renders that table's rows", () => {
+    const ability = find(SalvageUnionReference.Abilities.all(), 'System and Software Hacker')
+    render(<ReferenceEntityCard data={ability} />)
+
+    expect(screen.getByLabelText(ROLL_BUTTON)).toBeTruthy()
+    expect(screen.getByText('The System or Module is destroyed.')).toBeTruthy()
+  })
+
+  test('a system whose self-action names a table renders it', () => {
+    const system = find(SalvageUnionReference.Systems.all(), 'Mechapult')
+    render(<ReferenceEntityCard data={system} />)
+
+    expect(screen.getByLabelText(ROLL_BUTTON)).toBeTruthy()
+    expect(screen.getByText(/The Mechapult explodes and is destroyed\./)).toBeTruthy()
+  })
+
+  test('an action entity that names a table renders it on its own card', () => {
+    const action = find(SalvageUnionReference.Actions.all(), 'Area Salvage')
+    render(<ReferenceEntityCard data={action as unknown as SURefEntity} />)
+
+    expect(screen.getByLabelText(ROLL_BUTTON)).toBeTruthy()
+  })
+
+  test('an inline `table` still renders (roll-tables entity itself)', () => {
+    const rollTable = find(SalvageUnionReference.RollTables.all(), 'Trading Bay')
+    render(<ReferenceEntityCard data={rollTable as unknown as SURefEntity} />)
+
+    expect(screen.getByLabelText(ROLL_BUTTON)).toBeTruthy()
+    expect(screen.getByText('An Intact Mech Chassis is available for trade.')).toBeTruthy()
+  })
+
+  test('a NON-self action keeps its table on its own nested card — printed once', () => {
+    // "Trade Caravan" hosts "Improved Trading Bay", which names a table. The
+    // action renders as its own nested card, so pulling the table up to the
+    // host as well would print the same table twice.
+    const crawler = find(SalvageUnionReference.Crawlers.all(), 'Trade Caravan')
+    render(<ReferenceEntityCard data={crawler} />)
+
+    expect(screen.getAllByLabelText(ROLL_BUTTON)).toHaveLength(1)
+  })
+
+  test('every ability with by-reference table data resolves a table', () => {
+    const abilities = SalvageUnionReference.Abilities.all().filter((ability) => {
+      const selfAction = (extractVisibleActions(ability) ?? []).find((a) => a.name === ability.name)
+      return selfAction !== undefined && resolveCardTable(selfAction) !== undefined
+    })
+    // Guard the guard: this set is non-empty in the shipped dataset.
+    expect(abilities.length).toBeGreaterThan(0)
+
+    for (const ability of abilities) {
+      render(<ReferenceEntityCard data={ability} />)
+      expect(screen.getAllByLabelText(ROLL_BUTTON).length).toBeGreaterThan(0)
+      cleanup()
+    }
+  })
+})
+
+describe('resolveCardTable', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  test('prefers an inline table, resolves a name, ignores anything else', () => {
+    // An inline table wins over a name that would resolve to a different one.
+    const inline = find(SalvageUnionReference.RollTables.all(), 'Trading Bay').table
+    expect(resolveCardTable({ table: inline, tableName: 'Mechapult' })).toEqual(inline)
+    expect(resolveCardTable({ tableName: 'Trading Bay' })).toBeDefined()
+    expect(resolveCardTable({ tableName: 'no such table' })).toBeUndefined()
+    expect(resolveCardTable({ tableName: '' })).toBeUndefined()
+    expect(resolveCardTable(undefined)).toBeUndefined()
+    expect(resolveCardTable(null)).toBeUndefined()
+    expect(resolveCardTable('Trading Bay')).toBeUndefined()
+  })
+})

--- a/packages/component-lib/src/components/referenceEntity/card/resolveCardTable.ts
+++ b/packages/component-lib/src/components/referenceEntity/card/resolveCardTable.ts
@@ -1,0 +1,47 @@
+import type { SURefObjectTable } from 'salvageunion-reference'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+/**
+ * The roll table a card should render, for the entity itself or for the action
+ * that folds into it.
+ *
+ * Roll-table data reaches an entity two ways in this dataset: INLINE, as a
+ * `table` object on the entity or its action, or BY REFERENCE, as a
+ * `tableName` string naming an entry in the `roll-tables` schema. The card
+ * used to read `entity.table` only, so every by-reference table rendered as
+ * nothing at all — an ability like "System and Software Hacker" showed its
+ * prose and silently dropped the d20 outcomes that ARE the ability.
+ *
+ * Both shapes are equally canonical (the validator in
+ * `tools/validateReferencesLogic.ts` enforces that every `tableName` resolves),
+ * so resolution belongs at the render core rather than in the data.
+ *
+ * The lookup is defensive: `RollTables` is a LazyModel and throws when the
+ * `roll-tables` schema isn't preloaded. A card that can't resolve its table
+ * degrades to no table rather than taking the whole tree down — the same
+ * discipline as the other reference reads outside a preload gate.
+ */
+export function resolveCardTable(source: unknown): SURefObjectTable | undefined {
+  if (source === null || typeof source !== 'object') return undefined
+
+  if ('table' in source) {
+    const table = (source as { table?: unknown }).table
+    if (table !== null && typeof table === 'object') return table as SURefObjectTable
+  }
+
+  if ('tableName' in source) {
+    const tableName = (source as { tableName?: unknown }).tableName
+    if (typeof tableName === 'string' && tableName.length > 0) {
+      try {
+        const rollTable = SalvageUnionReference.RollTables.find(
+          (rt) => 'name' in rt && rt.name === tableName
+        )
+        if (rollTable?.table) return rollTable.table
+      } catch {
+        return undefined
+      }
+    }
+  }
+
+  return undefined
+}


### PR DESCRIPTION
## The bug

Abilities (and systems, modules, equipment…) with roll-table data rendered no roll table. Reported for **System and Software Hacker**, which shows its prose and silently drops the d20 outcomes that *are* the ability.

## Root cause

Roll-table data reaches an entity two ways in this dataset:

- **inline** — a `table` object on the entity or its action
- **by reference** — a `tableName` string naming an entry in the `roll-tables` schema (the data validator already enforces that every one of these resolves)

`ReferenceEntityCard` rendered `'table' in entity ? entity.table : undefined` — inline only, entity only. So a by-reference table rendered as nothing, and so did a table living on the action that folds into the card (which is exactly where an ability like System and Software Hacker keeps it).

**88 entities** were affected: 13 abilities, 44 actions, 15 systems, 10 modules, 3 equipment, plus crawlers, crawler-bays and bio-titans.

## The fix

`resolveCardTable(source)` resolves both shapes (inline wins over a name), applied to the entity **and** to its folded action:

```ts
const entityTable = resolveCardTable(entity) ?? resolveCardTable(foldedAction)
```

Only the **folded** action is consulted — a sibling action renders as its own nested card and resolves its table there, so pulling it up to the host would print the same table twice. A test pins that (`Trade Caravan` → exactly one roll table).

The name lookup is defensive: `RollTables` is a LazyModel that throws when `roll-tables` isn't preloaded, and a card that can't resolve its table should degrade to no table rather than take the render tree down. Both apps already preload it (srd via `ALWAYS_CORE`, itun via the full preload) — the srd render-equivalence test covers this.

## Verification

- New `resolveCardTable.test.tsx` — 7 tests; **5 of them fail against the pre-fix card** (verified by reverting the one line), so they pin the regression rather than the status quo. Includes a sweep over every ability whose self-action names a table.
- `bun run check:all` green (lint, format, typecheck, test, validate:all, knip, audit, tokens, styling) — 3565 tests pass.
- Also corrected two stale references in `apps/srd/src/lib/schemaPreloadDeps.ts`: its evidence notes cited `getTable()` as the card's unconditional `roll-tables` consumer; the card doesn't call it. Bundle membership is unchanged and still required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFCx7fTu36uM1FXk1MHXNH