### PR TITLE
fix(srd): give a guide card the colour of the link that opened it

### DIFF
--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/guideTone.test.ts
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/guideTone.test.ts
@@ -1,0 +1,106 @@
+/**
+ * A GUIDE WEARS THE COLOUR OF THE LINK THAT OPENED IT.
+ *
+ * The SRD index paints each guide's catalog tile with that guide's stored
+ * `guideColor` (`apps/srd/src/lib/catalogHelpers.ts` → `catalogBg`). The card the
+ * tile navigates to used to resolve through the glossary domain default
+ * (`bg-ink-2`), so every guide page was a different colour from the tile that
+ * opened it. `resolveDomainTone` now reads the stored hue, and these tests pin
+ * both halves of that contract:
+ *
+ * 1. the hue arrives as `bgColor` (a raw CSS colour the card applies inline),
+ *    NOT as `bg` (a Tailwind class) — the two are threaded to different props,
+ *    and only `bgColor` wins over the domain class in `accentSurface`;
+ * 2. no OTHER domain is disturbed — the guide branch is a data-shape check on a
+ *    field nothing else carries, so gear must still ride the tech-level ramp and
+ *    the remaining glossary schemas must still resolve to ink.
+ *
+ * The index-parity test is driven from the SHIPPED dataset rather than a
+ * fixture: it is the actual guide records, and their actual hues, that have to
+ * agree with the tiles.
+ */
+import { describe, expect, test } from 'bun:test'
+import type { SURefEnumSchemaName, SURefMetaEntity } from 'salvageunion-reference'
+import { SalvageUnionReference } from 'salvageunion-reference'
+import { resolveDomainTone } from '../entityCardTone'
+
+await SalvageUnionReference.preload('all')
+
+const guides = SalvageUnionReference.Guides.all()
+
+describe('guide tone — the card matches the index tile', () => {
+  test('the dataset actually exercises this (guides exist, and carry hues)', () => {
+    expect(guides.length).toBeGreaterThan(0)
+    expect(guides.every((guide) => typeof guide.guideColor === 'string')).toBe(true)
+  })
+
+  test('every shipped guide resolves to its own stored hue', () => {
+    for (const guide of guides) {
+      const tone = resolveDomainTone('guides', guide as unknown as SURefMetaEntity)
+      expect(tone.bgColor).toBe(guide.guideColor)
+    }
+  })
+
+  test('the hue rides bgColor, never a Tailwind bg class', () => {
+    // `bg` and `bgColor` reach different props: `accentSurface` puts `bg` on
+    // className and `bgColor` on an inline style. Leaving a stale domain class
+    // on `bg` would paint the glossary ink underneath the authored hue.
+    for (const guide of guides) {
+      const tone = resolveDomainTone('guides', guide as unknown as SURefMetaEntity)
+      expect(tone.bg).toBeUndefined()
+    }
+  })
+
+  test('guides still belong to the glossary domain (tone changed, grouping did not)', () => {
+    const [guide] = guides
+    expect(guide).toBeDefined()
+    const tone = resolveDomainTone('guides', guide as unknown as SURefMetaEntity)
+    expect(tone.domain).toBe('glossary')
+  })
+
+  test('more than one distinct hue is in play', () => {
+    // A guard against a regression that resolved every guide to one colour —
+    // which would still pass the per-guide equality test if the hues collapsed.
+    const hues = new Set(
+      guides.map(
+        (guide) => resolveDomainTone('guides', guide as unknown as SURefMetaEntity).bgColor
+      )
+    )
+    expect(hues.size).toBeGreaterThan(1)
+  })
+})
+
+describe('guide tone — no other domain is disturbed', () => {
+  test('a malformed guideColor falls back to the domain tone', () => {
+    // The schema defaults `guideColor` and validates it as a 6-digit hex, so
+    // this is a runtime guard, not an expected branch. An empty string must not
+    // produce a transparent header band.
+    const tone = resolveDomainTone('guides', { guideColor: '' } as unknown as SURefMetaEntity)
+    expect(tone.bgColor).toBeUndefined()
+    expect(tone.bg).toBe('bg-ink-2')
+  })
+
+  test('the remaining glossary schemas still resolve to ink', () => {
+    for (const schemaName of ['traits', 'keywords', 'distances'] as SURefEnumSchemaName[]) {
+      const tone = resolveDomainTone(schemaName, {} as SURefMetaEntity)
+      expect(tone.bg).toBe('bg-ink-2')
+      expect(tone.bgColor).toBeUndefined()
+    }
+  })
+
+  test('gear still rides the tech-level ramp', () => {
+    const system = SalvageUnionReference.Systems.all().find((s) => typeof s.techLevel === 'number')
+    expect(system).toBeDefined()
+    const tone = resolveDomainTone('systems', system as unknown as SURefMetaEntity)
+    expect(tone.bg).toMatch(/^bg-tl-/)
+    expect(tone.bgColor).toBeUndefined()
+  })
+
+  test('a mech still resolves to the mech domain hue', () => {
+    const [chassis] = SalvageUnionReference.Chassis.all()
+    expect(chassis).toBeDefined()
+    const tone = resolveDomainTone('chassis', chassis as unknown as SURefMetaEntity)
+    expect(tone.bg).toBe('bg-mech')
+    expect(tone.bgColor).toBeUndefined()
+  })
+})

--- a/packages/component-lib/src/components/referenceEntity/card/entityCardTone.ts
+++ b/packages/component-lib/src/components/referenceEntity/card/entityCardTone.ts
@@ -73,6 +73,21 @@ export type DomainTone = {
 }
 
 /**
+ * A guide's own authored hue, or `undefined` for every other entity.
+ *
+ * Validated as a 6-digit hex by `GuideSchema` (`lib/schemas/entities.ts`), which
+ * also supplies the `#282019` ink default — so a guide always has one, and the
+ * narrowing here is a runtime guard against malformed data rather than an
+ * expected `undefined` branch. Anything that is not a non-empty string falls
+ * through to the ordinary domain tone.
+ */
+function entityGuideColor(entity: SURefMetaEntity): string | undefined {
+  if (entity == null || typeof entity !== 'object' || !('guideColor' in entity)) return undefined
+  const guideColor = entity.guideColor
+  return typeof guideColor === 'string' && guideColor.length > 0 ? guideColor : undefined
+}
+
+/**
  * The tone resolution: DOMAIN from the exhaustive map, ACCENT from the resolved
  * token. Gear rides the tech-level blue ramp; everything else takes its colour
  * from `calculateBackgroundColor` (the tier hue for abilities, the crawler
@@ -84,6 +99,24 @@ export function resolveDomainTone(
   entity: SURefMetaEntity
 ): DomainTone {
   const domain = SCHEMA_DOMAIN[schemaName]
+
+  // GUIDES carry their OWN stored hue (`guideColor`), and it must win over the
+  // glossary-ink domain default. The SRD index already paints each guide's
+  // catalog tile with this exact hex (`catalogHelpers.ts` → `catalogBg`), so
+  // resolving the card to `bg-ink-2` made every guide page a different colour
+  // from the link that opened it — the one entity type whose tone is authored
+  // per-item rather than derived from its domain.
+  //
+  // A DATA-SHAPE check, not a schema-name one (display-system rule): the hue
+  // rides the stored field, so anything carrying a `guideColor` is toned by it.
+  // Returned as `bgColor` (a raw CSS colour) rather than `bg` (a Tailwind
+  // class) — the card threads `bgColor` to the header, sub-header, footer,
+  // frame and nested children, and `accentSurface` applies it as an inline
+  // background that wins over the class.
+  const guideColor = entityGuideColor(entity)
+  if (guideColor) {
+    return { domain, bg: undefined, bgColor: guideColor }
+  }
 
   // GEAR → tech-level blue ramp (numeric tl-1..6, or the Bio / Nanite utility
   // class). Literal `bg-tl-*` strings so Tailwind actually emits the utility.


### PR DESCRIPTION
> Stacked on **#564** (guide steps). Base is `worktree-srd-guide-steps`, so this diff is the **tone fix only** — one resolver + its tests. Merge #564 first; this retargets to `main` automatically.

## The bug

The SRD index renders `guides` as a **flat** catalog category — one tile per guide, not one tile for the schema — and paints each tile with that guide's own stored `guideColor`:

```ts
// apps/srd/src/lib/catalogHelpers.ts:94,100
const guideColor = typeof item.guideColor === 'string' ? item.guideColor : undefined
catalogBg: guideColor || getCatalogBg(schemaName),
```

The card that tile navigates to did not. `resolveDomainTone` sent guides through their `glossary` domain default, `calculateBackgroundColor` returned `bg-ink-2`, and every guide page came up flat ink regardless of its data.

So all **15 guides opened in a colour their link never promised**. Guides are the one entity type whose tone is *authored per item* rather than derived from its domain — five hues across the set — and the card was the only surface throwing that away. ITUN's `DowntimeWizard` already honours the field (`guide?.guideColor ?? CRAWLER_TONE`), so the SRD was the outlier.

## The fix

`resolveDomainTone` now reads the stored hue. Two details are load-bearing:

- It is a **data-shape check** on `guideColor`, not a `schemaName === 'guides'` branch, per the display-system rule that the card layer stays schema-agnostic. A malformed/empty value falls through to the domain tone rather than producing a transparent band.
- The hue is returned as **`bgColor`** (a raw CSS colour) and **`bg` is cleared**. The two reach different props — `accentSurface` puts `bg` on `className` and `bgColor` on an inline style — so leaving the stale domain class behind would paint glossary ink underneath the authored hue.

`bgColor` was already threaded to the header, sub-header, footer, frame and nested children, so nothing else needed to change.

## Verification

Measured in headless Chrome against the built site, comparing **each index tile's computed background to its guide card's header band**:

| | |
|---|---|
| guides matching their tile | **15 / 15** |
| distinct hues exercised | **5** |
| authored steps rendering (from #564) | **64 / 64** |
| horizontal overflow @ 1440 / 768 / 390 | **0** |

9 new tests in `guideTone.test.ts`, driven from the **shipped dataset** rather than a fixture, pinning index parity and asserting no other domain moved (gear still rides the tech-level ramp, traits/keywords/distances still ink, chassis still mech).

`bun run check:all` passes (lint, format, typecheck, test, validate, knip, schemas, tokens, styling, audit).

## Known, and pre-existing

White-on-hue for the two lightest guide colours measures **2.91:1** (`#5A9DB5`) and **3.04:1** (`#7A978A`) against the 3:1 WCAG bar for large text (titles are 48px/700, so the large-text threshold applies).

The index tiles **already ship those exact ratios today** — matching them is the point of this change — but the card previously sat on high-contrast ink, so this trades contrast for consistency on 5 of 15 guides. Raising it means darkening the authored palette at the source, which moves the index too and is a data/design call, not a rendering one. Flagging rather than deciding it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTG9VegyLmyrf49BdVotU6