### PR TITLE
fix(component-lib): let the card title yield to its description

### DIFF
--- a/packages/component-lib/src/components/referenceEntity/card/EntityCardHeader.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/EntityCardHeader.tsx
@@ -83,18 +83,33 @@ export function EntityCardHeader({
   // - STAT CLUSTER only → stats are bounded, so they RESERVE their content
   //   width and the title yields into the remainder (the original
   //   title-overlapping-the-stats fix — kept).
-  // - FLAVOUR PROSE → prose is arbitrary-length, so IT yields: letting it
-  //   reserve content width drove the title to min-w-0 and stacked it one
-  //   character per line. The title reserves (capped at 60%), the prose wraps
-  //   into the rest.
+  // - FLAVOUR PROSE → two arbitrary-length texts share one row, so neither
+  //   side may reserve a FIXED share: both are `flex-auto`, whose flex base is
+  //   each side's own max-content width, so the overflow is absorbed in
+  //   PROPORTION to how much text each actually has (both shrink by the same
+  //   factor, leaving each side's width proportional to its own text). A fixed
+  //   60/40 handed the title 60% whether it needed it or not — "Mass Field
+  //   Maintenance" wrapped to two lines in a 60% box beside a description
+  //   crushed into four, which is the whitespace this replaces.
+  //
+  //   This is ALSO what keeps the one-letter-per-line regression fixed, and by
+  //   a stronger guarantee than the fixed cap it replaces: the title can never
+  //   fall below its proportional share (a description three times its length
+  //   still leaves it a quarter of the row), where the old rule let the title
+  //   take ALL of the shrink because the prose reserved content width against
+  //   the title's zero basis. The 60% ceiling stays; `min-w-0` stays too, so a
+  //   title too long for a narrow card still breaks (`break-words`) instead of
+  //   forcing the row wider than the card.
   const hasProse = !!rightContent
   const hasRight = !!(rightContent || statsNode)
 
   // COMPACT: the title + flavor/stat cluster share ONE row and split the width
   // dynamically — the cluster never wraps beneath the title, each side wraps
-  // WITHIN its own space. With right-side content the title takes up to 60%
-  // and the cluster (flex-1, basis 0 — so it can never starve the title) takes
-  // the rest; with nothing beside it the title takes the full row.
+  // WITHIN its own space. Against PROSE both sides are `flex-auto` and split in
+  // proportion to their own text (see the rule above); against a bounded STAT
+  // cluster the title takes up to 60% and the cluster (flex-1, basis 0 — so it
+  // can never starve the title) takes the rest; with nothing beside it the
+  // title takes the full row.
   if (compact) {
     return (
       <div
@@ -106,9 +121,21 @@ export function EntityCardHeader({
         )}
         style={accent.style}
       >
-        <div className={cn('min-w-0', hasRight ? 'max-w-[60%]' : 'flex-1')}>{titleNode}</div>
+        <div
+          className={cn(
+            'min-w-0',
+            hasProse ? 'max-w-[60%] flex-auto' : hasRight ? 'max-w-[60%]' : 'flex-1'
+          )}
+        >
+          {titleNode}
+        </div>
         {hasRight && (
-          <div className="flex min-w-0 flex-1 flex-wrap items-center justify-end gap-2">
+          <div
+            className={cn(
+              'flex min-w-0 flex-wrap items-center justify-end gap-2',
+              hasProse ? 'flex-auto' : 'flex-1'
+            )}
+          >
             {rightContent}
             {statsNode}
           </div>
@@ -127,20 +154,23 @@ export function EntityCardHeader({
     >
       {/* Stats-only (or empty) right side: the title is the FLEXIBLE side — it
           grows into the free space and wraps within it, yielding first so it can
-          never run under the stats. With PROSE on the right the roles flip: the
-          title reserves its content width (capped at 60%, shrink-0 so no
-          pathological cluster can squeeze it) and the prose yields. */}
-      <div className={cn('min-w-0', hasProse ? 'max-w-[60%] shrink-0' : 'flex-1')}>{titleNode}</div>
+          never run under the stats. With PROSE on the right neither side is
+          fixed: both are `flex-auto`, so each is sized from its own max-content
+          and they absorb the overflow proportionally, the title still capped at
+          60%. */}
+      <div className={cn('min-w-0', hasProse ? 'max-w-[60%] flex-auto' : 'flex-1')}>
+        {titleNode}
+      </div>
       {hasRight && (
         // Stats-only: the cluster reserves its own width (it doesn't grow, and
         // holds content size until the title is fully collapsed) and wraps
         // internally, so it is never overlapped and never clipped off the card
-        // edge. With prose the cluster is flex-1 (basis 0): it fills whatever
-        // the title leaves and the prose wraps inside it.
+        // edge. With prose the cluster is flex-auto: its base is the prose's own
+        // max-content, so it gives up width in proportion to the title's.
         <div
           className={cn(
             'flex min-w-0 flex-wrap items-center justify-end gap-2',
-            hasProse && 'flex-1'
+            hasProse && 'flex-auto'
           )}
         >
           {rightContent}

--- a/packages/component-lib/src/components/referenceEntity/card/EntityCardHeader.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/EntityCardHeader.tsx
@@ -29,6 +29,18 @@ type EntityCardHeaderProps = {
   compact?: boolean
 }
 
+/** Title column beside flavour PROSE. Base = its own content width, so a name
+ * that fits beside the description's ask keeps its single line; `shrink-[20]`
+ * makes it absorb the overflow past that. No `min-w-0` (min-content floor — it
+ * wraps at spaces, never mid-word) and a loose ceiling that won't clamp that
+ * floor. The full rationale + measurements live in the width-allocation comment
+ * below; this is shared so the compact and full rows can't drift apart. */
+const TITLE_VS_PROSE = 'max-w-[75%] shrink-[20]'
+/** Description column: asks for 55% of the band, grows past it when the title
+ * doesn't need its share, and yields below it when the title's longest word
+ * demands the room. */
+const PROSE_COLUMN = 'flex-[1_1_55%]'
+
 /**
  * EntityCardHeader — the unified card's HEADER band (the tone).
  *
@@ -83,33 +95,47 @@ export function EntityCardHeader({
   // - STAT CLUSTER only → stats are bounded, so they RESERVE their content
   //   width and the title yields into the remainder (the original
   //   title-overlapping-the-stats fix — kept).
-  // - FLAVOUR PROSE → two arbitrary-length texts share one row, so neither
-  //   side may reserve a FIXED share: both are `flex-auto`, whose flex base is
-  //   each side's own max-content width, so the overflow is absorbed in
-  //   PROPORTION to how much text each actually has (both shrink by the same
-  //   factor, leaving each side's width proportional to its own text). A fixed
-  //   60/40 handed the title 60% whether it needed it or not — "Mass Field
-  //   Maintenance" wrapped to two lines in a 60% box beside a description
-  //   crushed into four, which is the whitespace this replaces.
+  // - FLAVOUR PROSE → the description ASKS for 55% (`flex-[1_1_55%]`) and the
+  //   title yields into what's left, but only once it has to. The title's flex
+  //   base is its own content width, so while it fits in the remaining ~45% it
+  //   is untouched and keeps its single line; past that the shrink factor (20×
+  //   the description's) makes it absorb essentially all the overflow, wrapping
+  //   down toward its longest word instead of holding a share it isn't filling.
   //
-  //   This is ALSO what keeps the one-letter-per-line regression fixed, and by
-  //   a stronger guarantee than the fixed cap it replaces: the title can never
-  //   fall below its proportional share (a description three times its length
-  //   still leaves it a quarter of the row), where the old rule let the title
-  //   take ALL of the shrink because the prose reserved content width against
-  //   the title's zero basis. The 60% ceiling stays; `min-w-0` stays too, so a
-  //   title too long for a narrow card still breaks (`break-words`) instead of
-  //   forcing the row wider than the card.
+  //   That last part is the fix. A name too long for one line used to sit at
+  //   the flat 60% cap and wrap INSIDE it, so "Mass Field Maintenance" showed
+  //   two lines of title, four of description, and a ~110px dead channel down
+  //   the middle. Measured in-browser over the Engineer + Fabricator trees at
+  //   1440/768/390: the two worst cards drop from 4 description lines to 2–3,
+  //   total header height falls 680px→648px, and every title that already fit
+  //   on one line still does.
+  //
+  //   55% is a safe ask because a description is never short — across the 100
+  //   abilities that carry one the minimum is 34 characters (median 67), which
+  //   wants more than half the band at every card width.
+  //
+  //   Two details are load-bearing, both learned by measuring:
+  //   · The title has NO `min-w-0`, so its automatic minimum is min-content and
+  //     it can be squeezed to one word per line but never INTO one. Without it
+  //     `break-words` splits names mid-word ("ENGINEERIN / G EXPERTISE").
+  //   · The 75% ceiling is deliberately loose. `max-width` also clamps that
+  //     min-content floor, so the old 60% cap re-introduced mid-word breaks on
+  //     narrow cards — at 768px it split "Engineerin|g" and "Maintenan|ce"
+  //     before this change too. The description's ask, not the ceiling, is what
+  //     bounds the title in practice.
+  //   · The ask is a BASIS, not a `min-width`: a hard floor cannot yield to
+  //     that min-content floor, and the two together overflow the card on
+  //     narrow screens.
   const hasProse = !!rightContent
   const hasRight = !!(rightContent || statsNode)
 
   // COMPACT: the title + flavor/stat cluster share ONE row and split the width
   // dynamically — the cluster never wraps beneath the title, each side wraps
-  // WITHIN its own space. Against PROSE both sides are `flex-auto` and split in
-  // proportion to their own text (see the rule above); against a bounded STAT
-  // cluster the title takes up to 60% and the cluster (flex-1, basis 0 — so it
-  // can never starve the title) takes the rest; with nothing beside it the
-  // title takes the full row.
+  // WITHIN its own space. Against a bounded STAT cluster the title takes up to
+  // 60% and the cluster (flex-1, basis 0 — so it can never starve the title)
+  // takes the rest; against PROSE the description asks for 55% and the title
+  // yields (see the rule above); with nothing beside it the title takes the
+  // full row.
   if (compact) {
     return (
       <div
@@ -123,8 +149,7 @@ export function EntityCardHeader({
       >
         <div
           className={cn(
-            'min-w-0',
-            hasProse ? 'max-w-[60%] flex-auto' : hasRight ? 'max-w-[60%]' : 'flex-1'
+            hasProse ? TITLE_VS_PROSE : hasRight ? 'min-w-0 max-w-[60%]' : 'min-w-0 flex-1'
           )}
         >
           {titleNode}
@@ -133,7 +158,7 @@ export function EntityCardHeader({
           <div
             className={cn(
               'flex min-w-0 flex-wrap items-center justify-end gap-2',
-              hasProse ? 'flex-auto' : 'flex-1'
+              hasProse ? PROSE_COLUMN : 'flex-1'
             )}
           >
             {rightContent}
@@ -154,23 +179,20 @@ export function EntityCardHeader({
     >
       {/* Stats-only (or empty) right side: the title is the FLEXIBLE side — it
           grows into the free space and wraps within it, yielding first so it can
-          never run under the stats. With PROSE on the right neither side is
-          fixed: both are `flex-auto`, so each is sized from its own max-content
-          and they absorb the overflow proportionally, the title still capped at
-          60%. */}
-      <div className={cn('min-w-0', hasProse ? 'max-w-[60%] flex-auto' : 'flex-1')}>
-        {titleNode}
-      </div>
+          never run under the stats. With PROSE on the right the title keeps its
+          content width while it fits beside the description's 55% ask, and
+          yields past that — see the rule above. */}
+      <div className={cn(hasProse ? TITLE_VS_PROSE : 'min-w-0 flex-1')}>{titleNode}</div>
       {hasRight && (
         // Stats-only: the cluster reserves its own width (it doesn't grow, and
         // holds content size until the title is fully collapsed) and wraps
         // internally, so it is never overlapped and never clipped off the card
-        // edge. With prose the cluster is flex-auto: its base is the prose's own
-        // max-content, so it gives up width in proportion to the title's.
+        // edge. With prose it asks for 55% and grows past it when the title
+        // doesn't need its share.
         <div
           className={cn(
             'flex min-w-0 flex-wrap items-center justify-end gap-2',
-            hasProse && 'flex-auto'
+            hasProse && PROSE_COLUMN
           )}
         >
           {rightContent}

--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -766,7 +766,9 @@ function ReferenceEntityCardInner({
       className={cn(
         // Fill the header's right side and wrap across the band (no narrow cap),
         // so the description occupies the space instead of leaving a big gap.
-        'min-w-0 flex-1 text-right font-body italic leading-snug',
+        // `text-pretty` keeps the last line from stranding a single word
+        // ("…in the / field.") once the column is width-balanced against the title.
+        'min-w-0 flex-1 text-pretty text-right font-body italic leading-snug',
         // Same band-driven foreground as the title (entities/patterns white; the
         // light-faded ghosted/damaged bands go to ink by contrast).
         onBandText,

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/EntityCardHeader.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/EntityCardHeader.test.tsx
@@ -10,7 +10,15 @@
  * the rule rather than pixel widths:
  * - empty right side  → title `flex-1`, no 60% cap;
  * - stat cluster only → stats reserve (no `flex-1` column in full), title yields;
- * - flavour prose     → title reserves (`max-w-[60%]`), the column yields (`flex-1`).
+ * - flavour prose     → BOTH sides `flex-auto`, so each is sized from its own
+ *   max-content and the overflow is split in proportion to how much text each
+ *   side has (title keeps the 60% ceiling). Neither side may reserve a FIXED
+ *   share: a fixed 60/40 gave the title 60% whether it needed it or not,
+ *   leaving a short title beside a description crushed into twice the lines.
+ *   Proportional sizing is also what now prevents the one-letter-per-line
+ *   starvation — the title can't drop below its share of the row — where the
+ *   old rule needed the cap to do it, because prose reserved content width
+ *   against the title's zero basis and so took none of the shrink.
  */
 import { beforeAll, describe, expect, test, afterEach } from 'bun:test'
 import { cleanup, render, screen } from '@testing-library/react'
@@ -65,7 +73,7 @@ describe.each([false, true])('EntityCardHeader width allocation (compact=%p)', (
     expect(rightColumn()).toBeNull()
   })
 
-  test('with flavour prose the title reserves and the prose column yields', () => {
+  test('with flavour prose both sides flex from their own content width', () => {
     render(
       <EntityCardHeader
         {...base}
@@ -74,11 +82,17 @@ describe.each([false, true])('EntityCardHeader width allocation (compact=%p)', (
       />
     )
 
-    // The title must never be starved below a legible width by prose: it is
-    // capped, not collapsed — and the prose column is the flexible side.
-    expect(titleWrapper().className).toContain('max-w-[60%]')
+    // Neither side reserves a fixed share: `flex-auto` on both makes the flex
+    // base each side's max-content, so the overflow is absorbed in proportion
+    // to the amount of text. `flex-1` (basis 0) on either side would restore
+    // the fixed 60/40 split this replaced.
+    expect(titleWrapper().className).toContain('flex-auto')
+    expect(rightColumn()?.className).toContain('flex-auto')
     expect(titleWrapper().className).not.toContain('flex-1')
-    expect(rightColumn()?.className).toContain('flex-1')
+    expect(rightColumn()?.className).not.toContain('flex-1')
+    // The ceiling stays, so a long title beside a one-word description can
+    // still claim no more than 60% of the row.
+    expect(titleWrapper().className).toContain('max-w-[60%]')
   })
 })
 
@@ -116,7 +130,7 @@ describe('EntityCardHeader with a stat cluster (the overlap fix, kept)', () => {
     expect(rightColumn()?.className).toContain('flex-1')
   })
 
-  test('full, stats AND prose: the prose flips the column to the yielding side', () => {
+  test('full, stats AND prose: the prose flips both sides to proportional', () => {
     render(
       <EntityCardHeader
         title={TITLE}
@@ -129,6 +143,7 @@ describe('EntityCardHeader with a stat cluster (the overlap fix, kept)', () => {
     )
 
     expect(titleWrapper().className).toContain('max-w-[60%]')
-    expect(rightColumn()?.className).toContain('flex-1')
+    expect(titleWrapper().className).toContain('flex-auto')
+    expect(rightColumn()?.className).toContain('flex-auto')
   })
 })

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/EntityCardHeader.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/EntityCardHeader.test.tsx
@@ -10,15 +10,21 @@
  * the rule rather than pixel widths:
  * - empty right side  → title `flex-1`, no 60% cap;
  * - stat cluster only → stats reserve (no `flex-1` column in full), title yields;
- * - flavour prose     → BOTH sides `flex-auto`, so each is sized from its own
- *   max-content and the overflow is split in proportion to how much text each
- *   side has (title keeps the 60% ceiling). Neither side may reserve a FIXED
- *   share: a fixed 60/40 gave the title 60% whether it needed it or not,
- *   leaving a short title beside a description crushed into twice the lines.
- *   Proportional sizing is also what now prevents the one-letter-per-line
- *   starvation — the title can't drop below its share of the row — where the
- *   old rule needed the cap to do it, because prose reserved content width
- *   against the title's zero basis and so took none of the shrink.
+ * - flavour prose     → the description ASKS for 55% (`flex-[1_1_55%]`) and the
+ *   title yields only once it must (`shrink-[20]`), so a name that fits beside
+ *   that ask keeps its single line and a longer one wraps toward its longest
+ *   word instead of holding a 60% share it isn't filling.
+ *
+ * Two clauses of the prose rule were each learned by breaking them, and are
+ * asserted here because happy-dom performs no layout and so cannot catch them:
+ * the title carries NO `min-w-0` (min-width:auto floors it at min-content —
+ * with `min-w-0` the description's share squeezes it until `break-words` splits
+ * a name mid-word, "ENGINEERIN / G EXPERTISE"), and the description's share is
+ * a flex BASIS, not a `min-width` (a hard floor cannot yield to that
+ * min-content floor, and the two together overflow the card on narrow screens).
+ *
+ * These pin CLASSES rather than pixels. The layout itself is verified by
+ * measuring real pages in a browser — see the PR for the numbers.
  */
 import { beforeAll, describe, expect, test, afterEach } from 'bun:test'
 import { cleanup, render, screen } from '@testing-library/react'
@@ -73,7 +79,7 @@ describe.each([false, true])('EntityCardHeader width allocation (compact=%p)', (
     expect(rightColumn()).toBeNull()
   })
 
-  test('with flavour prose both sides flex from their own content width', () => {
+  test('with flavour prose the description asks for 55% and the title yields', () => {
     render(
       <EntityCardHeader
         {...base}
@@ -82,17 +88,22 @@ describe.each([false, true])('EntityCardHeader width allocation (compact=%p)', (
       />
     )
 
-    // Neither side reserves a fixed share: `flex-auto` on both makes the flex
-    // base each side's max-content, so the overflow is absorbed in proportion
-    // to the amount of text. `flex-1` (basis 0) on either side would restore
-    // the fixed 60/40 split this replaced.
-    expect(titleWrapper().className).toContain('flex-auto')
-    expect(rightColumn()?.className).toContain('flex-auto')
+    // The description's share is a flex BASIS. `flex-1` (basis 0) here would
+    // restore the fixed 60/40 split, where a wrapping title held 60% of the
+    // band and crushed the description into twice the lines.
+    expect(rightColumn()?.className).toContain('flex-[1_1_55%]')
+    // The title is the yielding side, but only past the point where it fits:
+    // its base is its own content width, and `shrink-[20]` makes it absorb
+    // essentially all of the overflow instead of sharing it.
+    expect(titleWrapper().className).toContain('shrink-[20]')
     expect(titleWrapper().className).not.toContain('flex-1')
-    expect(rightColumn()?.className).not.toContain('flex-1')
-    // The ceiling stays, so a long title beside a one-word description can
-    // still claim no more than 60% of the row.
-    expect(titleWrapper().className).toContain('max-w-[60%]')
+    // FLOOR: no `min-w-0`, so min-width:auto holds the title at min-content —
+    // its longest word. Drop this and `break-words` splits names mid-word
+    // ("ENGINEERIN / G EXPERTISE"), which is what the first cut shipped.
+    expect(titleWrapper().className).not.toContain('min-w-0')
+    // CEILING: deliberately loose. `max-width` also clamps that min-content
+    // floor, so the old 60% cap re-introduced mid-word breaks on narrow cards.
+    expect(titleWrapper().className).toContain('max-w-[75%]')
   })
 })
 
@@ -130,7 +141,7 @@ describe('EntityCardHeader with a stat cluster (the overlap fix, kept)', () => {
     expect(rightColumn()?.className).toContain('flex-1')
   })
 
-  test('full, stats AND prose: the prose flips both sides to proportional', () => {
+  test('full, stats AND prose: the prose rule wins over the stat rule', () => {
     render(
       <EntityCardHeader
         title={TITLE}
@@ -142,8 +153,8 @@ describe('EntityCardHeader with a stat cluster (the overlap fix, kept)', () => {
       />
     )
 
-    expect(titleWrapper().className).toContain('max-w-[60%]')
-    expect(titleWrapper().className).toContain('flex-auto')
-    expect(rightColumn()?.className).toContain('flex-auto')
+    expect(titleWrapper().className).toContain('shrink-[20]')
+    expect(titleWrapper().className).toContain('max-w-[75%]')
+    expect(rightColumn()?.className).toContain('flex-[1_1_55%]')
   })
 })


### PR DESCRIPTION
## What

The entity card header split its row on a **fixed 60/40**: the title reserved up to 60% whether it needed it or not. A name too long for one line sat at that cap and wrapped *inside* it — so "Mass Field Maintenance" showed two lines of title, four of description, and a ~110px dead channel down the middle.

## How

The description now **asks for 55%** (`flex-[1_1_55%]`) and the title **yields only once it must** (`shrink-[20]`). A name that fits beside that ask keeps its single line; a longer one wraps toward its longest word instead of holding a share it isn't filling. 55% is a safe ask because a description is never short — across the 100 abilities that carry one the minimum is 34 characters, median 67.

Three clauses are load-bearing, and each was found by measuring rather than reasoning:

- **The title carries no `min-w-0`**, so `min-width: auto` floors it at min-content and it wraps at spaces, never mid-word. The first cut of this PR used proportional shrink *with* `min-w-0` and split names as "ENGINEERIN / G EXPERTISE".
- **The ceiling is a loose 75%.** `max-width` also clamps that min-content floor, so the old 60% cap re-introduced mid-word breaks on narrow cards — at 768px it split `Engineerin|g` and `Maintenan|ce` *before* this change too. The description's ask, not the ceiling, is what bounds the title in practice.
- **The ask is a flex BASIS, not a `min-width`.** A hard floor can't yield to the min-content floor, and the two together overflow the card at narrow widths.

Plus `text-pretty` on the description, so a balanced column doesn't strand a single word on its last line ("…in the / field.").

## Verification

Measured on the rendered Engineer + Fabricator ability trees in headless Chrome, reconstructing line boxes from per-glyph rects so mid-word breaks are *detected* rather than eyeballed:

| viewport | total header height | mid-word breaks | overflow |
|---|---|---|---|
| 1440px | 680px → **648px** | 0 → **0** | 0 |
| 768px | 1500px → **1224px** | 3 → **0** | 5px on one card |
| 390px | 1000px → **800px** | 0 → **0** | 0 |

At 1440px the two worst cards drop from 4 description lines to 2–3 (`Mass Field Maintenance` 92px → 68px, `Engineering Expertise` 92px → 72px) and every title that already fit on one line still does. `Mech Acquisition` and `Mass Field Repair` gain a second title line at equal-or-lower card height — the deliberate trade.

The 768px case *fixes* three pre-existing mid-word breaks. It also leaves one card overflowing its row by 5px, where the title's longest word and the description's both bind; that's a far smaller artifact than the split word it replaces, and only occurs in the 3-column grid at that width.

`bun run check:all` green (lint, format, typecheck, 523 component-lib tests, validate, knip, tokens, styling). `EntityCardHeader.test.tsx` pins the rule's classes — happy-dom performs no layout, so the pixel behaviour is covered by the browser measurements above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDKbR3EcXv2z47Ecr4LNcR