### PR TITLE
feat(itun): show the Actions deck as one catalog-tile grid, mech + pilot

### DIFF
--- a/apps/itun/src/components/dashboard/ActionsDeck.tsx
+++ b/apps/itun/src/components/dashboard/ActionsDeck.tsx
@@ -11,12 +11,16 @@
  *               Active Item band, never auto-written)
  *
  * On foot (`mount === 'pilot'`) the deck is the pilot's abilities + equipment on
- * the AP economy; boarded, it is the mech's chassis + systems + modules on EP.
+ * the AP economy. Boarded, it is BOTH: the mech's chassis + systems + modules on
+ * EP *and* the pilot's own actions on AP — the pilot is in the cockpit, so their
+ * abilities and equipment never leave the table. The two economies coexist in one
+ * flat deck; `PlayAction.currency` (not the mount) decides what an activation
+ * spends and whether it touches Heat.
  */
 
 import { useState } from 'react'
 import { ActionsDeck as ActionsDeckView } from 'component-lib'
-import type { ActionsDeckView as ActionsDeckViewModel, DeckGroup } from 'component-lib'
+import type { ActionsDeckView as ActionsDeckViewModel, DeckRow } from 'component-lib'
 
 import { CORE_ROLL_BANDS, describePushOutcome, performCoreRoll } from '../../lib/rules/coreMechanic'
 import type { CoreRollResult } from '../../lib/rules/coreMechanic'
@@ -36,7 +40,6 @@ import {
   buildPilotActions,
   economyForActivation,
   groupBySource,
-  groupByTiming,
   hasCurrencyChoice,
   hasVariableHot,
   isDestructiveOutcome,
@@ -69,12 +72,16 @@ export function ActionsDeck({ mech, pilot, mount = 'mech', store }: ActionsDeckP
   const setRange = usePlayStateStore((st) => st.setRange)
   const armDamagePrompt = usePlayStateStore((st) => st.armDamagePrompt)
 
-  const isPilotDeck = mount === 'pilot' && pilot != null
-  const deck = isPilotDeck ? buildPilotActions(pilot) : buildMechActions(mech)
+  // On foot the mech's actions are unreachable; boarded, the pilot's own actions
+  // ride along with the mech's in one deck (SU pilots keep their abilities and
+  // equipment in the cockpit).
+  const onFoot = mount === 'pilot'
+  const pilotDeck = pilot ? buildPilotActions(pilot) : []
+  const deck = onFoot ? pilotDeck : [...buildMechActions(mech), ...pilotDeck]
 
   // Heat context for reach + heat-lock (pilots carry no heat).
   const heatCtx = (() => {
-    if (isPilotDeck) return { currentHeat: 0, heatCap: HUGE_HEAT_CAP }
+    if (onFoot) return { currentHeat: 0, heatCap: HUGE_HEAT_CAP }
     const fresh = s.get('mech', mech.id) ?? mech
     const chassis = resolveChassisRef(mech.chassisRef)
     return { currentHeat: fresh.currentHeat ?? 0, heatCap: mechMaxHeat(fresh, chassis) }
@@ -91,7 +98,6 @@ export function ActionsDeck({ mech, pilot, mount = 'mech', store }: ActionsDeckP
   const [currency, setCurrency] = useState<PlayActionCurrency>('EP')
 
   const [tab, setTab] = useState<TimingTab>('All')
-  const [grouping, setGrouping] = useState<'source' | 'timing'>('source')
   const [sourceFilter, setSourceFilter] = useState<string | null>(null)
 
   const selected = deck.find((a) => a.key === selectedKey) ?? null
@@ -190,24 +196,30 @@ export function ActionsDeck({ mech, pilot, mount = 'mech', store }: ActionsDeckP
   }
 
   if (deck.length === 0) {
-    const text = isPilotDeck
+    const text = onFoot
       ? 'This pilot has no activatable actions.'
-      : 'This mech has no activatable actions.'
+      : 'This mech and pilot have no activatable actions.'
     return <ActionsDeckView view={{ kind: 'empty', text }} />
   }
 
   if (selected) {
+    // Whether THIS action runs on the pilot's AP economy — per action, not per
+    // deck, since a boarded deck carries both. Pilot actions never touch Heat and
+    // can never be Pushed (Push is the mech reactor's move).
+    const isPilotAction = selected.currency === 'AP'
     // Fold the player-picked Hot X into this activation's economy (no-op unless
     // the action carries a variable Hot); the chosen currency drives the patch.
-    const currencyChoice = hasCurrencyChoice(selected.action)
-    const variableHot = hasVariableHot(selected.action) && !isPilotDeck
+    // The mech's EP is only reachable from the cockpit, so the EP-vs-AP radios
+    // are offered only when boarded.
+    const currencyChoice = hasCurrencyChoice(selected.action) && !onFoot
+    const variableHot = hasVariableHot(selected.action) && !isPilotAction
     const eco = economyForActivation(selected.economy, selected.action, hotX)
     const effCurrency: PlayActionCurrency = currencyChoice ? currency : selected.currency
 
-    // Heat projection + cap gate (mech deck only; pilots carry no Heat).
+    // Heat projection + cap gate (EP activations only; pilots carry no Heat).
+    const heatApplies = effCurrency === 'EP' && !onFoot
     const heatOk =
-      isPilotDeck ||
-      effCurrency === 'AP' ||
+      !heatApplies ||
       eco.heat <= 0 ||
       canActivateAction(heatCtx.currentHeat, eco.heat, heatCtx.heatCap)
     const projectedHeat = heatCtx.currentHeat + eco.heat
@@ -216,7 +228,7 @@ export function ActionsDeck({ mech, pilot, mount = 'mech', store }: ActionsDeckP
 
     const cost: string[] = []
     if (eco.epCost > 0) cost.push(`${eco.epCost} ${effCurrency}`)
-    if (!isPilotDeck && effCurrency === 'EP' && eco.heat > 0) cost.push(`+${eco.heat} Heat`)
+    if (heatApplies && eco.heat > 0) cost.push(`+${eco.heat} Heat`)
     if (eco.maxUses > 0) cost.push(`Uses ${eco.maxUses}`)
 
     const view: ActionsDeckViewModel = {
@@ -253,7 +265,7 @@ export function ActionsDeck({ mech, pilot, mount = 'mech', store }: ActionsDeckP
             : 'Activating would exceed the Heat Cap',
         onActivate: () => activate(selected, effCurrency, eco),
         onRoll: doRoll,
-        push: isPilotDeck ? undefined : { disabled: roll === null, onPush: doPush },
+        push: isPilotAction ? undefined : { disabled: roll === null, onPush: doPush },
         applyLabel: applied ? 'Applied' : 'Apply',
         applyDisabled: roll === null || applied || applyRouted,
         onApply: () => roll && doApply(roll),
@@ -274,40 +286,38 @@ export function ActionsDeck({ mech, pilot, mount = 'mech', store }: ActionsDeckP
     return <ActionsDeckView view={view} />
   }
 
-  // ---- List view: filter → group → render ----
+  // ---- List view: filter → render (ONE flat grid, no source/timing headings) ----
   const byTab = deck.filter((pa) => tabMatchesAction(tab, pa.action))
   const visible =
     sourceFilter === null ? byTab : byTab.filter((pa) => pa.ownerName === sourceFilter)
-  const groups = grouping === 'source' ? groupBySource(visible) : groupByTiming(visible)
   const reach = reachSummary(visible, range, heatCtx.currentHeat, heatCtx.heatCap)
 
   // Source tags come from the whole deck so they never vanish under a tab filter.
+  // They are the only place a source name still appears — the grid itself files
+  // no action under a heading.
   const sources = groupBySource(deck).map((g) => ({
     label: g.label,
     stamp: g.items[0]?.stamp ?? 'SYS',
   }))
-  const familyClass = isPilotDeck ? 'pc-deck-fam-pilot' : 'pc-deck-fam-mech'
+  const familyClass = onFoot ? 'pc-deck-fam-pilot' : 'pc-deck-fam-mech'
 
-  const deckGroups: DeckGroup[] = groups.map((group) => ({
-    label: group.label,
-    rows: group.items.map((action) => {
-      const reachable = actionReachable(action, range, heatCtx.currentHeat, heatCtx.heatCap)
-      return {
-        key: action.key,
-        // The raw action entity drives the canonical shortform badge card; the
-        // deck no longer hand-assembles stamp/name/meta/cost rows.
-        entity: action.action,
-        name: action.name,
-        locked: !reachable,
-        lockTitle:
-          action.condition === 'destroyed'
-            ? 'Destroyed'
-            : reachable
-              ? undefined
-              : 'Out of range / overheat',
-      }
-    }),
-  }))
+  const rows: DeckRow[] = visible.map((action) => {
+    const reachable = actionReachable(action, range, heatCtx.currentHeat, heatCtx.heatCap)
+    return {
+      key: action.key,
+      // The raw action entity drives the canonical catalog tile; the deck no
+      // longer hand-assembles stamp/name/meta/cost rows.
+      entity: action.action,
+      name: action.name,
+      locked: !reachable,
+      lockTitle:
+        action.condition === 'destroyed'
+          ? 'Destroyed'
+          : reachable
+            ? undefined
+            : 'Out of range / overheat',
+    }
+  })
 
   const view: ActionsDeckViewModel = {
     kind: 'list',
@@ -317,9 +327,6 @@ export function ActionsDeck({ mech, pilot, mount = 'mech', store }: ActionsDeckP
       const next = TIMING_TABS.find((x) => x === t)
       if (next !== undefined) setTab(next)
     },
-    groupingLabel: grouping === 'source' ? 'Source' : 'Timing',
-    groupingTitle: grouping === 'source' ? 'Group by timing' : 'Group by source',
-    onToggleGrouping: () => setGrouping((g) => (g === 'source' ? 'timing' : 'source')),
     rangeBands: RANGE_BANDS,
     activeRange: range,
     onRange: (b) => {
@@ -331,9 +338,9 @@ export function ActionsDeck({ mech, pilot, mount = 'mech', store }: ActionsDeckP
     sourceFilter,
     onSourceFilter: setSourceFilter,
     familyClass,
-    // Action badges ghost the deck's host tone: pilot on foot, mech when boarded.
-    hostTone: isPilotDeck ? 'var(--color-pilot)' : 'var(--color-mech)',
-    groups: deckGroups,
+    // Action tiles ghost the deck's host tone: pilot on foot, mech when boarded.
+    hostTone: onFoot ? 'var(--color-pilot)' : 'var(--color-mech)',
+    rows,
     onOpen: (key) => {
       const action = deck.find((a) => a.key === key)
       if (action) open(action)

--- a/apps/itun/src/components/dashboard/__tests__/ActionsDeck.test.tsx
+++ b/apps/itun/src/components/dashboard/__tests__/ActionsDeck.test.tsx
@@ -1,9 +1,10 @@
 /**
  * Tests for ActionsDeck — the D1 actions instrument on the light display.
- * Verifies the flat deck renders from the real ORM (grouped by source owner),
- * selecting an action opens the resolve panel, Activate writes the EP/uses patch
- * through the store, the timing tabs filter by actionType, and the on-foot
- * (mount='pilot') deck lists pilot actions on the AP economy.
+ * Verifies the deck renders from the real ORM as ONE flat grid (no per-source
+ * headings), selecting an action opens the resolve panel, Activate writes the
+ * EP/uses patch through the store, the timing tabs filter by actionType, and the
+ * mount decides the roster: boarded lists the mech's actions AND the pilot's,
+ * on foot only the pilot's (on the AP economy).
  *
  * Reference content needs the ORM, so preload('all') runs once. A system with a
  * real EP cost is picked from the loaded set so the Activate write is exercised.
@@ -42,6 +43,10 @@ let costedSystemId = ''
 let varHotSystem: { id: string; actionName: string } | null = null
 /** A module with an 'EP or AP' action → drives the cost-radio test. */
 let epApModule: { id: string; actionName: string } | null = null
+/** An ability carrying visible actions → drives the pilot-deck tests. */
+let pilotAbility: { id: string; actionNames: string[] } | null = null
+/** A module whose visible action carries a ROLL TABLE → the nested-control guard. */
+let tableModule: { id: string; actionName: string } | null = null
 
 beforeAll(async () => {
   await SalvageUnionReference.preload('all')
@@ -76,7 +81,38 @@ beforeAll(async () => {
       break
     }
   }
+  // A module whose visible action carries its own roll table. The catalog extent
+  // keeps roll tables (they ARE the content on an SRD index page), so the deck
+  // has to suppress them — their Show/Roll buttons can't nest in a clickable tile.
+  for (const mod of SalvageUnionReference.Modules.all()) {
+    if (!mod.id) continue
+    const resolved = resolveModule(mod.id)
+    const acts = resolved ? (SalvageUnionReference.resolveActions(resolved) ?? []) : []
+    const hit = acts.find((a) => !a.hidden && (a.table != null || a.tableName != null))
+    if (hit) {
+      tableModule = { id: mod.id, actionName: hit.name }
+      break
+    }
+  }
+  // A pilot ability with at least one visible action (the on-foot / cockpit deck).
+  for (const ability of SalvageUnionReference.Abilities.all()) {
+    if (!ability.id) continue
+    const acts = (SalvageUnionReference.resolveActions(ability) ?? []).filter((a) => !a.hidden)
+    if (acts.length > 0) {
+      pilotAbility = { id: ability.id, actionNames: acts.map((a) => a.name) }
+      break
+    }
+  }
 })
+
+/** The visible action names the costed system contributes to the mech deck. */
+function mechActionNames(): string[] {
+  const item = resolveSystem(costedSystemId)
+  if (!item) throw new Error(`unresolved system ${costedSystemId}`)
+  return (SalvageUnionReference.resolveActions(item) ?? [])
+    .filter((a) => !a.hidden)
+    .map((a) => a.name)
+}
 
 function makeMech(): Mech {
   return mechFixture({
@@ -97,7 +133,7 @@ function renderDeck(mech: Mech, store: PlayStore) {
   )
 }
 
-/** The deck cards are shortform `ReferenceEntityCard` badges laid out as a
+/** The deck cards are catalog-extent `ReferenceEntityCard` tiles laid out as one
  * masonry grid: each is a clickable card exposing `role="button"` +
  * `aria-label` = the action name. */
 function deckCards(container: HTMLElement): HTMLElement[] {
@@ -125,14 +161,40 @@ function clickPrimaryAction(container: HTMLElement): { epCost: number } {
 }
 
 describe('ActionsDeck', () => {
-  test('lists the installed system as a source-owner group', () => {
+  test('renders ONE flat grid — no per-source headings above the cards', () => {
     expect(costedSystemId).toBeTruthy()
     const mech = makeMech()
     const { store } = stubStore(mech)
     const { container } = renderDeck(mech, store)
-    const item = resolveSystem(costedSystemId)
-    const labels = [...container.querySelectorAll('.pc-deck-group-lab')].map((n) => n.textContent)
-    expect(labels).toContain(item?.name ?? '')
+    // Every card lives in a single grid; the deck files none of them under a
+    // heading of its own name (the source names survive only as filter chips).
+    expect(container.querySelectorAll('.pc-deck-grid')).toHaveLength(1)
+    expect(container.querySelector('.pc-deck h1, .pc-deck h2, .pc-deck h3')).toBeNull()
+    expect(deckCards(container).length).toBeGreaterThan(0)
+  })
+
+  test('a catalog tile nests no control inside its own clickable card', () => {
+    const mod = tableModule as { id: string; actionName: string }
+    expect(mod).toBeTruthy()
+    const mech = mechFixture({
+      id: 'm1',
+      name: 'Rig',
+      chassisRef: 'unknown-chassis',
+      modules: [mod.id],
+      currentEP: 6,
+      currentHeat: 0,
+    })
+    const { store } = stubStore(mech)
+    const { container } = renderDeck(mech, store)
+    const card = deckCards(container).find((el) => el.getAttribute('aria-label') === mod.actionName)
+    expect(card).toBeTruthy()
+    // The tile's roll table (Show toggle + Roll button) is suppressed: a control
+    // inside the card would be invalid markup and its click would bubble into
+    // `onOpen`. The table is still one click away, in the resolve panel.
+    expect(card?.querySelectorAll('button, [role="button"]')).toHaveLength(0)
+    // …and the resolve panel DOES render it.
+    fireEvent.click(card as Element)
+    expect(screen.getByText('Roll the Die')).toBeTruthy()
   })
 
   test('selecting an action opens the resolve panel with Activate + Roll', () => {
@@ -297,25 +359,36 @@ describe('ActionsDeck', () => {
     expect(calls[0]?.patch.currentAP).toBe(4)
   })
 
-  test('on-foot deck (mount=pilot) lists pilot actions', () => {
-    const ability = SalvageUnionReference.Abilities.all().find((a) => {
-      const acts = SalvageUnionReference.resolveActions(a)
-      return acts !== undefined && acts.filter((x) => !x.hidden).length > 0
-    }) as { id?: string } | undefined
-    const pilot = pilotFixture({
-      id: 'p1',
-      name: 'Vex',
-      abilities: [ability?.id ?? ''],
-      currentAP: 5,
-    })
+  test('boarded deck (mount=mech) lists the pilot actions alongside the mech ones', () => {
+    const ability = pilotAbility as { id: string; actionNames: string[] }
+    expect(ability).toBeTruthy()
+    const mech = makeMech()
+    const pilot = pilotFixture({ id: 'p1', name: 'Vex', abilities: [ability.id], currentAP: 5 })
+    const { store } = stubStore(mech)
+    const { container } = render(
+      <EntityHrefProvider value={() => undefined}>
+        <ActionsDeck mech={mech} pilot={pilot} mount="mech" store={store} />
+      </EntityHrefProvider>
+    )
+    const labels = deckCards(container).map((el) => el.getAttribute('aria-label'))
+    // The mech's own system actions are there…
+    expect(mechActionNames().some((n) => labels.includes(n))).toBe(true)
+    // …and so is the pilot's ability action — the pilot is in the cockpit.
+    expect(ability.actionNames.some((n) => labels.includes(n))).toBe(true)
+  })
+
+  test('on-foot deck (mount=pilot) lists ONLY pilot actions', () => {
+    const ability = pilotAbility as { id: string; actionNames: string[] }
+    const pilot = pilotFixture({ id: 'p1', name: 'Vex', abilities: [ability.id], currentAP: 5 })
     const { store } = stubStore(pilot)
     const { container } = render(
       <EntityHrefProvider value={() => undefined}>
         <ActionsDeck mech={makeMech()} pilot={pilot} mount="pilot" store={store} />
       </EntityHrefProvider>
     )
-    // The pilot deck renders (a card or an empty note), never crashes; and there
-    // is no Push affordance until an action is opened (pilots have no Heat).
-    expect(container.querySelector('.pc-deck, .pc-deck-empty')).toBeTruthy()
+    const labels = deckCards(container).map((el) => el.getAttribute('aria-label'))
+    expect(ability.actionNames.some((n) => labels.includes(n))).toBe(true)
+    // The mech is left behind — none of its actions are reachable on foot.
+    expect(mechActionNames().some((n) => labels.includes(n))).toBe(false)
   })
 })

--- a/apps/itun/src/components/dashboard/__tests__/dashboardRules.test.ts
+++ b/apps/itun/src/components/dashboard/__tests__/dashboardRules.test.ts
@@ -23,7 +23,6 @@ import {
   critInjuryPatch,
   economyForActivation,
   groupBySource,
-  groupByTiming,
   hasCurrencyChoice,
   hasVariableHot,
   heatCheckOncePatch,
@@ -305,17 +304,15 @@ describe('deck filtering / grouping / range', () => {
     expect(summary).toEqual({ inReach: 1, total: 2 })
   })
 
-  test('groupBySource / groupByTiming bucket the flat deck', () => {
+  // The deck renders one flat grid; `groupBySource` survives only to build the
+  // source filter chips (one per owning item), never a heading above the cards.
+  test('groupBySource buckets the flat deck by owning item', () => {
     const s1 = { ...mkAction({ actionType: 'Turn' }), ownerName: 'Gun' }
     const s2 = { ...mkAction({ actionType: 'Free' }), ownerName: 'Gun' }
     const s3 = { ...mkAction({ actionType: 'Turn' }), ownerName: 'Shield' }
     const bySource = groupBySource([s1, s2, s3])
     expect(bySource.map((g) => g.label)).toEqual(['Gun', 'Shield'])
     expect(bySource[0]?.items).toHaveLength(2)
-
-    const byTiming = groupByTiming([s1, s2, s3])
-    expect(byTiming.map((g) => g.label)).toEqual(['Turn', 'Free'])
-    expect(byTiming[0]?.items).toHaveLength(2)
   })
 
   test('actionMicroMeta renders range initials, damage, and traits', () => {

--- a/apps/itun/src/components/dashboard/dashboardRules.ts
+++ b/apps/itun/src/components/dashboard/dashboardRules.ts
@@ -246,7 +246,7 @@ export type PlayAction = {
   condition: ItemCondition
 }
 
-/** A named bucket of actions (grouped by source owner or by timing). */
+/** A named bucket of actions (grouped by source owner). */
 export type PlayActionGroup = { label: string; items: PlayAction[] }
 
 /** Self-declared engagement range band (playStateStore, ephemeral). */
@@ -292,8 +292,9 @@ function deckActions(entity: SURefMetaEntity): SURefMetaAction[] {
 /**
  * The boarded mech's activatable actions, flat — every action of the chassis,
  * each installed System, and each installed Module surfaces as its own
- * `PlayAction`. Grouping/filtering is a UI concern (see `groupBySource` /
- * `groupByTiming` / `TIMING_TABS`), kept out of this pure builder.
+ * `PlayAction`. Filtering is a UI concern (see `groupBySource` — which now only
+ * feeds the source filter chips — and `TIMING_TABS`), kept out of this pure
+ * builder.
  */
 export function buildMechActions(mech: Mech): PlayAction[] {
   const out: PlayAction[] = []
@@ -468,30 +469,6 @@ export function groupBySource(actions: PlayAction[]): PlayActionGroup[] {
     }
     g.items.push(a)
   }
-  return groups
-}
-
-const TIMING_ORDER = ['Turn', 'Short', 'Long', 'Free', 'Reaction', 'Passive', 'DownTime']
-
-/** Group actions by their `actionType`, in canonical timing order. */
-export function groupByTiming(actions: PlayAction[]): PlayActionGroup[] {
-  const groups: PlayActionGroup[] = []
-  const index = new Map<string, PlayActionGroup>()
-  for (const a of actions) {
-    const t = a.action.actionType ?? 'Other'
-    let g = index.get(t)
-    if (!g) {
-      g = { label: t, items: [] }
-      index.set(t, g)
-      groups.push(g)
-    }
-    g.items.push(a)
-  }
-  groups.sort((x, y) => {
-    const ix = TIMING_ORDER.indexOf(x.label)
-    const iy = TIMING_ORDER.indexOf(y.label)
-    return (ix === -1 ? 99 : ix) - (iy === -1 ? 99 : iy)
-  })
   return groups
 }
 

--- a/docs/architecture/combat-loop.md
+++ b/docs/architecture/combat-loop.md
@@ -82,6 +82,15 @@ computed by `itemEconomy()` in `sheet/mechItemRules.ts` (primary action's
 `activationCost`, summed `Hot` amounts, max `Uses`); the Deck resolves a
 **per-action** economy via `economyForActivation()`.
 
+**What the deck offers** is decided by the mount, and it is not symmetrical.
+Boarded, the deck is the mech's chassis + systems + modules **and** the pilot's
+own abilities + equipment — the pilot is in the cockpit, so nothing of theirs
+leaves the table. On foot it is the pilot's actions alone. The two economies
+coexist in one flat grid: each `PlayAction` carries its own `currency`, and that
+(never the mount) decides whether an activation spends EP and adds Heat, or
+spends the pilot's AP and adds none. Push is likewise per action — an EP action
+can be Pushed, a pilot's cannot.
+
 `activationPatch` builds one patch and the caller applies it as a **single
 sequential write-through** ([ADR-008](../adrs/ADR-008-sequential-mutations.md)):
 

--- a/packages/component-lib/src/components/dashboard/ActionsDeck.stories.tsx
+++ b/packages/component-lib/src/components/dashboard/ActionsDeck.stories.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { SalvageUnionReference } from 'salvageunion-reference'
 import { Caption } from '../../stories/_harness'
 import { InstrumentStage } from '../../stories/_dashboardStage'
-import { ActionsDeck, type DeckGroup } from './ActionsDeck'
+import { ActionsDeck, type DeckRow } from './ActionsDeck'
 
 export default { title: 'Compositions/Dashboard/Actions Deck' }
 
@@ -11,54 +11,35 @@ const TABS = ['All', 'Turn', 'Short', 'Long', 'Free', 'React'] as const
 const RANGES = ['Close', 'Medium', 'Long', 'Far'] as const
 
 /**
- * Real SRD actions as the deck's cards — each drives a shortform
- * `ReferenceEntityCard` badge, exactly as the ITUN wrapper feeds it. The last
- * card is locked (dimmed in place) to exercise the reach/overheat overlay.
+ * Real SRD actions as the deck's tiles — each drives a catalog-extent
+ * `ReferenceEntityCard`, exactly as the ITUN wrapper feeds it, in ONE flat grid
+ * (no source headings). The last tile is locked (dimmed in place) to exercise
+ * the reach/overheat overlay.
  */
-function realGroups(): DeckGroup[] {
-  const actions = SalvageUnionReference.Actions.all()
-  const chassisAction = actions.find((a) => /ram/i.test(a.name)) ?? actions[0]
-  const rest = actions.filter((a) => a !== chassisAction).slice(0, 5)
-  return [
-    {
-      label: 'Chassis',
-      rows: chassisAction
-        ? [
-            {
-              key: `act-${chassisAction.id}`,
-              entity: chassisAction,
-              name: chassisAction.name,
-              locked: false,
-            },
-          ]
-        : [],
-    },
-    {
-      label: 'Systems',
-      rows: rest.map((action, i) => ({
-        key: `act-${action.id}`,
-        entity: action,
-        name: action.name,
-        locked: i === rest.length - 1,
-        lockTitle: i === rest.length - 1 ? 'Out of range / overheat' : undefined,
-      })),
-    },
-  ]
+function realRows(): DeckRow[] {
+  const actions = SalvageUnionReference.Actions.all().slice(0, 6)
+  return actions.map((action, i) => ({
+    key: `act-${action.id}`,
+    entity: action,
+    name: action.name,
+    locked: i === actions.length - 1,
+    lockTitle: i === actions.length - 1 ? 'Out of range / overheat' : undefined,
+  }))
 }
 
 /**
- * The Actions deck list view: timing tabs, group/range tools, source tags, and
- * a masonry grid of shortform action cards (out-of-range cards dim in place).
- * Real SRD systems drive them; the resolve panel (not shown) reuses
+ * The Actions deck list view: timing tabs, range/reach tools, source tags, and
+ * one masonry grid of catalog action tiles (out-of-range tiles dim in place).
+ * Real SRD actions drive them; the resolve panel (not shown) reuses
  * ReferenceEntityCard.
  */
 export const Default: Story = () => {
   const [tab, setTab] = useState<string>('All')
   const [range, setRange] = useState<string>('Close')
-  const groups = realGroups()
+  const rows = realRows()
   return (
     <div className="flex flex-col gap-4">
-      <Caption>Actions deck (list view) — filter tabs, range/reach, masonry card grid.</Caption>
+      <Caption>Actions deck (list view) — filter tabs, range/reach, masonry tile grid.</Caption>
       <InstrumentStage width={560}>
         <div
           className="pc-display-light"
@@ -70,9 +51,6 @@ export const Default: Story = () => {
               tabs: TABS,
               activeTab: tab,
               onTab: setTab,
-              groupingLabel: 'Source',
-              groupingTitle: 'Group by timing',
-              onToggleGrouping: () => {},
               rangeBands: RANGES,
               activeRange: range,
               onRange: setRange,
@@ -85,7 +63,7 @@ export const Default: Story = () => {
               onSourceFilter: () => {},
               familyClass: 'pc-deck-fam-mech',
               hostTone: 'var(--color-mech)',
-              groups,
+              rows,
               onOpen: () => {},
             }}
           />

--- a/packages/component-lib/src/components/dashboard/ActionsDeck.tsx
+++ b/packages/component-lib/src/components/dashboard/ActionsDeck.tsx
@@ -13,23 +13,22 @@ import { ReferenceEntityCard } from '../referenceEntity/card/ReferenceEntityCard
 import type { ReferenceCardEntity } from '../referenceEntity/card/ReferenceEntityCard'
 
 /**
- * A render-ready action card. The action ENTITY drives a shortform
- * `ReferenceEntityCard` badge (name · Cost · type · Damage · range) — the same
- * card the SRD renders — so the deck reuses the canonical action rendering
- * instead of a hand-rolled row. The card states its own name, so the deck adds
- * no describing label above it. Reach/lock is resolved by the caller and
- * layered on top (dim + tooltip), never baked into the card.
+ * A render-ready action card. The action ENTITY drives a CATALOG-extent
+ * `ReferenceEntityCard` tile — the same index tile the SRD catalog renders — so
+ * the deck reuses the canonical action rendering instead of a hand-rolled row.
+ * The card states its own name, so the deck adds no describing label above it.
+ * Reach/lock is resolved by the caller and layered on top (dim + tooltip), never
+ * baked into the card.
  */
 export type DeckRow = {
   key: string
   /** Any card-renderable entity — ACTIONS are meta-entities, not `SURefEntity`. */
   entity: ReferenceCardEntity
-  /** Accessible name for the clickable badge (the action name). */
+  /** Accessible name for the clickable tile (the action name). */
   name: string
   locked: boolean
   lockTitle?: string
 }
-export type DeckGroup = { label: string; rows: DeckRow[] }
 
 export type ActionsDeckResolve = {
   onBack: () => void
@@ -74,9 +73,6 @@ export type ActionsDeckList = {
   tabs: readonly string[]
   activeTab: string
   onTab: (tab: string) => void
-  groupingLabel: string
-  groupingTitle: string
-  onToggleGrouping: () => void
   rangeBands: readonly string[]
   activeRange: string
   onRange: (band: string) => void
@@ -85,9 +81,10 @@ export type ActionsDeckList = {
   sourceFilter: string | null
   onSourceFilter: (source: string | null) => void
   familyClass: string
-  /** Host tone the action badges GHOST (mech vs pilot) — a resolvable CSS colour. */
+  /** Host tone the action tiles GHOST (mech vs pilot) — a resolvable CSS colour. */
   hostTone: string
-  groups: DeckGroup[]
+  /** The whole deck, flat — one grid, no source/timing headings above it. */
+  rows: DeckRow[]
   onOpen: (key: string) => void
 }
 
@@ -273,14 +270,6 @@ export function ActionsDeck({ view }: ActionsDeckProps) {
         </div>
 
         <div className="pc-deck-toolrow">
-          <button
-            type="button"
-            className="pc-deck-tool"
-            onClick={view.onToggleGrouping}
-            title={view.groupingTitle}
-          >
-            Group: {view.groupingLabel}
-          </button>
           <div className="pc-deck-range">
             {view.rangeBands.map((band) => (
               <button
@@ -329,48 +318,51 @@ export function ActionsDeck({ view }: ActionsDeckProps) {
         )}
       </div>
 
-      {view.groups.length === 0 ? (
+      {view.rows.length === 0 ? (
         <div className="pc-deck-empty">No actions match this filter.</div>
       ) : (
         <div className="pc-deck">
-          {view.groups.map((group) => (
-            <section key={group.label}>
-              <h3 className="pc-deck-group-lab">{group.label}</h3>
-              {/*
-               * A masonry grid, not a column of rows. The cards stay the compact
-               * shortform (`small` + `head`) — deliberately NOT the full extent,
-               * which embeds its own buttons (nested sub-entity cards, the
-               * description expander, roll controls). Those are invalid inside
-               * this card's own `role="button"` wrapper, and their clicks would
-               * bubble into `onOpen` and open the resolve panel. Shortform cards
-               * still differ in height when a long action name wraps, which is
-               * what the masonry packing is for. `<ul>/<li>` stays — a set of
-               * actions IS a list semantically; "grid" is purely the layout.
-               */}
-              <ul className="pc-deck-grid">
-                {group.rows.map((row) => (
-                  // Lock (out of range / overheat) is a caller-resolved overlay,
-                  // layered on the canonical card — dim + tooltip — never a
-                  // property of the action card itself.
-                  <li
-                    key={row.key}
-                    className={row.locked ? 'is-locked' : undefined}
-                    title={row.lockTitle}
-                  >
-                    <ReferenceEntityCard
-                      data={row.entity}
-                      size="small"
-                      extent="head"
-                      hostTone={view.hostTone}
-                      disabled={row.locked}
-                      cardClickLabel={row.name}
-                      onCardClick={() => view.onOpen(row.key)}
-                    />
-                  </li>
-                ))}
-              </ul>
-            </section>
-          ))}
+          {/*
+           * ONE masonry grid over the whole deck — no source/timing headings, so
+           * an action is never filed under a name of its own; the tile already
+           * states what it is. The cards are the canonical CATALOG tile
+           * (`medium` + `catalog`), the same index tile the SRD catalog renders:
+           * it keeps the description but suppresses every nested element
+           * (sub-entities, roll tables, choices), which is what makes it safe
+           * inside this card's own `role="button"` wrapper — the full extent
+           * would embed buttons whose clicks bubble into `onOpen`. Tile heights
+           * differ with description length, which is what the masonry packing is
+           * for. `<ul>/<li>` stays — a set of actions IS a list semantically;
+           * "grid" is purely the layout.
+           */}
+          <ul className="pc-deck-grid">
+            {view.rows.map((row) => (
+              // Lock (out of range / overheat) is a caller-resolved overlay,
+              // layered on the canonical card — dim + tooltip — never a
+              // property of the action card itself.
+              <li
+                key={row.key}
+                className={row.locked ? 'is-locked' : undefined}
+                title={row.lockTitle}
+              >
+                <ReferenceEntityCard
+                  data={row.entity}
+                  size="medium"
+                  extent="catalog"
+                  // An action's roll table survives the catalog extent by design
+                  // (it IS the content on an SRD index page), but its Show/Roll
+                  // buttons cannot nest inside this tile's own `role="button"`.
+                  // The table is one click away — the resolve panel renders the
+                  // same action as a full card.
+                  hide={{ rollTable: true }}
+                  hostTone={view.hostTone}
+                  disabled={row.locked}
+                  cardClickLabel={row.name}
+                  onCardClick={() => view.onOpen(row.key)}
+                />
+              </li>
+            ))}
+          </ul>
         </div>
       )}
     </div>

--- a/packages/component-lib/src/components/dashboard/instruments.css
+++ b/packages/component-lib/src/components/dashboard/instruments.css
@@ -195,19 +195,10 @@
   color: var(--color-ink-50);
   text-align: center;
 }
-.pc-deck-group-lab {
-  margin: 0 0 6px;
-  font-family: var(--font-cond);
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: var(--tracking-caps-tight);
-  font-size: var(--text-badge);
-  color: var(--color-ink-50);
-}
 /*
  * Masonry via CSS multi-column — deliberately the plain, well-understood
  * mechanism rather than `grid-template-rows: masonry` (not shipping broadly)
- * or a JS-measured layout. Card heights differ once a long action name wraps;
+ * or a JS-measured layout. Tile heights differ with description length;
  * columns pack them tightly and `break-inside: avoid` keeps a card whole. Column
  * COUNT is implicit: `column-width` is a minimum, so the deck widens from one
  * to three columns with the display panel and needs no breakpoints.
@@ -216,7 +207,9 @@
   list-style: none;
   margin: 0;
   padding: 0;
-  column-width: 260px;
+  /* Wide enough that a catalog tile's description keeps a readable measure —
+     the old 260px was sized for the header-only badge these tiles replaced. */
+  column-width: 320px;
   column-gap: 8px;
 }
 .pc-deck-grid > li {
@@ -385,20 +378,6 @@
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-}
-.pc-deck-tool {
-  padding: 5px 10px;
-  border: var(--bw-chrome) solid color-mix(in srgb, var(--color-ink) 22%, transparent);
-  border-radius: var(--radius-card);
-  background: var(--color-paper);
-  color: var(--color-ink);
-  cursor: pointer;
-  font-family: var(--font-cond);
-  font-weight: 700;
-  font-size: var(--text-note);
-}
-.pc-deck-tool:hover {
-  border-color: color-mix(in srgb, var(--color-ink) 45%, transparent);
 }
 .pc-deck-range {
   display: flex;

--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -256,6 +256,14 @@ export type ReferenceEntityCardProps = {
 export type ReferenceEntityCardHideConfig = {
   actions?: boolean
   patterns?: boolean
+  /**
+   * Suppress the entity's (or its folded action's) roll table. Needed where the
+   * whole card is itself a control — the Dashboard's Actions deck wraps each
+   * tile in a `role="button"` — since even the collapsible table carries its own
+   * Show/Roll buttons, which may not nest inside a button and whose clicks would
+   * bubble into the card's own handler.
+   */
+  rollTable?: boolean
   damagedEffect?: boolean
   choices?: boolean
   stats?: boolean
@@ -1650,15 +1658,16 @@ function ReferenceEntityCardInner({
   // the legacy renderer passed it unconditionally, and it is the affordance
   // that makes a roll table a table you can USE. No `tableName`: the card it
   // sits in already carries that name in its header.
-  const rollTableNode = entityTable ? (
-    <RollTable
-      table={entityTable}
-      showCommand
-      size={compact ? 'compact' : 'full'}
-      collapsible={isCatalog || depth > 0}
-      disabled={isDown}
-    />
-  ) : null
+  const rollTableNode =
+    entityTable && !hide?.rollTable ? (
+      <RollTable
+        table={entityTable}
+        showCommand
+        size={compact ? 'compact' : 'full'}
+        collapsible={isCatalog || depth > 0}
+        disabled={isDown}
+      />
+    ) : null
 
   // PATTERN PROSE — the pattern's OWN flavour, name-tabbed like a folded
   // action's prose so it can't be mistaken for the chassis prose that leads the

--- a/packages/component-lib/src/index.ts
+++ b/packages/component-lib/src/index.ts
@@ -132,7 +132,7 @@ export type { ActiveItemBandView, BandButton } from './components/dashboard/Acti
 export { DisplayPanel } from './components/dashboard/DisplayPanel'
 export type { DisplayContent } from './components/dashboard/DisplayPanel'
 export { ActionsDeck } from './components/dashboard/ActionsDeck'
-export type { ActionsDeckView, DeckGroup } from './components/dashboard/ActionsDeck'
+export type { ActionsDeckView, DeckRow } from './components/dashboard/ActionsDeck'
 export { CountStepper } from './components/chrome/CountStepper'
 export { Panel, Row } from './components/chrome/Panel'
 export { Slab } from './components/chrome/Slab'


### PR DESCRIPTION
The Dashboard's Actions instrument filed every action under a heading of its own source name, listed only one side's actions, and rendered each as a header-only badge. Three changes, one surface.

## One flat grid

The per-source (and per-timing) headings are gone, and with them the **Group** toggle and `groupByTiming` — a heading per action is noise when the tile already states what it is. `groupBySource` survives to build the source filter chips, which is now the only place a source name appears.

## The mount decides the roster, asymmetrically

Boarded, the deck is the mech's chassis + systems + modules **and** the pilot's abilities + equipment — the pilot is in the cockpit. On foot it is the pilot's alone.

The two economies coexist in the one deck: `PlayAction.currency` (not the mount) now decides whether an activation spends EP and adds Heat or spends AP and adds none, whether the Hot(X) stepper appears, and whether Push is offered. That also closes a latent hole where an on-foot `EP or AP` action could spend the EP of a mech the pilot had left behind.

## Catalog tiles

Each action renders as the canonical `medium` + `catalog` `ReferenceEntityCard` — the same index tile the SRD catalog uses — so the deck reads as SRD content, with the description the badge never showed.

### One thing this surfaced

The catalog extent deliberately **keeps** an entity's roll table (on an SRD index page the table *is* the content). That put a Show toggle and a Roll button inside a tile that is itself a `role="button"` — invalid markup whose clicks would bubble into the deck's open handler. Caught on the rendered page, not in review. `hide.rollTable` is new for exactly this, with a regression test; the table stays one click away, in the resolve panel, which renders the same action as a full card.

Column minimum goes 260px → 320px so a tile's description keeps a readable measure at the width the header-only badge used to need.

## Verification

`bun run check:all` green (lint, format, typecheck, all workspace tests, validate, knip, styling-ownership). New/updated tests cover the flat grid, the boarded mech+pilot roster, the on-foot roster excluding mech actions, and the nested-control guard. Rendered and inspected in Ladle (`Compositions/Dashboard/Actions Deck`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124EiAQge3oRXwqWZ2A4YAs