### PR TITLE
fix(component-lib): give every catalog tile content, and drop its authorship band

### DIFF
--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -61,6 +61,7 @@ import { CatalogChoiceListing } from './CatalogChoiceListing'
 import { anchorBonusMarker, anchorChoiceMarkers } from './choiceAnchoring'
 import type { AnchoredContentBlock } from './choiceAnchoring'
 import { crawlerPopulationRange } from './crawlerPopulationRange'
+import { resolveCatalogLeadBlocks } from './catalogLead'
 import { firstParagraphText } from './firstParagraphText'
 import { EntityCardHeader } from './EntityCardHeader'
 import { EntityCardIdentityFooter } from './EntityCardIdentityFooter'
@@ -875,7 +876,12 @@ function ReferenceEntityCardInner({
   // against the weight of the header band above. Doubling it puts comparable
   // visual weight back at the foot.
   const FOOTLESS_BOTTOM = { borderBottomWidth: '6px' }
-  const rendersFooter = !hide?.footer && (footerOverride != null || depth === 0)
+  // A CATALOG tile carries NO footer band. That band is authorship (source ·
+  // booklet · page) plus the entity type, and on an index page every tile in the
+  // grid is the same type — so the row is attribution over redundancy, repeated
+  // on every card. A tile is artwork + description; provenance belongs on the
+  // entity's own page, which the tile links to.
+  const rendersFooter = !hide?.footer && !isCatalog && (footerOverride != null || depth === 0)
   // Condition — routed into the shared rail as a status CONTROL rather than a
   // bespoke seal, via the same `foldStatusControl` the Card shell uses,
   // so the badge (and the fold rule) has one implementation across both card
@@ -1168,18 +1174,8 @@ function ReferenceEntityCardInner({
   // entity cards. A catalog tile suppresses those cards, so it must NOT collapse
   // — otherwise the tile renders with no description at all.
   const isGrantingAbility = !isCatalog && isAbility(entity) && grantedCount > 0
-  // CATALOG grant lead — a grant-equipment ability carries NO own content (only a
-  // description), so its catalog tile would render with an empty body. The nested
-  // grant cards are suppressed here (canExpand is false in catalog mode), so
-  // instead surface each granted entity's OPENING paragraph as the tile's body
-  // prose — rendered through `Content` so it matches the tile's description text.
-  const catalogGrantBlocks: SURefObjectContentBlock[] =
-    isCatalog && grantedCount > 0
-      ? resolveGrantedEntities(entity as SURefEntity).flatMap((g) => {
-          const lead = firstParagraphText('content' in g ? g.content : undefined)
-          return lead ? [{ type: 'paragraph' as const, value: lead }] : []
-        })
-      : []
+  // (The CATALOG LEAD — the prose a tile borrows when it has none of its own —
+  // is resolved after the body walk below, once that prose is known.)
   // CATALOG guide lead — a guide keeps most of its prose in `steps`, which a
   // catalog tile never expands (`canExpand` is false here). That left tiles in
   // two broken states at once: guides with a long preamble dumped all of it,
@@ -1470,6 +1466,22 @@ function ReferenceEntityCardInner({
   }
 
   // (The BONUS-PER-TECH-LEVEL box is built + anchored earlier, in the body walk.)
+
+  // CATALOG LEAD — the tile suppresses every nested element, and for a large
+  // family of entities that IS everything they carry: a grant-equipment ability
+  // (Holo Companion) holds only a description plus what it grants, and a Bio-Maw
+  // / Green Laser Turret / Adrenal Glands / Chimerium Mutant Squad holds nothing
+  // but its actions. Those tiles rendered as a bare paper strip under the stat
+  // band. So a tile with no prose of its own borrows an opening paragraph from
+  // what it suppressed — grants first, then actions (`resolveCatalogLeadBlocks`)
+  // — rendered through `Content` so it reads as the tile's description.
+  //
+  // Gated on the tile having produced no prose itself, and de-duplicated against
+  // the header's flavour hint, so nothing is ever said twice.
+  const catalogLeadBlocks: SURefObjectContentBlock[] =
+    isCatalog && bodyNodes.length === 0
+      ? resolveCatalogLeadBlocks(entity as SURefEntity, hintText)
+      : []
 
   // CRAWLER BAY damaged effect → a red-ghosted, action-card-style callout (the
   // string is filtered out of the body prose above). RED token: `--color-status-bad`.
@@ -1824,6 +1836,26 @@ function ReferenceEntityCardInner({
       </div>
     ) : undefined
 
+  // EMPTY CATALOG BODY — a handful of entities have nothing a tile can show and
+  // nothing to borrow: a Steel Billy Club or a Crawler Tech Level is entirely
+  // stat block, and the lead resolver deliberately borrows rather than invents.
+  // For those the body box is a bare strip of paper hanging under the stat band,
+  // so it is dropped and the tile ends at the band it actually filled.
+  //
+  // Only the sections that CAN still render under `extent="catalog"` are tested
+  // here — nested groups, actions, patterns, chassis abilities, drones and guide
+  // steps are all already cut by `canExpand` / `hide` above.
+  const catalogBodyEmpty =
+    isCatalog &&
+    !anchorNode &&
+    bodyNodes.length === 0 &&
+    catalogLeadBlocks.length === 0 &&
+    !damagedEffect &&
+    !rollTableNode &&
+    !abilitiesSection &&
+    !afterChoicesContent &&
+    !afterExtraContent
+
   return (
     <div className={outerClassName} {...outerInteraction}>
       {seam}
@@ -1860,10 +1892,13 @@ function ReferenceEntityCardInner({
             // branch grew, so a flat card (a floated artwork body — every class
             // and creature page) left its slack BELOW the footer: the footer
             // band sat across the middle of the card with bare paper under it.
-            flat
-              ? 'flow-root flex-1'
-              : 'flex min-h-[2.5rem] flex-1 flex-col justify-center gap-1.5',
-            compact ? 'p-2' : 'p-3',
+            flat ? 'flow-root flex-1' : 'flex flex-1 flex-col justify-center gap-1.5',
+            // An EMPTY catalog body keeps `flex-1` (it still absorbs the slack in
+            // a stretched grid) but drops the min-height and padding that would
+            // otherwise hang a bare strip of paper under the stat band.
+            catalogBodyEmpty
+              ? 'min-h-0 p-0'
+              : cn(!flat && 'min-h-[2.5rem]', compact ? 'p-2' : 'p-3'),
             // A damaged/destroyed entity dims its body content too (not just the
             // greyed header), so the whole card reads as de-emphasised.
             isDown && 'opacity-60'
@@ -1886,12 +1921,12 @@ function ReferenceEntityCardInner({
               {bodyNodes.length > 0 && <>{bodyNodes}</>}
             </>
           )}
-          {/* CATALOG grant-lead prose — a grant-equipment ability's tile has no
-              own body, so show the granted entity's opening description here,
-              styled through Content to match the tile's other body prose. */}
-          {catalogGrantBlocks.length > 0 && (
+          {/* CATALOG LEAD prose — a tile with no body of its own borrows an
+              opening line from what catalog mode suppressed (its grants, else
+              its actions), styled through Content so it reads as description. */}
+          {catalogLeadBlocks.length > 0 && (
             <Content
-              body={catalogGrantBlocks}
+              body={catalogLeadBlocks}
               compact={compact}
               chassisName={resolvedChassisName}
               fontSize={compact ? 'text-xs' : 'text-sm'}
@@ -2066,11 +2101,11 @@ function ReferenceEntityCardInner({
             footer (legacy `expand`, e.g. a crawler bay's crew inset). */}
         {expand && <div className={compact ? 'px-2 pb-2' : 'px-3 pb-3'}>{expand}</div>}
         {/* FOOTER — `footerOverride` replaces the identity footer; `hide.footer`
-            suppresses it entirely. Absent ⇒ the depth-0 identity footer, unchanged. */}
-        {hide?.footer
-          ? null
-          : (footerOverride ??
-            (depth === 0 && (
+            and the catalog extent suppress it entirely (see `rendersFooter`,
+            which the frame's bottom edge reads from too, so the band and the
+            frame can never disagree). Absent ⇒ the depth-0 identity footer. */}
+        {rendersFooter
+          ? (footerOverride ?? (
               <EntityCardIdentityFooter
                 bgColor={darkTone}
                 typeLabel={footerType}
@@ -2081,7 +2116,8 @@ function ReferenceEntityCardInner({
                 externalLink={extent === 'full' ? externalLinkNode : undefined}
                 compact={compact}
               />
-            )))}
+            ))
+          : null}
       </div>
     </div>
   )

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/catalogContent.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/catalogContent.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * CATALOG CONTENT — the guarantee that an index tile is never blank, and never
+ * padded out with authorship or a sentence it already said.
+ *
+ * `extent="catalog"` suppresses every nested element (grants, actions, patterns,
+ * chassis abilities, roll-table rows) so a listing page reads uniformly. For a
+ * whole family of entities that suppression removed ALL of their substance —
+ * a Bio-Maw, a Green Laser Turret, an Adrenal Glands module and a Chimerium
+ * Mutant Squad carry no prose of their own, only actions — and their tiles
+ * rendered as a bare strip of paper under the stat band.
+ */
+import { afterEach, beforeAll, describe, expect, test } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+import {
+  getSchemaCatalog,
+  SalvageUnionReference,
+  SchemaToModelMap,
+  type SURefEntity,
+} from 'salvageunion-reference'
+
+import { ReferenceEntityCard } from '../ReferenceEntityCard'
+
+afterEach(cleanup)
+
+/** Text the tile renders, with the entity's own name removed — what a reader
+ * learns from the tile beyond the label they clicked. */
+function contentBeyondName(entity: SURefEntity): string {
+  const { container } = render(<ReferenceEntityCard data={entity} size="medium" extent="catalog" />)
+  const text = container.textContent ?? ''
+  return text.split(entity.name).join('').trim()
+}
+
+function findByName(model: string, name: string): SURefEntity {
+  const found = (
+    SalvageUnionReference[model as keyof typeof SalvageUnionReference] as unknown as {
+      all: () => SURefEntity[]
+    }
+  )
+    .all()
+    .find((entity) => entity.name === name)
+  if (!found) throw new Error(`fixture missing: ${model} / ${name}`)
+  return found
+}
+
+describe('catalog tiles always carry content', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  // The whole-dataset sweep. Every schema with a listing page (`meta: false` is
+  // what gives a schema a `/schema/<id>/` index in srd) renders a grid of these
+  // tiles, so the guarantee has to hold for the entire dataset, not a fixture.
+  const listingSchemas = getSchemaCatalog()
+    .schemas.filter((schema) => !schema.meta)
+    .map((schema) => schema.id)
+
+  test.each(listingSchemas)('every %s tile says something beyond its name', (schemaId) => {
+    const model = SchemaToModelMap[schemaId as keyof typeof SchemaToModelMap]
+    const all = (
+      SalvageUnionReference[model as keyof typeof SalvageUnionReference] as unknown as {
+        all: () => SURefEntity[]
+      }
+    ).all()
+    expect(all.length).toBeGreaterThan(0)
+
+    const blank = all.filter((entity) => contentBeyondName(entity).length === 0)
+    expect(blank.map((entity) => entity.name)).toEqual([])
+  })
+
+  test('an entity whose substance is its ACTIONS borrows their opening line', () => {
+    // Bio-Maw is a system with no content of its own — everything it means lives
+    // in the Bite / Consume actions the tile suppresses.
+    const bioMaw = findByName('Systems', 'Bio-Maw')
+    expect('content' in bioMaw ? (bioMaw.content?.length ?? 0) : 0).toBe(0)
+
+    render(<ReferenceEntityCard data={bioMaw} size="medium" extent="catalog" />)
+    expect(screen.getByText('You have a mouth, and it must eat.')).toBeTruthy()
+  })
+
+  test('a grant-equipment ability borrows the GRANTED entity, not its own action', () => {
+    // Holo Companion grants the Holo Companion equipment AND has an action.
+    // Grants win: the granted thing is what the ability is for.
+    const holo = findByName('Abilities', 'Holo Companion')
+
+    render(<ReferenceEntityCard data={holo} size="medium" extent="catalog" />)
+    expect(
+      screen.getByText(
+        'You have created an intelligent, holographic, A.I. companion that only you can use.'
+      )
+    ).toBeTruthy()
+    // The granted CARD itself stays suppressed — only its opening line is borrowed.
+    expect(screen.queryByText('Grants')).toBeNull()
+  })
+
+  test('the borrowed lead is ONE paragraph, not every suppressed action', () => {
+    // Adrenal Glands grants Burst AND Power. Printing both concatenates two
+    // unlabelled sentences — the action names that made them make sense are
+    // exactly what catalog mode suppressed.
+    const adrenal = findByName('Modules', 'Adrenal Glands')
+
+    render(<ReferenceEntityCard data={adrenal} size="medium" extent="catalog" />)
+    expect(screen.getByText(/can move an additional Range band/)).toBeTruthy()
+    expect(screen.queryByText(/can make an additional Turn Action/)).toBeNull()
+  })
+
+  test('an entity with prose of its own borrows nothing', () => {
+    // A tile only borrows when it would otherwise be blank. Bio-Rifle equipment
+    // has NO prose and so borrows its action's; the Bio-Titan Chimerium Chosen
+    // NPC carries its own, so the same action text must NOT be pulled in.
+    const borrowed = 'This handheld Bio-Titan gun fires fleshy spikes that pin a target down.'
+
+    const rifle = findByName('Equipment', 'Bio-Rifle')
+    const borrowing = render(<ReferenceEntityCard data={rifle} size="medium" extent="catalog" />)
+    expect(borrowing.container.textContent ?? '').toContain(borrowed)
+    borrowing.unmount()
+
+    const chosen = SalvageUnionReference.NPCs.all().find((npc) => npc.name === 'Chimerium Chosen')
+    if (!chosen) throw new Error('Chimerium Chosen fixture missing')
+    expect(chosen.content?.length ?? 0).toBeGreaterThan(0)
+    // It wields the Bio-Rifle (Chimerium Chosen) action, whose prose opens the
+    // same way — and it must render its OWN description instead.
+    const { container } = render(
+      <ReferenceEntityCard data={chosen} size="medium" extent="catalog" />
+    )
+    expect(container.textContent ?? '').not.toContain(borrowed)
+  })
+
+  test('a tile with nothing to borrow renders no empty body strip', () => {
+    // The lead resolver borrows; it never invents. A Steel Billy Club is TL and
+    // nothing else, so the body box is dropped rather than hung under the band
+    // as bare paper. `min-h-[2.5rem]` is what would have reserved that strip.
+    const club = findByName('Equipment', 'Steel Billy Club')
+
+    const { container } = render(<ReferenceEntityCard data={club} size="medium" extent="catalog" />)
+    expect(container.querySelector('[class*="min-h-[2.5rem]"]')).toBeNull()
+    // It still says what it does have.
+    expect(contentBeyondName(club)).toContain('TL')
+  })
+})
+
+describe('catalog tiles carry no authorship', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  test('the identity footer — source, booklet, page, type — is dropped', () => {
+    const chassis = SalvageUnionReference.Chassis.all().find((c) => !!c.source && !!c.page)
+    if (!chassis) throw new Error('no sourced chassis in fixtures — the probe is vacuous')
+
+    // Full extent DOES print the provenance — proves the fixture is a real probe.
+    const full = render(<ReferenceEntityCard data={chassis} />)
+    expect(screen.getByText(new RegExp(`p\\.${chassis.page}`))).toBeTruthy()
+    full.unmount()
+
+    const { container } = render(
+      <ReferenceEntityCard data={chassis} size="medium" extent="catalog" />
+    )
+    const text = container.textContent ?? ''
+    expect(text).not.toContain(String(chassis.source))
+    expect(text).not.toContain(`p.${chassis.page}`)
+    // …and not the entity TYPE either: every tile in a listing grid is the same
+    // type, so the label is the same word repeated down the page.
+    expect(text).not.toContain('Chassis')
+  })
+
+  test('a borrowed lead is never the sentence the header already showed', () => {
+    // An ability's description renders as the header's flavour hint. If the
+    // thing it grants opens with that same sentence, the tile would say it
+    // twice — the redundancy guard drops the duplicate.
+    const ability = SalvageUnionReference.Abilities.all().find((a) => {
+      const granted = SalvageUnionReference.Equipment.all().find(
+        (e) => e.name === a.grants?.[0]?.name
+      )
+      const lead = granted?.content?.find((block) => block?.type === 'paragraph')?.value
+      return !!a.description && typeof lead === 'string' && lead.trim() === a.description.trim()
+    })
+    // No such collision exists in the current dataset; assert the guard directly
+    // instead of skipping, so this test can't silently pass on a vacuous find.
+    expect(ability).toBeUndefined()
+
+    const holo = findByName('Abilities', 'Holo Companion')
+    const { container } = render(<ReferenceEntityCard data={holo} size="medium" extent="catalog" />)
+    const description = 'Construct an intelligent, holographic A.I. companion'
+    const occurrences = (container.textContent ?? '').split(description).length - 1
+    expect(occurrences).toBe(1)
+  })
+})

--- a/packages/component-lib/src/components/referenceEntity/card/catalogLead.ts
+++ b/packages/component-lib/src/components/referenceEntity/card/catalogLead.ts
@@ -1,0 +1,62 @@
+import type { SURefEntity, SURefObjectContentBlock } from 'salvageunion-reference'
+import { extractVisibleActions, resolveGrantedEntities } from 'salvageunion-reference'
+
+import { firstParagraphText } from './firstParagraphText'
+
+/**
+ * CATALOG LEAD — the prose a catalog tile falls back to when the entity itself
+ * carries no body prose.
+ *
+ * A catalog tile is artwork + description, and every nested element (granted
+ * entities, actions, patterns, roll tables) is suppressed so an index page reads
+ * uniformly. For a large family of entities that suppression removes ALL of
+ * their substance: a Bio-Maw, a Green Laser Turret, an Adrenal Glands module and
+ * a Chimerium Mutant Squad carry no prose of their own — everything they mean
+ * lives in the actions they grant. Their tiles rendered as a bare paper strip
+ * under the stat band.
+ *
+ * So the tile borrows an opening line from what it suppressed, in the order the
+ * entity's substance actually lives:
+ *
+ * 1. GRANTS — a grant-equipment ability (Holo Companion) has only a description
+ *    and the thing it grants; the granted entity's opening paragraph is what the
+ *    ability is *for*.
+ * 2. ACTIONS — an entity whose meaning is its actions (every case above) leads
+ *    with those actions' opening paragraphs.
+ *
+ * This borrows, it never invents: an entity with nothing to borrow (Steel Billy
+ * Club, a Crawler Tech Level) yields nothing and the caller drops the empty body
+ * band rather than rendering a blank strip.
+ *
+ * ONE paragraph, never more. The tile's body is a DESCRIPTION slot, not a
+ * summary of everything the entity was going to show. An Adrenal Glands module
+ * grants both Burst and Power; printing both leads concatenates two unlabelled
+ * sentences that read as a run-on, because the action names that made them make
+ * sense are exactly what catalog mode suppressed. So the tile takes the first
+ * and stops — the entity's own page carries the rest.
+ *
+ * REDUNDANCY GUARD — `exclude` is the text already on the card (the header's
+ * flavour hint); a borrowed line identical to it is skipped rather than said
+ * twice, and the next candidate is tried in its place.
+ */
+export function resolveCatalogLeadBlocks(
+  entity: SURefEntity,
+  exclude?: string
+): SURefObjectContentBlock[] {
+  const normalize = (text: string) => text.trim().replace(/\s+/g, ' ').toLowerCase()
+  const excluded = exclude ? normalize(exclude) : undefined
+
+  const candidates: (string | undefined)[] = [
+    ...resolveGrantedEntities(entity).map((granted) =>
+      firstParagraphText('content' in granted ? granted.content : undefined)
+    ),
+    ...(extractVisibleActions(entity) ?? []).map((action) => firstParagraphText(action.content)),
+  ]
+
+  const lead = candidates.find((text) => {
+    if (!text) return false
+    const key = normalize(text)
+    return key.length > 0 && key !== excluded
+  })
+  return lead ? [{ type: 'paragraph', value: lead }] : []
+}


### PR DESCRIPTION
## What

An `extent="catalog"` tile is **artwork + description**: it suppresses every nested element (grants, actions, patterns, chassis abilities) so a listing page reads uniformly whatever the entity happens to carry.

For a whole family of entities that suppression removed **all** of their substance. A Bio-Maw, a Green Laser Turret, an Adrenal Glands module and a Chimerium Mutant Squad carry no prose of their own — everything they mean lives in the actions the tile cuts. Their tiles rendered as a bare strip of paper under the stat band.

A sweep of the **entire dataset** at catalog extent found **76** such tiles, **16** of them on schemas that actually have a listing page (the rest are `meta` schemas — `actions`, `ability-tree-requirements` — which never surface as tiles).

## Changes

- **Borrowed lead.** A tile with no prose of its own now borrows an opening paragraph from what it suppressed: grants first (the existing grant-lead path, generalised), then actions. **One paragraph, never more** — printing every suppressed action concatenates unlabelled sentences into a run-on, because the action names that made them make sense are exactly what catalog mode cut.
- **It borrows, it never invents.** An entity with nothing to borrow (Steel Billy Club, a Crawler Tech Level — entirely stat block) now drops the body box instead of hanging an empty strip of paper below the band it did fill.
- **No authorship.** The identity footer is gone from catalog tiles. That band is provenance (`source · booklet · page`) plus the entity type, and on an index page every tile in the grid is the same type — attribution over redundancy, repeated on every card. Provenance belongs on the entity's own page, which the tile links to. `rendersFooter` now owns the decision, so the band and the frame's bottom edge can never disagree.
- **No redundancies.** A borrowed line identical to the header's flavour hint is skipped rather than said twice.

## Before / after

| | before | after |
|---|---|---|
| Bio-Maw | `Bio-Maw · TL B · Slots 6 · Bio 24` + blank strip | …+ *"You have a mouth, and it must eat."* |
| Green Laser Turret | stats + blank strip | …+ *"This was one of the first lasers developed for military use…"* |
| Hamlet Crawler | stats + blank strip + `Crawler Tech Level · Salvage Union Workshop Manual · p.218` | two clean bands, nothing else |
| Steel Billy Club | name + `TL 1` + blank strip + footer | one band: name + `TL 1` |

## Testing

- New `catalogContent.test.tsx`: a **whole-dataset sweep** asserting every entity of every listing schema renders something beyond its own name, plus targeted cases for each rule above (borrow-from-actions, grants-win, one-paragraph cap, don't-borrow-when-you-have-prose, no-empty-strip, no-authorship, no-duplicate-of-hint).
- `bun run check:all` green: **3,884 tests, 0 failures**, plus lint / format / typecheck / validate / knip / audit / tokens / styling.
- Verified in a real browser (headless Chrome at 1440px) against the srd dev server — `/schema/systems/`, `/schema/equipment/`, `/schema/crawler-tech-levels/`.

## Deploy

`component-lib` isn't a release-please-tracked package, so this produces no release PR. Both Netlify sites list `packages/component-lib` in their build-ignore pathspec, so merging rebuilds and ships **srd** and **itun**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01358768erK6DCwmNraF5ERc