### PR TITLE
docs: reconcile governing docs with the code, and guard the workspace list

### DIFF
--- a/.claude/rules/monorepo-patterns.md
+++ b/.claude/rules/monorepo-patterns.md
@@ -7,6 +7,7 @@ Bun workspace monorepo with multiple apps and shared packages.
 - `apps/srd/` - Static SRD reference site (Astro 5, React 19 islands, Tailwind v4)
 - `apps/itun/` - Character builder & game manager (React, TanStack Router/Query, ShadCN + Tailwind v4, local-first IndexedDB — no auth, no backend)
 - `apps/discord-bot/` - Discord.js bot for rolling on Salvage Union tables
+- `apps/su-assets/` - Netlify site (`assets.salvageunion.io`) serving licensed entity artwork from Netlify Blobs; `salvageunion-reference` resolves artwork URLs against it at runtime
 - `packages/component-lib/` - Shared React component library (no build step, exports TypeScript source)
 - `packages/salvageunion-reference/` - TypeScript ORM + schema-validated JSON dataset for game data
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Start here for navigation:** [`docs/README.md`](docs/README.md) maps user intent → relevant doc (architecture, ADRs, per-package CLAUDE.md).
 
-- [`docs/adrs/`](docs/adrs/) — architecture decision records (22 ADRs; 001–014 live in the code, 015–020 the proposed Dashboard play surface, 021 the governing surface/mode taxonomy + 022 provenance). Consult the matching ADR before revisiting a prior decision (e.g. [ADR-021](docs/adrs/ADR-021-itun-surface-taxonomy.md) — the **governing** surface/mode taxonomy for where a rule is enforced — and [ADR-007](docs/adrs/ADR-007-automation-boundary.md) automation boundary before building rules-driven features).
+- [`docs/adrs/`](docs/adrs/) — architecture decision records (26 ADRs; 001–014 live in the code, 015–020 the Dashboard play surface as built at `apps/itun/src/components/dashboard/`, 021 the governing surface/mode taxonomy + 022 provenance, both built). Consult the matching ADR before revisiting a prior decision (e.g. [ADR-021](docs/adrs/ADR-021-itun-surface-taxonomy.md) — the **governing** surface/mode taxonomy for where a rule is enforced — and [ADR-007](docs/adrs/ADR-007-automation-boundary.md) automation boundary before building rules-driven features).
 - [`docs/architecture/`](docs/architecture/) — cross-cutting architecture (display system, data flow, package contracts, rules-engine boundary, combat loop, SEO/a11y).
 - `docs/rules/` — agent-readable digest of the Salvage Union core rules + expansions (turn loop, heat, damage, salvage, creation, GM guidance, Meld/Chimerium subsystems). **Generated, gitignored, not committed** (condensed from the copyright-bearing PDFs in `rules/`, also gitignored) — produce it locally with `bun run rules:regen`, then read it instead of re-parsing the PDFs. Generator/manifest: `tools/rules-digest/`.
 
@@ -38,7 +38,7 @@ Bun monorepo ("SURef") for Salvage Union (tabletop RPG) tools, located in the `S
 
 The apps deploy to two platforms, each with an official MCP server wired up in the project-scoped [`.mcp.json`](.mcp.json) (committed; Claude Code prompts each contributor to approve it per-project):
 
-- **Netlify** — hosts `apps/srd` (static) and `apps/itun` (static SPA + the snapshot backend Netlify Functions + Blobs; see `apps/*/netlify.toml` and [ADR-004](docs/adrs/ADR-004-snapshot-netlify-functions.md)). MCP server: official `@netlify/mcp` (stdio); authenticates via the Netlify CLI/OAuth — no token in the file.
+- **Netlify** — hosts three sites: `apps/srd` (static), `apps/itun` (static SPA + the snapshot backend Netlify Functions + Blobs; see `apps/*/netlify.toml` and [ADR-004](docs/adrs/ADR-004-snapshot-netlify-functions.md)), and `apps/su-assets` (`assets.salvageunion.io` — one function serving licensed entity artwork out of the `lp-assets` Netlify Blobs store; `salvageunion-reference` resolves artwork URLs against it at runtime). MCP server: official `@netlify/mcp` (stdio); authenticates via the Netlify CLI/OAuth — no token in the file.
 - **Render** — hosts `apps/discord-bot` as a worker (see `render.yaml`). MCP server: official hosted server at `https://mcp.render.com/mcp`; reads `RENDER_API_KEY` from your shell env.
 - **GitHub** — repo host + Actions CI + PR workflow. MCP server: official remote `https://api.githubcopilot.com/mcp/`; reads `GITHUB_PAT` from your shell env.
 
@@ -97,6 +97,7 @@ bun run build:bot        # Build Discord bot
 - `apps/srd/` - Static SRD reference site (Astro 5, React 19 islands, Tailwind v4, Vite). No auth, no backend.
 - `apps/itun/` - Character builder & game manager (React 19, TanStack Router/Query, ShadCN + Tailwind v4, Vite). Local-first: IndexedDB persistence, no auth, no backend. Has dashboard, live sheets, snapshot sharing.
 - `apps/discord-bot/` - Discord.js bot for rolling on Salvage Union tables
+- `apps/su-assets/` - Dedicated Netlify site (`assets.salvageunion.io`) serving licensed entity artwork from a Netlify Blobs store via one function. Image bytes live in Blobs, never in git. `packages/salvageunion-reference` points at it at runtime (`ASSET_BASE_URL` in `lib/utilities.ts`), so entity-card artwork in both `srd` and `itun` depends on it.
 - `packages/component-lib/` - Shared React component library (ShadCN + Tailwind, entity display system, base typography, UI primitives). No build step, exports TypeScript source.
 - `packages/salvageunion-reference/` - TypeScript ORM + schema-validated JSON dataset for game data
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,9 +62,10 @@ generator is in git. Produce the digest locally with `bun run rules:regen`
 
 MADR-style records of architecturally significant decisions. ADR-001–014 are
 **live in the code today**. ADR-015–020 are **Accepted** — the Dashboard play
-surface, **built** as the Play Cockpit (`components/play/`, routed at `/play/$id`).
+surface, **built** at `components/dashboard/`, routed at `/dashboard/$id`.
 ADR-021 is the **governing** surface/mode taxonomy and ADR-022 its Change Log
-companion — a target the code is still moving toward. ADR-023–026 are
+companion — both now **built** (hard-enforced create wizards, the Dashboard, and
+the `entityStore.update` provenance log + cap overrides). ADR-023–026 are
 **Accepted**; ADR-024–025 (derived release changelogs + the ref surface gate)
 are being implemented together, and ADR-026 (entity card design rules) is
 **built**. Each says so in its Status.
@@ -93,16 +94,17 @@ Read the matching ADR before proposing alternatives.
 | [ADR-019](adrs/ADR-019-dashboard-play-state-ephemeral.md)            | Dashboard play-state & prefs ephemeral/local-first, under the ADR-007 boundary (built)                          |
 | [ADR-020](adrs/ADR-020-dashboard-fixed-canvas-scale-to-fit.md)       | Fixed 1280×800 scale-to-fit canvas with a phone-reflow floor (built)                                            |
 | [ADR-021](adrs/ADR-021-itun-surface-taxonomy.md)                     | **Governing** — surface/mode taxonomy; rule enforcement is per-mode (Guided Creation / Free Edit / Guided Play) |
-| [ADR-022](adrs/ADR-022-provenance-log-and-overrides.md)              | Per-entity **Change Log** (provenance, behind a menu) + non-destructive stat overrides (target)                 |
+| [ADR-022](adrs/ADR-022-provenance-log-and-overrides.md)              | Per-entity **Change Log** (provenance, behind a menu) + non-destructive stat overrides (built)                  |
 | [ADR-023](adrs/ADR-023-drone-equipment-installed-loadout.md)         | Granted drone/companion equipment hosts a real installed Systems/Modules loadout (built)                        |
 | [ADR-024](adrs/ADR-024-derived-release-changelogs.md)                | Derived, per-app release changelogs (release-please) + on-site history; supersedes the web hand-changelog       |
 | [ADR-025](adrs/ADR-025-reference-versioned-releases-surface-gate.md) | Versioned internal releases + public-surface (TS + schema) gate for the ref; partially supersedes ADR-014       |
-| [ADR-026](adrs/ADR-026-entity-card-design-rules.md)                  | **Entity card design rules** — one renderer (shim), choice/stat-atom/modified-stats/tech-level rules (built)    |
+| [ADR-026](adrs/ADR-026-entity-card-design-rules.md)                  | **Entity card design rules** — one renderer, choice/stat-atom/modified-stats/tech-level rules (built)           |
 
 > ADR-021 is the governing decision for rules enforcement and takes precedence
 > over prior ADRs where they conflict on _how hard a rule is enforced on which
-> surface_. ADR-021/022 describe a **target** the code only partly reflects today;
-> the Dashboard-design ADRs (015–020) are proposed. See the implementation-status
+> surface_. ADR-021/022 and the Dashboard-design ADRs (015–020) are all realized in
+> the code; the remaining gaps (unwired `salvage` / `crafting` / `scrapMech`
+> primitives, no Change Log replay surface) are listed in the implementation-status
 > note in [rules-engine-boundary.md](architecture/rules-engine-boundary.md).
 
 ### Per-package CLAUDE.md
@@ -115,5 +117,12 @@ conventions:
 - [`apps/discord-bot/CLAUDE.md`](../apps/discord-bot/CLAUDE.md) — Discord.js bot
 - [`packages/salvageunion-reference/CLAUDE.md`](../packages/salvageunion-reference/CLAUDE.md) — Game data ORM + schemas
 - [`packages/component-lib/CLAUDE.md`](../packages/component-lib/CLAUDE.md) — Shared component library
+
+`apps/su-assets/` has no `CLAUDE.md` — it is a single Netlify function
+(`assets.salvageunion.io`) that serves licensed entity artwork out of the
+`lp-assets` Netlify Blobs store, with the bytes deliberately kept out of git.
+`packages/salvageunion-reference` points at it at runtime (`ASSET_BASE_URL` in
+`lib/utilities.ts`), so entity-card artwork in both `srd` and `itun` depends on it.
+See [`apps/su-assets/netlify.toml`](../apps/su-assets/netlify.toml).
 
 Plus the agent-readable convention digests in [`.claude/rules/`](../.claude/rules/).

--- a/docs/adrs/ADR-015-dashboard-distinct-play-surface.md
+++ b/docs/adrs/ADR-015-dashboard-distinct-play-surface.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted — the Play Cockpit is **built** (realized in `apps/itun/src/components/play/`, Phases 1–7, routed at `/play/:id`; design in the [Dashboard design doc](../architecture/dashboard.md)). This is the specific
+Accepted — the Dashboard is **built** (realized in `apps/itun/src/components/dashboard/`, Phases 1–7, routed at `/dashboard/$id`; design in the [Dashboard design doc](../architecture/dashboard.md)). This is the specific
 play-surface instance of the governing surface taxonomy in
 [ADR-021](ADR-021-itun-surface-taxonomy.md) — the **Guided Play** surface.
 

--- a/docs/adrs/ADR-016-dashboard-rotary-dial-instrument-split.md
+++ b/docs/adrs/ADR-016-dashboard-rotary-dial-instrument-split.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted — the Play Cockpit is **built** (realized in `apps/itun/src/components/play/`, Phases 1–7, routed at `/play/:id`; design in the [Dashboard design doc](../architecture/dashboard.md)). Sub-decision of
+Accepted — the Dashboard is **built** (realized in `apps/itun/src/components/dashboard/`, Phases 1–7, routed at `/dashboard/$id`; design in the [Dashboard design doc](../architecture/dashboard.md)). Sub-decision of
 [ADR-015](ADR-015-dashboard-distinct-play-surface.md).
 
 ## Context

--- a/docs/adrs/ADR-017-dashboard-reuse-faithful-srd-display.md
+++ b/docs/adrs/ADR-017-dashboard-reuse-faithful-srd-display.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted — the Play Cockpit is **built** (realized in `apps/itun/src/components/play/`, Phases 1–7, routed at `/play/:id`; design in the [Dashboard design doc](../architecture/dashboard.md)). Sub-decision of
+Accepted — the Dashboard is **built** (realized in `apps/itun/src/components/dashboard/`, Phases 1–7, routed at `/dashboard/$id`; design in the [Dashboard design doc](../architecture/dashboard.md)). Sub-decision of
 [ADR-015](ADR-015-dashboard-distinct-play-surface.md).
 
 ## Context

--- a/docs/adrs/ADR-018-dashboard-instrument-viewfinder-aesthetic.md
+++ b/docs/adrs/ADR-018-dashboard-instrument-viewfinder-aesthetic.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted — the Play Cockpit is **built** (realized in `apps/itun/src/components/play/`, Phases 1–7, routed at `/play/:id`; design in the [Dashboard design doc](../architecture/dashboard.md)). Sub-decision of
+Accepted — the Dashboard is **built** (realized in `apps/itun/src/components/dashboard/`, Phases 1–7, routed at `/dashboard/$id`; design in the [Dashboard design doc](../architecture/dashboard.md)). Sub-decision of
 [ADR-015](ADR-015-dashboard-distinct-play-surface.md).
 
 ## Context

--- a/docs/adrs/ADR-019-dashboard-play-state-ephemeral.md
+++ b/docs/adrs/ADR-019-dashboard-play-state-ephemeral.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted — the Play Cockpit is **built** (realized in `apps/itun/src/components/play/`, Phases 1–7, routed at `/play/:id`; design in the [Dashboard design doc](../architecture/dashboard.md)). Sub-decision of
+Accepted — the Dashboard is **built** (realized in `apps/itun/src/components/dashboard/`, Phases 1–7, routed at `/dashboard/$id`; design in the [Dashboard design doc](../architecture/dashboard.md)). Sub-decision of
 [ADR-015](ADR-015-dashboard-distinct-play-surface.md); obeys the automation
 boundary of [ADR-007](ADR-007-automation-boundary.md) as scoped by
 [ADR-021](ADR-021-itun-surface-taxonomy.md).

--- a/docs/adrs/ADR-020-dashboard-fixed-canvas-scale-to-fit.md
+++ b/docs/adrs/ADR-020-dashboard-fixed-canvas-scale-to-fit.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted — the Play Cockpit is **built** (realized in `apps/itun/src/components/play/`, Phases 1–7, routed at `/play/:id`; design in the [Dashboard design doc](../architecture/dashboard.md)). Sub-decision of
+Accepted — the Dashboard is **built** (realized in `apps/itun/src/components/dashboard/`, Phases 1–7, routed at `/dashboard/$id`; design in the [Dashboard design doc](../architecture/dashboard.md)). Sub-decision of
 [ADR-015](ADR-015-dashboard-distinct-play-surface.md).
 
 ## Context

--- a/docs/adrs/ADR-021-itun-surface-taxonomy.md
+++ b/docs/adrs/ADR-021-itun-surface-taxonomy.md
@@ -6,9 +6,10 @@
 game rules. **Where it conflicts with any prior ADR, this ADR wins** (scope and
 the specific overrides are listed under [Supersession](#supersession--precedence)).
 
-"Accepted" records the **decision**; the code is mid-transition and closing the
-gap is the **next work** (the Wizard still soft-warns; the Dashboard play surface
-doesn't exist yet). The living, authoritative placement table is the matrix in
+"Accepted" records the **decision**; the code has since largely caught up (the
+Wizard enforces Guided Creation hard on the create path, the Dashboard ships at
+`/dashboard/$id`, and ADR-022's Change Log is live). The living, authoritative
+placement table is the matrix in
 [`rules-engine-boundary.md`](../architecture/rules-engine-boundary.md) — keep
 placements in sync **there**, not by re-editing the summary below. This ADR
 records _why_ the taxonomy exists; the arch doc records _what goes where_.
@@ -86,10 +87,10 @@ the behavior.
 
 **The Dashboard is a separate, multi-entity surface — built.** It composes a
 player's Pilot + Mech + Crawler into one live play surface (distinct from the
-single-entity Live Sheet), shipped as the Play Cockpit at `/play/$id`
-(`src/components/play/`). "Dashboard" is its surface name; the code rename and the
-final removal of the Live Sheet's leftover play control (`QuickRollFab`) are the
-remaining work. Detail in the architecture doc.
+single-entity Live Sheet), shipped at `/dashboard/$id`
+(`src/components/dashboard/`). The code rename from the working title "Play
+Cockpit" has landed, and the Live Sheet's leftover play control (`QuickRollFab`)
+is gone. Detail in the architecture doc.
 
 ## Supersession / precedence
 
@@ -101,8 +102,8 @@ Concretely it overrides:
   this model.
 - Any assumption that ITUN has a single, app-wide enforcement stance. Enforcement
   is per-mode.
-- The **Wizard's** current soft-warn-never-block behavior: the target is enforced
-  Guided Creation (soft → hard).
+- The **Wizard's** former soft-warn-never-block behavior: the create path is now
+  enforced Guided Creation (soft → hard; edit mode keeps the soft regime).
 - The **Live Sheet** hosting enforced play controls: Push, Heat Check, and using a
   system ([ADR-008](ADR-008-sequential-mutations.md)'s `activateItem`) relocate to
   the Dashboard; the Live Sheet becomes pure Free Edit plus overrides.

--- a/docs/adrs/ADR-022-provenance-log-and-overrides.md
+++ b/docs/adrs/ADR-022-provenance-log-and-overrides.md
@@ -2,7 +2,11 @@
 
 ## Status
 
-Accepted (decision recorded ahead of implementation). Subordinate to
+Accepted — **built**: the `changeLog` store (`apps/itun/src/lib/db/changeLog.ts`,
+schema in `lib/schemas/changeLog.ts`) is written at the `entityStore.update`
+chokepoint and read through `ChangeLogDrawer` behind the sheet menu; Live-Sheet
+cap overrides ship with the derived-baseline callout and revert. Replay/time-travel
+is still unbuilt. Subordinate to
 [ADR-021](ADR-021-itun-surface-taxonomy.md), which establishes the surface/mode
 model this ADR serves.
 

--- a/docs/adrs/ADR-026-entity-card-design-rules.md
+++ b/docs/adrs/ADR-026-entity-card-design-rules.md
@@ -23,14 +23,14 @@ taxonomy — which surface may enforce vs. free-edit), [ADR-023](ADR-023-drone-e
 
 ## Decision
 
-### 1. One renderer; `ReferenceEntityDisplay` is a compat shim
+### 1. One renderer — `ReferenceEntityCard`, and nothing else
 
 `ReferenceEntityCard` (`components/referenceEntity/card/`) is the **only**
-reference-entity renderer. The barrel still exports `ReferenceEntityDisplay`, but
-it is a thin **compat shim** that maps the legacy sugar (`mode` / `compact` /
-`listing` → `size`; `status` → `damaged`; the old single-SV `statsOverride`
-`{value, bottomLabel}` → `StatItem[]`) and forwards to the card. New code may call
-either; there is no second card. The legacy RED core is deleted.
+reference-entity renderer. The legacy RED core is deleted, and so is the
+`ReferenceEntityDisplay` compat shim that briefly carried the legacy sugar
+(`mode` / `compact` / `listing` → `size`; `status` → `damaged`; the old
+single-SV `statsOverride` `{value, bottomLabel}` → `StatItem[]`) across the
+migration: the barrel no longer exports that name. Call the card.
 
 ### 2. Entities always render as the card — layer UI on top
 

--- a/docs/architecture/rules-engine-boundary.md
+++ b/docs/architecture/rules-engine-boundary.md
@@ -231,29 +231,36 @@ snapshot remains a frozen point-in-time entity with no history. Full decision in
 
 ## Implementation status — target vs. current
 
-This doc is the target. Where the code differs today:
+This doc is the target. Where the code stands today:
 
-- **Wizard** currently _soft-guides_ (advisory `SoftWarningBanner`, never blocks —
-  `PilotWizard.tsx:96–97`). The target is enforced Guided Creation. This is a
-  planned move from soft → hard.
-- **Dashboard** is **built** — the Play Cockpit ships at `/play/$id`
-  (`src/components/play/`, Phases 1–7; design: [dashboard.md](dashboard.md),
-  decision: [ADR-015](../adrs/ADR-015-dashboard-distinct-play-surface.md)),
-  composing Pilot + Mech + Crawler with its lifecycle-transaction layers (use a
-  system, Push, Downtime, take damage). Remaining: adopt the **Dashboard** surface
-  name (the code is still `play/`), and confirm the Live Sheet's leftover play
-  control (`QuickRollFab` via `SheetMech.tsx` / `activateItem`,
-  [ADR-008](../adrs/ADR-008-sequential-mutations.md)) is fully superseded so the
-  sheet becomes pure Free Edit.
-- **Live Sheet** today mixes free editing with those leftover enforced controls.
-  The target strips the transactions out and adds cap **overrides** (with the
-  derived-baseline callout), which are not yet built.
-- **Provenance log** is not yet implemented; ADR-022 records the decision ahead of
-  the build. Several rules primitives (`salvage`, `crafting`, `downtime`,
-  `scrapMech`, `takeDamage`) are built and tested in `lib/rules` but unwired —
-  they are the raw material for the Dashboard's layers.
+- **Wizard** enforces Guided Creation **hard** on the create path
+  (`PilotWizard.tsx`, `MechWizard.tsx`, `CrawlerBuilder.tsx`): illegal options are
+  filtered out rather than rendered, `Next` is gated by the step gates in
+  `lib/rules/creation.ts` with the unmet requirement in the footer note,
+  cross-step invalidation and draft-restore clamping are announced by toast, and
+  the advisory `Banner` is removed from the create flow — nothing can be in
+  violation. The deliberate exit is `OffRulesEscape` (leave the wizard for the
+  blank Free-Edit path). **Edit** mode keeps the soft regime: presence-only gates,
+  lifted filters/budgets, advisory warnings on Review.
+- **Dashboard** is **built** at `/dashboard/$id` (`src/components/dashboard/`,
+  Phases 1–7; design: [dashboard.md](dashboard.md), decision:
+  [ADR-015](../adrs/ADR-015-dashboard-distinct-play-surface.md)), composing
+  Pilot + Mech + Crawler with its lifecycle-transaction layers (use a system,
+  Push, Downtime, take damage). The working title "Play Cockpit" and the
+  `components/play/` directory are gone.
+- **Live Sheet** is pure Free Edit — Push / Heat Check / `activateItem` no longer
+  live there (`SheetMech.tsx`), and cap **overrides** with the derived-baseline
+  callout and one-click revert are built.
+- **Provenance log** is **built** (ADR-022): the `changeLog` store
+  (`lib/db/changeLog.ts`, schema in `lib/schemas/changeLog.ts`) is written at the
+  `entityStore.update` chokepoint, tagged `transaction` / `override` / `manual`,
+  and read through `ChangeLogDrawer` behind the sheet menu. Replay/time-travel is
+  still unbuilt. Of the rules primitives in `lib/rules`, `downtime` and
+  `takeDamage` are wired into the Dashboard; `salvage`, `crafting`, and
+  `scrapMech` are built and tested but still unwired — raw material for further
+  Dashboard layers.
 
-When any of these lands, update the corresponding bullet (and, if a border moves,
+When any of these moves, update the corresponding bullet (and, if a border moves,
 the matrix above) rather than leaving the gap undocumented.
 
 ---

--- a/tools/check-doc-drift.ts
+++ b/tools/check-doc-drift.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 /**
- * Doc-drift guard (mechanical, narrow — 2 checks, not a general doc-linter).
+ * Doc-drift guard (mechanical, narrow — 3 checks, not a general doc-linter).
  *
  * A prior campaign PR had to hand-fix docs/architecture/package-contracts.md
  * after its "Entry Points" JSON block silently fell out of sync with
@@ -22,15 +22,20 @@
  *      the registry-codegen docs drifting from the actual generated-file
  *      layout (e.g. a generated file getting renamed/split/removed without
  *      the docs following).
+ *   3. The root CLAUDE.md's "Workspace structure" bullet list must name exactly
+ *      the workspaces the root package.json's `apps/*` + `packages/*` globs
+ *      resolve to — `apps/su-assets` was a real, deployed workspace member that
+ *      no doc mentioned for months.
  */
 
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { dirname, join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 const pkgDir = join(root, 'packages/salvageunion-reference')
 const contractsDocPath = join(root, 'docs/architecture/package-contracts.md')
+const rootClaudeMdPath = join(root, 'CLAUDE.md')
 
 let failed = false
 
@@ -144,8 +149,77 @@ function checkGeneratedFileReferences(): void {
   )
 }
 
+// ---------------------------------------------------------------------------
+// Check 3: root CLAUDE.md's "Workspace structure" list matches the real
+// apps/* + packages/* workspace glob expansion
+// ---------------------------------------------------------------------------
+
+function checkWorkspaceList(): void {
+  const workspaceGlobs = ['apps', 'packages']
+
+  const actual = new Set<string>()
+  for (const parent of workspaceGlobs) {
+    const parentDir = join(root, parent)
+    if (!existsSync(parentDir)) continue
+    for (const entry of readdirSync(parentDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue
+      if (!existsSync(join(parentDir, entry.name, 'package.json'))) continue
+      actual.add(`${parent}/${entry.name}`)
+    }
+  }
+
+  if (actual.size === 0) {
+    fail(
+      `Found no workspace members under ${workspaceGlobs.join('/, ')}/ — is this ` +
+        'running from the monorepo root? Update this check if the layout changed.'
+    )
+    return
+  }
+
+  const doc = readFileSync(rootClaudeMdPath, 'utf-8')
+  const sectionMatch = doc.match(/\*\*Workspace structure:\*\*\s*\n([\s\S]*?)\n\s*\n\*\*/)
+
+  if (!sectionMatch) {
+    fail(
+      `Could not find the "**Workspace structure:**" bullet list in ` +
+        `${relative(root, rootClaudeMdPath)} — has the section been renamed or removed?`
+    )
+    return
+  }
+
+  const documented = new Set<string>()
+  // biome-ignore lint/style/noNonNullAssertion: the regex has a single unconditional capture group — a successful match always defines [1]
+  for (const match of sectionMatch[1]!.matchAll(/^-\s+`((?:apps|packages)\/[^/`]+)\/?`/gm)) {
+    // biome-ignore lint/style/noNonNullAssertion: the regex has a single unconditional capture group — a successful match always defines [1]
+    documented.add(match[1]!)
+  }
+
+  const undocumented = [...actual].filter((w) => !documented.has(w)).sort()
+  const phantom = [...documented].filter((w) => !actual.has(w)).sort()
+
+  if (undocumented.length > 0 || phantom.length > 0) {
+    const bullets = (ws: string[]) => ws.map((w) => `    ${w}/`).join('\n')
+    const lines: string[] = []
+    if (undocumented.length > 0) {
+      lines.push(`  real workspaces missing from the doc:\n${bullets(undocumented)}`)
+    }
+    if (phantom.length > 0) {
+      lines.push(`  documented workspaces that don't exist:\n${bullets(phantom)}`)
+    }
+    fail(
+      `${relative(root, rootClaudeMdPath)}'s "Workspace structure" list has drifted from ` +
+        `the real apps/* + packages/* workspace expansion.\n\n${lines.join('\n\n')}\n\n` +
+        `  → add or remove the bullet(s) so the list names every workspace exactly once.`
+    )
+    return
+  }
+
+  console.log(`✓ CLAUDE.md "Workspace structure" names all ${actual.size} workspaces.`)
+}
+
 checkExportsMap()
 checkGeneratedFileReferences()
+checkWorkspaceList()
 
 if (failed) {
   process.exit(1)


### PR DESCRIPTION
## What

Makes the governing docs describe the code that actually exists, then adds a check so one class of that drift cannot silently recur.

### 1. The `/play/` rename

Nine docs referenced `apps/itun/src/components/play/` and the route `/play/$id` (or `/play/:id`). Neither exists — the directory has zero files and the route is `/dashboard/$id` (`apps/itun/src/routes/dashboard/$id.tsx`). Corrected in `docs/README.md`, `docs/adrs/ADR-015`…`ADR-021`, and `docs/architecture/rules-engine-boundary.md`.

### 2. Stale status claims

`rules-engine-boundary.md`'s "Implementation status" section (and the matching lines in `docs/README.md`, ADR-021, ADR-022, ADR-026) asserted four things that are no longer true. Each was restated as what is true, not deleted:

| Claim in the docs | Reality |
| --- | --- |
| Wizard "currently _soft-guides_ … never blocks" | The **create** path hard-enforces: illegal options are filtered out rather than rendered, `Next` is gated by `lib/rules/creation.ts` step gates with the unmet requirement in the footer note, cross-step invalidation + draft clamping are toast-announced, and the advisory `Banner` is removed from the create flow. `OffRulesEscape` is the deliberate exit. **Edit** mode keeps the soft regime — stated explicitly. (`PilotWizard.tsx`, `MechWizard.tsx`, `CrawlerBuilder.tsx` headers.) |
| Provenance / Change Log "is not yet implemented" | ADR-022 is **built**: `lib/db/changeLog.ts` + `lib/schemas/changeLog.ts`, written at the `entityStore.update` chokepoint, tagged `transaction`/`override`/`manual`, read via `ChangeLogDrawer` behind the sheet menu. Live-Sheet cap overrides ship too. Replay/time-travel is genuinely still unbuilt — kept. |
| Dashboard unbuilt / lives at `play/` | Built at `components/dashboard/`, routed `/dashboard/$id`. |
| ADR-026 §1: "the barrel still exports `ReferenceEntityDisplay` … a thin compat shim" | The shim is gone — no file in `packages/component-lib/src` matches, and the barrel does not export the name (`git grep`). Rewritten to record that it existed across the migration and was deleted. |

Two adjacent claims in the same section were also false and are corrected in the same pass: the Live Sheet no longer hosts Push / Heat Check / `activateItem` (`SheetMech.tsx`), and of the "unwired rules primitives" list, `downtime` and `takeDamage` **are** now wired into the Dashboard — only `salvage`, `crafting`, `scrapMech` remain unwired (verified by grep for their exported symbols outside `lib/rules`).

### 3. The undocumented live workspace

`apps/su-assets` is a real, deployed Netlify site (`assets.salvageunion.io`) with its own `package.json`, `netlify.toml`, and one function serving licensed artwork out of the `lp-assets` Netlify Blobs store. `packages/salvageunion-reference/lib/utilities.ts` points at it at **runtime** (`ASSET_BASE_URL`), so entity-card artwork in both apps depends on it. No doc mentioned it. Added to:

- root `CLAUDE.md` "Workspace structure" **and** "External Integrations" (Netlify hosts **three** sites, not two)
- `.claude/rules/monorepo-patterns.md` "Workspace Structure"
- `docs/README.md` per-package section (noting it has no `CLAUDE.md` of its own)

### 4. The drift check

`tools/check-doc-drift.ts` gains a third assertion in the file's existing structure/error style: the root `CLAUDE.md` "Workspace structure" bullet list must name exactly the workspaces `apps/*` + `packages/*` resolve to (directories carrying a `package.json`). It reports both directions — real-but-undocumented and documented-but-missing.

This is the check that would have caught item 3 automatically, so it must pass by the end of this PR — it does.

## How verified

Preflight in the fresh worktree: `bun install --frozen-lockfile` + `bun run build:package`.

```
bun run typecheck    → exit 0 (srd 0 errors/0 warnings/0 hints; itun, discord-bot, component-lib all clean)
bun run lint         → exit 0 (974 files, 2 pre-existing warnings, 3 infos — none in this diff)
bun run format:check → exit 0 (968 files)
bun run test         → exit 0 — 0 fail across all workspaces
                       component-lib 469 pass · srd 1003 pass · itun 1227 pass
                       salvageunion-reference 913 pass · tools 68 pass
bun run validate:all → all validations passed, incl. the new drift check
bun run knip         → clean
```

New assertion, negative test — with the `apps/su-assets` bullet stripped out of `CLAUDE.md`:

```
✗ CLAUDE.md's "Workspace structure" list has drifted from the real apps/* + packages/* workspace expansion.

  real workspaces missing from the doc:
    apps/su-assets/

  → add or remove the bullet(s) so the list names every workspace exactly once.
exit=1
```

and with the bullet restored: `✓ CLAUDE.md "Workspace structure" names all 6 workspaces.` (exit 0).

Nothing here needs a browser, so there is no unverifiable surface in this PR.

## Deliberately left out

- **No application code touched.** Only `docs/**`, root `CLAUDE.md`, `.claude/rules/monorepo-patterns.md`, `tools/check-doc-drift.ts`.
- **Historical Context sections left alone.** ADR-021's Context cites `PilotWizard.tsx:96–97` and `SheetMech.tsx:71–76` as the situation at decision time; those line refs are stale but the section is a record of *why* the decision was made, not a status claim.
- Two things noticed and **not** fixed, flagged for a follow-up:
  - Root `CLAUDE.md`'s "Architecture Reference" bullet still describes the display stack as `Card -> ReferenceEntityDisplay -> consumer patterns` — the same dead name as ADR-026 §1, but not part of this lane's list.
  - `tools/check-bun-version.ts` pins Bun across "both Netlify sites"; now that there are three, `apps/su-assets/netlify.toml` is outside its coverage (it has no Bun pin at all today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoXC3pFgFjYYoUM12MGHpL
