### PR TITLE
docs: rules-parity ADRs + delivery plan (ADR-028, ADR-022 amendment)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -99,6 +99,8 @@ Read the matching ADR before proposing alternatives.
 | [ADR-024](adrs/ADR-024-derived-release-changelogs.md)                | Derived, per-app release changelogs (release-please) + on-site history; supersedes the web hand-changelog       |
 | [ADR-025](adrs/ADR-025-reference-versioned-releases-surface-gate.md) | Versioned internal releases + public-surface (TS + schema) gate for the ref; partially supersedes ADR-014       |
 | [ADR-026](adrs/ADR-026-entity-card-design-rules.md)                  | **Entity card design rules** — one renderer, choice/stat-atom/modified-stats/tech-level rules (built)           |
+| [ADR-027](adrs/ADR-027-partners-owned-by-host.md)                    | Partners are owned by their host entity                                                                         |
+| [ADR-028](adrs/ADR-028-contribution-model-and-stat-provenance.md)    | **Proposed** — one contribution model for caps/traits/damage + stat provenance; amends ADR-022's overrides      |
 
 > ADR-021 is the governing decision for rules enforcement and takes precedence
 > over prior ADRs where they conflict on _how hard a rule is enforced on which

--- a/docs/adrs/ADR-022-provenance-log-and-overrides.md
+++ b/docs/adrs/ADR-022-provenance-log-and-overrides.md
@@ -10,6 +10,12 @@ is still unbuilt. Subordinate to
 [ADR-021](ADR-021-itun-surface-taxonomy.md), which establishes the surface/mode
 model this ADR serves.
 
+**Amended 2026-07** — an override is now an **absolute pin**, not a signed delta
+in the same field the rules derivation reads. See
+[Amendment](#amendment-2026-07-overrides-become-absolute-pins); the amendment is a
+hard prerequisite for
+[ADR-028](ADR-028-contribution-model-and-stat-provenance.md).
+
 ## Context
 
 [ADR-021](ADR-021-itun-surface-taxonomy.md) makes the **Live Sheet** a Free-Edit
@@ -77,6 +83,10 @@ both the pinned value and the value it would derive to, so the UI can render an
 therefore **non-destructive and reversible**: reverting drops the pin and the stat
 resumes tracking its derivation.
 
+- **An override is an absolute pin, not a delta** (amended 2026-07 — see
+  [Amendment](#amendment-2026-07-overrides-become-absolute-pins)). The stored value is
+  the pinned maximum itself; the derived baseline is recomputed live and never
+  persisted.
 - The override marker is a small, visible graphical indicator on the affected stat
   — enough to tell an overridden value from a derived one at a glance. It appears
   **on the Live Sheet only**; a published snapshot renders the value plainly (a
@@ -103,3 +113,89 @@ resumes tracking its derivation.
 - Replay is preserved as a future option at low present cost — the log is designed
   for it even though no replay surface ships now.
 - Snapshot payloads and their privacy surface are unchanged: history stays local.
+
+## Amendment (2026-07): overrides become absolute pins
+
+### What was wrong
+
+As built, an override is stored as a **signed delta** in the same field the rules
+derivation reads — `maxSpModifier`, `maxHpModifier`, `maxApModifier`,
+`maxEpModifier`, `maxHeatModifier`, `maxCargoModifier` — and the "derived
+baseline" this ADR requires is recovered by **subtracting it back out**:
+
+```ts
+const derivedMaxSP = maxSP - (mech.maxSpModifier ?? 0) // MechSheet.tsx
+```
+
+So one field carries two incompatible meanings: the Free-Edit override pin _and_
+the only channel through which any rules modifier reaches a maximum today (which
+is why hand-entering Beefcake works at all, and why the Eldridge Coast pregens
+write these fields directly).
+
+The consequence is blocking. The moment a contribution applies automatically
+([ADR-028](ADR-028-contribution-model-and-stat-provenance.md)), it must not be
+written there — or a **rules-legal bonus renders as a hand override**, complete
+with an "overridden from N" callout and an offer to revert it. The sheet would
+actively lie. No data backfill can proceed until this is separated.
+
+### The amendment
+
+1. **An override stores the pinned value absolutely** (`max*Override`), not a
+   delta. The derived baseline is recomputed live from contributions and is never
+   persisted — which is closer to what this ADR always specified ("stores both the
+   pinned value and the value it would derive to") than the delta ever was.
+2. **`overridden` becomes an explicit flag**, not an inference. `VitalGauge` must
+   not decide whether a value was pinned by comparing two numbers.
+3. **Rules modifiers are never persisted on the entity.** They are derived
+   contributions, resolved at read time.
+4. **An override appends to the breakdown; it never replaces it.** The provenance
+   panel shows every derived contribution, subtotals them, and applies the pin as
+   the final line. This makes the retained baseline _visible_ rather than merely
+   stored, and makes the revert self-explanatory: the player can see the number it
+   falls back to and why that number is what it is.
+
+### Migration
+
+Existing `max*Modifier` values are an unrecoverable mixture of hand overrides and
+rules bonuses players typed in manually because the app would not apply them. A
+migration cannot distinguish the two.
+
+**Decision: convert every existing value to an absolute pin.** This is lossless —
+no displayed number changes for any character. The cost is cosmetic and accepted:
+a sheet where someone hand-entered a rules bonus will now show an override marker
+it did not show before. That marker is arguably correct, since the value genuinely
+was entered by hand.
+
+Rejected alternatives: grandfathering the marker behind a legacy flag (leaves a
+permanent flag in the schema to hide one migration); reconciling per stat by
+dropping values now covered by an automatic contribution (silently changes live
+characters' maxima); adding a parallel field without migrating (leaves the
+collision in place, so it solves nothing).
+
+The five Eldridge Coast pregens are the unambiguous case in the other direction:
+those are **authored content**, not player overrides, and become real
+contributions rather than pins. `eldridgeCoast.ts` says so in its own header —
+"class/ability bonuses ... are encoded via `maxHpModifier` / `maxApModifier`" —
+which is precisely the conflation this amendment removes. `pilotInventory.ts`
+carries the same admission for the third field ("base 6 + `maxInventorySlotsModifier`
+(Beefcake +4)"), a bonus no UI can even write today.
+
+**There is a direct precedent for the migration.** Migration 8
+(`8-crawler-battle-sp-to-derived.ts`) already performed this exact move for the
+Battle Crawler's +5 Max SP: a bonus that had been hand-carried in `maxSpModifier`
+was reclassified as derived, with the stored field healed rather than dropped.
+The pin migration is that operation generalized to the remaining five fields.
+
+### Also fixed alongside
+
+Three gaps in this ADR's own "every mutation is logged" guarantee, all found by
+inspection and none of them behavioural changes to the log's design:
+
+- `kind: 'transaction'` is defined in the schema, documented at
+  `entityStore.ts`, and badged in `ChangeLogDrawer` — but **emitted nowhere**. Every
+  Dashboard lifecycle transaction currently logs as a manual edit.
+- `source` is **never passed** by any call site; every persisted entry reads
+  `'unknown'`.
+- `entityStore.transfer()` performs cross-entity writes and **never calls
+  `emitChangeLog`**, so cargo stow/load and scrap hand-offs leave no trace. This is
+  the one true hole in the chokepoint guarantee.

--- a/docs/adrs/ADR-028-contribution-model-and-stat-provenance.md
+++ b/docs/adrs/ADR-028-contribution-model-and-stat-provenance.md
@@ -1,0 +1,207 @@
+# ADR-028: Unified Contribution Model & Stat Provenance
+
+## Status
+
+**Proposed.** Subordinate to [ADR-021](ADR-021-itun-surface-taxonomy.md) (the
+governing surface/mode taxonomy) and paired with the amendment to
+[ADR-022](ADR-022-provenance-log-and-overrides.md) that makes a cap override an
+absolute pin. Extends the "modified stats" rust language of
+[ADR-026](ADR-026-entity-card-design-rules.md) from stat cells to prose.
+
+## Context
+
+Two problems were found together, and they share one cause.
+
+**1. Content cannot declare what it does.** The dataset has _two_ mechanisms for
+saying "this thing changes that number", and neither is reachable from an
+ability:
+
+|                  | Engine A                                                           | Engine B                                           |
+| ---------------- | ------------------------------------------------------------------ | -------------------------------------------------- |
+| Field            | `statBonus` (`MechStatBonusSchema`)                                | `effects` (`ChoiceEffectSchema`)                   |
+| Vocabulary       | `structurePoints`, `energyPoints`, `heatCapacity`, `cargoCapacity` | `addTrait`, `removeTrait`, `setRange`, `addDamage` |
+| Declared on      | systems, modules                                                   | `choices[].choiceOptions[]` only                   |
+| Applied by       | `rules/derivedStats.ts`                                            | `resolveChoiceView.ts`                             |
+| Records using it | 8                                                                  | a handful of choice-bearing granted equipment      |
+
+`AbilitySchema` carries neither. So Beefcake ("Any Mech you Pilot increases its
+Max Structure Points by 3+X … your Pilot increases their Max Hit Points by 2"),
+Bionic Arms, Bionic Legs and Modular Face Implant are inert prose — the numbers
+on the sheet are simply wrong for any pilot holding them. The content type most
+likely to modify a character is the one type that can declare nothing.
+
+A survey of the core book plus the three expansions found **23 records whose
+text changes a maximum** (9 encoded, 5 stated-but-unapplied, 9 correctly
+excluded) and a further **~21 that change a trait, damage value or range**.
+
+One case is a plain defect rather than a schema gap: **Composite Armour** states
+"increases your Mech's Max SP by 5 for each Composite Armour System you have
+installed" — exactly the shape `statBonus.structurePoints` exists for — and
+carries no `statBonus` at all.
+
+**2. No derived value can explain itself.** Every maximum is computed as a flat
+sum that returns a bare `number`, so nothing downstream can say _why_ it is that
+number. The single exception is `crawlerMaxSPParts`, which returns
+`{ base, typeBonus, modifier, total }` and is rendered on exactly one screen (the
+crawler wizard, as "20 + 5 type bonus (Battle) = 25"). The shape to generalize
+already exists and is already proven; it is used once.
+
+These are one problem. A contribution that cannot be _declared_ also cannot be
+_attributed_, and a value assembled from anonymous addends cannot be explained.
+
+## Decision
+
+### 1. One contribution model
+
+**A single vocabulary replaces both engines.** A contribution is a **source**, an
+**operation**, and a **target** — regardless of whether the operation raises Max
+SP, adds Burn 1, or bumps damage by 1.
+
+```
+Contribution {
+  op        // the four cap keys, plus addTrait | removeTrait | setRange | addDamage
+  target    // self | pilot | pilotedMech | crawler | <named item>
+  amount    // an integer, or a small expression over tech level
+  stacks    // per installed copy (the existing statBonus semantic)
+  voidWhen  // damaged | destroyed — with the current-value clamp
+  duration  // permanent (default) | activated (see §4)
+}
+```
+
+**Any content type may declare contributions** — abilities, systems, modules,
+crawler bays, crawler types, equipment. Ability parity is the point of the
+exercise; a schema in which abilities are second-class is the bug.
+
+**Do not fork the resolver.** `resolveChoiceView.ts` already applies
+trait/damage/range correctly, including upgrading a duplicate trait's magnitude
+(Explosive 1 → 2), and is already shared by srd and ITUN. This ADR widens where
+effects may be **declared**; how they are **applied** is left alone.
+
+**"Never infer a number from prose" survives.** The existing instruction on
+`MechStatBonusSchema` is correct and is promoted to govern the whole model. The
+remedy for an unencoded record is **authoring** the number where the text states
+one flatly, or recording an explicit exemption — never inference. See §5.
+
+### 2. Derivations return parts, not numbers
+
+Every derivation returns a breakdown generalizing the existing
+`crawlerMaxSPParts` shape:
+
+```
+StatBreakdown { contributions: Contribution[], derived, total, overridden }
+```
+
+Each contribution carries a **label**, a **source kind**, a **signed amount**,
+and — where it exists — a **ref** to the granting entity, so provenance UI can
+link back to it. Existing scalar functions (`mechMaxSP`, `pilotMaxHP`, …) become
+thin `.total` wrappers so no call site changes when this lands.
+
+### 3. Provenance is a property of the value, not of a surface
+
+Any surface that renders a derived value can render its breakdown. Concretely:
+Live Sheet, Dashboard, partner cards (rendered in place since #590), Frozen
+snapshot, wizard previews, and entity reference cards.
+
+- The panel opens on **hover, focus _and_ tap**. Hover alone is unreachable by
+  keyboard and on touch, and is not acceptable.
+- **Frozen** shows the breakdown and never the revert — a published snapshot has
+  no editing affordance ([ADR-010](ADR-010-srd-choices-ephemeral-vs-persisted.md)).
+- **The Dashboard carries it.** `DashboardGauge` currently discards the
+  override/breakdown props. Restoring them _is_ the "teach as they enforce"
+  affordance [ADR-021](ADR-021-itun-surface-taxonomy.md) requires of Guided Play
+  and the Dashboard presently lacks.
+- **An override appends; it never replaces.** See the ADR-022 amendment.
+
+### 4. Duration-bound effects are Dashboard-applied, and never persisted on the entity
+
+Some contributions are temporary: Squeeze It In (+4 Cargo, 12 hours, stacks with
+itself), Hull Magnetiser (Cargo += the mech's System Slot Value, 1 hour,
+toggleable).
+
+These are **in scope as `duration: activated` contributions**, with two hard
+constraints:
+
+- They are **applied only by the Dashboard** (Guided Play). No other mode may
+  switch one on — activating an effect is a lifecycle transaction.
+- They resolve against **ephemeral play state**, never the persisted entity, per
+  [ADR-019](ADR-019-dashboard-play-state-ephemeral.md). Time does not enter the
+  data layer; reference data declares _that_ an effect is activated and for how
+  long, and play state records _when_.
+
+The provenance panel shows them like any other contribution, annotated with
+their remaining life ("Squeeze It In +4 — expires in 9h").
+
+### 5. The parity audit is the durable guarantee
+
+A CI check scans every reference record whose text states a mechanical change —
+a cap, a trait, a damage value, a range — and asserts **either** a structured
+contribution **or** an explicit, reasoned exemption. Exemption classes, each
+established by a real record:
+
+| Class                     | Example                                                 | Why exempt                                                                             |
+| ------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Chassis-integrated        | "Integrated Cargo Bay: +10, **to 16**"                  | Already the absolute chassis stat (Mule is 16). Encoding it double-counts.             |
+| Current-pool effect       | Parasitic Membrane, Bite, Transfer                      | Moves or restores a current pool; reads a cap without changing it.                     |
+| Already-modelled mechanic | Rad Wave Generator → Major Injuries                     | Handled by the existing injury penalty.                                                |
+| Effect-of-an-effect       | Mender: "+4 SP each time you heal"                      | Modifies another effect's output, not a stat. Out of the model.                        |
+| Grant at a moment         | Pilot Bay: "a **one-off** improvement of +2 HP / +1 AP" | A transaction, not a standing modifier. Encoding it as standing re-applies it forever. |
+
+The audit is what makes "content denotes what it claims" **stay** true across
+future content drops, rather than being a one-time sweep that silently rots. It
+is the first thing built and the last thing removed.
+
+### 6. Rules-bearing prose is marked inline
+
+On entity reference cards, the indicator that a contribution exists is rendered
+**inline with the sentence that grants it**, not as a separate badge or footer
+row. It extends the **rust "modified" language** already established by
+[ADR-026](ADR-026-entity-card-design-rules.md) §5 for choice- and
+scaling-touched stat cells, applying it to a prose span.
+
+This is deliberate and does double duty:
+
+- A reader sees _which clause_ the app actually understands, adjacent to the
+  claim itself.
+- Unmarked prose that plainly states a number becomes a **visible coverage gap in
+  the product**, not only a CI failure. The parity backlog is legible to anyone
+  reading a card.
+
+Note ADR-026 §5 currently scopes the rust language to `Stat` cells and
+explicitly not `VitalGauge`. This ADR does not change that; it adds a third
+carrier (a prose span) alongside it.
+
+## Consequences
+
+- **Ability parity becomes possible at all.** Today it is not expressible, so no
+  amount of data work fixes Beefcake.
+- **One vocabulary, one provenance implementation.** The alternative — extending
+  both engines separately — means two things to learn, two places to look when a
+  number is wrong, and a third mechanism the first time someone needs an ability
+  to grant a trait.
+- **Ordering is forced.** The ADR-022 override amendment must land _before_ any
+  automatic contribution, or a rules-legal bonus renders as a hand override. See
+  that ADR for why.
+- **The dataset gains authoring obligations.** Every future record stating a flat
+  mechanical change must encode it or justify itself to the audit. This is the
+  intended cost.
+- **`resolveChoiceView` becomes load-bearing for more of the app**, which raises
+  the value of its existing test coverage and the bar for changing it.
+- Duration-bound effects introduce the first contributions whose value depends on
+  play state rather than reference data alone. §4's constraints exist to stop
+  that leaking into IndexedDB.
+
+## Cross-references
+
+- [ADR-021](ADR-021-itun-surface-taxonomy.md) — governing; which mode enforces what.
+- [ADR-022](ADR-022-provenance-log-and-overrides.md) — the Change Log and stat
+  overrides; amended by this work to make an override an absolute pin.
+- [ADR-026](ADR-026-entity-card-design-rules.md) — entity card design rules; §5's
+  rust "modified" language, extended here to prose.
+- [ADR-019](ADR-019-dashboard-play-state-ephemeral.md) — ephemeral play state, the
+  home of activated contributions.
+- [ADR-006](ADR-006-pure-rules-logic.md) — rules as pure functions; breakdowns
+  stay pure and side-effect-free.
+- [ADR-010](ADR-010-srd-choices-ephemeral-vs-persisted.md) — the Frozen end of the
+  display contract.
+- [architecture/rules-engine-boundary.md](../architecture/rules-engine-boundary.md)
+  — the authoritative mode × rule-class matrix.

--- a/docs/design/rules-parity-plan.md
+++ b/docs/design/rules-parity-plan.md
@@ -1,0 +1,160 @@
+# Rules Parity & Stat Provenance — Delivery Plan
+
+> **Decisions live in the ADRs, not here.**
+> [ADR-028](../adrs/ADR-028-contribution-model-and-stat-provenance.md) (the
+> contribution model + provenance) and the
+> [ADR-022 amendment](../adrs/ADR-022-provenance-log-and-overrides.md#amendment-2026-07-overrides-become-absolute-pins)
+> (overrides become absolute pins) are authoritative. This document is the
+> **delivery breakdown** — units, sizes, dependencies and definition of done.
+
+## The problem in one paragraph
+
+ITUN's derivation is sound and its Change Log is built, but content cannot
+declare what it does and no derived value can explain itself. The dataset has two
+modifier engines — `statBonus` for four mech maxima, and `ChoiceEffectSchema` for
+traits/damage/range — and **neither is reachable from an ability**, so Beefcake,
+Bionic Arms, Bionic Legs and Modular Face Implant are inert prose and the numbers
+on the sheet are wrong for any pilot holding them. Separately, every maximum is a
+flat sum returning a bare number, so nothing can say why `Max SP` is 25.
+
+## Measured baseline
+
+Surveyed against the core book (1.2) and the three expansions, verified directly
+against the working tree.
+
+| Finding                                                                   | Count |
+| ------------------------------------------------------------------------- | ----: |
+| Records whose text changes a **maximum**                                  |    23 |
+| — correctly encoded (`statBonus` ×8, crawler `mutations` ×1)              |     9 |
+| — **stated but never applied**                                            |     5 |
+| — correctly excluded (chassis-integrated, current-pool, already-modelled) |     9 |
+| Records that change a **trait, damage value or range**                    |   ~21 |
+| Derivations that expose a breakdown (`crawlerMaxSPParts`, one screen)     |     1 |
+| Change Log entries ever tagged `kind: 'transaction'`                      |     0 |
+| Rules modules implemented, tested, and unreachable                        |     3 |
+
+The five stated-but-unapplied: **Composite Armour** (a plain defect — its text
+fits `statBonus.structurePoints` exactly and the field is simply absent), plus
+**Beefcake**, **Bionic Arms**, **Bionic Legs** and **Modular Face Implant**,
+which the schema cannot express at all.
+
+Two traps worth carrying into the work, both verified:
+
+- **Chassis-integrated bonuses are already absolute.** "Integrated Cargo Bay: +10,
+  _to 16_" — the Mule's `cargoCapacity` **is** 16 (Gopher 12, Atlas 30). Backfilling
+  these double-counts.
+- **Not every stated number is a cap modifier.** Mender's "+4 SP each time you
+  heal" modifies another effect's output; Armour Plating states no cap change at
+  all and is correctly unencoded.
+
+## Sequencing decisions taken
+
+| Question               | Decision                                                                                                                                                   |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Scope                  | **Full contextual parity** — all six phases below                                                                                                          |
+| Migration              | **Convert every `max*Modifier` to an absolute pin.** Lossless; no displayed number changes. Accepted cost: some sheets gain an override marker they lacked |
+| Model                  | **Converge the two engines** into one contribution vocabulary; widen where effects may be _declared_, leave `resolveChoiceView`'s application logic alone  |
+| Process                | **ADR-022 amendment + new ADR-028**, both before code                                                                                                      |
+| Duration-bound effects | **In scope**, as `duration: activated` contributions applied only by the Dashboard against ephemeral play state (ADR-019)                                  |
+| Order                  | **Provenance first** (A→B), then the model and data (C→D), then Dashboard wiring (F)                                                                       |
+| Surfaces               | Live Sheet, Dashboard, **partner cards, Frozen snapshot, wizard previews, entity reference cards**                                                         |
+
+## Units
+
+Sizes use the repo's existing effort labels: **S** under 1 day · **M** 1–2 · **L** 2–3 · **XL** 3+.
+
+### Phase A — Foundation (blocks everything downstream)
+
+| ID     | Unit                        | Size | Depends | Done when                                                                                                                                                                                 |
+| ------ | --------------------------- | ---- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A1** | ADR-022 amendment + ADR-028 | S    | —       | Both merged; `docs/README.md` index updated                                                                                                                                               |
+| **A2** | Parity audit + CI gate      | M    | A1      | Scans every record stating a mechanical change; asserts a contribution or a reasoned exemption; names record + sentence on failure. Advisory for one week, then blocking                  |
+| **A3** | Absolute-pin overrides      | L    | A1      | `max*Override` replaces the six delta fields; IDB migration lossless (property test: no displayed maximum changes); `VitalGauge` reads an explicit `overridden` flag, never a subtraction |
+
+### Phase B — Provenance (the visible feature)
+
+| ID     | Unit                            | Size | Depends | Done when                                                                                                                                  |
+| ------ | ------------------------------- | ---- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **B1** | Breakdown-shaped derivations    | L    | A3      | Every maximum returns `StatBreakdown`, generalizing `crawlerMaxSPParts`; scalar functions become `.total` wrappers so no call site changes |
+| **B2** | Provenance panel primitive      | M    | B1      | component-lib panel opens on hover **and** focus **and** tap; contributions link to the granting entity; passes a11y scan                  |
+| **B3** | Live Sheet wiring               | M    | B2, A3  | All gauges carry breakdowns; **an override appends as the final line**, never replaces the list; revert target visible                     |
+| **B4** | Dashboard wiring                | S    | B2      | `DashboardGauge` stops discarding the props; Guided Play gains the "teach as it enforces" affordance                                       |
+| **B5** | Partner cards + Frozen snapshot | M    | B2      | Partner stats explain their `bonusPerTechLevel` scaling in `PartnerCard`; snapshots show the breakdown and never the revert                |
+| **B6** | Wizard previews                 | S    | B2      | The bespoke `sp-breakdown` string is retired in favour of the shared panel                                                                 |
+
+### Phase C — The converged model
+
+| ID     | Unit                           | Size | Depends | Done when                                                                                                                                                              |
+| ------ | ------------------------------ | ---- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **C1** | Contribution schema            | XL   | A2      | One vocabulary: `op` / `target` / `amount` / `stacks` / `voidWhen` / `duration`, covering the four cap keys plus `addTrait` / `removeTrait` / `setRange` / `addDamage` |
+| **C2** | Declaration sites              | L    | C1      | Abilities, systems, modules, bays and crawler types may all carry contributions. **Ability parity is the acceptance test**                                             |
+| **C3** | Resolver extension             | L    | C2      | Contributions from non-choice sources flow through `resolveChoiceView`; its application logic is unchanged and its tests still pass                                    |
+| **C4** | Inline rules-bearing indicator | M    | C2      | The granting **sentence** is marked on entity reference cards, extending ADR-026 §5's rust "modified" language to a prose span                                         |
+
+### Phase D — Data backfill
+
+| ID     | Unit                             | Size | Depends | Done when                                                                                                                              |
+| ------ | -------------------------------- | ---- | ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| **D1** | Composite Armour                 | S    | —       | `statBonus.structurePoints: 5` + test. **Fits today's schema — shippable immediately**                                                 |
+| **D2** | Cap-class backfill               | M    | C2      | Beefcake, Bionic Arms, Bionic Legs, Modular Face Implant; Pilot Bay explicitly triaged as a grant-at-a-moment, not a standing modifier |
+| **D3** | Trait / damage / range backfill  | L    | C3      | The ~21 records the audit surfaces; one record per change, each with a test                                                            |
+| **D4** | Coverage past the four mech keys | L    | C2      | Pilot HP/AP/inventory, system + module slots, crawler bays and weapon mounts                                                           |
+
+### Phase E — Change Log truth (independent quick wins)
+
+| ID     | Unit                             | Size | Depends | Done when                                                                       |
+| ------ | -------------------------------- | ---- | ------- | ------------------------------------------------------------------------------- |
+| **E1** | Tag transactions + pass `source` | S    | —       | Dashboard writes emit `kind: 'transaction'`; no entry reads `source: 'unknown'` |
+| **E2** | Log `entityStore.transfer()`     | S    | —       | Cargo stow/load and scrap hand-offs appear in the Change Log                    |
+
+### Phase F — Dashboard rules wiring
+
+| ID     | Unit                               | Size | Depends | Done when                                                                                                                         |
+| ------ | ---------------------------------- | ---- | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| **F1** | Activated contributions            | L    | C1, B2  | Squeeze It In and Hull Magnetiser work; expiry lives in ephemeral play state, never IndexedDB; the panel annotates remaining life |
+| **F2** | Wire salvage                       | M    | —       | `salvage.ts` reachable from the Dashboard                                                                                         |
+| **F3** | Wire crafting                      | M    | —       | `crafting.ts` reachable                                                                                                           |
+| **F4** | Wire scrap-mech                    | M    | —       | `scrapMech.ts` reachable                                                                                                          |
+| **F5** | Downtime writes                    | L    | F2–F4   | Downtime stops narrating and starts writing, with ADR-007 confirmation on destructive consequences                                |
+| **F6** | `RuleBrief` at enforcement moments | S    | —       | A disabled Push cites the Heat Cap rule rather than greying out silently                                                          |
+
+## Critical path
+
+```
+A1 ──► A3 ──► B1 ──► B2 ──► B3 / B4 / B5 / B6
+  └──► A2 ──► C1 ──► C2 ──► C3 ──► D3
+                      └──► D2 / D4 / C4
+```
+
+`D1`, `E1`, `E2`, `F2`–`F4` and `F6` hang off nothing and can be picked up at any
+time — useful for parallel capacity or a short slot.
+
+**Rough total: ~41 person-days** (S=0.5, M=1.5, L=2.5, XL=4). Phases C and F are
+each about a quarter of the work.
+
+## Definition of done
+
+Parity is reached when:
+
+1. Every record whose text states a mechanical change — cap, trait, damage or
+   range — either encodes it or carries a reasoned exemption, **enforced in CI**.
+2. Any content type that can modify a character can declare it. Abilities are not
+   second-class citizens of the schema.
+3. Every derived value can name its own contributions on **every** surface that
+   shows it — gauges, damage readouts and trait lists alike.
+4. An override is distinguishable from a modifier **in storage**, not by
+   arithmetic, and is shown **on top of** the full derivation rather than in place
+   of it.
+5. Every mutation is logged with a truthful `kind` and `source`.
+6. Every implemented rules module is reachable from the mode ADR-021 assigns it.
+
+## Explicitly out of scope
+
+- **Procedural adjudication** — surfaced, never enforced. Unchanged by design.
+- **Effect-of-an-effect modifiers** (Mender's "+4 SP each time you heal") — modifies
+  another effect's output, not a stat. Exempted by the audit, not modelled.
+- **Net-new homebrew authoring** — a future authoring surface, not a Free-Edit
+  affordance.
+- **Change Log replay / time travel** — the log is shaped for it; the surface stays
+  deferred.
+- **Live Sheet hard blocks** — wanting one is a proposal to amend ADR-021, not a bug.


### PR DESCRIPTION
Records the decisions behind the **Rules Parity & Stat Provenance** goal. Docs only — no code or data changed.

## What's here

- **`ADR-028`** (new, Proposed) — one contribution model for caps *and* traits/damage/range, breakdown-shaped derivations, and provenance as a property of the value rather than of a surface.
- **`ADR-022` amendment** — an override becomes an **absolute pin** instead of a signed delta sharing a field with the rules derivation.
- **`docs/design/rules-parity-plan.md`** — the delivery breakdown: 24 units across 6 phases, with sizes, dependencies, critical path and definition of done.
- **`docs/README.md`** — indexes ADR-028, and adds ADR-027, which had been omitted.

## Why

Surveyed the core book (1.2) + three expansions against the working tree:

| Finding | |
| --- | ---: |
| Records whose text changes a maximum | 23 |
| — encoded | 9 |
| — **stated but never applied** | 5 |
| Records changing a trait / damage / range | ~21 |
| Derivations exposing a breakdown | 1 |
| Change Log entries ever tagged `transaction` | 0 |
| Rules modules implemented, tested, unreachable | 3 |

The root cause is one shared by both gaps: the dataset has **two** modifier engines — `statBonus` (four mech maxima, systems/modules only) and `ChoiceEffectSchema` (traits/damage/range, choice options only) — and **neither is reachable from an ability**. Beefcake, Bionic Arms, Bionic Legs and Modular Face Implant are inert prose, so the numbers on the sheet are wrong for any pilot holding them.

**Composite Armour** is a plain defect rather than a schema gap: its text fits `statBonus.structurePoints` exactly and the field is simply absent.

## The blocker the amendment removes

`max*Modifier` is one field doing two incompatible jobs — the ADR-022 override pin *and* the only channel a rules modifier has — with the derived baseline recovered by subtraction. Any automatic contribution written there would render as a hand override with a revert button. `eldridgeCoast.ts` and `pilotInventory.ts` both admit the conflation in their own header comments.

Migration 8 (`8-crawler-battle-sp-to-derived.ts`) already performed exactly this move for the Battle Crawler's +5 Max SP, so the pin migration is that operation generalized.

## Traps recorded so the backfill doesn't repeat them

- **Chassis-integrated bonuses are already absolute.** "Integrated Cargo Bay: +10, *to 16*" — the Mule's `cargoCapacity` **is** 16 (Gopher 12, Atlas 30). Backfilling double-counts.
- **Not every stated number is a cap modifier.** Mender's "+4 SP each time you heal" modifies another effect's output; Armour Plating states no cap change at all.

## Notes for review

- ADR-028 is **Proposed**, not Accepted — it's the thing to argue with.
- Rebased after #590 landed; partner references updated to the in-place `PartnerCard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MT6q22Y1MtuCYHormXwQ4