### PR TITLE
fix(itun): start Heat at zero, never at capacity

### DIFF
--- a/apps/itun/src/components/dashboard/ActionsDeck.tsx
+++ b/apps/itun/src/components/dashboard/ActionsDeck.tsx
@@ -177,7 +177,7 @@ export function ActionsDeck({ mech, pilot, mount = 'mech', store }: ActionsDeckP
     const fresh = s.get('mech', mech.id) ?? mech
     const cap = mechMaxHeat(fresh, chassis)
     const { patch, effect, nextHeat } = pushPatch({
-      heat: Math.min(fresh.currentHeat ?? cap, cap),
+      heat: Math.min(fresh.currentHeat ?? 0, cap),
       heatCap: cap,
       currentSP: fresh.currentSP ?? 0,
       roll: defaultRoll,

--- a/apps/itun/src/components/dashboard/ActiveItemBand.tsx
+++ b/apps/itun/src/components/dashboard/ActiveItemBand.tsx
@@ -148,7 +148,7 @@ function MechBand({
   const maxCargo = mechMaxCargo(mech, chassis)
   const sp = Math.min(mech.currentSP ?? maxSP, maxSP)
   const ep = Math.min(mech.currentEP ?? maxEP, maxEP)
-  const heat = Math.min(mech.currentHeat ?? maxHeat, maxHeat)
+  const heat = Math.min(mech.currentHeat ?? 0, maxHeat)
   const cargo = totalLotUnits(mech.cargoLots)
 
   const [prompt, setPrompt] = useState<MechPrompt>(null)
@@ -175,7 +175,7 @@ function MechBand({
     const cap = mechMaxHeat(m, chassis)
     const spMax = mechMaxSP(m, chassis)
     const { patch, effect, nextHeat, meltdown } = pushPatch({
-      heat: Math.min(m.currentHeat ?? cap, cap),
+      heat: Math.min(m.currentHeat ?? 0, cap),
       heatCap: cap,
       currentSP: Math.min(m.currentSP ?? spMax, spMax),
       roll: defaultRoll,
@@ -189,7 +189,7 @@ function MechBand({
     const cap = mechMaxHeat(m, chassis)
     const spMax = mechMaxSP(m, chassis)
     const { patch, effect, meltdown } = heatCheckOncePatch({
-      heat: Math.min(m.currentHeat ?? cap, cap),
+      heat: Math.min(m.currentHeat ?? 0, cap),
       currentSP: Math.min(m.currentSP ?? spMax, spMax),
       roll: defaultRoll,
     })

--- a/apps/itun/src/components/dashboard/__tests__/dialItems.test.ts
+++ b/apps/itun/src/components/dashboard/__tests__/dialItems.test.ts
@@ -40,6 +40,18 @@ describe('dialItems', () => {
     expect(items.some((i) => i.label.startsWith('Crawler'))).toBe(false)
   })
 
+  test('a mech with no stored Heat reads 0, not Heat-at-capacity', () => {
+    const fresh = mechFixture({ id: 'm2', name: 'Fresh Rig', chassisRef: 'Mule' })
+    expect(fresh.currentHeat).toBeUndefined()
+    const item = dialItems({ mount: 'pilot', mech: fresh, pilot, crawler: null }).find(
+      (i) => i.label === 'Mech · Fresh Rig'
+    )
+    if (!item || item.statless) throw new Error('expected a statful mech dial item')
+    const heat = item.gauges.find((g) => g.label === 'Heat')
+    expect(heat?.max).toBeGreaterThan(0)
+    expect(heat?.value).toBe(0)
+  })
+
   test('statless views carry no gauges', () => {
     const items = dialItems({ mount: 'mech', mech, pilot: null, crawler: null })
     const actions = items.find((i) => i.label === 'Actions')

--- a/apps/itun/src/components/dashboard/dialItems.ts
+++ b/apps/itun/src/components/dashboard/dialItems.ts
@@ -70,7 +70,7 @@ function mechItem(mech: Mech): DialItem {
       { label: 'SP', value: Math.min(mech.currentSP ?? maxSP, maxSP), max: maxSP, tone: 'mech' },
       {
         label: 'Heat',
-        value: Math.min(mech.currentHeat ?? maxHeat, maxHeat),
+        value: Math.min(mech.currentHeat ?? 0, maxHeat),
         max: maxHeat,
         tone: 'mech',
         danger: Math.max(0, maxHeat - 2),

--- a/apps/itun/src/components/mech/MechStatsStep.tsx
+++ b/apps/itun/src/components/mech/MechStatsStep.tsx
@@ -42,7 +42,7 @@ export function MechStatsStep({ chassisName }: MechStatsStepProps) {
           size="mini"
         />
         <Stat label="EP" value={chassis.energyPoints} max={chassis.energyPoints} size="mini" />
-        <Stat label="HEAT" value={chassis.heatCapacity} max={chassis.heatCapacity} size="mini" />
+        <Stat label="HEAT" value={0} max={chassis.heatCapacity} size="mini" />
         <Stat label="SYS" value={chassis.systemSlots} max={chassis.systemSlots} size="mini" />
         <Stat label="MOD" value={chassis.moduleSlots} max={chassis.moduleSlots} size="mini" />
         <Stat label="CARGO" value={chassis.cargoCapacity} max={chassis.cargoCapacity} size="mini" />

--- a/apps/itun/src/components/sheet/MechSheet.tsx
+++ b/apps/itun/src/components/sheet/MechSheet.tsx
@@ -172,7 +172,7 @@ export function MechSheet({
   const heatCap = mechMaxHeat(mech, chassis)
   const currentSP = mech.currentSP ?? maxSP
   const currentEP = mech.currentEP ?? maxEP
-  const currentHeat = mech.currentHeat ?? heatCap
+  const currentHeat = Math.min(mech.currentHeat ?? 0, heatCap)
 
   // Slot budgets for the picker's loadout panel (soft — never blocks).
   const capacity = computeMechCapacity({

--- a/apps/itun/src/components/sheet/ShareSnapshotScreen.tsx
+++ b/apps/itun/src/components/sheet/ShareSnapshotScreen.tsx
@@ -532,7 +532,7 @@ function SnapshotPreviewCard({ entity }: SnapshotPreviewCardProps) {
             <VitalGauge
               label="Heat"
               max={maxHeat}
-              value={Math.min(mech.currentHeat ?? maxHeat, maxHeat)}
+              value={Math.min(mech.currentHeat ?? 0, maxHeat)}
               danger={maxHeat > 0 ? heatDangerFrom(maxHeat) : undefined}
               readOnly
             />

--- a/apps/itun/src/components/sheet/SheetMech.tsx
+++ b/apps/itun/src/components/sheet/SheetMech.tsx
@@ -49,7 +49,7 @@ export function SheetMech({
   const cargoUsed = totalLotUnits(mech.cargoLots)
   const sp = Math.min(mech.currentSP ?? maxSP, maxSP)
   const ep = Math.min(mech.currentEP ?? maxEP, maxEP)
-  const heat = Math.min(mech.currentHeat ?? maxHeat, maxHeat)
+  const heat = Math.min(mech.currentHeat ?? 0, maxHeat)
 
   // U-5: on phones the condensed bar leads with Heat + SP; EP/Hold fold
   // until the sm breakpoint.

--- a/apps/itun/src/components/sheet/__tests__/railStats.test.ts
+++ b/apps/itun/src/components/sheet/__tests__/railStats.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Unit tests for the rail vital readings.
+ *
+ * The Heat case is the point: SP and EP fall back to their MAXIMUM when the
+ * record carries no stored value (an unrecorded mech is undamaged), but Heat is
+ * inverted — an unrecorded mech is COOL, so it must fall back to 0. A fresh
+ * mech is never Heat-at-capacity.
+ */
+
+import { beforeAll, describe, expect, test } from 'bun:test'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import { mechRailItems } from '../railStats'
+import { mechFixture } from '../../__tests__/fixtures'
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+describe('mechRailItems', () => {
+  test('a mech with no stored Heat reads 0/cap', () => {
+    const mech = mechFixture({ id: 'm1', chassisRef: 'Mule' })
+    expect(mech.currentHeat).toBeUndefined()
+    const heat = mechRailItems(mech).find((s) => s.label === 'Heat')
+    expect(heat?.max).toBeGreaterThan(0)
+    expect(heat?.value).toBe(0)
+  })
+
+  test('SP and EP still fall back to full — an unrecorded mech is undamaged', () => {
+    const mech = mechFixture({ id: 'm2', chassisRef: 'Mule' })
+    const items = mechRailItems(mech)
+    for (const label of ['SP', 'EP']) {
+      const stat = items.find((s) => s.label === label)
+      expect(stat?.value).toBe(stat?.max as number)
+    }
+  })
+
+  test('a stored Heat above the cap is clamped, not shown over cap', () => {
+    const mech = mechFixture({ id: 'm3', chassisRef: 'Mule', currentHeat: 999 })
+    const heat = mechRailItems(mech).find((s) => s.label === 'Heat')
+    expect(heat?.value).toBe(heat?.max as number)
+  })
+})

--- a/apps/itun/src/components/sheet/railStats.ts
+++ b/apps/itun/src/components/sheet/railStats.ts
@@ -55,7 +55,7 @@ export function mechRailItems(mech: Mech): RailStat[] {
   return [
     { label: 'SP', value: mech.currentSP ?? maxSP, max: maxSP },
     { label: 'EP', value: mech.currentEP ?? maxEP, max: maxEP },
-    { label: 'Heat', value: mech.currentHeat ?? maxHeat, max: maxHeat },
+    { label: 'Heat', value: Math.min(mech.currentHeat ?? 0, maxHeat), max: maxHeat },
   ]
 }
 


### PR DESCRIPTION
## What

A mech with no stored `currentHeat` rendered as **Heat at capacity** instead of Heat 0.

Every live stat used the same `?? max` fallback. That is right for SP and EP — an unrecorded mech is undamaged — and inverted for Heat, where an unrecorded mech is *cool*. So `mech.currentHeat ?? maxHeat` pegged a fresh mech's Heat gauge full and red.

Concretely, before this change:

- A fresh mech, and any mech mounted in the **Dashboard** whose Heat had never been written, read Heat `cap/cap`.
- Push was locked out on that mech (`heat + 2 > maxHeat` is true at cap).
- `pushPatch` / `heatCheckOncePatch` were handed a **capped** starting Heat, so the first roll ran from the wrong number.
- The mech wizard's stats step previewed a fresh chassis as `HEAT cap/cap`.

## Change

Heat falls back to `0` (still `Math.min`-clamped to the cap for stored values above it) on every path:

- Dashboard — `ActiveItemBand` (band gauge + the Push/Heat-Check patch inputs), `dialItems`, `ActionsDeck`
- Live sheets — `MechSheet`, `SheetMech`, `railStats`
- Shared snapshot — `ShareSnapshotScreen`
- Wizard — `MechStatsStep` now previews `HEAT 0/cap`

SP and EP fallbacks are deliberately untouched. The three creation paths (`mechFormState`, `dashboardLaunch`, `InstantiateFromPattern`) already seeded `currentHeat: 0`; this fixes what happens when it's absent.

## Tests

- `dialItems.test.ts` — a chassis-resolved mech with no stored Heat yields a Heat gauge of `0` with a non-zero max (the Dashboard case).
- `railStats.test.ts` (new) — same for the sheet rail, plus a guard that SP/EP still fall back to full, plus clamping of a stored Heat above cap.

`bun run check:all` passes (lint, format, typecheck, 1292+ itun tests, validate, knip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAxZfRPrgJq8U9mm4b2LzE