### PR TITLE
docs: state SRD content provenance in LLM statement

### DIFF
--- a/LLM_STATEMENT.md
+++ b/LLM_STATEMENT.md
@@ -19,6 +19,8 @@ This was started as a hand-made project, and it predates the LLMs now used to wo
 
 Much of the code since then has been written with LLM assistance. Every change is directed, read, run, and merged by me, and the commit history shows which parts.
 
+The content described in the SRD is all sourced from Leyline Press, and none of it has been authored by me or any of my LLM coding assistants.
+
 My job requires proficiency in these tools, and I best gain proficiency through passion projects like this. It has been my intention to use LLMs as a force multiplier, not as a replacement for my own judgment: to more consistently and efficiently implement my changes, not to decide on the changes themselves. Bugs or issues in this project are solely my responsibility and my fault.
 
 I support open-weight models. I am against consolidated ownership of LLM infrastructure, and against the obtrusive, environmentally unsound data centers built to serve it.


### PR DESCRIPTION
Adds one line to the shared LLM statement making the content provenance explicit:

> The content described in the SRD is all sourced from Leyline Press, and none of it has been authored by me or any of my LLM coding assistants.

It sits after the paragraph about LLM-assisted code, so the statement now separates *how the code was written* from *where the content came from*.

`LLM_STATEMENT.md` is the single source rendered verbatim in the colophon on both about pages — srd's `/about` (read at build time via `node:fs`) and ITUN's `/about` (inlined via a Vite `?raw` import) — so both sites pick this up together.

## Verification

- `bun --filter component-lib test` — 462 pass, 0 fail (includes `MarkdownSection.test.tsx`, which parses the real `LLM_STATEMENT.md`)
- `bun run format:check` — clean
- Complies with the file's format contract: plain blank-line-separated paragraph, no inline markdown beyond links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L94Vkhha6BaaWb3bTqzW79