### PR TITLE
chore: remove dead ladle:web/ladle:itun scripts and stale render-stack comments

### DIFF
--- a/apps/srd/src/lib/schemaPreloadDeps.ts
+++ b/apps/srd/src/lib/schemaPreloadDeps.ts
@@ -60,7 +60,7 @@
  *   (themselves CONTENT_BUNDLE members, so also need `actions`). A chassis
  *   ability can also carry a `.drone` reference, resolved via
  *   `SalvageUnionReference.findIn('drones', ...)`
- *   (ReferenceEntityDisplayContent.tsx). `factions` formation entries
+ *   (referenceEntity/card/resolveNestedEntities.ts). `factions` formation entries
  *   resolve to a full entity via `resolveFormationMember`
  *   (utilities.ts) — `member.schema` is one of a fixed, documented set
  *   (`chassis` default, or `vehicles`/`drones`/`squads`/`npcs`), each then

--- a/docs/design-system/ladle-styleguide.md
+++ b/docs/design-system/ladle-styleguide.md
@@ -81,9 +81,10 @@ component it demonstrates, and the guard (§7) fails CI on either violation.
 | `bun --filter component-lib ladle:build`        | static build into `build-ladle/`                            |
 | `bun --filter component-lib exec ladle preview` | serve a built catalog (used for the VR harness)             |
 
-> Note: root `package.json` also defines `ladle:web` and `ladle:itun`, but those apps define no
-> `ladle` script, so those two aliases are inert. Only `bun run ladle` (→ component-lib) works. This
-> is intentional — the catalog is centralized, not per-app.
+> Note: `bun run ladle` (→ component-lib) is the only catalog entry point. There are no per-app
+> Ladle scripts, and there should not be — the catalog is centralized, not per-app. Root
+> `package.json` used to carry inert `ladle:web` / `ladle:itun` aliases pointing at `ladle` scripts
+> those apps never defined; they have been removed.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -94,9 +94,7 @@
     "check:styling": "bun tools/check-styling-ownership.ts",
     "check:all": "bun run check:schemas && concurrently -g 'bun run lint' 'bun run format:check' && bun run typecheck && concurrently -g 'bun run test' 'bun run validate:all' 'bun run knip' 'bun run check:audit' 'bun run check:tokens' 'bun run check:styling'",
     "fix:all": "bun run lint -- --write && bun run format",
-    "ladle": "bun --filter component-lib ladle",
-    "ladle:web": "bun --filter srd ladle",
-    "ladle:itun": "bun --filter itun ladle"
+    "ladle": "bun --filter component-lib ladle"
   },
   "patchedDependencies": {
     "@ladle/react@5.1.1": "patches/@ladle%2Freact@5.1.1.patch"

--- a/packages/component-lib/.ladle/components.tsx
+++ b/packages/component-lib/.ladle/components.tsx
@@ -9,7 +9,7 @@ import '../src/styles/ladle.css'
  * Ladle's router dynamically imports that story's chunk. Without a preload
  * gate ahead of that import, every model access throws "Schema not loaded"
  * (see salvageunion-reference's LazyModel guard) and the story renders
- * nothing — silently blank, not an error page. `apps/in-the-union-now`'s
+ * nothing — silently blank, not an error page. `apps/itun`'s
  * `GameDataReady` and `apps/srd`'s `useGameData` use the same
  * `use()` + `Suspense` gate for the same reason; mirrored here so Ladle
  * (and the visual-regression harness built on it) actually renders content.

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/entityExternalLink.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/entityExternalLink.test.tsx
@@ -4,12 +4,13 @@
  * `EntityExternalLinkProvider` and is read by `useEntityExternalLink`.
  *
  * WHY THIS EXISTS. This link silently disappeared once already, and nothing
- * caught it. The legacy render core (`ReferenceEntityDisplayContent`) held the
- * only `useEntityExternalLink` call; when that file was deleted in favour of
+ * caught it. The since-deleted legacy render core held the only
+ * `useEntityExternalLink` call; when that file was removed in favour of
  * `ReferenceEntityCard`, the call went with it and was never reinstated. ITUN
  * still wired the provider in `GameDataReady` and still shipped a tested
  * builder, so both ends of the feature looked healthy — only the middle was
- * gone.
+ * gone. The call now lives in `ReferenceEntityCard` itself, which is what this
+ * file renders.
  *
  * The failure was invisible to every gate we had: deleting the sole *reader*
  * of a context removes no export, breaks no type, and fails no test. Typecheck,


### PR DESCRIPTION
Three small, unrelated cleanups in one PR. No behaviour change.

## 1. Dead root scripts

Root `package.json` defined:

```
"ladle:web": "bun --filter srd ladle",
"ladle:itun": "bun --filter itun ladle"
```

**Verified dead:** neither `apps/srd/package.json` nor `apps/itun/package.json`
defines a `ladle` script (`grep '"ladle' apps/*/package.json` → no matches), so
both aliases were inert. The Ladle catalog is component-lib-only by design — one
centralized catalog, not per-app. Both entries removed; `ladle` (component-lib,
which works) is kept.

`docs/design-system/ladle-styleguide.md` carried a note documenting these two as
inert-but-present. That note is updated to reflect the removal rather than left
describing scripts that no longer exist.

## 2. Stale comments (comments only, no code touched)

Three comments still named things deleted in the #466 rename:

| File | Was | Now |
| --- | --- | --- |
| `apps/srd/src/lib/schemaPreloadDeps.ts` | `ReferenceEntityDisplayContent.tsx` | `referenceEntity/card/resolveNestedEntities.ts` (verified: that's where the `findIn('drones', …)` calls live) |
| `packages/component-lib/.ladle/components.tsx` | `apps/in-the-union-now` | `apps/itun` |
| `.../card/__tests__/entityExternalLink.test.tsx` | named only the deleted legacy render core | still records the history, but now also says the `useEntityExternalLink` call lives in `ReferenceEntityCard` today (verified at `ReferenceEntityCard.tsx:422`) |

## 3. Ghost directories — local-disk cleanup, **no committed diff**

`apps/in-the-union-now` (22 MB) and `packages/suref-react` (15 MB) were pure
gitignored build residue from the #466 rename — `dist/`, `node_modules/`,
`build-ladle/`, `playwright-report/`, `test-results/`, `tsconfig.tsbuildinfo`.

Confirmed before deleting:

- `git ls-files apps/in-the-union-now packages/suref-react` → **0 files**
- `git status --porcelain` stayed clean with them present *and* after removal
- neither contains a `package.json`, so bun's `apps/*` / `packages/*` workspace
  globs never picked them up

Deleted from disk (~37 MB reclaimed). **There is intentionally no diff for this
item** — nothing was tracked, so there is nothing to commit. Anyone else with a
stale checkout can reclaim the same space with the same two `rm -rf`s.

## Verification

All run from a fresh worktree after `bun install --frozen-lockfile` + `bun run build:package`:

- `bun run typecheck` — **pass**, 0 errors (srd astro check: 66 files, 0 errors/warnings/hints; itun, discord-bot, component-lib, package all exit 0)
- `bun run lint` — **exit 0**. 2 warnings + 2 infos, all pre-existing in files this PR does not touch (`DialConfig.tsx`, `parseTraitReferences.tsx` + its test)
- `bun run format:check` — **exit 0**
- `bun run test` — **3612 pass, 0 fail** (component-lib 469, itun 1227, salvageunion-reference 913, srd 1003)
- `bun run validate:all` — **pass** (ids, references, actions, action-backrefs, orphans, traits, schemas, bun-version, architecture, doc-drift)
- `bun run knip` — clean (one pre-existing `.css` configuration hint)

Nothing here needs a browser, so there is no unverifiable surface.

## Deliberately left out

Noted, not fixed, to keep the diff minimal — `apps/srd/src/lib/schemaPreloadDeps.ts`
has **more** stale symbol names in the same comment block beyond the one my lane
named: `DataValueDisplayView.tsx`, `TraitKeywordDisplayView`,
`ReferenceEntityFormation.tsx`, `resolveFormationMember`, `GuideStepsDisplay`,
`ReferenceEntityGrants` — none of which resolve to anything in
`packages/component-lib/src` or `apps/*/src` anymore. Worth a follow-up pass over
that whole header, but it is a larger rewrite than this lane covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoXC3pFgFjYYoUM12MGHpL