### PR TITLE
chore(deps): bump brace-expansion override to 5.0.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -138,7 +138,7 @@
     },
     "packages/salvageunion-reference": {
       "name": "salvageunion-reference",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "dependencies": {
         "jsonc-parser": "^3.3.1",
         "zod": "^4.4.3",
@@ -149,7 +149,7 @@
     "@ladle/react@5.1.1": "patches/@ladle%2Freact@5.1.1.patch",
   },
   "overrides": {
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.8",
     "fast-uri": "4.1.1",
     "filelist": "2.0.2",
     "js-yaml": "4.3.0",
@@ -1222,7 +1222,7 @@
 
     "boxen": ["boxen@8.0.1", "", { "dependencies": { "ansi-align": "^3.0.1", "camelcase": "^8.0.0", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "string-width": "^7.2.0", "type-fest": "^4.21.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0" } }, "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
+    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "shell-quote": "1.10.0",
     "js-yaml": "4.3.0",
     "filelist": "2.0.2",
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.8",
     "svgo": "4.0.2",
     "sharp": "0.35.3",
     "fast-uri": "4.1.1",


### PR DESCRIPTION
## Why

[GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (**high**, published 2026-07-24T21:53Z) reports a DoS in `brace-expansion <=5.0.7`: unbounded expansion length causing an out-of-memory process crash.

It reaches the tree transitively through itun's dev dependencies (`@sentry/vite-plugin`, `vite-plugin-pwa`) via `minimatch`.

## This is currently blocking every PR

The advisory landed **~3 minutes before main's last CI run** (21:56Z), too late for `bun audit` to pick it up — so main went green, and then every PR opened since started failing the `audit` job. Since `quality-checks` gates on `audit`, **nothing can merge until this lands**.

## The fix

The repo already pins this package in the root `overrides` block, so the fix is that pin moving to the patched 5.0.8 — the same mechanism already used for `undici`, `shell-quote`, `js-yaml` and `filelist`:

```diff
   "overrides": {
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.8",
```

`bun install` also syncs the lockfile's `salvageunion-reference` version `2.5.2 → 2.5.3`, catching up to the release that landed in 17eac370. That's the lockfile reconciling with main, not a deliberate change — reverting it would just be undone by the next `bun install`.

## Verification

- `bun audit --audit-level=high` — **clean, exit 0** (was 1 high)
- Full `check:all` passes: `lint`, `format:check`, `typecheck` (4 workspaces), `test`, `validate:all`, `knip`, `check:audit`, `check:tokens`, `check:styling`

Diff is 2 files / 4 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7bpJDjgxeHSx7cNTkJ5Rn