### PR TITLE
feat(component-lib): ability cards render the Mech/Pilot action split

### DIFF
--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -292,12 +292,24 @@ function formatActionType(type: string): string {
   return `${type} Action`
 }
 
-/** An action's classification + range / damage / traits as sub-header cells. The
+/**
+ * An action's classification + range / damage / traits as sub-header cells. The
  * action TYPE leads (a label-only cell), then range/damage/traits. The EP/AP
- * cost is the sub-header's `leading` node, rendered before all of these. */
-function actionCells(action: ActionFields): EntityCardSubHeaderCell[] {
+ * cost is the sub-header's `leading` node, rendered before all of these.
+ *
+ * `mechActionType` is the SPLIT: a handful of abilities cost a different action
+ * depending on whether you perform them in a Mech or on foot, and the book prints
+ * both — "Turn Action (Mech) // Short Action (Pilot)" (core book p.248-249). When
+ * it is present the single type cell becomes two qualified cells, Mech first, in
+ * the book's own order. Without it nothing changes: one unqualified cell, exactly
+ * as before, which is every other action in the dataset.
+ */
+function actionCells(action: ActionFields, mechActionType?: string): EntityCardSubHeaderCell[] {
   const cells: EntityCardSubHeaderCell[] = []
-  if (action.actionType) {
+  if (mechActionType && action.actionType) {
+    cells.push({ key: 'action-type-mech', label: `${formatActionType(mechActionType)} (Mech)` })
+    cells.push({ key: 'action-type', label: `${formatActionType(action.actionType)} (Pilot)` })
+  } else if (action.actionType) {
     cells.push({ key: 'action-type', label: formatActionType(action.actionType) })
   }
   if (action.range && action.range.length > 0) {
@@ -1026,7 +1038,16 @@ function ReferenceEntityCardInner({
   // A folded single action surfaces its type/range/damage/traits into the
   // sub-header; entity traits follow, deduped so a shared trait (e.g.
   // "Explosive") isn't listed twice.
-  const foldedActionCells = foldedActionFields ? actionCells(foldedActionFields) : []
+  // An ability carries the MECH half of a split action type; the action record
+  // carries the Pilot half. Only the ability knows both, so the split is resolved
+  // here rather than inside `actionCells`.
+  const abilityMechActionType =
+    isAbility(entity) && typeof entity.mechActionType === 'string'
+      ? entity.mechActionType
+      : undefined
+  const foldedActionCells = foldedActionFields
+    ? actionCells(foldedActionFields, abilityMechActionType)
+    : []
   const entityCells = traitCells(getTraits(entity) ?? [])
   const dedupedEntityCells = entityCells.filter(
     (cell) => !foldedActionCells.some((folded) => folded.key === cell.key)

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/abilityActionSplit.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/abilityActionSplit.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * The Mech/Pilot action SPLIT on an ability card.
+ *
+ * A handful of abilities cost a different action depending on whether you
+ * perform them boarded or on foot, and the book prints both halves on one line —
+ * "Turn Action (Mech) // Short Action (Pilot)" (core book p.248-249). The card
+ * previously rendered only the Pilot half, unqualified, so a reader had no way to
+ * tell the mech timing existed: `mechActionType` was stored on all seven split
+ * abilities and read by nothing.
+ *
+ * These tests pin BOTH halves to the card, and pin the far larger unsplit case
+ * (every other action in the dataset) to its unchanged single unqualified cell.
+ */
+import { afterEach, beforeAll, describe, expect, test } from 'bun:test'
+import { cleanup, render } from '@testing-library/react'
+import { SalvageUnionReference } from 'salvageunion-reference'
+import { ReferenceEntityCard } from '../ReferenceEntityCard'
+
+const ability = (name: string) => {
+  const found = SalvageUnionReference.Abilities.all().find((a) => a.name === name)
+  if (!found) throw new Error(`${name} fixture missing`)
+  return found
+}
+
+/** Rendered text, whitespace-collapsed, for substring assertions. */
+const textOf = (node: Parameters<typeof render>[0]) =>
+  (render(node).container.textContent ?? '').replace(/\s+/g, ' ')
+
+afterEach(cleanup)
+
+describe('ability card action split', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  // Scrap is the sharpest case: the two halves are DIFFERENT action types, so a
+  // card showing only one of them is visibly missing a rule.
+  test('Scrap shows both halves, Mech first, as the book prints them', () => {
+    const text = textOf(<ReferenceEntityCard data={ability('Scrap')} />)
+
+    expect(text).toContain('Turn Action (Mech)')
+    expect(text).toContain('Short Action (Pilot)')
+    expect(text.indexOf('Turn Action (Mech)')).toBeLessThan(text.indexOf('Short Action (Pilot)'))
+  })
+
+  test('Load shows its Turn/Short split', () => {
+    const text = textOf(<ReferenceEntityCard data={ability('Load')} />)
+
+    expect(text).toContain('Turn Action (Mech)')
+    expect(text).toContain('Short Action (Pilot)')
+  })
+
+  // Repair is the common shape among the seven — Short in a Mech, Long on foot.
+  test('Repair shows its Short/Long split', () => {
+    const text = textOf(<ReferenceEntityCard data={ability('Repair')} />)
+
+    expect(text).toContain('Short Action (Mech)')
+    expect(text).toContain('Long Action (Pilot)')
+  })
+
+  test('every ability carrying a mech variant renders both halves', () => {
+    const split = SalvageUnionReference.Abilities.all().filter((a) => a.mechActionType)
+    expect(split.length).toBeGreaterThan(0)
+
+    for (const entity of split) {
+      const text = textOf(<ReferenceEntityCard data={entity} />)
+      expect(text).toContain('(Mech)')
+      expect(text).toContain('(Pilot)')
+    }
+  })
+
+  // The unsplit case is the overwhelming majority — it must not gain qualifiers.
+  test('an ability with no mech variant stays a single unqualified type', () => {
+    const plain = ability('Craft')
+    expect(plain.mechActionType).toBeUndefined()
+
+    const text = textOf(<ReferenceEntityCard data={plain} />)
+    expect(text).not.toContain('(Mech)')
+    expect(text).not.toContain('(Pilot)')
+  })
+})


### PR DESCRIPTION
The SRD-facing half of the Generic-ability work. Stacked on #570 because it needs that PR's corrected data — retarget to `main` once #570 lands.

## What was wrong

Seven abilities cost a different action depending on whether you perform them boarded or on foot, and the book prints both halves on one line — **"Turn Action (Mech) // Short Action (Pilot)"** (core book p.248-249).

The card rendered only the Pilot half, unqualified. A reader looking at Scrap saw `Short Action` with nothing to suggest it is a **Turn** Action in a Mech. The mech half was stored on all seven (`ability.mechActionType`) and read by **no runtime code at all** — the data was there and simply never reached a surface.

## The change

`actionCells` takes the mech variant and, when present, emits two qualified cells instead of one bare cell — **Mech first**, matching the book's own order. The ability owns the mech half and the action record owns the pilot half, so the split is resolved at the call site, the only place that sees both.

Unsplit actions are untouched: with no mech variant it is the same single unqualified cell as before, which covers every other action in the dataset.

## Why it stacks on #570

Before that PR's corrections, Scrap's two halves were **both wrong** (`Short`/`Long` instead of `Turn`/`Short`), so rendering the split on today's `main` would faithfully display two incorrect action types.

## Scope note

This is `component-lib`, so ITUN's ability cards gain the split too. That is the book's own presentation of these abilities rather than an ITUN behaviour change — no deck, sheet, activation or store logic is touched, and the diff contains no `apps/itun` files.

## Tests

Five new tests pin both halves for Scrap (`Turn`/`Short`), Load, and Repair, assert Mech renders before Pilot, sweep *every* ability carrying a mech variant, and pin the unsplit case (Craft) to no qualifiers at all.

`typecheck` ✅ · `test` ✅ · `lint` ✅ · `knip` ✅ · `validate:all` ✅ (all exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVPz2xEoHcXCpTS44PFqPG