### PR TITLE
fix(live-sheets): black-on-black titles + Workshop Manual redesign (mockup for sign-off)

### DIFF
--- a/apps/itun/src/components/sheet/CrawlerSheet.tsx
+++ b/apps/itun/src/components/sheet/CrawlerSheet.tsx
@@ -2,15 +2,18 @@
  * CrawlerSheet — the crawler variant BODY for the LiveSheet shell (design
  * §4.4, plan 4.6; redesigned to the poster layout, Phase 2).
  *
- * Identity/Economy moved OUT of the hero (SheetCrawler.tsx now carries only
- * the name row + meta) and into this body's region flow. Following the printed
- * Workshop-Manual crawler sheet (`Editable_..._Crawler_Sheets.pdf`), the sheet
- * is a single-column region stack, inside the same `@container` shape
+ * The body OWNS the identity band now (Workshop-Manual crawler sheet):
+ * SheetCrawler passes NO `renderHero`, and this body renders `SheetHero` in
+ * band mode as its first region (wrapped with the shell's `heroRef`).
+ * Following the printed sheet (`Editable_..._Crawler_Sheets.pdf`), the sheet is
+ * a single-column region stack, inside the same `@container` shape
  * PilotSheet/MechSheet use:
  *
- *   Identity + Economy (one card) → Bays (3-column `EntityGrid`) → Armament
- *     Bay Weapons (3-column) → Linked Units (bare section, no card frame,
- *     matching PilotSheet/MechSheet) → Storage Bay.
+ *   Identity Band: edge wordmark ∥ Name/Type/Ability/Description fields ∥ the
+ *     Economy rail (SP `VitalGauge` + Tech-LVL/Upkeep/Upgrade readouts, built
+ *     by SheetCrawler and passed as `economy`) → Bays (3-column `EntityGrid`)
+ *     → Armament Bay Weapons (3-column) → Linked Units (bare section, no card
+ *     frame) → Storage Bay.
  *   Storage Bay is the FULL-WIDTH band at the very BOTTOM (printed sheet p.2 —
  *     Storage Bay spans the whole width beneath the bays), NOT a full-height
  *     right column.
@@ -62,8 +65,8 @@
  */
 
 import { useState } from 'react'
-import type { ReactNode } from 'react'
-import { ReferenceEntityCard, Stat } from 'component-lib'
+import type { ReactNode, Ref } from 'react'
+import { ReferenceEntityCard, SheetHero, Stat } from 'component-lib'
 
 import { addToScrapPool, scrapPoolBucket } from '../../lib/cargo/cargoTransfer'
 import { useCargo } from '../../lib/cargo/useCargo'
@@ -105,10 +108,16 @@ type CrawlerSheetProps = {
   /** Suppresses every edit affordance (published snapshots). */
   readOnly?: boolean
   /**
+   * Condense sentinel from the LiveSheet shell — wraps the identity band (the
+   * body's first region) so the sticky bar still condenses when it scrolls
+   * away. Undefined in bare test renders (no shell).
+   */
+  heroRef?: Ref<HTMLElement>
+  /**
    * The economy band content (SP `VitalGauge` + Tech-LVL/Upkeep/Upgrade
    * lozenges) — built by `SheetCrawler` (it owns the economy-dialog state
-   * and `patch`), rendered inside the Identity card. Undefined renders
-   * nothing extra (e.g. a bare test render with no economy slot wired).
+   * and `patch`), rendered as the identity band's vitals rail. Undefined
+   * renders nothing extra (e.g. a bare test render with no economy slot wired).
    */
   economy?: ReactNode
   /**
@@ -125,6 +134,7 @@ export function CrawlerSheet({
   mech = null,
   store = useEntityStore,
   readOnly = false,
+  heroRef,
   economy,
   linkedUnits,
 }: CrawlerSheetProps) {
@@ -222,38 +232,39 @@ export function CrawlerSheet({
           `Editable_..._Crawler_Sheets.pdf` p.2), not a full-height right
           column. ===== */}
       <div className="flex min-w-0 flex-col gap-6">
-        {/* ----- Content region (Identity/Economy, Bays, Weapons) ----- */}
-        <div className="flex min-w-0 flex-col gap-6">
-          {/* Identity + Economy */}
-          <SheetSectionCard
-            title="Identity"
-            controls={
-              !readOnly ? (
-                <SectionEditButton
-                  section="Identity"
-                  editing={identityEditing}
-                  onToggle={() => setIdentityEditing((v) => !v)}
-                />
-              ) : undefined
-            }
-          >
-            <div className="flex min-w-0 flex-col gap-4">
-              <CrawlerIdentityPanel
-                crawler={crawler}
-                store={store}
-                storeState={storeState}
-                patch={readOnly ? undefined : patchCrawler}
+        {/* ===== Identity Band (Workshop-Manual crawler sheet top region) =====
+            Edge wordmark ∥ Name/Type/Ability/Description fields ∥ the Economy
+            rail (SP `VitalGauge` + Tech-LVL/Upkeep/Upgrade readouts), in one
+            toned frame — no name pseudoheader stamp. Carries the shell's
+            condense sentinel (heroRef). */}
+        <SheetHero
+          heroRef={heroRef}
+          cat="Crawler"
+          name={crawler.name}
+          controls={
+            !readOnly ? (
+              <SectionEditButton
+                section="Identity"
                 editing={identityEditing}
-                readOnly={readOnly}
+                onToggle={() => setIdentityEditing((v) => !v)}
               />
-              {economy && (
-                <div className="border-t border-dashed border-[color-mix(in_srgb,var(--tone-deep)_40%,transparent)] pt-4">
-                  {economy}
-                </div>
-              )}
-            </div>
-          </SheetSectionCard>
+            ) : undefined
+          }
+          fields={
+            <CrawlerIdentityPanel
+              crawler={crawler}
+              store={store}
+              storeState={storeState}
+              patch={readOnly ? undefined : patchCrawler}
+              editing={identityEditing}
+              readOnly={readOnly}
+            />
+          }
+          vitals={economy}
+        />
 
+        {/* ----- Content region (Bays, Weapons) ----- */}
+        <div className="flex min-w-0 flex-col gap-6">
           {/* Bays — ONE unified grid, all bays together (no crew/functional
               split). // TODO(redesign): render homebrew/custom bays in a
               separate "Custom Bays" group underneath once the data

--- a/apps/itun/src/components/sheet/CrawlerSheet.tsx
+++ b/apps/itun/src/components/sheet/CrawlerSheet.tsx
@@ -3,17 +3,17 @@
  * §4.4, plan 4.6; redesigned to the poster layout, Phase 2).
  *
  * Identity/Economy moved OUT of the hero (SheetCrawler.tsx now carries only
- * the name row + meta) and into this body's poster region grid — a 2-col
- * macro grid mirroring `clean-crawler.html`'s `.layout` (54fr content column
- * ∥ 46fr full-height Storage rail, split at the poster's 880px container
- * breakpoint), inside the same `@container` shape PilotSheet/MechSheet use:
+ * the name row + meta) and into this body's region flow. Following the printed
+ * Workshop-Manual crawler sheet (`Editable_..._Crawler_Sheets.pdf`), the sheet
+ * is a single-column region stack, inside the same `@container` shape
+ * PilotSheet/MechSheet use:
  *
- *   Content column (54fr): Identity + Economy (one card) → Bays → Armament
- *     Bay Weapons → Linked Units (bare section, no card frame, matching
- *     PilotSheet/MechSheet).
- *   Storage rail (46fr): Storage Bay, one `SheetSectionCard` that stretches
- *     to match the content column's full height via the grid row's default
- *     stretch (the poster's "full-height Storage right rail").
+ *   Identity + Economy (one card) → Bays (3-column `EntityGrid`) → Armament
+ *     Bay Weapons (3-column) → Linked Units (bare section, no card frame,
+ *     matching PilotSheet/MechSheet) → Storage Bay.
+ *   Storage Bay is the FULL-WIDTH band at the very BOTTOM (printed sheet p.2 —
+ *     Storage Bay spans the whole width beneath the bays), NOT a full-height
+ *     right column.
  *
  * Economy (SP `VitalGauge` + Tech-LVL/Upkeep/Upgrade lozenges) is built by
  * `SheetCrawler` (it owns the economy-dialog state + `patch`) and handed
@@ -200,18 +200,14 @@ export function CrawlerSheet({
       // width (redesign D7), not the viewport.
       className="sheet-section @container flex flex-col gap-6"
     >
-      {/* ===== 2-col macro grid: content column ∥ full-height Storage rail
-          (poster `.layout`, split at its 880px container breakpoint) =====
-          DOM order is content-column, Storage, THEN Linked Units — the
-          poster's own `grid-template-areas` stacks mobile rows as "id" "bays"
-          "storage" "links" (clean-crawler.html:215-222), so Storage reads
-          BEFORE Linked Units on a single column even though Storage is a
-          separate full-height rail at the desktop breakpoint. Explicit
-          `@[880px]:col-start-*`/`row-start-*` restores that desktop layout
-          (Storage spans both rows on the right) without reordering the DOM. */}
-      <div className="grid grid-cols-1 items-stretch gap-8 @[880px]:grid-cols-[minmax(0,54fr)_minmax(0,46fr)] @[880px]:gap-x-7">
-        {/* ----- Content column (Identity/Economy, Bays, Weapons) ----- */}
-        <div className="flex min-w-0 flex-col gap-6 @[880px]:col-start-1 @[880px]:row-start-1">
+      {/* ===== Single-column region flow (Workshop-Manual crawler sheet):
+          Identity → Bays → Armament Weapons → Linked Units → Storage Bay.
+          Storage is the FULL-WIDTH band at the very bottom (printed
+          `Editable_..._Crawler_Sheets.pdf` p.2), not a full-height right
+          column. ===== */}
+      <div className="flex min-w-0 flex-col gap-6">
+        {/* ----- Content region (Identity/Economy, Bays, Weapons) ----- */}
+        <div className="flex min-w-0 flex-col gap-6">
           {/* Identity + Economy */}
           <SheetSectionCard
             title="Identity"
@@ -255,7 +251,7 @@ export function CrawlerSheet({
                 </span>
               }
             >
-              <EntityGrid>
+              <EntityGrid columns={3}>
                 {bays.map((entry, i) => {
                   const isMechBay =
                     entry.bayRef === 'mech-bay' ||
@@ -302,7 +298,7 @@ export function CrawlerSheet({
               {crawler.systems.length === 0 ? (
                 <p className="font-body text-caption text-wk-muted">No weapons mounted.</p>
               ) : (
-                <EntityGrid>
+                <EntityGrid columns={3}>
                   {crawler.systems.map((slug) => {
                     const system = resolveCrawlerSystem(slug)
                     return (
@@ -338,8 +334,16 @@ export function CrawlerSheet({
           )}
         </div>
 
-        {/* ----- Storage rail (full-height, spans both content-column rows
-            at the desktop breakpoint) ----- */}
+        {/* Linked Units — poster renders this as a bare section header +
+            rail stack (no `.dcard` frame), matching PilotSheet/MechSheet. */}
+        <div>
+          <Slab variant="solid" label="Linked Units" />
+          <div className="flex flex-col gap-4">{linkedUnits}</div>
+        </div>
+
+        {/* ----- Storage Bay — the FULL-WIDTH bottom band (printed crawler
+            sheet p.2: Storage Bay spans the whole width beneath the bays), not
+            a full-height right column. ----- */}
         <SheetSectionCard
           title="Storage Bay"
           count={
@@ -347,7 +351,7 @@ export function CrawlerSheet({
               {lots.length} {lots.length === 1 ? 'lot' : 'lots'} · unlimited
             </span>
           }
-          className="min-w-0 @[880px]:col-start-2 @[880px]:row-start-1 @[880px]:row-span-2"
+          className="min-w-0"
         >
           <StorageManifest
             side="crawler"
@@ -357,13 +361,6 @@ export function CrawlerSheet({
             readOnly={readOnly}
           />
         </SheetSectionCard>
-
-        {/* Linked Units — poster renders this as a bare section header +
-            rail stack (no `.dcard` frame), matching PilotSheet/MechSheet. */}
-        <div className="@[880px]:col-start-1 @[880px]:row-start-2">
-          <Slab variant="solid" label="Linked Units" />
-          <div className="flex flex-col gap-4">{linkedUnits}</div>
-        </div>
       </div>
 
       {/* The weapons picker — the existing master-detail modal, mounted

--- a/apps/itun/src/components/sheet/CrawlerSheet.tsx
+++ b/apps/itun/src/components/sheet/CrawlerSheet.tsx
@@ -63,7 +63,7 @@
 
 import { useState } from 'react'
 import type { ReactNode } from 'react'
-import { ReferenceEntityCard } from 'component-lib'
+import { ReferenceEntityCard, Stat } from 'component-lib'
 
 import { addToScrapPool, scrapPoolBucket } from '../../lib/cargo/cargoTransfer'
 import { useCargo } from '../../lib/cargo/useCargo'
@@ -190,6 +190,22 @@ export function CrawlerSheet({
   /** Remove one mounted weapon (per-card ✕ — archetype B). */
   function removeWeapon(slug: string) {
     patchCrawler((current) => ({ systems: current.systems.filter((s) => s !== slug) }))
+  }
+
+  /**
+   * Set one Scrap Pool tech-level bucket to `next` (Free Edit — hand-patch the
+   * pool directly). Reads the FRESHEST record so rapid steps don't race the
+   * async write, then applies the delta through `addToScrapPool` (floored at 0).
+   */
+  function setScrapBucket(tlBucket: number, next: number) {
+    if (readOnly) return
+    const fresh = storeState.get('crawler', crawler.id) ?? crawler
+    const currentPool = fresh.scrapPool ?? {}
+    const delta = next - scrapPoolBucket(currentPool, tlBucket)
+    if (delta === 0) return
+    void storeState.update('crawler', crawler.id, {
+      scrapPool: addToScrapPool(currentPool, tlBucket, delta),
+    })
   }
 
   return (
@@ -353,6 +369,32 @@ export function CrawlerSheet({
           }
           className="min-w-0"
         >
+          {/* Scrap Pool — the crawler's abstract TL-bucketed scrap store (rules
+              S12; the bucket bay-repair spends). Per-tech-level `Stat` steppers
+              let a crawler stow arbitrary scrap by hand (Free Edit). The
+              physical-scrap-cargo path lives in the Hold add-form's Scrap kind. */}
+          <div className="mb-4 border-b border-dashed border-[color-mix(in_srgb,var(--tone-deep)_40%,transparent)] pb-4">
+            <span
+              className="mb-2 block font-cond text-label font-bold uppercase leading-none tracking-caps"
+              style={{ color: 'var(--tone-deep, var(--color-ink))' }}
+            >
+              Scrap Pool
+            </span>
+            <div className="flex flex-wrap gap-2">
+              {SCRAP_TLS.map((t) => (
+                <Stat
+                  key={t}
+                  label={`T${t}`}
+                  value={scrapPoolBucket(pool, t)}
+                  min={0}
+                  size="mini"
+                  mode={readOnly ? 'read' : 'edit'}
+                  ariaLabel={`Tech ${t} scrap`}
+                  onChange={readOnly ? undefined : (next) => setScrapBucket(t, next)}
+                />
+              ))}
+            </div>
+          </div>
           <StorageManifest
             side="crawler"
             cargo={cargo}

--- a/apps/itun/src/components/sheet/LiveSheet.tsx
+++ b/apps/itun/src/components/sheet/LiveSheet.tsx
@@ -70,6 +70,15 @@ type LiveSheetHeroContext = {
   rail: ReactNode
 }
 
+type LiveSheetBodyContext = {
+  /**
+   * The condense sentinel ref. Sheets that own their identity band inside the
+   * BODY (no `renderHero`) wrap that band's frame with this so the sticky bar
+   * still condenses when the band scrolls away (Workshop-Manual layout).
+   */
+  heroRef: RefObject<HTMLElement | null>
+}
+
 type LiveSheetProps = {
   variant: SheetVariant
   name: string
@@ -89,8 +98,14 @@ type LiveSheetProps = {
   segments?: LiveSheetSegment[]
   /** Sticky condense bar on scroll (default true — shipped tweak default). */
   condense?: boolean
-  renderHero: (ctx: LiveSheetHeroContext) => ReactNode
-  renderBody: () => ReactNode
+  /**
+   * The hero band. Optional: Workshop-Manual sheets fold their identity band
+   * into the BODY's first region (so identity + vitals stay in one component
+   * with their handlers), pass no `renderHero`, and wrap that band with the
+   * `heroRef` handed to `renderBody` instead.
+   */
+  renderHero?: (ctx: LiveSheetHeroContext) => ReactNode
+  renderBody: (ctx: LiveSheetBodyContext) => ReactNode
   /** Derived stat overlays merged onto strip items by key (e.g. {cargo: used}). */
   syncStats?: Record<string, number>
   /** Trailing top-bar actions (Share/Publish). */
@@ -266,15 +281,24 @@ export function LiveSheet({
 
       {/* Hero band — the rail is passed through so the hero slots it inside
           its own frame (design: hero rail strip sits under the band, inside
-          the 3px entity border). */}
-      <div className="px-4 pb-1.5 pt-4 sm:px-[30px] sm:pt-[22px]">
-        {renderHero({ heroRef, rail })}
-      </div>
+          the 3px entity border). Optional: Workshop-Manual sheets own their
+          identity band in the body and pass no renderHero. */}
+      {renderHero && (
+        <div className="px-4 pb-1.5 pt-4 sm:px-[30px] sm:pt-[22px]">
+          {renderHero({ heroRef, rail })}
+        </div>
+      )}
 
       {/* Body slabs — extra phone bottom padding when the FAB floats so the
-          last card's controls stay reachable behind the thumb zone. */}
-      <div className={cn('px-4 pb-[34px] pt-[18px] sm:px-[30px] sm:pb-[60px] sm:pt-6')}>
-        {renderBody()}
+          last card's controls stay reachable behind the thumb zone. When the
+          body owns the hero (no renderHero), it takes the hero's top padding. */}
+      <div
+        className={cn(
+          'px-4 pb-[34px] sm:px-[30px] sm:pb-[60px]',
+          renderHero ? 'pt-[18px] sm:pt-6' : 'pt-4 sm:pt-[22px]'
+        )}
+      >
+        {renderBody({ heroRef })}
       </div>
     </div>
   )

--- a/apps/itun/src/components/sheet/MechSheet.tsx
+++ b/apps/itun/src/components/sheet/MechSheet.tsx
@@ -2,27 +2,23 @@
  * MechSheet — the mech variant BODY for the LiveSheet shell (design §4.3,
  * plan 4.5; redesigned to the poster layout, Phase 2).
  *
- * Identity/Vitals moved OUT of the hero (SheetMech.tsx now carries only the
- * name row + meta) and into this body's poster region grid — a 12-col
- * `@container` grid mirroring PilotSheet's Phase 2 shape:
+ * The body OWNS the identity band now (Workshop-Manual mech sheet): SheetMech
+ * passes NO `renderHero`, and this body renders `SheetHero` in band mode as
+ * its first region (wrapped with the shell's `heroRef`). Region order mirrors
+ * the printed mech sheet:
  *
- *   R1: Identity (span 7, the pattern-name/chassis fields + the 8-lozenge
- *       chassis-stats strip) ∥ Vitals (span 5, SP/EP/Heat `VitalGauge`s +
- *       Conditions).
- *   R2: Chassis Ability (span 7, the chassis's ability actions as
- *       EntityGridRow'd cards with a Use action that spends EP; blocked while
- *       shut down) ∥
- *       Quirk & Appearance (span 5, ONE combined field section as a 2-row
- *       dt/dd list — the poster has no separate Quirk/Appearance cards).
- *   R3: Systems & Modules — KEPT as the existing two-section split (each its
- *       own `SheetSectionCard`) rather than unified into one grid: Systems
- *       and Modules are different collections with different '+ Add'
- *       pickers/slot budgets, so folding them into one card/grid is not a
- *       trivial change (see plan Phase 2 item 2's "unify-vs-split" note).
- *   R4: Linked Units (span 5, a bare `.sect` header + rail stack — no card
- *       frame, matching PilotSheet's Linked Units) ∥ The Hold (span 7,
- *       `StorageManifest side='mech'` unchanged, now framed in a
- *       `SheetSectionCard`).
+ *   Identity Band: edge wordmark ∥ the pattern-name/chassis fields + the
+ *       8-lozenge chassis-stats strip ∥ SP/EP/Heat `VitalGauge`s + Conditions
+ *       vitals rail — one toned frame (the printed top band).
+ *   Chassis Ability ∥ Quirk & Appearance — the chassis's ability actions as
+ *       EntityGridRow'd cards (Use spends EP; blocked while shut down) and one
+ *       combined Quirk/Appearance field section.
+ *   Systems & Modules — KEPT as two sections (each its own `SheetSectionCard`,
+ *       3-column card grids): different collections with different '+ Add'
+ *       pickers/slot budgets, so folding them into one grid is not trivial.
+ *   Linked Units (bare `.sect` header + rail stack) then The Hold — the full-
+ *       width Cargo band at the BOTTOM (`StorageManifest side='mech'`),
+ *       matching the printed sheet.
  *
  * Every collection/field section is framed by `SheetSectionCard` (the poster
  * `.dcard`) except Linked Units.
@@ -44,9 +40,16 @@
  */
 
 import { useState } from 'react'
-import type { ReactNode } from 'react'
+import type { ReactNode, Ref } from 'react'
 import { SalvageUnionReference, nameToSlug } from 'salvageunion-reference'
-import { Stat, VitalGauge, heatDangerFrom, FieldError, ReferenceEntityCard } from 'component-lib'
+import {
+  Stat,
+  VitalGauge,
+  heatDangerFrom,
+  FieldError,
+  ReferenceEntityCard,
+  SheetHero,
+} from 'component-lib'
 
 import { useCargo } from '../../lib/cargo/useCargo'
 import { computeMechCapacity, resolveChassisRef } from 'salvageunion-reference/rules'
@@ -99,6 +102,12 @@ type MechSheetProps = {
   /** Suppresses every edit affordance (published snapshots). */
   readOnly?: boolean
   /**
+   * Condense sentinel from the LiveSheet shell — wraps the identity band (the
+   * body's first region) so the sticky bar still condenses when it scrolls
+   * away. Undefined in bare test renders (no shell).
+   */
+  heroRef?: Ref<HTMLElement>
+  /**
    * The linked home crawler (composition resolver) — powers The Hold's stow
    * target and the optional repair scrap-pool deduction. Null = unlinked.
    */
@@ -123,6 +132,7 @@ export function MechSheet({
   chassis: chassisOverride,
   store = useEntityStore,
   readOnly = false,
+  heroRef,
   crawler = null,
   linkedUnits,
 }: MechSheetProps) {
@@ -377,7 +387,7 @@ export function MechSheet({
       )
     }
     return (
-      <EntityGrid>
+      <EntityGrid columns={3}>
         {slugs.map((slug, index) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: the same system/module slug may be installed more than once, so the slug alone is not unique; install order is stable
           <EntityGridRow key={`${slug}-${index}`}>
@@ -430,91 +440,89 @@ export function MechSheet({
         </FieldError>
       )}
 
-      {/* ===== R1: Identity ∥ Vitals (poster top band) ===== */}
-      <div className="grid grid-cols-1 gap-[22px] @5xl:grid-cols-12 @5xl:gap-6">
-        <div className="@5xl:col-span-7">
-          <SheetSectionCard
-            title="Identity"
-            controls={
-              !readOnly ? (
-                <SectionEditButton
-                  section="Identity"
-                  editing={identityEditing}
-                  onToggle={() => setIdentityEditing((v) => !v)}
-                />
-              ) : undefined
-            }
-          >
-            <div className="flex min-w-0 flex-col gap-3">
-              <MechIdentityPanel
-                mech={mech}
-                chassisName={chassisName}
-                techLevel={techLevel}
-                editing={identityEditing}
-                patch={readOnly ? undefined : patchMech}
-              />
-              <ChassisStats items={specs} className="grid grid-cols-2 gap-2 @sm:grid-cols-4" />
-            </div>
-          </SheetSectionCard>
-        </div>
-
-        <div className="@5xl:col-span-5">
-          <SheetSectionCard title="Vitals">
-            <div className="flex w-full flex-col [&>*+*]:mt-[14px] [&>*+*]:border-t [&>*+*]:border-dashed [&>*+*]:border-[color-mix(in_srgb,var(--tone-deep)_40%,transparent)] [&>*+*]:pt-[14px]">
-              <VitalGauge
-                label="SP"
-                subLabel="Structure"
-                value={currentSP}
-                max={maxSP}
-                onChange={readOnly ? undefined : (v) => patchMech({ currentSP: v })}
-                onMaxChange={
-                  readOnly
-                    ? undefined
-                    : (next) => overrideMechMax({ maxSpModifier: modOrUndef(next, derivedMaxSP) })
-                }
-                overriddenFrom={readOnly ? undefined : derivedMaxSP}
-                onRevertOverride={
-                  readOnly ? undefined : () => overrideMechMax({ maxSpModifier: undefined })
-                }
-                readOnly={readOnly}
-              />
-              <VitalGauge
-                label="EP"
-                subLabel="Energy"
-                value={currentEP}
-                max={maxEP}
-                onChange={readOnly ? undefined : (v) => patchMech({ currentEP: v })}
-                onMaxChange={
-                  readOnly
-                    ? undefined
-                    : (next) => overrideMechMax({ maxEpModifier: modOrUndef(next, derivedMaxEP) })
-                }
-                overriddenFrom={readOnly ? undefined : derivedMaxEP}
-                onRevertOverride={
-                  readOnly ? undefined : () => overrideMechMax({ maxEpModifier: undefined })
-                }
-                readOnly={readOnly}
-              />
-              <VitalGauge
-                label="Heat"
-                value={currentHeat}
-                max={heatCap}
-                danger={heatCap > 0 ? heatDangerFrom(heatCap) : undefined}
-                onChange={readOnly ? undefined : (v) => patchMech({ currentHeat: v })}
-                onMaxChange={
-                  readOnly
-                    ? undefined
-                    : (next) =>
-                        overrideMechMax({ maxHeatModifier: modOrUndef(next, derivedHeatCap) })
-                }
-                overriddenFrom={readOnly ? undefined : derivedHeatCap}
-                onRevertOverride={
-                  readOnly ? undefined : () => overrideMechMax({ maxHeatModifier: undefined })
-                }
-                readOnly={readOnly}
-              />
-            </div>
-            <div className="mt-4 flex w-full flex-col gap-2 border-t border-dashed border-[color-mix(in_srgb,var(--tone-deep)_40%,transparent)] pt-[14px]">
+      {/* ===== Identity Band (Workshop-Manual mech sheet top region) =====
+          Edge wordmark ∥ Chassis/Pattern fields + Chassis-Stats strip ∥
+          SP/EP/Heat + Conditions vitals rail, in one toned frame. Carries the
+          shell's condense sentinel (heroRef). */}
+      <SheetHero
+        heroRef={heroRef}
+        cat="Mech"
+        name={mech.name}
+        controls={
+          !readOnly ? (
+            <SectionEditButton
+              section="Identity"
+              editing={identityEditing}
+              onToggle={() => setIdentityEditing((v) => !v)}
+            />
+          ) : undefined
+        }
+        fields={
+          <div className="flex min-w-0 flex-col gap-3">
+            <MechIdentityPanel
+              mech={mech}
+              chassisName={chassisName}
+              techLevel={techLevel}
+              editing={identityEditing}
+              patch={readOnly ? undefined : patchMech}
+            />
+            <ChassisStats items={specs} className="grid grid-cols-2 gap-2 @sm:grid-cols-4" />
+          </div>
+        }
+        vitals={
+          <div className="flex w-full flex-col [&>*+*]:mt-[14px] [&>*+*]:border-t [&>*+*]:border-dashed [&>*+*]:border-[color-mix(in_srgb,var(--tone-deep)_40%,transparent)] [&>*+*]:pt-[14px]">
+            <VitalGauge
+              label="SP"
+              subLabel="Structure"
+              value={currentSP}
+              max={maxSP}
+              onChange={readOnly ? undefined : (v) => patchMech({ currentSP: v })}
+              onMaxChange={
+                readOnly
+                  ? undefined
+                  : (next) => overrideMechMax({ maxSpModifier: modOrUndef(next, derivedMaxSP) })
+              }
+              overriddenFrom={readOnly ? undefined : derivedMaxSP}
+              onRevertOverride={
+                readOnly ? undefined : () => overrideMechMax({ maxSpModifier: undefined })
+              }
+              readOnly={readOnly}
+            />
+            <VitalGauge
+              label="EP"
+              subLabel="Energy"
+              value={currentEP}
+              max={maxEP}
+              onChange={readOnly ? undefined : (v) => patchMech({ currentEP: v })}
+              onMaxChange={
+                readOnly
+                  ? undefined
+                  : (next) => overrideMechMax({ maxEpModifier: modOrUndef(next, derivedMaxEP) })
+              }
+              overriddenFrom={readOnly ? undefined : derivedMaxEP}
+              onRevertOverride={
+                readOnly ? undefined : () => overrideMechMax({ maxEpModifier: undefined })
+              }
+              readOnly={readOnly}
+            />
+            <VitalGauge
+              label="Heat"
+              value={currentHeat}
+              max={heatCap}
+              danger={heatCap > 0 ? heatDangerFrom(heatCap) : undefined}
+              onChange={readOnly ? undefined : (v) => patchMech({ currentHeat: v })}
+              onMaxChange={
+                readOnly
+                  ? undefined
+                  : (next) => overrideMechMax({ maxHeatModifier: modOrUndef(next, derivedHeatCap) })
+              }
+              overriddenFrom={readOnly ? undefined : derivedHeatCap}
+              onRevertOverride={
+                readOnly ? undefined : () => overrideMechMax({ maxHeatModifier: undefined })
+              }
+              readOnly={readOnly}
+            />
+            <div className="flex w-full flex-col gap-2">
               <span
                 className="font-cond text-label font-bold uppercase tracking-caps"
                 style={{ color: 'var(--tone-deep, var(--color-ink))' }}
@@ -523,9 +531,9 @@ export function MechSheet({
               </span>
               <MechConditionsEditor mech={mech} store={store} readOnly={readOnly} />
             </div>
-          </SheetSectionCard>
-        </div>
-      </div>
+          </div>
+        }
+      />
 
       {/* ===== R2: Chassis Ability ∥ Quirk & Appearance ===== */}
       <div className="grid grid-cols-1 gap-[22px] @5xl:grid-cols-12 @5xl:gap-6">
@@ -624,42 +632,32 @@ export function MechSheet({
         {renderItems('module', mech.modules)}
       </SheetSectionCard>
 
-      {/* ===== R4: Linked Units ∥ The Hold =====
-          DOM order is Hold THEN Linked Units — the poster's own mobile stack
-          puts `.bcargo` (Hold) before `.blinks` (Linked Units) even though
-          both share `grid-row:1` at the desktop breakpoint (`.bcargo{grid-
-          column:6/13}` / `.blinks{grid-column:1/6}`, clean-mech.html:547-548)
-          — Linked Units reads LAST on mobile. `@5xl:order-*` restores the
-          desktop visual (Linked Units left/span5, Hold right/span7) without
-          reordering the DOM. */}
-      <div className="grid grid-cols-1 gap-[22px] @5xl:grid-cols-12 @5xl:gap-6">
-        <div className="@5xl:order-2 @5xl:col-span-7">
-          <SheetSectionCard
-            title="The Hold"
-            count={
-              <span className="tabular-nums">
-                {cargo.state.mechLots.length} {cargo.state.mechLots.length === 1 ? 'lot' : 'lots'} ·{' '}
-                {cargo.usage.used}/{cargo.usage.cap} slots
-              </span>
-            }
-          >
-            <StorageManifest
-              side="mech"
-              cargo={cargo}
-              mechName={mech.name}
-              crawlerName={crawler?.name ?? null}
-              readOnly={readOnly}
-            />
-          </SheetSectionCard>
-        </div>
-
-        <div className="@5xl:order-1 @5xl:col-span-5">
-          {/* Linked Units — poster renders this as a bare section header + rail
-              stack (no `.dcard` frame), matching PilotSheet. */}
-          <Slab variant="solid" label="Linked Units" />
-          <div className="flex flex-col gap-4">{linkedUnits}</div>
-        </div>
+      {/* ===== Linked Units, then The Hold (full-width bottom band) =====
+          The printed mech sheet puts Cargo as a full-width band at the bottom
+          (p.2), so Linked Units reads first (bare `.sect` header + rail stack,
+          matching PilotSheet) and The Hold is the full-width band below it. */}
+      <div>
+        <Slab variant="solid" label="Linked Units" />
+        <div className="flex flex-col gap-4">{linkedUnits}</div>
       </div>
+
+      <SheetSectionCard
+        title="The Hold"
+        count={
+          <span className="tabular-nums">
+            {cargo.state.mechLots.length} {cargo.state.mechLots.length === 1 ? 'lot' : 'lots'} ·{' '}
+            {cargo.usage.used}/{cargo.usage.cap} slots
+          </span>
+        }
+      >
+        <StorageManifest
+          side="mech"
+          cargo={cargo}
+          mechName={mech.name}
+          crawlerName={crawler?.name ?? null}
+          readOnly={readOnly}
+        />
+      </SheetSectionCard>
 
       {/* The ONE shared picker modal — Systems & Modules '+ Add' both open it
           (the wizard's install grid writes through on click; no Save button). */}

--- a/apps/itun/src/components/sheet/PilotSheet.tsx
+++ b/apps/itun/src/components/sheet/PilotSheet.tsx
@@ -1,17 +1,20 @@
 /**
- * PilotSheet — the pilot body for the LiveSheet shell (redesign Phase 2:
- * poster containers & section structure, pilot slice).
+ * PilotSheet — the pilot body for the LiveSheet shell (Workshop-Manual pilot
+ * sheet, region-for-region).
  *
- * The poster region grid (`clean-pilot.html`) — a single-column stack on
- * mobile, a 12-col `@container` grid at the wide breakpoint:
- *   - R1: Identity (span 7) ∥ Vitals (span 5) — MOVED here from the hero
- *     (SheetHero now carries only the name row + meta for pilot).
- *   - R2: Abilities (full width) — entity cards with Spend AP (fixed costs
- *     only) and a used/recharge toggle in the card foot.
- *   - R3: Inventory (span 7) ∥ Linked Units (span 5) — the linked-unit rail
- *     MOVED here from the hero's bottom strip.
+ * The body OWNS the identity band (no LiveSheet `renderHero`): it renders
+ * `SheetHero` in band mode as its first region, wrapped with the shell's
+ * `heroRef` so the sticky bar still condenses when the band scrolls away. This
+ * keeps the identity + vitals rendering (and all their handlers) in one
+ * component. Region order mirrors the printed pilot sheet:
+ *   - Identity Band: edge wordmark ∥ identity fields ∥ HP/AP/TP + Conditions
+ *     vitals rail (one toned frame — the printed top band).
+ *   - Abilities (full width, 3-column card grid) — entity cards with Spend AP
+ *     (fixed costs only) and a used/recharge toggle in the card foot.
+ *   - Inventory (full-width band) — equipment cards + generic entries.
+ *   - Linked Units — the assigned-mech / home-crawler rail.
  *
- * Every collection/field section is framed by `SheetSectionCard` (the poster
+ * Every collection section is framed by `SheetSectionCard` (the poster
  * `.dcard`), except Linked Units which the poster renders as a bare `.sect`
  * header + rail stack (no card frame).
  *
@@ -33,10 +36,10 @@
  */
 
 import { useMemo, useState } from 'react'
-import type { ReactNode } from 'react'
+import type { ReactNode, Ref } from 'react'
 import { SalvageUnionReference } from 'salvageunion-reference'
 import type { SURefAbility } from 'salvageunion-reference'
-import { Panel, Stat, VitalGauge } from 'component-lib'
+import { Badge, Panel, SheetHero, Stat, VitalGauge } from 'component-lib'
 
 import type { ItemCondition } from '../../lib/schemas/mech'
 import type { GenericInventoryEntry, Pilot } from '../../lib/schemas/pilot'
@@ -115,6 +118,12 @@ type PilotSheetProps = {
   /** When true, every edit affordance is suppressed (published snapshots). */
   readOnly?: boolean
   /**
+   * Condense sentinel from the LiveSheet shell — wraps the identity band (the
+   * body's first region) so the sticky bar still condenses when it scrolls
+   * away. Undefined in bare test renders (no shell).
+   */
+  heroRef?: Ref<HTMLElement>
+  /**
    * The Linked Units rail content (mech + crawler RailChip/RailEmpty), built
    * by SheetPilot from `composition` — PilotSheet has no composition access
    * of its own, so this is passed straight through into the R3 section.
@@ -126,6 +135,7 @@ export function PilotSheet({
   pilot,
   store = useEntityStore,
   readOnly = false,
+  heroRef,
   linkedUnits,
 }: PilotSheetProps) {
   const storeState = store()
@@ -366,91 +376,95 @@ export function PilotSheet({
         </div>
       )}
 
-      {/* ===== R1: Identity ∥ Vitals (poster top band) ===== */}
-      <div className="grid grid-cols-1 gap-[22px] @5xl:grid-cols-12 @5xl:gap-6">
-        <div className="@5xl:col-span-7">
-          <SheetSectionCard
-            title="Identity"
-            controls={
-              !readOnly ? (
-                <SectionEditButton
-                  section="Identity"
-                  editing={identityEditing}
-                  onToggle={() => setIdentityEditing((v) => !v)}
-                />
-              ) : undefined
-            }
-          >
-            <PilotIdentityPanel
-              pilot={pilot}
+      {/* ===== Identity Band (Workshop-Manual pilot sheet top region) =====
+          Edge wordmark ∥ identity fields ∥ HP/AP/TP + Conditions vitals rail,
+          in one toned frame — the printed pilot sheet's top band. Carries the
+          shell's condense sentinel (heroRef). */}
+      <SheetHero
+        heroRef={heroRef}
+        cat="Pilot"
+        name={pilot.name}
+        meta={
+          dead ? (
+            <Badge surface="tone" tone="bad">
+              Dead
+            </Badge>
+          ) : undefined
+        }
+        controls={
+          !readOnly ? (
+            <SectionEditButton
+              section="Identity"
               editing={identityEditing}
-              onToggleUsed={readOnly ? undefined : toggleUsed}
-              patch={readOnly ? undefined : patchPilot}
+              onToggle={() => setIdentityEditing((v) => !v)}
             />
-          </SheetSectionCard>
-        </div>
-
-        <div className="@5xl:col-span-5">
-          <SheetSectionCard title="Vitals">
-            <div className="flex w-full flex-col [&>*+*]:mt-[14px] [&>*+*]:border-t [&>*+*]:border-dashed [&>*+*]:border-[color-mix(in_srgb,var(--tone-deep)_40%,transparent)] [&>*+*]:pt-[14px]">
-              <VitalGauge
-                label="HP"
-                value={hp}
-                max={maxHP}
-                onChange={readOnly ? undefined : (v) => patchPilot({ currentHP: v })}
-                onMaxChange={
-                  readOnly
-                    ? undefined
-                    : (next) => overridePilotMax({ maxHpModifier: modOrUndef(next, derivedMaxHP) })
-                }
-                overriddenFrom={readOnly ? undefined : derivedMaxHP}
-                onRevertOverride={
-                  readOnly ? undefined : () => overridePilotMax({ maxHpModifier: undefined })
-                }
-                readOnly={readOnly}
-              />
-              <VitalGauge
-                label="AP"
-                value={ap}
-                max={maxAP}
-                onChange={readOnly ? undefined : (v) => patchPilot({ currentAP: v })}
-                onMaxChange={
-                  readOnly
-                    ? undefined
-                    : (next) => overridePilotMax({ maxApModifier: modOrUndef(next, derivedMaxAP) })
-                }
-                overriddenFrom={readOnly ? undefined : derivedMaxAP}
-                onRevertOverride={
-                  readOnly ? undefined : () => overridePilotMax({ maxApModifier: undefined })
-                }
+          ) : undefined
+        }
+        fields={
+          <PilotIdentityPanel
+            pilot={pilot}
+            editing={identityEditing}
+            onToggleUsed={readOnly ? undefined : toggleUsed}
+            patch={readOnly ? undefined : patchPilot}
+          />
+        }
+        vitals={
+          <div className="flex w-full flex-col [&>*+*]:mt-[14px] [&>*+*]:border-t [&>*+*]:border-dashed [&>*+*]:border-[color-mix(in_srgb,var(--tone-deep)_40%,transparent)] [&>*+*]:pt-[14px]">
+            <VitalGauge
+              label="HP"
+              value={hp}
+              max={maxHP}
+              onChange={readOnly ? undefined : (v) => patchPilot({ currentHP: v })}
+              onMaxChange={
+                readOnly
+                  ? undefined
+                  : (next) => overridePilotMax({ maxHpModifier: modOrUndef(next, derivedMaxHP) })
+              }
+              overriddenFrom={readOnly ? undefined : derivedMaxHP}
+              onRevertOverride={
+                readOnly ? undefined : () => overridePilotMax({ maxHpModifier: undefined })
+              }
+              readOnly={readOnly}
+            />
+            <VitalGauge
+              label="AP"
+              value={ap}
+              max={maxAP}
+              onChange={readOnly ? undefined : (v) => patchPilot({ currentAP: v })}
+              onMaxChange={
+                readOnly
+                  ? undefined
+                  : (next) => overridePilotMax({ maxApModifier: modOrUndef(next, derivedMaxAP) })
+              }
+              overriddenFrom={readOnly ? undefined : derivedMaxAP}
+              onRevertOverride={
+                readOnly ? undefined : () => overridePilotMax({ maxApModifier: undefined })
+              }
+              readOnly={readOnly}
+            />
+            <TpBlock
+              value={tp}
+              onChange={readOnly ? undefined : (v) => patchPilot({ trainingPoints: v })}
+              editable={!readOnly}
+            />
+            <div className="w-full min-w-0">
+              <span
+                className="mb-2 block font-cond text-label font-bold uppercase leading-none tracking-caps"
+                style={{ color: 'var(--tone-deep, var(--color-ink))' }}
+              >
+                Conditions
+              </span>
+              <ConditionsEditor
+                conditions={pilot.conditions}
+                onChange={handleConditionsChange}
                 readOnly={readOnly}
               />
             </div>
-            <div className="mt-4 flex flex-wrap gap-4 border-t border-dashed border-[color-mix(in_srgb,var(--tone-deep)_40%,transparent)] pt-[14px]">
-              <TpBlock
-                value={tp}
-                onChange={readOnly ? undefined : (v) => patchPilot({ trainingPoints: v })}
-                editable={!readOnly}
-              />
-              <div className="w-full min-w-0 flex-1">
-                <span
-                  className="mb-2 block font-cond text-label font-bold uppercase leading-none tracking-caps"
-                  style={{ color: 'var(--tone-deep, var(--color-ink))' }}
-                >
-                  Conditions
-                </span>
-                <ConditionsEditor
-                  conditions={pilot.conditions}
-                  onChange={handleConditionsChange}
-                  readOnly={readOnly}
-                />
-              </div>
-            </div>
-          </SheetSectionCard>
-        </div>
-      </div>
+          </div>
+        }
+      />
 
-      {/* ===== R2: Abilities (full width) ===== */}
+      {/* ===== Abilities (full width, 3-column card grid — printed pilot sheet) ===== */}
       <SheetSectionCard
         title="Abilities"
         count={
@@ -470,7 +484,7 @@ export function PilotSheet({
         {pilot.abilities.length === 0 ? (
           <p className="font-body text-caption text-wk-muted">No abilities learned yet.</p>
         ) : (
-          <EntityGrid>
+          <EntityGrid columns={3}>
             {pilot.abilities.map((slug) => {
               const ability = resolveAbility(slug)
               if (!ability) {
@@ -508,7 +522,7 @@ export function PilotSheet({
         )}
       </SheetSectionCard>
 
-      {/* ===== R3: Inventory (full width) ===== */}
+      {/* ===== Inventory (full-width band, printed pilot sheet bottom) ===== */}
       <SheetSectionCard
         title="Inventory"
         count={

--- a/apps/itun/src/components/sheet/SheetCrawler.tsx
+++ b/apps/itun/src/components/sheet/SheetCrawler.tsx
@@ -2,21 +2,20 @@
  * SheetCrawler — the crawler branch of the live sheet (extracted from
  * Sheet.tsx, audit item 19; redesigned to the poster layout, Phase 2).
  *
- * The hero now carries ONLY the name row + meta (poster region grid, D7):
- * Identity, the economy readouts and the linked-unit rail all moved into the
- * body's poster regions (see `CrawlerSheet`) — SheetHero no longer receives
- * `identityBlock`/`vitals`/`rail`, which have since been deleted from it
- * outright, mirroring SheetPilot/SheetMech.
+ * The body owns the identity band now (Workshop-Manual layout): SheetCrawler
+ * passes NO `renderHero`, and `CrawlerSheet` renders the `SheetHero` band as
+ * its first region (wrapping it with the `heroRef` from `renderBody`).
  * This component's remaining job is composing the economy band (the poster
  * `.econ` frame — `CrawlerEconFrame` — wrapping the SP `VitalGauge` + the
- * Tech-LVL/Upkeep/Upgrade/Trade/Crew lozenges, the R-4 action entry points)
- * and the docked-mech/lead-pilot rail content, and handing both to
- * `CrawlerSheet` as `economy` / `linkedUnits`. Owns the economy-dialog state
- * (it was hoisted to Sheet only because the branch wasn't a component).
+ * Tech-LVL/Upkeep/Upgrade/Trade/Crew lozenges, the R-4 action entry points),
+ * which is handed to `CrawlerSheet` as `economy` and rendered as the identity
+ * band's vitals rail, plus the docked-mech/lead-pilot rail content handed down
+ * as `linkedUnits`. Owns the economy-dialog state (it was hoisted to Sheet
+ * only because the branch wasn't a component).
  */
 
 import { useState } from 'react'
-import { EntityRow, Stat, VitalGauge } from 'component-lib'
+import { EntityRow, VitalGauge } from 'component-lib'
 
 import { parseCrawlerTechLevel } from '../../lib/crawlerLevel'
 import { bayGate, tradingSourceTl } from '../../lib/rules/crawlerEconomy'
@@ -29,7 +28,6 @@ import type { CrawlerEconomyDialog } from './CrawlerEconomyControl'
 import { CrawlerSheet } from './CrawlerSheet'
 import { LiveSheet } from './LiveSheet'
 import type { LiveSheetStripItem } from './LiveSheet'
-import { SheetHero } from 'component-lib'
 import { RailChip } from './SheetRail'
 import { RailCta, RailStatLine } from './SheetRailParts'
 import { bayStates, mechRailItems, mechStatusPill, pilotRailItems } from './railStats'
@@ -237,24 +235,13 @@ export function SheetCrawler({
         pill={{ label: 'Crawler', tone: 'crawler' }}
         segments={segments}
         actions={actions}
-        renderHero={({ heroRef }) => (
-          <SheetHero
-            heroRef={heroRef}
-            cat="Crawler"
-            name={crawler.name}
-            meta={
-              tl !== undefined ? (
-                <Stat orientation="horizontal" label="Tech LV" value={tl} />
-              ) : undefined
-            }
-          />
-        )}
-        renderBody={() => (
+        renderBody={({ heroRef }) => (
           <CrawlerSheet
             crawler={crawler}
             mech={composition.mech}
             store={store}
             readOnly={readOnly}
+            heroRef={heroRef}
             economy={economy}
             linkedUnits={rail}
           />

--- a/apps/itun/src/components/sheet/SheetMech.tsx
+++ b/apps/itun/src/components/sheet/SheetMech.tsx
@@ -2,11 +2,9 @@
  * SheetMech — the mech branch of the live sheet (extracted from
  * Sheet.tsx, audit item 19; redesigned to the poster layout, Phase 2).
  *
- * The hero now carries ONLY the name row + meta (poster region grid, D7):
- * Identity, Vitals and the linked-unit rail all moved into the body's R1/R4
- * poster regions (see `MechSheet`) — SheetHero no longer receives
- * `identityBlock`/`inset`/`rail`, which have since been deleted from it
- * outright, mirroring SheetPilot. This
+ * The body owns the identity band now (Workshop-Manual layout): SheetMech
+ * passes NO `renderHero`, and `MechSheet` renders the `SheetHero` band as its
+ * first region, wrapping it with the `heroRef` from `renderBody`. This
  * component's remaining job is the condensed top-bar strip and composing the
  * assigned-pilot/home-crawler rail content handed to `MechSheet` as
  * `linkedUnits`. Push / Heat Check are Guided-Play transactions that live on
@@ -23,7 +21,6 @@ import { LiveSheet } from './LiveSheet'
 import type { LiveSheetStripItem } from './LiveSheet'
 import { DashboardChooser } from '../dashboard/DashboardChooser'
 import { MechSheet } from './MechSheet'
-import { SheetHero } from 'component-lib'
 import { EntityRow } from 'component-lib'
 import { RailChip } from './SheetRail'
 import { RailCta, RailStatLine } from './SheetRailParts'
@@ -151,12 +148,12 @@ export function SheetMech({
           actions
         )
       }
-      renderHero={({ heroRef }) => <SheetHero heroRef={heroRef} cat="Mech" name={mech.name} />}
-      renderBody={() => (
+      renderBody={({ heroRef }) => (
         <MechSheet
           mech={mech}
           store={store}
           readOnly={readOnly}
+          heroRef={heroRef}
           crawler={composition.crawler}
           linkedUnits={rail}
         />

--- a/apps/itun/src/components/sheet/SheetPilot.tsx
+++ b/apps/itun/src/components/sheet/SheetPilot.tsx
@@ -2,17 +2,14 @@
  * SheetPilot — the pilot branch of the live sheet (extracted from
  * Sheet.tsx, audit item 19; redesigned to the poster layout, Phase 2).
  *
- * The hero now carries ONLY the name row + meta (poster region grid, D7):
- * Identity, Vitals and the linked-unit rail all moved into the body's R1/R3
- * poster regions (see `PilotSheet`) — SheetHero no longer receives
- * `identityBlock`/`inset`/`rail`, which have since been deleted from it
- * outright (nothing had passed them since this migration). This component's
- * remaining job
- * is composing the assigned-mech/home-crawler rail content and handing it to
- * `PilotSheet` as `linkedUnits`.
+ * The body owns the identity band now (Workshop-Manual layout): SheetPilot
+ * passes NO `renderHero`, and `PilotSheet` renders the `SheetHero` band as its
+ * first region, wrapping it with the `heroRef` from `renderBody`. This
+ * component's remaining job is composing the assigned-mech/home-crawler rail
+ * content and handing it to `PilotSheet` as `linkedUnits`.
  */
 
-import { Badge, EntityRow, Stat } from 'component-lib'
+import { EntityRow, Stat } from 'component-lib'
 
 import { parseCrawlerTechLevel } from '../../lib/crawlerLevel'
 import { isPilotDead, pilotMaxAP, pilotMaxHP } from '../../lib/rules/derivedStats'
@@ -22,7 +19,6 @@ import { LiveSheet } from './LiveSheet'
 import type { LiveSheetStripItem } from './LiveSheet'
 import { DashboardChooser } from '../dashboard/DashboardChooser'
 import { PilotSheet } from './PilotSheet'
-import { SheetHero } from 'component-lib'
 import { RailChip } from './SheetRail'
 import { RailCta, RailStatLine } from './SheetRailParts'
 import { crawlerRailItems, mechRailItems, mechStatusPill } from './railStats'
@@ -153,22 +149,14 @@ export function SheetPilot({
           actions
         )
       }
-      renderHero={({ heroRef }) => (
-        <SheetHero
+      renderBody={({ heroRef }) => (
+        <PilotSheet
+          pilot={pilot}
+          store={store}
+          readOnly={readOnly}
           heroRef={heroRef}
-          cat="Pilot"
-          name={pilot.name}
-          meta={
-            dead ? (
-              <Badge surface="tone" tone="bad">
-                Dead
-              </Badge>
-            ) : undefined
-          }
+          linkedUnits={rail}
         />
-      )}
-      renderBody={() => (
-        <PilotSheet pilot={pilot} store={store} readOnly={readOnly} linkedUnits={rail} />
       )}
     />
   )

--- a/apps/itun/src/components/sheet/StorageManifest.tsx
+++ b/apps/itun/src/components/sheet/StorageManifest.tsx
@@ -48,7 +48,7 @@ import { Badge, Button, Card, Input, SlotGrid, Stat, toast } from 'component-lib
 import type { CargoTransferResult } from '../../lib/cargo/cargoTransfer'
 import type { UseCargoResult } from '../../lib/cargo/useCargo'
 import type { CargoLot } from '../../lib/schemas/cargoLot'
-import { makeUnitLot, totalLotUnits } from '../../lib/schemas/cargoLot'
+import { makeScrapLot, makeUnitLot, totalLotUnits } from '../../lib/schemas/cargoLot'
 import { cn } from '../../lib/utils'
 
 /**
@@ -350,14 +350,26 @@ function CargoLotItem({ lot, side, cargo, linked, readOnly, onRemove }: CargoLot
   )
 }
 
+/** Clamp a typed tech level to the 1–6 scrap range. */
+function coerceTl(raw: string): number {
+  const n = Math.trunc(Number(raw))
+  if (!Number.isFinite(n)) return 1
+  return Math.min(6, Math.max(1, n))
+}
+
 /**
- * HoldAdder — a container's own intake form: a free-text lot with an explicit
- * slot cost, added straight into that container. Needs NO counterpart on the
- * other side of the boundary (the mech hold works with no crawler; the Storage
- * Bay works with no docked mech). Mirrors the pilot inventory's
- * GenericEntryAdder shape (name + slots); new lots are SEALED unit lots via
- * `makeUnitLot`. The verb is the side's intake word — 'Load' into the mech
- * hold, 'Stow' into the crawler Storage Bay.
+ * HoldAdder — a container's own intake form, added straight into that
+ * container. Needs NO counterpart on the other side of the boundary (the mech
+ * hold works with no crawler; the Storage Bay works with no docked mech). A
+ * Kind toggle picks what is entered:
+ *   - `Cargo` (default) — a free-text SEALED unit lot (name + slot cost) via
+ *     `makeUnitLot`, the original behaviour.
+ *   - `Scrap` — an arbitrary bulk SCRAP lot at a chosen tech level (1–6) via
+ *     `makeScrapLot`, so a crawler (or mech) can stow scrap by hand. This is
+ *     the physical-cargo path; the crawler's abstract scrap POOL is edited
+ *     separately by `ScrapPoolAdder`.
+ * The verb is the side's intake word — 'Load' into the mech hold, 'Stow' into
+ * the crawler Storage Bay.
  */
 function HoldAdder({
   onAdd,
@@ -369,56 +381,101 @@ function HoldAdder({
   containerLabel: string
 }) {
   const slotsId = useId()
+  const tlId = useId()
+  const [kind, setKind] = useState<'cargo' | 'scrap'>('cargo')
   const [name, setName] = useState('')
-  const [slots, setSlots] = useState(1)
+  const [amount, setAmount] = useState(1)
+  const [tl, setTl] = useState(1)
+
+  const canCommit = kind === 'scrap' ? amount > 0 : name.trim().length > 0
 
   function commit() {
-    const trimmed = name.trim()
-    if (!trimmed) return
-    onAdd(makeUnitLot(trimmed, { units: coerceSlots(String(slots)) }))
+    if (!canCommit) return
+    if (kind === 'scrap') {
+      onAdd(makeScrapLot(tl, amount))
+    } else {
+      onAdd(makeUnitLot(name.trim(), { units: coerceSlots(String(amount)) }))
+    }
     setName('')
-    setSlots(1)
+    setAmount(1)
   }
 
   const compactInput = 'px-2 py-1.5 text-xs'
 
   return (
     <div className="mt-3 flex flex-wrap items-center gap-2 rounded-[3px] border-chrome border-dashed border-wk-faint p-2.5">
-      <Input
-        type="text"
-        value={name}
-        aria-label="New cargo name"
-        placeholder="Cargo name"
-        onChange={(e) => setName(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') commit()
-        }}
-        className={`${compactInput} w-36 flex-1`}
-      />
+      {/* Kind toggle — Cargo (named lot) vs Scrap (TL bulk lot). */}
+      {/* biome-ignore lint/a11y/useSemanticElements: a fieldset+legend carries min-content sizing quirks in this inline add-row; role="group" + aria-label conveys the same semantics (matches FilterRow/Stat) */}
+      <div className="flex items-center gap-1" role="group" aria-label="Cargo kind">
+        {(['cargo', 'scrap'] as const).map((k) => (
+          <Badge
+            key={k}
+            as="button"
+            surface={kind === k ? 'solid' : 'ghost'}
+            aria-pressed={kind === k}
+            onClick={() => setKind(k)}
+          >
+            {k === 'cargo' ? 'Cargo' : 'Scrap'}
+          </Badge>
+        ))}
+      </div>
+
+      {kind === 'cargo' ? (
+        <Input
+          type="text"
+          value={name}
+          aria-label="New cargo name"
+          placeholder="Cargo name"
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') commit()
+          }}
+          className={`${compactInput} w-36 flex-1`}
+        />
+      ) : (
+        <label
+          htmlFor={tlId}
+          className="flex items-center gap-1 font-cond text-label font-bold uppercase tracking-wide text-wk-muted"
+        >
+          Tech
+          <Input
+            id={tlId}
+            type="number"
+            min={1}
+            max={6}
+            step={1}
+            value={tl}
+            aria-label="Scrap tech level"
+            onChange={(e) => setTl(coerceTl(e.target.value))}
+            className={`${compactInput} w-14`}
+          />
+        </label>
+      )}
+
       <label
         htmlFor={slotsId}
         className="flex items-center gap-1 font-cond text-label font-bold uppercase tracking-wide text-wk-muted"
       >
-        Slots
+        {kind === 'scrap' ? 'Qty' : 'Slots'}
         <Input
           id={slotsId}
           type="number"
           min={0}
           step={1}
-          value={slots}
-          aria-label="New cargo slot cost"
+          value={amount}
+          aria-label={kind === 'scrap' ? 'Scrap quantity' : 'New cargo slot cost'}
           // `CargoLotSchema.units` is `.int()`, and a `type="number"` field still
           // accepts a typed "1.5". Without truncating here the lot fails its Zod
           // parse on commit — and since the form clears itself immediately, the
           // cargo would just vanish. Coerce at the edge instead.
-          onChange={(e) => setSlots(coerceSlots(e.target.value))}
+          onChange={(e) => setAmount(coerceSlots(e.target.value))}
           className={`${compactInput} w-14`}
         />
       </label>
       <Button
         size="compact"
-        disabled={!name.trim()}
-        aria-label={`${verb} cargo into the ${containerLabel}`}
+        disabled={!canCommit}
+        aria-label={`${verb} ${kind} into the ${containerLabel}`}
         onClick={commit}
       >
         {verb}

--- a/apps/itun/src/components/sheet/__tests__/CrawlerSheet-editable.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/CrawlerSheet-editable.test.tsx
@@ -6,11 +6,11 @@
  *   1. Bay status: Intact bays lead with their function action; a Damaged bay
  *      disables the function and promotes Repair (design §4.4 / pattern 8).
  *   2. Repair decrements 5 Scrap from the crawler-TL pool bucket, spilling
- *      into higher buckets, and flips the bay Intact (S12) — the scrapPool
- *      DATA/logic is kept (#413) even though the hand-edit Scrap Pool slab
- *      UI was dropped (D6).
+ *      into higher buckets, and flips the bay Intact (S12).
  *   3. A short pool is advisory — Repair still proceeds, never blocks (S12).
  *   4. readOnly suppresses every edit affordance.
+ *   5. The Storage Bay's Scrap Pool steppers hand-edit `crawler.scrapPool`
+ *      (Free Edit) — a crawler can stow arbitrary scrap by tech level.
  *
  * Uses the store-injection seam + a patched CrawlerBays.all. NO mock.module().
  */
@@ -272,5 +272,43 @@ describe('CrawlerSheet — readOnly suppresses edits', () => {
 
     expect(update).not.toHaveBeenCalled()
     expect(updateCrawlerBay).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scrap Pool editor (Free Edit — stow arbitrary scrap by tech level)
+// ---------------------------------------------------------------------------
+
+describe('CrawlerSheet — Scrap Pool steppers', () => {
+  let restore: () => void
+  afterEach(() => {
+    restore?.()
+  })
+
+  test('incrementing a tech-level bucket patches crawler.scrapPool', async () => {
+    restore = await patchCrawlerBays()
+    const update = mock(async () => fakeCrawler)
+    render(<CrawlerSheet crawler={fakeCrawler} store={makeStubStore(fakeCrawler, { update })} />)
+
+    // fakeCrawler.scrapPool = { tl2: 3, tl3: 4 } → step T2 up to 4. Each TL box
+    // labels its stepper `Increase T{n}`, so T2's increment is unique.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /increase t2/i }))
+    })
+
+    const call = update.mock.calls.at(-1)
+    expect(call?.[0]).toBe('crawler')
+    expect(call?.[2]).toMatchObject({ scrapPool: { tl2: 4, tl3: 4 } })
+  })
+
+  test('readOnly renders the pool as read-only (no steppers)', async () => {
+    restore = await patchCrawlerBays()
+    const update = mock(async () => fakeCrawler)
+    render(
+      <CrawlerSheet crawler={fakeCrawler} store={makeStubStore(fakeCrawler, { update })} readOnly />
+    )
+
+    expect(screen.queryByRole('button', { name: /increase t2/i })).toBeNull()
+    expect(update).not.toHaveBeenCalled()
   })
 })

--- a/apps/itun/src/components/sheet/__tests__/CrawlerSheet-editable.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/CrawlerSheet-editable.test.tsx
@@ -296,7 +296,7 @@ describe('CrawlerSheet — Scrap Pool steppers', () => {
       fireEvent.click(screen.getByRole('button', { name: /increase t2/i }))
     })
 
-    const call = update.mock.calls.at(-1)
+    const call = update.mock.calls.at(-1) as [string, string, Record<string, unknown>] | undefined
     expect(call?.[0]).toBe('crawler')
     expect(call?.[2]).toMatchObject({ scrapPool: { tl2: 4, tl3: 4 } })
   })

--- a/apps/itun/src/components/sheet/__tests__/MechSheet-hold.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/MechSheet-hold.test.tsx
@@ -203,6 +203,28 @@ describe('MechSheet — The Hold (standalone Load / Unload, no crawler)', () => 
     expect(lots[0]).toMatchObject({ name: 'Water Barrel', units: 3, kind: 'unit' })
   })
 
+  test('the Scrap kind adds a tech-level scrap lot (cat SCRAP + tl + qty)', async () => {
+    const captured: CapturedUpdate[] = []
+    const mech = makeMech({ cargoLots: [] })
+    render(<MechSheet mech={mech} store={makeStore(mech, captured)} />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^scrap$/i }))
+    })
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/scrap tech level/i), { target: { value: '3' } })
+      fireEvent.change(screen.getByLabelText(/scrap quantity/i), { target: { value: '5' } })
+    })
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /load scrap into the mech hold/i }))
+    })
+
+    expect(captured).toHaveLength(1)
+    const lots = must(captured[0]).patch.cargoLots as Array<Record<string, unknown>>
+    expect(lots).toHaveLength(1)
+    expect(lots[0]).toMatchObject({ cat: 'SCRAP', tl: 3, qty: 5, units: 5, kind: 'bulk' })
+  })
+
   test('a fractional slot cost is truncated, not silently dropped', async () => {
     // `CargoLotSchema.units` is `.int()`, and a `type="number"` field still
     // accepts a typed "1.5". Before coercion the lot failed its Zod parse on

--- a/apps/itun/src/components/sheet/__tests__/MechSheet-unresolved-chassis.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/MechSheet-unresolved-chassis.test.tsx
@@ -65,9 +65,10 @@ describe('MechSheet — unresolved chassis (chassis=null)', () => {
   test('the body still renders: Identity/Vitals regions, item fallback, hold', () => {
     render(<MechSheet mech={fakeMech} chassis={null} store={makeStubStore(fakeMech)} />)
 
-    // Identity/Vitals poster regions stay available (maxima derive to 0, never crash).
-    expect(screen.getByText('Identity')).toBeTruthy()
-    expect(screen.getByText('Vitals')).toBeTruthy()
+    // The identity band stays available (maxima derive to 0, never crash): its
+    // fields and the SP vitals gauge render even with no chassis resolved.
+    expect(screen.getByText(/pattern name/i)).toBeTruthy()
+    expect(screen.getByText('Structure')).toBeTruthy()
     // The unresolvable system slug falls back to plain text.
     expect(screen.getByText('mystery-system')).toBeTruthy()
     // The Hold renders against a zero cargo cap.

--- a/apps/itun/src/components/sheet/__tests__/responsive-layout.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/responsive-layout.test.tsx
@@ -133,11 +133,12 @@ describe('Sheet responsive layout — wired composition (LiveSheet shell)', () =
     expect(container.querySelector('[data-variant="mech"]')).toBeTruthy()
   })
 
-  test('Sheet crawler body macro-grid stacks on mobile and splits content ∥ Storage rail at its container breakpoint', () => {
-    // Pilot, Mech and (Phase 2) Crawler all moved identity/vitals/rail
-    // content OUT of the hero into the body's poster regions — the crawler
-    // body additionally carries a 2-col macro grid (content column ∥
-    // full-height Storage rail) that stacks to one column on mobile.
+  test('Sheet crawler body is a single-column region flow with Storage as a full-width bottom band', () => {
+    // Workshop-Manual crawler sheet: a single-column region stack (Identity →
+    // Bays → Weapons → Linked Units → Storage Bay), NOT the old 2-col macro
+    // grid that stood Storage up as a full-height right column. The old
+    // `54fr`-split grid is gone; the crawler section flows in one column and
+    // the Storage Bay renders as its own section at the bottom.
     const { container } = render(
       <Sheet
         kind="crawler"
@@ -146,9 +147,14 @@ describe('Sheet responsive layout — wired composition (LiveSheet shell)', () =
         softLinkStore={makeSoftLinkStore([])}
       />
     )
-    const macroGrid = container.querySelector('[class*="54fr"]')
-    expect(macroGrid).toBeTruthy()
-    expect((macroGrid as HTMLElement).className).toContain('grid-cols-1')
+    // The old right-column macro grid is removed.
+    expect(container.querySelector('[class*="54fr"]')).toBeNull()
+    // The crawler body's region flow is a single column.
+    const flow = container.querySelector('section[aria-label$="crawler sheet"] > div')
+    expect(flow).toBeTruthy()
+    expect((flow as HTMLElement).className).toContain('flex-col')
+    // The Storage Bay band is present.
+    expect(container.textContent).toContain('Storage Bay')
   })
 })
 

--- a/apps/itun/src/components/sheet/__tests__/sheet-smoke.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/sheet-smoke.test.tsx
@@ -228,7 +228,7 @@ describe('Smoke — crawler-only sheet', () => {
     expect(screen.getAllByText(/Rust Colossus/).length).toBeGreaterThan(0)
   })
 
-  test('crawler tech level appears in the sheet (hero Tech LV mchip)', () => {
+  test('crawler tech level appears in the sheet (economy rail Tech LVL readout)', () => {
     render(
       <Sheet
         kind="crawler"
@@ -237,7 +237,7 @@ describe('Smoke — crawler-only sheet', () => {
         softLinkStore={makeSoftLinkStore([])}
       />
     )
-    expect(screen.getByText('Tech LV')).toBeTruthy()
+    expect(screen.getByText('Tech LVL')).toBeTruthy()
   })
 })
 

--- a/packages/component-lib/src/components/shared/EntityGrid.tsx
+++ b/packages/component-lib/src/components/shared/EntityGrid.tsx
@@ -26,16 +26,29 @@ import type { CardFootMeta } from './Card'
 
 type EntityGridProps = {
   children: ReactNode
+  /**
+   * Max desktop column count. `2` (default) keeps the original two-column cap.
+   * `3` opts into the three-across ladder the Workshop-Manual live sheets use
+   * (abilities / systems & modules / bays), matching the printed sheets; it
+   * still steps down to 2 at tablet and 1 on mobile so a card never crushes.
+   */
+  columns?: 2 | 3
   className?: string
 }
 
 /**
- * Entity-card grid — 1 column on mobile, max 2 on desktop, equal-height rows.
- * Gap rhythm: 26px between rows, 18px between columns.
+ * Entity-card grid — 1 column on mobile, up to `columns` on desktop (default
+ * 2), equal-height rows. Gap rhythm: 26px between rows, 18px between columns.
  */
-export function EntityGrid({ children, className }: EntityGridProps) {
+export function EntityGrid({ children, columns = 2, className }: EntityGridProps) {
   return (
-    <div className={cn('grid grid-cols-1 items-stretch gap-x-4 gap-y-6 md:grid-cols-2', className)}>
+    <div
+      className={cn(
+        'grid grid-cols-1 items-stretch gap-x-4 gap-y-6 md:grid-cols-2',
+        columns === 3 && 'xl:grid-cols-3',
+        className
+      )}
+    >
       {children}
     </div>
   )

--- a/packages/component-lib/src/components/sheet/SheetHero.tsx
+++ b/packages/component-lib/src/components/sheet/SheetHero.tsx
@@ -33,7 +33,7 @@ type HeroIdentityLine = {
 }
 
 type SheetHeroProps = {
-  /** Black category tab, e.g. 'PILOT'. */
+  /** Category, e.g. 'PILOT' — the edge wordmark in band mode, the black tab in legacy mode. */
   cat: string
   name: string
   /** mchip / pill row under the name. */
@@ -44,6 +44,21 @@ type SheetHeroProps = {
   specs?: ReactNode
   /** lg StatBlock tracker cluster (rendered inside the VITALS region). */
   trackers?: ReactNode
+  /**
+   * BAND MODE (Workshop-Manual identity band). When provided, the hero renders
+   * the printed-sheet identity band — a left **edge wordmark** (`cat`, paper on
+   * the sheet tone, NOT a black stamp), the `fields` identity block in the
+   * middle, and the `vitals` current/max rail on the right — and DROPS the big
+   * name stamp (the name lives in its own field). `name` still becomes the
+   * accessible `<h1>`. Legacy mode (name stamp + `identity`/`specs`/`trackers`)
+   * is unchanged when `fields` is absent, so snapshots and un-migrated sheets
+   * keep working.
+   */
+  fields?: ReactNode
+  /** Band mode: the current/max gauge rail (right column). */
+  vitals?: ReactNode
+  /** Band mode: header-right controls (e.g. the identity Edit/Done toggle). */
+  controls?: ReactNode
   /** Forwarded to the hero root for the shell's condense observer. */
   heroRef?: Ref<HTMLElement>
   className?: string
@@ -56,9 +71,48 @@ export function SheetHero({
   identity = [],
   specs,
   trackers,
+  fields,
+  vitals,
+  controls,
   heroRef,
   className,
 }: SheetHeroProps) {
+  // BAND MODE — the printed-sheet identity band: edge wordmark ∥ fields ∥
+  // vitals rail. Drops the name stamp; the name is the accessible <h1>.
+  if (fields) {
+    return (
+      <section
+        ref={heroRef}
+        aria-label={`${name} sheet header`}
+        className={cn('relative overflow-hidden rounded-card border-entity border-ink', className)}
+        style={{ background: 'var(--tone)' }}
+      >
+        <h1 className="sr-only">{name}</h1>
+        <div className="grid grid-cols-1 gap-3 p-3 sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:gap-4 sm:p-4">
+          {/* Edge wordmark — paper on the sheet tone (NOT an ink stamp): a
+              horizontal eyebrow on mobile, a vertical left-edge wordmark that
+              reads bottom-to-top on sm+, mirroring the printed sheets. */}
+          <span
+            aria-hidden="true"
+            className="font-cond text-display font-extrabold uppercase leading-none tracking-caps-tight text-paper sm:self-stretch sm:rotate-180 sm:place-self-center sm:text-display-lg sm:[writing-mode:vertical-rl]"
+          >
+            {cat}
+          </span>
+
+          {/* Identity fields (middle) + optional edit control. */}
+          <div className="flex min-w-0 flex-col gap-2">
+            {controls && <div className="flex justify-end">{controls}</div>}
+            {fields}
+            {meta && <div className="flex flex-wrap items-center gap-1.5">{meta}</div>}
+          </div>
+
+          {/* Current/max gauge rail (right). */}
+          {vitals && <div className="min-w-0 sm:w-[220px]">{vitals}</div>}
+        </div>
+      </section>
+    )
+  }
+
   const identityLines = identity.filter((line) => line.value.trim().length > 0)
   const hasIdentityRegion = Boolean(specs || identityLines.length > 0)
   const hasVitalsRegion = Boolean(trackers)

--- a/packages/component-lib/src/utils/__tests__/cn.test.ts
+++ b/packages/component-lib/src/utils/__tests__/cn.test.ts
@@ -49,6 +49,19 @@ describe('cn', () => {
       expect(cn('text-label-lg text-paper')).toBe('text-label-lg text-paper')
     })
 
+    // Regression: the display/heading rungs (readout/title/display/display-lg/
+    // hero) were missing from the registered scale, so tailwind-merge treated
+    // them as COLORS and dropped a real color that shared the list. The sheet
+    // hero name-stamp is `cn('… bg-ink text-paper …', 'text-display …')`, which
+    // lost `text-paper` and rendered ink-on-ink — an invisible title.
+    test('keeps the display/heading font sizes alongside text colors', () => {
+      expect(cn('bg-ink text-paper', 'text-display')).toBe('bg-ink text-paper text-display')
+      expect(cn('text-paper text-display-lg')).toBe('text-paper text-display-lg')
+      expect(cn('text-readout text-ink')).toBe('text-readout text-ink')
+      expect(cn('text-title text-paper')).toBe('text-title text-paper')
+      expect(cn('text-hero text-ink')).toBe('text-hero text-ink')
+    })
+
     test('resolves semantic font-size conflicts (last wins)', () => {
       expect(cn('text-nano', 'text-micro')).toBe('text-micro')
       expect(cn('text-sm', 'text-caption')).toBe('text-caption')

--- a/packages/component-lib/src/utils/cn.ts
+++ b/packages/component-lib/src/utils/cn.ts
@@ -9,8 +9,13 @@ import { extendTailwindMerge } from 'tailwind-merge'
  * `twMerge('border-entity border-ink')` would strip `border-entity`, leaving
  * the element with no border width at all.
  *
- * - `theme.text` — the semantic type scale (`--text-nano` … `--text-lede` in
- *   ITUN's index.css) feeds the font-size class group.
+ * - `theme.text` — the WHOLE semantic type scale (`--text-nano` … `--text-hero`
+ *   in `theme.css`, including the display/heading rungs `readout`/`title`/
+ *   `display`/`display-lg`/`hero`) feeds the font-size class group. Registering
+ *   only the body rungs was a latent bug: an unregistered size like
+ *   `text-display` was treated as a COLOR, so `cn('text-paper', 'text-display')`
+ *   dropped `text-paper` — which is exactly how the sheet hero name-stamp lost
+ *   its white ink and rendered black-on-ink (an invisible title).
  * - `theme.tracking` — the caps tracking steps (`--tracking-caps*`) feed the
  *   letter-spacing group (defensive: unknown tracking values pass through
  *   today, but registering them gives correct conflict resolution).
@@ -21,7 +26,21 @@ import { extendTailwindMerge } from 'tailwind-merge'
 const twMerge = extendTailwindMerge({
   extend: {
     theme: {
-      text: ['nano', 'micro', 'label', 'label-lg', 'badge', 'note', 'caption', 'lede'],
+      text: [
+        'nano',
+        'micro',
+        'label',
+        'label-lg',
+        'badge',
+        'note',
+        'caption',
+        'lede',
+        'readout',
+        'title',
+        'display',
+        'display-lg',
+        'hero',
+      ],
       tracking: ['caps', 'caps-tight', 'caps-snug', 'caps-wide'],
       // Radius scale (--radius-* in theme.css) → rounded-pip/badge/card/panel.
       radius: ['pip', 'badge', 'card', 'panel'],


### PR DESCRIPTION
## Summary

Redesigns the ITUN **live sheets** (pilot / mech / crawler) to read region-for-region like the printed Salvage Union **Workshop Manual** character sheets, using existing shared primitives — no new visual language, one small new composition. Also fixes an invisible-title bug found along the way.

Built incrementally, each step verified (typecheck + tests + a headless-Chrome no-horizontal-scroll pass at 1440 / 768 / 390):

1. **Black-on-black titles — fixed (systemic).** The hero name rendered ink-on-ink on all three sheets: `cn()`'s tailwind-merge config didn't register the display/heading font-size names, so `text-display` was treated as a text *color* and stripped `text-paper`. One-line config fix + regression test.
2. **Crawler Storage → full-width bottom band.** Single-column region flow; Storage spans the full width at the bottom (printed sheet p.2) instead of a full-height right column. Bays/weapons open to 3 columns via a new opt-in `columns` prop on the shared `EntityGrid` (default stays 2).
3. **Stow arbitrary scrap — both paths.** A crawler **Scrap Pool** editor (T1–T6 `Stat` steppers editing `scrapPool`) and a **Cargo/Scrap kind toggle** on the Hold add-form (`makeScrapLot`).
4. **Identity Band, all three sheets.** The top region is now one toned frame: a **paper-on-tone edge wordmark** (PILOT / MECH / CRAWLER), the identity fields, and a current/max **vitals rail** (Pilot HP/AP/TP · Mech SP/EP/Heat + 8-box Chassis-Stats strip · Crawler SP + Tech/Upkeep/Upgrade economy). **No name pseudoheader stamp** — the name lives in its field. Card grids open to 3 columns; Cargo/Inventory become full-width bottom bands.

### Architecture
`SheetHero` gained a **band mode** (`fields`/`vitals`/`controls` slots + wordmark); legacy mode is untouched so snapshots keep working. `LiveSheet.renderHero` is now optional and `renderBody` receives the condense `heroRef`, so each **body owns its identity band** — identity + vitals stay in one component with their handlers, which is why the body-targeting sheet tests kept passing.

## Design sign-off
Mockup + primitive map + the locked decisions (edge wordmark, no name pseudoheader, max 3 cols, reuse `VitalGauge`, scrap-pool editor in the Storage band, no horizontal scroll) were reviewed before build.

## Test
- `bun run typecheck` (all packages) — clean
- itun **1249** · component-lib **524** · srd **1003** tests pass
- No horizontal scroll on any sheet at 1440 / 768 / 390

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnkS8zm9UR79ZhMDaSvH5D