### PR TITLE
fix(reference): correct Generic ability data against core book p.248-249

### DIFF
--- a/packages/salvageunion-reference/data/abilities.json
+++ b/packages/salvageunion-reference/data/abilities.json
@@ -1380,7 +1380,7 @@
       }
     ],
     "actions": ["Area Salvage"],
-    "description": "You salvage an area for scrap. This could be an abandoned factory, a ruined settlement, or a crumbling research facility. The Mediator will tell you if an area can be Area Salvaged or not. It costs 1 AP for a Pilot or 1 EP in a Mech."
+    "description": "You salvage an area for scrap."
   },
   {
     "id": "07cd4482-d26b-40d4-8bb8-4881fbbebbd4",
@@ -1398,7 +1398,7 @@
       }
     ],
     "actions": ["Mech Salvage"],
-    "description": "You salvage a destroyed Mech Chassis for Scrap and Systems."
+    "description": "You salvage a Mech, this could be one you have found in the wastelands or just downed in combat."
   },
   {
     "id": "2a992b4f-45ea-4810-9039-9226ba15b7e5",
@@ -1406,7 +1406,7 @@
     "tree": "Generic",
     "level": "G",
     "source": "Salvage Union Workshop Manual",
-    "mechActionType": "Short",
+    "mechActionType": "Turn",
     "page": 248,
     "additionalSources": [
       {
@@ -1416,7 +1416,7 @@
       }
     ],
     "actions": ["Scrap"],
-    "description": "You break down a Mech Chassis, System, or Module into Scrap."
+    "description": "You break down an Intact or Damaged Mech Chassis, System, Module, or Vehicle in Range into Scrap."
   },
   {
     "id": "f70b4b9a-3887-46fb-a217-b99c8841ae64",
@@ -1434,7 +1434,7 @@
       }
     ],
     "actions": ["Repair"],
-    "description": "You repair a damaged Mech Chassis, System, or Module."
+    "description": "You repair a damaged Mech Chassis, Vehicle, System, or Module in Range to the Intact Condition."
   },
   {
     "id": "b926e557-d8ad-45db-a933-056b85563ea0",
@@ -1451,7 +1451,8 @@
         "page": 33
       }
     ],
-    "actions": ["Mount"]
+    "actions": ["Mount"],
+    "description": "You Mount a System or Module onto a target Mech in Range."
   },
   {
     "id": "ad933f31-b106-413f-ac75-1a7b933091cd",
@@ -1468,7 +1469,8 @@
         "page": 33
       }
     ],
-    "actions": ["Patch Up"]
+    "actions": ["Patch Up"],
+    "description": "You restore up to 3 + X Structure Points on a target Mech or Vehicle."
   },
   {
     "id": "888c8bb1-efa9-41cc-9a71-515c96fb6a37",
@@ -1485,7 +1487,8 @@
         "page": 33
       }
     ],
-    "actions": ["Load"]
+    "actions": ["Load"],
+    "description": "You pick up and load a Mech Chassis, System, Module, or piece of Scrap in Range."
   },
   {
     "id": "8a689f26-b3f3-4473-a2a0-f0d2fde5b9d9",

--- a/packages/salvageunion-reference/data/actions.json
+++ b/packages/salvageunion-reference/data/actions.json
@@ -464,6 +464,7 @@
   },
   {
     "id": "c8a3aedc-fea0-4355-b255-83504b66ed50",
+    "range": ["Close"],
     "actionType": "Long",
     "activationCost": 1,
     "name": "Area Salvage",
@@ -8521,7 +8522,7 @@
   {
     "id": "7c006633-d112-4369-bbe0-8fa86f165ab5",
     "range": ["Close"],
-    "actionType": "Long",
+    "actionType": "Short",
     "name": "Scrap",
     "requiredTraits": ["salvaging"],
     "content": [

--- a/packages/salvageunion-reference/lib/ability-schema.test.ts
+++ b/packages/salvageunion-reference/lib/ability-schema.test.ts
@@ -5,7 +5,8 @@
  *   - tree:    103/103 — always present → required
  *   - level:   103/103 — always present → required
  *   - actions: 103/103 — always present → required
- *   - description:        100/103 — sometimes present → optional (unchanged)
+ *   - description:        103/103 — now always present, but kept optional so
+ *                                  homebrew data need not supply one
  *   - mechActionType:       7/103 — sometimes present → optional (unchanged)
  *   - grants:               6/103 — sometimes present → optional (unchanged)
  *   - activationCurrency:   1/103 — sometimes present → optional (unchanged)

--- a/packages/salvageunion-reference/lib/abilitySchema.test.ts
+++ b/packages/salvageunion-reference/lib/abilitySchema.test.ts
@@ -84,17 +84,19 @@ describe('AbilitySchema optionality audit', () => {
     expect(defined(withActivationCurrency[0]).activationCurrency).toBe('Variable')
   })
 
-  it('description is present on 100 out of 103 abilities', () => {
+  // Load, Mount, and Patch Up were the last three abilities without a
+  // description — the card renders `description` as its header flavor with no
+  // fallback, so those three rendered as blank Generic cards. They now carry a
+  // clipped first sentence of their rules text like every other ability. The
+  // schema field stays optional (homebrew data need not supply one); this audit
+  // records that the shipped dataset is complete.
+  it('description is present on all 103 abilities', () => {
     const abilities = SalvageUnionReference.Abilities.all()
 
     const withDescription = abilities.filter((a) => a.description !== undefined)
-    expect(withDescription.length).toBe(100)
+    expect(withDescription.length).toBe(103)
 
     const withoutDescription = abilities.filter((a) => a.description === undefined)
-    expect(withoutDescription.length).toBe(3)
-
-    // Verify which abilities are missing it
-    const names = withoutDescription.map((a) => a.name).sort()
-    expect(names).toEqual(['Load', 'Mount', 'Patch Up'])
+    expect(withoutDescription.length).toBe(0)
   })
 })


### PR DESCRIPTION
The Generic ability tree rendered wrong in ITUN — Mount, Patch Up, and Load showed as blank cards and Area Salvage's header flavour overflowed. The entity card renders `ability.description` as its header hint with no fallback (`ReferenceEntityCard.tsx:748`), so every defect traced to the data, not the display.

Compared all 8 Generic abilities against **"Salvaging Abilities", core book p.248–249**.

## Mechanical corrections

| | book | was | now |
|---|---|---|---|
| **Scrap** mech action | Turn | `Short` | `Turn` |
| **Scrap** pilot action | Short | `Long` | `Short` |
| **Area Salvage** range | Close | *(absent)* | `["Close"]` |

Load carries the identical book line to Scrap (`Turn Action (Mech) // Short Action (Pilot)`) and was already encoded correctly — Scrap was the lone outlier. Every other Generic action already had `range: ["Close"]`.

## Descriptions

Three abilities had **no** `description` at all — the only 3 of 103 in the dataset missing one, which is exactly why they rendered blank. Area Salvage's was the full action paragraph pasted verbatim: 233 chars against a 67-char dataset median (next-longest is 103).

Per review feedback, the new text is a **clipped first sentence of the official rules text**, not an authored summary — so the flavour line can't drift from the action body it captions.

- **Area Salvage** — 233 chars → `You salvage an area for scrap.`
- **Mount** / **Patch Up** / **Load** — added (were blank)
- **Mech Salvage** — said "destroyed"; the book allows a Mech merely *downed in combat*
- **Scrap** — restored `Intact or Damaged` and `Vehicle` to the target list
- **Repair** — restored `Vehicle` to the target list

Craft was already correct and is untouched. Longest ability description in the dataset is back to 103 (Ascension); Generic now spans 30–97.

## Pilot vs. mech split preserved

Flagged in review, and verified — this does **not** collapse the two:

- `ability.mechActionType` is the mech variant; the linked action's `actionType` is the pilot variant.
- Scrap keeps **two distinct values** (Turn / Short). It previously held two *wrong* ones, not one merged one.
- `mechActionType` count is unchanged at 7 abilities (the audit test asserts this).
- Both edited action records are referenced by **exactly one** ability each, so nothing else inherits the change.

Worth noting separately: `mechActionType` currently has **no runtime consumer** — the card renders only the pilot `actionType`, unlabelled. That pre-existing display gap is left untouched here.

## Schema

`description` stays **optional** so homebrew data need not supply one. The two optionality-audit tests are updated to record that the shipped dataset is now complete (103/103).

## Verification

`build:package` (no schema drift) · `validate:all` ✅ · `typecheck` ✅ · `test` — 3766 pass, 0 fail · `lint` (3 warnings, all pre-existing in untouched files) · `knip` clean.

Rules text quoted from the gitignored core-book PDF for comparison only; no copyrighted prose beyond the existing per-ability descriptions is added to the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVPz2xEoHcXCpTS44PFqPG