### PR TITLE
fix(srd): render guide steps — most guide prose was missing from every guide page

### DIFF
--- a/apps/srd/src/lib/schemaPreloadDeps.ts
+++ b/apps/srd/src/lib/schemaPreloadDeps.ts
@@ -69,7 +69,7 @@
  * - `guides` steps reference an arbitrary schema chosen in the guide's own
  *   JSON data (`step.schema[0]`, resolved via
  *   `SalvageUnionReference.findAllIn(schemaName, ...)` in
- *   GuideStepsDisplay.resolveSchemaEntities) — this is the same
+ *   referenceEntity/card/resolveGuideSteps.ts) — this is the same
  *   "any route can render any cross-referenced entity" situation ADR-005
  *   describes for ITUN. Not safely narrowable; kept at `'all'`.
  * - Every other schema (no `actions` field, not chassis/classes/factions/

--- a/packages/component-lib/src/components/referenceEntity/__tests__/resolveGuideSteps.test.ts
+++ b/packages/component-lib/src/components/referenceEntity/__tests__/resolveGuideSteps.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'bun:test'
+import { SalvageUnionReference } from 'salvageunion-reference'
+import { enrichForFiltering, matchesFilter, resolveGuideSteps } from '../card/resolveGuideSteps'
+
+const guideByName = (name: string) => {
+  const guide = SalvageUnionReference.Guides.find((g) => g.name === name)
+  if (!guide) throw new Error(`Guide "${name}" not in the reference set`)
+  return guide
+}
+
+describe('resolveGuideSteps', () => {
+  it('resolves every step of every shipped guide', () => {
+    const guides = SalvageUnionReference.Guides.all()
+    expect(guides.length).toBeGreaterThan(0)
+    for (const guide of guides) {
+      expect(resolveGuideSteps(guide)).toHaveLength(guide.steps.length)
+    }
+  })
+
+  it('returns [] for an entity that has no steps', () => {
+    const chassis = SalvageUnionReference.Chassis.all()[0]
+    expect(chassis).toBeDefined()
+    if (chassis) expect(resolveGuideSteps(chassis)).toEqual([])
+  })
+
+  /** The regression this module exists for: guides keep most of their prose in
+   *  `steps`, so a renderer reading only top-level `content` shows almost none
+   *  of the guide. "Salvaging" has NO top-level content at all. */
+  it('surfaces the step prose that top-level content omits', () => {
+    const salvaging = guideByName('Salvaging')
+    expect(salvaging.content ?? []).toHaveLength(0)
+
+    const resolved = resolveGuideSteps(salvaging)
+    const prose = resolved
+      .flatMap(({ step }) => step.content ?? [])
+      .filter((block) => typeof block.value === 'string')
+      .map((block) => String(block.value))
+      .join(' ')
+    expect(prose.length).toBeGreaterThan(2000)
+  })
+
+  it('numbers steps within a section, restarting at each section boundary', () => {
+    const downtime = guideByName('Crawler Downtime')
+    const resolved = resolveGuideSteps(downtime)
+
+    // Every step that opens a section restarts the count at 1.
+    for (const entry of resolved) {
+      if (entry.section) expect(entry.number).toBe(1)
+    }
+    // And numbering is strictly consecutive between boundaries.
+    resolved.forEach((entry, index) => {
+      const previous = resolved[index - 1]
+      if (!previous || entry.section) return
+      expect(entry.number).toBe(previous.number + 1)
+    })
+  })
+
+  it('resolves a roll-table step to its table entity', () => {
+    const resolved = resolveGuideSteps(guideByName('Create a Pilot'))
+    const callsign = resolved.find(({ step }) => step.rollTable === 'Callsign Table')
+    expect(callsign?.table?.name).toBe('Callsign Table')
+    expect(callsign?.table?.table).toBeDefined()
+  })
+
+  it('keeps a schemaEntities step in the data order the book lists', () => {
+    const resolved = resolveGuideSteps(guideByName('Create a Pilot'))
+    const classes = resolved.find(({ step }) => step.name === 'Choose your Pilot Class')
+    const names = step0Names(classes?.entities)
+    expect(names).toEqual(classes?.step.schemaEntities ?? [])
+  })
+
+  /** `treeType` is COMPUTED, not stored — without enrichment this step would
+   *  resolve to all 100+ abilities instead of the level-1 core ones. */
+  it('applies computed-field filters when a step names no explicit entities', () => {
+    const resolved = resolveGuideSteps(guideByName('Create a Pilot'))
+    const ability = resolved.find(({ step }) => step.name === 'Choose your first Ability')
+    expect(ability?.step.schemaEntities ?? []).toHaveLength(0)
+
+    const all = SalvageUnionReference.Abilities.all().length
+    expect(ability?.entities.length).toBeGreaterThan(0)
+    expect(ability?.entities.length).toBeLessThan(all)
+    for (const entity of ability?.entities ?? []) {
+      expect((entity as { level?: number }).level).toBe(1)
+    }
+  })
+})
+
+function step0Names(entities: { name?: string }[] | undefined): string[] {
+  return (entities ?? []).map((e) => e.name ?? '')
+}
+
+describe('matchesFilter', () => {
+  it('skips a filter whose field the entity does not carry', () => {
+    expect(matchesFilter({}, { field: 'techLevel', value: 1 })).toBe(true)
+  })
+
+  it('compares with eq by default and honours ne', () => {
+    expect(matchesFilter({ techLevel: 1 }, { field: 'techLevel', value: 1 })).toBe(true)
+    expect(matchesFilter({ techLevel: 2 }, { field: 'techLevel', value: 1 })).toBe(false)
+    expect(matchesFilter({ techLevel: 2 }, { field: 'techLevel', operator: 'ne', value: 1 })).toBe(
+      true
+    )
+  })
+
+  it('applies min/max bounds to numeric fields', () => {
+    expect(matchesFilter({ techLevel: 3 }, { field: 'techLevel', min: 2, max: 4 })).toBe(true)
+    expect(matchesFilter({ techLevel: 5 }, { field: 'techLevel', min: 2, max: 4 })).toBe(false)
+    expect(matchesFilter({ techLevel: 'B' }, { field: 'techLevel', min: 2 })).toBe(false)
+  })
+})
+
+describe('enrichForFiltering', () => {
+  it('classifies an ability tree as core when a class lists it', () => {
+    const coreTree = SalvageUnionReference.Classes.all()
+      .flatMap((c) => (c as { coreTrees?: string[] }).coreTrees ?? [])
+      .find(Boolean)
+    expect(coreTree).toBeDefined()
+    const enriched = enrichForFiltering({ tree: coreTree }, 'abilities')
+    expect(enriched.treeType).toBe('core')
+  })
+
+  it('classifies Generic and Legendary trees', () => {
+    expect(enrichForFiltering({ tree: 'Generic' }, 'abilities').treeType).toBe('generic')
+    expect(enrichForFiltering({ tree: 'Legendary Ace' }, 'abilities').treeType).toBe('legendary')
+  })
+
+  it('leaves entities of other schemas untouched', () => {
+    const input = { tree: 'Generic' }
+    expect(enrichForFiltering(input, 'equipment')).toBe(input)
+  })
+})

--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -86,6 +86,7 @@ import {
   resolvePatternDrone,
   resolvePatternGroups,
 } from './resolveNestedEntities'
+import { resolveGuideSteps } from './resolveGuideSteps'
 
 /** Beyond this nesting depth a card renders header-only (no body expansion) —
  * bounds runaway recursion (deep chassis → systems → actions, or grant cycles). */
@@ -1652,6 +1653,100 @@ function ReferenceEntityCardInner({
       </div>
     ) : null
 
+  // GUIDE STEPS — a guide keeps almost all of its prose in `steps` (28.7k of
+  // 34.2k characters across the dataset), so a card that renders only the
+  // top-level `content` renders almost none of the guide: the "Salvaging" page
+  // was a heading and a source line with all 3.7k characters of its rules
+  // missing. Each step is a dashed `Slab` (its name) + its prose, with the
+  // entities it selects from and its roll table rendered through the same
+  // primitives every other section uses. A `section` opens a solid `Slab`
+  // above it — those are the book's major divisions ("Post-Session Downtime").
+  //
+  // Read-only by design: this is the SRD's transcription of the procedure.
+  // Walking a guide as an interactive wizard is ITUN's job (`DowntimeWizard`),
+  // and belongs to the surfaces that own player state (ADR-021).
+  const guideSteps = canExpand && !isAction ? resolveGuideSteps(entity) : []
+  const guideStepsNode =
+    guideSteps.length > 0 ? (
+      <div className="flex flex-col gap-3">
+        {guideSteps.map(({ step, number, section, entities, table, subGuide }) => {
+          // `sidebar` marks a step whose entities are a progression LADDER
+          // (crawler tech levels) rather than a set of options — they read down
+          // a narrow column beside the prose instead of across a masonry.
+          const sidebar = step.entityLayout === 'sidebar' && entities.length > 0
+          const prose = step.content && step.content.length > 0 && (
+            <Content
+              body={step.content}
+              compact={compact}
+              chassisName={resolvedChassisName}
+              fontSize={compact ? 'text-xs' : 'text-sm'}
+              headerBg={tone.bg}
+              headerBgColor={tone.bgColor}
+            />
+          )
+          const cards = entities.map((option, index) => (
+            <ReferenceEntityCardInner
+              key={cardKey(option, index)}
+              size="medium"
+              extent="head"
+              depth={depth + 1}
+              hostDown={isDown}
+              data={option}
+              chassisName={resolvedChassisName}
+            />
+          ))
+          return (
+            <div key={step.id} className="flex flex-col gap-1.5">
+              {section && <Slab variant="solid" label={section} />}
+              <Slab
+                variant="dashed"
+                label={`${number}. ${step.name}`}
+                count={step.optional ? 'Optional' : undefined}
+              />
+              {sidebar ? (
+                <div className="flex flex-col gap-3 md:flex-row md:items-start">
+                  <div className="flex shrink-0 flex-col gap-1.5 md:w-2/5">{cards}</div>
+                  <div className="min-w-0 flex-1">{prose}</div>
+                </div>
+              ) : (
+                <>
+                  {prose}
+                  {cards.length > 0 && (
+                    <div className="columns-1 gap-1.5 sm:columns-2">
+                      {entities.map((option, index) => (
+                        <div key={cardKey(option, index)} className="mb-1.5 break-inside-avoid">
+                          {cards[index]}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </>
+              )}
+              {table && (
+                <RollTable
+                  table={table.table}
+                  tableName={table.name}
+                  showCommand
+                  size={compact ? 'compact' : 'full'}
+                  collapsible={isCatalog || depth > 0}
+                  disabled={isDown}
+                />
+              )}
+              {subGuide && (
+                <ReferenceEntityCardInner
+                  size="medium"
+                  extent="head"
+                  depth={depth + 1}
+                  hostDown={isDown}
+                  data={subGuide}
+                />
+              )}
+            </div>
+          )
+        })}
+      </div>
+    ) : null
+
   // LEFT ANCHOR — the artwork image if present, else a prominent nested NPC.
   // Content (flavor + nested groups/actions) flows to the RIGHT of / below the
   // anchor, filling the whitespace. Responsive: stacks full-width on narrow.
@@ -1842,6 +1937,9 @@ function ReferenceEntityCardInner({
               <p className="bg-paper p-2 text-xs leading-snug text-ink">{damagedEffect}</p>
             </div>
           )}
+
+          {/* GUIDE STEPS — the bulk of a guide, straight after its intro prose. */}
+          {guideStepsNode}
 
           {/* ROLL TABLE — the entity's own table, after its prose preamble. */}
           {rollTableNode}

--- a/packages/component-lib/src/components/referenceEntity/card/resolveGuideSteps.ts
+++ b/packages/component-lib/src/components/referenceEntity/card/resolveGuideSteps.ts
@@ -1,0 +1,188 @@
+import type {
+  SURefEntity,
+  SURefMetaEntity,
+  SURefObjectGuideStep,
+  SURefObjectTable,
+} from 'salvageunion-reference'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+/**
+ * Resolve a guide's `steps` into everything the card needs to RENDER them.
+ *
+ * A guide keeps almost all of its prose in `steps`, not in its top-level
+ * `content` — across the shipped dataset that is 28.7k of 34.2k characters. The
+ * legacy `GuideStepsDisplay` rendered them; it was deleted with the rest of the
+ * legacy render core and the unified card never grew a replacement, so every
+ * guide page rendered its title, one intro paragraph and nothing else (the
+ * "Salvaging" page rendered a heading and a source line, no rules at all).
+ *
+ * This module is the RESOLUTION half only — pure, testable, no JSX. The card
+ * renders the result through the same primitives every other section uses
+ * (`Slab`, `Content`, `RollTable`, nested cards), so guide steps inherit the
+ * card's typography and tone instead of carrying their own.
+ */
+
+/** A single guide step, with every reference it names already resolved. */
+export type ResolvedGuideStep = {
+  step: SURefObjectGuideStep
+  /** 1-based position WITHIN its section — restarts at each `section` boundary. */
+  number: number
+  /** Section label this step opens (absent ⇒ it continues the current one). */
+  section?: string
+  /** Entities the step selects from (`schema` + `schemaEntities`/`filters`). */
+  entities: SURefEntity[]
+  /** The step's roll table, resolved by name from the `roll-tables` schema. */
+  table?: { name: string; table: SURefObjectTable }
+  /** A `sub-guide` step's target guide, resolved by id. */
+  subGuide?: SURefEntity
+}
+
+/**
+ * Check one guide-step filter against an entity.
+ *
+ * A filter naming a field the entity does not carry is SKIPPED, not failed:
+ * filters are written against the richest schema in the step and must not
+ * exclude entities that simply lack the field.
+ */
+export function matchesFilter(
+  entity: Record<string, unknown>,
+  filter: {
+    field: string
+    operator?: 'eq' | 'ne'
+    value?: string | number | boolean
+    min?: number
+    max?: number
+  }
+): boolean {
+  const fieldValue = entity[filter.field]
+  if (fieldValue === undefined) return true
+  if (filter.value !== undefined) {
+    const op = filter.operator ?? 'eq'
+    return op === 'ne' ? fieldValue !== filter.value : fieldValue === filter.value
+  }
+  if (filter.min !== undefined && (typeof fieldValue !== 'number' || fieldValue < filter.min))
+    return false
+  if (filter.max !== undefined && (typeof fieldValue !== 'number' || fieldValue > filter.max))
+    return false
+  return true
+}
+
+/** Core ability-tree names, read once from class data. */
+let coreTreeNames: Set<string> | null = null
+function getCoreTreeNames(): Set<string> {
+  if (!coreTreeNames) {
+    coreTreeNames = new Set(
+      SalvageUnionReference.Classes.all().flatMap(
+        (c) => ((c as Record<string, unknown>).coreTrees as string[]) ?? []
+      )
+    )
+  }
+  return coreTreeNames
+}
+
+/**
+ * Add the COMPUTED fields guide filters are written against — they are not
+ * stored on the entities themselves:
+ *
+ * - `hasDamage` (systems/modules) — does any resolved action deal damage.
+ *   "Choose Weapons Systems" in Create a Crawler filters on it.
+ * - `treeType` (abilities) — core / advanced / legendary / generic.
+ *   "Choose your first Ability" filters on it; without this the step would
+ *   list all 103 abilities instead of the level-1 core ones.
+ */
+export function enrichForFiltering(
+  entity: Record<string, unknown>,
+  schemaName: string
+): Record<string, unknown> {
+  if ((schemaName === 'systems' || schemaName === 'modules') && Array.isArray(entity.actions)) {
+    const hasDamage = (entity.actions as string[]).some((name) => {
+      const action = SalvageUnionReference.Actions.find((a) => a.name === name)
+      return action?.damage !== undefined
+    })
+    return { ...entity, hasDamage }
+  }
+  if (schemaName === 'abilities' && typeof entity.tree === 'string') {
+    const { tree } = entity
+    const treeType =
+      tree === 'Generic'
+        ? 'generic'
+        : getCoreTreeNames().has(tree)
+          ? 'core'
+          : tree.startsWith('Legendary')
+            ? 'legendary'
+            : 'advanced'
+    return { ...entity, treeType }
+  }
+  return entity
+}
+
+/**
+ * The entities a step selects from.
+ *
+ * `schemaEntities` (an explicit name list) preserves the DATA's order — the
+ * book lists a step's options in a deliberate order, and re-sorting them would
+ * silently disagree with the page it is transcribed from. Without that list the
+ * step means "everything in the schema matching `filters`".
+ *
+ * `actions` is not a real schema (it is a virtual one on the step type), so a
+ * step naming it resolves to no entities and renders as prose only.
+ */
+function resolveStepEntities(step: SURefObjectGuideStep): SURefEntity[] {
+  const schemaName = step.schema?.[0]
+  if (!schemaName || schemaName === 'actions') return []
+
+  const filters = step.filters ?? []
+  const passes = (entity: SURefEntity): boolean =>
+    filters.length === 0 ||
+    filters.every((filter) =>
+      matchesFilter(enrichForFiltering(entity as Record<string, unknown>, schemaName), filter)
+    )
+
+  if (!step.schemaEntities || step.schemaEntities.length === 0) {
+    return SalvageUnionReference.findAllIn(schemaName, passes) as SURefEntity[]
+  }
+
+  const wanted = new Set(step.schemaEntities)
+  const found = SalvageUnionReference.findAllIn(
+    schemaName,
+    (entity) => wanted.has(entity.name) && passes(entity as SURefEntity)
+  ) as SURefEntity[]
+  const byName = new Map(found.map((entity) => [entity.name, entity]))
+  return step.schemaEntities
+    .map((name) => byName.get(name))
+    .filter((entity): entity is SURefEntity => entity !== undefined)
+}
+
+/**
+ * Resolve every step of a guide. Returns `[]` for any entity that is not a
+ * guide (or a guide with no steps), so the caller can render unconditionally.
+ */
+export function resolveGuideSteps(entity: SURefMetaEntity): ResolvedGuideStep[] {
+  if (!('steps' in entity) || !Array.isArray(entity.steps)) return []
+  const steps = entity.steps as SURefObjectGuideStep[]
+
+  let number = 0
+  return steps.map((step) => {
+    if (step.section) number = 0
+    number += 1
+
+    const table = step.rollTable
+      ? SalvageUnionReference.RollTables.find((t) => t.name === step.rollTable)
+      : undefined
+    const subGuide = step.guideRef
+      ? SalvageUnionReference.findIn('guides', (g) => g.id === step.guideRef)
+      : undefined
+
+    return {
+      step,
+      number,
+      section: step.section,
+      entities: resolveStepEntities(step),
+      table:
+        table && 'table' in table && table.table
+          ? { name: table.name, table: table.table as SURefObjectTable }
+          : undefined,
+      subGuide: (subGuide as SURefEntity | undefined) ?? undefined,
+    }
+  })
+}

--- a/packages/component-lib/src/components/shared/StaticEntityContent.tsx
+++ b/packages/component-lib/src/components/shared/StaticEntityContent.tsx
@@ -50,6 +50,26 @@ export function StaticEntityContent({ summary, resolveTraitHref }: StaticEntityC
         </div>
       )}
 
+      {/* Named sections (a guide's steps) — most of a guide's text lives here,
+          so without it a guide's no-JS/crawler rendering is a title and one
+          paragraph. Headings are h2: they sit under the h1 above. */}
+      {summary.sections.length > 0 && (
+        <div className="mb-3 space-y-3">
+          {summary.sections.map((section) => (
+            <section key={section.name}>
+              <h2 className="mb-1 font-cond text-base font-bold uppercase tracking-caps-tight">
+                {section.name}
+              </h2>
+              <div className="space-y-2">
+                {section.paragraphs.map((p) => (
+                  <p key={p}>{p}</p>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+
       {summary.traits.length > 0 && (
         <p className="mb-3">
           <span className="font-cond font-bold uppercase">Traits:</span>{' '}

--- a/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
+++ b/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
@@ -566,6 +566,19 @@ export type StaticEntitySummary = {
         value: string | number;
     }[];
     traits: string[];
+    /**
+     * Named prose sections BELOW the entity's own content — currently a guide's
+     * `steps`, which hold most of a guide's text (28.7k of 34.2k characters
+     * across the shipped guides). Without these the no-JS/crawler rendering of a
+     * guide is its title and one intro paragraph, so the pages that carry the
+     * game's procedures were the ones indexing with almost no text.
+     *
+     * Empty for every entity that has no such sections.
+     */
+    sections: {
+        name: string;
+        paragraphs: string[];
+    }[];
 };
 /**
  * Extract a static summary from an entity for server-side rendering (SEO)

--- a/packages/salvageunion-reference/lib/helpers.ts
+++ b/packages/salvageunion-reference/lib/helpers.ts
@@ -385,6 +385,16 @@ export type StaticEntitySummary = {
   contentParagraphs: string[]
   stats: { label: string; value: string | number }[]
   traits: string[]
+  /**
+   * Named prose sections BELOW the entity's own content — currently a guide's
+   * `steps`, which hold most of a guide's text (28.7k of 34.2k characters
+   * across the shipped guides). Without these the no-JS/crawler rendering of a
+   * guide is its title and one intro paragraph, so the pages that carry the
+   * game's procedures were the ones indexing with almost no text.
+   *
+   * Empty for every entity that has no such sections.
+   */
+  sections: { name: string; paragraphs: string[] }[]
 }
 
 /**
@@ -474,6 +484,30 @@ export function extractStaticEntitySummary(entity: SURefEntity): StaticEntitySum
     }
   }
 
+  // Guide STEPS — the bulk of a guide's prose. Each step becomes a named
+  // section so the no-JS/crawler rendering carries the whole procedure, not
+  // just the one-line intro that precedes it.
+  const sections: { name: string; paragraphs: string[] }[] = []
+  if ('steps' in entity && Array.isArray(entity.steps)) {
+    for (const step of entity.steps) {
+      if (!step || typeof step !== 'object' || typeof step.name !== 'string') continue
+      const paragraphs: string[] = []
+      if (Array.isArray(step.content)) {
+        for (const block of step.content) {
+          if (
+            block &&
+            typeof block === 'object' &&
+            (!block.type || block.type === 'paragraph') &&
+            typeof block.value === 'string'
+          ) {
+            paragraphs.push(block.value)
+          }
+        }
+      }
+      sections.push({ name: step.name, paragraphs })
+    }
+  }
+
   return {
     name,
     description,
@@ -483,5 +517,6 @@ export function extractStaticEntitySummary(entity: SURefEntity): StaticEntitySum
     contentParagraphs,
     stats,
     traits,
+    sections,
   }
 }


### PR DESCRIPTION
## The bug

A guide keeps almost all of its text in `steps`, not in its top-level `content` — across the shipped dataset that is **28,771 of 34,178 characters (84%)**. Nothing in the SRD rendered `steps`, so every guide page showed its title, its one-paragraph intro, and nothing else.

The **Salvaging** page rendered, in its entirety:

> Salvaging — Source: Salvage Union Workshop Manual, p. 245

All 3,749 characters of its rules were absent. Five guides have *no* top-level content at all, so they rendered a heading and a source line.

## Root cause

A regression from #466 ("delete the legacy RED render core"), which deleted `GuideStepsDisplay.tsx`; the unified `ReferenceEntityCard` never grew a replacement. A dangling reference to `GuideStepsDisplay.resolveSchemaEntities` survived in `apps/srd/src/lib/schemaPreloadDeps.ts` and is corrected here.

ITUN was unaffected — its `DowntimeWizard` walks guide steps itself.

## The fix

Both of the SRD's render paths were missing the content, and both are fixed:

- **`ReferenceEntityCard`** (the hydrated island) grows a guide-steps section, built on a new pure resolver `card/resolveGuideSteps.ts`. Steps render through the same primitives every other section uses — `Slab` for the step name and section divider, `Content` for prose, `RollTable` for a step's table, and nested cards for the entities a step selects from — so they inherit the card's typography and tone rather than carrying their own.
- **`StaticEntityContent`** (the no-JS / crawler fallback) gains a `sections` field on `StaticEntitySummary`. The pages carrying the game's procedures were the ones indexing with almost no text.

The resolver ports the computed-field enrichment the deleted helpers had: `treeType` and `hasDamage` are **not stored** on entities, so without it "Choose your first Ability" would list all 103 abilities instead of the level-1 core ones. A step naming explicit `schemaEntities` keeps the data's order — the order the book lists its options in.

**Read-only by design.** The SRD transcribes the procedure; walking a guide as an interactive wizard stays ITUN's job ([ADR-021](docs/adrs/ADR-021-itun-surface-taxonomy.md)).

## Verification

Measured in headless Chrome against the built site — all **15** guide pages render their full procedure, with no horizontal overflow at 1440px or 390px:

| guide | card text |
|---|---|
| create-a-pilot | 10,068 |
| create-a-mech | 5,425 |
| mech-damage | 4,490 |
| crawler-downtime | 3,951 |
| salvaging | 3,812 (was ~0) |
| heat | 3,305 |
| safety-protocols | 3,211 |
| …and 8 more | all ≥ 837 |

`entityLayout: 'sidebar'` is honoured (the crawler tech-level ladder reads down a narrow column beside its prose) — previously a dead data field.

- 13 new tests in `resolveGuideSteps.test.ts`; full suite **0 fail**
- `lint`, `format:check`, `typecheck` (4 workspaces), `validate:all`, `knip`, `check:tokens`, `check:styling` all pass

⚠️ `check:audit` fails on `brace-expansion` (high, DoS) reached via itun's `@sentry/vite-plugin` and `vite-plugin-pwa`. **Pre-existing and unrelated** — no dependency files are touched here. Worth a separate bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7bpJDjgxeHSx7cNTkJ5Rn