### PR TITLE
fix(reference): point nine equipment records at their entry page + an index-backed name/page scan

### DIFF
--- a/packages/salvageunion-reference/data/equipment.json
+++ b/packages/salvageunion-reference/data/equipment.json
@@ -99,7 +99,7 @@
     "source": "Salvage Union Workshop Manual",
     "name": "Improvised Melee Weapon",
     "techLevel": 1,
-    "page": 298,
+    "page": 81,
     "actions": ["Improvised Melee Weapon"],
     "additionalSources": [
       {
@@ -114,7 +114,7 @@
     "source": "Salvage Union Workshop Manual",
     "name": "Portable Comms Unit",
     "techLevel": 1,
-    "page": 301,
+    "page": 81,
     "actions": ["Portable Comms Unit"],
     "additionalSources": [
       {
@@ -129,7 +129,7 @@
     "source": "Salvage Union Workshop Manual",
     "name": "Salvaging Tools",
     "techLevel": 1,
-    "page": 298,
+    "page": 81,
     "actions": ["Salvaging Tools"],
     "additionalSources": [
       {
@@ -174,7 +174,7 @@
     "source": "Salvage Union Workshop Manual",
     "name": "Pistol",
     "techLevel": 2,
-    "page": 314,
+    "page": 81,
     "actions": ["Pistol"],
     "additionalSources": [
       {
@@ -327,7 +327,7 @@
     "source": "Salvage Union Workshop Manual",
     "name": "Green Laser Rifle",
     "techLevel": 3,
-    "page": 313,
+    "page": 82,
     "actions": ["Green Laser Rifle"],
     "additionalSources": [
       {
@@ -438,7 +438,7 @@
     "source": "Salvage Union Workshop Manual",
     "name": "Reactive Armour",
     "techLevel": 3,
-    "page": 333,
+    "page": 83,
     "actions": ["Reactive Armour"],
     "additionalSources": [
       {
@@ -453,7 +453,7 @@
     "source": "Salvage Union Workshop Manual",
     "name": "Rifle",
     "techLevel": 3,
-    "page": 127,
+    "page": 83,
     "actions": ["Rifle"],
     "additionalSources": [
       {
@@ -504,7 +504,7 @@
     "source": "Salvage Union Workshop Manual",
     "name": "Electro Grappling Hook",
     "techLevel": 4,
-    "page": 301,
+    "page": 84,
     "actions": ["Electro Grappling Hook"]
   },
   {
@@ -573,7 +573,7 @@
     "source": "Salvage Union Workshop Manual",
     "name": "Monomolecular Sword",
     "techLevel": 5,
-    "page": 301,
+    "page": 85,
     "actions": ["Monomolecular Sword"]
   },
   {

--- a/tools/check-printed-names.ts
+++ b/tools/check-printed-names.ts
@@ -1,0 +1,269 @@
+/**
+ * Cross-checks every entity's `name` and `page` against the Core Book's own
+ * index — the book's authoritative name → page map.
+ *
+ * This replaces an earlier substring scan that compared each entity's name
+ * against the text of the page it cited. That approach had two flaws that this
+ * one does not:
+ *
+ *   1. A name contained in a longer name passed silently. "Sniper Rifle" was
+ *      found on the page it cited only because "Custom Sniper Rifle" appeared
+ *      there, so its genuinely wrong page reference went unreported.
+ *   2. A page mention counted as an entry. Items are named all over the book —
+ *      in class trees, pattern loadouts and summary tables — so citing any page
+ *      that merely mentions the item looked correct.
+ *
+ * The index sidesteps both: it is an exact-name lookup that yields the page the
+ * book itself considers definitive. But the index is not infallible either — it
+ * is off by one for a run of entries in the Systems and Modules chapters — so a
+ * disagreement is put to the page itself before being called a data bug. Three
+ * classes fall out, reported separately because they need different responses:
+ *
+ *   PAGE MISMATCH — the index disagrees AND the cited page does not print the
+ *     name. The data is wrong; take the index's page.
+ *   INDEX SUSPECT — the index disagrees but the cited page prints the name as a
+ *     heading. The data is corroborated and the index is the one that is off.
+ *     No action; this class exists so those entries stop being reported as bugs.
+ *   NAME NOT IN INDEX — the dataset name is not printed. Either a deliberate
+ *     deviation (see lib/printedNameDeviations.test.ts) or a typo. The tool
+ *     suggests candidates by reporting which index entries point at the page
+ *     the entity cites.
+ *
+ * Everything here is advisory. The index parse and the heading test are both
+ * heuristics over a PDF text layer; read the findings, do not apply them blind.
+ *
+ * Requires the gitignored PDF extract: `bun tools/extract-rules.ts` first. With
+ * no extract present this exits 0 with a notice — it is a local diagnostic, not
+ * a CI gate, because the copyright-bearing PDFs are not available to CI.
+ *
+ * Run:  bun tools/check-printed-names.ts
+ */
+import { readdirSync, readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { SalvageUnionReference } from '../packages/salvageunion-reference/lib/index'
+
+const EXTRACT_DIR = 'rules/extracted'
+/** Entities carrying this `source` are printed in the Core Book. */
+const CORE_SOURCE = 'Salvage Union Workshop Manual'
+
+/**
+ * Normalise for comparison.
+ *
+ * The book's index is typeset without the punctuation the dataset carries, so a
+ * literal comparison reports dozens of non-differences: the index prints "self
+ * destruct" for "Self-Destruct", "auto repair droid" for "Auto-Repair Droid",
+ * "adv targeting array" for "Adv. Targeting Array", and a plain "2" for the
+ * subscript in "He₂". Hyphens and periods are folded to spaces and subscript
+ * digits to ASCII so only real name differences survive.
+ */
+function norm(s: string): string {
+  return s
+    .replace(/[’‘]/g, "'")
+    .replace(/[–—]/g, '-')
+    .replace(/-\s*\n\s*/g, '')
+    .replace(/[₀-₉]/g, (d) => String('₀₁₂₃₄₅₆₇₈₉'.indexOf(d)))
+    .replace(/[.-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase()
+}
+
+/** Split an extract into `page number -> text`, using the `<!-- page N -->` markers. */
+function pagesOf(text: string): Map<number, string> {
+  const out = new Map<number, string>()
+  const parts = text.split(/<!-- page (\d+) -->/)
+  for (let i = 1; i < parts.length; i += 2) {
+    out.set(Number(parts[i]), parts[i + 1] ?? '')
+  }
+  return out
+}
+
+/**
+ * Parse the book's index into `normalised name -> pages`.
+ *
+ * Index pages are found by shape rather than by hardcoded page numbers, so this
+ * survives a repaginated edition: an index page is one where most non-blank
+ * lines look like `Some Entry, 123`.
+ *
+ * Long entries wrap, and the page number lands on the continuation line:
+ *
+ *     Refractive Shield
+ *     Projector, 171
+ *
+ * Read line-by-line that registers an entry called "Projector", which then
+ * matches nothing and makes every genuinely-unindexed name look like it sits on
+ * a page full of one-word entries. Lines without a trailing page number are
+ * therefore held and prepended to the line that has one.
+ */
+function parseIndex(pages: Map<number, string>): Map<string, number[]> {
+  // An entry may cite several pages ("Mech Melee Armament, 110,127"); capture
+  // the whole list, or the name keeps the first page number glued to it.
+  const ENTRY = /^(.+?),\s*(\d{1,3}(?:\s*,\s*\d{1,3})*)$/
+  // Alphabet headings ("D", "0-9") sit on their own line exactly where a wrapped
+  // entry's first half would, and would otherwise be glued onto the next entry.
+  const HEADING = /^(?:[A-Z]|[0-9]\s*-\s*[0-9])$/
+  const index = new Map<string, number[]>()
+  for (const [, raw] of pages) {
+    const lines = raw
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean)
+    if (lines.length < 10) continue
+    const entries = lines.filter((l) => ENTRY.test(l))
+    // An index page is overwhelmingly entries; a prose page is not.
+    if (entries.length / lines.length < 0.6) continue
+    let carry = ''
+    for (const line of lines) {
+      if (!ENTRY.test(line)) {
+        // A wrapped entry's first half. Two in a row means the second is a new
+        // entry's opening, not a continuation of the first.
+        carry = HEADING.test(line) ? '' : line
+        continue
+      }
+      const m = `${carry ? `${carry} ` : ''}${line}`.match(ENTRY)
+      carry = ''
+      if (!m) continue
+      const key = norm(m[1])
+      if (!key) continue
+      const list = index.get(key) ?? []
+      for (const p of m[2].split(',')) list.push(Number(p.trim()))
+      index.set(key, list)
+    }
+  }
+  return index
+}
+
+/**
+ * Does this page actually print this name, as a whole name rather than inside a
+ * longer one?
+ *
+ * A word-boundary anchor alone is not enough. "Sniper Rifle" sits inside "Custom
+ * Sniper Rifle" with a space before it, so it clears any boundary test while
+ * being nothing but the tail of a different item — the exact conflation that hid
+ * a wrong page reference from the first version of this scan, and that reappeared
+ * the moment this corroboration step was added.
+ *
+ * Nor is erasing longer names enough on its own: p. 47 says "gain a specialised
+ * sniper rifle that only you can use", a prose mention with no longer name
+ * around it, which would still read as proof that the Sniper Rifle entry lives
+ * there.
+ *
+ * What separates an entry from a mention is layout — a heading occupies its own
+ * line. The text layer has no heading markup, but it does preserve line breaks,
+ * so the test is line equality rather than containment. Adjacent line pairs are
+ * also joined, because a long heading wraps ("Portable / Communications Unit").
+ *
+ * This is a heuristic, not an oracle: it answers "is the cited page plausibly
+ * the entry page", and its findings are meant to be looked at, not applied.
+ */
+function printsName(pageText: string | undefined, name: string): boolean {
+  if (!pageText) return false
+  const needle = norm(name)
+  const lines = pageText
+    .split('\n')
+    .map((l) => norm(l))
+    .filter(Boolean)
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i] === needle) return true
+    if (i + 1 < lines.length && `${lines[i]} ${lines[i + 1]}` === needle) return true
+  }
+  return false
+}
+
+type Finding = {
+  kind: 'page' | 'index-suspect' | 'name'
+  schema: string
+  name: string
+  cited: number
+  detail: string
+}
+
+async function main() {
+  if (!existsSync(EXTRACT_DIR)) {
+    console.log(
+      `No ${EXTRACT_DIR}/ — run \`bun tools/extract-rules.ts\` first (needs the PDFs in rules/).`
+    )
+    return
+  }
+  const coreFile = readdirSync(EXTRACT_DIR).find((f) => /core book/i.test(f))
+  if (!coreFile) {
+    console.log(`No Core Book extract in ${EXTRACT_DIR}/ — nothing to check against.`)
+    return
+  }
+
+  const pages = pagesOf(readFileSync(join(EXTRACT_DIR, coreFile), 'utf8'))
+  const index = parseIndex(pages)
+  if (index.size < 100) {
+    console.log(
+      `Parsed only ${index.size} index entries — the index heuristic did not match. Aborting.`
+    )
+    return
+  }
+  /** page -> names the index files under it, for suggesting a printed name. */
+  const byPage = new Map<number, string[]>()
+  for (const [name, ps] of index)
+    for (const p of ps) byPage.set(p, [...(byPage.get(p) ?? []), name])
+
+  await SalvageUnionReference.preload('all')
+  const SCHEMAS = ['Modules', 'Systems', 'Equipment'] as const
+
+  const findings: Finding[] = []
+  let checked = 0
+  for (const schema of SCHEMAS) {
+    for (const entity of SalvageUnionReference[schema].all()) {
+      if (!('name' in entity) || typeof entity.name !== 'string') continue
+      if (!('source' in entity) || entity.source !== CORE_SOURCE) continue
+      if (!('page' in entity) || typeof entity.page !== 'number') continue
+      checked++
+      const cited = entity.page
+      const indexed = index.get(norm(entity.name))
+      if (!indexed) {
+        const printed = (byPage.get(cited) ?? []).slice(0, 4)
+        findings.push({
+          kind: 'name',
+          schema,
+          name: entity.name,
+          cited,
+          detail: printed.length
+            ? `p${cited} is indexed as: ${printed.join(' | ')}`
+            : `nothing indexed on p${cited}`,
+        })
+      } else if (!indexed.includes(cited)) {
+        // The index is not infallible: through the Systems and Modules chapters
+        // it is off by one for a run of entries, and blindly "correcting" the
+        // data to it would move a dozen right answers to wrong pages. So ask the
+        // page itself who is right — if the cited page prints the name, the data
+        // is corroborated and the index is the one that is off.
+        const corroborated = printsName(pages.get(cited), entity.name)
+        findings.push({
+          kind: corroborated ? 'index-suspect' : 'page',
+          schema,
+          name: entity.name,
+          cited,
+          detail: corroborated
+            ? `p${cited} prints this name; index says p${indexed.join(', p')} — index looks wrong, data left alone`
+            : `index says p${indexed.join(', p')}`,
+        })
+      }
+    }
+  }
+
+  console.log(`Parsed ${index.size} index entries from ${coreFile}`)
+  console.log(`Checked ${checked} Core Book entities\n`)
+  const LABELS = {
+    page: 'PAGE MISMATCH (name not on the cited page — data is wrong)',
+    'index-suspect':
+      "INDEX SUSPECT (cited page prints the name — the book's index is off; no action)",
+    name: 'NAME NOT IN INDEX (deliberate deviation, or a typo)',
+  } as const
+  for (const kind of ['page', 'index-suspect', 'name'] as const) {
+    const rows = findings.filter((f) => f.kind === kind)
+    const label = LABELS[kind]
+    console.log(`${label}: ${rows.length}`)
+    for (const f of rows)
+      console.log(`  ${f.schema.padEnd(10)} ${f.name} — cited p${f.cited}; ${f.detail}`)
+    console.log()
+  }
+}
+
+await main()


### PR DESCRIPTION
Follow-up to #567, which flagged a cluster of equipment records citing back-matter pages and asked for a ruling rather than a guess. **The ruling taken here: `page` means the entry, not any page the item is listed on.**

## The page fixes

Nine Pilot Equipment records cited a summary table in the 290s–310s — one cited the **index itself** (`Reactive Armour`, p. 333). Each is corrected to its entry page in the Pilot Equipment chapter, taken from the Core Book index and confirmed by reading the page:

```
Improvised Melee Weapon   298 -> 81      Reactive Armour   333 -> 83
Salvaging Tools           298 -> 81      Rifle             127 -> 83
Pistol                    314 -> 81      Electro Grappling Hook  301 -> 84
Portable Comms Unit       301 -> 81      Monomolecular Sword     301 -> 85
Green Laser Rifle         313 -> 82
```

`Rifle` needed care: its old p. 127 does contain the string — but only inside longer names (`Green Laser Rifle` and friends). The book prints a bare **"Rifle — Range: Medium // Damage: 5 HP // Ballistic"** on p. 83.

## The improved scan

`bun tools/check-printed-names.ts` replaces the throwaway substring scan, which had two flaws that each hid real bugs:

1. **A name inside a longer name passed silently.** `Sniper Rifle` was "found" on the page it cited only because `Custom Sniper Rifle` appears there — which is exactly how its wrong page reference escaped the first sweep.
2. **A mention counted as an entry.** Items are named all over the book, so citing any page that mentions them looked correct.

It now checks against the **Core Book's own index** — an exact-name lookup for the page the book considers definitive. Index pages are located by shape rather than hardcoded numbers, and the parser handles the two things that made a naive parse useless: entries that wrap with the page number on the continuation line (`Refractive Shield / Projector, 171`), and alphabet headings that otherwise glue onto the next entry.

### The index is not infallible either — and that matters

Taking it at face value would have **moved six correct page references to wrong pages**. Through a run of the Systems and Modules chapters the index is off by one. So a disagreement is now put to the page itself before being called a bug, and findings come out in three classes:

```
PAGE MISMATCH (name not on the cited page — data is wrong): 6
INDEX SUSPECT (cited page prints the name — the index is off; no action): 6
  Matter Phaser p206 (index 207) · Rigging Arm p167 (168) · Fabrication Bay p183 (182)
  Ion Cannon p183 (182) · Monomolecular Blade p184 (183) · Blue Beam Laser p182 (181)
NAME NOT IN INDEX (deliberate deviation, or a typo): 29
```

All six remaining PAGE MISMATCHes are already fixed in #566 and #567.

**"Prints the name" is line equality, not containment.** Containment was tried and reintroduced flaw 1 immediately: even after erasing every longer indexed name, p. 47's prose *"gain a specialised sniper rifle that only you can use"* still read as proof the entry lived there. A heading occupies its own line and the text layer preserves line breaks, so line equality is what separates an entry from a mention.

It's a **local diagnostic, not a CI gate** — it needs the gitignored PDF extract (`bun tools/extract-rules.ts`) and exits 0 with a notice when absent. Findings are advisory; both the index parse and the heading test are heuristics over a PDF text layer.

## Also worth knowing

**VR Tubes is resolved** — it isn't a bad reference. RAINMAKER p. 57 prints it as **"[19] Mech Simulator"** and the dataset text is near-verbatim from that entry. It's a deliberate rename (a location in the adventure; a crawler bay in the data), so it belongs in the deviation list — added in #567, not here.

## Verification

Full suite green: lint, format, typecheck, **3738 tests / 0 fail**, validate:all, knip, tokens, styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6ruExb7Pe9EQ8h35vx4Lj