### PR TITLE
fix(itun): crawler bay sheet pass + card action rail moves to the top-right corner

### DIFF
--- a/apps/itun/src/components/sheet/CrawlerSheet.tsx
+++ b/apps/itun/src/components/sheet/CrawlerSheet.tsx
@@ -11,12 +11,16 @@
  *
  *   Identity Band: edge wordmark ∥ Name/Type/Ability/Description fields ∥ the
  *     Economy rail (SP `VitalGauge` + Tech-LVL/Upkeep/Upgrade readouts, built
- *     by SheetCrawler and passed as `economy`) → Bays (3-column `EntityGrid`)
- *     → Armament Bay Weapons (3-column) → Linked Units (bare section, no card
- *     frame) → Storage Bay.
- *   Storage Bay is the FULL-WIDTH band at the very BOTTOM (printed sheet p.2 —
- *     Storage Bay spans the whole width beneath the bays), NOT a full-height
- *     right column.
+ *     by SheetCrawler and passed as `economy`) → Bays (3-column MASONRY
+ *     `EntityGrid`) → Storage Bay (the full-width bay band) → the mounted
+ *     Armament Bay weapons (standalone sealed cards) → Linked Units (bare
+ *     section, no card frame).
+ *   Storage Bay is the FULL-WIDTH band, and it sits WITH the rest of the bays
+ *     rather than at the very bottom of the sheet. It is an installed bay like
+ *     any other, so it used to render twice — once as a grid cell and once as
+ *     this band, in two different regions. The band is the richer rendering
+ *     (Scrap Pool + the unlimited manifest), so it is the only one, and it sits
+ *     where the thing it renders belongs.
  *
  * Economy (SP `VitalGauge` + Tech-LVL/Upkeep/Upgrade lozenges) is built by
  * `SheetCrawler` (it owns the economy-dialog state + `patch`) and handed
@@ -27,23 +31,24 @@
  *
  * Bays stay ONE unified grid (no crew/functional split — redesign
  * refinement; the poster's homebrew/custom-bay split is blocked on a
- * data-model flag, #403 — leave unified) as compact entity cards (max 2
- * columns), each with Intact/Damaged status (rules C8), its crew lead as an
- * NpcInset, a "Docks <mech>" one-liner on the Mech Bay, and a
- * function/Repair action pair. Repair decrements 5 Scrap from the
- * crawler-TL pool bucket, spilling into higher buckets — a short pool is
- * advisory, never a block (S12).
+ * data-model flag, #403 — leave unified), each with Intact/Damaged status
+ * (rules C8), its crew lead as an NpcInset, a "Docks <mech>" one-liner on the
+ * Mech Bay, and a function/Repair action pair. Repair decrements 5 Scrap from
+ * the crawler-TL pool bucket, spilling into higher buckets — a short pool is
+ * advisory, never a block (S12). The grid is MASONRY: bays range from a couple
+ * of lines to a full crew inset, and row alignment padded every short bay out
+ * to its tallest neighbour.
  *
- * Armament Bay Weapons — collection section (unified edit language
- * archetype B): always-available '+ Add' opening the existing weapons
- * picker (CrawlerSystemsEditModal), per-card remove (✕). The poster has no
- * region for this (it's live mounted loadout, not a play-control panel, so
- * it's not part of the D6 drop list below) — it gets its own content-column
- * card.
+ * Armament Bay Weapons — NOT a section. Each mounted weapon is a standalone
+ * reference card wearing an "Armament Bay" seam stampseal (top-left) and a
+ * "Change" control on its top-right rail that opens the weapons picker
+ * (CrawlerSystemsEditModal); the per-card remove (✕) rides the same rail. The
+ * section frame that used to hold them restated, in chrome, exactly what the
+ * seal and the Change control say on the card itself.
  *
- * Storage Bay (The Hold) — the unlimited StorageManifest (side='crawler'),
- * in the full-height right rail; ← Load is cap-checked against the docked
- * mech. Keeps the Stow/Load transfer feature.
+ * Storage Bay (The Hold) — the unlimited StorageManifest (side='crawler') over
+ * the Scrap Pool, as the full-width band beneath the bay grid; ← Load is
+ * cap-checked against the docked mech. Keeps the Stow/Load transfer feature.
  *
  * Dropped (redesign D6 — no poster counterpart; tracking issues filed for
  * re-homing as an off-sheet action surface):
@@ -66,7 +71,8 @@
 
 import { useState } from 'react'
 import type { ReactNode, Ref } from 'react'
-import { ReferenceEntityCard, SheetHero, Stat } from 'component-lib'
+import { Badge, ReferenceEntityCard, SheetHero, Stat } from 'component-lib'
+import type { ReferenceEntityControl } from 'component-lib'
 
 import { addToScrapPool, scrapPoolBucket } from '../../lib/cargo/cargoTransfer'
 import { useCargo } from '../../lib/cargo/useCargo'
@@ -92,6 +98,13 @@ import { StorageManifest } from './StorageManifest'
 import { CrawlerBayCard } from './CrawlerSheetItems'
 import type { CrawlerBayEntry } from './CrawlerSheetItems'
 import { BAY_REPAIR_COST, SCRAP_TLS, resolveCrawlerSystem } from './crawlerSheetItemRules'
+
+/**
+ * The seam stampseal branding every mounted weapon as Armament Bay kit — the
+ * card's own top-left seal slot, which is what replaces the section frame these
+ * cards used to sit inside. Crawler tone, matching the sheet.
+ */
+const ARMAMENT_SEAL = { label: 'Armament Bay', tone: 'var(--color-crawler)' } as const
 
 type CrawlerSheetProps = {
   crawler: Crawler
@@ -163,8 +176,24 @@ export function CrawlerSheet({
   }
 
   const tl = parseCrawlerTechLevel(crawler.techLevel) ?? 1
-  const bays = crawler.crawlerBays ?? []
-  const intactBays = bays.filter((b) => (b.condition ?? 'intact') === 'intact').length
+  const allBays = crawler.crawlerBays ?? []
+  // The Storage Bay is rendered ONCE, as the full-width band below the grid —
+  // it was appearing twice, because it is an installed bay like any other AND
+  // the sheet gives it its own band for the manifest. The band is the richer of
+  // the two (Scrap Pool + cargo lots), so the grid cell is what goes.
+  const isStorageBay = (entry: CrawlerBayEntry) =>
+    entry.bayRef === 'storage-bay' || resolveCrawlerBay(entry.bayRef)?.name === 'Storage Bay'
+  // Carry each entry's ORIGINAL index through the filter. Bays are addressed
+  // POSITIONALLY for writes (`updateCrawlerBay(..., index)`, because a crawler
+  // may install the same bayRef twice), so re-deriving the index from the
+  // filtered array would silently patch the wrong bay for every bay after
+  // Storage — the exact bug a filter over a positionally-addressed list invites.
+  const gridBays = allBays
+    .map((entry, index) => ({ entry, index }))
+    .filter(({ entry }) => !isStorageBay(entry))
+  // The count still reads over ALL installed bays, Storage included — it is a
+  // statement about the crawler, not about how many cells the grid drew.
+  const intactBays = allBays.filter((b) => (b.condition ?? 'intact') === 'intact').length
   const pool = crawler.scrapPool ?? {}
   const lots = crawler.cargoLots ?? []
 
@@ -200,6 +229,28 @@ export function CrawlerSheet({
   /** Remove one mounted weapon (per-card ✕ — archetype B). */
   function removeWeapon(slug: string) {
     patchCrawler((current) => ({ systems: current.systems.filter((s) => s !== slug) }))
+  }
+
+  /**
+   * A mounted weapon's top-right rail: "Change" opens the picker (the whole
+   * armament loadout is edited there), and the remove ✕ stays as the direct
+   * per-card action it already was.
+   */
+  function armamentControls(slug: string): ReferenceEntityControl[] {
+    const system = resolveCrawlerSystem(slug)
+    return [
+      {
+        key: 'change',
+        label: 'Change',
+        ariaLabel: `Change ${system?.name ?? slug}`,
+        title: 'Open the crawler weapons picker',
+        onClick: () => setSystemsModalOpen(true),
+      },
+      ...cardRemoveControls({
+        name: system?.name ?? slug,
+        onRemove: () => removeWeapon(slug),
+      }),
+    ]
   }
 
   /**
@@ -269,27 +320,30 @@ export function CrawlerSheet({
               split). // TODO(redesign): render homebrew/custom bays in a
               separate "Custom Bays" group underneath once the data
               distinguishes them (#403). */}
-          {bays.length > 0 && (
+          {gridBays.length > 0 && (
             <SheetSectionCard
               title="Bays"
               count={
                 <span className="tabular-nums">
-                  {intactBays}/{bays.length} intact
+                  {intactBays}/{allBays.length} intact
                 </span>
               }
             >
-              <EntityGrid columns={3}>
-                {bays.map((entry, i) => {
+              {/* MASONRY — bays vary wildly in height (a Mech Bay carries a crew
+                  inset and a docked-mech line; a Cantina is a couple of lines),
+                  and row alignment padded every short bay out to its tallest
+                  neighbour. */}
+              <EntityGrid columns={3} masonry>
+                {gridBays.map(({ entry, index }) => {
                   const isMechBay =
                     entry.bayRef === 'mech-bay' ||
                     resolveCrawlerBay(entry.bayRef)?.name === 'Mech Bay'
                   return (
-                    // biome-ignore lint/suspicious/noArrayIndexKey: a crawler may install the same bay type more than once, so bayRef alone is not unique; bays are addressed positionally throughout the sheet
-                    <EntityGridRow key={`${entry.bayRef}-${i}`}>
+                    <EntityGridRow key={`${entry.bayRef}-${index}`}>
                       <CrawlerBayCard
                         crawlerId={crawler.id}
                         entry={entry}
-                        index={i}
+                        index={index}
                         crawlerTl={tl}
                         repairShortfall={repairShortfall}
                         onRepair={repairBay}
@@ -305,59 +359,97 @@ export function CrawlerSheet({
             </SheetSectionCard>
           )}
 
-          {/* Armament Bay weapons — crawler weapon systems mount here (Core
-              Book p.213). Collection section: '+ Add' is always available
-              and opens the existing weapons picker; each card carries a
-              remove (✕). */}
-          {(crawler.systems.length > 0 || !readOnly) && (
-            <SheetSectionCard
-              title="Armament Bay Weapons"
-              count={<span className="tabular-nums">{crawler.systems.length}</span>}
-              controls={
-                readOnly ? undefined : (
-                  <SectionAddButton
-                    label="weapons system"
-                    onClick={() => setSystemsModalOpen(true)}
+          {/* ----- Storage Bay — the crawler's OTHER bay, rendered as the
+              full-width band (Scrap Pool + the unlimited manifest) rather than
+              a grid cell, and sitting directly beneath the rest of the bays. It
+              used to render BOTH ways, in two different places on the sheet. ----- */}
+          <SheetSectionCard
+            title="Storage Bay"
+            count={
+              <span className="tabular-nums">
+                {lots.length} {lots.length === 1 ? 'lot' : 'lots'} · unlimited
+              </span>
+            }
+            className="min-w-0"
+          >
+            {/* Scrap Pool — the crawler's abstract TL-bucketed scrap store (rules
+                S12; the bucket bay-repair spends). Per-tech-level `Stat` steppers
+                let a crawler stow arbitrary scrap by hand (Free Edit). The
+                physical-scrap-cargo path lives in the Hold add-form's Scrap kind. */}
+            <div className="mb-4 border-b border-dashed border-[color-mix(in_srgb,var(--tone-deep)_40%,transparent)] pb-4">
+              <span
+                className="mb-2 block font-cond text-label font-bold uppercase leading-none tracking-caps"
+                style={{ color: 'var(--tone-deep, var(--color-ink))' }}
+              >
+                Scrap Pool
+              </span>
+              <div className="flex flex-wrap gap-2">
+                {SCRAP_TLS.map((t) => (
+                  <Stat
+                    key={t}
+                    label={`T${t}`}
+                    value={scrapPoolBucket(pool, t)}
+                    min={0}
+                    size="mini"
+                    mode={readOnly ? 'read' : 'edit'}
+                    ariaLabel={`Tech ${t} scrap`}
+                    onChange={readOnly ? undefined : (next) => setScrapBucket(t, next)}
                   />
+                ))}
+              </div>
+            </div>
+            <StorageManifest
+              side="crawler"
+              cargo={cargo}
+              mechName={mech?.name ?? null}
+              crawlerName={crawler.name}
+              readOnly={readOnly}
+            />
+          </SheetSectionCard>
+
+          {/* Armament Bay weapons — crawler weapon systems mount here (Core
+              Book p.213). NOT its own section row: each mounted weapon is a
+              STANDALONE reference card branded with an "Armament Bay" seam
+              stampseal (top-left) and a "Change" control on the top-right rail
+              that opens the weapons picker. The section frame, its title, its
+              count and the separate '+ Add' button were all chrome restating
+              what the seal and the Change control already say. */}
+          {crawler.systems.length > 0 && (
+            <div className="flex min-w-0 flex-col gap-6">
+              {crawler.systems.map((slug) => {
+                const system = resolveCrawlerSystem(slug)
+                return system ? (
+                  <ReferenceEntityCard
+                    key={slug}
+                    data={system}
+                    size="medium"
+                    parentSeal={ARMAMENT_SEAL}
+                    controls={readOnly ? undefined : armamentControls(slug)}
+                    cardStyle={readOnly ? undefined : REMOVABLE_CARD_STYLE}
+                  />
+                ) : (
+                  <div
+                    key={slug}
+                    className="flex items-center justify-between gap-2 rounded border border-ink px-2 py-1 text-sm text-wk-muted"
+                  >
+                    <span className="min-w-0 truncate">{slug}</span>
+                    {!readOnly && (
+                      <CardRemoveButton name={slug} onRemove={() => removeWeapon(slug)} />
+                    )}
+                  </div>
                 )
-              }
-            >
-              {crawler.systems.length === 0 ? (
-                <p className="font-body text-caption text-wk-muted">No weapons mounted.</p>
-              ) : (
-                <EntityGrid columns={3}>
-                  {crawler.systems.map((slug) => {
-                    const system = resolveCrawlerSystem(slug)
-                    return (
-                      <EntityGridRow key={slug}>
-                        {system ? (
-                          <ReferenceEntityCard
-                            data={system}
-                            size="medium"
-                            controls={
-                              readOnly
-                                ? undefined
-                                : cardRemoveControls({
-                                    name: system.name,
-                                    onRemove: () => removeWeapon(slug),
-                                  })
-                            }
-                            cardStyle={readOnly ? undefined : REMOVABLE_CARD_STYLE}
-                          />
-                        ) : (
-                          <div className="flex items-center justify-between gap-2 rounded border border-ink px-2 py-1 text-sm text-wk-muted">
-                            <span className="min-w-0 truncate">{slug}</span>
-                            {!readOnly && (
-                              <CardRemoveButton name={slug} onRemove={() => removeWeapon(slug)} />
-                            )}
-                          </div>
-                        )}
-                      </EntityGridRow>
-                    )
-                  })}
-                </EntityGrid>
-              )}
-            </SheetSectionCard>
+              })}
+            </div>
+          )}
+          {/* Nothing mounted — the Change affordance still has to exist, so the
+              empty state IS the seal + Change, with no card under it. */}
+          {crawler.systems.length === 0 && !readOnly && (
+            <div className="flex items-center justify-between gap-3">
+              <Badge shape="stamp" size="mini">
+                Armament Bay
+              </Badge>
+              <SectionAddButton label="weapons system" onClick={() => setSystemsModalOpen(true)} />
+            </div>
           )}
         </div>
 
@@ -367,53 +459,6 @@ export function CrawlerSheet({
           <Slab variant="solid" label="Linked Units" />
           <div className="flex flex-col gap-4">{linkedUnits}</div>
         </div>
-
-        {/* ----- Storage Bay — the FULL-WIDTH bottom band (printed crawler
-            sheet p.2: Storage Bay spans the whole width beneath the bays), not
-            a full-height right column. ----- */}
-        <SheetSectionCard
-          title="Storage Bay"
-          count={
-            <span className="tabular-nums">
-              {lots.length} {lots.length === 1 ? 'lot' : 'lots'} · unlimited
-            </span>
-          }
-          className="min-w-0"
-        >
-          {/* Scrap Pool — the crawler's abstract TL-bucketed scrap store (rules
-              S12; the bucket bay-repair spends). Per-tech-level `Stat` steppers
-              let a crawler stow arbitrary scrap by hand (Free Edit). The
-              physical-scrap-cargo path lives in the Hold add-form's Scrap kind. */}
-          <div className="mb-4 border-b border-dashed border-[color-mix(in_srgb,var(--tone-deep)_40%,transparent)] pb-4">
-            <span
-              className="mb-2 block font-cond text-label font-bold uppercase leading-none tracking-caps"
-              style={{ color: 'var(--tone-deep, var(--color-ink))' }}
-            >
-              Scrap Pool
-            </span>
-            <div className="flex flex-wrap gap-2">
-              {SCRAP_TLS.map((t) => (
-                <Stat
-                  key={t}
-                  label={`T${t}`}
-                  value={scrapPoolBucket(pool, t)}
-                  min={0}
-                  size="mini"
-                  mode={readOnly ? 'read' : 'edit'}
-                  ariaLabel={`Tech ${t} scrap`}
-                  onChange={readOnly ? undefined : (next) => setScrapBucket(t, next)}
-                />
-              ))}
-            </div>
-          </div>
-          <StorageManifest
-            side="crawler"
-            cargo={cargo}
-            mechName={mech?.name ?? null}
-            crawlerName={crawler.name}
-            readOnly={readOnly}
-          />
-        </SheetSectionCard>
       </div>
 
       {/* The weapons picker — the existing master-detail modal, mounted

--- a/apps/itun/src/components/sheet/CrawlerSheetItems.tsx
+++ b/apps/itun/src/components/sheet/CrawlerSheetItems.tsx
@@ -32,8 +32,13 @@ const BAY_FUNCTIONS: Record<string, string> = {
   Cantina: 'Rumour',
 }
 
-/** Stable hide literal — the bay's long rules text lives in the detail modal. */
-const HIDE_BAY_CONTENT = { content: true } as const
+// Nothing is hidden on a bay card any more. It used to hide `content` — which,
+// combined with the card's then-unconditional "When Damaged" callout, left an
+// intact bay rendering as nothing but a standing damage warning. The card now
+// shows its actual content, and (because this card passes `status`) routes the
+// damaged effect into a centred overlay that appears only while the bay is
+// broken. Both halves live in ReferenceEntityCard; there is no hide config to
+// state here.
 
 type CrawlerBayCardProps = {
   crawlerId: string
@@ -172,11 +177,10 @@ export function CrawlerBayCard({
   )
 
   const functionLabel = BAY_FUNCTIONS[bay.name] ?? 'Use'
-  const leadName = entry.npcName?.trim() ? entry.npcName : (npc?.position ?? '—')
-  const footMeta: CardFootMeta[] = [
-    { label: 'Lead', value: leadName },
-    ...(damaged ? [{ label: 'Repair', value: `5·T${crawlerTl}` }] : []),
-  ]
+  // The crew lead is NOT footer meta — the NpcInset directly above states the
+  // name (and now the role) in full, so a "Lead · <name>" pair in the foot was
+  // repeating the inset's own head bar one row below it.
+  const footMeta: CardFootMeta[] = damaged ? [{ label: 'Repair', value: `5·T${crawlerTl}` }] : []
 
   // Damaged disables the function action and promotes Repair (design §4.4 /
   // interaction pattern 8). Both ride the standard controls overlay — no footer.
@@ -216,7 +220,6 @@ export function CrawlerBayCard({
       <ReferenceEntityCard
         data={cardData}
         size="medium"
-        hide={HIDE_BAY_CONTENT}
         status={condition}
         onStatusClick={readOnly ? undefined : toggleCondition}
         selections={selections}

--- a/apps/itun/src/components/sheet/__tests__/CrawlerSheet-bay-npc.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/CrawlerSheet-bay-npc.test.tsx
@@ -140,7 +140,9 @@ describe('CrawlerSheet — crew lead identity (NpcInset)', () => {
 
     const inset = screen.getByLabelText('Command Bay crew lead')
     expect(within(inset).getByText('Dax Orsund')).toBeTruthy()
-    expect(within(inset).getByText('Princeps')).toBeTruthy()
+    // The SRD role is the head-bar tag now, definite-article'd ("THE PRINCEPS"),
+    // replacing the generic "Crew" tag it used to sit beside.
+    expect(within(inset).getByText('The Princeps')).toBeTruthy()
     expect(within(inset).getByText('A stern veteran.')).toBeTruthy()
   })
 

--- a/apps/itun/src/components/sheet/__tests__/CrawlerSheet-type.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/CrawlerSheet-type.test.tsx
@@ -155,7 +155,10 @@ describe('CrawlerIdentityPanel — type + ability cards', () => {
 
     const inset = screen.getByLabelText('Battle crew lead')
     expect(within(inset).getByText('Vex')).toBeTruthy()
-    expect(within(inset).getByText('Grizzled Veteran')).toBeTruthy()
+    // The SRD role is the inset's head-bar tag, definite-article'd — the tag
+    // slot used to carry a generic "Crew" and the role sat as muted right-edge
+    // text; they swapped, and HP took the freed right edge.
+    expect(within(inset).getByText('The Grizzled Veteran')).toBeTruthy()
   })
 
   test('renders the type NPC Keepsake/Motto from bayChoices keyed by the type ref', async () => {

--- a/packages/component-lib/src/components/chrome/InlineEditField.tsx
+++ b/packages/component-lib/src/components/chrome/InlineEditField.tsx
@@ -31,11 +31,30 @@ type InlineEditFieldProps = {
   placeholder?: string
   /** Strip the edit affordance — renders as plain text only. */
   readOnly?: boolean
+  /**
+   * The GROUND the resting readout sits on. `ink` (default) is the normal
+   * paper-ground field: ink text, muted placeholder, ink hover wash. `paper`
+   * inverts it for a field sitting ON an ink surface (the `Inset` head bar).
+   *
+   * This is a prop rather than a `className` override because the readout's
+   * colour is set on the INNER display span, not the wrapper `className` lands
+   * on — so passing `text-paper` from outside left the hardcoded `text-ink`
+   * standing and rendered the crawler bay's crew-lead name black on the black
+   * head bar. The three colours (text, placeholder, hover wash) also have to
+   * move together; a single class override could only ever fix one of them.
+   */
+  tone?: 'ink' | 'paper'
   ariaLabel?: string
   className?: string
 }
 
 const ERROR_SKIN = 'border-status-bad focus:ring-status-bad/25'
+
+/** Resting-readout colours per ground: text, empty-placeholder, hover wash. */
+const READOUT_TONE = {
+  ink: { text: 'text-ink', empty: 'text-wk-muted', hover: 'hover:bg-ink-8' },
+  paper: { text: 'text-paper', empty: 'text-paper/60', hover: 'hover:bg-paper/15' },
+} as const
 
 // ---------------------------------------------------------------------------
 // Component — the pure edit-in-place engine. Labelling + the straddling stamp
@@ -53,9 +72,11 @@ export function InlineEditField({
   bordered = false,
   placeholder,
   readOnly = false,
+  tone = 'ink',
   ariaLabel,
   className,
 }: InlineEditFieldProps) {
+  const readout = READOUT_TONE[tone]
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -141,12 +162,13 @@ export function InlineEditField({
           // The display state is the tap target that opens the editor, so it
           // keeps a 44px minimum in BOTH layouts — dropping to min-h-9 would
           // have silently shrunk it below the touch target.
-          'inline-flex min-h-11 items-center font-body font-bold text-ink',
+          'inline-flex min-h-11 items-center font-body font-bold',
+          readout.text,
           // Bordered mode fills its value box; plain mode stays inline.
           bordered && 'w-full rounded-card px-3',
-          !hasValue && 'font-normal text-wk-muted',
+          !hasValue && cn('font-normal', readout.empty),
           !readOnly &&
-            cn('cursor-pointer hover:bg-ink-8', INPUT_FOCUS, !bordered && 'rounded-card px-1')
+            cn('cursor-pointer', readout.hover, INPUT_FOCUS, !bordered && 'rounded-card px-1')
         )}
       >
         {hasValue ? value : (placeholder ?? '—')}

--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -1429,6 +1429,18 @@ function ReferenceEntityCardInner({
   // CRAWLER BAY damaged effect → a red-ghosted, action-card-style callout (the
   // string is filtered out of the body prose above). RED token: `--color-status-bad`.
   const damagedBands = damagedEffect ? ghostActionTone('var(--color-status-bad)') : undefined
+  // WHERE that callout goes depends on whether this card is DOCUMENTING the
+  // effect or SUFFERING it, and `status` is exactly that distinction: a
+  // reference card (SRD bay page) has no condition and reads the effect as part
+  // of the entity's rules, so it stays inline in the body. A condition-tracked
+  // card (the crawler live sheet) has one, so the effect is a STATE: silent
+  // while intact — where an always-on "When Damaged" panel was both the only
+  // thing in the body and a standing false alarm — and a centred overlay
+  // stamped across the card once it actually breaks.
+  const showDamagedEffect = !hide?.damagedEffect && !!damagedEffect && !!damagedBands
+  const damagedIsLive = status !== undefined
+  const inlineDamagedEffect = showDamagedEffect && !damagedIsLive
+  const overlayDamagedEffect = showDamagedEffect && damagedIsLive && status === 'damaged'
 
   // DRONE — a chassis controls a drone (named by a chassis ability); a pattern
   // specifies one. Rendered as a compact drone card + its systems/modules listings,
@@ -1687,6 +1699,32 @@ function ReferenceEntityCardInner({
     <div className={outerClassName} {...outerInteraction}>
       {seam}
       {topRightRail}
+      {/* DAMAGED OVERLAY — the "When Damaged" text stamped across the middle of
+          a live card that is currently broken. `pointer-events-none` is
+          load-bearing: the card underneath keeps every affordance (the status
+          badge that flips it back, the Repair button), and the rail sits at
+          z-30 so it stays above this. z-20 puts the panel over the body without
+          reaching the rail. */}
+      {overlayDamagedEffect && damagedBands && (
+        <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center p-3">
+          <div
+            className="max-w-full overflow-hidden rounded-card"
+            style={{ border: `3px solid ${damagedBands.frame}` }}
+          >
+            <div
+              className="flex items-center justify-center px-3 py-1.5"
+              style={{ backgroundColor: damagedBands.header }}
+            >
+              <Badge shape="stamp" size="mini">
+                When Damaged
+              </Badge>
+            </div>
+            <p className="m-0 bg-paper p-2 text-center text-xs leading-snug text-ink">
+              {damagedEffect}
+            </p>
+          </div>
+        </div>
+      )}
       <div
         className="flex flex-1 flex-col overflow-hidden rounded-card bg-paper"
         style={frameStyle}
@@ -1790,7 +1828,7 @@ function ReferenceEntityCardInner({
           {/* CRAWLER BAY "WHEN DAMAGED" callout — action-card style (ghosted
               bands + black name-tab + paper body), tinted from the RED danger
               token so it clearly signals the damaged effect. */}
-          {!hide?.damagedEffect && damagedEffect && damagedBands && (
+          {inlineDamagedEffect && damagedBands && (
             <div
               className="overflow-hidden rounded-card"
               style={{ border: `3px solid ${damagedBands.frame}` }}

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/damagedEffect.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/damagedEffect.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * A crawler bay's "When Damaged" text has two jobs, and the card tells them
+ * apart by whether it was given a `status`.
+ *
+ * A REFERENCE card (the SRD bay page) has no condition: the effect is part of
+ * the entity's rules, so it renders inline in the body, always.
+ *
+ * A LIVE card (the crawler sheet, which tracks Intact/Damaged) has one: the
+ * effect is a STATE. Inline-and-always was wrong in both directions there — an
+ * intact bay showed a standing "When Damaged" panel as the only thing in its
+ * body, and a bay that actually broke announced it no more loudly than one that
+ * had not. So on a live card it is silent while intact and a centred overlay
+ * once damaged.
+ *
+ * These tests pin all three cases; the overlay's `pointer-events-none` is pinned
+ * too, because without it the overlay would swallow the very controls that
+ * repair the bay.
+ */
+import { beforeAll, describe, expect, test, afterEach } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+import { ReferenceEntityCard } from '../ReferenceEntityCard'
+
+const commandBay = () => {
+  const found = SalvageUnionReference.CrawlerBays.all().find((b) => b.name === 'Command Bay')
+  if (!found) throw new Error('Command Bay fixture missing')
+  return found
+}
+
+afterEach(cleanup)
+
+describe('crawler bay "When Damaged" — reference vs live', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  test('REFERENCE (no status): renders inline, in the body flow', () => {
+    const { container } = render(<ReferenceEntityCard data={commandBay()} size="medium" />)
+    expect(screen.getByText('When Damaged')).toBeTruthy()
+    // Inline means NOT in an absolutely-positioned overlay.
+    const overlay = container.querySelector('div.absolute.z-20')
+    expect(overlay).toBeNull()
+  })
+
+  test('LIVE + intact: silent — no callout at all', () => {
+    render(<ReferenceEntityCard data={commandBay()} size="medium" status="intact" />)
+    expect(screen.queryByText('When Damaged')).toBeNull()
+  })
+
+  test('LIVE + damaged: a centred overlay that does not eat the card controls', () => {
+    const { container } = render(
+      <ReferenceEntityCard data={commandBay()} size="medium" status="damaged" />
+    )
+    expect(screen.getByText('When Damaged')).toBeTruthy()
+    const overlay = container.querySelector('div.absolute.z-20')
+    if (!(overlay instanceof HTMLElement)) throw new Error('expected the damaged overlay')
+    expect(overlay.className).toContain('inset-0')
+    expect(overlay.className).toContain('items-center')
+    expect(overlay.className).toContain('justify-center')
+    // Load-bearing: the status badge and Repair button live UNDER this.
+    expect(overlay.className).toContain('pointer-events-none')
+  })
+
+  test('LIVE + damaged: renders the effect ONCE (overlay, not overlay + inline)', () => {
+    render(<ReferenceEntityCard data={commandBay()} size="medium" status="damaged" />)
+    expect(screen.getAllByText('When Damaged')).toHaveLength(1)
+  })
+
+  test('hide.damagedEffect still suppresses it in every mode', () => {
+    render(
+      <ReferenceEntityCard
+        data={commandBay()}
+        size="medium"
+        status="damaged"
+        hide={{ damagedEffect: true }}
+      />
+    )
+    expect(screen.queryByText('When Damaged')).toBeNull()
+  })
+})

--- a/packages/component-lib/src/components/shared/CardControlRail.tsx
+++ b/packages/component-lib/src/components/shared/CardControlRail.tsx
@@ -8,7 +8,7 @@ type CardControlRailProps = {
   /** Every card affordance — action buttons and the typed item variants
    * (stepper / badge / status / link). */
   controls?: ReferenceEntityControl[]
-  /** Compact geometry: the rail rides centred on the frame edge rather than
+  /** Compact geometry: the rail rides straddling the frame edge rather than
    * hanging above it. */
   compact?: boolean
   /** Extra nodes rendered between the status cell and the action cluster —
@@ -32,19 +32,23 @@ type CardControlRailProps = {
  * entity card's version here gives both layers the working geometry, and gives
  * `status` exactly one rendering path — a `controls` entry — instead of two.
  *
- * The rail is CENTRED on the card's top edge (`left-1/2 -translate-x-1/2` +
- * `justify-center`), not pinned to the right corner. Centring does NOT relax the
- * overflow containment: the containment comes from `flex-wrap` +
- * `max-w-[calc(100%-1rem)]`, which cap the row at the card width minus a 0.5rem
- * gutter each side and wrap a crowded rail (status seal + selection seal + count
- * seal + three controls) onto stacked, equal-height lines rather than letting it
- * escape the frame. `justify` only sets how those wrapped lines align INSIDE
- * that capped box — it has no bearing on whether the box overflows — so moving
- * from `justify-end` to `justify-center` keeps the exact same bound. Because the
- * box is centred, the max-width leaves the gutter symmetric (0.5rem each side)
- * instead of only on the left. Centring must not reorder the cells: `status`
- * stays the first child so a card carrying both a condition and a selection seal
- * keeps the condition leftmost within the (now centred) row.
+ * The rail is pinned to the card's TOP-RIGHT corner (`right-2` +
+ * `justify-end`). It briefly rode centred (`left-1/2 -translate-x-1/2` +
+ * `justify-center`); that put the action cluster over the middle of the header
+ * band, where it read as content rather than as chrome and crowded the title.
+ * The corner is also the only free edge — the seam stamp owns the top-LEFT on
+ * both shells (`Card`'s callout at `ml-3`, the entity card's at `left-[15px]`),
+ * so a centred rail was drifting toward an occupied corner as it grew.
+ *
+ * Alignment is NOT what contains the rail: the containment comes from
+ * `flex-wrap` + `max-w-[calc(100%-1rem)]`, which cap the row at the card width
+ * minus a 0.5rem gutter and wrap a crowded rail (status seal + selection seal +
+ * count seal + three controls) onto stacked, equal-height lines rather than
+ * letting it escape the frame. `justify` only sets how those wrapped lines align
+ * INSIDE that capped box, so the switch back to `justify-end` keeps the exact
+ * same bound. Cell order is unchanged either way: `status` stays the first child
+ * so a card carrying both a condition and a selection seal keeps the condition
+ * leftmost within the row.
  */
 export function CardControlRail({ controls, compact = false, seals }: CardControlRailProps) {
   const visible = (controls ?? []).filter((c) => !c.hidden)
@@ -62,7 +66,7 @@ export function CardControlRail({ controls, compact = false, seals }: CardContro
   return (
     <div
       className={cn(
-        'absolute left-1/2 z-30 flex max-w-[calc(100%-1rem)] -translate-x-1/2 flex-wrap items-center justify-center gap-1.5',
+        'absolute right-2 z-30 flex max-w-[calc(100%-1rem)] flex-wrap items-center justify-end gap-1.5',
         compact ? 'top-0 -translate-y-1/2' : '-mt-2'
       )}
     >

--- a/packages/component-lib/src/components/shared/EntityGrid.tsx
+++ b/packages/component-lib/src/components/shared/EntityGrid.tsx
@@ -33,14 +33,50 @@ type EntityGridProps = {
    * still steps down to 2 at tablet and 1 on mobile so a card never crushes.
    */
   columns?: 2 | 3
+  /**
+   * MASONRY: pack cards by column instead of by row, so each card is only as
+   * tall as its own content and the next one starts immediately beneath it.
+   *
+   * The default row grid stretches every card in a row to the tallest of them
+   * (`items-stretch`), which is right when the cards are peers of similar
+   * weight and wrong when they are not — a crawler's bays range from a one-line
+   * Storage Bay to a Mech Bay carrying a crew inset and a docked-mech line, and
+   * row alignment gave every short bay a slab of dead paper to match its
+   * tallest neighbour.
+   *
+   * Implemented with CSS multi-column, not `grid-template-rows: masonry`, which
+   * is still not in a stable browser. That choice has one visible consequence
+   * worth knowing: multi-column fills columns top-to-bottom, so reading order
+   * runs DOWN each column rather than across each row.
+   */
+  masonry?: boolean
   className?: string
 }
 
 /**
  * Entity-card grid — 1 column on mobile, up to `columns` on desktop (default
- * 2), equal-height rows. Gap rhythm: 26px between rows, 18px between columns.
+ * 2). Rows are equal-height by default; `masonry` packs by column instead.
+ * Gap rhythm: 26px between rows, 18px between columns.
  */
-export function EntityGrid({ children, columns = 2, className }: EntityGridProps) {
+export function EntityGrid({ children, columns = 2, masonry = false, className }: EntityGridProps) {
+  if (masonry) {
+    return (
+      <div
+        className={cn(
+          // `gap` is column-gap in a multi-column box; the row rhythm is the
+          // children's own bottom margin, and `break-inside-avoid` is what stops
+          // a card being sliced across a column boundary. Both are applied from
+          // here rather than in EntityGridRow so the row primitive stays
+          // layout-agnostic and every child (row-wrapped or bare) is covered.
+          'columns-1 gap-4 md:columns-2 [&>*]:mb-6 [&>*]:break-inside-avoid',
+          columns === 3 && 'xl:columns-3',
+          className
+        )}
+      >
+        {children}
+      </div>
+    )
+  }
   return (
     <div
       className={cn(

--- a/packages/component-lib/src/components/shared/__tests__/CardControlRail.test.tsx
+++ b/packages/component-lib/src/components/shared/__tests__/CardControlRail.test.tsx
@@ -1,14 +1,16 @@
 /**
- * THE CENTRED CONTROL RAIL — centring must not cost overflow containment.
+ * THE TOP-RIGHT CONTROL RAIL — corner-pinned, and still contained.
  *
- * The rail is centred on the card's top edge (`left-1/2 -translate-x-1/2` +
- * `justify-center`) rather than pinned to the right corner. The containment is
- * NOT provided by the alignment — it is provided by `flex-wrap` +
- * `max-w-[calc(100%-1rem)]`, which cap the row at the card width and wrap a
- * crowded rail onto stacked lines. These tests pin both facts on the WORST CASE
- * a card can carry — a status seal, a selection seal, a count seal and three
- * action controls — so a future "just centre it" edit that drops the max-width
- * (and lets the rail spill) fails here.
+ * The rail rides the card's top-RIGHT corner (`right-2` + `justify-end`), not
+ * the middle of the top edge: centred, the action cluster sat over the header
+ * band and read as content rather than chrome, and it grew toward the top-left
+ * corner the seam stamp already owns. The containment is NOT provided by the
+ * alignment — it is provided by `flex-wrap` + `max-w-[calc(100%-1rem)]`, which
+ * cap the row at the card width and wrap a crowded rail onto stacked lines.
+ * These tests pin both facts on the WORST CASE a card can carry — a status seal,
+ * a selection seal, a count seal and three action controls — so a future
+ * re-anchoring edit that drops the max-width (and lets the rail spill) fails
+ * here.
  */
 import { afterEach, describe, expect, test } from 'bun:test'
 import { cleanup, render, screen } from '@testing-library/react'
@@ -41,32 +43,33 @@ function railEl(container: HTMLElement): HTMLElement {
 
 afterEach(cleanup)
 
-describe('CardControlRail — centred, still contained', () => {
-  test('the rail is centred (not right-pinned)', () => {
+describe('CardControlRail — top-right, still contained', () => {
+  test('the rail is pinned top-right (not centred)', () => {
     const { container } = render(
       <CardControlRail controls={crowdedControls} seals={crowdedSeals} />
     )
     const rail = railEl(container)
-    expect(rail.className).toContain('left-1/2')
-    expect(rail.className).toContain('-translate-x-1/2')
-    expect(rail.className).toContain('justify-center')
-    // The old right-corner anchor must be gone.
-    expect(rail.className).not.toContain('right-2')
-    expect(rail.className).not.toContain('justify-end')
+    expect(rail.className).toContain('right-2')
+    expect(rail.className).toContain('justify-end')
+    // The centred anchor must be gone — including the horizontal translate,
+    // which would shift a right-pinned rail half its own width off the card.
+    expect(rail.className).not.toContain('left-1/2')
+    expect(rail.className).not.toContain('-translate-x-1/2')
+    expect(rail.className).not.toContain('justify-center')
   })
 
-  test('centring keeps the overflow bound — flex-wrap + max-w survive', () => {
+  test('corner-pinning keeps the overflow bound — flex-wrap + max-w survive', () => {
     const { container } = render(
       <CardControlRail controls={crowdedControls} seals={crowdedSeals} />
     )
     const rail = railEl(container)
     // These two together are what actually contain a crowded rail; the alignment
-    // does not. If a "centre it" change drops either, a full rail spills.
+    // does not. If a re-anchoring change drops either, a full rail spills.
     expect(rail.className).toContain('flex-wrap')
     expect(rail.className).toContain('max-w-[calc(100%-1rem)]')
   })
 
-  test('centring does not reorder cells — status stays leftmost', () => {
+  test('re-anchoring does not reorder cells — status stays leftmost', () => {
     render(<CardControlRail controls={crowdedControls} seals={crowdedSeals} />)
     const status = screen.getByRole('button', { name: /damaged/i })
     const selection = screen.getByTestId('selection-seal')

--- a/packages/component-lib/src/components/shared/__tests__/EntityGrid.test.tsx
+++ b/packages/component-lib/src/components/shared/__tests__/EntityGrid.test.tsx
@@ -66,6 +66,43 @@ describe('EntityGridRow — mode card (default)', () => {
   })
 })
 
+describe('EntityGrid — masonry', () => {
+  afterEach(cleanup)
+
+  test('packs by column, and keeps the break/rhythm rules that make it work', () => {
+    const { container } = render(
+      <EntityGrid columns={3} masonry>
+        <EntityGridRow>
+          <StubCard />
+        </EntityGridRow>
+      </EntityGrid>
+    )
+    const grid = rootEl(container)
+    expect(grid.className).toContain('columns-1')
+    expect(grid.className).toContain('md:columns-2')
+    expect(grid.className).toContain('xl:columns-3')
+    // Without these two a multi-column box slices cards across column
+    // boundaries and loses the row rhythm entirely — they are not decoration.
+    expect(grid.className).toContain('[&>*]:break-inside-avoid')
+    expect(grid.className).toContain('[&>*]:mb-6')
+    // The row grid's equal-height stretch is the thing masonry exists to drop.
+    expect(grid.className).not.toContain('items-stretch')
+  })
+
+  test('is opt-in — the default stays the equal-height row grid', () => {
+    const { container } = render(
+      <EntityGrid columns={3}>
+        <EntityGridRow>
+          <StubCard />
+        </EntityGridRow>
+      </EntityGrid>
+    )
+    const grid = rootEl(container)
+    expect(grid.className).toContain('items-stretch')
+    expect(grid.className).not.toContain('columns-1')
+  })
+})
+
 describe('EntityGridRow — mode rail', () => {
   afterEach(cleanup)
 

--- a/packages/component-lib/src/components/sheet/NpcInset.tsx
+++ b/packages/component-lib/src/components/sheet/NpcInset.tsx
@@ -4,10 +4,15 @@
  * lead (rules C11: name, keepsake, detail, 4 HP).
  *
  * Composes the shared `Inset` (style-unification pass §3 — the boxed
- * sub-panel: 1.5px ink frame on paper, ink head bar): a pink 'CREW' tag +
- * the lead's (editable) name on the head bar, their SRD role title riding
- * the right edge; body = sm HP Stat beside quiet Keepsake/Detail/Facts id
- * lines.
+ * sub-panel: 1.5px ink frame on paper, ink head bar). Head bar, left to right:
+ * a pink tag carrying the lead's SRD role as a definite-article title ("THE
+ * DOC"), the lead's (editable) name, then the HP `Stat` riding the right edge.
+ * Body = the quiet Keepsake/Motto/Detail/Facts id lines.
+ *
+ * The head bar previously read `[CREW] Name … greaser`: a generic tag, and the
+ * role as muted right-edge text. The role is the informative half of that pair
+ * and the literal "Crew" was restating the inset's own position inside a bay
+ * card, so the role took the tag and HP took the freed right edge.
  *
  * Persistence stays with the caller: name/HP/detail/facts patch the crawler's
  * bay entry; keepsake persists through the bay's SRD freeform 'Keepsake'
@@ -102,7 +107,11 @@ export function NpcInset({
     <div role="group" aria-label={`${bayName} crew lead`}>
       <Inset
         tone="crawler"
-        tag="Crew"
+        // The head-bar tag is the lead's SRD ROLE, definite-article'd — "THE
+        // DOC", not a generic "CREW" keyword. The tag slot already reads as
+        // "what this person is", so the role belongs there and the literal
+        // "Crew" said nothing the inset's position inside a bay card didn't.
+        tag={title ? `The ${title}` : undefined}
         label={
           onNameChange ? (
             <InlineEditField
@@ -110,32 +119,32 @@ export function NpcInset({
               onSave={(next) => onNameChange(String(next))}
               type="text"
               ariaLabel={`Edit ${bayName} crew name`}
-              className="text-paper"
+              // The head bar is ink — the readout has to invert with it. A
+              // `text-paper` className could not do this: it lands on the
+              // wrapper, leaving the readout's own `text-ink` standing (which
+              // is exactly how this rendered black on black).
+              tone="paper"
             />
           ) : (
             name || '—'
           )
         }
+        // HP rides the head bar's right edge — the vital is the thing you read
+        // and poke most, so it sits on the bar rather than leading the body.
         headRight={
-          title ? (
-            <span className="font-cond text-micro uppercase leading-none tracking-caps text-paper/60">
-              {title}
-            </span>
+          maxHp > 0 ? (
+            <Stat
+              label="HP"
+              value={hp}
+              max={maxHp}
+              size="mini"
+              mode={onHpChange ? 'edit' : 'read'}
+              onChange={onHpChange}
+            />
           ) : undefined
         }
         bodyClassName="flex flex-wrap items-start gap-3"
       >
-        {maxHp > 0 && (
-          <Stat
-            label="HP"
-            value={hp}
-            max={maxHp}
-            size="mini"
-            mode={onHpChange ? 'edit' : 'read'}
-            onChange={onHpChange}
-          />
-        )}
-
         <dl className="m-0 min-w-0 flex-1 space-y-1.5">
           <NpcRow label="Keepsake">
             {onKeepsakeChange ? (


### PR DESCRIPTION
## 1 — Card action rail: centre → top-right corner

`CardControlRail` — the shared rail both card shells use for every card affordance (status badge, selection/count seals, action buttons) — was pinned to the **middle** of the card's top edge. Centred, the cluster sat over the header band and read as content rather than chrome, and it grew toward the top-LEFT corner the seam stamp already owns (`Card`'s callout at `ml-3`, the entity card's at `left-[15px]`). Now `right-2` + `justify-end`.

Containment is unchanged: `flex-wrap` + `max-w-[calc(100%-1rem)]` are what bound a crowded rail, not the alignment. Cell order is unchanged (`status` stays leftmost). Tests re-pinned to the corner; the negative assertion now also rejects `-translate-x-1/2`, which would shift a right-pinned rail half its own width off the card.

## 2 — Crawler bay live sheet pass

**NPC crew inset**
- The lead's name rendered **black on the black head bar**. `NpcInset` passed `className="text-paper"`, which lands on `InlineEditField`'s *wrapper* while the readout's own hardcoded `text-ink` stayed put. `InlineEditField` gains a `tone` prop instead, so text, empty-placeholder and hover wash move together — a single class override could only ever have fixed one of the three.
- Dropped the generic **"CREW"** tag; the tag now carries the lead's SRD role, definite-article'd — **"THE DOC"**. The role previously sat as muted right-edge text, i.e. the informative half of the pair was the quiet one.
- **HP** moved from leading the body to riding the head bar's **right edge**.

**Bay cards**
- The crew lead is no longer footer meta — the inset directly above states the name and role in full.
- The **"When Damaged"** callout was inline and unconditional, and the card also hid its `content`, so an *intact* bay rendered as nothing but a standing damage warning. The card now tells documentation from state by whether it was given a `status`: a reference card (SRD bay page) keeps the inline callout; a live card is **silent while intact** and stamps a **centred overlay** across itself once damaged. The overlay is `pointer-events-none`, so the status badge and Repair button underneath stay live, and it sits at z-20 under the z-30 rail.
- Bays are **masonry**-packed via a new opt-in `EntityGrid masonry`. They range from two lines to a full crew inset, and row alignment padded every short bay out to its tallest neighbour. CSS multi-column, not `grid-template-rows: masonry` (not yet in a stable browser) — so reading order runs down each column.

**Sheet layout**
- The **Storage Bay rendered twice**, as a grid cell and as the full-width band, in two different regions. The band is the richer of the two (Scrap Pool + manifest), so it is now the only rendering, and it sits with the rest of the bays. Bay indices are carried through the filter — bays are addressed **positionally** for writes, so a naive filter would have patched the wrong bay for everything after Storage.
- **Armament Bay weapons** are no longer a section. Each mounted weapon is a standalone reference card with an **"Armament Bay" seam stampseal (top-left)** and a **"Change"** control on the top-right rail; the remove ✕ rides the same rail.

## Verification

- `bun run check:all` — green except the pre-existing `postcss`/vite advisory in `check:audit`, untouched by this work.
- component-lib 531 pass · itun 1249 pass · srd 1003 pass · package 889 pass. New tests cover the damaged inline/overlay/silent split and `EntityGrid masonry`.
- **Measured in Chromium at 1440px** against a real built crawler (rail: four Ladle stories; sheet: a crawler built through the wizard): rail 8–11px inside the card's right edge with no overflow; one Storage Bay occurrence; 3 masonry columns; crew name paper-on-ink with HP in the head bar; the damaged panel centred on both axes and rendered exactly once; the armament seal 15px from the card's left with Change on the rail.

## Note

Filtering the Storage Bay out of the grid means its **crew lead (Bullwhacker), condition toggle and Repair** no longer have a home on the sheet — the band renders the manifest, not the bay-card affordances. That follows from "the full-width bar is the only rendering"; say the word and I'll fold those three into the band's header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2kiMSPLHnDr7F2Gq4GCUK