### PR TITLE
feat(component-lib): make the roll-table title its own table picker

### DIFF
--- a/apps/itun/src/components/dashboard/__tests__/DisplayPanel.test.tsx
+++ b/apps/itun/src/components/dashboard/__tests__/DisplayPanel.test.tsx
@@ -104,11 +104,19 @@ describe('DisplayPanel', () => {
     sublabel: 'roll',
   }
 
-  test('Tables focus → a RollTable renders under the picker bar (D3)', () => {
+  test('Tables focus → a RollTable whose title is the picker trigger (D3)', () => {
     const { container } = renderDV(tablesFocus)
     expect(container.querySelector('.pc-display-scroll')).toBeTruthy()
-    // The picker bar replaces the old <select>.
-    expect(container.querySelector('[aria-haspopup="dialog"]')).toBeTruthy()
+    // The trigger lives IN the RollTable header band — the band that also
+    // carries the Roll control — rather than in a bar above it repeating the
+    // name that band already prints.
+    const trigger = container.querySelector('[aria-haspopup="dialog"]')
+    expect(trigger).toBeTruthy()
+    expect(
+      trigger?.closest('div')?.querySelector('button[aria-label="Roll on this table"]')
+    ).toBeTruthy()
+    expect(trigger?.textContent).toContain('Core Mechanic')
+    expect(trigger?.getAttribute('aria-expanded')).toBe('false')
     expect(container.querySelector('select')).toBeNull()
     // The reused RollTable renders a real table (not the fallback note).
     expect(container.querySelector('table')).toBeTruthy()
@@ -122,6 +130,7 @@ describe('DisplayPanel', () => {
     fireEvent.click(openBtn)
     const overlay = container.querySelector('[role="dialog"]')
     expect(overlay).toBeTruthy()
+    expect(openBtn.getAttribute('aria-expanded')).toBe('true')
     const cats = [...container.querySelectorAll('.pc-tablepick-cat')].map((c) => c.textContent)
     expect(cats).toEqual(['Combat', 'Pilot', 'Salvage', 'Crawler', 'Downtime'])
     // Closing removes the overlay.
@@ -129,18 +138,19 @@ describe('DisplayPanel', () => {
     expect(container.querySelector('.pc-tablepick')).toBeNull()
   })
 
-  test('Tables picker → picking a table updates the bar and closes (D3)', () => {
+  test('Tables picker → picking a table retitles the table and closes (D3)', () => {
     const { container } = renderDV(tablesFocus)
     fireEvent.click(container.querySelector('[aria-haspopup="dialog"]') as HTMLButtonElement)
     const items = [...container.querySelectorAll('.pc-tablepick-item')] as HTMLButtonElement[]
     const initiative = items.find((b) => b.textContent === 'Group Initiative')
     expect(initiative).toBeTruthy()
     fireEvent.click(initiative as HTMLButtonElement)
-    // Overlay closed and the mini-bar now names the picked table.
+    // Overlay closed and the header title now names the picked table.
     expect(container.querySelector('.pc-tablepick')).toBeNull()
     expect(container.querySelector('[aria-haspopup="dialog"]')?.textContent).toContain(
       'Group Initiative'
     )
+    expect(container.querySelector('caption')?.textContent).toBe('Group Initiative')
   })
 
   test('Tables → rolling records a roll-history row (D3)', async () => {

--- a/packages/component-lib/src/components/dashboard/DisplayPanel.tsx
+++ b/packages/component-lib/src/components/dashboard/DisplayPanel.tsx
@@ -37,9 +37,14 @@ type RollHistoryEntry = {
 }
 
 /**
- * TablesView — the Tables focus (D3): a 5-column category picker overlay, the
- * selected table rendered via the reused `RollTable`, and an ephemeral roll
- * history. Self-contained (reads the ORM roll tables).
+ * TablesView — the Tables focus (D3): the selected table rendered via the reused
+ * `RollTable`, whose header TITLE is the trigger for the 5-column category
+ * picker overlay, plus an ephemeral roll history. Self-contained (reads the ORM
+ * roll tables).
+ *
+ * The trigger used to be a separate bar above the table — a "Roll table" label
+ * and a button repeating the name the header band printed directly beneath it.
+ * `titleSelect` folds the two into one control (see `RollTable`).
  */
 function TablesView() {
   const tables: RollTableEntity[] = SalvageUnionReference.RollTables.all()
@@ -55,24 +60,12 @@ function TablesView() {
 
   return (
     <div className="pc-display-scroll pc-tables">
-      <div className="pc-tables-bar">
-        <span className="pc-tables-lab">Roll table</span>
-        <Button
-          size="compact"
-          className="min-w-0 flex-1 justify-start text-left"
-          onClick={() => setPickerOpen(true)}
-          aria-haspopup="dialog"
-          aria-expanded={pickerOpen}
-        >
-          {selected?.name ?? 'Choose a table'} ▾
-        </Button>
-      </div>
-
       {selected ? (
         <RollTable
           table={selected.table}
           tableName={selected.name}
           showCommand
+          titleSelect={{ onOpen: () => setPickerOpen(true), open: pickerOpen }}
           onRollResult={(text, key) => {
             seqRef.current += 1
             const entry: RollHistoryEntry = {

--- a/packages/component-lib/src/components/dashboard/instruments.css
+++ b/packages/component-lib/src/components/dashboard/instruments.css
@@ -827,21 +827,10 @@
   position: relative;
 }
 
-/* Mini-bar: label + the "open picker" button. */
-.pc-tables-bar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 10px;
-}
-.pc-tables-lab {
-  font-family: var(--font-cond);
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: var(--tracking-caps-tight);
-  font-size: var(--text-badge);
-  color: var(--color-ink-50);
-}
+/* The picker trigger is the RollTable header title itself (`titleSelect`), so
+ * this focus has no mini-bar of its own — `.pc-tables-bar` / `.pc-tables-lab`
+ * were removed with it. */
+
 /* Roll history — last N results with a clear. */
 .pc-rollhist {
   margin-top: 14px;

--- a/packages/component-lib/src/components/shared/RollTable.stories.tsx
+++ b/packages/component-lib/src/components/shared/RollTable.stories.tsx
@@ -1,4 +1,5 @@
 import type { Story } from '@ladle/react'
+import { useState } from 'react'
 import type { ReactNode } from 'react'
 import { RollTable } from './RollTable'
 import { SalvageUnionReference } from 'salvageunion-reference'
@@ -36,7 +37,8 @@ export const Default: Story = () =>
       <p className="max-w-2xl font-body text-xs leading-relaxed text-ink-2">
         The banded d20 roll table. showCommand adds the rust Roll control + command name;
         size=&quot;compact&quot; tightens for rails/tooltips; disabled suppresses the Roll action
-        (Reference surface).
+        (Reference surface); titleSelect turns the header title into the surface&apos;s table picker
+        trigger.
       </p>
       <Row label="bare">
         <RollTable table={table} />
@@ -50,5 +52,26 @@ export const Default: Story = () =>
       <Row label="disabled (Reference)">
         <RollTable table={table} showCommand tableName={tableName} disabled />
       </Row>
+      <Row label="titleSelect (Dashboard Tables)">
+        <TitleSelectRow />
+      </Row>
     </div>
   ) : null
+
+/**
+ * `titleSelect` — the header title as the surface's table picker trigger, the
+ * shape the Dashboard Tables focus uses. Toggling stands in for the caller's
+ * picker opening: the caret flips and `aria-expanded` follows.
+ */
+function TitleSelectRow() {
+  const [open, setOpen] = useState(false)
+  if (!table) return null
+  return (
+    <RollTable
+      table={table}
+      showCommand
+      tableName={tableName}
+      titleSelect={{ onOpen: () => setOpen((v) => !v), open }}
+    />
+  )
+}

--- a/packages/component-lib/src/components/shared/RollTable.tsx
+++ b/packages/component-lib/src/components/shared/RollTable.tsx
@@ -8,6 +8,7 @@ import { toast } from 'sonner'
 import { useParseTraitReferences } from '../../utils/parseTraitReferences'
 import { Text } from '../base/Text'
 import { Badge } from '../chrome/Badge'
+import { FOCUS_RING_ON_TONE } from '../chrome/interaction'
 import { cn } from '../../utils/cn'
 import type { SizeRung } from '../../styles/sizing'
 
@@ -25,6 +26,31 @@ type RollTableType =
   | { type: 'standard' | 'alternate' | 'flat' | 'full'; [key: string]: TableContent }
 
 type ColumnsTableData = Extract<SURefObjectTable, { type: 'columns' }>
+
+/**
+ * Turns the header title into the surface's TABLE PICKER trigger.
+ *
+ * A surface that shows one of many tables (the Dashboard Tables view) used to
+ * carry a separate bar above the table — a label, then a button repeating the
+ * table's name, directly above the header band already printing that same name.
+ * With this the header title IS the trigger: one name, one control.
+ *
+ * Typed rather than a `node` slot, so the header keeps ownership of its own
+ * affordance (chevron, hit area, focus ring, aria) and every consumer gets the
+ * same one — the same reason entity-card interactivity is typed `controls`.
+ * The caller still owns what opening means; it renders its own picker.
+ *
+ * Independent of `disabled`, which suppresses the ROLL action only: choosing
+ * which table to read is not rolling on it.
+ */
+type RollTableTitleSelect = {
+  /** Open the caller's picker. */
+  onOpen: () => void
+  /** Whether that picker is currently open — drives `aria-expanded`. */
+  open?: boolean
+  /** Overrides the trigger's accessible name (default names the current table). */
+  ariaLabel?: string
+}
 
 type RollTableDisplayProps = {
   table: RollTableType
@@ -47,6 +73,11 @@ type RollTableDisplayProps = {
    * from the header and auto-expands to reveal the result). Implies the header.
    */
   collapsible?: boolean
+  /**
+   * Renders the header title as a picker trigger (see `RollTableTitleSelect`).
+   * Requires the header — pass `showCommand` or `collapsible`.
+   */
+  titleSelect?: RollTableTitleSelect
 }
 
 /**
@@ -68,6 +99,7 @@ function RollTableHeader({
   singleRoll,
   hasRolled,
   handleRoll,
+  titleSelect,
 }: {
   showHeader?: boolean
   collapsible?: boolean
@@ -78,8 +110,10 @@ function RollTableHeader({
   singleRoll?: boolean
   hasRolled: boolean
   handleRoll: () => void
+  titleSelect?: RollTableTitleSelect
 }) {
   if (!showHeader) return null
+  const title = tableName || 'Roll table'
   return (
     <Badge
       shape="stamp"
@@ -87,11 +121,11 @@ function RollTableHeader({
       size="compact"
       className="flex w-full items-center justify-between gap-2 px-2.5 py-1.5 tracking-caps-snug"
     >
-      <span className="inline-flex items-center gap-3">
+      <span className="inline-flex min-w-0 items-center gap-3">
         {collapsible && (
           <ExpandToggle expanded={expanded} onToggle={() => setExpanded((v) => !v)} />
         )}
-        {tableName || 'Roll table'}
+        {titleSelect ? <TitleSelect title={title} select={titleSelect} /> : title}
       </span>
       {!disabled && (
         <span className="inline-flex items-center gap-2">
@@ -118,6 +152,21 @@ function RollTableHeader({
   )
 }
 
+/** The 10px caret both header controls use — flipped when what it opens is open. */
+function Caret({ flipped }: { flipped?: boolean }) {
+  return (
+    <svg
+      width="10"
+      height="10"
+      viewBox="0 0 12 12"
+      aria-hidden="true"
+      className={cn('shrink-0 transition-transform', flipped && 'rotate-180')}
+    >
+      <path d="M2 4l4 4 4-4" fill="none" stroke="currentColor" strokeWidth="2" />
+    </svg>
+  )
+}
+
 /** The expand/collapse control shown in a collapsible roll-table header. */
 function ExpandToggle({ expanded, onToggle }: { expanded: boolean; onToggle: () => void }) {
   return (
@@ -128,15 +177,35 @@ function ExpandToggle({ expanded, onToggle }: { expanded: boolean; onToggle: () 
       className="inline-flex items-center gap-1 font-cond text-badge font-bold uppercase tracking-caps-tight text-paper/80 hover:text-paper"
     >
       {expanded ? 'Hide' : 'Show'}
-      <svg
-        width="10"
-        height="10"
-        viewBox="0 0 12 12"
-        aria-hidden="true"
-        className={cn('transition-transform', expanded && 'rotate-180')}
-      >
-        <path d="M2 4l4 4 4-4" fill="none" stroke="currentColor" strokeWidth="2" />
-      </svg>
+      <Caret flipped={expanded} />
+    </button>
+  )
+}
+
+/**
+ * The title-as-picker-trigger. Reads as the title it replaces (same band type),
+ * with a hairline plate + caret marking it as choosable and the on-tone focus
+ * ring — the paper-offset rung, because the rust ring would vanish on the ink
+ * band this sits in.
+ */
+function TitleSelect({ title, select }: { title: string; select: RollTableTitleSelect }) {
+  return (
+    <button
+      type="button"
+      onClick={select.onOpen}
+      aria-haspopup="dialog"
+      aria-expanded={select.open ?? false}
+      aria-label={select.ariaLabel ?? `Choose a roll table (current: ${title})`}
+      className={cn(
+        // `uppercase` is NOT redundant with the band: the UA reset gives
+        // `button` its own `text-transform: none`, so without it the trigger
+        // reads Title Case beside a band that is otherwise all caps.
+        'inline-flex min-w-0 cursor-pointer items-center gap-1.5 rounded-badge border border-paper/40 px-2 py-0.5 text-left uppercase text-paper hover:border-paper hover:bg-paper/10',
+        FOCUS_RING_ON_TONE
+      )}
+    >
+      <span className="truncate">{title}</span>
+      <Caret flipped={select.open} />
     </button>
   )
 }
@@ -408,6 +477,7 @@ function ColumnsRollTable({
   singleRoll = false,
   onRollResult,
   collapsible = false,
+  titleSelect,
 }: Omit<RollTableDisplayProps, 'table'> & { table: ColumnsTableData }) {
   const compact = size === 'compact'
   const [result, setResult] = useState<ColumnsRollResult | null>(null)
@@ -468,6 +538,7 @@ function ColumnsRollTable({
           singleRoll={singleRoll}
           hasRolled={hasRolled}
           handleRoll={handleRoll}
+          titleSelect={titleSelect}
         />
 
         <CollapsedResultSlideout
@@ -590,6 +661,7 @@ function StandardRollTable({
   singleRoll = false,
   onRollResult,
   collapsible = false,
+  titleSelect,
 }: RollTableDisplayProps) {
   const compact = size === 'compact'
   const digestedTable = digestRollTable(table)
@@ -657,6 +729,7 @@ function StandardRollTable({
           singleRoll={singleRoll}
           hasRolled={hasRolled}
           handleRoll={handleRoll}
+          titleSelect={titleSelect}
         />
         <CollapsedResultSlideout
           show={collapsible && !expanded}


### PR DESCRIPTION
## What

The Dashboard **Tables** focus carried a mini-bar above the table — a `Roll table` label plus a button repeating the very name the `RollTable` header band printed one row below it. Two controls, one fact.

`RollTable` now takes a typed `titleSelect` — `{ onOpen, open?, ariaLabel? }` — that renders the header **title** as the picker trigger. The Dashboard passes it and drops the bar (and `.pc-tables-bar` / `.pc-tables-lab` with it); the 5-column `TablePickerOverlay` is unchanged.

## Design notes

- **Typed, not a `node` slot** — the header keeps ownership of the affordance (caret, hit area, focus ring, `aria-haspopup="dialog"` / `aria-expanded`), so every consumer gets the same one. Same reasoning as the entity-card `controls` unification.
- **Independent of `disabled`**, which suppresses the ROLL action only: choosing which table to read is not rolling on it.
- **The `uppercase` on the trigger is load-bearing.** The UA reset gives `button` its own `text-transform: none`, so without it the title reads Title Case beside an all-caps band. Caught by measuring, not by reading.
- Focus uses `FOCUS_RING_ON_TONE` — the rust ring vanishes against the ink band.

## Verification

Measured in headless Chrome against the plain `showCommand` band: identical 12px Barlow Semi Condensed, 0.72px tracking, weight 700, paper ink — and an **unchanged 36.66px band height**, so nothing reflows. Caret flip + `aria-expanded` confirmed by clicking the real control.

| plain band | title as picker | open |
|---|---|---|
| `CORE MECHANIC` | `[ CORE MECHANIC ⌄ ]` | `[ CORE MECHANIC ⌃ ]` |

Full suite green: typecheck, lint, format, knip, `validate:all`, and all workspace tests (component-lib 599, itun 1298). ITUN's `DisplayPanel` tests now assert the trigger sits **in** the header band beside the Roll control, that picking retitles the table (`<caption>`), and that `aria-expanded` tracks the overlay.

A Ladle row (`titleSelect (Dashboard Tables)`) demonstrates it on the real Core Mechanic table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xZthKycfTXBWcvXs2ykij