### PR TITLE
test(component-lib): cover the entity-display resolvers and detail modal

### DIFF
--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -1,6 +1,6 @@
 {
   "packages/salvageunion-reference": 89,
-  "packages/component-lib": 71,
+  "packages/component-lib": 75,
   "apps/srd": 95,
   "apps/itun": 90,
   "apps/discord-bot": 92

--- a/packages/component-lib/src/components/referenceEntity/__tests__/Content.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/__tests__/Content.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * `Content` is the block renderer every entity card's prose goes through. Each
+ * `type` maps to a different atom — a `cost` datavalue becomes an
+ * ActivationCost, a `trait`/`keyword` datavalue becomes a tooltip-bearing Stat,
+ * a heading becomes a Slab, `choice` markers are stripped entirely — and an
+ * unhandled type silently falls through to plain prose. None of that mapping is
+ * type-checked (the block `type` is a free string), so the branches are pinned
+ * here with assertions about what actually reaches the DOM.
+ */
+import { afterEach, describe, expect, test } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+import type { SURefObjectContentBlock } from 'salvageunion-reference'
+import { Content } from '../Content'
+
+const blocks = (...items: unknown[]) => items as SURefObjectContentBlock[]
+
+afterEach(cleanup)
+
+describe('Content — empty inputs', () => {
+  test('renders nothing for an absent or empty body', () => {
+    expect(render(<Content body={[]} />).container.innerHTML).toBe('')
+    cleanup()
+    expect(
+      render(<Content body={undefined as unknown as SURefObjectContentBlock[]} />).container
+        .innerHTML
+    ).toBe('')
+  })
+
+  test('a body of nothing but `choice` markers renders nothing', () => {
+    // `choice` blocks are position markers for the editable walk — they carry
+    // no display content, so read-only output must be identical to data
+    // without them (not an empty wrapper full of blanks).
+    const { container } = render(
+      <Content body={blocks({ type: 'choice', value: 'ignored' }, { type: 'choice' })} />
+    )
+    expect(container.innerHTML).toBe('')
+  })
+
+  test('`choice` markers are stripped from a body that also has prose', () => {
+    render(
+      <Content
+        body={blocks(
+          { type: 'choice', value: 'MARKER TEXT' },
+          { type: 'paragraph', value: 'real prose' }
+        )}
+      />
+    )
+    expect(screen.getByText('real prose')).toBeTruthy()
+    expect(screen.queryByText('MARKER TEXT')).toBeNull()
+  })
+})
+
+describe('Content — block types', () => {
+  test('paragraph, hint and flavor each render their text', () => {
+    render(
+      <Content
+        body={blocks(
+          { type: 'paragraph', value: 'plain prose' },
+          { type: 'hint', value: 'a helpful hint' },
+          { type: 'flavor', value: 'evocative flavour' }
+        )}
+      />
+    )
+    expect(screen.getByText('plain prose')).toBeTruthy()
+    expect(screen.getByText('a helpful hint')).toBeTruthy()
+    expect(screen.getByText('evocative flavour')).toBeTruthy()
+  })
+
+  test('an unknown block type falls back to body prose rather than disappearing', () => {
+    render(<Content body={blocks({ type: 'not-a-real-type', value: 'still visible' })} />)
+    expect(screen.getByText('still visible')).toBeTruthy()
+  })
+
+  test('a `label` block stamps its label above its prose', () => {
+    render(<Content body={blocks({ type: 'label', label: 'Effect', value: 'the effect' })} />)
+    expect(screen.getByText('Effect')).toBeTruthy()
+    expect(screen.getByText('the effect')).toBeTruthy()
+  })
+
+  test('a `label` block with no label renders just its prose', () => {
+    render(<Content body={blocks({ type: 'label', value: 'unlabelled' })} />)
+    expect(screen.getByText('unlabelled')).toBeTruthy()
+  })
+
+  test('a labelled list-item leads with a bold label; an unlabelled one is a bare bullet', () => {
+    render(
+      <Content
+        body={blocks(
+          { type: 'list-item', label: 'Motivation', value: 'find the crawler' },
+          { type: 'list-item', value: 'no label here' }
+        )}
+      />
+    )
+    expect(screen.getByText('Motivation:')).toBeTruthy()
+    expect(screen.getByText('find the crawler')).toBeTruthy()
+    expect(screen.getByText('no label here')).toBeTruthy()
+  })
+
+  test('[(CHASSIS)] is substituted with the owning chassis name', () => {
+    render(
+      <Content
+        body={blocks({ type: 'paragraph', value: '[(CHASSIS)] comes with a drone.' })}
+        chassisName="Little Sestra"
+      />
+    )
+    expect(screen.getByText('The Little Sestra comes with a drone.')).toBeTruthy()
+  })
+})
+
+describe('Content — datavalues chips', () => {
+  test('an empty or non-array datavalues block renders nothing', () => {
+    expect(
+      render(<Content body={blocks({ type: 'datavalues', value: [] })} />).container.textContent
+    ).toBe('')
+    cleanup()
+    expect(
+      render(<Content body={blocks({ type: 'datavalues', value: 'not an array' })} />).container
+        .textContent
+    ).toBe('')
+  })
+
+  test('a cost datavalue splits a trailing currency out of its label', () => {
+    // "3 AP" arrives as one label with no `value`. ActivationCost always prints
+    // `cost + " " + currency` and defaults the currency to AP, so if the chip
+    // does not split the label itself the pennant reads "3 AP AP".
+    render(
+      <Content body={blocks({ type: 'datavalues', value: [{ type: 'cost', label: '3 AP' }] })} />
+    )
+    expect(screen.getByText('3 AP')).toBeTruthy()
+  })
+
+  test('every recognised currency suffix is split, not just AP', () => {
+    for (const currency of ['AP', 'EP', 'XP']) {
+      render(
+        <Content
+          body={blocks({ type: 'datavalues', value: [{ type: 'cost', label: `2 ${currency}` }] })}
+        />
+      )
+      expect(screen.getByText(`2 ${currency}`)).toBeTruthy()
+      cleanup()
+    }
+  })
+
+  test('a cost datavalue with an explicit value keeps both halves as given', () => {
+    render(
+      <Content
+        body={blocks({ type: 'datavalues', value: [{ type: 'cost', label: '2', value: 'EP' }] })}
+      />
+    )
+    expect(screen.getByText('2 EP')).toBeTruthy()
+  })
+
+  test('a cost label with no recognised currency suffix is left unsplit', () => {
+    render(
+      <Content body={blocks({ type: 'datavalues', value: [{ type: 'cost', label: 'Free' }] })} />
+    )
+    // Not split — the whole label stays the cost and the AP default applies.
+    expect(screen.getByText('Free AP')).toBeTruthy()
+  })
+
+  test('a plain datavalue joins its value and unit', () => {
+    render(
+      <Content
+        body={blocks({
+          type: 'datavalues',
+          value: [{ type: 'stat', label: 'Range', value: '3', unit: 'Hexes' }],
+        })}
+      />
+    )
+    expect(screen.getByText('Range')).toBeTruthy()
+    expect(screen.getByText('3 Hexes')).toBeTruthy()
+  })
+
+  test('a trait datavalue renders its label as a stat chip', () => {
+    render(
+      <Content
+        body={blocks({ type: 'datavalues', value: [{ type: 'trait', label: 'Anti-Personnel' }] })}
+      />
+    )
+    expect(screen.getByText('Anti-Personnel')).toBeTruthy()
+  })
+
+  test('a keyword datavalue renders its label as a stat chip', () => {
+    render(
+      <Content
+        body={blocks({ type: 'datavalues', value: [{ type: 'keyword', label: 'Melee' }] })}
+      />
+    )
+    expect(screen.getByText('Melee')).toBeTruthy()
+  })
+})
+
+describe('Content — section grouping', () => {
+  // Grouping is gated on a derivable border colour: with no `headerBg` the
+  // blocks render as one flat flow, with one they split into sections led by
+  // the heading. Both shapes must still show every block.
+  const body = () =>
+    blocks(
+      { type: 'paragraph', value: 'lead-in prose' },
+      { type: 'heading', level: 1, value: 'Big Heading' },
+      { type: 'paragraph', value: 'section prose' }
+    )
+
+  test('renders every block ungrouped when no header colour is supplied', () => {
+    render(<Content body={body()} />)
+    expect(screen.getByText('lead-in prose')).toBeTruthy()
+    expect(screen.getByText('Big Heading')).toBeTruthy()
+    expect(screen.getByText('section prose')).toBeTruthy()
+  })
+
+  test('renders every block when grouping into sections', () => {
+    render(<Content body={body()} headerBg="bg-pilot" />)
+    expect(screen.getByText('lead-in prose')).toBeTruthy()
+    expect(screen.getByText('Big Heading')).toBeTruthy()
+    expect(screen.getByText('section prose')).toBeTruthy()
+  })
+
+  test("a datavalues block's own label leads its section", () => {
+    render(
+      <Content
+        body={blocks({
+          type: 'datavalues',
+          label: 'Requirements',
+          value: [{ type: 'stat', label: 'Tech Level', value: '2' }],
+        })}
+        headerBg="bg-pilot"
+      />
+    )
+    expect(screen.getByText('Requirements')).toBeTruthy()
+    expect(screen.getByText('Tech Level')).toBeTruthy()
+  })
+})

--- a/packages/component-lib/src/components/referenceEntity/__tests__/useDetailModal.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/__tests__/useDetailModal.test.tsx
@@ -38,6 +38,15 @@ function Harness({ data, forceModal }: { data: SURefEntity | undefined; forceMod
 
 afterEach(cleanup)
 
+/** Captured before any test can swap it. Link-mode tests stub `window.open` to
+ *  observe the navigation; restoring in an `afterEach` rather than at the end of
+ *  each test body means a failing assertion cannot leak the stub into every
+ *  later test in the process. */
+const REAL_WINDOW_OPEN = window.open
+afterEach(() => {
+  window.open = REAL_WINDOW_OPEN
+})
+
 describe('useDetailModal — modal mode (no link provider)', () => {
   beforeAll(async () => {
     await SalvageUnionReference.preload('all')
@@ -86,7 +95,6 @@ describe('useDetailModal — link mode (srd)', () => {
 
   const renderLinked = (opts: { forceModal?: boolean; noHref?: boolean } = {}) => {
     const opened: Array<[string?, string?, string?]> = []
-    const original = window.open
     // biome-ignore lint/suspicious/noExplicitAny: test double for window.open
     ;(window as any).open = (...args: [string?, string?, string?]) => {
       opened.push(args)
@@ -101,37 +109,28 @@ describe('useDetailModal — link mode (srd)', () => {
         </EntityDetailLinkProvider>
       </EntityHrefProvider>
     )
-    return {
-      opened,
-      restore: () => {
-        window.open = original
-      },
-      ...result,
-    }
+    return { opened, ...result }
   }
 
   test('clicking navigates to the show page in a new tab instead of opening a dialog', () => {
-    const { opened, restore } = renderLinked()
+    const { opened } = renderLinked()
     fireEvent.click(screen.getByLabelText('View details'))
     expect(opened).toEqual([['/schema/systems/item/red-laser', '_blank', 'noopener,noreferrer']])
     expect(screen.queryByRole('dialog')).toBeNull()
-    restore()
   })
 
   test('forceModal beats link mode — pattern views have no URL to link to', () => {
-    const { opened, restore } = renderLinked({ forceModal: true })
+    const { opened } = renderLinked({ forceModal: true })
     fireEvent.click(screen.getByLabelText('View details'))
     expect(opened).toEqual([])
     expect(screen.getByRole('dialog')).toBeTruthy()
-    restore()
   })
 
   test('link mode with no resolvable href falls back to the modal', () => {
-    const { opened, restore } = renderLinked({ noHref: true })
+    const { opened } = renderLinked({ noHref: true })
     fireEvent.click(screen.getByLabelText('View details'))
     expect(opened).toEqual([])
     expect(screen.getByRole('dialog')).toBeTruthy()
-    restore()
   })
 })
 

--- a/packages/component-lib/src/components/referenceEntity/__tests__/useDetailModal.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/__tests__/useDetailModal.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * `useDetailModal` is the one place that decides what "View details" DOES: open
+ * the in-place `EntityDetailDialog`, or navigate to the entity's show page in a
+ * new tab. Two apps depend on opposite answers — srd sets link mode (its
+ * entities have real URLs), ITUN leaves it off (its href would deep-link out of
+ * the app) — and `forceModal` overrides link mode for views with no standalone
+ * URL (chassis patterns). Nothing about that routing is visible to typecheck,
+ * so it is pinned here alongside the dialog chrome it mounts.
+ */
+import { afterEach, beforeAll, describe, expect, test } from 'bun:test'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+import type { SURefEntity } from 'salvageunion-reference'
+import { useDetailModal } from '../useDetailModal'
+import { EntityDetailLinkProvider, EntityHrefProvider } from '../entityHrefContext'
+import { PatternEquipmentItem } from '../pattern/PatternEquipmentItem'
+
+const system = (name: string): SURefEntity => {
+  const match = SalvageUnionReference.Systems.all().find((s) => s.name === name)
+  if (!match) throw new Error(`fixture missing: system ${name}`)
+  return match as SURefEntity
+}
+
+/** Minimal consumer: a plain trigger wired to the hook's control, plus the
+ *  modal node the hook hands back. Keeps the assertions about the hook rather
+ *  than about whichever card happens to host the control. */
+function Harness({ data, forceModal }: { data: SURefEntity | undefined; forceModal?: boolean }) {
+  const { control, modal } = useDetailModal(data, { forceModal })
+  return (
+    <>
+      <button type="button" onClick={control.onClick} aria-label={control.ariaLabel}>
+        trigger
+      </button>
+      {modal}
+    </>
+  )
+}
+
+afterEach(cleanup)
+
+describe('useDetailModal — modal mode (no link provider)', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  test('the dialog stays closed until the control is clicked', () => {
+    render(<Harness data={system('Red Laser')} />)
+    expect(screen.queryByRole('dialog')).toBeNull()
+    fireEvent.click(screen.getByLabelText('View details'))
+    expect(screen.getByRole('dialog')).toBeTruthy()
+  })
+
+  test("the open dialog renders the entity's card and an accessible name", () => {
+    render(<Harness data={system('Red Laser')} />)
+    fireEvent.click(screen.getByLabelText('View details'))
+    // The screen-reader-only Dialog.Title carries the entity name; the visible
+    // title comes from the card inside it — hence two matches, not one.
+    expect(screen.getAllByText('Red Laser').length).toBeGreaterThan(1)
+    expect(screen.getByText('Entity display details')).toBeTruthy()
+  })
+
+  test('the dialog closes again via its close button', () => {
+    render(<Harness data={system('Red Laser')} />)
+    fireEvent.click(screen.getByLabelText('View details'))
+    fireEvent.click(screen.getByText('Close'))
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  test('no entity means no modal node at all', () => {
+    render(<Harness data={undefined} />)
+    fireEvent.click(screen.getByLabelText('View details'))
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  test('an entity with no schemaName gets no modal — the card could not route it', () => {
+    render(<Harness data={{ name: 'Orphan' } as unknown as SURefEntity} />)
+    fireEvent.click(screen.getByLabelText('View details'))
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+})
+
+describe('useDetailModal — link mode (srd)', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  const renderLinked = (opts: { forceModal?: boolean; noHref?: boolean } = {}) => {
+    const opened: Array<[string?, string?, string?]> = []
+    const original = window.open
+    // biome-ignore lint/suspicious/noExplicitAny: test double for window.open
+    ;(window as any).open = (...args: [string?, string?, string?]) => {
+      opened.push(args)
+      return null
+    }
+    const result = render(
+      <EntityHrefProvider
+        value={() => (opts.noHref ? undefined : '/schema/systems/item/red-laser')}
+      >
+        <EntityDetailLinkProvider value={true}>
+          <Harness data={system('Red Laser')} forceModal={opts.forceModal} />
+        </EntityDetailLinkProvider>
+      </EntityHrefProvider>
+    )
+    return {
+      opened,
+      restore: () => {
+        window.open = original
+      },
+      ...result,
+    }
+  }
+
+  test('clicking navigates to the show page in a new tab instead of opening a dialog', () => {
+    const { opened, restore } = renderLinked()
+    fireEvent.click(screen.getByLabelText('View details'))
+    expect(opened).toEqual([['/schema/systems/item/red-laser', '_blank', 'noopener,noreferrer']])
+    expect(screen.queryByRole('dialog')).toBeNull()
+    restore()
+  })
+
+  test('forceModal beats link mode — pattern views have no URL to link to', () => {
+    const { opened, restore } = renderLinked({ forceModal: true })
+    fireEvent.click(screen.getByLabelText('View details'))
+    expect(opened).toEqual([])
+    expect(screen.getByRole('dialog')).toBeTruthy()
+    restore()
+  })
+
+  test('link mode with no resolvable href falls back to the modal', () => {
+    const { opened, restore } = renderLinked({ noHref: true })
+    fireEvent.click(screen.getByLabelText('View details'))
+    expect(opened).toEqual([])
+    expect(screen.getByRole('dialog')).toBeTruthy()
+    restore()
+  })
+})
+
+describe('PatternEquipmentItem — the hook wired into a real card', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  test('exposes a visible detail control on the head listing that opens the card', () => {
+    render(<PatternEquipmentItem data={system('Red Laser')} />)
+    // The listing itself shows the name once; the modal is not mounted yet.
+    expect(screen.queryByRole('dialog')).toBeNull()
+    fireEvent.click(screen.getByLabelText('View details'))
+    expect(screen.getByRole('dialog')).toBeTruthy()
+  })
+})

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/resolveNestedEntities.test.ts
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/resolveNestedEntities.test.ts
@@ -1,0 +1,210 @@
+/**
+ * `resolveNestedEntities` and its siblings are the single collection point for
+ * every nested entity a card surfaces — grants, chassis-ability drones, a
+ * crawler's embedded commander, and a pattern's systems/modules/drone loadout.
+ * If a resolver silently returns nothing the card renders a *plausible* page
+ * with the nested content missing, which is exactly the failure mode that made
+ * roll tables vanish (see `resolveCardTable.test.tsx`). These tests pin the
+ * grouping, the name -> entity resolution, and the "nothing to resolve" exits.
+ */
+import { beforeAll, describe, expect, test } from 'bun:test'
+import { SalvageUnionReference } from 'salvageunion-reference'
+import type { SURefEntity, SURefMetaEntity, SURefObjectPattern } from 'salvageunion-reference'
+import {
+  resolveChassisDrone,
+  resolveDroneOwnLoadout,
+  resolveNestedEntities,
+  resolvePatternDrone,
+  resolvePatternGroups,
+} from '../resolveNestedEntities'
+
+const chassis = (name: string): SURefMetaEntity => {
+  const match = SalvageUnionReference.Chassis.all().find((c) => c.name === name)
+  if (!match) throw new Error(`fixture missing: chassis ${name}`)
+  return match as SURefMetaEntity
+}
+
+const pattern = (chassisName: string, patternName: string): SURefObjectPattern => {
+  const patterns = (chassis(chassisName) as { patterns?: SURefObjectPattern[] }).patterns ?? []
+  const match = patterns.find((p) => p.name === patternName)
+  if (!match) throw new Error(`fixture missing: pattern ${chassisName}/${patternName}`)
+  return match
+}
+
+const names = (entities: readonly SURefEntity[]): string[] =>
+  entities.map((e) => ('name' in e && typeof e.name === 'string' ? e.name : '?'))
+
+const group = (groups: ReturnType<typeof resolveNestedEntities>, label: string) =>
+  groups.find((g) => g.label === label)
+
+describe('resolveNestedEntities', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  test('an OBJECT-shaped chassis ability naming a drone resolves it into "Drones"', () => {
+    // In the shipped dataset `chassisAbilities` is an array of id STRINGS, so
+    // this branch only fires for the object-shaped form the type permits (and
+    // that `resolveChassisDrone`, which goes through `getChassisAbilities`,
+    // handles for real chassis — see the drone-loadout suite below).
+    const groups = resolveNestedEntities({
+      chassisAbilities: [
+        'some-ability-id',
+        { name: 'Controller', drone: 'Sestra Drone' },
+        { name: 'No drone here' },
+        null,
+      ],
+    } as unknown as SURefMetaEntity)
+    expect(names(group(groups, 'Drones')?.entities ?? [])).toEqual(['Sestra Drone'])
+  })
+
+  test('the same drone named by two abilities is listed once', () => {
+    const groups = resolveNestedEntities({
+      chassisAbilities: [
+        { drone: 'Sestra Drone' },
+        { drone: 'Sestra Drone' },
+        { drone: 'No Such Drone' },
+      ],
+    } as unknown as SURefMetaEntity)
+    expect(group(groups, 'Drones')?.entities).toHaveLength(1)
+  })
+
+  test('a chassis carries no embedded commander, so no NPCs group', () => {
+    expect(group(resolveNestedEntities(chassis('Big Brother')), 'NPCs')).toBeUndefined()
+  })
+
+  test("a crawler's embedded commander is synthesized into an npcs-schema entity", () => {
+    const groups = resolveNestedEntities(
+      SalvageUnionReference.Crawlers.all().find((c) => c.name === 'Augmented') as SURefMetaEntity
+    )
+    const npcs = group(groups, 'NPCs')
+    expect(npcs).toBeDefined()
+    const [commander] = npcs?.entities ?? []
+    // The Augmented crawler's commander object carries `position`, not `name` —
+    // the resolver has to fall back to it or the group is dropped entirely.
+    expect((commander as { name?: string })?.name).toBe('Union Crawler A.I.')
+    // Synthesized `schemaName` is what routes it back through the same card.
+    expect((commander as { schemaName?: string })?.schemaName).toBe('npcs')
+  })
+
+  test('an ability that grants equipment surfaces it under "Grants"', () => {
+    const ability = SalvageUnionReference.Abilities.all().find((a) => a.name === 'Auto-Turret')
+    if (!ability) throw new Error('fixture missing: Auto-Turret')
+    const grants = group(resolveNestedEntities(ability as SURefMetaEntity), 'Grants')
+    expect(names(grants?.entities ?? [])).toContain('Auto-Turret')
+  })
+
+  test('an entity with nothing nested resolves to no groups at all', () => {
+    const plain = SalvageUnionReference.Systems.all().find((s) => s.name === 'Red Laser')
+    if (!plain) throw new Error('fixture missing: Red Laser')
+    expect(resolveNestedEntities(plain as SURefMetaEntity)).toEqual([])
+  })
+})
+
+describe('resolvePatternGroups', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  test("a pattern's systems, modules and drones each resolve into their own group", () => {
+    const groups = resolvePatternGroups(pattern('Little Sestra', 'Surveyor'))
+    expect(groups.map((g) => g.label)).toEqual(['Systems', 'Modules', 'Drones'])
+    expect(names(group(groups, 'Systems')?.entities ?? [])).toEqual([
+      'Green Laser',
+      'Escape Hatch',
+      'Locomotion System',
+      'Tracking Node',
+    ])
+    expect(names(group(groups, 'Modules')?.entities ?? [])).toEqual([
+      'Comms Module',
+      'Reactor Flare',
+    ])
+    expect(names(group(groups, 'Drones')?.entities ?? [])).toEqual(['Sestra Drone'])
+  })
+
+  test('a name that resolves to nothing is dropped rather than rendered blank', () => {
+    const groups = resolvePatternGroups({
+      name: 'Fake',
+      systems: [{ name: 'Green Laser' }, { name: 'No Such System' }],
+    } as SURefObjectPattern)
+    expect(names(group(groups, 'Systems')?.entities ?? [])).toEqual(['Green Laser'])
+  })
+
+  test('duplicate entries within a group are de-duplicated', () => {
+    const groups = resolvePatternGroups({
+      name: 'Fake',
+      systems: [{ name: 'Green Laser' }, { name: 'Green Laser' }],
+    } as SURefObjectPattern)
+    expect(group(groups, 'Systems')?.entities).toHaveLength(1)
+  })
+
+  test('an empty pattern yields no groups', () => {
+    expect(resolvePatternGroups({ name: 'Fake' } as SURefObjectPattern)).toEqual([])
+  })
+})
+
+describe('drone loadouts', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  test("resolveChassisDrone uses the DRONE's own loadout, not the chassis's", () => {
+    const loadout = resolveChassisDrone(chassis('Little Sestra'))
+    expect((loadout?.drone as { name?: string })?.name).toBe('Sestra Drone')
+    // The Sestra Drone entity ships a single system and no modules of its own;
+    // the pattern-specific loadout below is a different, richer list.
+    expect(names(loadout?.systems ?? [])).toEqual(['Hover Locomotion System'])
+    expect(loadout?.modules).toEqual([])
+  })
+
+  test('resolveChassisDrone returns undefined when no ability names a drone', () => {
+    const noDrone = SalvageUnionReference.Chassis.all().find(
+      (c) => resolveChassisDrone(c as SURefMetaEntity) === undefined
+    )
+    expect(noDrone).toBeDefined()
+    expect(resolveChassisDrone(noDrone as SURefMetaEntity)).toBeUndefined()
+  })
+
+  test("resolvePatternDrone resolves the PATTERN's drone loadout by name", () => {
+    const loadout = resolvePatternDrone(pattern('Little Sestra', 'Surveyor'))
+    expect((loadout?.drone as { name?: string })?.name).toBe('Sestra Drone')
+    expect(names(loadout?.systems ?? [])).toEqual([
+      'Long Barrelled Green Laser',
+      'High Gain Antenna',
+      'Cargo Pod',
+    ])
+    expect(names(loadout?.modules ?? [])).toEqual(['Survey Scanner', 'M315 Motion Scanner'])
+  })
+
+  test('resolvePatternDrone returns undefined for a pattern with no drones', () => {
+    expect(resolvePatternDrone(pattern('Mule', 'Hauler'))).toBeUndefined()
+    expect(resolvePatternDrone({ name: 'Fake' } as SURefObjectPattern)).toBeUndefined()
+  })
+
+  test('resolvePatternDrone returns undefined when the named drone does not exist', () => {
+    expect(
+      resolvePatternDrone({
+        name: 'Fake',
+        drones: [{ name: 'No Such Drone', systems: [], modules: [] }],
+      } as unknown as SURefObjectPattern)
+    ).toBeUndefined()
+  })
+
+  test("resolveDroneOwnLoadout reads the drone entity's own name arrays", () => {
+    const drone = SalvageUnionReference.findIn('drones', (d) => d.name === 'Sestra Drone')
+    if (!drone) throw new Error('fixture missing: Sestra Drone')
+    const loadout = resolveDroneOwnLoadout(drone as SURefMetaEntity)
+    expect(names(loadout.systems)).toEqual(['Hover Locomotion System'])
+    expect(loadout.modules).toEqual([])
+  })
+
+  test('resolveDroneOwnLoadout tolerates missing / non-array loadout fields', () => {
+    expect(resolveDroneOwnLoadout({} as SURefMetaEntity)).toEqual({ systems: [], modules: [] })
+    expect(
+      resolveDroneOwnLoadout({
+        systems: 'Green Laser',
+        modules: null,
+      } as unknown as SURefMetaEntity)
+    ).toEqual({ systems: [], modules: [] })
+  })
+})

--- a/packages/component-lib/src/components/referenceEntity/pattern/__tests__/ChassisAbilitiesContent.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/pattern/__tests__/ChassisAbilitiesContent.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * `ChassisAbilitiesContent` is the chassis card's abilities block. Beyond
+ * listing the abilities it does two things nothing else does: it resolves the
+ * drone an ability NAMES into a real drone card, and — in the pre-baked pattern
+ * mode — resolves that drone's pattern-specific systems/modules names into
+ * entity listings under their own slabs. Both resolutions are by name against
+ * the dataset, so a rename or a lookup regression makes content vanish without
+ * failing typecheck.
+ */
+import { afterEach, beforeAll, describe, expect, test } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+import { SalvageUnionReference, getChassisAbilities } from 'salvageunion-reference'
+import type { SURefMetaAction, SURefMetaEntity } from 'salvageunion-reference'
+import { ChassisAbilitiesContent } from '../ChassisAbilitiesContent'
+
+const abilitiesOf = (chassisName: string): SURefMetaAction[] => {
+  const chassis = SalvageUnionReference.Chassis.all().find((c) => c.name === chassisName)
+  if (!chassis) throw new Error(`fixture missing: chassis ${chassisName}`)
+  const abilities = getChassisAbilities(chassis as SURefMetaEntity)
+  if (!abilities || abilities.length === 0)
+    throw new Error(`fixture has no chassis abilities: ${chassisName}`)
+  return abilities
+}
+
+afterEach(cleanup)
+
+describe('ChassisAbilitiesContent', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  test('renders nothing when the chassis has no abilities', () => {
+    const { container } = render(<ChassisAbilitiesContent compact={false} />)
+    expect(container.innerHTML).toBe('')
+    cleanup()
+    const empty = render(<ChassisAbilitiesContent compact={false} chassisAbilities={[]} />)
+    expect(empty.container.innerHTML).toBe('')
+  })
+
+  test('renders a card for each ability', () => {
+    const abilities = abilitiesOf('Little Sestra')
+    render(
+      <ChassisAbilitiesContent
+        compact={false}
+        chassisName="Little Sestra"
+        chassisAbilities={abilities}
+      />
+    )
+    for (const ability of abilities) {
+      expect(screen.getAllByText(ability.name as string).length).toBeGreaterThan(0)
+    }
+  })
+
+  test("an ability naming a drone mounts that drone's own card", () => {
+    render(
+      <ChassisAbilitiesContent
+        compact={false}
+        chassisName="Little Sestra"
+        chassisAbilities={abilitiesOf('Little Sestra')}
+      />
+    )
+    // "Sestra Drone" appears as the ability's name too, so assert on the drone
+    // card's own content rather than the string alone.
+    expect(screen.getByText('Sestra Drone')).toBeTruthy()
+  })
+
+  test('hideDrone suppresses the drone card for consumers rendering it themselves', () => {
+    render(
+      <ChassisAbilitiesContent
+        compact={false}
+        chassisName="Little Sestra"
+        chassisAbilities={abilitiesOf('Little Sestra')}
+        hideDrone
+      />
+    )
+    expect(screen.queryByText('Sestra Drone')).toBeNull()
+  })
+
+  test("pre-baked droneEquipment resolves the pattern's systems and modules by name", () => {
+    render(
+      <ChassisAbilitiesContent
+        compact={false}
+        chassisName="Little Sestra"
+        chassisAbilities={abilitiesOf('Little Sestra')}
+        droneEquipment={[
+          {
+            name: 'Sestra Drone',
+            systems: ['Long Barrelled Green Laser', 'High Gain Antenna'],
+            modules: ['Survey Scanner'],
+          },
+        ]}
+      />
+    )
+    expect(screen.getByText('Long Barrelled Green Laser')).toBeTruthy()
+    expect(screen.getByText('High Gain Antenna')).toBeTruthy()
+    expect(screen.getByText('Survey Scanner')).toBeTruthy()
+  })
+
+  test('an unresolvable equipment name is dropped, not rendered blank', () => {
+    render(
+      <ChassisAbilitiesContent
+        compact={false}
+        chassisName="Little Sestra"
+        chassisAbilities={abilitiesOf('Little Sestra')}
+        droneEquipment={[{ systems: ['No Such System'], modules: ['Survey Scanner'] }]}
+      />
+    )
+    expect(screen.queryByText('No Such System')).toBeNull()
+    // The modules half still renders — one bad name must not take the block down.
+    expect(screen.getByText('Survey Scanner')).toBeTruthy()
+  })
+
+  test('an empty droneEquipment loadout renders no equipment listings', () => {
+    render(
+      <ChassisAbilitiesContent
+        compact={false}
+        chassisName="Little Sestra"
+        chassisAbilities={abilitiesOf('Little Sestra')}
+        droneEquipment={[{ systems: [], modules: [] }]}
+      />
+    )
+    expect(screen.queryByText('Long Barrelled Green Laser')).toBeNull()
+    expect(screen.queryByText('Survey Scanner')).toBeNull()
+  })
+
+  test('an unknown chassis name still renders the abilities (no host tone to ghost)', () => {
+    render(
+      <ChassisAbilitiesContent
+        compact
+        chassisName="No Such Chassis"
+        chassisAbilities={abilitiesOf('Little Sestra')}
+      />
+    )
+    expect(screen.getAllByText('Sestra Drone Controller').length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Why

`packages/component-lib` is the least-tested surface in the repo — 60 test files against 273 sources, and the lowest coverage baseline (71, vs srd 95 / discord-bot 92 / itun 90 / reference 89) — while **both** apps depend on it. The thinnest-covered code was the entity-display system, which is the heart of the UI.

## Before / after (actual `bun tools/coverage-report.ts` output)

| | `packages/component-lib` |
| --- | --- |
| before | **73.06%** (baseline 71) |
| after | **75.79%** (baseline 75) |

**+2.73pp of real coverage.** No source files were changed — tests and the baseline bump only.

`coverage-baseline.json` goes `71 → 75`, not `71 → 75.79`: every other entry is an integer with a couple of points of headroom, which is the convention `tools/coverage-report.ts` documents in its own comments (CI runners wobble, and the ratchet tolerance is only 0.5pp). 75 is still a genuine ratchet — the previous run would have failed against it.

## What's covered

Four new test files, all following the existing sibling `__tests__` conventions (real SRD fixtures, a doc comment stating what would break, assertions about rendered output rather than "renders without throwing"):

- **`card/__tests__/resolveNestedEntities.test.ts`** — the single collection point for nested entities. Grants / Drones / NPCs grouping, the crawler-commander synthesis (falls back to `position` when the embedded object has no `name`, and stamps `schemaName: 'npcs'` so it routes back through the same card), global de-duplication, `resolvePatternGroups`, and all three drone-loadout resolvers, including the unresolvable-name and empty exits.
- **`__tests__/useDetailModal.test.tsx`** — the "View details" routing two apps need opposite answers for: in-place modal by default (ITUN), new-tab navigation under link mode (srd), `forceModal` beating link mode, and the fallbacks when there is no href / no `schemaName` / no entity. This also brings **`EntityDetailDialog`, `DetailIcon` and `PatternEquipmentItem`** — previously 0% — under test.
- **`pattern/__tests__/ChassisAbilitiesContent.test.tsx`** — ability cards, the drone an ability names, `hideDrone`, and the pre-baked `droneEquipment` name → entity resolution (including a name that resolves to nothing, which must be dropped rather than take the block down).
- **`__tests__/Content.test.tsx`** — the block renderer's `type` mapping, none of which is type-checked: cost-datavalue currency splitting (`"3 AP"` arrives as one label; without the split the pennant reads "3 AP AP"), trait/keyword/plain chips, hint / flavor / label / list-item / unknown-type fallback, `[(CHASSIS)]` substitution, `choice`-marker stripping, and both section-grouping shapes.

## Verification (verbatim)

- `bun run typecheck` — all four workspaces `exited with code 0`
- `bun run lint` — `Found 3 warnings. Found 2 infos.` (0 errors). One warning is new: `useDetailModal.test.tsx:27` `useComponentExportOnlyModules` for the test `Harness` component — same class as the pre-existing accepted warning at `src/utils/__tests__/parseTraitReferences.test.tsx:7`.
- `bun run format:check` — `Checked 972 files. No fixes applied.`
- `bun run test` — `Ran 1246 tests across 136 files` / `Ran 1003` / `Ran 913` / `Ran 523` / `Ran 68`, **0 fail** in every workspace. component-lib went 469 → 523 tests, 1304 → 1398 expect() calls.
- `bun run knip` — clean (one pre-existing `.css` configuration hint).
- `bun run validate:all` — not run; no `packages/salvageunion-reference/data` files were touched.

Nothing here needs a real browser, so everything above was verified locally.

## Deliberately left out

- **Did not chase 90%.** The next-biggest gaps in this workspace are `shared/RollTable.tsx` (302 uncovered lines) and `chrome/InlineEditField.tsx` (194, at 3%). Both are worth their own PR; cramming them in here would have made the diff unreviewable.
- **Did not refactor anything to make it testable** — no source file is modified.
- **One observation, not fixed:** the chassis-ability-drone branch in `resolveNestedEntities` (`'drone' in ability`) is unreachable with the shipped dataset, because a chassis's `chassisAbilities` is an array of id *strings*, not objects — only `getChassisAbilities` resolves them, which is the path `resolveChassisDrone` takes. The branch is covered here with the object-shaped form the type permits, and the test says so. Whether the branch should instead go through `getChassisAbilities` is a behaviour question for a separate change; I did not want to alter rendering under a coverage PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoXC3pFgFjYYoUM12MGHpL