### PR TITLE
fix(component-lib): one size for every card control; the remove ✕ is a red stamp

### DIFF
--- a/packages/component-lib/src/components/chrome/Field.tsx
+++ b/packages/component-lib/src/components/chrome/Field.tsx
@@ -82,7 +82,7 @@ const FIELD_BOX =
  * 1. **static** — caller passes `children` (an `Input`/`Textarea`/`Select`); the
  *    child owns the border the stamp rides. Used by the pilot/mech wizard steps.
  * 2. **edit-in-place** — `value` + `onSave`: an `InlineEditField` engine inside
- *    a bordered value box; the dashed `EDIT_CUE_CLASS` signals editability.
+ *    a bordered value box; the dashed `EDIT_CUE_HOVER_CLASS` signals editability.
  * 3. **picker** — `value` + `onEditClick`: a button value box opening a modal.
  *
  * Shapes 2–3 are the absorbed `IdentityField`: the sheet identity rows lose the

--- a/packages/component-lib/src/components/shared/ControlButtons.tsx
+++ b/packages/component-lib/src/components/shared/ControlButtons.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react'
 import { Tooltip } from '@base-ui/react/tooltip'
 import { cn } from '../../utils/cn'
 import { Badge } from '../chrome/Badge'
+import { RUNG_INLINE_PADDING, RUNG_TYPE } from '../../styles/sizing'
 import { CountStepper } from '../chrome/CountStepper'
 import { StatusBadge } from '../chrome/StatusBadge'
 import type {
@@ -32,16 +33,19 @@ const VARIANT: Record<
 
 type ControlButtonsProps = {
   controls: ReferenceEntityControl[]
+  /**
+   * Retained for the caller contract. It no longer changes control SIZE — every
+   * control renders at the seam stamp's `mini` rung so a rail never mixes
+   * heights — and nothing else in this component reads density.
+   */
   compact?: boolean
 }
 
 function ControlButton({
   control,
-  compact,
   onClickWithStop,
 }: {
   control: ReferenceEntityControl
-  compact: boolean
   onClickWithStop: (e: React.MouseEvent, onClick: () => void) => void
 }) {
   // Typed item variants — render a primitive instead of an action button.
@@ -81,29 +85,45 @@ function ControlButton({
   const hasCustomColors = !!(control.bgColor || control.textColor)
   const onClick = control.onClick ?? (() => {})
 
+  // Every rail control is stamp-sized. The rail sits beside the card's seam
+  // stamp, and the buttons used to run a rung larger than it (and the icon-only
+  // ones larger again, as fixed 28/32px squares), so one row carried three
+  // different heights. These are the `mini` stamp's own metrics — the same
+  // constants `Badge shape="stamp" size="mini"` resolves — so the row and the
+  // seam agree by construction rather than by matching numbers by eye.
   const segmentClasses = cn(
-    'px-1 font-cond font-bold uppercase tracking-caps-tight',
-    compact ? 'text-label' : 'text-xs'
+    'flex items-center font-cond font-bold uppercase tracking-caps-tight',
+    RUNG_INLINE_PADDING.mini,
+    RUNG_TYPE.mini.label
   )
 
-  // Icon-only control (design-spec `.ctl`): a square 28/32px button with a
-  // centred icon and no text — used by the live-sheet per-card remove/swap
-  // cluster. Neutral ink chrome (paper fill, ink border, hover inverts) so it
-  // reads consistently beside the absolute status badge. `min-h-11`/`min-w-11`
-  // holds the 44px coarse-pointer tap target without changing desktop size.
+  // Icon-only control (design-spec `.ctl`) — the live-sheet per-card
+  // remove/swap/fold cluster. It is a STAMP like every other control in the
+  // rail: same padding, same height, the glyph sized to the label line it
+  // replaces, so an icon button and a worded one are interchangeable in the
+  // row. `min-h-11`/`min-w-11` still holds the 44px coarse-pointer tap target
+  // without changing the desktop size.
+  //
+  // A `danger` icon (the ✕ remove) is a RED stamp — filled, not outlined —
+  // because it is the one control in the rail that destroys something, and as
+  // neutral paper chrome it read like the fold chevron beside it.
   const Icon = control.icon
   const isIconOnly = !!Icon && !control.label && !control.segmentText
   if (Icon && isIconOnly) {
+    const danger = variant === 'danger'
     return (
       <button
         type="button"
         className={cn(
-          'inline-flex shrink-0 items-center justify-center rounded-card border-2 transition-colors',
+          'inline-flex shrink-0 items-center justify-center border-2 transition-colors',
           'min-h-11 min-w-11 sm:min-h-0 sm:min-w-0',
-          compact ? 'h-7 w-7' : 'h-8 w-8',
+          RUNG_INLINE_PADDING.mini,
+          RUNG_TYPE.mini.label,
           isDisabled
             ? 'cursor-not-allowed border-wk-muted text-ink-2'
-            : 'cursor-pointer border-ink bg-paper text-ink hover:bg-ink hover:text-paper',
+            : danger
+              ? 'cursor-pointer border-status-bad bg-status-bad text-paper hover:brightness-110'
+              : 'cursor-pointer border-ink bg-paper text-ink hover:bg-ink hover:text-paper',
           control.className
         )}
         title={control.title ?? control.ariaLabel}
@@ -112,7 +132,7 @@ function ControlButton({
         aria-disabled={isDisabled || undefined}
         onClick={isDisabled ? undefined : (e) => onClickWithStop(e, onClick)}
       >
-        <Icon className={compact ? 'h-3.5 w-3.5' : 'h-4 w-4'} />
+        <Icon className="h-3 w-3" />
       </button>
     )
   }
@@ -170,12 +190,10 @@ function ControlButton({
 
 function ControlButtonWithHover({
   control,
-  compact,
   onClickWithStop,
   hoverContent,
 }: {
   control: ReferenceEntityControl
-  compact: boolean
   onClickWithStop: (e: React.MouseEvent, onClick: () => void) => void
   hoverContent: ReactNode
 }) {
@@ -185,9 +203,7 @@ function ControlButtonWithHover({
         <Tooltip.Trigger
           delay={200}
           closeDelay={100}
-          render={
-            <ControlButton control={control} compact={compact} onClickWithStop={onClickWithStop} />
-          }
+          render={<ControlButton control={control} onClickWithStop={onClickWithStop} />}
         />
         <Tooltip.Portal>
           <Tooltip.Positioner sideOffset={5} align="start">
@@ -201,7 +217,7 @@ function ControlButtonWithHover({
   )
 }
 
-export function ControlButtons({ controls, compact = false }: ControlButtonsProps) {
+export function ControlButtons({ controls }: ControlButtonsProps) {
   const handleClick = useCallback((e: React.MouseEvent, onClick: () => void) => {
     // preventDefault so a control nested inside a wrapping navigation <a> (e.g.
     // the schema list cards) doesn't also trigger that anchor's navigation; a
@@ -222,17 +238,11 @@ export function ControlButtons({ controls, compact = false }: ControlButtonsProp
           <ControlButtonWithHover
             key={control.key}
             control={control}
-            compact={compact}
             onClickWithStop={handleClick}
             hoverContent={control.hoverContent}
           />
         ) : (
-          <ControlButton
-            key={control.key}
-            control={control}
-            compact={compact}
-            onClickWithStop={handleClick}
-          />
+          <ControlButton key={control.key} control={control} onClickWithStop={handleClick} />
         )
       )}
     </div>

--- a/packages/component-lib/src/components/shared/SheetSection.tsx
+++ b/packages/component-lib/src/components/shared/SheetSection.tsx
@@ -12,7 +12,7 @@
  *       per-card remove (✕) control.
  *   (C) STAT cells stay always-live StatBlock pips — no primitive needed here.
  *
- * `EDIT_CUE_CLASS` is the single editing cue: a consistent dashed outline on
+ * `EDIT_CUE_HOVER_CLASS` is the single editing cue: a dashed outline on
  * section-edit fields and per-card controls (StatBlocks carry no cue).
  */
 
@@ -26,7 +26,6 @@ import {
 import { Button } from '../chrome/Button'
 import { Glyph } from '../chrome/glyphs'
 import { ModalShell } from './ModalShell'
-import { EDIT_CUE_CLASS } from './editLanguage'
 
 import { cn } from '../../utils/cn'
 import { FOCUS_RING } from '../chrome/interaction'
@@ -161,9 +160,10 @@ export function CardRemoveButton({ name, onRemove, className }: CardRemoveButton
   return (
     <Button
       size="mini"
+      variant="danger"
       aria-label={`Remove ${name}`}
       onClick={onRemove}
-      className={cn(EDIT_CUE_CLASS, 'min-h-11 sm:min-h-6 print:hidden', className)}
+      className={cn('min-h-11 sm:min-h-6 print:hidden', className)}
     >
       &#10005; Remove
     </Button>

--- a/packages/component-lib/src/components/shared/SheetSectionCard.tsx
+++ b/packages/component-lib/src/components/shared/SheetSectionCard.tsx
@@ -16,7 +16,7 @@
  * the region; the `Ecflow` entity-card grid is passed as `children`.
  *
  * Themes per sheet automatically via the `--tone` / `--tone-deep` CSS vars
- * (same route as `EDIT_CUE_CLASS` / `VitalGauge`), never per-section color
+ * (same route as `EDIT_CUE_HOVER_CLASS` / `VitalGauge`), never per-section color
  * classes. Keeps the `.sheet-section` print class for the page-break rule.
  */
 

--- a/packages/component-lib/src/components/shared/__tests__/ControlButtons.test.tsx
+++ b/packages/component-lib/src/components/shared/__tests__/ControlButtons.test.tsx
@@ -77,16 +77,15 @@ describe('ControlButtons', () => {
     expect(button.className).toContain('my-custom')
   })
 
-  test('compact renders smaller text', () => {
+  // Every control renders at the seam stamp's `mini` rung, at both densities:
+  // the rail sits beside that stamp, so a row that mixed heights read as three
+  // unrelated chips. `compact` no longer changes the size.
+  test('renders at the stamp rung regardless of density', () => {
     render(<ControlButtons controls={[makeControl()]} compact />)
-    const button = screen.getByRole('button')
-    expect(button.innerHTML).toContain('text-label')
-  })
-
-  test('default size renders text-xs', () => {
+    expect(screen.getByRole('button').innerHTML).toContain('text-badge')
+    cleanup()
     render(<ControlButtons controls={[makeControl()]} />)
-    const button = screen.getByRole('button')
-    expect(button.innerHTML).toContain('text-xs')
+    expect(screen.getByRole('button').innerHTML).toContain('text-badge')
   })
 
   test('empty controls array renders nothing', () => {
@@ -168,11 +167,34 @@ describe('ControlButtons', () => {
     const button = screen.getByLabelText('Remove Charge')
     // The accessible name comes from ariaLabel, not visible text.
     expect(button.textContent).toBe('')
-    // Square chrome (not the segmented label pill).
-    expect(button.className).toContain('h-8')
-    expect(button.className).toContain('w-8')
+    // Stamp chrome at the same rung as a worded control (no fixed 28/32px
+    // square), so an icon button and a worded one are interchangeable in a row.
+    expect(button.className).toContain('px-1')
+    expect(button.className).toContain('py-0.5')
+    expect(button.className).not.toContain('h-8')
     // The provided icon renders inside.
     expect(screen.getByTestId('remove-glyph')).toBeTruthy()
+  })
+
+  test('a danger icon control is a RED stamp, not neutral chrome', () => {
+    render(
+      <ControlButtons
+        controls={[
+          makeControl({
+            label: undefined,
+            ariaLabel: 'Remove Charge',
+            icon: RemoveGlyph,
+            variant: 'danger',
+          }),
+        ]}
+      />
+    )
+    // Remove is the one control in the rail that DESTROYS something; in
+    // paper-and-ink it read like the fold chevron beside it.
+    const button = screen.getByLabelText('Remove Charge')
+    expect(button.className).toContain('bg-status-bad')
+    expect(button.className).toContain('border-status-bad')
+    expect(button.className).not.toContain('bg-paper')
   })
 
   test('icon-only control keeps the 44px coarse-pointer tap floor', () => {

--- a/packages/component-lib/src/components/shared/editLanguage.tsx
+++ b/packages/component-lib/src/components/shared/editLanguage.tsx
@@ -11,20 +11,17 @@ import { Glyph } from '../chrome/glyphs'
 import type { ReferenceEntityControl } from '../referenceEntity/referenceEntityControlTypes'
 
 /**
- * The ONE editing cue (redesign rule): dashed outline in the sheet's deep tone
- * on anything editable.
- */
-export const EDIT_CUE_CLASS =
-  'outline-dashed outline-2 outline-offset-2 outline-[color:var(--tone-deep,var(--color-rust))]'
-
-/**
- * The same cue, ON DEMAND — shown when the field is hovered or holds focus.
+ * The ONE editing cue (redesign rule): a dashed outline in the sheet's deep
+ * tone, shown ON DEMAND — when the field is hovered or holds focus.
  *
- * Live-sheet fields are always editable now (the section Edit toggle is gone),
- * and a permanent dashed outline on every field would draw the whole sheet in
+ * Live-sheet fields are always editable (the section Edit toggle is gone), and
+ * a permanent dashed outline on every field would draw the whole sheet in
  * dashes. Revealing it on approach says "this one is writable" at the moment
  * you ask, and `focus-within` keeps that promise for the keyboard, which has no
  * hover.
+ *
+ * The always-on variant this replaced is gone: its last consumer was the
+ * standalone remove button, which is a red stamp now.
  */
 export const EDIT_CUE_HOVER_CLASS =
   'outline-offset-2 outline-[color:var(--tone-deep,var(--color-rust))] hover:outline-dashed hover:outline-2 focus-within:outline-dashed focus-within:outline-2'
@@ -66,6 +63,10 @@ export function cardRemoveControls({
     ariaLabel: `Remove ${name}`,
     icon: (props) => <Glyph name="remove" {...props} />,
     onClick: onRemove,
+    // A red STAMP, not neutral chrome: this is the one control in the rail that
+    // destroys something, and in paper-and-ink it read like the fold chevron
+    // sitting next to it.
+    variant: 'danger',
   })
   return controls
 }


### PR DESCRIPTION
## The problem

A card's control rail carried **three different heights** in one row: worded buttons at one type rung, icon-only ones as fixed 28/32px squares, and the seam stamp they sit beside at a third.

## The fix

Every control renders at the seam stamp's own `mini` metrics — the same `RUNG_INLINE_PADDING` / `RUNG_TYPE` constants `Badge shape="stamp" size="mini"` resolves — so the row and the seam agree **by construction**, not by matching numbers by eye.

Measured in the browser: Spend AP, the fold chevron and the seam stamp are all **20px**.

The icon-only control is a stamp too rather than a square: same padding, glyph sized to the label line it replaces, so an icon button and a worded one are interchangeable in a row. The 44px coarse-pointer tap target is untouched.

**The remove ✕ is a red stamp** — filled `status-bad`, via `variant: 'danger'` on both the `cardRemoveControls` factory and the standalone `CardRemoveButton`. It is the one control in the rail that destroys something, and as neutral paper-and-ink chrome it read like the fold chevron next to it.

## Notes

- `compact` no longer changes control size (nothing else in the component read density). The prop stays for the caller contract, with that stated on it.
- Two tests pinned the old per-density type sizes and the 28/32px square; they pin the single rung now. A new test covers the red danger stamp — closing a coverage gap I flagged when reviewing #561.
- `EDIT_CUE_CLASS` is deleted. The always-on dashed outline's last consumer was that remove button; knip caught it. Three docblocks that named it now name `EDIT_CUE_HOVER_CLASS`, the on-demand cue that survived.

## Verification

typecheck clean across 4 packages · full suite green · knip, design-tokens, styling-ownership clean · lint at the repo's 4 pre-existing warnings · rail heights measured in headless Chrome against the seam stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcJNHRYHTM8TCPTqfC3L5r