### PR TITLE
fix(component-lib): pattern cards render their own source/page, not the chassis's

### DIFF
--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -573,6 +573,17 @@ function ReferenceEntityCardInner({
   // The entity TYPE for the depth-0 footer (patterns read "Pattern"; actions
   // never render a depth-0 footer).
   const footerType = isAction ? undefined : isPattern ? 'Pattern' : resolveEyebrow(schemaName).type
+  // FOOTER PROVENANCE — a pattern carries its OWN source/booklet/page, often a
+  // different book than its chassis (e.g. an Acid Spitter sourced from another
+  // book than the Mule's Workshop Manual). On a pattern card the `entity` IS the
+  // chassis, so use the pattern's provenance. Booklet + page are meaningful only
+  // relative to a source, so provenance falls back as ONE unit: only when the
+  // pattern omits its own `source` do we borrow the chassis's source/booklet/page
+  // — never mix a pattern's source with the chassis's page.
+  const usePatternProvenance = isPattern && !!pattern.source
+  const footerSource = usePatternProvenance ? pattern.source : getSource(entity)
+  const footerBooklet = usePatternProvenance ? pattern.booklet : getBooklet(entity)
+  const footerPage = usePatternProvenance ? pattern.page : getPageReference(entity)
   // A PATTERN names its owning chassis as a horizontal stat stampseal in the
   // seam — `[Chassis | Little Sestra]` — rather than a bare stampseal, so it
   // reads as the same `[label | value]` pill vocabulary as every other axis.
@@ -1864,9 +1875,9 @@ function ReferenceEntityCardInner({
               <EntityCardIdentityFooter
                 bgColor={darkTone}
                 typeLabel={footerType}
-                source={getSource(entity)}
-                booklet={getBooklet(entity)}
-                page={getPageReference(entity)}
+                source={footerSource}
+                booklet={footerBooklet}
+                page={footerPage}
                 footMeta={footMeta}
                 externalLink={extent === 'full' ? externalLinkNode : undefined}
                 compact={compact}

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/PatternView.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/PatternView.test.tsx
@@ -107,6 +107,54 @@ describe('full pattern view reading order', () => {
 })
 
 /**
+ * FOOTER PROVENANCE. A pattern carries its OWN source/booklet/page — often a
+ * DIFFERENT book than the chassis it hangs off (the Mule ships from the Workshop
+ * Manual, but its Acid Spitter pattern is from "We Were Here First!"). Because a
+ * pattern card's `data` IS the chassis, the identity footer must read the
+ * pattern's provenance, never the chassis's. Booklet + page fall back as one
+ * unit with the source, so a pattern's source is never paired with the chassis's
+ * page.
+ */
+describe('pattern footer provenance', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  const patternOf = (name: string): SURefObjectPattern => {
+    const found = mule().patterns?.find((p) => p.name === name)
+    if (!found) throw new Error(`${name} pattern fixture missing`)
+    return found
+  }
+
+  test("the footer shows the pattern's own source + page, not the chassis's", () => {
+    const chassis = mule()
+    const acidSpitter = patternOf('Acid Spitter')
+    // Guard the fixture: the pattern must genuinely diverge from its chassis.
+    expect(acidSpitter.source).toBe('We Were Here First!')
+    expect(acidSpitter.source).not.toBe(chassis.source)
+    expect(acidSpitter.page).not.toBe(chassis.page)
+
+    render(<ReferenceEntityCard data={chassis} pattern={acidSpitter} />)
+
+    // The footer joins source · page into one line.
+    expect(screen.getByText(`We Were Here First! · p.${acidSpitter.page}`)).toBeTruthy()
+    // The chassis's own provenance must NOT leak into the pattern footer.
+    expect(screen.queryByText(`${chassis.source} · p.${chassis.page}`)).toBeNull()
+  })
+
+  test('a booklet rides with the pattern source', () => {
+    const survivor = patternOf('Survivor')
+    // Survivor is from the Starter Set, booklet "PC" — booklet must pair with
+    // the pattern's source, not be borrowed from the chassis.
+    expect(survivor.source).toBe('Salvage Union Starter Set')
+    expect(survivor.booklet).toBe('PC')
+
+    render(<ReferenceEntityCard data={mule()} pattern={survivor} />)
+    expect(screen.getByText(`Salvage Union Starter Set (PC) · p.${survivor.page}`)).toBeTruthy()
+  })
+})
+
+/**
  * The "Legal Starting Pattern" seam stamp. It rides the seam RIGHT of the
  * `[Chassis | …]` marker specifically so it survives the LISTING extent — the
  * pattern rows under a chassis are header-only, and that list is where a reader


### PR DESCRIPTION
## Problem

Pattern entity cards showed the **chassis's** source book and page, not the pattern's own. For example, the Mule's **Acid Spitter** pattern rendered `Salvage Union Workshop Manual · p.100` (the Mule's provenance) when it should read `We Were Here First! · p.76`.

## Root cause

A chassis pattern has no entity of its own — it's a nested object on the chassis, so a pattern card's `data` **is** the chassis (`entity`). The identity footer read `getSource(entity)` / `getPageReference(entity)`, which is always the chassis's provenance. The `pattern` prop — which carries the pattern's own `source`/`booklet`/`page` — was never consulted for the footer.

This affected **205 of 209** patterns (those whose source/page differ from their chassis).

## Fix

`ReferenceEntityCard` now reads the pattern's own provenance for pattern cards. Booklet + page are meaningful only relative to a source, so provenance falls back **as one unit**: only when a pattern omits its own `source` do we borrow the chassis's — a pattern's source is never paired with the chassis's page. (All 209 patterns currently carry their own source, so the fallback is a safety net.)

## Tests

Added a `pattern footer provenance` describe block to `PatternView.test.tsx`:
- Acid Spitter shows its own `We Were Here First! · p.76`, and the chassis's `Workshop Manual · p.100` does **not** leak in.
- Survivor's booklet rides with its own source (`Salvage Union Starter Set (PC) · p.13`).

Full `component-lib` suite: 464 pass / 0 fail. Typecheck clean across all packages; lint/format clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfQhm9emCrU4oAKH6par17