### PR TITLE
docs(reference): correct the guideColor default note, which was never true

### DIFF
--- a/packages/salvageunion-reference/lib/schemas/entities.ts
+++ b/packages/salvageunion-reference/lib/schemas/entities.ts
@@ -446,8 +446,22 @@ export const GuideSchema = BaseEntitySchema.extend({
     // #282019 IS `--color-ink`, spelled as a literal because this validates
     // DATA, not styling: the field's contract is a 6-digit hex (see the regex
     // above), so `var(--color-ink)` is not a legal value here. The default was
-    // pure black, which the warm palette retired — and it is load-bearing, not
-    // decorative: 64 of the 79 guides omit `guideColor` and render on it.
+    // pure black, which the warm palette retired.
+    //
+    // It is a FALLBACK, not a shipped value. Every guide in `data/guides.json`
+    // carries its own explicit hue and none of them is `#282019`, so nothing
+    // currently renders on this default; it exists so a guide added without a
+    // colour still parses and still gets an ink band rather than a blank one.
+    //
+    // The previous version of this note asserted the opposite — "load-bearing,
+    // not decorative: 64 of the 79 guides omit `guideColor` and render on it".
+    // That was never true of this schema: the file has held 15 guides, every one
+    // with an explicit colour, since before the note was written. It is recorded
+    // rather than silently deleted because the false claim pointed the wrong way
+    // for a reader deciding how much this field matters — the card layer now
+    // resolves a guide's whole tone from it (`entityCardTone.ts`, matching the
+    // SRD index tile), and "most guides just use the default" would have been a
+    // materially wrong thing to believe while touching that.
     .default('#282019')
     .describe('Hex color for entity display header/footer'),
   steps: z.array(GuideStepSchema).describe('Ordered sequence of steps'),


### PR DESCRIPTION
Follow-up to #579, which is where this was noticed.

## The claim

The docblock on `GuideSchema.guideColor` asserted:

> The default was pure black, which the warm palette retired — and it is **load-bearing, not decorative: 64 of the 79 guides omit `guideColor` and render on it.**

## Every part of that is false — and it did not go stale, it was never true

| | claimed | actual |
|---|---|---|
| guides in `data/guides.json` | 79 | **15** |
| omitting `guideColor` | 64 | **0** |
| rendering on the `#282019` default | 64 | **0** (no guide's hue even *equals* it) |

Checked at the commit that introduced the note (#466) and at the one before it — 15 guides, 15 explicit colours, both times. The claim never described this schema's data.

## Why it's corrected in place rather than deleted

The false claim pointed the **wrong way** for anyone deciding how much this field matters, and that decision is now live: #579 made the card layer resolve a guide's *entire* tone from `guideColor` (`entityCardTone.ts`), matching the SRD index tile. "Most guides just use the default" would have been a materially wrong thing to believe while touching that code — so the old wording is quoted in the new note rather than quietly dropped.

The corrected note says what the default actually is: a **fallback**, so a guide added without a colour still parses and still gets an ink band rather than a blank one.

The `#282019`-as-a-literal rationale was accurate and is kept — the field validates **data**, not styling, so `var(--color-ink)` is not a legal value here.

## Scope

Comment-only. No schema, data, or behaviour change.

- `bun run build:package` → no drift in generated `schemas/*.schema.json`
- `lint` and `format:check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTG9VegyLmyrf49BdVotU6