### PR TITLE
fix(ci): unbreak the nightly e2e suite, its alerting, and the routeTree drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,22 @@ jobs:
       - name: Build itun
         run: bun --filter itun build
 
+      # The TanStack Router plugin regenerates src/routeTree.gen.ts as part of
+      # the build. It is a COMMITTED artifact, so if the build emits something
+      # different from what is checked in, every contributor gets a spuriously
+      # dirty working tree and the committed file slowly stops describing the
+      # real route graph. That had already happened — the checked-in file was
+      # stale by an entire plugin version (import ordering) and nothing caught
+      # it, because the only generated-file drift gate covers the reference
+      # package. The build ran here anyway, so this check is ~free.
+      - name: Check routeTree.gen.ts is not stale
+        run: |
+          if ! git diff --exit-code -- apps/itun/src/routeTree.gen.ts; then
+            echo "::error::apps/itun/src/routeTree.gen.ts is stale — the itun build regenerated it." \
+              "Run 'bun --filter itun build' and commit the result."
+            exit 1
+          fi
+
   build-discord-bot:
     needs: [changes, build-package, lint, typecheck, test, validate, knip, audit]
     if: needs.changes.outputs.bot == 'true'

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -222,27 +222,59 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Notification — GitHub-native, no external service or webhook secret. On
-  # any suite failure, open (or comment on) a single tracking issue labeled
-  # `nightly-e2e-failure`; on the next all-green run, comment + close it. Uses
+  # any suite result that is not `success` — failed assertions OR a job that ran
+  # out its `timeout-minutes` (which reports as `cancelled`) — open (or comment
+  # on) a single tracking issue labeled `nightly-e2e-failure`; on the next
+  # all-green run, comment + close it. Uses
   # the default GITHUB_TOKEN (issues: write, scoped to just these two jobs) —
   # nothing to provision. `a11y-srd` is intentionally absent from `needs:`: it
   # is advisory and must not open or hold open the tracking issue.
   # ---------------------------------------------------------------------------
   notify-failure:
     needs: [e2e-itun, e2e-srd]
-    if: failure()
+    # NOT `failure()`. A job that exhausts its `timeout-minutes` is reported with
+    # result `cancelled`, and `failure()` does not cover `cancelled` — so when
+    # e2e-itun started timing out, `notify-failure` AND `notify-recovery` were
+    # both skipped and the suite broke silently for days. Nothing was red except
+    # the Actions tab nobody was watching, which is the exact hole this tracking
+    # issue exists to close.
+    #
+    # So: fire on any non-success result from either suite. `!cancelled()` still
+    # exempts a genuine cancellation of the whole run (manual stop, or the
+    # concurrency group superseding this run) — that is a human action, not a
+    # regression, and should not open an issue. A per-job timeout does NOT set
+    # `cancelled()`, so timeouts still notify.
+    if: >-
+      always() && !cancelled() &&
+      (needs.e2e-itun.result != 'success' || needs.e2e-srd.result != 'success')
     runs-on: ubuntu-latest
     permissions:
       issues: write
     steps:
       - name: Open or update the nightly-e2e-failure tracking issue
         uses: actions/github-script@v9
+        env:
+          ITUN_RESULT: ${{ needs.e2e-itun.result }}
+          SRD_RESULT: ${{ needs.e2e-srd.result }}
         with:
           script: |
             const label = 'nightly-e2e-failure'
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            // Name the per-suite results explicitly. 'cancelled' here almost
+            // always means "hit timeout-minutes", which reads very differently
+            // from 'failure' (assertions failed) and points at a hang rather
+            // than a broken expectation.
+            const results = [
+              ['e2e-itun', process.env.ITUN_RESULT],
+              ['e2e-srd', process.env.SRD_RESULT],
+            ]
             const body = [
-              `Nightly E2E (\`e2e-nightly.yml\`) failed on \`${context.ref}\`.`,
+              `Nightly E2E (\`e2e-nightly.yml\`) did not pass on \`${context.ref}\`.`,
+              '',
+              ...results.map(
+                ([job, result]) =>
+                  `- \`${job}\`: **${result}**${result === 'cancelled' ? ' (hit `timeout-minutes` — likely a hang, not an assertion failure)' : ''}`
+              ),
               '',
               `Run: ${runUrl}`,
             ].join('\n')

--- a/apps/itun/e2e/_helpers.ts
+++ b/apps/itun/e2e/_helpers.ts
@@ -134,7 +134,18 @@ export async function advanceUntilVisible(
     const next = page.getByRole('button', { name: /^Next( ·|$)/ }).first()
     await next.waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {})
     if (!(await next.isVisible().catch(() => false))) break
-    if (await next.isDisabled().catch(() => false)) break
+
+    // Next goes briefly disabled while a step swaps in, so a bare
+    // `isDisabled()` here reads a transition as "this step is gated" and ends
+    // the walk early. Give it a bounded chance to settle and only stop when it
+    // stays disabled — that is a genuine gate the caller must satisfy itself.
+    if (await next.isDisabled().catch(() => false)) {
+      const settled = await expect(next)
+        .toBeEnabled({ timeout: 3_000 })
+        .then(() => true)
+        .catch(() => false)
+      if (!settled) break
+    }
     await next.click()
   }
   await expect(target, 'target step should be reachable by advancing the wizard').toBeVisible({
@@ -170,8 +181,13 @@ export async function pickByName(page: Page, name: string): Promise<void> {
  * target that button rather than clicking the card.
  */
 export async function installLoadoutItem(page: Page, name: string): Promise<void> {
-  const add = page.getByRole('button', { name: `Add ${name}` })
-  await expect(add, `"Add ${name}" install button should render`).toBeVisible({
+  // The button reads "Add one <name>" on the craft steps ("one" because
+  // installing the same System/Module twice is rules-legal, so each press
+  // appends a single copy). Accept the bare "Add <name>" too rather than
+  // pinning whichever wording is current.
+  const label = new RegExp(`^Add (one )?${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'i')
+  const add = page.getByRole('button', { name: label })
+  await expect(add, `"Add one ${name}" install button should render`).toBeVisible({
     timeout: 15_000,
   })
   await add.click()

--- a/apps/itun/e2e/_helpers.ts
+++ b/apps/itun/e2e/_helpers.ts
@@ -101,12 +101,61 @@ export async function waitForReady(page: Page): Promise<void> {
 }
 
 /**
+ * Advance a guided wizard forward until `target` shows up, then stop.
+ *
+ * Specs that want to exercise ONE step used to `goto('/<kind>/new')` and assume
+ * that step was the landing step. Both assumptions have now broken once each: a
+ * `CreateModeChooser` gate was added in front of every wizard (hence
+ * `?mode=guided`), and the pilot wizard gained a "Your Stats" step ahead of
+ * "Class & Ability". Each time, the spec sat waiting for an element that was one
+ * click away until it burned its whole timeout.
+ *
+ * So don't encode WHICH step index a thing lives on — walk forward until it is
+ * on screen. Inserting another step ahead of the target then costs nothing.
+ */
+export async function advanceUntilVisible(
+  page: Page,
+  target: Locator,
+  maxSteps = 8
+): Promise<void> {
+  for (let step = 0; step < maxSteps; step++) {
+    // Target first, with a RETRYING wait. `isVisible()` resolves immediately —
+    // it does not retry the way `click()` and `expect().toBeVisible()` do — so
+    // probing it bare straight after `waitForReady()` (which only awaits the
+    // game-data flag, not the step's own paint) answers about a step that is
+    // one tick from rendering. Guarding this loop on a bare `isVisible()` is
+    // what made it fall straight through without ever clicking.
+    await target.waitFor({ state: 'visible', timeout: 2_000 }).catch(() => {})
+    if (await target.isVisible().catch(() => false)) return
+
+    // Not on this step, so look for the CTA. Waiting on it here also absorbs a
+    // slow first paint: if nothing had rendered yet, the next pass re-checks
+    // the target before clicking anything.
+    const next = page.getByRole('button', { name: /^Next( ·|$)/ }).first()
+    await next.waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {})
+    if (!(await next.isVisible().catch(() => false))) break
+    if (await next.isDisabled().catch(() => false)) break
+    await next.click()
+  }
+  await expect(target, 'target step should be reachable by advancing the wizard').toBeVisible({
+    timeout: 15_000,
+  })
+}
+
+/**
  * Click a chassis / class / ability / equipment / system / module card by its
  * displayed entity name. Asserts the card exists first so test failures point
  * at the right step.
  */
 export async function pickByName(page: Page, name: string): Promise<void> {
   const card = choiceCardByName(page, name)
+  // Step-agnostic, for the same reason `runWizard` is (see its note): these
+  // wizards get restructured, and a spec that says "pick Engineer" means it
+  // regardless of which step index Engineer currently lives on. When a step was
+  // inserted ahead of the Class/Chassis step, every one of these calls sat
+  // waiting for a card one click away until it burned its timeout — which is
+  // how ~18 specs went red at once. Walk forward to wherever the card is.
+  await advanceUntilVisible(page, card).catch(() => {})
   await expect(card, `card containing "${name}" should render`).toBeVisible({
     timeout: 15_000,
   })
@@ -199,7 +248,17 @@ async function runWizard(
   page: Page,
   kind: 'pilots' | 'mechs' | 'crawlers',
   identity: Record<string, string>,
-  createLabel: RegExp
+  createLabel: RegExp,
+  /**
+   * Option names to choose when this walk is offered them. Being step-agnostic
+   * means "take whatever is on offer", which makes the BUILT ENTITY
+   * nondeterministic — and specs downstream assert on it ("the sheet header
+   * shows Engineer"). Those assertions were really depending on which option
+   * happened to sit last in the DOM. Naming the picks here keeps the walk
+   * structure-agnostic while making its OUTPUT deterministic, which is what
+   * the downstream specs actually need.
+   */
+  prefer: string[] = []
 ): Promise<void> {
   await gotoStable(page, `/${kind}/new?mode=guided`)
   await waitForReady(page)
@@ -241,15 +300,35 @@ async function runWizard(
       // instead just re-picks within the first section (click every class in
       // turn and you end on the last one, ability still unchosen).
       for (let round = 0; round < 6 && (await next.isDisabled()); round++) {
-        const unselected = optionCells(page).filter({
-          hasNot: page.locator('[aria-checked="true"], [aria-pressed="true"]'),
-        })
-        const count = await unselected.count()
-        if (count === 0) break
-        await unselected
-          .nth(count - 1)
-          .click()
-          .catch(() => {})
+        // Match unselected cells by their OWN state attribute. The previous
+        // `filter({ hasNot })` asked whether a cell CONTAINS a selected
+        // descendant, which a selected cell does not — so every already-picked
+        // option counted as unselected and the walk could re-click (and thereby
+        // DEselect) what it had just chosen. Measured on the class step: 9
+        // cells, 1 picked, `hasNot` reported 9 unselected; the attribute
+        // selector reports the correct 8.
+        const unselected = page.locator('[aria-pressed="false"], [aria-checked="false"]')
+
+        // Take a named pick when one is on offer, so the built entity is the
+        // same every run.
+        let picked = false
+        for (const want of prefer) {
+          const candidate = unselected.filter({ hasText: want }).first()
+          if (await candidate.isVisible().catch(() => false)) {
+            await candidate.click().catch(() => {})
+            picked = true
+            break
+          }
+        }
+
+        if (!picked) {
+          const count = await unselected.count()
+          if (count === 0) break
+          await unselected
+            .nth(count - 1)
+            .click()
+            .catch(() => {})
+        }
         await page.waitForTimeout(350)
       }
       await expect(next, `wizard ${kind} step ${step} should unlock after picking`).toBeEnabled({
@@ -264,7 +343,10 @@ async function runWizard(
 
 /** Build a pilot. Steps: Stats → Class & Ability → Equipment → Callsign → Background → Motto → Keepsake → Appearance → Review. */
 export async function buildPilot(page: Page, name: string, callsign: string): Promise<void> {
-  await runWizard(page, 'pilots', { name, callsign }, /Create Pilot/i)
+  // Engineer, so specs may assert the built pilot's class on the sheet. Without
+  // a named pick the walk takes whatever option sits last in the DOM and the
+  // class silently varies between runs.
+  await runWizard(page, 'pilots', { name, callsign }, /Create Pilot/i, ['Engineer'])
 }
 
 /**
@@ -275,7 +357,10 @@ export async function buildPilot(page: Page, name: string, callsign: string): Pr
  * so both spellings are offered; whichever is absent is a no-op.
  */
 export async function buildMech(page: Page, name: string): Promise<void> {
-  await runWizard(page, 'mechs', { 'name / pattern': name, 'mech name': name }, /Create Mech/i)
+  // Mule chassis — the one downstream specs assert on. See buildPilot.
+  await runWizard(page, 'mechs', { 'name / pattern': name, 'mech name': name }, /Create Mech/i, [
+    'Mule',
+  ])
 }
 
 /** Build a crawler. Steps: Type → Statistics → Armament Bay → Crew → Name → Review. */
@@ -284,17 +369,23 @@ export async function buildCrawler(page: Page, name: string): Promise<void> {
 }
 
 /**
- * Open the live sheet for the named entity from the dashboard's saved rows
- * (each row is an <li> with a 'Sheet' link).
+ * Open the live sheet for the named entity from the Roster's saved rows.
+ *
+ * Each row is an <li> rendering component-lib's `EntityRow`, whose sheet link
+ * is labelled **"View"**. It used to read "Sheet"; when the label changed this
+ * helper kept waiting for the old name until the whole job hit its 30-minute
+ * ceiling, so match the link by its `/sheet/` href instead of its text — the
+ * href is the contract this helper actually depends on, and it survives the
+ * next copy change.
  */
 export async function openSheetFor(page: Page, name: string): Promise<void> {
   await gotoStable(page, '/')
   await waitForReady(page)
   const row = page.locator('li', { hasText: name }).first()
-  await expect(row, `dashboard row for "${name}" should render`).toBeVisible({
+  await expect(row, `roster row for "${name}" should render`).toBeVisible({
     timeout: 15_000,
   })
-  await row.getByRole('link', { name: /^Sheet$/ }).click()
+  await row.locator('a[href*="/sheet/"]').first().click()
   await page.waitForURL(/\/sheet\//, { timeout: 20_000 })
 }
 

--- a/apps/itun/e2e/bundle-budget.e2e.ts
+++ b/apps/itun/e2e/bundle-budget.e2e.ts
@@ -129,9 +129,14 @@ test.describe('bundle-size budget', () => {
   })
 
   test('the pilot wizard stays under budget', async ({ page }) => {
+    // `?mode=guided` is load-bearing, not decoration: bare `/pilots/new` renders
+    // the CreateModeChooser (two doors), NOT the wizard, so without it this
+    // measures the chooser's chunk and reports it under the wizard's name — a
+    // budget that would sit green while the thing it claims to guard grew
+    // unwatched. `mode=guided` is what mounts PilotWizard (NewEntityScreen.tsx).
     const CEILING = 3_000_000
-    const totals = await captureJsTotals(page, '/pilots/new')
-    report('/pilots/new (wizard)', totals, CEILING)
+    const totals = await captureJsTotals(page, '/pilots/new?mode=guided')
+    report('/pilots/new?mode=guided (wizard)', totals, CEILING)
     expect(totals.bytes).toBeLessThan(CEILING)
   })
 

--- a/apps/itun/e2e/class-step-ui.e2e.ts
+++ b/apps/itun/e2e/class-step-ui.e2e.ts
@@ -1,5 +1,11 @@
 import { test, expect } from '@playwright/test'
-import { pickByName, selectedOption, waitForReady } from './_helpers'
+import {
+  advanceUntilVisible,
+  choiceCardByName,
+  pickByName,
+  selectedOption,
+  waitForReady,
+} from './_helpers'
 
 /**
  * Visual / interactive contract for the WizShell Class step master-detail:
@@ -20,8 +26,10 @@ import { pickByName, selectedOption, waitForReady } from './_helpers'
  * the detail pane fails to mount, ability listing fails to render.
  */
 test('selecting a class marks it selected and reveals its trees', async ({ page }) => {
-  await page.goto('/pilots/new')
+  await page.goto('/pilots/new?mode=guided')
   await waitForReady(page)
+  // The Class step is no longer the landing step — "Your Stats" precedes it.
+  await advanceUntilVisible(page, choiceCardByName(page, 'Engineer'))
 
   // Pre-selection: nothing is chosen.
   await expect(selectedOption(page)).toHaveCount(0)
@@ -38,8 +46,10 @@ test('selecting a class marks it selected and reveals its trees', async ({ page 
 })
 
 test('switching class moves the selection', async ({ page }) => {
-  await page.goto('/pilots/new')
+  await page.goto('/pilots/new?mode=guided')
   await waitForReady(page)
+  // The Class step is no longer the landing step — "Your Stats" precedes it.
+  await advanceUntilVisible(page, choiceCardByName(page, 'Engineer'))
 
   await pickByName(page, 'Engineer')
   await expect(selectedOption(page)).toContainText('Engineer')

--- a/apps/itun/e2e/crawler-build.e2e.ts
+++ b/apps/itun/e2e/crawler-build.e2e.ts
@@ -1,83 +1,93 @@
-import { test, expect } from '@playwright/test'
-import { clickNext, pickByName, waitForReady } from './_helpers'
+import { test, expect, type Page } from '@playwright/test'
+import { advanceUntilVisible, fillIdentity, pickByName, waitForReady } from './_helpers'
 
 /**
- * Crawler build + edit on the WizShell skeleton (plan 3.2/3.6):
- * Crawler (crawler-type entity cards, radio) -> Systems (Sel grid) ->
- * Crew (bay-NPC details) -> Identity -> Review -> 'Create Crawler ✦'.
+ * Drive the wizard to a created 'Iron Wagon'. Three steps gate — Crawler Type,
+ * Armament Bay (at least one weapon) and Name — and everything between them is
+ * informational, so each is reached by its own content rather than by counting
+ * Next clicks.
+ */
+async function buildIronWagon(page: Page): Promise<void> {
+  await page.goto('/crawlers/new?mode=guided')
+  await waitForReady(page)
+
+  // Crawler Type — one entity card per type.
+  await pickByName(page, 'Battle')
+
+  // Armament Bay — gated until the bay holds a weapon. The offered weapons
+  // depend on the crawler's tech level, so take the first on offer instead of
+  // naming one.
+  await advanceUntilVisible(page, page.getByRole('heading', { name: /Arm the Armament Bay/i }))
+  const weapon = page.locator('[aria-pressed="false"], [aria-checked="false"]').first()
+  await expect(weapon).toBeVisible()
+  await weapon.click()
+
+  // Name — a click-to-edit control, not the labelled input this spec once used.
+  const nameEditor = page.getByLabel(/^Edit crawler name$/i)
+  await advanceUntilVisible(page, nameEditor)
+  await fillIdentity(page, 'crawler name', 'Iron Wagon')
+
+  const createCrawler = page.getByRole('button', { name: /Create Crawler/i })
+  await advanceUntilVisible(page, createCrawler)
+  await createCrawler.click()
+  await page.waitForURL((url) => url.pathname === '/', { timeout: 15_000 })
+  await waitForReady(page)
+}
+
+/**
+ * Crawler build — steps through the crawler wizard and submits, then arms the
+ * created crawler from its live sheet.
+ *
+ * The wizard is Crawler Type → Statistics → Armament Bay → Crew → Name →
+ * Review. Only the Name step gates, and its field is a click-to-edit control
+ * ("Edit crawler name"), not the labelled `Crawler Name` input this spec used
+ * to fill. Walk to the steps by content rather than counting Next clicks, so
+ * the next reshuffle does not silently strand this spec on the wrong step.
+ *
  * Tech level is fixed at TL1 on create; bays are not chosen — every crawler
  * seeds the full SRD bay set on creation.
  */
 test('build a crawler from scratch', async ({ page }) => {
-  await page.goto('/crawlers/new?mode=guided')
-  await waitForReady(page)
-
-  // Step 1 — Crawler. One entity card per crawler type; pick Battle.
-  await pickByName(page, 'Battle')
-  await clickNext(page) // -> Systems
-
-  // Step 2 — Systems (optional; capacity is soft)
-  await clickNext(page) // -> Crew
-
-  // Step 3 — Crew (bay-NPC details all optional)
-  await clickNext(page) // -> Identity
-
-  // Step 4 — Identity
-  await page.getByLabel(/Crawler Name/i).fill('Iron Wagon')
-  await clickNext(page) // -> Review
-
-  // Step 5 — Review -> create
-  await page.getByRole('button', { name: /Create Crawler/i }).click()
-
-  await page.waitForURL((url) => url.pathname === '/', { timeout: 15_000 })
+  await buildIronWagon(page)
   await expect(page.getByText('Iron Wagon').first()).toBeVisible({
     timeout: 15_000,
   })
 })
 
 /**
- * Crawler edit round-trip (plan 3.6): open the created crawler's edit route
- * from the detail page, install a system, save, and confirm the upsert branch
- * saved in place (back on the detail page, no duplicate).
+ * Crawler edit round-trip. /crawlers/$id is now a bare redirect and there is no
+ * /crawlers/$id/edit route — the detail page was collapsed into the live sheet,
+ * the Free Edit surface under ADR-021. Intent is unchanged: change the crawler
+ * after creation and have the change persist.
  */
-test('edit a crawler via /crawlers/$id/edit', async ({ page }) => {
-  // Build first.
-  await page.goto('/crawlers/new?mode=guided')
-  await waitForReady(page)
-  await pickByName(page, 'Battle')
-  await clickNext(page) // -> Systems
-  await clickNext(page) // -> Crew
-  await clickNext(page) // -> Identity
-  await page.getByLabel(/Crawler Name/i).fill('Iron Wagon')
-  await clickNext(page) // -> Review
-  await page.getByRole('button', { name: /Create Crawler/i }).click()
-  await page.waitForURL((url) => url.pathname === '/', { timeout: 15_000 })
+test('arm a crawler further from its live sheet', async ({ page }) => {
+  await buildIronWagon(page)
 
-  // Open the crawler detail page from the dashboard, then Edit.
+  // Open the crawler's live sheet from its roster row.
   await page
     .locator('li', { hasText: 'Iron Wagon' })
     .getByRole('link', { name: /^View$/ })
     .click()
-  await page.waitForURL(/\/crawlers\//, { timeout: 15_000 })
-  await page.getByRole('link', { name: /^Edit$/ }).click()
-  await page.waitForURL(/\/crawlers\/.+\/edit/, { timeout: 15_000 })
+  await page.waitForURL(/\/sheet\/crawler\//, { timeout: 15_000 })
   await waitForReady(page)
 
-  // Wizard is prefilled (type chosen), eyebrow flips to edit mode.
-  await expect(page.getByText('Edit Crawler')).toBeVisible()
-  await clickNext(page) // -> Systems
-  // Install a system in edit mode — pick the first Sel card in the grid.
-  await page.locator('div[role="button"]').first().click()
-  await clickNext(page) // -> Crew
-  await clickNext(page) // -> Identity (prefilled)
-  await clickNext(page) // -> Review
-  await page.getByRole('button', { name: /Save Crawler/i }).click()
+  // '+ Add weapons system' opens CrawlerSystemsEditModal, whose searcher runs
+  // in toggle mode — click the selectable cell itself, not its prose.
+  await page.getByRole('button', { name: /^Add weapons system$/i }).click()
+  const picker = page.getByRole('dialog')
+  await expect(picker).toBeVisible()
+  const weapon = picker.locator('[aria-pressed="false"], [aria-checked="false"]').first()
+  await expect(weapon).toBeVisible()
+  await weapon.click()
+  await page.keyboard.press('Escape')
+  await expect(picker).toBeHidden()
 
-  // Save navigates back to the detail page — the same record, edited.
-  await page.waitForURL((url) => /\/crawlers\/[^/]+$/.test(url.pathname), {
-    timeout: 15_000,
-  })
-  await expect(page.getByText('Iron Wagon').first()).toBeVisible({
-    timeout: 15_000,
-  })
+  // The bay's installed count is the write-through's visible effect, and it
+  // survives a reload (IndexedDB, same record — no duplicate crawler).
+  await expect(page.getByText('No weapons installed.')).toHaveCount(0)
+
+  await page.reload()
+  await waitForReady(page)
+  await expect(page.getByText('No weapons installed.')).toHaveCount(0)
+  await expect(page.getByText('Iron Wagon').first()).toBeVisible({ timeout: 15_000 })
 })

--- a/apps/itun/e2e/crawler-build.e2e.ts
+++ b/apps/itun/e2e/crawler-build.e2e.ts
@@ -9,7 +9,7 @@ import { clickNext, pickByName, waitForReady } from './_helpers'
  * seeds the full SRD bay set on creation.
  */
 test('build a crawler from scratch', async ({ page }) => {
-  await page.goto('/crawlers/new')
+  await page.goto('/crawlers/new?mode=guided')
   await waitForReady(page)
 
   // Step 1 — Crawler. One entity card per crawler type; pick Battle.
@@ -42,7 +42,7 @@ test('build a crawler from scratch', async ({ page }) => {
  */
 test('edit a crawler via /crawlers/$id/edit', async ({ page }) => {
   // Build first.
-  await page.goto('/crawlers/new')
+  await page.goto('/crawlers/new?mode=guided')
   await waitForReady(page)
   await pickByName(page, 'Battle')
   await clickNext(page) // -> Systems

--- a/apps/itun/e2e/crawler-corner-cases.e2e.ts
+++ b/apps/itun/e2e/crawler-corner-cases.e2e.ts
@@ -1,58 +1,65 @@
 import { test, expect } from '@playwright/test'
-import { clickNext, pickByName, waitForReady } from './_helpers'
+import { advanceUntilVisible, clickNext, fillIdentity, pickByName, waitForReady } from './_helpers'
 
 /**
- * CrawlerBuilder corner cases (WizShell flow: Crawler -> Systems -> Crew ->
- * Identity -> Review):
- *  - The CTA is gated: disabled on the Crawler step until a crawler type card
- *    is picked, disabled again on Identity until a name is entered.
- *  - The Systems step reveals the Sel grid (new crawlers are fixed at TL1, so
- *    the offer is the TL1-and-below systems; tech level is raised later on the
- *    live sheet, not in the wizard).
+ * CrawlerBuilder corner cases. The wizard is Crawler Type → Statistics →
+ * Armament Bay → Crew → Name → Review; three steps gate (type, at least one
+ * weapon, a name) and the rest are informational.
+ *
+ * This previously described a Crawler → Systems → Crew → Identity flow and
+ * filled a labelled `Crawler Name` input. The name is now a click-to-edit
+ * control ("Edit crawler name"), and the systems grid is the Armament Bay step.
+ * Steps are reached by their content rather than by counting Next clicks, so an
+ * inserted step does not strand these assertions on the wrong screen.
  *
  * Crawler types render as `ReferenceEntityCard` radio cells (role="radio",
  * aria-checked) whose accessible name is the type name ('Augmented' … 'Trade
  * Caravan') — `pickByName` matches radios as well as buttons.
- * Systems render as Sel-wrapped `<div role="button">` cards, so
- * `div[role="button"]` counts only system cards, never the nav buttons. The
- * primary CTA is labelled from the steps array ('Next · Systems →' etc.) and
- * matched via the /^Next ·/ prefix.
  */
 
-test('wizard gates progress until type + name are set', async ({ page }) => {
+test('wizard gates progress until type, armament and name are set', async ({ page }) => {
   await page.goto('/crawlers/new?mode=guided')
   await waitForReady(page)
 
   const next = page.getByRole('button', { name: /^Next ·/ })
 
-  // Crawler step — CTA disabled until a crawler type is chosen.
+  // Crawler Type — CTA disabled until a type is chosen.
   await expect(next).toBeDisabled()
   await pickByName(page, 'Battle')
   await expect(next).toBeEnabled()
 
-  // Crawler -> Systems -> Crew -> Identity
-  await clickNext(page)
-  await clickNext(page)
-  await clickNext(page)
+  // Armament Bay — gated until the bay holds a weapon.
+  await advanceUntilVisible(page, page.getByRole('heading', { name: /Arm the Armament Bay/i }))
+  await expect(next).toBeDisabled()
+  const weapon = page.locator('[aria-pressed="false"], [aria-checked="false"]').first()
+  await expect(weapon).toBeVisible()
+  await weapon.click()
+  await expect(next).toBeEnabled()
 
-  // Identity step — CTA disabled until a name is entered.
-  await expect(page.getByRole('button', { name: /^Next ·/ })).toBeDisabled()
-  await page.getByLabel(/Crawler Name/i).fill('Wagon')
-  await expect(page.getByRole('button', { name: /^Next ·/ })).toBeEnabled()
+  // Name — gated until the crawler is named.
+  const nameEditor = page.getByLabel(/^Edit crawler name$/i)
+  await advanceUntilVisible(page, nameEditor)
+  await expect(next).toBeDisabled()
+  await fillIdentity(page, 'crawler name', 'Wagon')
+  await expect(next).toBeEnabled()
 
-  // Identity -> Review — Create is enabled.
+  // Name -> Review — Create is enabled.
   await clickNext(page)
   await expect(page.getByRole('button', { name: /Create Crawler/i })).toBeEnabled()
 })
 
-test('Systems step reveals the Sel grid for a new (TL1) crawler', async ({ page }) => {
+test('the Armament Bay offers weapons for a new (TL1) crawler', async ({ page }) => {
   await page.goto('/crawlers/new?mode=guided')
   await waitForReady(page)
 
-  // Crawler step -> pick a type -> advance to Systems.
   await pickByName(page, 'Battle')
-  await clickNext(page)
+  await advanceUntilVisible(page, page.getByRole('heading', { name: /Arm the Armament Bay/i }))
 
-  // At least one system Sel card (div[role="button"]) should be visible.
-  await expect(page.locator('div[role="button"]').first()).toBeVisible()
+  // New crawlers are fixed at TL1, so the offer is the TL1-and-below weapon
+  // systems; tech level is raised later on the live sheet, not in the wizard.
+  // Assert on selectable cells rather than `div[role="button"]`, which counts
+  // whatever happens to be rendered as a div-button anywhere on the page.
+  const options = page.locator('[aria-pressed], [aria-checked]')
+  await expect(options.first()).toBeVisible()
+  expect(await options.count()).toBeGreaterThan(0)
 })

--- a/apps/itun/e2e/crawler-corner-cases.e2e.ts
+++ b/apps/itun/e2e/crawler-corner-cases.e2e.ts
@@ -20,7 +20,7 @@ import { clickNext, pickByName, waitForReady } from './_helpers'
  */
 
 test('wizard gates progress until type + name are set', async ({ page }) => {
-  await page.goto('/crawlers/new')
+  await page.goto('/crawlers/new?mode=guided')
   await waitForReady(page)
 
   const next = page.getByRole('button', { name: /^Next ·/ })
@@ -46,7 +46,7 @@ test('wizard gates progress until type + name are set', async ({ page }) => {
 })
 
 test('Systems step reveals the Sel grid for a new (TL1) crawler', async ({ page }) => {
-  await page.goto('/crawlers/new')
+  await page.goto('/crawlers/new?mode=guided')
   await waitForReady(page)
 
   // Crawler step -> pick a type -> advance to Systems.

--- a/apps/itun/e2e/display-verification.e2e.ts
+++ b/apps/itun/e2e/display-verification.e2e.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { pickByName, waitForReady, clickNext } from './_helpers'
+import { advanceUntilVisible, buildPilot, openSheetFor, pickByName, waitForReady } from './_helpers'
 
 /**
  * Display verification — confirms that the right *information* renders on
@@ -37,8 +37,10 @@ test.describe('ability cards show their descriptions', () => {
   test('Engineering Expertise card includes its rules text', async ({ page }) => {
     await page.goto('/pilots/new?mode=guided')
     await waitForReady(page)
+    // The first-Ability pool now lives on the SAME step as the class, so the
+    // ability's rules text is on screen as soon as a class is picked — the
+    // clickNext that used to be here advanced past it to Equipment.
     await pickByName(page, 'Engineer')
-    await clickNext(page)
 
     // The description (per SU SRD) mentions "questions" about
     // mechanical/engineering topics. Match a phrase fragment to stay
@@ -54,6 +56,10 @@ test.describe('chassis cards show stats from the SRD', () => {
     await page.goto('/mechs/new?mode=guided')
     await waitForReady(page)
 
+    // The mech wizard opens on the informational "Gain Scrap" step, so the
+    // chassis list is one step in.
+    await advanceUntilVisible(page, page.getByRole('heading', { name: /Craft your Mech Chassis/i }))
+
     // Mule should be present in the chassis row list.
     await expect(page.getByText(/^Mule$/).first()).toBeVisible()
 
@@ -67,59 +73,28 @@ test.describe('chassis cards show stats from the SRD', () => {
 })
 
 test.describe('dashboard surfaces created entities with their identity', () => {
-  test('newly built pilot shows up in the dashboard list with their name', async ({ page }) => {
-    await page.goto('/pilots/new?mode=guided')
-    await waitForReady(page)
-    await pickByName(page, 'Engineer')
-    await clickNext(page)
-    await clickNext(page)
-    await clickNext(page)
-    await page.getByLabel(/^Name/).fill('Display Test Pilot')
-    await page.getByLabel(/Callsign/).fill('DTP')
-    await clickNext(page)
-    await clickNext(page)
-    await page.getByRole('button', { name: /Create Pilot/i }).click()
-
-    // onComplete navigates to '/'; wait for that navigation then assert
-    // immediately — the Zustand in-memory store already holds the created
-    // pilot, so no extra page.goto('/') reload is needed (and adding one
-    // can race with the IndexedDB re-hydration that happens on mount).
-    await page.waitForURL(/\/(pilots\/|$)/, { timeout: 15_000 })
+  test('newly built pilot shows up in the roster with their name', async ({ page }) => {
+    // Drive the wizard through the shared builder rather than a fixed number
+    // of Next clicks — that count was wrong the moment a step was inserted.
+    // buildPilot lands back on the roster.
+    await buildPilot(page, 'Display Test Pilot', 'DTP')
 
     // Name is displayed.
     await expect(page.getByText('Display Test Pilot').first()).toBeVisible({ timeout: 15_000 })
-    // EntityListItem renders a "View" and "Sheet" link for each entity.
+    // EntityRow renders one link per entity, to its live sheet. It is labelled
+    // "View"; the second "Sheet" link this used to expect no longer exists.
     await expect(page.getByRole('link', { name: /^View$/ }).first()).toBeVisible()
-    await expect(page.getByRole('link', { name: /^Sheet$/ }).first()).toBeVisible()
   })
 })
 
 test.describe('sheet renders the right pilot identity', () => {
   test('opening a pilot sheet shows their name and class context', async ({ page }) => {
-    await page.goto('/pilots/new?mode=guided')
-    await waitForReady(page)
-    await pickByName(page, 'Engineer')
-    await clickNext(page)
-    await pickByName(page, 'Engineering Expertise')
-    await clickNext(page)
-    await page.locator('div[role="button"]').first().click()
-    await clickNext(page)
-    await page.getByLabel(/^Name/).fill('Sheet Name')
-    await page.getByLabel(/Callsign/).fill('SN')
-    await clickNext(page)
-    await clickNext(page)
-    await page.getByRole('button', { name: /Create Pilot/i }).click()
-
-    // onComplete navigates to '/'; wait then interact from there — no extra
-    // page.goto('/') needed (avoids IndexedDB re-hydration race on reload).
-    await page.waitForURL(/\/(pilots\/|$)/, { timeout: 15_000 })
+    // buildPilot deterministically picks Engineer, which is what the ability
+    // assertions below depend on.
+    await buildPilot(page, 'Sheet Name', 'SN')
     await expect(page.getByText('Sheet Name').first()).toBeVisible({ timeout: 15_000 })
-    await page
-      .getByRole('link', { name: /^Sheet$/ })
-      .first()
-      .click()
-    await page.waitForURL(/\/sheet\//)
-    await waitForReady(page)
+
+    await openSheetFor(page, 'Sheet Name')
 
     await expect(page.getByText('Sheet Name').first()).toBeVisible()
     // "Engineering Expertise" contains "Engineer" — the ability is resolved

--- a/apps/itun/e2e/display-verification.e2e.ts
+++ b/apps/itun/e2e/display-verification.e2e.ts
@@ -9,7 +9,7 @@ import { pickByName, waitForReady, clickNext } from './_helpers'
 
 test.describe('class step displays meaningful class info', () => {
   test('class card surfaces ability tree names', async ({ page }) => {
-    await page.goto('/pilots/new')
+    await page.goto('/pilots/new?mode=guided')
     await waitForReady(page)
 
     // Master-detail: selecting a class row renders its full card + ability
@@ -22,7 +22,7 @@ test.describe('class step displays meaningful class info', () => {
   })
 
   test('selected class reveals trees + abilities listing', async ({ page }) => {
-    await page.goto('/pilots/new')
+    await page.goto('/pilots/new?mode=guided')
     await waitForReady(page)
     await pickByName(page, 'Engineer')
 
@@ -35,7 +35,7 @@ test.describe('class step displays meaningful class info', () => {
 
 test.describe('ability cards show their descriptions', () => {
   test('Engineering Expertise card includes its rules text', async ({ page }) => {
-    await page.goto('/pilots/new')
+    await page.goto('/pilots/new?mode=guided')
     await waitForReady(page)
     await pickByName(page, 'Engineer')
     await clickNext(page)
@@ -51,7 +51,7 @@ test.describe('ability cards show their descriptions', () => {
 
 test.describe('chassis cards show stats from the SRD', () => {
   test('Mule chassis card renders its name and at least one stat', async ({ page }) => {
-    await page.goto('/mechs/new')
+    await page.goto('/mechs/new?mode=guided')
     await waitForReady(page)
 
     // Mule should be present in the chassis row list.
@@ -68,7 +68,7 @@ test.describe('chassis cards show stats from the SRD', () => {
 
 test.describe('dashboard surfaces created entities with their identity', () => {
   test('newly built pilot shows up in the dashboard list with their name', async ({ page }) => {
-    await page.goto('/pilots/new')
+    await page.goto('/pilots/new?mode=guided')
     await waitForReady(page)
     await pickByName(page, 'Engineer')
     await clickNext(page)
@@ -96,7 +96,7 @@ test.describe('dashboard surfaces created entities with their identity', () => {
 
 test.describe('sheet renders the right pilot identity', () => {
   test('opening a pilot sheet shows their name and class context', async ({ page }) => {
-    await page.goto('/pilots/new')
+    await page.goto('/pilots/new?mode=guided')
     await waitForReady(page)
     await pickByName(page, 'Engineer')
     await clickNext(page)

--- a/apps/itun/e2e/mech-build.e2e.ts
+++ b/apps/itun/e2e/mech-build.e2e.ts
@@ -9,7 +9,7 @@ import { clickNext, installLoadoutItem, pickByName, waitForReady } from './_help
  * with the mech visible.
  */
 test('build a mech from scratch', async ({ page }) => {
-  await page.goto('/mechs/new')
+  await page.goto('/mechs/new?mode=guided')
   await waitForReady(page)
 
   // Step 1 — Chassis. Mule is a guaranteed SU starter chassis.
@@ -45,7 +45,7 @@ test('build a mech from scratch', async ({ page }) => {
  */
 test('edit a mech loadout via /mechs/$id/edit', async ({ page }) => {
   // Build first.
-  await page.goto('/mechs/new')
+  await page.goto('/mechs/new?mode=guided')
   await waitForReady(page)
   await pickByName(page, 'Mule')
   await clickNext(page) // -> Pattern

--- a/apps/itun/e2e/mech-build.e2e.ts
+++ b/apps/itun/e2e/mech-build.e2e.ts
@@ -1,36 +1,46 @@
 import { test, expect } from '@playwright/test'
-import { clickNext, installLoadoutItem, pickByName, waitForReady } from './_helpers'
+import {
+  advanceUntilVisible,
+  fillIdentity,
+  installLoadoutItem,
+  pickByName,
+  waitForReady,
+} from './_helpers'
 
 /**
- * Mech-only build — steps through the chassis-first WizShell wizard
- * (Chassis -> Pattern -> Loadout -> Identity -> Review) and submits.
- * Verifies the entity-card chassis + pattern steps (radio cells) and the combined
- * Loadout step work in a real browser and that submit lands on the dashboard
- * with the mech visible.
+ * Mech-only build — steps through the Mech Workshop wizard and submits, then
+ * edits the created mech's loadout on its live sheet.
+ *
+ * The wizard is Gain Scrap → Craft your Mech Chassis → Statistics → Craft your
+ * Systems → Craft your Modules → Quirk → Appearance → Name → Review. It used to
+ * be described here as Chassis → Pattern → Loadout → Identity → Review, and
+ * this spec picked a "Custom Pattern" card that no longer exists — chassis are
+ * chosen directly and the loadout is crafted across the Systems/Modules steps.
+ *
+ * Only the chassis step gates, so walk to the steps this test cares about by
+ * their content instead of counting Next clicks.
  */
 test('build a mech from scratch', async ({ page }) => {
   await page.goto('/mechs/new?mode=guided')
   await waitForReady(page)
 
-  // Step 1 — Chassis. Mule is a guaranteed SU starter chassis.
+  // Chassis — Mule is a guaranteed SU starter chassis. pickByName walks past
+  // the ungated Gain Scrap step to reach it.
   await pickByName(page, 'Mule')
-  await clickNext(page) // -> Pattern
 
-  // Step 2 — Pattern. Build a custom, named loadout.
-  await pickByName(page, 'Custom Pattern')
-  await page.getByLabel(/Pattern name/i).fill('Field Rig')
-  await clickNext(page) // -> Loadout
-
-  // Step 3 — Loadout (Systems tab by default; optional, soft budget)
+  // Systems — install one, so the created mech carries a real loadout.
+  const addCargoPod = page.getByRole('button', { name: /^Add (one )?Cargo Pod$/i })
+  await advanceUntilVisible(page, addCargoPod)
   await installLoadoutItem(page, 'Cargo Pod')
-  await clickNext(page) // -> Identity
 
-  // Step 4 — Identity
-  await page.getByLabel(/Mech name/i).fill('Iron Fist')
-  await clickNext(page) // -> Review
+  // Name — a mech's name IS its pattern, behind a click-to-edit field.
+  const nameEditor = page.getByLabel(/^Edit name \/ pattern$/i)
+  await advanceUntilVisible(page, nameEditor)
+  await fillIdentity(page, 'name / pattern', 'Iron Fist')
 
-  // Step 5 — Review -> create
-  await page.getByRole('button', { name: /Create Mech/i }).click()
+  const createMech = page.getByRole('button', { name: /Create Mech/i })
+  await advanceUntilVisible(page, createMech)
+  await createMech.click()
 
   await page.waitForURL((url) => url.pathname === '/', { timeout: 15_000 })
   await expect(page.getByText('Iron Fist').first()).toBeVisible({
@@ -39,50 +49,52 @@ test('build a mech from scratch', async ({ page }) => {
 })
 
 /**
- * Mech edit round-trip (plan 3.6): open the created mech's edit route from
- * the detail page, change the loadout, save, and confirm the upsert branch
- * saved in place (back on the detail page, no duplicate).
+ * Mech edit round-trip. The old /mechs/$id/edit route is gone — /mechs/$id is
+ * now a bare redirect and the per-entity detail page was collapsed into the
+ * live sheet, which under ADR-021 is the Free Edit surface. The intent is
+ * unchanged: change the loadout after creation and have it persist.
  */
-test('edit a mech loadout via /mechs/$id/edit', async ({ page }) => {
+test('edit a mech loadout on its live sheet', async ({ page }) => {
   // Build first.
   await page.goto('/mechs/new?mode=guided')
   await waitForReady(page)
   await pickByName(page, 'Mule')
-  await clickNext(page) // -> Pattern
-  await pickByName(page, 'Custom Pattern')
-  await page.getByLabel(/Pattern name/i).fill('Field Rig')
-  await clickNext(page) // -> Loadout
-  await clickNext(page) // -> Identity
-  await page.getByLabel(/Mech name/i).fill('Iron Fist')
-  await clickNext(page) // -> Review
-  await page.getByRole('button', { name: /Create Mech/i }).click()
-  await page.waitForURL((url) => url.pathname === '/', { timeout: 15_000 })
 
-  // Open the mech detail page from the dashboard row's View link, then Edit.
+  const nameEditor = page.getByLabel(/^Edit name \/ pattern$/i)
+  await advanceUntilVisible(page, nameEditor)
+  await fillIdentity(page, 'name / pattern', 'Iron Fist')
+
+  const createMech = page.getByRole('button', { name: /Create Mech/i })
+  await advanceUntilVisible(page, createMech)
+  await createMech.click()
+  await page.waitForURL((url) => url.pathname === '/', { timeout: 15_000 })
+  await waitForReady(page)
+
+  // Open the mech's live sheet from its roster row.
   await page
     .locator('li', { hasText: 'Iron Fist' })
     .getByRole('link', { name: /^View$/ })
     .click()
-  await page.waitForURL(/\/mechs\//, { timeout: 15_000 })
-  await page.getByRole('link', { name: /^Edit$/ }).click()
-  await page.waitForURL(/\/mechs\/.+\/edit/, { timeout: 15_000 })
+  await page.waitForURL(/\/sheet\/mech\//, { timeout: 15_000 })
   await waitForReady(page)
 
-  // Wizard is prefilled (chassis chosen), eyebrow flips to edit mode. Edit
-  // lands on the custom-loadout path, so the Loadout step is present.
-  await expect(page.getByText('Edit Mech')).toBeVisible()
-  await clickNext(page) // -> Pattern
-  await clickNext(page) // -> Loadout
-  await installLoadoutItem(page, 'Cargo Pod') // install a system in edit mode
-  await clickNext(page) // -> Identity
-  await clickNext(page) // -> Review
-  await page.getByRole('button', { name: /Save Mech/i }).click()
+  // '+ Add system' opens the shared picker, which writes through on toggle.
+  await page.getByRole('button', { name: /^Add system$/i }).click()
+  const picker = page.getByRole('dialog')
+  await expect(picker).toBeVisible()
+  // The systems picker runs the searcher in `mode="count"` (installing the
+  // same System twice is rules-legal), so each row carries an "Add one <name>"
+  // button rather than being a click-to-toggle card. Clicking the card's prose
+  // does nothing at all.
+  await picker.getByRole('button', { name: /^Add (one )?Cargo Pod$/i }).click()
+  await page.keyboard.press('Escape')
+  await expect(picker).toBeHidden()
 
-  // Save navigates back to the detail page — the same record, edited.
-  await page.waitForURL((url) => /\/mechs\/[^/]+$/.test(url.pathname), {
-    timeout: 15_000,
-  })
-  await expect(page.getByText('Iron Fist').first()).toBeVisible({
-    timeout: 15_000,
-  })
+  await expect(page.getByText('Cargo Pod').first()).toBeVisible({ timeout: 15_000 })
+
+  // Reload — the edit persisted to IndexedDB against the same record.
+  await page.reload()
+  await waitForReady(page)
+  await expect(page.getByText('Cargo Pod').first()).toBeVisible({ timeout: 15_000 })
+  await expect(page.getByText('Iron Fist').first()).toBeVisible()
 })

--- a/apps/itun/e2e/mech-corner-cases.e2e.ts
+++ b/apps/itun/e2e/mech-corner-cases.e2e.ts
@@ -1,71 +1,65 @@
 import { test, expect } from '@playwright/test'
-import { clickNext, pickByName, waitForReady } from './_helpers'
+import { advanceUntilVisible, clickNext, fillIdentity, pickByName, waitForReady } from './_helpers'
 
 /**
- * MechWizard corner cases (chassis-first WizShell wizard):
- *  - The stepper gates progress: Next is disabled until a chassis is chosen,
- *    then the Pattern step requires a pattern (a custom build needs a name),
- *    then Identity requires a mech name before Create is enabled on Review.
- *  - The combined Loadout step renders the 1fr/300px grid: TL filter chips on
- *    the left, the 'Loadout · {name}' panel with budget tracks on the right,
- *    split by Systems / Modules tabs.
+ * MechWizard corner cases (Mech Workshop wizard):
+ *  - The stepper gates progress: the Chassis step needs a chassis, and the Name
+ *    step needs a name, before Create is enabled on Review.
+ *  - The craft steps show their budget trackers — Scrap plus the slot budget
+ *    for whichever of Systems / Modules is being crafted.
  *
- * The primary CTA is labeled from the steps array ('Next · Pattern →'), so
- * the shared clickNext/^Next ·/ matcher is used throughout.
+ * Both cases were written against a Chassis → Pattern → Loadout → Identity →
+ * Review wizard that no longer exists. There is no "Custom Pattern" card (a
+ * chassis is picked directly), and no combined Loadout step with TL filter
+ * chips and a 'Loadout · {name}' panel — that HUD is edit-mode only
+ * (`if (!isEdit) return undefined` in MechWizard), while create mode shows the
+ * WizTracker pill asserted below. Nothing about the first step is gated either:
+ * "Gain Scrap" is informational, so Next is open from the start.
  */
 
-test('wizard gates progress until chassis + pattern + name are set', async ({ page }) => {
+test('wizard gates progress until chassis + name are set', async ({ page }) => {
   await page.goto('/mechs/new?mode=guided')
   await waitForReady(page)
 
   const next = page.getByRole('button', { name: /^Next ·/ })
 
-  // Chassis step — Next disabled until a chassis is chosen.
+  // Step 1 (Gain Scrap) is informational — nothing to satisfy.
+  await expect(next).toBeEnabled()
+  await clickNext(page)
+
+  // Chassis step — Next is gated until a chassis is chosen.
   await expect(next).toBeDisabled()
   await pickByName(page, 'Mule')
   await expect(next).toBeEnabled()
-  await clickNext(page) // -> Pattern
 
-  // Pattern step — Custom build requires a name before advancing.
+  // Name step — gated until the mech is named (its name IS its pattern).
+  const nameEditor = page.getByLabel(/^Edit name \/ pattern$/i)
+  await advanceUntilVisible(page, nameEditor)
   await expect(next).toBeDisabled()
-  await pickByName(page, 'Custom Pattern')
-  await expect(next).toBeDisabled()
-  await page.getByLabel(/Pattern name/i).fill('Field Rig')
-  await expect(next).toBeEnabled()
-  await clickNext(page) // -> Loadout
-  await clickNext(page) // -> Identity (loadout optional)
-
-  // Identity step — Next disabled until a name is entered.
-  await expect(next).toBeDisabled()
-  await page.getByLabel(/Mech name/i).fill('Iron Fist')
+  await fillIdentity(page, 'name / pattern', 'Iron Fist')
   await expect(next).toBeEnabled()
 
-  // Identity -> Review — Create is enabled.
+  // Review — Create is enabled.
   await clickNext(page)
   await expect(page.getByRole('button', { name: /Create Mech/i })).toBeEnabled()
 })
 
-test('loadout step shows TL filter chips and the Loadout budget panel', async ({ page }) => {
+test('the craft steps show their scrap and slot budget trackers', async ({ page }) => {
   await page.goto('/mechs/new?mode=guided')
   await waitForReady(page)
 
-  // Chassis -> Pattern (custom) -> Loadout.
   await pickByName(page, 'Mule')
-  await clickNext(page) // -> Pattern
-  await pickByName(page, 'Custom Pattern')
-  await page.getByLabel(/Pattern name/i).fill('Field Rig')
-  await clickNext(page) // -> Loadout
 
-  // Left column — TL filter chips.
-  await expect(page.getByRole('button', { name: 'TL1' })).toBeVisible()
-  await expect(page.getByRole('button', { name: 'TL6' })).toBeVisible()
+  // Systems craft step — Scrap plus the System Slots budget.
+  const systemSlots = page.getByTestId('system-slot-count')
+  await advanceUntilVisible(page, systemSlots)
+  await expect(page.getByTestId('scrap-remaining')).toBeVisible()
+  await expect(systemSlots).toHaveText(/\d+ \/ \d+/)
 
-  // Right column — Loadout panel with the pip budget tracks (Systems tab).
-  await expect(page.getByText(/Loadout ·/)).toBeVisible()
-  await expect(page.getByText(/System Slots ·/i)).toBeVisible()
-  await expect(page.getByText(/Energy ·/i).first()).toBeVisible()
-
-  // The Modules tab shows its own budget track.
-  await page.getByRole('tab', { name: 'Modules' }).click()
-  await expect(page.getByText(/Module Slots ·/i)).toBeVisible()
+  // Modules craft step — Scrap plus its own Module Slots budget. These are
+  // separate steps now, not two tabs of one Loadout step.
+  const moduleSlots = page.getByTestId('module-slot-count')
+  await advanceUntilVisible(page, moduleSlots)
+  await expect(page.getByTestId('scrap-remaining')).toBeVisible()
+  await expect(moduleSlots).toHaveText(/\d+ \/ \d+/)
 })

--- a/apps/itun/e2e/mech-corner-cases.e2e.ts
+++ b/apps/itun/e2e/mech-corner-cases.e2e.ts
@@ -15,7 +15,7 @@ import { clickNext, pickByName, waitForReady } from './_helpers'
  */
 
 test('wizard gates progress until chassis + pattern + name are set', async ({ page }) => {
-  await page.goto('/mechs/new')
+  await page.goto('/mechs/new?mode=guided')
   await waitForReady(page)
 
   const next = page.getByRole('button', { name: /^Next ·/ })
@@ -46,7 +46,7 @@ test('wizard gates progress until chassis + pattern + name are set', async ({ pa
 })
 
 test('loadout step shows TL filter chips and the Loadout budget panel', async ({ page }) => {
-  await page.goto('/mechs/new')
+  await page.goto('/mechs/new?mode=guided')
   await waitForReady(page)
 
   // Chassis -> Pattern (custom) -> Loadout.

--- a/apps/itun/e2e/pilot-build.e2e.ts
+++ b/apps/itun/e2e/pilot-build.e2e.ts
@@ -1,80 +1,95 @@
 import { test, expect } from '@playwright/test'
-import { clickNext, pickByName, waitForReady } from './_helpers'
+import { advanceUntilVisible, clickNext, pickByName, waitForReady } from './_helpers'
 
 /**
- * Pilot wizard happy path on the WizShell skeleton (plan 3.2/3.6) — create a
- * pilot, then EDIT it (add a 4th, level-2 ability — advancement beyond the
- * creation budget), reload, and verify persistence. Runs through a real
- * browser engine so it catches Chromium-level CSS/interaction issues the
+ * Pilot wizard happy path — create a pilot, then EDIT it (add a second ability
+ * beyond the creation budget), reload, and verify persistence. Runs through a
+ * real browser engine so it catches Chromium-level CSS/interaction issues the
  * happy-dom integration tests can't.
+ *
+ * CREATION BUDGETS ARE THE RULEBOOK'S, NOT THIS FILE'S. A pilot starts with
+ * exactly **1** Ability (Core Book p.18) and **2** Tech 1 Equipment (p.19) —
+ * `PILOT_CREATION_ABILITY_PICKS` / `PILOT_CREATION_EQUIPMENT_PICKS` in
+ * `salvageunion-reference/lib/rules/creation.ts` are the source of truth. This
+ * spec previously walked a separate "Abilities" step and asserted `3 / 3`,
+ * which had stopped matching both the wizard's shape and the rule it was
+ * meant to be guarding. If these numbers ever disagree with the constants
+ * again, fix whichever is wrong by checking the book — do not simply relax
+ * the test to whatever the app currently does.
  */
-test('build a pilot from scratch, then edit to add a 4th ability', async ({ page }) => {
-  await page.goto('/pilots/new')
+test('build a pilot from scratch, then edit to add a second ability', async ({ page }) => {
+  await page.goto('/pilots/new?mode=guided')
   await waitForReady(page)
 
-  // Step 1: Class — selectable class entity cards, ability pool below
+  // Step 1: Your Stats — derived starting values, nothing to choose.
+  await clickNext(page)
+
+  // Step 2: Class & Ability — the class, then exactly one Ability from the
+  // trees that class reveals. Both halves gate Next.
   await pickByName(page, 'Engineer')
-  await clickNext(page)
-
-  // Step 2: Abilities — three level-1 picks across Engineer's trees,
-  // live 'n / 3' count in the subtitle
   await pickByName(page, 'Engineering Expertise')
-  await pickByName(page, 'Jury Rig')
-  await pickByName(page, 'Mass Field Maintenance')
-  await expect(page.getByTestId('ability-count')).toHaveText(/3 \/ 3 selected/)
+  await expect(page.getByTestId('ability-count')).toHaveText('1 / 1')
   await clickNext(page)
 
-  // Step 3: Equipment — pick the first TL1 card (Sel-wrapped, aria-labelled)
-  const equipmentCards = page.locator('div[role="button"]')
-  await expect(equipmentCards.first()).toBeVisible()
-  await equipmentCards.first().click()
+  // Step 3: Equipment — exactly two Tech 1 picks.
+  const equipmentOptions = page.locator('[aria-pressed="false"], [aria-checked="false"]')
+  await expect(equipmentOptions.first()).toBeVisible()
+  await equipmentOptions.first().click()
+  await equipmentOptions.first().click()
+  await expect(page.getByTestId('equipment-count')).toHaveText('2 / 2')
   await clickNext(page)
 
-  // Step 4: Identity — name + callsign are required
+  // Step 4: identity — name + callsign both required before Next opens.
   await page.getByLabel(/^Name/).fill('Mira Voss')
   await page.getByLabel(/Callsign/).fill('Sparks')
-  await clickNext(page)
 
-  // Step 5: Background (optional)
-  await clickNext(page)
+  // Steps 5-8 (Background / Motto / Keepsake / Appearance) are optional prose.
+  // Walk to the Create CTA rather than counting them, so inserting or removing
+  // an optional step does not break this spec — the mistake that put the whole
+  // suite on the floor.
+  const createPilot = page.getByRole('button', { name: /Create Pilot/i })
+  await advanceUntilVisible(page, createPilot)
 
-  // Step 6: Review → Create Pilot ✦
-  await expect(page.getByText(/Mira Voss/)).toBeVisible()
-  await expect(page.getByText(/Sparks/)).toBeVisible()
-  await page.getByRole('button', { name: /Create Pilot/i }).click()
+  // Review shows what we entered.
+  await expect(page.getByText(/Mira Voss/).first()).toBeVisible()
+  await expect(page.getByText(/Sparks/).first()).toBeVisible()
+  await createPilot.click()
 
-  // After submission we land on the dashboard.
+  // After submission we land on the roster.
   await page.waitForURL(/\/$/, { timeout: 15_000 })
   await waitForReady(page)
   await expect(page.getByText('Mira Voss').first()).toBeVisible({
     timeout: 15_000,
   })
 
-  // --- Edit flow (plan 3.1/3.3): /pilots/$id/edit via detail page ---
+  // --- Advancement, on the live sheet ---
+  //
+  // This used to walk /pilots/$id → /pilots/$id/edit and re-run the wizard in
+  // "edit mode". Both routes are gone: /pilots/$id is now a bare redirect
+  // (see its route file) and the per-entity detail page was collapsed into the
+  // live sheet, which under ADR-021 is the Free Edit surface — you edit in
+  // place rather than replaying Guided Creation. The INTENT is unchanged and is
+  // what matters: an ability beyond the creation budget can be added, and it
+  // persists.
   await page
     .getByRole('link', { name: /^View$/ })
     .first()
     .click()
-  await page.waitForURL(/\/pilots\/[^/]+$/)
-  await page.getByRole('link', { name: /^Edit$/ }).click()
-  await page.waitForURL(/\/pilots\/[^/]+\/edit$/)
+  await page.waitForURL(/\/sheet\/pilot\//, { timeout: 15_000 })
   await waitForReady(page)
 
-  // Wizard opens in edit mode, prefilled — class step Next is enabled.
-  await expect(page.getByText('Edit Pilot')).toBeVisible()
-  await clickNext(page)
+  // The Abilities section's '+ Add ability' opens the one shared picker modal.
+  // It writes through on toggle — there is no Save button to press.
+  await page.getByRole('button', { name: /^Add ability$/i }).click()
+  const picker = page.getByRole('dialog')
+  await expect(picker).toBeVisible()
 
-  // Abilities in edit mode: all levels offered (Slab groups), uncapped.
-  // 'Talk Shop' is Mechanical Knowledge level 2 — a legal 4th pick.
-  await pickByName(page, 'Talk Shop')
-  await clickNext(page) // Equipment
-  await clickNext(page) // Identity (prefilled)
-  await clickNext(page) // Background
-  await clickNext(page) // Review
-  await page.getByRole('button', { name: /Save Pilot/i }).click()
+  // 'Talk Shop' is Mechanical Knowledge level 2, so creation never offers it —
+  // reaching it here is exactly the advancement-past-the-budget case.
+  await picker.getByText('Talk Shop').first().click()
+  await page.keyboard.press('Escape')
+  await expect(picker).toBeHidden()
 
-  // Save navigates to the pilot detail; the new ability renders there.
-  await page.waitForURL(/\/pilots\/[^/]+$/, { timeout: 15_000 })
   await expect(page.getByText('Talk Shop').first()).toBeVisible({
     timeout: 15_000,
   })
@@ -90,24 +105,31 @@ test('build a pilot from scratch, then edit to add a 4th ability', async ({ page
   await expect(page.getByRole('link', { name: /^View$/ })).toHaveCount(1)
 })
 
-test('ability budget cap renders Budget reached after 3 picks', async ({ page }) => {
-  await page.goto('/pilots/new')
+test('the creation ability budget caps at one pick', async ({ page }) => {
+  await page.goto('/pilots/new?mode=guided')
   await waitForReady(page)
 
   await pickByName(page, 'Engineer')
-  await clickNext(page)
-
   await pickByName(page, 'Engineering Expertise')
-  await pickByName(page, 'Jury Rig')
-  await pickByName(page, 'Mass Field Maintenance')
+  await expect(page.getByTestId('ability-count')).toHaveText('1 / 1')
 
-  // After the third pick, remaining (if any) cards render with the rust
-  // "Budget reached" inline reason. If Engineer's trees have exactly three
-  // level-1 abilities the message may not appear (cap is naturally
-  // enforced), so we tolerate either outcome.
-  const budgetMsg = page.getByText(/Budget reached/i)
-  const count = await budgetMsg.count()
-  expect(count >= 0).toBe(true)
-  // Sanity: the Next CTA is still enabled (abilities are optional).
+  // Further level-1 abilities stay on screen and stay clickable, but the
+  // budget holds: clicking them cannot push the count past the rulebook's one
+  // pick. That invariant — not the presence of any particular affordance — is
+  // what this test guards. It used to look for a "Budget reached" message and
+  // then assert `count >= 0`, which is true of every number, so it could not
+  // fail; the message no longer renders at all.
+  for (const other of ['Jury Rig', 'Mass Field Maintenance']) {
+    const card = page
+      .getByRole('button')
+      .or(page.getByRole('radio'))
+      .filter({ hasText: other })
+      .first()
+    if (!(await card.isVisible().catch(() => false))) continue
+    await card.click().catch(() => {})
+    await expect(page.getByTestId('ability-count')).toHaveText('1 / 1')
+  }
+
+  // And the step stays satisfiable — the budget gates the count, not progress.
   await expect(page.getByRole('button', { name: /^Next ·/ })).toBeEnabled()
 })

--- a/apps/itun/e2e/pilot-corner-cases.e2e.ts
+++ b/apps/itun/e2e/pilot-corner-cases.e2e.ts
@@ -20,7 +20,7 @@ test('cancel mid-wizard leaves the dashboard with no new pilot', async ({ page }
   // carries between tests in the same browser context).
   const initialCount = await page.getByRole('link', { name: /Sheet$/i }).count()
 
-  await page.goto('/pilots/new')
+  await page.goto('/pilots/new?mode=guided')
   await waitForReady(page)
   await pickByName(page, 'Engineer')
   // The form is now dirty (a class was picked), so #334's `confirmCancel`
@@ -39,7 +39,7 @@ test('cancel mid-wizard leaves the dashboard with no new pilot', async ({ page }
 })
 
 test('switching class after picking abilities resets the ability list', async ({ page }) => {
-  await page.goto('/pilots/new')
+  await page.goto('/pilots/new?mode=guided')
   await waitForReady(page)
 
   // Pick Engineer → advance to Abilities → pick one
@@ -60,7 +60,7 @@ test('switching class after picking abilities resets the ability list', async ({
 })
 
 test('Identity step gates Next until name + callsign are present', async ({ page }) => {
-  await page.goto('/pilots/new')
+  await page.goto('/pilots/new?mode=guided')
   await waitForReady(page)
   await pickByName(page, 'Engineer')
   await clickNext(page)
@@ -81,7 +81,7 @@ test('Identity step gates Next until name + callsign are present', async ({ page
 })
 
 test('4th ability pick is blocked once the budget is reached', async ({ page }) => {
-  await page.goto('/pilots/new')
+  await page.goto('/pilots/new?mode=guided')
   await waitForReady(page)
   await pickByName(page, 'Engineer')
   await clickNext(page)
@@ -97,7 +97,7 @@ test('4th ability pick is blocked once the budget is reached', async ({ page }) 
 })
 
 test('4th equipment pick is blocked once the budget is reached', async ({ page }) => {
-  await page.goto('/pilots/new')
+  await page.goto('/pilots/new?mode=guided')
   await waitForReady(page)
   await pickByName(page, 'Engineer')
   await clickNext(page)

--- a/apps/itun/e2e/pilot-corner-cases.e2e.ts
+++ b/apps/itun/e2e/pilot-corner-cases.e2e.ts
@@ -1,16 +1,20 @@
 import { test, expect } from '@playwright/test'
-import { clickNext, pickByName, waitForReady } from './_helpers'
+import { advanceUntilVisible, clickNext, pickByName, waitForReady } from './_helpers'
 
 /**
  * Pilot wizard corner cases that the happy-path test doesn't cover:
  *  - Cancelling mid-wizard does not leave a pilot in the store.
- *  - Switching class after picking abilities clears the previous picks
+ *  - Switching class after picking an ability clears the previous pick
  *    (different class trees → different ability set) — create mode only.
- *  - The Identity step gates Next until both name and callsign are present.
- *  - Picking a 4th ability after the 3-pick budget is hit is a no-op
- *    (the budget-reached card is non-interactive).
- *  - Picking a 4th equipment item after the 3-pick budget is hit is
- *    a no-op.
+ *  - The identity step gates Next until both name and callsign are present.
+ *  - Picking past the ability budget is a no-op.
+ *  - Picking past the equipment budget is a no-op.
+ *
+ * The budgets are the rulebook's: exactly 1 Ability (Core Book p.18) and 2
+ * Tech 1 Equipment (p.19) — `PILOT_CREATION_ABILITY_PICKS` /
+ * `PILOT_CREATION_EQUIPMENT_PICKS`. These cases previously asserted a 3-pick
+ * budget and a `3 / 3 selected` counter, neither of which matched the rules or
+ * the UI; if they disagree again, check the book before touching the app.
  */
 
 test('cancel mid-wizard leaves the dashboard with no new pilot', async ({ page }) => {
@@ -38,41 +42,45 @@ test('cancel mid-wizard leaves the dashboard with no new pilot', async ({ page }
   expect(afterCount).toBe(initialCount)
 })
 
-test('switching class after picking abilities resets the ability list', async ({ page }) => {
+test('switching class after picking an ability resets the ability list', async ({ page }) => {
   await page.goto('/pilots/new?mode=guided')
   await waitForReady(page)
 
-  // Pick Engineer → advance to Abilities → pick one
+  // Class and first Ability now share one step, so switching class no longer
+  // needs a trip Back — the ability pool re-renders underneath the new class.
   await pickByName(page, 'Engineer')
-  await clickNext(page)
   await pickByName(page, 'Engineering Expertise')
-  // Counter should read 1 / 3 selected.
-  await expect(page.getByTestId('ability-count')).toHaveText(/1 \/ 3 selected/)
+  await expect(page.getByTestId('ability-count')).toHaveText('1 / 1')
 
-  // Back to class step, switch to Scout.
-  await page.getByRole('button', { name: /^Back$/ }).click()
+  // Switch to Scout: its trees do not include Engineering Expertise, so the
+  // pick cannot carry over and the counter falls back to empty.
   await pickByName(page, 'Scout')
-  await clickNext(page)
-
-  // Scout's trees should not include Engineering Expertise. Counter
-  // should reset to 0 / 3.
-  await expect(page.getByTestId('ability-count')).toHaveText(/0 \/ 3 selected/)
+  await expect(page.getByTestId('ability-count')).toHaveText('0 / 1')
 })
 
-test('Identity step gates Next until name + callsign are present', async ({ page }) => {
+test('identity step gates Next until name + callsign are present', async ({ page }) => {
   await page.goto('/pilots/new?mode=guided')
   await waitForReady(page)
-  await pickByName(page, 'Engineer')
-  await clickNext(page)
-  await clickNext(page) // skip abilities
-  await clickNext(page) // skip equipment
 
-  // Identity step — required fields. Without filling them, Next is disabled.
+  // Satisfy the gated steps ahead of identity, then walk to it by content
+  // rather than by counting Next clicks.
+  await pickByName(page, 'Engineer')
+  await pickByName(page, 'Engineering Expertise')
+  await clickNext(page)
+  const equipmentOptions = page.locator('[aria-pressed="false"], [aria-checked="false"]')
+  await expect(equipmentOptions.first()).toBeVisible()
+  await equipmentOptions.first().click()
+  await equipmentOptions.first().click()
+
+  const nameField = page.getByLabel(/^Name/)
+  await advanceUntilVisible(page, nameField)
+
+  // Identity step — both fields required. Without them, Next is disabled.
   const next = page.getByRole('button', { name: /^Next ·/ })
   await expect(next).toBeDisabled()
 
   // Fill only the name, leave callsign blank.
-  await page.getByLabel(/^Name/).fill('Only Name')
+  await nameField.fill('Only Name')
   await expect(next).toBeDisabled()
 
   // Add callsign — Next enables.
@@ -80,37 +88,48 @@ test('Identity step gates Next until name + callsign are present', async ({ page
   await expect(next).toBeEnabled()
 })
 
-test('4th ability pick is blocked once the budget is reached', async ({ page }) => {
+test('a further ability pick is blocked once the budget is reached', async ({ page }) => {
   await page.goto('/pilots/new?mode=guided')
   await waitForReady(page)
   await pickByName(page, 'Engineer')
-  await clickNext(page)
   await pickByName(page, 'Engineering Expertise')
-  await pickByName(page, 'Jury Rig')
-  await pickByName(page, 'Mass Field Maintenance')
-  await expect(page.getByTestId('ability-count')).toHaveText(/3 \/ 3 selected/)
+  await expect(page.getByTestId('ability-count')).toHaveText('1 / 1')
 
-  // At budget the notice renders ONCE, in the wizard footer beside the
-  // buttons ("Max Abilities selected") — blocked cards just grey out.
-  await expect(page.getByText(/Max Abilities selected \(3 \/ 3\)/i)).toBeVisible()
-  await expect(page.getByTestId('ability-count')).toHaveText(/3 \/ 3 selected/)
+  // Other level-1 abilities stay on screen and stay clickable; the budget is
+  // what holds. The old "Max Abilities selected (3 / 3)" footer notice no
+  // longer exists anywhere in the app, so assert the invariant that matters —
+  // the count cannot be pushed past the rulebook's single pick.
+  for (const other of ['Jury Rig', 'Mass Field Maintenance']) {
+    const card = page
+      .getByRole('button')
+      .or(page.getByRole('radio'))
+      .filter({ hasText: other })
+      .first()
+    if (!(await card.isVisible().catch(() => false))) continue
+    await card.click().catch(() => {})
+    await expect(page.getByTestId('ability-count')).toHaveText('1 / 1')
+  }
 })
 
-test('4th equipment pick is blocked once the budget is reached', async ({ page }) => {
+test('a further equipment pick is blocked once the budget is reached', async ({ page }) => {
   await page.goto('/pilots/new?mode=guided')
   await waitForReady(page)
   await pickByName(page, 'Engineer')
+  await pickByName(page, 'Engineering Expertise')
   await clickNext(page)
-  await clickNext(page) // skip abilities
-  // Equipment step — click the first three Sel-wrapped cards.
-  const cards = page.locator('div[role="button"]')
-  await cards.nth(0).click()
-  await cards.nth(1).click()
-  await cards.nth(2).click()
-  await expect(page.getByTestId('equipment-count')).toHaveText(/3 \/ 3 selected/)
 
-  // At budget the notice renders ONCE, in the wizard footer beside the
-  // buttons ("Max Equipment selected") — blocked cards just grey out.
-  await expect(page.getByText(/Max Equipment selected \(3 \/ 3\)/i)).toBeVisible()
-  await expect(page.getByTestId('equipment-count')).toHaveText(/3 \/ 3 selected/)
+  // Equipment step — the budget is two Tech 1 picks (p.19).
+  const unpicked = page.locator('[aria-pressed="false"], [aria-checked="false"]')
+  await expect(unpicked.first()).toBeVisible()
+  await unpicked.first().click()
+  await unpicked.first().click()
+  await expect(page.getByTestId('equipment-count')).toHaveText('2 / 2')
+
+  // A third pick cannot exceed the budget. As with abilities, the footer
+  // notice is gone; the count holding at the budget is the real contract.
+  await unpicked
+    .first()
+    .click()
+    .catch(() => {})
+  await expect(page.getByTestId('equipment-count')).toHaveText('2 / 2')
 })

--- a/apps/itun/e2e/pilot-next-button.e2e.ts
+++ b/apps/itun/e2e/pilot-next-button.e2e.ts
@@ -1,32 +1,56 @@
 import { test, expect } from '@playwright/test'
-import { optionCells, pickByName, waitForReady } from './_helpers'
+import {
+  advanceUntilVisible,
+  choiceCardByName,
+  optionCells,
+  pickByName,
+  waitForReady,
+} from './_helpers'
 
 /**
- * Regression guard: selecting a class on Step 1 must enable the Next CTA.
+ * Regression guard: the Class step's Next CTA must open once — and only once —
+ * the step is actually satisfied.
  *
- * The WizShell class step is a master-detail: selectable class entity cards
- * first, then the chosen class's first-Ability pool. A render-time failure
- * inside the detail listing could leave the wizard stuck on the Class step
- * with no way to advance.
+ * The step is a master-detail: selectable class entity cards first, then the
+ * chosen class's first-Ability pool. A render-time failure inside the detail
+ * listing could leave the wizard stuck here with no way to advance.
+ *
+ * The gate is BOTH halves — "Step 2 of 9 · Choose your Pilot and your first
+ * Ability". This test used to assert that picking a class alone enabled Next,
+ * which stopped being true when the step absorbed the first-Ability pick;
+ * asserting the real two-part gate is the stronger guard anyway, because it
+ * fails if EITHER half stops registering.
  */
-test('Next is disabled before class pick and enabled after', async ({ page }) => {
-  await page.goto('/pilots/new')
+test('Next opens only once both class and first ability are picked', async ({ page }) => {
+  await page.goto('/pilots/new?mode=guided')
   await waitForReady(page)
+  // "Your Stats" now precedes the Class step, so the Class step is no longer
+  // the landing step these assertions were written against.
+  await advanceUntilVisible(page, choiceCardByName(page, 'Engineer'))
 
   const next = page.getByRole('button', { name: /^Next ·/ })
   await expect(next).toBeDisabled()
 
+  // Half one: the class. Not enough on its own.
   await pickByName(page, 'Engineer')
+  await expect(next, 'a class alone must not satisfy the class+ability step').toBeDisabled()
+
+  // Half two: a first Ability from the pool the class just revealed
+  // (Engineer / Mechanical Knowledge L1).
+  await pickByName(page, 'Engineering Expertise')
   await expect(next).toBeEnabled()
 
-  // And clicking Next actually advances to the Abilities step.
+  // And clicking Next actually advances to Equipment (step 3 of 9).
   await next.click()
-  await expect(page.getByRole('heading', { name: /Choose Abilities/i })).toBeVisible()
+  await expect(page.getByRole('heading', { name: /Choose your Equipment/i })).toBeVisible()
 })
 
 test('every base class renders a selectable row', async ({ page }) => {
-  await page.goto('/pilots/new')
+  await page.goto('/pilots/new?mode=guided')
   await waitForReady(page)
+  // "Your Stats" now precedes the Class step, so the Class step is no longer
+  // the landing step these assertions were written against.
+  await advanceUntilVisible(page, choiceCardByName(page, 'Engineer'))
 
   // Each base class is a selectable entity card. SU core book has 6 base
   // classes; allow more from additional sources. The stepper, footer and CTA
@@ -42,8 +66,11 @@ test('every base class renders a selectable row', async ({ page }) => {
 })
 
 test('selecting Engineer reveals its abilities in the detail pane', async ({ page }) => {
-  await page.goto('/pilots/new')
+  await page.goto('/pilots/new?mode=guided')
   await waitForReady(page)
+  // "Your Stats" now precedes the Class step, so the Class step is no longer
+  // the landing step these assertions were written against.
+  await advanceUntilVisible(page, choiceCardByName(page, 'Engineer'))
 
   // Selecting the Engineer row renders its trees + abilities in the detail
   // pane directly (no disclosure). The Mechanical Knowledge L1 ability

--- a/apps/itun/e2e/print-preview.e2e.ts
+++ b/apps/itun/e2e/print-preview.e2e.ts
@@ -31,11 +31,16 @@ test.describe('sheet print preview', () => {
     // #334's print CSS hides the <header>, whose condensed copy of the name is
     // a <span>; role=heading targets the visible hero <h1> and dodges it.
     await expect(page.getByRole('heading', { name: 'Print Test' })).toBeVisible()
-    // The class chip should also render — scope to the hero region landmark
-    // (`<section aria-label="… sheet header">`) so we hit the visible MChip,
-    // not any duplicate outside the hero.
+    // The class must also survive print. It is no longer inside the hero
+    // landmark — the poster redesign left `… sheet header` holding just the
+    // <h1> and moved identity fields into the `… pilot details` region — so
+    // scope there. Still scoped rather than page-wide, so this fails if the
+    // class stops rendering rather than matching some unrelated occurrence.
     await expect(
-      page.getByRole('region', { name: /sheet header/i }).getByText('Engineer')
+      page
+        .getByRole('region', { name: /pilot details/i })
+        .getByText('Engineer', { exact: true })
+        .first()
     ).toBeVisible()
     // Stat pips keep their print hooks (filled pips survive the bg reset).
     expect(await page.locator('[data-pip]').count()).toBeGreaterThan(0)
@@ -51,7 +56,10 @@ test.describe('sheet print preview', () => {
 
     await expect(page.getByRole('heading', { name: 'Print Test' })).toBeVisible()
     await expect(
-      page.getByRole('region', { name: /sheet header/i }).getByText('Engineer')
+      page
+        .getByRole('region', { name: /pilot details/i })
+        .getByText('Engineer', { exact: true })
+        .first()
     ).toBeVisible()
   })
 })

--- a/apps/itun/e2e/wired-build-and-snapshot.e2e.ts
+++ b/apps/itun/e2e/wired-build-and-snapshot.e2e.ts
@@ -45,10 +45,12 @@ test('wire pilot + mech + crawler on the live sheets and share a snapshot', asyn
   await page.getByRole('link', { name: /Assigned Pilot: Mira Voss/i }).click()
   await page.waitForURL(/\/sheet\/pilot\//, { timeout: 10_000 })
 
-  // Top-bar Edit is a trailing link into the Phase-3 edit wizard.
-  const editLink = page.getByRole('link', { name: /edit this pilot/i })
-  await expect(editLink).toBeVisible()
-  await expect(editLink).toHaveAttribute('href', /\/pilots\/.+\/edit$/)
+  // There is deliberately no top-bar "edit this pilot" link any more: the edit
+  // wizard route is gone (/pilots/$id is a bare redirect) and the Live Sheet is
+  // itself the Free Edit surface under ADR-021, edited in place per section.
+  // `Sheet-topbar-segments.test.tsx` pins its ABSENCE, so asserting it here
+  // would contradict a unit test rather than guard anything.
+  await expect(page.getByRole('link', { name: /edit this pilot/i })).toHaveCount(0)
 
   // --- Wire the crawler from the pilot sheet's rail ---
   await assignCrawlerOnPilotSheet(page, 'Iron Wagon')

--- a/apps/itun/src/routeTree.gen.ts
+++ b/apps/itun/src/routeTree.gen.ts
@@ -9,30 +9,25 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as EncounterRouteImport } from './routes/encounter'
-import { Route as ChangelogRouteImport } from './routes/changelog'
-import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as SIdRouteImport } from './routes/s/$id'
-import { Route as PilotsNewRouteImport } from './routes/pilots/new'
-import { Route as PilotsIdRouteImport } from './routes/pilots/$id'
-import { Route as MechsNewRouteImport } from './routes/mechs/new'
-import { Route as MechsIdRouteImport } from './routes/mechs/$id'
-import { Route as DashboardIdRouteImport } from './routes/dashboard/$id'
-import { Route as CrawlersNewRouteImport } from './routes/crawlers/new'
+import { Route as AboutRouteImport } from './routes/about'
+import { Route as ChangelogRouteImport } from './routes/changelog'
+import { Route as EncounterRouteImport } from './routes/encounter'
 import { Route as CrawlersIdRouteImport } from './routes/crawlers/$id'
+import { Route as CrawlersNewRouteImport } from './routes/crawlers/new'
+import { Route as DashboardIdRouteImport } from './routes/dashboard/$id'
+import { Route as MechsIdRouteImport } from './routes/mechs/$id'
+import { Route as MechsNewRouteImport } from './routes/mechs/new'
+import { Route as PilotsIdRouteImport } from './routes/pilots/$id'
+import { Route as PilotsNewRouteImport } from './routes/pilots/new'
+import { Route as SIdRouteImport } from './routes/s/$id'
 import { Route as MechsPatternsIndexRouteImport } from './routes/mechs/patterns/index'
 import { Route as SheetKindIdRouteImport } from './routes/sheet/$kind/$id'
 import { Route as SheetKindIdShareRouteImport } from './routes/sheet/$kind/$id_.share'
 
-const EncounterRoute = EncounterRouteImport.update({
-  id: '/encounter',
-  path: '/encounter',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ChangelogRoute = ChangelogRouteImport.update({
-  id: '/changelog',
-  path: '/changelog',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AboutRoute = AboutRouteImport.update({
@@ -40,39 +35,19 @@ const AboutRoute = AboutRouteImport.update({
   path: '/about',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+const ChangelogRoute = ChangelogRouteImport.update({
+  id: '/changelog',
+  path: '/changelog',
   getParentRoute: () => rootRouteImport,
 } as any)
-const SIdRoute = SIdRouteImport.update({
-  id: '/s/$id',
-  path: '/s/$id',
+const EncounterRoute = EncounterRouteImport.update({
+  id: '/encounter',
+  path: '/encounter',
   getParentRoute: () => rootRouteImport,
 } as any)
-const PilotsNewRoute = PilotsNewRouteImport.update({
-  id: '/pilots/new',
-  path: '/pilots/new',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const PilotsIdRoute = PilotsIdRouteImport.update({
-  id: '/pilots/$id',
-  path: '/pilots/$id',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const MechsNewRoute = MechsNewRouteImport.update({
-  id: '/mechs/new',
-  path: '/mechs/new',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const MechsIdRoute = MechsIdRouteImport.update({
-  id: '/mechs/$id',
-  path: '/mechs/$id',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const DashboardIdRoute = DashboardIdRouteImport.update({
-  id: '/dashboard/$id',
-  path: '/dashboard/$id',
+const CrawlersIdRoute = CrawlersIdRouteImport.update({
+  id: '/crawlers/$id',
+  path: '/crawlers/$id',
   getParentRoute: () => rootRouteImport,
 } as any)
 const CrawlersNewRoute = CrawlersNewRouteImport.update({
@@ -80,9 +55,34 @@ const CrawlersNewRoute = CrawlersNewRouteImport.update({
   path: '/crawlers/new',
   getParentRoute: () => rootRouteImport,
 } as any)
-const CrawlersIdRoute = CrawlersIdRouteImport.update({
-  id: '/crawlers/$id',
-  path: '/crawlers/$id',
+const DashboardIdRoute = DashboardIdRouteImport.update({
+  id: '/dashboard/$id',
+  path: '/dashboard/$id',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MechsIdRoute = MechsIdRouteImport.update({
+  id: '/mechs/$id',
+  path: '/mechs/$id',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MechsNewRoute = MechsNewRouteImport.update({
+  id: '/mechs/new',
+  path: '/mechs/new',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PilotsIdRoute = PilotsIdRouteImport.update({
+  id: '/pilots/$id',
+  path: '/pilots/$id',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PilotsNewRoute = PilotsNewRouteImport.update({
+  id: '/pilots/new',
+  path: '/pilots/new',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SIdRoute = SIdRouteImport.update({
+  id: '/s/$id',
+  path: '/s/$id',
   getParentRoute: () => rootRouteImport,
 } as any)
 const MechsPatternsIndexRoute = MechsPatternsIndexRouteImport.update({
@@ -227,18 +227,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/encounter': {
-      id: '/encounter'
-      path: '/encounter'
-      fullPath: '/encounter'
-      preLoaderRoute: typeof EncounterRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/changelog': {
-      id: '/changelog'
-      path: '/changelog'
-      fullPath: '/changelog'
-      preLoaderRoute: typeof ChangelogRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/about': {
@@ -248,53 +241,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AboutRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+    '/changelog': {
+      id: '/changelog'
+      path: '/changelog'
+      fullPath: '/changelog'
+      preLoaderRoute: typeof ChangelogRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/s/$id': {
-      id: '/s/$id'
-      path: '/s/$id'
-      fullPath: '/s/$id'
-      preLoaderRoute: typeof SIdRouteImport
+    '/encounter': {
+      id: '/encounter'
+      path: '/encounter'
+      fullPath: '/encounter'
+      preLoaderRoute: typeof EncounterRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/pilots/new': {
-      id: '/pilots/new'
-      path: '/pilots/new'
-      fullPath: '/pilots/new'
-      preLoaderRoute: typeof PilotsNewRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/pilots/$id': {
-      id: '/pilots/$id'
-      path: '/pilots/$id'
-      fullPath: '/pilots/$id'
-      preLoaderRoute: typeof PilotsIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/mechs/new': {
-      id: '/mechs/new'
-      path: '/mechs/new'
-      fullPath: '/mechs/new'
-      preLoaderRoute: typeof MechsNewRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/mechs/$id': {
-      id: '/mechs/$id'
-      path: '/mechs/$id'
-      fullPath: '/mechs/$id'
-      preLoaderRoute: typeof MechsIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/dashboard/$id': {
-      id: '/dashboard/$id'
-      path: '/dashboard/$id'
-      fullPath: '/dashboard/$id'
-      preLoaderRoute: typeof DashboardIdRouteImport
+    '/crawlers/$id': {
+      id: '/crawlers/$id'
+      path: '/crawlers/$id'
+      fullPath: '/crawlers/$id'
+      preLoaderRoute: typeof CrawlersIdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/crawlers/new': {
@@ -304,11 +269,46 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CrawlersNewRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/crawlers/$id': {
-      id: '/crawlers/$id'
-      path: '/crawlers/$id'
-      fullPath: '/crawlers/$id'
-      preLoaderRoute: typeof CrawlersIdRouteImport
+    '/dashboard/$id': {
+      id: '/dashboard/$id'
+      path: '/dashboard/$id'
+      fullPath: '/dashboard/$id'
+      preLoaderRoute: typeof DashboardIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mechs/$id': {
+      id: '/mechs/$id'
+      path: '/mechs/$id'
+      fullPath: '/mechs/$id'
+      preLoaderRoute: typeof MechsIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mechs/new': {
+      id: '/mechs/new'
+      path: '/mechs/new'
+      fullPath: '/mechs/new'
+      preLoaderRoute: typeof MechsNewRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/pilots/$id': {
+      id: '/pilots/$id'
+      path: '/pilots/$id'
+      fullPath: '/pilots/$id'
+      preLoaderRoute: typeof PilotsIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/pilots/new': {
+      id: '/pilots/new'
+      path: '/pilots/new'
+      fullPath: '/pilots/new'
+      preLoaderRoute: typeof PilotsNewRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/s/$id': {
+      id: '/s/$id'
+      path: '/s/$id'
+      fullPath: '/s/$id'
+      preLoaderRoute: typeof SIdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/mechs/patterns/': {


### PR DESCRIPTION
Three fixes that all trace back to the same thing: something broke, and nothing said so.

## 1. The nightly alerting had a hole (`.github/workflows/e2e-nightly.yml`)

`notify-failure` was gated on `failure()`, which does **not** cover a job killed by `timeout-minutes` — GitHub reports that as `cancelled`. So when the ITUN suite's failure mode changed from "assertions fail" to "hangs to the 30-minute cap", `notify-failure` **and** `notify-recovery` both evaluated false and were skipped.

The evidence is in the tracking issue: [#383](../../issues/383) collected one comment per nightly failure, daily, through 2026-07-22 — then went silent from 07-23, the exact day the suite started timing out. **The alerting stopped at the moment the breakage got worse.**

Now fires on any non-success result. `!cancelled()` still exempts a genuine cancellation of the whole run (manual stop, concurrency supersede); a per-job timeout doesn't set that, so timeouts notify. The issue body names each suite's result and flags `cancelled` as "hit `timeout-minutes` — likely a hang", which reads very differently from a failed expectation when triaging.

## 2. `routeTree.gen.ts` was stale, and nothing checked

Building itun rewrote the committed file every time, so any contributor who ran a build got a dirty tree and the artifact slowly stopped describing the real route graph.

- The drift is **import ordering only** — sorting both versions yields identical files, so this is a no-op regeneration.
- Verified the plugin is **idempotent** (two consecutive builds → byte-identical output).
- Verified `autoCodeSplitting` (#543) is **not** the cause: output is identical with it on and off.
- Guarded in `build-itun`, which already runs the build, so the check is ~free. The only generated-file drift gate we had covers the reference package.

## 3. The ITUN e2e suite: 11/40 → 40/40

Red since 2026-07-09. Every cause was **test-side rot**, not app bugs — but a few real defects surfaced along the way.

**Drift:** a `CreateModeChooser` now fronts every wizard (~21 specs landed on it → `?mode=guided`); a "Your Stats" step was inserted ahead of Class & Ability (`pickByName` is now step-agnostic, matching the contract `runWizard` already documented); `EntityRow`'s link was renamed "Sheet" → "View" (`openSheetFor` now matches the `/sheet/` href, the contract it actually depends on); the mech/crawler wizards were restructured entirely (mech is 9 steps, no "Custom Pattern"; the TL-chips/`Loadout ·` panel is **edit-mode only**, so assertions moved to the create-mode tracker pill's stable testids).

**Real defects found:**
- `runWizard`'s "unselected options" filter used `hasNot`, which matches **descendants** — a selected cell contains no selected descendant, so picked options counted as unselected and the walk could re-click and *deselect* its own choice. Measured: 9 cells, 1 picked, `hasNot` reported 9 unselected instead of 8.
- The builders took whatever option sat last in the DOM, so the built entity varied per run while downstream specs asserted `Engineer`/`Mule`. They now name their picks.
- `expect(count >= 0).toBe(true)` — true of every number, so that budget test could never fail.
- **In #543, which I merged earlier today:** the bundle budget probed bare `/pilots/new`, measuring the *chooser* instead of the wizard it claimed to guard — green while the real thing grew unwatched.

**A superseded rule, fixed toward the book:** `pilot-build` expected 3 ability picks at creation. `PILOT_CREATION_ABILITY_PICKS = 1` ("starts with 1 Ability", Core Book p.18) and equipment is 2 (p.19). The app was right and the tests were wrong, so the tests moved — with a note pinning them to the constants and saying to check the book first if they ever disagree again.

**Removed surfaces:** `/{pilots,mechs,crawlers}/$id/edit` are gone (bare redirects; editing is in place on the Live Sheet per ADR-021), so the edit halves are re-authored against the sheet pickers with their intent — advancement past the creation budget persists — unchanged. `wired-build` asserted a top-bar "edit this pilot" link whose *absence* `Sheet-topbar-segments.test.tsx` already pins; the e2e was contradicting a unit test, and now asserts absence so the two agree.

## Verification

- ITUN e2e: **40/40 passing** locally against the CI-equivalent target (`vite build` + `vite preview`), from 11/40.
- `bun run check:all`: clean (lint, format, typecheck, test, validate, knip, audit, tokens, styling).
- Unit tests: zero failures.
- `actionlint` on both workflows: no new findings vs. main.

## Note

The nightly `a11y-srd` job (merged earlier in #541) ran for the first time and works end-to-end — every step succeeded, no `continue-on-error` masking. It found 1 `color-contrast` violation (impact: *serious*) on all four scanned pages, one shared cause: `.text-lede`'s `text-shadow` gives 4.37:1 where AA needs 4.5:1. Left alone deliberately — that job is advisory by design, and `docs/architecture/seo-accessibility.md`'s AA claim is currently overstated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hKawMJ2GazPAN3HYJ4n3q