### PR TITLE
feat(component-lib): changelog content parses inline markdown links

### DIFF
--- a/packages/component-lib/src/changelog/Changelog.test.tsx
+++ b/packages/component-lib/src/changelog/Changelog.test.tsx
@@ -42,6 +42,24 @@ describe('Changelog', () => {
     expect(frame?.getAttribute('style')).toContain('var(--bw-chrome)')
   })
 
+  test('renders inline markdown links in a bullet item as anchors', () => {
+    // release-please items carry issue/commit refs as `[label](href)` links;
+    // they must render as clickable anchors, not literal markdown punctuation.
+    const entries: ChangelogEntry[] = [
+      {
+        date: '2026-07-23',
+        version: '2.5.0',
+        area: 'Data',
+        items: ['chassis patterns get their own pages ([#518](https://example.com/issues/518))'],
+      },
+    ]
+    render(<Changelog entries={entries} />)
+    const link = screen.getByRole('link', { name: '#518' })
+    expect(link.getAttribute('href')).toBe('https://example.com/issues/518')
+    // The non-link prose around it is still present.
+    expect(screen.getByText(/chassis patterns get their own pages/)).toBeTruthy()
+  })
+
   test('uses the title as the headline for historical (unversioned) entries', () => {
     const entries: ChangelogEntry[] = [
       { date: '2026-07-14', title: 'Support on Ko-fi', area: 'Site', items: ['Added a link'] },

--- a/packages/component-lib/src/changelog/Changelog.tsx
+++ b/packages/component-lib/src/changelog/Changelog.tsx
@@ -1,4 +1,5 @@
 import { Card } from '../components/shared/Card'
+import { InlineMarkdown } from '../markdownSection/InlineMarkdown'
 import { cn } from '../utils/cn'
 import type { ChangelogEntry } from './parseChangelog'
 
@@ -67,7 +68,9 @@ export function Changelog({ entries, className }: ChangelogProps) {
             {entry.items.length > 0 && (
               <ul className="ml-4 list-disc space-y-1 font-body text-sm text-ink-2 marker:text-wk-muted">
                 {entry.items.map((item) => (
-                  <li key={item}>{item}</li>
+                  <li key={item}>
+                    <InlineMarkdown text={item} />
+                  </li>
                 ))}
               </ul>
             )}

--- a/packages/component-lib/src/markdownSection/InlineMarkdown.tsx
+++ b/packages/component-lib/src/markdownSection/InlineMarkdown.tsx
@@ -1,0 +1,58 @@
+import { Fragment } from 'react'
+
+import { cn } from '../utils/cn'
+import { type InlineNode, parseInline } from './parseMarkdownSection'
+
+/** Pair each run with its start offset in the text — a stable React key. */
+function withOffsets(nodes: InlineNode[]): Array<{ node: InlineNode; offset: number }> {
+  let offset = 0
+  return nodes.map((node) => {
+    const at = offset
+    offset += node.text.length
+    return { node, offset: at }
+  })
+}
+
+type InlineMarkdownProps = {
+  /** A single line of prose; `[label](href)` links are interpreted. */
+  text: string
+  /** Class applied to rendered `<a>` links. */
+  linkClassName?: string
+}
+
+/**
+ * The inline half of the shared markdown contract: split `text` into plain runs
+ * and `[label](href)` links (via {@link parseInline}) and render each, links as
+ * new-tab anchors. Bold, italics and lists stay literal — the one inline form
+ * both markdown surfaces interpret is links.
+ *
+ * Shared by {@link MarkdownSection} (repo-root prose) and `Changelog` (release
+ * notes) so an issue/commit reference like `([#518](…))` renders as a link on
+ * both, from one rendering path rather than two hand-kept copies.
+ */
+export function InlineMarkdown({
+  text,
+  linkClassName = 'font-semibold text-rust hover:underline',
+}: InlineMarkdownProps) {
+  return (
+    <>
+      {/* Keyed by running offset: two runs in one line can hold the same text,
+          and `key={node.text}` would collide on those. */}
+      {withOffsets(parseInline(text)).map(({ node, offset }) =>
+        node.href ? (
+          <a
+            key={`${offset}-${node.text}`}
+            href={node.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={cn(linkClassName)}
+          >
+            {node.text}
+          </a>
+        ) : (
+          <Fragment key={`${offset}-${node.text}`}>{node.text}</Fragment>
+        )
+      )}
+    </>
+  )
+}

--- a/packages/component-lib/src/markdownSection/MarkdownSection.tsx
+++ b/packages/component-lib/src/markdownSection/MarkdownSection.tsx
@@ -1,18 +1,7 @@
-import { Fragment } from 'react'
-
 import { Slab } from '../components/chrome/Slab'
 import { cn } from '../utils/cn'
-import { type InlineNode, parseInline, parseMarkdownSection } from './parseMarkdownSection'
-
-/** Pair each run with its start offset in the paragraph — a stable React key. */
-function withOffsets(nodes: InlineNode[]): Array<{ node: InlineNode; offset: number }> {
-  let offset = 0
-  return nodes.map((node) => {
-    const at = offset
-    offset += node.text.length
-    return { node, offset: at }
-  })
-}
+import { InlineMarkdown } from './InlineMarkdown'
+import { parseMarkdownSection } from './parseMarkdownSection'
 
 type MarkdownSectionProps = {
   /** Raw contents of a repo-root prose document. */
@@ -42,23 +31,7 @@ export function MarkdownSection({ markdown, className }: MarkdownSectionProps) {
       {heading && <Slab as="h2" variant="solid" label={heading} className="mb-0" />}
       {paragraphs.map((paragraph) => (
         <p key={paragraph}>
-          {/* Keyed by running offset: two runs in one paragraph can hold the
-              same text, and `key={node.text}` would collide on those. */}
-          {withOffsets(parseInline(paragraph)).map(({ node, offset }) =>
-            node.href ? (
-              <a
-                key={`${offset}-${node.text}`}
-                href={node.href}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-semibold text-rust hover:underline"
-              >
-                {node.text}
-              </a>
-            ) : (
-              <Fragment key={`${offset}-${node.text}`}>{node.text}</Fragment>
-            )
-          )}
+          <InlineMarkdown text={paragraph} />
         </p>
       ))}
     </section>


### PR DESCRIPTION
## What

Changelog bullet items were rendered as raw strings, so release-please issue/commit refs — `([#518](…)) ([02824e9](…))` — showed as **literal markdown** on the `/changelog` page instead of clickable links.

Now each item renders through the same `[label](href)` inline-link contract the about/back pages already established (`parseInline` in `parseMarkdownSection.ts`: regex-free, href-guarded to http(s)/site-relative).

## How

- **New** `packages/component-lib/src/markdownSection/InlineMarkdown.tsx` — internal shared renderer that splits a line into plain runs + links via `parseInline` and renders links as new-tab anchors. Not barrel-exported (internal sub-part, no story required).
- `MarkdownSection.tsx` now delegates to it (removes the duplicated `withOffsets` + link JSX — net −33/+0 there).
- `Changelog.tsx` renders each bullet via `<InlineMarkdown>` instead of `{item}`.
- Added a `Changelog` test asserting a `[#518](href)` item renders an `<a>` with the right href while surrounding prose survives.

Scope kept to links only — the one inline form the repo's markdown contract interprets, and the only inline markdown present in the changelog data. Bold/italics stay literal, matching `MarkdownSection`.

## Verification

- `bun --filter component-lib test` → 463 pass
- `bun run typecheck` → clean (srd, itun, discord-bot, package)
- `bun run lint` → only 2 pre-existing warnings (unrelated `parseTraitReferences.tsx`)
- `bun run format` → no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SABVtgHFdyy7Muxs5YXyAP