### PR TITLE
ci: stop the coverage ratchet failing on a phantom "(missing)" workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "format": "biome format --write . && prettier --write '**/*.md' '**/*.{yml,yaml}' --ignore-unknown --log-level=warn",
     "format:check": "biome format . && prettier --check '**/*.md' '**/*.{yml,yaml}' --ignore-unknown --log-level=warn",
     "test": "bun --filter \"*\" test",
-    "test:coverage": "bun --filter salvageunion-reference test:coverage && bun --filter component-lib test:coverage && bun --filter srd test:coverage && bun --filter itun test:coverage && bun --filter discord-bot test:coverage",
+    "test:coverage": "bun tools/run-coverage.ts",
     "test:package": "bun --filter salvageunion-reference test",
     "test:react": "bun --filter component-lib test",
     "test:web": "bun --filter srd test",

--- a/tools/run-coverage.test.ts
+++ b/tools/run-coverage.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The two coverage tools each carry their own workspace list: `run-coverage.ts`
+ * decides what gets RUN and verified, `coverage-report.ts` decides what gets
+ * SCORED against the baseline. They cannot import from one another —
+ * `coverage-report.ts` does its work at module scope, so importing it would run
+ * the whole ratchet — so this asserts they agree instead.
+ *
+ * A drift either way is silent and bad: a workspace in the runner but not the
+ * report produces coverage nobody scores, and one in the report but not the
+ * runner is scored `(missing)` forever, which is precisely the failure mode the
+ * runner exists to prevent.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const toolsDir = dirname(fileURLToPath(import.meta.url))
+const root = resolve(toolsDir, '..')
+
+const read = (file: string) => readFileSync(join(toolsDir, file), 'utf-8')
+
+/** Pull the string entries out of a named array literal in a source file. */
+function arrayLiteralEntries(source: string, declaration: string): string[] {
+  const start = source.indexOf(declaration)
+  if (start === -1) throw new Error(`"${declaration}" not found — the tool was renamed or reshaped`)
+  const open = source.indexOf('[', start)
+  const close = source.indexOf(']', open)
+  if (open === -1 || close === -1) throw new Error(`no array literal after "${declaration}"`)
+  return [...source.slice(open, close).matchAll(/'([^']+)'/g)].map((m) => m[1] as string)
+}
+
+describe('coverage tooling workspace lists', () => {
+  const runner = read('run-coverage.ts')
+  const report = read('coverage-report.ts')
+
+  // run-coverage's entries are `{ dir, filter }` pairs, so the odd-indexed
+  // matches are the filter names; take the directories.
+  const runnerDirs = arrayLiteralEntries(runner, 'const WORKSPACES').filter((s) => s.includes('/'))
+  const reportDirs = arrayLiteralEntries(report, 'const WORKSPACES')
+
+  it('the report scores a non-empty set of workspaces', () => {
+    expect(reportDirs.length).toBeGreaterThan(0)
+  })
+
+  it('the runner runs exactly the workspaces the report scores', () => {
+    expect([...runnerDirs].sort()).toEqual([...reportDirs].sort())
+  })
+
+  it('every listed workspace exists and has a test:coverage script', () => {
+    for (const dir of reportDirs) {
+      const pkg = JSON.parse(readFileSync(join(root, dir, 'package.json'), 'utf-8')) as {
+        scripts?: Record<string, string>
+      }
+      expect(pkg.scripts?.['test:coverage']).toBeTruthy()
+    }
+  })
+
+  it("each runner filter matches its workspace's package name", () => {
+    const pairs = [...runner.matchAll(/\{\s*dir:\s*'([^']+)',\s*filter:\s*'([^']+)'\s*\}/g)]
+    expect(pairs.length).toBe(reportDirs.length)
+
+    for (const [, dir, filter] of pairs) {
+      const pkg = JSON.parse(readFileSync(join(root, dir as string, 'package.json'), 'utf-8')) as {
+        name: string
+      }
+      expect(pkg.name).toBe(filter as string)
+    }
+  })
+})

--- a/tools/run-coverage.ts
+++ b/tools/run-coverage.ts
@@ -1,0 +1,117 @@
+/**
+ * run-coverage — run every workspace's `test:coverage` and VERIFY each one
+ * actually wrote its `coverage/lcov.info`, retrying once when it silently did
+ * not.
+ *
+ * ## The flake this exists for
+ *
+ * Bun's coverage run intermittently exits 0, having passed every test, while
+ * writing no coverage output at all. When that happens the workspace's whole
+ * `coverage/` directory is absent, `coverage-report.ts` scores it `(missing)`,
+ * and the ratchet fails the build — on a PR that may not touch that workspace.
+ *
+ * This is not hypothetical and it is not new. `coverage-report.ts` carries a
+ * comment about it costing "a real debugging cycle when apps/srd intermittently
+ * reported nothing in CI while its tests passed and exited 0"; the response at
+ * the time was to improve the ratchet's error message, not to stop the flake.
+ * It has since moved to `apps/itun` — a merge-queue run of #570 (a data-only PR
+ * touching no ITUN file) was ejected by it, and a run of #569 before that. The
+ * CI log shows the text reporter printing its table header and then nothing:
+ * no per-file rows, no "Ran N tests" summary, no lcov — yet exit code 0.
+ *
+ * It does not reproduce locally, where the same command writes a 331 KB lcov
+ * every time, so this is an environment-dependent flush/truncation failure in
+ * the reporter rather than anything the repo can fix at the source.
+ *
+ * ## Why a retry is the right shape, and why it is safe
+ *
+ * A retry hides a genuine regression only if the regression is intermittent.
+ * The failure this guards against — "this workspace has stopped emitting
+ * coverage" — is deterministic: a workspace that genuinely cannot write lcov
+ * fails BOTH attempts and this script exits non-zero with the workspace named.
+ * What the retry absorbs is exactly the non-deterministic case, which is the
+ * one that carries no signal about the PR under test.
+ *
+ * The ratchet itself is untouched and still authoritative: this script only
+ * ensures the ratchet is fed real numbers rather than a phantom `(missing)`.
+ * If coverage genuinely drops, `coverage-report.ts` still fails the build.
+ */
+
+import { existsSync, rmSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+/**
+ * Workspace directory → its package name (the `bun --filter` target). Order is
+ * the run order and mirrors `WORKSPACES` in `coverage-report.ts`; the two lists
+ * are asserted to agree by `run-coverage.test.ts`, so a workspace can never be
+ * covered here but unscored there (or the reverse).
+ */
+const WORKSPACES: ReadonlyArray<{ dir: string; filter: string }> = [
+  { dir: 'packages/salvageunion-reference', filter: 'salvageunion-reference' },
+  { dir: 'packages/component-lib', filter: 'component-lib' },
+  { dir: 'apps/srd', filter: 'srd' },
+  { dir: 'apps/itun', filter: 'itun' },
+  { dir: 'apps/discord-bot', filter: 'discord-bot' },
+]
+
+const lcovFor = (dir: string) => join(root, dir, 'coverage', 'lcov.info')
+
+/** Run one workspace's `test:coverage`. Returns the exit code. */
+async function runCoverage(filter: string): Promise<number> {
+  const proc = Bun.spawn(['bun', '--filter', filter, 'test:coverage'], {
+    cwd: root,
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+  return await proc.exited
+}
+
+let failed = false
+
+for (const { dir, filter } of WORKSPACES) {
+  // Clear any stale lcov first, so "the file exists" can only mean THIS run
+  // wrote it. Without this a previous run's artifact would mask a silent
+  // no-write on a developer machine.
+  rmSync(join(root, dir, 'coverage'), { recursive: true, force: true })
+
+  const code = await runCoverage(filter)
+
+  // A non-zero exit is a real test failure — report it as such and do NOT
+  // retry. Retrying failing tests is how a flaky suite gets normalised.
+  if (code !== 0) {
+    console.error(`\n✗ ${dir}: test:coverage exited ${code} — tests failed.`)
+    failed = true
+    continue
+  }
+
+  if (existsSync(lcovFor(dir))) continue
+
+  console.error(
+    `\n⚠ ${dir}: test:coverage passed (exit 0) but wrote no coverage/lcov.info.` +
+      ` This is the known intermittent reporter flake — retrying once.`
+  )
+
+  const retryCode = await runCoverage(filter)
+  if (retryCode !== 0) {
+    console.error(`\n✗ ${dir}: retry exited ${retryCode} — tests failed on the second attempt.`)
+    failed = true
+    continue
+  }
+
+  if (!existsSync(lcovFor(dir))) {
+    console.error(
+      `\n✗ ${dir}: still no coverage/lcov.info after a retry. Two clean runs produced` +
+        ` no coverage, so this is NOT the intermittent flake — the workspace has stopped` +
+        ` emitting coverage and needs fixing at the source.`
+    )
+    failed = true
+    continue
+  }
+
+  console.error(`✓ ${dir}: retry produced coverage.`)
+}
+
+if (failed) process.exit(1)


### PR DESCRIPTION
The merge queue has been ejecting PRs over coverage on workspaces they don't touch. #570 — a data-only change with no ITUN files — was ejected with:

```
| apps/itun | (missing) | 90.00% | FAIL missing |
```

and #569 before it. Both were reference-data-only, and both merged unchanged on a retry, so nothing about either diff caused it.

## Root cause is not the ratchet

Bun's coverage run **intermittently exits 0, having passed every test, while writing no coverage output at all.** In #570's queue run the text reporter printed its table header and then stopped — no per-file rows, no `Ran N tests` summary, no lcov, exit code 0. `coverage-report.ts` then correctly reports the workspace missing and correctly fails the build. It is being fed a phantom, not misreading a real number.

This isn't new either. `coverage-report.ts` already carries a comment about the same thing costing *"a real debugging cycle when apps/srd intermittently reported nothing in CI while its tests passed and exited 0"* — that round improved the error message without stopping the flake. It has since moved to `apps/itun`.

It does not reproduce locally, where the same command writes a 331 KB lcov every time, so it's an environment-dependent flush/truncation failure in the reporter rather than something this repo can fix at the source.

## The change

Root `test:coverage` becomes `tools/run-coverage.ts`, which runs each workspace in turn, verifies it actually produced `coverage/lcov.info`, and retries that workspace **once** when it didn't. It clears any stale `coverage/` first, so "the file exists" can only mean *this* run wrote it.

## Why the retry can't mask a regression

- **"This workspace has stopped emitting coverage" is deterministic** — it fails both attempts, and the script exits 1 naming the workspace and stating explicitly that this is *not* the flake and needs fixing at the source.
- **A non-zero exit from the tests is never retried.** That's a real failure; retrying it is how a flaky suite gets normalised.
- **The ratchet is untouched and still authoritative.** If coverage genuinely drops, the build still goes red.

## Verification

Simulated the flake by pointing a workspace's `test:coverage` at a command that exits 0 and writes nothing:

```
⚠ apps/discord-bot: test:coverage passed (exit 0) but wrote no coverage/lcov.info. ... retrying once.
✗ apps/discord-bot: still no coverage/lcov.info after a retry. Two clean runs produced no coverage,
  so this is NOT the intermittent flake — the workspace has stopped emitting coverage ...
FAILURE-CASE EXIT CODE: 1
```

Happy path: all five workspaces emit lcov and the ratchet passes, with `apps/itun` scoring **91.40%** instead of `(missing)`.

`run-coverage.test.ts` pins the two tools' workspace lists together. They can't import from each other (`coverage-report.ts` does its work at module scope, so importing it would run the whole ratchet), and drift either way is silent — a workspace in the runner but not the report produces coverage nobody scores; one in the report but not the runner is scored `(missing)` forever, which is exactly the failure this removes.

`typecheck` ✅ · `test` ✅ · `lint` ✅ · `knip` ✅ · `validate:all` ✅

## Not addressed here

`smoke-web` separately timed out waiting 240s for its webserver in the same run. That's a different flake with a different cause; I've left it alone rather than bundle two unrelated CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVPz2xEoHcXCpTS44PFqPG