### PR TITLE
perf(itun): route-level code splitting + a PR-blocking bundle budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,6 +424,48 @@ jobs:
           path: apps/itun/playwright-report/
           retention-days: 7
 
+  bundle-budget-itun:
+    # PR-blocking bundle-size regression guard for ITUN, the counterpart to
+    # bundle-budget-web. Runs ONLY apps/itun/e2e/bundle-budget.e2e.ts against
+    # the same hermetic `vite build` + `vite preview` target smoke-itun uses,
+    # asserting per-route total JS stays under a byte budget and that no
+    # single chunk balloons back to a monolithic entry bundle (the guard for
+    # `autoCodeSplitting` in apps/itun/vite.config.ts). Kept as its own job so
+    # a budget regression reads as its own clearly-named failure rather than
+    # an ambiguous smoke failure.
+    needs: [changes, build-package, build-itun]
+    if: needs.changes.outputs.itun == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+
+      - name: Install Playwright browsers (Chromium)
+        working-directory: apps/itun
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run bundle-budget test
+        working-directory: apps/itun
+        run: bunx playwright test bundle-budget.e2e.ts
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-bundle-budget-itun
+          path: apps/itun/playwright-report/
+          retention-days: 7
+
   # ---------------------------------------------------------------------------
   # Single aggregate gate. Always runs; fails if any job actually failed (a
   # path-filtered "skipped" job is fine). Branch protection should require just
@@ -448,6 +490,7 @@ jobs:
       - smoke-web
       - bundle-budget-web
       - smoke-itun
+      - bundle-budget-itun
       # NOTE: the FULL browser e2e suites (ITUN + srd) still only run
       # nightly, not per-PR — see .github/workflows/e2e-nightly.yml.
       # smoke-web/smoke-itun above cover only the PR-blocking smoke tier, so

--- a/apps/itun/e2e/bundle-budget.e2e.ts
+++ b/apps/itun/e2e/bundle-budget.e2e.ts
@@ -1,0 +1,158 @@
+import { test, expect } from '@playwright/test'
+import { waitForReady } from './_helpers'
+
+/**
+ * Bundle-size budget suite — ITUN's counterpart to
+ * `apps/srd/e2e/bundle-budget.e2e.ts`, and the regression guard for the
+ * route-level code splitting turned on in `vite.config.ts`
+ * (`TanStackRouterVite({ autoCodeSplitting: true })`).
+ *
+ * ## What this measures, and why it differs from srd's suite
+ *
+ * srd's budget proves that per-route *data* preload lists keep large schema
+ * chunks off pages that don't need them. ITUN cannot make that claim and
+ * deliberately doesn't try: `GameDataReady` calls
+ * `SalvageUnionReference.preload('all')` on every route by design (see the
+ * long rationale in `src/components/shared/GameDataReady.tsx` — the entity
+ * display layer resolves traits/actions/keywords inline, so per-route
+ * preload lists reintroduce the "Schema 'traits' not loaded" footgun). The
+ * whole reference corpus therefore loads on every route, and is the same
+ * ~1.4 MB floor under all four budgets below.
+ *
+ * What IS route-dependent is the *app* code, and that is what
+ * `autoCodeSplitting` moves: each route's component now ships as its own
+ * chunk instead of being linked into one monolithic entry bundle.
+ *
+ * ## Why `decodedBodySize` rather than srd's `transferSize`
+ *
+ * `vite preview` (the CI target, see playwright.config.ts) serves through
+ * `@polka/compression`, so `transferSize`/`encodedBodySize` report *gzipped*
+ * bytes — while the local dev server this suite also has to run against does
+ * not compress. That makes a transport-size budget depend on which server
+ * answered. `decodedBodySize` is the uncompressed byte count the browser
+ * parses either way, so it is stable across dev/preview AND directly
+ * comparable to the file sizes in `dist/assets/`, which is how the ceilings
+ * below were derived.
+ *
+ * ## How the ceilings were set
+ *
+ * From the real `dist/` output of `bun --filter itun build` plus the Vite
+ * manifest's module graph (eager entry closure + the route's own chunk
+ * closure + the full reference-data corpus). Every ceiling sits ~20% above
+ * its measured value — see the PR that added this file for the
+ * measured-vs-ceiling table. A budget pinned at today's size is a tripwire,
+ * not a budget; 20% absorbs dependency churn while still failing on a real
+ * regression (a newly-eager heavy import, or a jump in the data corpus).
+ */
+
+type JsTotals = { count: number; bytes: number; names: string[]; largest: number }
+
+/** Sum uncompressed bytes of every same-origin `/assets/*.js` chunk the page
+ *  pulled in, keyed by URL so duplicates aren't double counted. `names`
+ *  records the chunk filenames for assert-not-present checks; `largest` is
+ *  the biggest single chunk (the code-splitting tripwire below). */
+async function captureJsTotals(
+  page: import('@playwright/test').Page,
+  path: string
+): Promise<JsTotals> {
+  await page.goto(path)
+  await waitForReady(page)
+  await page.waitForLoadState('networkidle')
+
+  const entries = await page.evaluate(() =>
+    performance
+      .getEntriesByType('resource')
+      .filter((e) => e.name.includes('/assets/') && e.name.endsWith('.js'))
+      .map((e) => ({
+        name: e.name.split('/assets/')[1] ?? e.name,
+        // decodedBodySize is the uncompressed size regardless of Content-
+        // Encoding; encodedBodySize is the fallback for the (unexpected)
+        // case of a response that reports neither.
+        size:
+          (e as PerformanceResourceTiming).decodedBodySize ||
+          (e as PerformanceResourceTiming).encodedBodySize,
+      }))
+  )
+
+  const seen = new Map<string, number>()
+  for (const e of entries) if (!seen.has(e.name)) seen.set(e.name, e.size)
+
+  const sizes = [...seen.values()]
+  return {
+    count: seen.size,
+    bytes: sizes.reduce((sum, n) => sum + n, 0),
+    names: [...seen.keys()],
+    largest: sizes.length ? Math.max(...sizes) : 0,
+  }
+}
+
+/** Print the real numbers into the CI log so the measured-vs-ceiling margin
+ *  stays reviewable on a PASSING run too (the Playwright HTML report is only
+ *  uploaded on failure), and so the ceilings can be re-tightened from an
+ *  actual run rather than re-derived by hand from `dist/`. `console.warn`
+ *  rather than `.log` because biome.jsonc's `noConsole` allowlist for this
+ *  workspace is `["warn", "error"]` — this is informational output, not a
+ *  problem report. Also recorded as a test annotation so it survives into the
+ *  HTML report when the budget does fail. */
+function report(label: string, totals: JsTotals, ceiling: number): void {
+  const line =
+    `[bundle-budget] ${label}: ${totals.bytes} B across ${totals.count} chunks ` +
+    `(largest ${totals.largest} B) — ceiling ${ceiling} B`
+  console.warn(line)
+  test.info().annotations.push({ type: 'bundle-budget', description: line })
+}
+
+test.describe('bundle-size budget', () => {
+  test('roster stays under budget and route components are split out', async ({ page }) => {
+    const CEILING = 3_000_000
+    const totals = await captureJsTotals(page, '/')
+    report('/ (roster)', totals, CEILING)
+
+    // The single-largest-chunk tripwire. With autoCodeSplitting the biggest
+    // app chunk is the shared vendor/component-lib chunk (~615 KB) and the
+    // entry is ~274 KB; with it OFF every route is linked into one ~1.24 MB
+    // entry chunk, which blows this ceiling immediately. The biggest
+    // reference-data chunk (actions, ~369 KB) sits well under it too, so
+    // this asserts against the app bundle without needing to classify
+    // chunks by name.
+    expect(totals.largest).toBeLessThan(800_000)
+
+    // Other routes' component chunks must not ride along on the roster.
+    // These two route chunks have unambiguous names, so a future eager
+    // import of the changelog parser or the encounter tray into shared code
+    // fails here instead of silently widening every route.
+    for (const forbidden of ['changelog-', 'encounter-']) {
+      expect(totals.names.some((n) => n.startsWith(forbidden))).toBe(false)
+    }
+
+    expect(totals.bytes).toBeLessThan(CEILING)
+  })
+
+  test('the pilot wizard stays under budget', async ({ page }) => {
+    const CEILING = 3_000_000
+    const totals = await captureJsTotals(page, '/pilots/new')
+    report('/pilots/new (wizard)', totals, CEILING)
+    expect(totals.bytes).toBeLessThan(CEILING)
+  })
+
+  test('a live sheet stays under budget', async ({ page }) => {
+    // An unknown id on purpose: the sheet route renders its own "not found"
+    // state (src/components/sheet/Sheet.tsx) *after* downloading the whole
+    // route chunk, so this measures the route's real JS cost without paying
+    // for a full wizard run to seed IndexedDB first.
+    const CEILING = 2_950_000
+    const totals = await captureJsTotals(page, '/sheet/pilot/budget-probe')
+    report('/sheet/pilot/:id', totals, CEILING)
+    expect(totals.bytes).toBeLessThan(CEILING)
+  })
+
+  test('the dashboard stays under budget', async ({ page }) => {
+    // Same unknown-id probe as the sheet test — Dashboard.tsx renders
+    // "Mech not found" only after its chunk (instruments, dial, display) has
+    // loaded, so the byte count is the route's true cost.
+    const CEILING = 3_000_000
+    const totals = await captureJsTotals(page, '/dashboard/budget-probe')
+    report('/dashboard/:id', totals, CEILING)
+    expect(totals.bytes).toBeLessThan(CEILING)
+  })
+})

--- a/apps/itun/vite.config.ts
+++ b/apps/itun/vite.config.ts
@@ -18,6 +18,15 @@ export default defineConfig({
     TanStackRouterVite({
       routesDirectory: './src/routes',
       generatedRouteTree: './src/routeTree.gen.ts',
+      // Split each route's component out of the entry bundle so a visitor
+      // pays only for the route they land on. Without this every route
+      // (roster, the three wizards, both sheets, dashboard, encounter,
+      // snapshot viewer) is linked into one ~1.2 MB entry chunk, and the
+      // per-route JS budget in e2e/bundle-budget.e2e.ts is what keeps it
+      // that way. Route *definitions* (path, loader, params) stay eager so
+      // matching still happens synchronously; only the component/pending/
+      // error boundaries move behind a dynamic import.
+      autoCodeSplitting: true,
     }),
     tailwindcss(),
     react({


### PR DESCRIPTION
Closes part of #215 ([M3] TTI re-verification + performance budget) — the "performance budget documented; regression test or CI hook if feasible" half. Lighthouse/TTI re-verification is not attempted here.

ITUN had neither route-level code splitting nor a bundle budget, while srd has had an enforced, PR-blocking one for a while. This copies that pattern.

## What changed

**1. `apps/itun/vite.config.ts` — `autoCodeSplitting: true`**

`TanStackRouterVite` was running without it, so every route (roster, three wizards, both sheets, dashboard, encounter, snapshot viewer, changelog) was linked into one entry chunk. Route *definitions* (path/loader/params) stay eager so matching is still synchronous; only the component/pending/error boundaries move behind a dynamic import.

**2. `apps/itun/e2e/bundle-budget.e2e.ts` — new (modelled on `apps/srd/e2e/bundle-budget.e2e.ts`)**

Per-route JS budgets for roster, the pilot wizard, a live sheet, and the dashboard, plus a single-largest-chunk tripwire that is the actual guard on the code splitting above.

**3. `.github/workflows/ci.yml` — new `bundle-budget-itun` job**

Placed and wired exactly like the existing `bundle-budget-web`: `needs: [changes, build-package, build-itun]`, gated on the `itun` path filter, its own job (not folded into `smoke-itun`) so a budget regression reads as its own named failure, Playwright browser cache + report-on-failure artifact, and added to the `quality-checks` aggregate gate so it is PR-blocking.

## Measured vs ceiling

All figures are **uncompressed bytes**, derived from the real output of `bun --filter itun build` plus the Vite build manifest's module graph (eager entry closure + the route's own chunk closure + the reference corpus). See "measurement caveat" below — the spec itself was not executed.

Shared floor on **every** route:

| component | bytes |
|---|---|
| eager entry closure (entry chunk + 32 `modulepreload`ed static imports) | 1,066,363 |
| reference data corpus (`data/*.json` chunks) | 993,928 |
| reference JSON-schema chunks | 402,508 |
| **shared floor** | **2,462,799** |

The corpus is on every route by design — `GameDataReady` calls `SalvageUnionReference.preload('all')` app-wide (its file comment explains why per-route preload lists were rejected). Unlike srd, ITUN therefore cannot assert "this data chunk never loads here", and the spec says so explicitly instead of pretending otherwise.

| route | route-chunk closure | measured total | ceiling | headroom |
|---|---|---|---|---|
| `/` (roster) | +46,324 | 2,509,123 | 3,000,000 | +19.6% |
| `/pilots/new` (wizard) | +26,889 | 2,489,688 | 3,000,000 | +20.5% |
| `/sheet/pilot/:id` | +1,031 | 2,463,830 | 2,950,000 | +19.7% |
| `/dashboard/:id` | +27,888 | 2,490,687 | 3,000,000 | +20.4% |

| tripwire | measured | ceiling | headroom |
|---|---|---|---|
| largest single JS chunk | 614,868 (shared vendor/`component-lib`) | 800,000 | +30.1% |

## Why a largest-single-chunk tripwire as well as totals

Honest limitation worth flagging in review: the reference corpus is ~57% of every route's payload, so the *totals* barely differ between routes and a total-bytes budget with any real headroom (20%) would **not** catch someone turning `autoCodeSplitting` back off — that only moves ~130–175 KB. The single-chunk ceiling does catch it deterministically: without splitting, the entry chunk is 1,241,029 B, which is over 800,000. The biggest data chunk (`actions`, 369,164 B) sits well under it, so this needs no fragile name-based classification of app-vs-data chunks.

## Before / after (app JS only)

- **Before:** one app chunk, `index-*.js` = 1,241,029 B, downloaded on every route.
- **After:** 1,066,363 B eager (entry 273,959 + shared 614,868 + 31 small shared chunks), plus 13 route-component chunks (893 B – 27,888 B) fetched on demand. Eager app JS on the heaviest route is 1,112,687 B.
- Net: **~128–175 KB less app JS per route** (10–14%). Total emitted app code grew 1,241,029 → 1,261,189 B (+20 KB of chunk-boundary overhead), which is the expected trade.

## `decodedBodySize`, not srd's `transferSize`

srd's suite sums `transferSize`. ITUN cannot: `vite preview` (the CI target) serves through `@polka/compression`, so `transferSize`/`encodedBodySize` are *gzipped*, while the dev server this config also targets locally does not compress — the budget would depend on which server answered. `decodedBodySize` is the uncompressed count either way, and is directly comparable to `dist/assets/` file sizes, which is how the ceilings above were derived. Documented in the spec's header.

## Verification

Run from the worktree root after `bun install --frozen-lockfile && bun run build:package`:

- `bun run typecheck` — **pass** (srd 0 errors / 0 warnings / 0 hints, itun, discord-bot, package all exit 0)
- `bun run lint` — **pass**, 2 warnings / 2 infos, both pre-existing on `main` (this branch adds none)
- `bun run format:check` — **pass** (969 files)
- `bun run test` — **pass**, 3,680 pass / 0 fail (68 + 1,003 + 1,227 + 913 + 469 across the five workspaces)
- `bun run knip` — **pass**
- `bun --filter itun build` — **pass**, and the emitted chunk graph is where every number above comes from
- `bun run validate:all` — not run; no `packages/salvageunion-reference/data` change

### Measurement caveat — please let CI prove this one

**`bundle-budget.e2e.ts` was never executed locally.** Chromium cannot launch in this environment, so Playwright could not run. Every figure above is derived from real emitted bytes in `dist/assets/` plus the build manifest's import graph — nothing is invented, and no check was disabled or weakened to make anything green — but the runtime totals are a *prediction* of what the browser will fetch, not a measurement of it. The ~20% headroom is sized partly to absorb that prediction error.

The spec logs its real measured bytes on every run (`[bundle-budget] <route>: N B ... — ceiling M B`), including on a pass, precisely so the first CI run publishes the true baseline. **If the printed numbers come in materially below the ceilings, the ceilings should be tightened in a follow-up** — 20% was chosen for safety under uncertainty, not because 20% is the right long-term margin.

## Deliberately left out

- **`apps/itun/src/routeTree.gen.ts` is not in this diff.** It *is* rewritten by any `vite build` on this repo today — but I verified the regenerated file is **byte-identical with `autoCodeSplitting` on and off**, so the drift is pre-existing (a plugin-version import-ordering change), not caused by this PR. Committing 220 lines of unrelated reordering would bury the diff. Worth a separate one-line commit; nothing in CI checks it, so it is currently harmless but permanently dirty in every contributor's tree.
- **`Sheet-*.js` (90,899 B) is still in the eager entry closure**, as are `WorkspaceSwitcher` (32,459 B) and a 614,868 B shared vendor chunk. Something still pulls the sheet renderer eagerly despite the sheet route's own component chunk being only 1,031 B — probably the `s/$id` snapshot or `$id_.share` route. Chasing that is a real further win and a separate lane.
- **Lighthouse / TTI re-verification** (#215's other acceptance criterion) — needs a browser.
- No change to srd's existing budget, to `GameDataReady`'s `preload('all')` model, or to any route/component code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoXC3pFgFjYYoUM12MGHpL
