### PR TITLE
tools: cut the printed-name scan's noise from 29 findings to 1

### DIFF
--- a/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
+++ b/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
@@ -759,6 +759,49 @@ export declare function resetAllForTesting(): void;
  */
 export declare function toPascalCase(id: string): string;
 //# sourceMappingURL=naming.d.ts.map
+// === lib/printedNameDeviations.d.ts ===
+/**
+ * Entities whose dataset `name` deliberately differs from the heading printed
+ * in the rulebook.
+ *
+ * These are NOT errors. Each one is a considered choice — usually because the
+ * book itself uses two names for the same thing (an entry heading plus a
+ * different form in its contents list, pattern loadouts, or summary tables) and
+ * the dataset picked the form that reads better in a list, or that a public URL
+ * already depends on.
+ *
+ * The problem this file solves is that the choice is invisible in the data. A
+ * future contributor re-deriving names from the PDFs sees `Video Projection
+ * Array` against a printed heading of `Projection Array`, reads it as a typo,
+ * "corrects" it — and silently breaks `/schema/modules/item/video-projection-
+ * array`, a URL that is canon.
+ *
+ * A documentary `alias` field on the records themselves was considered and
+ * rejected: a field written but read by nothing is exactly the `indexable`
+ * flag's failure mode (set on 39 records, consumed by no code, impossible to
+ * tell whether it is load-bearing), and knip cannot see a dead data field the
+ * way it sees a dead export. Encoding the decision as a test instead gives it
+ * teeth — renaming one of these to its printed form fails the build, with a
+ * message pointing at the reason — and it cannot rot into decoration.
+ *
+ * Search does not need this list: it already resolves both forms, because the
+ * dataset and printed names overlap enough to match on substring.
+ *
+ * Adding an entry is a claim you have checked the book. Include the page.
+ */
+export type Deviation = {
+    /** The `SalvageUnionReference` accessor the entity lives under. */
+    schema: 'Modules' | 'Systems' | 'Equipment' | 'CrawlerBays';
+    /** The name in the dataset — the canonical one, which slugs and URLs use. */
+    name: string;
+    /** The heading as printed in the book. */
+    printedAs: string;
+    /** Printed page carrying that heading. */
+    page: number;
+    why: string;
+};
+export declare const DEVIATIONS: Deviation[];
+//# sourceMappingURL=printedNameDeviations.d.ts.map
 // === lib/resolveChoiceView.d.ts ===
 /**
  * resolveChoiceView — pure resolver for granted-equipment choices.

--- a/packages/salvageunion-reference/lib/printedNameDeviations.test.ts
+++ b/packages/salvageunion-reference/lib/printedNameDeviations.test.ts
@@ -1,105 +1,13 @@
 /**
- * Entities whose dataset `name` deliberately differs from the heading printed
- * in the rulebook.
+ * Enforces the printed-name deviation record in `printedNameDeviations.ts`.
  *
- * These are NOT errors. Each one is a considered choice — usually because the
- * book itself uses two names for the same thing (an entry heading plus a
- * different form in its contents list, pattern loadouts, or summary tables) and
- * the dataset picked the form that reads better in a list, or that a public URL
- * already depends on.
- *
- * The problem this file solves is that the choice is invisible in the data. A
- * future contributor re-deriving names from the PDFs sees `Video Projection
- * Array` against a printed heading of `Projection Array`, reads it as a typo,
- * "corrects" it — and silently breaks `/schema/modules/item/video-projection-
- * array`, a URL that is canon.
- *
- * A documentary `alias` field on the records themselves was considered and
- * rejected: a field written but read by nothing is exactly the `indexable`
- * flag's failure mode (set on 39 records, consumed by no code, impossible to
- * tell whether it is load-bearing), and knip cannot see a dead data field the
- * way it sees a dead export. Encoding the decision as a test instead gives it
- * teeth — renaming one of these to its printed form fails the build, with a
- * message pointing at the reason — and it cannot rot into decoration.
- *
- * Search does not need this list: it already resolves both forms, because the
- * dataset and printed names overlap enough to match on substring.
- *
- * Adding an entry is a claim you have checked the book. Include the page.
+ * The list lives in its own module because `tools/check-printed-names.ts` reads
+ * it too — the scan suppresses names already recorded here, so its output is
+ * only ever findings nobody has ruled on yet.
  */
 import { describe, expect, test } from 'bun:test'
 import { SalvageUnionReference } from './index.js'
-
-type Deviation = {
-  /** The `SalvageUnionReference` accessor the entity lives under. */
-  schema: 'Modules' | 'Systems' | 'Equipment' | 'CrawlerBays'
-  /** The name in the dataset — the canonical one, which slugs and URLs use. */
-  name: string
-  /** The heading as printed in the book. */
-  printedAs: string
-  /** Printed page carrying that heading. */
-  page: number
-  why: string
-}
-
-const DEVIATIONS: Deviation[] = [
-  {
-    schema: 'Modules',
-    name: 'Video Projection Array',
-    printedAs: 'Projection Array',
-    page: 196,
-    why: 'The book uses both: the entry heading and index say "Projection Array", while the module contents list and the summary tables say "Video Projection Array". The dataset form is canon because /schema/modules/item/video-projection-array is a public URL.',
-  },
-  {
-    schema: 'Modules',
-    name: 'Adv. Weapon Link',
-    printedAs: 'Advanced Weapon Link',
-    page: 198,
-    why: 'The book abbreviates to "Adv." in chassis pattern loadouts (e.g. p. 109) and spells it out in the entry heading. Abbreviated here to distinguish it at a glance from the plain "Weapon Link" (p. 193).',
-  },
-  {
-    schema: 'Modules',
-    name: 'Adv. Reactor Safety Protocols',
-    printedAs: 'Advanced Reactor Safety Protocols',
-    page: 202,
-    why: 'Same "Adv." abbreviation, distinguishing it from "Reactor Safety Protocols" (p. 197).',
-  },
-  {
-    schema: 'Modules',
-    name: 'He₂ Coolant Flush',
-    printedAs: 'He2 Coolant Flush',
-    page: 205,
-    why: 'Typographic only: the dataset uses a Unicode subscript two, the book sets a plain "2".',
-  },
-  {
-    schema: 'Systems',
-    name: 'Adv. Fabrication Arm',
-    printedAs: 'Advanced Fabrication Arm',
-    page: 177,
-    why: 'Same "Adv." abbreviation, distinguishing it from "Fabrication Arm" (p. 174).',
-  },
-  {
-    schema: 'Systems',
-    name: 'Sandblaster',
-    printedAs: 'Sand Blaster',
-    page: 168,
-    why: 'The book sets the heading as two words in small caps ("SAND BLASTER"); the dataset closes it up.',
-  },
-  {
-    schema: 'Equipment',
-    name: 'Adv. Epoxy Applicator',
-    printedAs: 'Advanced Epoxy Applicator',
-    page: 84,
-    why: 'Same "Adv." abbreviation, distinguishing it from the Handheld Epoxy Canister (p. 83) and Integrated Epoxy Printer (p. 110).',
-  },
-  {
-    schema: 'CrawlerBays',
-    name: 'VR Tubes',
-    printedAs: 'Mech Simulator',
-    page: 57,
-    why: 'RAINMAKER prints this as location "[19] Mech Simulator" in an adventure map, and the bay text is near-verbatim from it. The dataset renames it because it exists here as an installable Crawler Bay rather than a room: "Mech Simulator" reads as a place, "VR Tubes" as equipment. The book\'s own name is unusable anyway — an adventure location and a Crawler Bay are different kinds of thing.',
-  },
-]
+import { DEVIATIONS, type Deviation } from './printedNameDeviations.js'
 
 const named = (schema: Deviation['schema'], name: string) =>
   SalvageUnionReference[schema].all().find((e) => 'name' in e && e.name === name)

--- a/packages/salvageunion-reference/lib/printedNameDeviations.ts
+++ b/packages/salvageunion-reference/lib/printedNameDeviations.ts
@@ -1,0 +1,113 @@
+/**
+ * Entities whose dataset `name` deliberately differs from the heading printed
+ * in the rulebook.
+ *
+ * These are NOT errors. Each one is a considered choice — usually because the
+ * book itself uses two names for the same thing (an entry heading plus a
+ * different form in its contents list, pattern loadouts, or summary tables) and
+ * the dataset picked the form that reads better in a list, or that a public URL
+ * already depends on.
+ *
+ * The problem this file solves is that the choice is invisible in the data. A
+ * future contributor re-deriving names from the PDFs sees `Video Projection
+ * Array` against a printed heading of `Projection Array`, reads it as a typo,
+ * "corrects" it — and silently breaks `/schema/modules/item/video-projection-
+ * array`, a URL that is canon.
+ *
+ * A documentary `alias` field on the records themselves was considered and
+ * rejected: a field written but read by nothing is exactly the `indexable`
+ * flag's failure mode (set on 39 records, consumed by no code, impossible to
+ * tell whether it is load-bearing), and knip cannot see a dead data field the
+ * way it sees a dead export. Encoding the decision as a test instead gives it
+ * teeth — renaming one of these to its printed form fails the build, with a
+ * message pointing at the reason — and it cannot rot into decoration.
+ *
+ * Search does not need this list: it already resolves both forms, because the
+ * dataset and printed names overlap enough to match on substring.
+ *
+ * Adding an entry is a claim you have checked the book. Include the page.
+ */
+export type Deviation = {
+  /** The `SalvageUnionReference` accessor the entity lives under. */
+  schema: 'Modules' | 'Systems' | 'Equipment' | 'CrawlerBays'
+  /** The name in the dataset — the canonical one, which slugs and URLs use. */
+  name: string
+  /** The heading as printed in the book. */
+  printedAs: string
+  /** Printed page carrying that heading. */
+  page: number
+  why: string
+}
+
+export const DEVIATIONS: Deviation[] = [
+  {
+    schema: 'Modules',
+    name: 'Video Projection Array',
+    printedAs: 'Projection Array',
+    page: 196,
+    why: 'The book uses both: the entry heading and index say "Projection Array", while the module contents list and the summary tables say "Video Projection Array". The dataset form is canon because /schema/modules/item/video-projection-array is a public URL.',
+  },
+  {
+    schema: 'Modules',
+    name: 'Adv. Weapon Link',
+    printedAs: 'Advanced Weapon Link',
+    page: 198,
+    why: 'The book abbreviates to "Adv." in chassis pattern loadouts (e.g. p. 109) and spells it out in the entry heading. Abbreviated here to distinguish it at a glance from the plain "Weapon Link" (p. 193).',
+  },
+  {
+    schema: 'Modules',
+    name: 'Adv. Reactor Safety Protocols',
+    printedAs: 'Advanced Reactor Safety Protocols',
+    page: 202,
+    why: 'Same "Adv." abbreviation, distinguishing it from "Reactor Safety Protocols" (p. 197).',
+  },
+  {
+    schema: 'Modules',
+    name: 'He₂ Coolant Flush',
+    printedAs: 'He2 Coolant Flush',
+    page: 205,
+    why: 'Typographic only: the dataset uses a Unicode subscript two, the book sets a plain "2".',
+  },
+  {
+    schema: 'Systems',
+    name: 'Adv. Fabrication Arm',
+    printedAs: 'Advanced Fabrication Arm',
+    page: 177,
+    why: 'Same "Adv." abbreviation, distinguishing it from "Fabrication Arm" (p. 174).',
+  },
+  {
+    schema: 'Systems',
+    name: 'Sandblaster',
+    printedAs: 'Sand Blaster',
+    page: 168,
+    why: 'The book sets the heading as two words in small caps ("SAND BLASTER"); the dataset closes it up.',
+  },
+  {
+    schema: 'Equipment',
+    name: 'Adv. Epoxy Applicator',
+    printedAs: 'Advanced Epoxy Applicator',
+    page: 84,
+    why: 'Same "Adv." abbreviation, distinguishing it from the Handheld Epoxy Canister (p. 83) and Integrated Epoxy Printer (p. 110).',
+  },
+  {
+    schema: 'CrawlerBays',
+    name: 'VR Tubes',
+    printedAs: 'Mech Simulator',
+    page: 57,
+    why: 'RAINMAKER prints this as location "[19] Mech Simulator" in an adventure map, and the bay text is near-verbatim from it. The dataset renames it because it exists here as an installable Crawler Bay rather than a room: "Mech Simulator" reads as a place, "VR Tubes" as equipment. The book\'s own name is unusable anyway — an adventure location and a Crawler Bay are different kinds of thing.',
+  },
+  {
+    schema: 'Modules',
+    name: 'Electro-Magnetic Self-Destruct',
+    printedAs: 'EM Self-Destruct',
+    page: 203,
+    why: 'The heading abbreviates and the entry\'s own first sentence spells it out ("the Electro-Magnetic Self-Destruct was intended to counter..."), so both names are the book\'s. The dataset takes the expanded one because "EM" is opaque in a list where nothing else is abbreviated.',
+  },
+  {
+    schema: 'Equipment',
+    name: 'Portable Comms Unit',
+    printedAs: 'Portable Communications Unit',
+    page: 81,
+    why: 'The book uses both: the entry heading on p. 81 spells it out, while the equipment summary tables and every NPC gear list say "Portable Comms Unit". The dataset follows the tables — the short form is what a player reads on a sheet, and the dataset carries a matching "Portable Comms Unit (NPC)" action.',
+  },
+]

--- a/tools/check-printed-names.ts
+++ b/tools/check-printed-names.ts
@@ -25,12 +25,28 @@
  *     heading. The data is corroborated and the index is the one that is off.
  *     No action; this class exists so those entries stop being reported as bugs.
  *   NAME NOT IN INDEX — the dataset name is not printed. Either a deliberate
- *     deviation (see lib/printedNameDeviations.test.ts) or a typo. The tool
- *     suggests candidates by reporting which index entries point at the page
- *     the entity cites.
+ *     deviation or a typo. The tool suggests candidates by reporting which
+ *     index entries point at the page the entity cites.
+ *
+ * Two kinds of non-finding are counted rather than listed, because listing them
+ * is what turns a diagnostic into something people stop reading:
+ *
+ *   - The book's index is not a complete list of its own contents. A name that
+ *     is missing from it but printed on the page it cites is simply unindexed,
+ *     and fine.
+ *   - A name already ruled on and recorded in
+ *     `packages/salvageunion-reference/lib/printedNameDeviations.ts` has been
+ *     looked at, with a reason. That list is shared with the test that enforces
+ *     it, so recording a deviation both protects it and silences it here.
+ *
+ * Together those took this scan's name findings from 29 to 1 without loosening
+ * a single check.
  *
  * Everything here is advisory. The index parse and the heading test are both
  * heuristics over a PDF text layer; read the findings, do not apply them blind.
+ * The known false positive is an all-caps stylised entry ("AARDVARKS TONGUE",
+ * p. 202) whose heading the text layer interleaves with body copy, so it never
+ * occupies a line of its own.
  *
  * Requires the gitignored PDF extract: `bun tools/extract-rules.ts` first. With
  * no extract present this exits 0 with a notice — it is a local diagnostic, not
@@ -41,6 +57,7 @@
 import { readdirSync, readFileSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { SalvageUnionReference } from '../packages/salvageunion-reference/lib/index'
+import { DEVIATIONS } from '../packages/salvageunion-reference/lib/printedNameDeviations'
 
 const EXTRACT_DIR = 'rules/extracted'
 /** Entities carrying this `source` are printed in the Core Book. */
@@ -96,9 +113,15 @@ function pagesOf(text: string): Map<number, string> {
  * therefore held and prepended to the line that has one.
  */
 function parseIndex(pages: Map<number, string>): Map<string, number[]> {
-  // An entry may cite several pages ("Mech Melee Armament, 110,127"); capture
-  // the whole list, or the name keeps the first page number glued to it.
-  const ENTRY = /^(.+?),\s*(\d{1,3}(?:\s*,\s*\d{1,3})*)$/
+  // An entry may cite several pages ("Mech Melee Armament, 110,127") and any of
+  // them may be a range ("Persona, 49-50"). Both forms must be recognised, or
+  // the name keeps a page number glued to it — and worse, an entry ending in a
+  // range fails to match at all, so it is treated as a wrapped entry's first
+  // half and glued onto the NEXT entry ("persona, 49 50 personal recreation
+  // device"). That one omission accounted for most of the false "not in index"
+  // reports.
+  const PAGES = String.raw`\d{1,3}(?:\s*[-–—]\s*\d{1,3})?`
+  const ENTRY = new RegExp(String.raw`^(.+?),\s*(${PAGES}(?:\s*,\s*${PAGES})*)$`)
   // Alphabet headings ("D", "0-9") sit on their own line exactly where a wrapped
   // entry's first half would, and would otherwise be glued onto the next entry.
   const HEADING = /^(?:[A-Z]|[0-9]\s*-\s*[0-9])$/
@@ -126,7 +149,11 @@ function parseIndex(pages: Map<number, string>): Map<string, number[]> {
       const key = norm(m[1])
       if (!key) continue
       const list = index.get(key) ?? []
-      for (const p of m[2].split(',')) list.push(Number(p.trim()))
+      for (const part of m[2].split(',')) {
+        const [from, to] = part.split(/[-–—]/).map((n) => Number(n.trim()))
+        // A range is expanded so that citing any page within it counts as a hit.
+        for (let p = from; p <= (Number.isFinite(to) ? to : from); p++) list.push(p)
+      }
       index.set(key, list)
     }
   }
@@ -209,6 +236,11 @@ async function main() {
 
   const findings: Finding[] = []
   let checked = 0
+  /** Names absent from the index but printed on their cited page — fine, not reported. */
+  let unindexed = 0
+  /** Names already recorded as deliberate deviations — suppressed, not reported. */
+  let known = 0
+  const recorded = new Set(DEVIATIONS.map((d) => d.name))
   for (const schema of SCHEMAS) {
     for (const entity of SalvageUnionReference[schema].all()) {
       if (!('name' in entity) || typeof entity.name !== 'string') continue
@@ -218,6 +250,23 @@ async function main() {
       const cited = entity.page
       const indexed = index.get(norm(entity.name))
       if (!indexed) {
+        // The book's index is not a complete list of its own contents — plenty
+        // of real entries are simply missing from it. So "not indexed" on its
+        // own says nothing. Ask the page: if it prints the name as a heading,
+        // the entity is fine and merely unindexed, and reporting it is noise
+        // that buries the handful of names that really do differ.
+        if (printsName(pages.get(cited), entity.name)) {
+          unindexed++
+          continue
+        }
+        // Already ruled on and recorded, with a reason, in
+        // lib/printedNameDeviations.ts. Re-reporting these every run is what
+        // makes a diagnostic get ignored — the output should only ever be
+        // things nobody has looked at yet.
+        if (recorded.has(entity.name)) {
+          known++
+          continue
+        }
         const printed = (byPage.get(cited) ?? []).slice(0, 4)
         findings.push({
           kind: 'name',
@@ -249,7 +298,9 @@ async function main() {
   }
 
   console.log(`Parsed ${index.size} index entries from ${coreFile}`)
-  console.log(`Checked ${checked} Core Book entities\n`)
+  console.log(
+    `Checked ${checked} Core Book entities (${unindexed} unindexed but printed on their cited page, ${known} recorded deviations)\n`
+  )
   const LABELS = {
     page: 'PAGE MISMATCH (name not on the cited page — data is wrong)',
     'index-suspect':


### PR DESCRIPTION
Finishing the tail I stopped short of in #569. The scan's 29 "name not in index" findings are down to **1** — with no check loosened. Two of the three causes were parser bugs; the third was a design gap.

## 1. Page ranges were unparseable — the big one

`Persona, 49-50` didn't match the entry pattern, so it was treated as a wrapped entry's first half and glued onto the next line:

```
persona, 49 50 personal recreation device
```

That loses **both** entries — the range one and its innocent neighbour — and it happened all over the index (`Behemoth, 41-42`, `Hacker, 32-37`, `Keywords, 321-326`, `Stat Training, 224-225`…). This single omission accounted for most of the false reports. Ranges are now parsed and expanded, so citing any page inside one counts as a hit.

**Index entries parsed: 837 → 944.**

## 2. "Not in the index" meant nothing on its own

The book's index is not a complete list of its own contents. A name missing from it but printed as a heading on the page it cites is simply unindexed and fine — now counted (7), not listed.

## 3. Rulings were re-reported every run

The deviation list moves out of the test file into `lib/printedNameDeviations.ts` so the scan can read it too. Recording a deviation now both **protects** it (the test still enforces it) and **silences** it here (8). The test's teeth were re-verified after the split by renaming an entry and watching three assertions fail.

## What the cleared noise revealed

Two genuine deviations, now recorded:

| Dataset | Printed as | Page |
|---|---|---|
| Electro-Magnetic Self-Destruct | `EM Self-Destruct` | 203 |
| Portable Comms Unit | `Portable Communications Unit` | 81 |

Both are cases where the book uses two names for one thing. The p. 203 entry sits under an `EM Self-Destruct` heading but its own first sentence reads *"the Electro-Magnetic Self-Destruct was intended to counter…"*; the p. 81 heading spells out `Portable Communications Unit` while every summary table says `Portable Comms Unit`.

**PAGE MISMATCH is now 0** — every page bug this scan ever found is fixed on main.

## The one remaining finding is a false positive, left in on purpose

`AARDVARKS TONGUE` (p. 202) is set in an all-caps stylised block that the PDF text layer interleaves with body copy, so its heading never occupies a line of its own. The data is correct.

I could clear it by relaxing the heading test to plain containment — but that would **simultaneously re-break the Electro-Magnetic Self-Destruct finding**, whose expanded name appears in that very entry's prose. One honest false positive beats silently losing a real one, so it stays, and it's documented in the tool header.

## Current output

```
Checked 220 Core Book entities (7 unindexed but printed on their cited page, 8 recorded deviations)

PAGE MISMATCH (name not on the cited page — data is wrong): 0
INDEX SUSPECT (cited page prints the name — the book's index is off; no action): 6
NAME NOT IN INDEX (deliberate deviation, or a typo): 1
  Modules    Aardvarks Tongue — cited p202; ...
```

## Verification

Full suite green: lint, format, typecheck, **3773 tests / 0 fail** (+6), validate:all, knip, tokens, styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6ruExb7Pe9EQ8h35vx4Lj