### PR TITLE
fix(reference): restore Eggs Mayhem module facets and roll table

### DIFF
--- a/packages/salvageunion-reference/data/actions.json
+++ b/packages/salvageunion-reference/data/actions.json
@@ -2738,7 +2738,15 @@
   },
   {
     "id": "c0af420b-1690-42c9-99b4-b17f084a1191",
-    "name": "Eggs",
+    "traits": [
+      {
+        "type": "hacking"
+      }
+    ],
+    "actionType": "Turn",
+    "range": ["Medium"],
+    "activationCost": 2,
+    "name": "Eggs Mayhem",
     "content": [
       {
         "type": "paragraph",
@@ -2747,9 +2755,14 @@
       {
         "type": "paragraph",
         "value": "This can only be used to read data and not to write or manipulate it."
+      },
+      {
+        "type": "paragraph",
+        "value": "When activated, choose a target Mech, database, or computer system within Range."
       }
     ],
-    "actionSource": "modules"
+    "actionSource": "modules",
+    "tableName": "Eggs Mayhem"
   },
   {
     "id": "a6e97497-6266-49f4-8c2f-796d62825070",

--- a/packages/salvageunion-reference/data/modules.json
+++ b/packages/salvageunion-reference/data/modules.json
@@ -42,7 +42,7 @@
     "slotsRequired": 1,
     "salvageValue": 3,
     "page": 190,
-    "actions": ["Eggs"],
+    "actions": ["Eggs Mayhem"],
     "additionalSources": [
       {
         "source": "Salvage Union Starter Set",


### PR DESCRIPTION
## What

The **Eggs Mayhem** module (Core Book 2.0a, p. 190) rendered as a bare stat block — Tech Level, Slots Required, Salvage Value and nothing else — with its description detached into a stray sub-card titled *"Eggs"*, and its d20 outcomes missing entirely.

| | Book (p. 190) | Rendered before | Rendered after |
|---|---|---|---|
| Cost | 2EP | — | 2EP |
| Action | Turn Action | — | Turn |
| Range | Medium | — | Medium |
| Trait | Hacking | — | hacking |
| Roll table | 20 / 11-19 / 6-10 / 2-5 / 1 | — | 5 rows |

## Why it broke

Three stacked defects in this module's action record:

1. **The action was misnamed.** `modules.json` had `"name": "Eggs Mayhem"` but `actions: ["Eggs"]`. Both the metadata resolver (`findMatchingAction`, `lib/utilities.ts:199`) and the render core (`resolveFoldedAction.ts:21`) fold an action into its entity only on **exact name equality**, so nothing folded — the action detached into its own sub-card instead. That strict match is deliberate: its doc comment cites the bug where a lone differently-named action put *"Iron Claw"*'s stats into the Molebear's sub-header. So the fix belongs in the data, not the matcher.
2. **The action carried no facets at all** — no `actionType`, `range`, `activationCost` or `traits`, despite `traits.json:333` already asserting Eggs Mayhem has the Hacking trait. The data contradicted itself.
3. **The roll table was orphaned.** A complete, book-accurate `Eggs Mayhem` table sits in `roll-tables.json`, and no `tableName` anywhere pointed at it.

## The fix

Data-only. Renames the action to match its module, adds the four missing facets plus the `tableName` reference, and restores the book's activation sentence ("When activated, choose a target Mech, database, or computer system within Range.").

Values mirror **Panda Sneeze** — the write-counterpart hacking module on the same book page, already correct — and **Firewall**, its neighbour: `Turn` / `Medium` / `2EP` / `hacking` / `tableName`.

## Why CI was blind to it

`validate:all` passes both before and after. The namesake back-reference validator only fires when an action's name *does* match an entity — it never checks the inverse. The orphan validator explicitly exempts `roll-tables` as intentionally-unreferenced root entities.

## Verification

Runtime probe against the real ORM utilities:

```
before:  Eggs Mayhem  type=undefined range=undefined cost=undefined traits=undefined table=MISSING
after:   Eggs Mayhem  type=Turn      range=["Medium"] cost=2        traits=["hacking"] table=PRESENT (5 rows)
control: Panda Sneeze type=Turn      range=["Medium"] cost=2        traits=["hacking"] table=PRESENT (5 rows)
```

Full suite green: lint, format, typecheck, **3738 tests / 0 fail**, validate:all, knip, tokens, styling. (`check:audit` fails on a pre-existing `brace-expansion` advisory reached through `apps/itun`'s dev deps — unrelated to this diff, which touches two JSON data files and does not alter the lockfile.)

## Not included

Eight sibling entities share the same "sole action is a renaming of its entity" shape and also fail to fold — most visibly **Omega Push Module**, whose action is likewise completely bare. They each need their own book verification, so they are left for a follow-up rather than bundled here:

`Video Projection Array`, `Alpha Strike Module`, `Omega Push Module`, `DDR Module`, `Corrupted Neuralink Module`, `Power Transference Cable`, `Portable Comms Unit`, `Bio-Rifle`

(Multi-action entities like `Adv. Targeting Array` and `Bio-Maw` also don't fold, but that is correct by design — they grant several distinct named actions and use the `Name (Host)` convention.)

One judgement call worth a reviewer's eye: `Firewall` and `Panda Sneeze` both carry an editorial *"When activated, roll on the table below to determine the result."* line that is **not** in the book. I left it off Eggs Mayhem to stay book-faithful; say the word if you'd rather it match the sibling convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6ruExb7Pe9EQ8h35vx4Lj