### PR TITLE
fix(itun): Generic abilities are universal — surface them in both Dashboard decks

### DIFF
--- a/apps/itun/src/components/dashboard/__tests__/dashboardRules.test.ts
+++ b/apps/itun/src/components/dashboard/__tests__/dashboardRules.test.ts
@@ -185,6 +185,57 @@ describe('activationPatch', () => {
   })
 })
 
+/**
+ * Every deck now ends with the universal Generic abilities (core book p.248),
+ * which are derived rather than stored on the pilot. Tests that assert on what a
+ * mech's own loadout contributes drop them first.
+ */
+const isGenericRow = (pa: { key: string }) => pa.key.startsWith('generic:')
+const loadoutRows = <T extends { key: string }>(deck: T[]) => deck.filter((pa) => !isGenericRow(pa))
+const genericRows = <T extends { key: string }>(deck: T[]) => deck.filter(isGenericRow)
+
+describe('generic abilities in the decks', () => {
+  test('the boarded mech deck carries them on the EP economy', () => {
+    const mech = mechFixture({ id: 'gm', name: 'Rig', chassisRef: 'not-a-real-chassis' })
+    const rows = genericRows(buildMechActions(mech))
+
+    expect(rows.length).toBeGreaterThan(0)
+    expect(rows.every((pa) => pa.currency === 'EP')).toBe(true)
+    expect(rows.map((pa) => pa.ownerName)).toContain('Scrap')
+  })
+
+  test('the on-foot pilot deck carries them on the AP economy', () => {
+    const pilot = pilotFixture({ id: 'gp', name: 'Vex' })
+    const rows = genericRows(buildPilotActions(pilot))
+
+    expect(rows.length).toBeGreaterThan(0)
+    expect(rows.every((pa) => pa.currency === 'AP')).toBe(true)
+    expect(rows.map((pa) => pa.ownerName)).toContain('Scrap')
+  })
+
+  test('they need no pick — an empty pilot still has them', () => {
+    const pilot = pilotFixture({ id: 'gp2', name: 'Ghost' })
+    const rows = genericRows(buildPilotActions(pilot))
+
+    expect(rows.map((pa) => pa.ownerName)).toContain('Area Salvage')
+  })
+
+  test('both decks agree on which abilities are universal', () => {
+    const mechOwners = new Set(
+      genericRows(
+        buildMechActions(mechFixture({ id: 'gm2', name: 'R', chassisRef: 'not-a-real-chassis' }))
+      ).map((pa) => pa.ownerName)
+    )
+    const pilotOwners = new Set(
+      genericRows(buildPilotActions(pilotFixture({ id: 'gp3', name: 'V' }))).map(
+        (pa) => pa.ownerName
+      )
+    )
+
+    expect([...mechOwners].sort()).toEqual([...pilotOwners].sort())
+  })
+})
+
 describe('buildMechActions', () => {
   test('surfaces a chassis ability action, stamped CHS', () => {
     // Find a chassis whose resolveActions returns at least one action.
@@ -195,7 +246,7 @@ describe('buildMechActions', () => {
     expect(chassis?.id).toBeTruthy()
 
     const mech = mechFixture({ id: 'm1', name: 'Rig', chassisRef: chassis?.id ?? '' })
-    const deck = buildMechActions(mech)
+    const deck = loadoutRows(buildMechActions(mech))
     expect(deck.length).toBeGreaterThan(0)
     expect(deck.every((pa) => pa.stamp === 'CHS')).toBe(true)
     expect(deck.every((pa) => pa.currency === 'EP')).toBe(true)
@@ -215,7 +266,7 @@ describe('buildMechActions', () => {
       chassisRef: 'not-a-real-chassis',
       systems: [multi.id],
     })
-    const deck = buildMechActions(mech)
+    const deck = loadoutRows(buildMechActions(mech))
     expect(deck.length).toBeGreaterThan(1)
     expect(deck.every((pa) => pa.stamp === 'SYS')).toBe(true)
     // Every card shares the same owner (the system) but has a distinct key.
@@ -223,9 +274,9 @@ describe('buildMechActions', () => {
     expect(new Set(deck.map((pa) => pa.key)).size).toBe(deck.length)
   })
 
-  test('empty for an unresolvable chassis with no items', () => {
+  test('no loadout rows for an unresolvable chassis with no items', () => {
     const mech = mechFixture({ id: 'm2', name: 'Ghost', chassisRef: 'not-a-real-chassis' })
-    expect(buildMechActions(mech)).toEqual([])
+    expect(loadoutRows(buildMechActions(mech))).toEqual([])
   })
 })
 
@@ -238,15 +289,15 @@ describe('buildPilotActions', () => {
     expect(ability?.id).toBeTruthy()
 
     const pilot = pilotFixture({ id: 'p1', name: 'Vex', abilities: [ability?.id ?? ''] })
-    const deck = buildPilotActions(pilot)
+    const deck = loadoutRows(buildPilotActions(pilot))
     expect(deck.length).toBeGreaterThan(0)
     expect(deck.every((pa) => pa.stamp === 'ABL')).toBe(true)
     expect(deck.every((pa) => pa.currency === 'AP')).toBe(true)
   })
 
-  test('empty for a pilot with no abilities or equipment', () => {
+  test('no learned rows for a pilot with no abilities or equipment', () => {
     const pilot = pilotFixture({ id: 'p2', name: 'Ghost' })
-    expect(buildPilotActions(pilot)).toEqual([])
+    expect(loadoutRows(buildPilotActions(pilot))).toEqual([])
   })
 })
 

--- a/apps/itun/src/components/dashboard/dashboardRules.ts
+++ b/apps/itun/src/components/dashboard/dashboardRules.ts
@@ -24,7 +24,11 @@ import type {
   SURefMetaEntity,
 } from 'salvageunion-reference'
 
-import { canActivateAction, resolveChassisRef } from 'salvageunion-reference/rules'
+import {
+  canActivateAction,
+  genericAbilities,
+  resolveChassisRef,
+} from 'salvageunion-reference/rules'
 import type { CoreRollBand } from '../../lib/rules/coreMechanic'
 import { clampHeat, heatCheckPatch, performHeatCheck, performPush } from '../../lib/rules/heatCheck'
 import type { HeatCheckEffect, Roll } from '../../lib/rules/heatCheck'
@@ -343,6 +347,48 @@ export function buildMechActions(mech: Mech): PlayAction[] {
   build(mech.systems ?? [], 'system')
   build(mech.modules ?? [], 'module')
 
+  // The boarded Pilot keeps their universal abilities — Scrap, Repair, Mount and
+  // the rest are Mech actions in the book, and were previously unreachable from
+  // the cockpit because this deck only walked chassis/systems/modules.
+  out.push(...genericAbilityActions('EP'))
+
+  return out
+}
+
+/**
+ * The Generic abilities every Pilot has, as deck rows. They are universal (core
+ * book p.248, "All Pilots have the following Abilities") and derived rather than
+ * stored — see `genericAbilities` for why they can't live in `pilot.abilities`.
+ *
+ * Both decks get them, because both contexts are real: the book gives these
+ * abilities a Mech action type *and* a Pilot action type precisely because you
+ * perform them either boarded or on foot. `currency` is the deck's economy —
+ * mech rows spend EP, pilot rows spend AP.
+ *
+ * NOTE: the action's own `actionType` / `activationCost` are the PILOT variant,
+ * so a mech row currently states the on-foot timing. Correcting that needs the
+ * per-context action split, which is deliberately a separate change.
+ */
+function genericAbilityActions(currency: PlayActionCurrency): PlayAction[] {
+  const out: PlayAction[] = []
+
+  for (const ability of genericAbilities(SalvageUnionReference.Abilities.all())) {
+    deckActions(ability).forEach((action, i) => {
+      out.push({
+        key: `generic:${ability.id}:${action.id ?? i}`,
+        name: action.name,
+        kind: 'ability',
+        stamp: 'ABL',
+        currency,
+        ownerName: ability.name,
+        slug: ability.id,
+        economy: actionEconomy(action),
+        action,
+        condition: 'intact',
+      })
+    })
+  }
+
   return out
 }
 
@@ -399,6 +445,9 @@ export function buildPilotActions(pilot: Pilot): PlayAction[] {
       })
     })
   }
+
+  // Universal abilities, on the on-foot AP economy.
+  out.push(...genericAbilityActions('AP'))
 
   return out
 }

--- a/packages/salvageunion-reference/lib/rules/genericAbilities.test.ts
+++ b/packages/salvageunion-reference/lib/rules/genericAbilities.test.ts
@@ -1,0 +1,50 @@
+import { beforeAll, describe, expect, it } from 'bun:test'
+
+import { SalvageUnionReference } from '../index.js'
+import { isLegalCreationAbility } from './creation.js'
+import { GENERIC_ABILITY_TREE, genericAbilities, isGenericAbility } from './genericAbilities.js'
+
+describe('genericAbilities', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload(['abilities'])
+  })
+
+  it('is the eight universal abilities from core book p.248-249', () => {
+    const found = genericAbilities(SalvageUnionReference.Abilities.all())
+
+    expect(found.map((a) => a.name).sort()).toEqual([
+      'Area Salvage',
+      'Craft',
+      'Load',
+      'Mech Salvage',
+      'Mount',
+      'Patch Up',
+      'Repair',
+      'Scrap',
+    ])
+  })
+
+  it('classifies by tree', () => {
+    expect(isGenericAbility({ tree: GENERIC_ABILITY_TREE })).toBe(true)
+    expect(isGenericAbility({ tree: 'Mechanical Knowledge' })).toBe(false)
+  })
+
+  // The load-bearing reason these are derived rather than seeded onto a pilot:
+  // they are not pickable, so they were never meant to occupy a creation pick.
+  it('none of them is a legal creation pick under any core tree', () => {
+    const all = SalvageUnionReference.Abilities.all()
+    const everyTree = [...new Set(all.map((a) => a.tree))]
+
+    for (const ability of genericAbilities(all)) {
+      expect(isLegalCreationAbility(ability, everyTree)).toBe(false)
+    }
+  })
+
+  it('leaves learned class abilities out', () => {
+    const all = SalvageUnionReference.Abilities.all()
+    const found = genericAbilities(all)
+
+    expect(found.length).toBeLessThan(all.length)
+    expect(found.some((a) => a.name === 'Jury Rig')).toBe(false)
+  })
+})

--- a/packages/salvageunion-reference/lib/rules/genericAbilities.ts
+++ b/packages/salvageunion-reference/lib/rules/genericAbilities.ts
@@ -1,0 +1,41 @@
+/**
+ * Generic abilities — the ones EVERY Pilot has, without spending a pick.
+ *
+ * The core book prints them under "Salvaging Abilities" (p.248-249) with the
+ * flat statement "All Pilots have the following Abilities." They are the eight
+ * Area Salvage / Mech Salvage / Scrap / Repair / Patch Up / Mount / Craft / Load
+ * entries, carried in the dataset under `tree: 'Generic'`, `level: 'G'`.
+ *
+ * They are DERIVED, never stored on a pilot. Two independent reasons:
+ *
+ *   1. `pilot.abilities.length` is counted against `PILOT_CREATION_ABILITY_PICKS`
+ *      (see `creation.ts`), so persisting the universal eight into that array
+ *      would report every freshly-created pilot as eight picks over budget.
+ *   2. `isLegalCreationAbility` admits only `level === 1` abilities whose tree is
+ *      one of the class's core trees. 'Generic' is never a core tree and 'G' is
+ *      never level 1, so these can't be *picked* — which is the schema already
+ *      saying they aren't chosen.
+ *
+ * Consumers therefore fold `genericAbilities()` in at read time alongside the
+ * pilot's learned abilities, rather than seeding them at creation.
+ */
+
+/** The dataset tree that holds the universal abilities. */
+export const GENERIC_ABILITY_TREE = 'Generic'
+
+/** The minimum shape needed to classify an ability as Generic. */
+export type GenericAbilityInput = { tree: string }
+
+/** Whether an ability is one every Pilot has by default. */
+export function isGenericAbility(ability: GenericAbilityInput): boolean {
+  return ability.tree === GENERIC_ABILITY_TREE
+}
+
+/**
+ * The universal abilities, filtered out of a full ability list. Pure (takes the
+ * list rather than reaching for the ORM) so it matches `legalCreationAbilities`
+ * and stays callable without a preload.
+ */
+export function genericAbilities<T extends GenericAbilityInput>(abilities: readonly T[]): T[] {
+  return abilities.filter(isGenericAbility)
+}

--- a/packages/salvageunion-reference/lib/rules/index.ts
+++ b/packages/salvageunion-reference/lib/rules/index.ts
@@ -50,6 +50,12 @@ export type {
   MechCreationBudgetInput,
   MechCreationLoadoutEntry,
 } from './creation.js'
+export {
+  GENERIC_ABILITY_TREE,
+  isGenericAbility,
+  genericAbilities,
+} from './genericAbilities.js'
+export type { GenericAbilityInput } from './genericAbilities.js'
 export { enrichPilotSnapshot } from './pilotSnapshot.js'
 export { computeCrawlerCapacity } from './crawlerCapacity.js'
 export { salvageValueFor, scrapCostFor, tierUpgradeCost } from './scrap.js'


### PR DESCRIPTION
First of two. This one closes the gap that made the pilot-vs-mech rendering question moot; the per-context action split follows on top.

## The gap is bigger than "missing when mounted"

The eight Generic abilities — Area Salvage, Mech Salvage, Scrap, Repair, Patch Up, Mount, Craft, Load — appear **nowhere in ITUN**. Not the mech deck, not the pilot deck, not any sheet. The core book states flatly on p.248: *"All Pilots have the following Abilities."* Every pilot should have had all eight since character creation.

Both deck builders only walk **stored** refs — `buildPilotActions` iterates `pilot.abilities`, `buildMechActions` walks chassis + installed systems + modules. Nothing seeds the universal eight into `pilot.abilities`: no wizard step, and neither the Starter Set nor the Eldridge Coast fixtures. So they resolved to nothing on both paths.

## Why they're derived, not seeded

Writing them into `pilot.abilities` would break two things:

1. `pilot.abilities.length` is counted against `PILOT_CREATION_ABILITY_PICKS` (`creation.ts:219`), so persisting eight universal entries would report every freshly-created pilot as **eight picks over budget**.
2. `isLegalCreationAbility` admits only `level === 1` abilities whose tree is one of the class's core trees. `'Generic'` is never a core tree and `'G'` is never level 1 — the schema is already saying these aren't chosen.

So `genericAbilities()` derives them at read time. It lands in the reference package's rules barrel per the data-first principle and ADR-006 — pure, taking the ability list rather than reaching for the ORM, mirroring `legalCreationAbilities`. Both deck builders fold it in: mech rows on the EP economy, pilot rows on AP.

## Deliberately not fixed here

A mech row still states the action's **pilot** timing and cost. The mech variant currently exists only as `mechActionType` on the ability, has no matching cost field, and is read by no runtime code. Rendering the right variant per context needs the per-context action split — that's PR 2, as agreed.

## Test changes

Four existing deck assertions were scoped to loadout rows rather than the whole deck (`every stamp === 'CHS'` / `'SYS'`, plus the two "empty deck" cases), since every deck now legitimately ends with the universal rows. Added a `generic abilities in the decks` block covering both economies, the no-pick-required case, and that both decks agree on the set — plus four unit tests on `genericAbilities` itself, including one asserting none of the eight is a legal creation pick under *any* core tree.

## Verification

`typecheck` ✅ · `test` ✅ · `validate:all` ✅ · `knip` ✅ · `lint` ✅ (all exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVPz2xEoHcXCpTS44PFqPG