### PR TITLE
ci: run the a11y scan nightly as an advisory job

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -11,6 +11,10 @@ name: E2E (nightly)
 # failure and closed on the next green run — GitHub-native, no external
 # notification service or webhook secret.
 #
+# The `a11y-srd` job also lives here (rather than in ci.yml) because this
+# workflow already builds and serves hermetic static bundles for Playwright, so
+# the scan gets its server for free. It is ADVISORY — see the job's own notes.
+#
 # Trigger manually any time via the "Run workflow" button (workflow_dispatch).
 
 on:
@@ -98,12 +102,131 @@ jobs:
           path: apps/srd/playwright-report/
           retention-days: 7
 
+  a11y-srd:
+    # WCAG 2.1 AA scan (axe-core via puppeteer-core, `tools/a11y-scan.ts`) over
+    # a representative slice of the srd static build. `docs/architecture/
+    # seo-accessibility.md` asserts AA compliance; until this job existed that
+    # claim was verified by nothing on a schedule.
+    #
+    # ADVISORY, deliberately: `continue-on-error: true` and NOT listed in the
+    # notify-* `needs:` below, so a violation can neither redden the nightly run
+    # nor open/keep-open the `nightly-e2e-failure` tracking issue. The signal is
+    # the job's step summary (a per-page violation table) plus the uploaded
+    # `a11y-report.json`. Turning it into a gate on day one would strand work on
+    # a backlog nobody has triaged yet.
+    #
+    # PROMOTING TO BLOCKING, once the report is clean (or its violations are
+    # accepted), in order:
+    #   1. Commit a baseline: `a11y-baseline.json` next to the scanner, mapping
+    #      each page to its accepted violation ids (e.g.
+    #      `{"/": ["color-contrast"], "/schema/chassis/": []}`) with a comment
+    #      per entry saying why it is tolerated.
+    #   2. Teach `tools/a11y-scan.ts` a `--baseline <file>` flag that diffs the
+    #      run against it and exits non-zero only on ids NOT in the baseline
+    #      (new regressions), so accepted debt does not block.
+    #   3. Drop `continue-on-error` here — the job then fails the nightly run.
+    #   4. Only after it has been stable for a while, add `a11y-srd` to the
+    #      notify-failure/notify-recovery `needs:` so regressions open the
+    #      tracking issue, and/or move it into ci.yml as a PR gate behind the
+    #      `web` path filter.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      # The scanner drives Chrome over CDP with puppeteer-core, which ships no
+      # browser of its own. Reuse the Chromium the e2e jobs already install and
+      # cache instead of pulling a second one.
+      - name: Install Playwright browsers (Chromium)
+        working-directory: apps/srd
+        run: bunx playwright install --with-deps chromium
+
+      - name: Resolve the Chromium binary
+        working-directory: apps/srd
+        run: |
+          set -euo pipefail
+          CHROME_PATH="$(bun -e 'const { chromium } = await import("playwright"); console.log(chromium.executablePath())')"
+          echo "Chromium: $CHROME_PATH"
+          echo "CHROME_PATH=$CHROME_PATH" >> "$GITHUB_ENV"
+
+      # Same static-preview approach as e2e-srd's Playwright webServer: plain
+      # `astro build` (not the `build` package script, which chains the slow
+      # OG-screenshot pass) served by `astro preview` on 4321.
+      - name: Build srd static bundle
+        working-directory: apps/srd
+        run: bunx --bun astro build
+
+      - name: Serve the build and run the a11y scan
+        run: |
+          set -euo pipefail
+          (cd apps/srd && bunx --bun astro preview --port 4321) &
+          SERVER_PID=$!
+          trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+          for _ in $(seq 1 60); do
+            if curl -sfo /dev/null http://localhost:4321/; then break; fi
+            sleep 2
+          done
+          curl -sfo /dev/null http://localhost:4321/
+          bun tools/a11y-scan.ts http://localhost:4321 \
+            / \
+            /about/ \
+            /schema/chassis/ \
+            /schema/chassis/item/mule/ \
+            > a11y-report.json
+
+      - name: Summarise violations
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ ! -s a11y-report.json ]; then
+            echo "### Accessibility scan (advisory) — srd" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "The scanner produced no report; see the step log above." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          {
+            echo "### Accessibility scan (advisory) — srd"
+            echo ""
+            echo "| Page | Violations | Passes | Incomplete |"
+            echo "| --- | ---: | ---: | ---: |"
+            jq -r '.[] | "| `\(.page)` | \(.violations) | \(.passes) | \(.incomplete) |"' a11y-report.json
+            echo ""
+            echo "Total violations: **$(jq '[.[].violations | select(. > 0)] | add // 0' a11y-report.json)**"
+            echo "(a \`-1\` in the table means that page failed to scan, not that it is clean.)"
+            echo ""
+            echo "Rule ids per page — full node-level detail is in the \`a11y-report-srd\` artifact:"
+            echo ""
+            echo '```json'
+            jq -c '[.[] | {page, rules: [.details[].id]}]' a11y-report.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload a11y report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: a11y-report-srd
+          path: a11y-report.json
+          retention-days: 7
+
   # ---------------------------------------------------------------------------
   # Notification — GitHub-native, no external service or webhook secret. On
   # any suite failure, open (or comment on) a single tracking issue labeled
   # `nightly-e2e-failure`; on the next all-green run, comment + close it. Uses
   # the default GITHUB_TOKEN (issues: write, scoped to just these two jobs) —
-  # nothing to provision.
+  # nothing to provision. `a11y-srd` is intentionally absent from `needs:`: it
+  # is advisory and must not open or hold open the tracking issue.
   # ---------------------------------------------------------------------------
   notify-failure:
     needs: [e2e-itun, e2e-srd]

--- a/tools/a11y-scan.ts
+++ b/tools/a11y-scan.ts
@@ -36,6 +36,14 @@ const CHROME_TMP = join(homedir(), '.cache', 'chrome-a11y')
 mkdirSync(CHROME_TMP, { recursive: true })
 process.env.MAC_CHROMIUM_TMPDIR = CHROME_TMP
 
+// Chrome binary. Defaults to the macOS Google Chrome install this script was
+// written against; any other environment overrides it. CI (the nightly a11y
+// job) points this at the Chromium that Playwright already installs for the
+// e2e suites, so no second browser download is needed.
+const MACOS_CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+const CHROME_EXECUTABLE =
+  process.env.PUPPETEER_EXECUTABLE_PATH || process.env.CHROME_PATH || MACOS_CHROME
+
 type AxeNode = {
   html: string
   target: string[]
@@ -117,7 +125,7 @@ async function main() {
   }
 
   const browser = await puppeteer.launch({
-    executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    executablePath: CHROME_EXECUTABLE,
     headless: true,
     userDataDir: join(CHROME_TMP, 'profile'),
     args: [


### PR DESCRIPTION
## What

Wires the existing `tools/a11y-scan.ts` (axe-core + puppeteer-core, WCAG 2.1 AA) into CI as a **new advisory job `a11y-srd` in `.github/workflows/e2e-nightly.yml`**.

- **`tools/a11y-scan.ts`** — the Chrome binary was hardcoded to `/Applications/Google Chrome.app/...`, so the scanner could only ever run on a Mac. It now reads `PUPPETEER_EXECUTABLE_PATH` / `CHROME_PATH` first and keeps the macOS path as the local-dev default. No behaviour change for anyone running `/a11y-scan` locally.
- **`.github/workflows/e2e-nightly.yml`** — new `a11y-srd` job that follows the surrounding jobs exactly: `actions/checkout@v7`, the `./.github/actions/setup-bun` composite (which already does the dependency cache + `bun install --frozen-lockfile`), the same `playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}` browser cache, and the same static-build/serve pair the `e2e-srd` Playwright `webServer` uses (`bunx --bun astro build` then `astro preview --port 4321`, deliberately not the `build` package script with its slow OG-screenshot pass).

  It **reuses the Chromium the e2e jobs already install** — puppeteer-core ships no browser, so the job resolves `playwright.chromium.executablePath()` and exports it as `CHROME_PATH` rather than downloading a second browser.

  Pages scanned (the four routes the srd e2e suite already exercises, one per route shape): `/`, `/about/`, `/schema/chassis/`, `/schema/chassis/item/mule/`.

  Results surface as a per-page violation table in the job's **step summary** plus a `a11y-report-srd` artifact holding the full node-level `a11y-report.json` (7-day retention, matching the Playwright report uploads).

## Why here and not `ci.yml`

Two reasons, both deliberate:

1. **The nightly already boots hermetic static builds and serves them for Playwright**, so this scan gets its server (and its Chromium, and its warm caches) almost for free. `ci.yml` has no equivalent serve step for srd, so putting it there would mean standing up a build+serve lane from scratch on every PR.
2. **A concurrent lane in this batch is editing `ci.yml`.** Staying out of that file avoids a pointless merge conflict.

## Why advisory

`continue-on-error: true`, and `a11y-srd` is **not** in the `needs:` of `notify-failure` / `notify-recovery`. So a violation can neither redden the nightly run nor open (or hold open) the `nightly-e2e-failure` tracking issue. Nobody has triaged the current violation set yet; making it a gate on day one would strand PRs behind an unknown backlog. The signal is the step summary + artifact.

The job comment in the workflow records the promotion path, in order:

1. **Commit a baseline** — `a11y-baseline.json` next to the scanner, mapping each scanned page to its accepted violation ids (e.g. `{"/": ["color-contrast"], "/schema/chassis/": []}`), one comment per entry saying why it's tolerated.
2. **Teach the scanner a `--baseline <file>` flag** that diffs the run against it and exits non-zero only on ids *not* in the baseline — i.e. fail on regressions, not on accepted debt.
3. **Drop `continue-on-error`** so the job fails the nightly run.
4. **Only after it's been stable**, add `a11y-srd` to the notify jobs' `needs:` so regressions open the tracking issue, and/or move it into `ci.yml` as a PR gate behind the existing `web` path filter.

## Verification

Run from the worktree root after `bun install --frozen-lockfile && bun run build:package`:

- `bun run typecheck` — **pass** (all five workspaces, 0 errors; srd `astro check`: 66 files, 0 errors / 0 warnings / 0 hints)
- `bun run lint` — **pass**, exit 0 (2 warnings + 2 infos, all pre-existing on `main`: `DialConfig.tsx` `useIndexOf`, two `useComponentExportOnlyModules` in component-lib, biome schema-version info — none in the files this PR touches)
- `bun run format:check` — **pass** (968 files, no fixes)
- `bun run test` — **pass**, exit 0: 3680 passing across the five workspaces (1227 + 1003 + 913 + 469 + 68), **0 failing**
- Workflow YAML parses cleanly (`js-yaml`): jobs resolve to `e2e-itun, e2e-srd, a11y-srd, notify-failure, notify-recovery`; `a11y-srd.continue-on-error === true`; notify `needs` unchanged at `[e2e-itun, e2e-srd]`
- All three new `run: |` blocks pass `bash -n`
- The `jq` summary expressions were exercised against a hand-built sample report (including the `violations: -1` scan-error case, which the total correctly excludes)

**Could NOT be verified locally: the scan itself.** Chromium cannot launch in this environment (the sandbox denies the Mach bootstrap check-in Chrome needs), so the browser leg — launch, axe injection, actual violation counts — is unproven here and CI is the proof. Nothing was stubbed, faked, or disabled to work around it; if the first nightly run shows the job erroring, the likely suspects are the Chromium-path resolution step or the preview-server readiness loop, both of which are self-contained and easy to iterate on.

## Deliberately left out

- No baseline file and no `--baseline` flag yet — that's step 1–2 of the promotion path above, and it needs a real report to write against.
- No ITUN a11y scan. ITUN is an interactive SPA where meaningful coverage means driving state, which is a Playwright-shaped job, not a static route list.
- No change to `ci.yml`, `docs/architecture/seo-accessibility.md`, or the `/a11y-scan` skill.
- No new dependency: `axe-core` and `puppeteer-core` are already root devDependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoXC3pFgFjYYoUM12MGHpL
