### PR TITLE
docs: add ownership + licence notice to both about pages

### DIFF
--- a/apps/srd/src/pages/about.astro
+++ b/apps/srd/src/pages/about.astro
@@ -126,15 +126,18 @@ const structuredData = {
           </a>. It provides a searchable, browsable reference for all game content released under the Salvage Union OGL.
         </p>
         <p class="mb-2">
-          Browse the full catalog:{' '}
-          <a href="/schema/chassis/" class="font-bold text-rust hover:underline">Chassis</a>,{' '}
-          <a href="/schema/systems/" class="font-bold text-rust hover:underline">Systems</a>,{' '}
-          <a href="/schema/modules/" class="font-bold text-rust hover:underline">Modules</a>,{' '}
-          <a href="/schema/abilities/" class="font-bold text-rust hover:underline">Abilities</a>,{' '}
-          <a href="/schema/classes/" class="font-bold text-rust hover:underline">Classes</a>, and more.
+          The site is open source and contributions are welcome.
         </p>
         <p>
-          The site is open source and contributions are welcome.
+          I am not the owner or publisher of this content. Salvage Union and all associated names, marks, characters, and artwork are the property of Leyline Press. Game text and mechanics are used under the{' '}
+          <a
+            href="https://leyline.press/pages/salvage-union-open-game-licence-1-0b"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="font-bold text-rust hover:underline"
+          >
+            Salvage Union Open Game Licence 1.0b
+          </a>. Artwork is not covered by that licence and is reproduced with the special permission of Leyline Press. This is an unofficial fan project, and is not affiliated with Leyline Press.
         </p>
       </section>
 

--- a/packages/component-lib/src/components/shared/AboutScreen.tsx
+++ b/packages/component-lib/src/components/shared/AboutScreen.tsx
@@ -78,6 +78,22 @@ export function AboutScreen({ version, aboutJrvs, llmStatement }: AboutScreenPro
             </a>
             .
           </p>
+          <p>
+            I am not the owner or publisher of this content. Salvage Union and all associated names,
+            marks, characters, and artwork are the property of Leyline Press. Game text and
+            mechanics are used under the{' '}
+            <a
+              href="https://leyline.press/pages/salvage-union-open-game-licence-1-0b"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold text-rust hover:underline"
+            >
+              Salvage Union Open Game Licence 1.0b
+            </a>
+            . Artwork is not covered by that licence and is reproduced with the special permission
+            of Leyline Press. This is an unofficial fan project, and is not affiliated with Leyline
+            Press.
+          </p>
         </section>
 
         <Colophon


### PR DESCRIPTION
Makes the licensing position explicit in the **"What is this?"** section of both about surfaces.

## The notice

> I am not the owner or publisher of this content. Salvage Union and all associated names, marks, characters, and artwork are the property of Leyline Press. Game text and mechanics are used under the [Salvage Union Open Game Licence 1.0b](https://leyline.press/pages/salvage-union-open-game-licence-1-0b). Artwork is not covered by that licence and is reproduced with the special permission of Leyline Press. This is an unofficial fan project, and is not affiliated with Leyline Press.

The wording matches the licensing facts already asserted in `/llms.txt` (OGL 1.0b for text and mechanics; artwork out of scope, used with special permission).

It claims **non-affiliation only**. An earlier draft said "neither affiliated with nor endorsed by" — the non-endorsement half was dropped as inaccurate.

## Changes

- **`apps/srd/src/pages/about.astro`** — adds the notice as the closing paragraph, and removes the `Browse the full catalog:` link list (Chassis / Systems / Modules / Abilities / Classes). The catalog is already reachable from the nav and the home page.
- **`packages/component-lib/src/components/shared/AboutScreen.tsx`** — the same notice on ITUN's about page. ITUN's "Looking for the rules?" link to salvageunion.io is left in place.

Each surface keeps its own local link styling (`font-bold` on srd, `font-semibold` in the shared component).

## Verification

- `bun run typecheck` — clean across component-lib, srd, itun, discord-bot
- `bun --filter component-lib test` (462 pass) and `bun --filter srd test` (1,003 pass) — 0 fail; full `bun run test` was green at 3,673 pass before the wording fix
- `bun run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L94Vkhha6BaaWb3bTqzW79