### PR TITLE
feat(dashboard): lay the Actions deck out as a masonry grid

### DIFF
--- a/apps/itun/src/components/dashboard/__tests__/ActionsDeck.test.tsx
+++ b/apps/itun/src/components/dashboard/__tests__/ActionsDeck.test.tsx
@@ -97,10 +97,11 @@ function renderDeck(mech: Mech, store: PlayStore) {
   )
 }
 
-/** The deck rows are shortform `ReferenceEntityCard` badges: each is a clickable
- * card exposing `role="button"` + `aria-label` = the action name. */
+/** The deck cards are shortform `ReferenceEntityCard` badges laid out as a
+ * masonry grid: each is a clickable card exposing `role="button"` +
+ * `aria-label` = the action name. */
 function deckCards(container: HTMLElement): HTMLElement[] {
-  return [...container.querySelectorAll<HTMLElement>('.pc-deck-list > li [role="button"]')]
+  return [...container.querySelectorAll<HTMLElement>('.pc-deck-grid > li [role="button"]')]
 }
 
 /** Click the deck badge whose action name (aria-label) matches exactly. */
@@ -169,19 +170,19 @@ describe('ActionsDeck', () => {
     const mech = makeMech()
     const { store } = stubStore(mech)
     const { container } = renderDeck(mech, store)
-    const before = container.querySelectorAll('.pc-deck-list > li').length
+    const before = container.querySelectorAll('.pc-deck-grid > li').length
     expect(before).toBeGreaterThan(0)
     // Pick a timing tab that the system's actions do NOT match by intersecting
     // with a type absent from the deck. DownTime is not a tab, so use React
     // (Reaction) — most weapon systems are Turn actions, so React empties it.
     fireEvent.click(screen.getByRole('tab', { name: 'React' }))
-    const reactItems = container.querySelectorAll('.pc-deck-list > li').length
+    const reactItems = container.querySelectorAll('.pc-deck-grid > li').length
     // Either the deck filtered down, or it shows the no-match note.
     const emptied = reactItems < before || container.querySelector('.pc-deck-empty') !== null
     expect(emptied).toBe(true)
     // Back to All restores the full deck.
     fireEvent.click(screen.getByRole('tab', { name: 'All' }))
-    expect(container.querySelectorAll('.pc-deck-list > li').length).toBe(before)
+    expect(container.querySelectorAll('.pc-deck-grid > li').length).toBe(before)
   })
 
   test('a range readout renders with the reach count', () => {

--- a/packages/component-lib/src/components/dashboard/ActionsDeck.stories.tsx
+++ b/packages/component-lib/src/components/dashboard/ActionsDeck.stories.tsx
@@ -11,9 +11,9 @@ const TABS = ['All', 'Turn', 'Short', 'Long', 'Free', 'React'] as const
 const RANGES = ['Close', 'Medium', 'Long', 'Far'] as const
 
 /**
- * Real SRD actions as the deck's rows — each drives a shortform
+ * Real SRD actions as the deck's cards — each drives a shortform
  * `ReferenceEntityCard` badge, exactly as the ITUN wrapper feeds it. The last
- * row is locked (dimmed in place) to exercise the reach/overheat overlay.
+ * card is locked (dimmed in place) to exercise the reach/overheat overlay.
  */
 function realGroups(): DeckGroup[] {
   const actions = SalvageUnionReference.Actions.all()
@@ -48,8 +48,9 @@ function realGroups(): DeckGroup[] {
 
 /**
  * The Actions deck list view: timing tabs, group/range tools, source tags, and
- * grouped action rows (out-of-range rows dim in place). Real SRD systems drive
- * the rows; the resolve panel (not shown) reuses ReferenceEntityCard.
+ * a masonry grid of shortform action cards (out-of-range cards dim in place).
+ * Real SRD systems drive them; the resolve panel (not shown) reuses
+ * ReferenceEntityCard.
  */
 export const Default: Story = () => {
   const [tab, setTab] = useState<string>('All')
@@ -57,7 +58,7 @@ export const Default: Story = () => {
   const groups = realGroups()
   return (
     <div className="flex flex-col gap-4">
-      <Caption>Actions deck (list view) — filter tabs, range/reach, grouped rows.</Caption>
+      <Caption>Actions deck (list view) — filter tabs, range/reach, masonry card grid.</Caption>
       <InstrumentStage width={560}>
         <div
           className="pc-display-light"

--- a/packages/component-lib/src/components/dashboard/ActionsDeck.tsx
+++ b/packages/component-lib/src/components/dashboard/ActionsDeck.tsx
@@ -13,10 +13,11 @@ import { ReferenceEntityCard } from '../referenceEntity/card/ReferenceEntityCard
 import type { ReferenceCardEntity } from '../referenceEntity/card/ReferenceEntityCard'
 
 /**
- * A render-ready action row. The action ENTITY drives a shortform
+ * A render-ready action card. The action ENTITY drives a shortform
  * `ReferenceEntityCard` badge (name · Cost · type · Damage · range) — the same
  * card the SRD renders — so the deck reuses the canonical action rendering
- * instead of a hand-rolled row. Reach/lock is resolved by the caller and
+ * instead of a hand-rolled row. The card states its own name, so the deck adds
+ * no describing label above it. Reach/lock is resolved by the caller and
  * layered on top (dim + tooltip), never baked into the card.
  */
 export type DeckRow = {
@@ -335,10 +336,21 @@ export function ActionsDeck({ view }: ActionsDeckProps) {
           {view.groups.map((group) => (
             <section key={group.label}>
               <h3 className="pc-deck-group-lab">{group.label}</h3>
-              <ul className="pc-deck-list">
+              {/*
+               * A masonry grid, not a column of rows. The cards stay the compact
+               * shortform (`small` + `head`) — deliberately NOT the full extent,
+               * which embeds its own buttons (nested sub-entity cards, the
+               * description expander, roll controls). Those are invalid inside
+               * this card's own `role="button"` wrapper, and their clicks would
+               * bubble into `onOpen` and open the resolve panel. Shortform cards
+               * still differ in height when a long action name wraps, which is
+               * what the masonry packing is for. `<ul>/<li>` stays — a set of
+               * actions IS a list semantically; "grid" is purely the layout.
+               */}
+              <ul className="pc-deck-grid">
                 {group.rows.map((row) => (
                   // Lock (out of range / overheat) is a caller-resolved overlay,
-                  // layered on the canonical badge — dim + tooltip — never a
+                  // layered on the canonical card — dim + tooltip — never a
                   // property of the action card itself.
                   <li
                     key={row.key}

--- a/packages/component-lib/src/components/dashboard/instruments.css
+++ b/packages/component-lib/src/components/dashboard/instruments.css
@@ -204,13 +204,25 @@
   font-size: var(--text-badge);
   color: var(--color-ink-50);
 }
-.pc-deck-list {
+/*
+ * Masonry via CSS multi-column — deliberately the plain, well-understood
+ * mechanism rather than `grid-template-rows: masonry` (not shipping broadly)
+ * or a JS-measured layout. Card heights differ once a long action name wraps;
+ * columns pack them tightly and `break-inside: avoid` keeps a card whole. Column
+ * COUNT is implicit: `column-width` is a minimum, so the deck widens from one
+ * to three columns with the display panel and needs no breakpoints.
+ */
+.pc-deck-grid {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
+  column-width: 260px;
+  column-gap: 8px;
+}
+.pc-deck-grid > li {
+  break-inside: avoid;
+  /* Multi-column has no row gap; the item's own bottom margin is the gutter. */
+  margin: 0 0 8px;
 }
 .pc-deck-panel {
   display: flex;


### PR DESCRIPTION
## What

The Dashboard's Actions instrument rendered its cards as a single-column list, leaving the ~990px display panel mostly empty. Each group's cards now flow into a **masonry grid**.

## How

Masonry is **CSS multi-column**, deliberately over `grid-template-rows: masonry` (not shipping broadly) or a JS-measured layout:

- `column-width: 260px` is a *minimum*, so the deck widens from one to three columns with the panel — no breakpoints.
- `break-inside: avoid` keeps a card whole; the item's own bottom margin is the row gutter (multi-column has no row gap).

`.pc-deck-list` → `.pc-deck-grid`. `<ul>`/`<li>` is kept — a set of actions is semantically a list; "grid" here is purely how it is laid out.

## The one judgement call — cards stay shortform

The cards stay the compact shortform (`small` + `head`), and the deck adds **no describing label above them** (the card states its own name).

Going to the full extent was tried and **reverted**: full action cards embed their own buttons — nested sub-entity cards, the description expander, roll controls. Those are invalid inside the card's own `role="button"` wrapper, and their clicks would bubble into `onOpen` and open the resolve panel. A sweep of all 687 SRD actions found up to **5** such nested buttons per card at `extent="full"` and **2** at `catalog`; `head` is the only clean extent.

Two follow-ups are available if you want bigger cards — say which and I'll do it:

1. Keep the group headings but drop them (I read "no label above the action" as *don't add a per-action label*, so the existing per-group `Source`/`Timing` headings were left alone — they're a tested, toggleable feature).
2. Move to full-extent cards by dropping the whole-card click in favour of an explicit control in the card rail.

## Verification

`bun run check:all` green (lint, format, typecheck, 1246 itun + 523 component-lib tests, validate, knip, audit, tokens, styling). Not visually confirmed — worth a look at the Dashboard → Actions panel and the Ladle story `Compositions/Dashboard/ActionsDeck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wVMMdDvGz1zQfpKVhu5bY