### PR TITLE
fix(itun): Change Log truth + Composite Armour's missing +5 Max SP

### DIFF
--- a/apps/itun/src/components/crawler/CrawlerBuilder.tsx
+++ b/apps/itun/src/components/crawler/CrawlerBuilder.tsx
@@ -47,6 +47,7 @@ import { CrawlerReviewStep } from './CrawlerReviewStep'
 import { CrawlerStatsStep } from 'component-lib'
 import { CrawlerTypeSelectStep } from 'component-lib'
 import { SystemsList } from 'component-lib'
+import { WIZARD_TXN } from '../../stores/surfaceProvenance'
 
 /**
  * Book-order steps (Union Crawler pp.212–213 + Review — plan §4.3). Edit mode
@@ -290,7 +291,7 @@ export function CrawlerBuilder({
         const stored = store.get('crawler', crawlerId)
         const oldType = stored?.type ?? null
 
-        await store.update('crawler', crawlerId, crawlerFormToUpdatePatch(form))
+        await store.update('crawler', crawlerId, crawlerFormToUpdatePatch(form), WIZARD_TXN)
 
         // Crew/NPC edits + the type-NPC reset / orphan cleanup route through the
         // shared multi-write helper (also used by the live sheet's inline build

--- a/apps/itun/src/components/dashboard/ActionsDeck.tsx
+++ b/apps/itun/src/components/dashboard/ActionsDeck.tsx
@@ -52,6 +52,7 @@ import {
 } from './dashboardRules'
 import type { MechItemEconomy } from '../sheet/mechItemRules'
 import type { PlayAction, PlayActionCurrency, TimingTab } from './dashboardRules'
+import { DASHBOARD_TXN } from '../../stores/surfaceProvenance'
 
 type ActionsDeckProps = {
   mech: Mech
@@ -136,7 +137,7 @@ export function ActionsDeck({ mech, pilot, mount = 'mech', store }: ActionsDeckP
         apCost: economy.epCost,
         currentAP: fresh.currentAP ?? 0,
       })
-      if (Object.keys(patch).length > 0) void s.update('pilot', pilot.id, patch)
+      if (Object.keys(patch).length > 0) void s.update('pilot', pilot.id, patch, DASHBOARD_TXN)
       setActivated(true)
       return
     }
@@ -152,7 +153,7 @@ export function ActionsDeck({ mech, pilot, mount = 'mech', store }: ActionsDeckP
       prevUses: fresh.itemUses,
     })
     if (Object.keys(patch).length > 0) {
-      void s.update('mech', mech.id, patch)
+      void s.update('mech', mech.id, patch, DASHBOARD_TXN)
     }
     setActivated(true)
   }
@@ -188,7 +189,7 @@ export function ActionsDeck({ mech, pilot, mount = 'mech', store }: ActionsDeckP
       currentSP: fresh.currentSP ?? 0,
       roll: defaultRoll,
     })
-    void s.update('mech', mech.id, patch)
+    void s.update('mech', mech.id, patch, DASHBOARD_TXN)
     setRoll(performCoreRoll(defaultRoll))
     setPushLog(describePushOutcome(nextHeat, effect))
     setApplied(false)

--- a/apps/itun/src/components/dashboard/ActiveItemBand.tsx
+++ b/apps/itun/src/components/dashboard/ActiveItemBand.tsx
@@ -36,6 +36,7 @@ import type { EntityState } from '../../stores/entityStore'
 import { usePlayStateStore } from '../../stores/playStateStore'
 import { ActiveItemBand as ActiveItemBandView, CountStepper, StorageBay } from 'component-lib'
 import type { ActiveItemBandView as ActiveItemBandViewModel, BandButton } from 'component-lib'
+import { DASHBOARD_TXN } from '../../stores/surfaceProvenance'
 import {
   VENT_PATCH,
   critDamagePatch,
@@ -180,7 +181,7 @@ function MechBand({
       currentSP: Math.min(m.currentSP ?? spMax, spMax),
       roll: defaultRoll,
     })
-    void store.update('mech', mech.id, patch)
+    void store.update('mech', mech.id, patch, DASHBOARD_TXN)
     setPrompt({ kind: 'reactor', log: describePushOutcome(nextHeat, effect), meltdown })
   }
 
@@ -193,12 +194,12 @@ function MechBand({
       currentSP: Math.min(m.currentSP ?? spMax, spMax),
       roll: defaultRoll,
     })
-    void store.update('mech', mech.id, patch)
+    void store.update('mech', mech.id, patch, DASHBOARD_TXN)
     setPrompt({ kind: 'reactor', log: describeHeatCheck(effect), meltdown })
   }
 
   function doVent() {
-    void store.update('mech', mech.id, VENT_PATCH)
+    void store.update('mech', mech.id, VENT_PATCH, DASHBOARD_TXN)
     setPrompt({
       kind: 'reactor',
       log: 'Vented — Heat 0, Vulnerable. (Shut down separately if needed.)',
@@ -206,7 +207,7 @@ function MechBand({
   }
 
   function doShutdown() {
-    void store.update('mech', mech.id, shutdownTogglePatch(fresh().shutdown))
+    void store.update('mech', mech.id, shutdownTogglePatch(fresh().shutdown), DASHBOARD_TXN)
   }
 
   function applyDamage() {
@@ -218,7 +219,7 @@ function MechBand({
       amount: dmg,
       vulnerable: m.vulnerable ?? false,
     })
-    void store.update('mech', mech.id, patch)
+    void store.update('mech', mech.id, patch, DASHBOARD_TXN)
     if (effect.criticalDue) {
       setPrompt({ kind: 'crit', effect: null, log: `−${effect.effectiveDamage} SP → 0.` })
     } else {
@@ -228,20 +229,23 @@ function MechBand({
 
   function rollCritical() {
     const { patch, effect } = critDamagePatch(defaultRoll)
-    void store.update('mech', mech.id, patch)
+    void store.update('mech', mech.id, patch, DASHBOARD_TXN)
     setPrompt({ kind: 'crit', effect, log: describeCritDamage(effect) })
   }
 
   function confirmDestroyed() {
-    void store.update('mech', mech.id, { destroyed: true })
+    void store.update('mech', mech.id, { destroyed: true }, DASHBOARD_TXN)
     setPrompt(null)
   }
 
   function jettison(lotId: string) {
     const m = fresh()
-    void store.update('mech', mech.id, {
-      cargoLots: m.cargoLots.filter((lot) => lot.id !== lotId),
-    })
+    void store.update(
+      'mech',
+      mech.id,
+      { cargoLots: m.cargoLots.filter((lot) => lot.id !== lotId) },
+      DASHBOARD_TXN
+    )
   }
 
   const overlay = ((): ActiveItemBandViewModel['overlay'] => {
@@ -461,7 +465,7 @@ function PilotBand({
       amount: dmg,
       vulnerable: false,
     })
-    void store.update('pilot', pilot.id, patch)
+    void store.update('pilot', pilot.id, patch, DASHBOARD_TXN)
     if (effect.criticalDue) {
       setPrompt({ kind: 'crit', effect: null, log: `−${effect.effectiveDamage} HP → 0.` })
     } else {
@@ -471,7 +475,7 @@ function PilotBand({
 
   function rollInjury() {
     const { patch, effect } = critInjuryPatch(defaultRoll)
-    void store.update('pilot', pilot.id, patch)
+    void store.update('pilot', pilot.id, patch, DASHBOARD_TXN)
     setPrompt({ kind: 'crit', effect, log: describeCritInjury(effect) })
   }
 

--- a/apps/itun/src/components/mech/MechWizard.tsx
+++ b/apps/itun/src/components/mech/MechWizard.tsx
@@ -41,6 +41,7 @@ import type { ChassisPattern } from './MechChassisStep'
 import { MechFlavorStep } from 'component-lib'
 import { MechReviewStep } from './MechReviewStep'
 import { MechStatsStep } from './MechStatsStep'
+import { WIZARD_TXN } from '../../stores/surfaceProvenance'
 import {
   clearWizardDraft,
   readWizardDraft,
@@ -384,7 +385,7 @@ export function MechWizard({
 
       // Upsert branch: update when editing — NEVER a second create.
       if (mechId) {
-        await store.update('mech', mechId, mechFormToUpdatePatch(form))
+        await store.update('mech', mechId, mechFormToUpdatePatch(form), WIZARD_TXN)
         toast.success(`Saved ${form.name.trim() || 'mech'}.`)
         clearWizardDraft(draftKey)
         onComplete(mechId)

--- a/apps/itun/src/components/pilot/PilotWizard.tsx
+++ b/apps/itun/src/components/pilot/PilotWizard.tsx
@@ -38,6 +38,7 @@ import { FlavorStep } from 'component-lib'
 import { ReviewStep } from './ReviewStep'
 import { StatsStep } from './StatsStep'
 import type { RollTableDeps } from 'component-lib'
+import { WIZARD_TXN } from '../../stores/surfaceProvenance'
 import {
   clearWizardDraft,
   readWizardDraft,
@@ -356,7 +357,7 @@ export function PilotWizard({
 
       // Upsert branch: update when editing — NEVER a second create.
       if (pilotId) {
-        await store.update('pilot', pilotId, pilotFormToUpdatePatch(form))
+        await store.update('pilot', pilotId, pilotFormToUpdatePatch(form), WIZARD_TXN)
         toast.success(`Saved ${form.name.trim() || 'pilot'}.`)
         clearWizardDraft(draftKey)
         onComplete(pilotId)

--- a/apps/itun/src/components/shared/__tests__/useEntityChoices.test.ts
+++ b/apps/itun/src/components/shared/__tests__/useEntityChoices.test.ts
@@ -18,6 +18,7 @@ import { act, renderHook } from '@testing-library/react'
 import { useEntityChoices } from '../useEntityChoices'
 import type { Pilot } from '../../../lib/schemas/pilot'
 import { makeEntityStoreMock } from '../../__tests__/mockEntityStore'
+import { LIVE_SHEET_MANUAL } from '../../../stores/surfaceProvenance'
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -125,11 +126,16 @@ describe('useEntityChoices — setSelections persistence', () => {
     })
 
     expect(updateFn).toHaveBeenCalledTimes(1)
-    expect(updateFn).toHaveBeenCalledWith('pilot', PILOT_ID, {
-      equipmentChoices: {
-        'custom-sniper-rifle': { 'choice-weapon-type': ['Ballistic'] },
+    expect(updateFn).toHaveBeenCalledWith(
+      'pilot',
+      PILOT_ID,
+      {
+        equipmentChoices: {
+          'custom-sniper-rifle': { 'choice-weapon-type': ['Ballistic'] },
+        },
       },
-    })
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('merges into the per-item map without clobbering sibling items', async () => {
@@ -152,12 +158,17 @@ describe('useEntityChoices — setSelections persistence', () => {
       result.current.setSelections({ 'choice-weapon-type': ['Energy'] })
     })
 
-    expect(updateFn).toHaveBeenCalledWith('pilot', PILOT_ID, {
-      equipmentChoices: {
-        'auto-turret': { 'choice-name': ['Sentinel'] },
-        'custom-sniper-rifle': { 'choice-weapon-type': ['Energy'] },
+    expect(updateFn).toHaveBeenCalledWith(
+      'pilot',
+      PILOT_ID,
+      {
+        equipmentChoices: {
+          'auto-turret': { 'choice-name': ['Sentinel'] },
+          'custom-sniper-rifle': { 'choice-weapon-type': ['Energy'] },
+        },
       },
-    })
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('reads the freshest field map from the store (stale-closure guard)', async () => {

--- a/apps/itun/src/components/shared/useEntityChoices.ts
+++ b/apps/itun/src/components/shared/useEntityChoices.ts
@@ -34,6 +34,7 @@ import type { ChoiceSelections } from 'component-lib'
 
 import { useEntityStore } from '../../stores/entityStore'
 import type { EntityType, EntityForType } from '../../stores/types'
+import { LIVE_SHEET_MANUAL } from '../../stores/surfaceProvenance'
 
 /**
  * Stable empty-selections reference. ReferenceEntityCard is wrapped in
@@ -86,7 +87,7 @@ export function useEntityChoices<T extends EntityType>(
       const patch = {
         [field]: { ...prevAll, [itemSlug]: next },
       } as Partial<EntityForType<T>>
-      void storeState.update(entityType, entityId, patch)
+      void storeState.update(entityType, entityId, patch, LIVE_SHEET_MANUAL)
     },
     [storeState, entityType, entityId, itemSlug, field]
   )

--- a/apps/itun/src/components/sheet/CrawlerEconomyControl.tsx
+++ b/apps/itun/src/components/sheet/CrawlerEconomyControl.tsx
@@ -47,6 +47,7 @@ import type { Roll } from '../../lib/rules/heatCheck'
 import type { Crawler } from '../../lib/schemas/crawler'
 import type { useEntityStore } from '../../stores/entityStore'
 import { freshEntity } from './controlPrimitives'
+import { LIVE_SHEET_MANUAL } from '../../stores/surfaceProvenance'
 
 /** Which economy dialog is open (the lozenge that was clicked). */
 export type CrawlerEconomyDialog = 'upkeep' | 'upgrade' | 'trade'
@@ -138,10 +139,15 @@ function UpkeepDialog({ crawler, store, roll, onClose }: DialogProps & { roll: R
       return
     }
     const nextUpgradePool = (fresh.upgradePool ?? 0) + payment.upgradeCredit
-    await storeState.update('crawler', crawler.id, {
-      scrapPool: payment.pool,
-      upgradePool: nextUpgradePool,
-    })
+    await storeState.update(
+      'crawler',
+      crawler.id,
+      {
+        scrapPool: payment.pool,
+        upgradePool: nextUpgradePool,
+      },
+      LIVE_SHEET_MANUAL
+    )
     const drawText = payment.draws.map((d) => `${d.count}× T${d.tl}`).join(' + ')
     setResult(
       `Paid ${UPKEEP_SCRAP} Scrap (${drawText}) — Upgrade Pool now ${nextUpgradePool}${
@@ -164,7 +170,12 @@ function UpkeepDialog({ crawler, store, roll, onClose }: DialogProps & { roll: R
     const effect = performDeterioration({ currentSP, bayCount: bays.length, roll })
 
     if (effect.spLoss > 0) {
-      await storeState.update('crawler', crawler.id, { currentSP: effect.nextSP })
+      await storeState.update(
+        'crawler',
+        crawler.id,
+        { currentSP: effect.nextSP },
+        LIVE_SHEET_MANUAL
+      )
     }
     let bayName: string | null = null
     if (effect.randomBayIndex !== null) {
@@ -174,7 +185,8 @@ function UpkeepDialog({ crawler, store, roll, onClose }: DialogProps & { roll: R
           crawler.id,
           entry.bayRef,
           { condition: 'damaged' },
-          effect.randomBayIndex
+          effect.randomBayIndex,
+          LIVE_SHEET_MANUAL
         )
         bayName = resolveCrawlerBay(entry.bayRef)?.name ?? entry.bayRef
       }
@@ -272,10 +284,15 @@ function UpgradeDialog({ crawler, store, onClose }: DialogProps) {
     const freshTl = parseCrawlerTechLevel(fresh.techLevel) ?? 1
     const result = contributeToUpgradePool(fresh.scrapPool ?? {}, freshTl, contribution)
     if (!result) return
-    await storeState.update('crawler', crawler.id, {
-      scrapPool: result.pool,
-      upgradePool: (fresh.upgradePool ?? 0) + contribution,
-    })
+    await storeState.update(
+      'crawler',
+      crawler.id,
+      {
+        scrapPool: result.pool,
+        upgradePool: (fresh.upgradePool ?? 0) + contribution,
+      },
+      LIVE_SHEET_MANUAL
+    )
   }
 
   /** Consume the pool, bump the Tech Level, repair damaged Bays (p.219). */
@@ -292,7 +309,7 @@ function UpgradeDialog({ crawler, store, onClose }: DialogProps) {
     if (bays.some((bay) => (bay.condition ?? 'intact') === 'damaged')) {
       patch.crawlerBays = bays.map((bay) => ({ ...bay, condition: 'intact' as const }))
     }
-    await storeState.update('crawler', crawler.id, patch)
+    await storeState.update('crawler', crawler.id, patch, LIVE_SHEET_MANUAL)
     onClose()
   }
 
@@ -415,7 +432,7 @@ function TradeDialog({ crawler, store, roll, onClose }: DialogProps & { roll: Ro
       setConvertNote('The pool no longer covers that trade.')
       return
     }
-    await storeState.update('crawler', crawler.id, { scrapPool: result.pool })
+    await storeState.update('crawler', crawler.id, { scrapPool: result.pool }, LIVE_SHEET_MANUAL)
     setConvertNote(`Traded ${count}× T${fromTl} for ${result.toCount}× T${toTl}.`)
   }
 

--- a/apps/itun/src/components/sheet/CrawlerSheet.tsx
+++ b/apps/itun/src/components/sheet/CrawlerSheet.tsx
@@ -85,6 +85,7 @@ import { StorageManifest } from './StorageManifest'
 import { CrawlerBayCard } from './CrawlerSheetItems'
 import type { CrawlerBayEntry } from './CrawlerSheetItems'
 import { BAY_REPAIR_COST, SCRAP_TLS, resolveCrawlerSystem } from './crawlerSheetItemRules'
+import { LIVE_SHEET_MANUAL } from '../../stores/surfaceProvenance'
 
 type CrawlerSheetProps = {
   crawler: Crawler
@@ -151,7 +152,7 @@ export function CrawlerSheet({
     if (readOnly) return
     const fields =
       typeof input === 'function' ? input(storeState.get('crawler', crawler.id) ?? crawler) : input
-    void storeState.update('crawler', crawler.id, fields)
+    void storeState.update('crawler', crawler.id, fields, LIVE_SHEET_MANUAL)
   }
 
   const tl = parseCrawlerTechLevel(crawler.techLevel) ?? 1
@@ -184,8 +185,14 @@ export function CrawlerSheet({
         remaining -= take
       }
     }
-    void storeState.update('crawler', crawler.id, { scrapPool: nextPool })
-    void storeState.updateCrawlerBay(crawler.id, entry.bayRef, { condition: 'intact' }, index)
+    void storeState.update('crawler', crawler.id, { scrapPool: nextPool }, LIVE_SHEET_MANUAL)
+    void storeState.updateCrawlerBay(
+      crawler.id,
+      entry.bayRef,
+      { condition: 'intact' },
+      index,
+      LIVE_SHEET_MANUAL
+    )
   }
 
   /** Remove one mounted weapon (per-card ✕ — archetype B). */
@@ -204,9 +211,14 @@ export function CrawlerSheet({
     const currentPool = fresh.scrapPool ?? {}
     const delta = next - scrapPoolBucket(currentPool, tlBucket)
     if (delta === 0) return
-    void storeState.update('crawler', crawler.id, {
-      scrapPool: addToScrapPool(currentPool, tlBucket, delta),
-    })
+    void storeState.update(
+      'crawler',
+      crawler.id,
+      {
+        scrapPool: addToScrapPool(currentPool, tlBucket, delta),
+      },
+      LIVE_SHEET_MANUAL
+    )
   }
 
   /** The Armament Bay's mounted weapons — rendered INSIDE that bay. */

--- a/apps/itun/src/components/sheet/CrawlerSheetItems.tsx
+++ b/apps/itun/src/components/sheet/CrawlerSheetItems.tsx
@@ -15,6 +15,7 @@ import { useEntityChoices } from '../shared/useEntityChoices'
 import type { ComponentProps, ReactNode } from 'react'
 import { Content, NpcInset } from 'component-lib'
 import { BAY_REPAIR_COST } from './crawlerSheetItemRules'
+import { LIVE_SHEET_MANUAL } from '../../stores/surfaceProvenance'
 
 export type CrawlerBayEntry = NonNullable<Crawler['crawlerBays']>[number]
 
@@ -149,7 +150,7 @@ export function CrawlerBayCard({
     // the freshest persisted record and patches only this entry, so
     // concurrent edits to different bays don't clobber each other. index
     // disambiguates duplicate bayRefs.
-    void storeState.updateCrawlerBay(crawlerId, entry.bayRef, patch, index)
+    void storeState.updateCrawlerBay(crawlerId, entry.bayRef, patch, index, LIVE_SHEET_MANUAL)
   }
 
   /** Bays are Intact/Damaged ONLY — never Destroyed (rules C8). */
@@ -355,9 +356,14 @@ export function CrawlerTypeCard({
 
   function patchNpc(patch: Partial<CrawlerNpcState>) {
     const fresh = storeState.get('crawler', crawlerId)
-    void storeState.update('crawler', crawlerId, {
-      typeNpc: { ...(fresh?.typeNpc ?? {}), ...patch },
-    })
+    void storeState.update(
+      'crawler',
+      crawlerId,
+      {
+        typeNpc: { ...(fresh?.typeNpc ?? {}), ...patch },
+      },
+      LIVE_SHEET_MANUAL
+    )
   }
 
   const keepsakeChoice = findNpcChoiceByName(npc, 'Keepsake')

--- a/apps/itun/src/components/sheet/MechConditionsEditor.tsx
+++ b/apps/itun/src/components/sheet/MechConditionsEditor.tsx
@@ -16,6 +16,7 @@ import { useEntityStore } from '../../stores/entityStore'
 import { ConditionsEditor } from 'component-lib'
 import { mechConditionsPatch } from './mechItemRules'
 import { freshEntity } from './controlPrimitives'
+import { LIVE_SHEET_MANUAL } from '../../stores/surfaceProvenance'
 
 type MechConditionsEditorProps = {
   mech: Mech
@@ -34,7 +35,7 @@ export function MechConditionsEditor({
   async function handleChange(next: string[]) {
     // Freshest record from the store so rapid edits don't stomp each other.
     const fresh = freshEntity(storeState, 'mech', mech)
-    await storeState.update('mech', mech.id, mechConditionsPatch(fresh, next))
+    await storeState.update('mech', mech.id, mechConditionsPatch(fresh, next), LIVE_SHEET_MANUAL)
   }
 
   return (

--- a/apps/itun/src/components/sheet/MechSheet.tsx
+++ b/apps/itun/src/components/sheet/MechSheet.tsx
@@ -80,6 +80,7 @@ import type { ChassisStatItem } from 'component-lib'
 import { StorageManifest } from './StorageManifest'
 import { freshEntity } from './controlPrimitives'
 import type { SheetPatch } from './sheetViewProps'
+import { LIVE_SHEET_MANUAL, LIVE_SHEET_OVERRIDE } from '../../stores/surfaceProvenance'
 
 // Narrow subset of chassis data the stat derivations need
 type ChassisLike = {
@@ -220,7 +221,7 @@ export function MechSheet({
   /** Partial merge on this mech, reading the freshest record when needed. */
   const patchMech: SheetPatch = (input) => {
     const fields = typeof input === 'function' ? input(freshMech()) : input
-    void storeState.update('mech', mech.id, fields)
+    void storeState.update('mech', mech.id, fields, LIVE_SHEET_MANUAL)
   }
 
   // Cap overrides (ADR-022, Free Edit): a derived maximum is pinned by storing
@@ -230,7 +231,7 @@ export function MechSheet({
   const derivedMaxEP = maxEP - (mech.maxEpModifier ?? 0)
   const derivedHeatCap = heatCap - (mech.maxHeatModifier ?? 0)
   const overrideMechMax = (fields: Partial<Mech>) => {
-    void storeState.update('mech', mech.id, fields, { kind: 'override' })
+    void storeState.update('mech', mech.id, fields, LIVE_SHEET_OVERRIDE)
   }
   const modOrUndef = (next: number, derived: number): number | undefined => {
     const mod = next - derived
@@ -253,7 +254,8 @@ export function MechSheet({
       mech.id,
       kind === 'system'
         ? { systems: [...fresh.systems, slug] }
-        : { modules: [...fresh.modules, slug] }
+        : { modules: [...fresh.modules, slug] },
+      LIVE_SHEET_MANUAL
     )
   }
 
@@ -267,9 +269,14 @@ export function MechSheet({
   function removeItem(kind: ItemKind, index: number) {
     const fresh = freshMech()
     if (kind === 'module') {
-      void storeState.update('mech', mech.id, {
-        modules: fresh.modules.filter((_, i) => i !== index),
-      })
+      void storeState.update(
+        'mech',
+        mech.id,
+        {
+          modules: fresh.modules.filter((_, i) => i !== index),
+        },
+        LIVE_SHEET_MANUAL
+      )
       return
     }
     const removed = fresh.systems[index]
@@ -289,7 +296,8 @@ export function MechSheet({
     await storeState.update(
       'mech',
       mech.id,
-      kind === 'system' ? { systemConditions: nextMap } : { moduleConditions: nextMap }
+      kind === 'system' ? { systemConditions: nextMap } : { moduleConditions: nextMap },
+      LIVE_SHEET_MANUAL
     )
   }
 
@@ -311,9 +319,14 @@ export function MechSheet({
   async function setItemUses(slug: string, next: number) {
     const fresh = freshMech()
     const prevUses = fresh.itemUses ?? {}
-    await storeState.update('mech', mech.id, {
-      itemUses: { ...prevUses, [slug]: Math.max(0, next) },
-    })
+    await storeState.update(
+      'mech',
+      mech.id,
+      {
+        itemUses: { ...prevUses, [slug]: Math.max(0, next) },
+      },
+      LIVE_SHEET_MANUAL
+    )
   }
 
   /**
@@ -331,27 +344,38 @@ export function MechSheet({
     await storeState.update(
       'mech',
       mech.id,
-      kind === 'system' ? { systemConditions: nextMap } : { moduleConditions: nextMap }
+      kind === 'system' ? { systemConditions: nextMap } : { moduleConditions: nextMap },
+      LIVE_SHEET_MANUAL
     )
     if (deductTl !== null && crawler) {
       const freshCrawler = freshEntity(storeState, 'crawler', crawler)
-      await storeState.update('crawler', crawler.id, {
-        scrapPool: addToScrapPool(freshCrawler.scrapPool ?? {}, deductTl, -cost),
-      })
+      await storeState.update(
+        'crawler',
+        crawler.id,
+        {
+          scrapPool: addToScrapPool(freshCrawler.scrapPool ?? {}, deductTl, -cost),
+        },
+        LIVE_SHEET_MANUAL
+      )
     }
   }
 
   /** Quirk / Appearance field save — mirrors the old SheetDescription saves. */
   function saveQuirk(next: string) {
-    void storeState.update('mech', mech.id, { quirk: next.trim() || undefined })
+    void storeState.update('mech', mech.id, { quirk: next.trim() || undefined }, LIVE_SHEET_MANUAL)
   }
 
   /** Appearance heals the deprecated `description` field into `appearance`. */
   function saveAppearance(next: string) {
-    void storeState.update('mech', mech.id, {
-      appearance: next.trim() || undefined,
-      description: undefined,
-    })
+    void storeState.update(
+      'mech',
+      mech.id,
+      {
+        appearance: next.trim() || undefined,
+        description: undefined,
+      },
+      LIVE_SHEET_MANUAL
+    )
   }
 
   function renderItems(kind: ItemKind, slugs: string[]) {
@@ -659,9 +683,14 @@ export function MechSheet({
                   readOnly
                     ? undefined
                     : () => {
-                        void store.getState().update('mech', mech.id, {
-                          partners: (mech.partners ?? []).filter((p) => p.id !== partner.id),
-                        })
+                        void store.getState().update(
+                          'mech',
+                          mech.id,
+                          {
+                            partners: (mech.partners ?? []).filter((p) => p.id !== partner.id),
+                          },
+                          LIVE_SHEET_MANUAL
+                        )
                       }
                 }
               />

--- a/apps/itun/src/components/sheet/PartnerCard.tsx
+++ b/apps/itun/src/components/sheet/PartnerCard.tsx
@@ -53,6 +53,7 @@ import { MechItemCard } from './MechItemCard'
 import { PartnerHold } from './PartnerHold'
 import { partnerDisplayName } from './partnerDisplay'
 import { resolveModule, resolveSystem } from './mechItemRules'
+import { LIVE_SHEET_MANUAL } from '../../stores/surfaceProvenance'
 
 type PartnerCardProps = {
   /**
@@ -116,9 +117,14 @@ export function PartnerCard({
   /** Write through the HOST — a partner has no store row of its own. */
   const patch = (fields: Partial<PartnerInstance>): void => {
     if (readOnly) return
-    void storeState.update(hostKind, host.id, {
-      partners: replacePartner(host.partners, partner.id, fields),
-    })
+    void storeState.update(
+      hostKind,
+      host.id,
+      {
+        partners: replacePartner(host.partners, partner.id, fields),
+      },
+      LIVE_SHEET_MANUAL
+    )
   }
 
   const clamp = (next: number, ceiling: number) => Math.max(0, Math.min(next, ceiling))

--- a/apps/itun/src/components/sheet/PilotSheet.tsx
+++ b/apps/itun/src/components/sheet/PilotSheet.tsx
@@ -71,6 +71,7 @@ import {
 } from './PilotSheetItems'
 import { PartnerCard } from './PartnerCard'
 import { resolveAbility } from './pilotAbilities'
+import { LIVE_SHEET_MANUAL, LIVE_SHEET_OVERRIDE } from '../../stores/surfaceProvenance'
 
 /**
  * The tree every pilot has regardless of class (Repair, Scrap, Mount, …).
@@ -324,7 +325,7 @@ export function PilotSheet({
       saveBuildEdit(fields, 'Change class')
       return
     }
-    void storeState.update('pilot', pilot.id, fields)
+    void storeState.update('pilot', pilot.id, fields, LIVE_SHEET_MANUAL)
   }
 
   // Cap overrides (ADR-022, Free Edit): pin HP/AP maxima via a signed
@@ -333,7 +334,7 @@ export function PilotSheet({
   const derivedMaxHP = maxHP - (pilot.maxHpModifier ?? 0)
   const derivedMaxAP = maxAP - (pilot.maxApModifier ?? 0)
   const overridePilotMax = (fields: Partial<Pilot>) => {
-    void storeState.update('pilot', pilot.id, fields, { kind: 'override' })
+    void storeState.update('pilot', pilot.id, fields, LIVE_SHEET_OVERRIDE)
   }
   const modOrUndef = (next: number, derived: number): number | undefined => {
     const mod = next - derived
@@ -344,14 +345,19 @@ export function PilotSheet({
   function toggleUsed(key: UsedToggleKey, next: boolean) {
     const fresh = freshPilot()
     const prev = fresh.usedToggles ?? {}
-    void storeState.update('pilot', pilot.id, {
-      usedToggles: { ...prev, [key]: next },
-    })
+    void storeState.update(
+      'pilot',
+      pilot.id,
+      {
+        usedToggles: { ...prev, [key]: next },
+      },
+      LIVE_SHEET_MANUAL
+    )
   }
 
   /** Persist the full conditions list (flat string set, no partial merge). */
   function handleConditionsChange(next: string[]) {
-    void storeState.update('pilot', pilot.id, { conditions: next })
+    void storeState.update('pilot', pilot.id, { conditions: next }, LIVE_SHEET_MANUAL)
   }
 
   // Collection add/remove (unified edit language archetype B) — always
@@ -376,19 +382,29 @@ export function PilotSheet({
 
   function toggleEquipment(equipmentId: string) {
     const equipment = freshPilot().equipment
-    void storeState.update('pilot', pilot.id, {
-      equipment: equipment.includes(equipmentId)
-        ? equipment.filter((e) => e !== equipmentId)
-        : [...equipment, equipmentId],
-    })
+    void storeState.update(
+      'pilot',
+      pilot.id,
+      {
+        equipment: equipment.includes(equipmentId)
+          ? equipment.filter((e) => e !== equipmentId)
+          : [...equipment, equipmentId],
+      },
+      LIVE_SHEET_MANUAL
+    )
   }
 
   async function handleEquipmentConditionChange(slug: string, next: ItemCondition) {
     const prev = freshPilot().equipmentConditions ?? {}
     const prevCondition = prev[slug] ?? 'intact'
-    await storeState.update('pilot', pilot.id, {
-      equipmentConditions: { ...prev, [slug]: next },
-    })
+    await storeState.update(
+      'pilot',
+      pilot.id,
+      {
+        equipmentConditions: { ...prev, [slug]: next },
+      },
+      LIVE_SHEET_MANUAL
+    )
     // U-6: landing on 'destroyed' offers a one-tap Undo (mis-tap mid-combat).
     if (next === 'destroyed' && prevCondition !== 'destroyed') {
       const name = resolveEquipment(slug)?.name ?? slug
@@ -400,9 +416,14 @@ export function PilotSheet({
 
   async function handleUsesChange(slug: string, next: number) {
     const prev = freshPilot().equipmentUses ?? {}
-    await storeState.update('pilot', pilot.id, {
-      equipmentUses: { ...prev, [slug]: next },
-    })
+    await storeState.update(
+      'pilot',
+      pilot.id,
+      {
+        equipmentUses: { ...prev, [slug]: next },
+      },
+      LIVE_SHEET_MANUAL
+    )
   }
 
   async function handleSpendAP(cost: number) {
@@ -410,7 +431,7 @@ export function PilotSheet({
     const current = p.currentAP ?? pilotMaxAP(p)
     const next = Math.max(0, current - cost)
     if (next === current) return
-    await storeState.update('pilot', pilot.id, { currentAP: next })
+    await storeState.update('pilot', pilot.id, { currentAP: next }, LIVE_SHEET_MANUAL)
   }
 
   async function handleAbilityUsedChange(slug: string, next: boolean) {
@@ -420,13 +441,18 @@ export function PilotSheet({
     } else {
       prev.delete(slug)
     }
-    await storeState.update('pilot', pilot.id, {
-      usedAbilities: Array.from(prev),
-    })
+    await storeState.update(
+      'pilot',
+      pilot.id,
+      {
+        usedAbilities: Array.from(prev),
+      },
+      LIVE_SHEET_MANUAL
+    )
   }
 
   async function handleGenericInventoryChange(next: GenericInventoryEntry[]) {
-    await storeState.update('pilot', pilot.id, { genericInventory: next })
+    await storeState.update('pilot', pilot.id, { genericInventory: next }, LIVE_SHEET_MANUAL)
   }
 
   /** One learned ability card — identical wherever its tree puts it. */
@@ -707,9 +733,14 @@ export function PilotSheet({
                   readOnly
                     ? undefined
                     : () => {
-                        void storeState.update('pilot', pilot.id, {
-                          partners: partners.filter((p) => p.id !== partner.id),
-                        })
+                        void storeState.update(
+                          'pilot',
+                          pilot.id,
+                          {
+                            partners: partners.filter((p) => p.id !== partner.id),
+                          },
+                          LIVE_SHEET_MANUAL
+                        )
                       }
                 }
               />

--- a/apps/itun/src/components/sheet/Sheet.tsx
+++ b/apps/itun/src/components/sheet/Sheet.tsx
@@ -40,6 +40,7 @@ import { SheetCrawler } from './SheetCrawler'
 import { SheetMech } from './SheetMech'
 import { SheetPilot } from './SheetPilot'
 import type { SheetPatch } from './sheetViewProps'
+import { LIVE_SHEET_MANUAL } from '../../stores/surfaceProvenance'
 
 // Re-exported so existing consumers (PublishButton, tests) keep their import.
 export type { EntityLookup } from './composition'
@@ -237,7 +238,7 @@ export function Sheet({
    */
   const patch: SheetPatch = (input) => {
     const fields = typeof input === 'function' ? input(storeState.get(kind, id) ?? entity) : input
-    void storeState.update(kind, id, fields)
+    void storeState.update(kind, id, fields, LIVE_SHEET_MANUAL)
   }
 
   const common = {

--- a/apps/itun/src/components/sheet/SheetCrawler.tsx
+++ b/apps/itun/src/components/sheet/SheetCrawler.tsx
@@ -32,6 +32,7 @@ import { RailCta } from './SheetRailParts'
 import { AppLink } from '../shared/AppLink'
 import { bayStates, mechRailItems, mechStatusPill, pilotRailItems, rowStats } from './railStats'
 import type { SheetViewCommonProps } from './sheetViewProps'
+import { LIVE_SHEET_OVERRIDE } from '../../stores/surfaceProvenance'
 
 type SheetCrawlerProps = SheetViewCommonProps & { crawler: Crawler }
 
@@ -59,7 +60,7 @@ export function SheetCrawler({
   // delta; the gauge shows "overridden from N" + a revert. Tagged `override`.
   const derivedMaxSP = maxSP - (crawler.maxSpModifier ?? 0)
   const overrideCrawlerMax = (fields: Partial<Crawler>) => {
-    void storeState.update('crawler', crawler.id, fields, { kind: 'override' })
+    void storeState.update('crawler', crawler.id, fields, LIVE_SHEET_OVERRIDE)
   }
   const modOrUndef = (next: number, derived: number): number | undefined => {
     const mod = next - derived

--- a/apps/itun/src/components/sheet/__tests__/CrawlerEconomyControl.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/CrawlerEconomyControl.test.tsx
@@ -25,6 +25,8 @@ import { CrawlerEconomyControl } from '../CrawlerEconomyControl'
 import type { Roll } from '../../../lib/rules/heatCheck'
 import type { Crawler } from '../../../lib/schemas/crawler'
 import { makeEntityStoreMock } from '../../__tests__/mockEntityStore'
+import { LIVE_SHEET_MANUAL } from '../../../stores/surfaceProvenance'
+import type { ChangeMeta } from '../../../stores/entityStore'
 
 beforeAll(async () => {
   await SalvageUnionReference.preload(['crawler-bays', 'crawler-tech-levels'])
@@ -57,11 +59,17 @@ function makeCrawler(overrides: Partial<Crawler> = {}): Crawler {
 type BayPatch = Partial<NonNullable<Crawler['crawlerBays']>[number]>
 
 function makeStubStore(crawler: Crawler) {
-  const update = mock<(type: string, id: string, patch: Partial<Crawler>) => Promise<Crawler>>(
-    async () => crawler
-  )
+  const update = mock<
+    (type: string, id: string, patch: Partial<Crawler>, meta?: ChangeMeta) => Promise<Crawler>
+  >(async () => crawler)
   const updateCrawlerBay = mock<
-    (id: string, bayRef: string, patch: BayPatch, index?: number) => Promise<Crawler>
+    (
+      id: string,
+      bayRef: string,
+      patch: BayPatch,
+      index?: number,
+      meta?: ChangeMeta
+    ) => Promise<Crawler>
   >(async () => crawler)
   const store = makeEntityStoreMock({
     crawlers: [crawler],
@@ -117,6 +125,7 @@ describe('CrawlerEconomyControl — Pay Upkeep', () => {
       'crawler',
       crawler.id,
       { scrapPool: { tl2: 1 }, upgradePool: 15 },
+      LIVE_SHEET_MANUAL,
     ])
     expect(screen.getByRole('status').textContent).toContain('Upgrade Pool now 15 of 30')
   })
@@ -148,6 +157,7 @@ describe('CrawlerEconomyControl — Pay Upkeep', () => {
       'Med Bay',
       { condition: 'damaged' },
       1,
+      LIVE_SHEET_MANUAL,
     ])
     expect(screen.getByRole('status').textContent).toContain('Med Bay is Damaged')
   })
@@ -168,7 +178,12 @@ describe('CrawlerEconomyControl — Pay Upkeep', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Roll Deterioration (d20)' }))
     await screen.findByRole('status')
 
-    expect(update.mock.calls[0]).toEqual(['crawler', crawler.id, { currentSP: 5 }])
+    expect(update.mock.calls[0]).toEqual([
+      'crawler',
+      crawler.id,
+      { currentSP: 5 },
+      LIVE_SHEET_MANUAL,
+    ])
     expect(updateCrawlerBay).not.toHaveBeenCalled()
   })
 
@@ -224,6 +239,7 @@ describe('CrawlerEconomyControl — Upgrade Crawler', () => {
           { bayRef: 'Med Bay', condition: 'intact' },
         ],
       },
+      LIVE_SHEET_MANUAL,
     ])
     expect(onClose).toHaveBeenCalled()
   })
@@ -254,6 +270,7 @@ describe('CrawlerEconomyControl — Upgrade Crawler', () => {
       'crawler',
       crawler.id,
       { scrapPool: { tl2: 5 }, upgradePool: 11 },
+      LIVE_SHEET_MANUAL,
     ])
   })
 })
@@ -276,7 +293,12 @@ describe('CrawlerEconomyControl — Trading Bay', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Trade' }))
     await screen.findByRole('status')
 
-    expect(update.mock.calls[0]).toEqual(['crawler', crawler.id, { scrapPool: { tl1: 1, tl4: 1 } }])
+    expect(update.mock.calls[0]).toEqual([
+      'crawler',
+      crawler.id,
+      { scrapPool: { tl1: 1, tl4: 1 } },
+      LIVE_SHEET_MANUAL,
+    ])
   })
 
   test('the availability roll reports the band and the TL+1 source', async () => {

--- a/apps/itun/src/components/sheet/__tests__/CrawlerSheet-bay-choices.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/CrawlerSheet-bay-choices.test.tsx
@@ -31,6 +31,7 @@ import { CrawlerSheet } from '../CrawlerSheet'
 import type { Crawler } from '../../../lib/schemas/crawler'
 import { makeEntityStoreMock } from '../../__tests__/mockEntityStore'
 import { expandCards } from '../../__tests__/expandCards'
+import { LIVE_SHEET_MANUAL } from '../../../stores/surfaceProvenance'
 
 afterEach(() => {
   cleanup()
@@ -176,11 +177,16 @@ describe('CrawlerSheet — bay choice cards (Slice B)', () => {
       fireEvent.click(autocannon)
     })
 
-    expect(updateMock).toHaveBeenCalledWith('crawler', crawler.id, {
-      bayChoices: {
-        [BAY_REF]: { [CHOICE_ID]: ['Autocannon'] },
+    expect(updateMock).toHaveBeenCalledWith(
+      'crawler',
+      crawler.id,
+      {
+        bayChoices: {
+          [BAY_REF]: { [CHOICE_ID]: ['Autocannon'] },
+        },
       },
-    })
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('toggling does not clobber a sibling bay choice', async () => {
@@ -199,12 +205,17 @@ describe('CrawlerSheet — bay choice cards (Slice B)', () => {
       fireEvent.click(autocannon)
     })
 
-    expect(updateMock).toHaveBeenCalledWith('crawler', crawler.id, {
-      bayChoices: {
-        'other-bay': { 'other-choice': ['Preserved'] },
-        [BAY_REF]: { [CHOICE_ID]: ['Autocannon'] },
+    expect(updateMock).toHaveBeenCalledWith(
+      'crawler',
+      crawler.id,
+      {
+        bayChoices: {
+          'other-bay': { 'other-choice': ['Preserved'] },
+          [BAY_REF]: { [CHOICE_ID]: ['Autocannon'] },
+        },
       },
-    })
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('persisted selection renders as chosen (aria-pressed)', async () => {

--- a/apps/itun/src/components/sheet/__tests__/CrawlerSheet-bay-npc.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/CrawlerSheet-bay-npc.test.tsx
@@ -27,6 +27,7 @@ import type { Crawler } from '../../../lib/schemas/crawler'
 import type { useEntityStore } from '../../../stores/entityStore'
 import { makeEntityStoreMock } from '../../__tests__/mockEntityStore'
 import { expandCards } from '../../__tests__/expandCards'
+import { LIVE_SHEET_MANUAL } from '../../../stores/surfaceProvenance'
 
 afterEach(() => {
   cleanup()
@@ -171,7 +172,8 @@ describe('CrawlerSheet — crew lead identity (NpcInset)', () => {
       baseCrawler.id,
       'command-bay',
       { npcName: 'Mara Vex' },
-      0
+      0,
+      LIVE_SHEET_MANUAL
     )
   })
 
@@ -202,7 +204,8 @@ describe('CrawlerSheet — crew lead identity (NpcInset)', () => {
       baseCrawler.id,
       'command-bay',
       { npcDescription: 'A grizzled commander.' },
-      0
+      0,
+      LIVE_SHEET_MANUAL
     )
   })
 })
@@ -240,7 +243,8 @@ describe('CrawlerSheet — crew HP editing (NpcInset)', () => {
       baseCrawler.id,
       'command-bay',
       { npcCurrentHP: 3 },
-      0
+      0,
+      LIVE_SHEET_MANUAL
     )
   })
 
@@ -295,9 +299,14 @@ describe('CrawlerSheet — crew keepsake via bayChoices', () => {
       fireEvent.blur(input)
     })
 
-    expect(update).toHaveBeenCalledWith('crawler', baseCrawler.id, {
-      bayChoices: { 'command-bay': { [KEEPSAKE_CHOICE_ID]: ['A bent cog'] } },
-    })
+    expect(update).toHaveBeenCalledWith(
+      'crawler',
+      baseCrawler.id,
+      {
+        bayChoices: { 'command-bay': { [KEEPSAKE_CHOICE_ID]: ['A bent cog'] } },
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('a bay whose NPC has no Keepsake choice renders a read-only dash', async () => {
@@ -347,9 +356,14 @@ describe('CrawlerSheet — crew motto via bayChoices', () => {
       fireEvent.blur(input)
     })
 
-    expect(update).toHaveBeenCalledWith('crawler', baseCrawler.id, {
-      bayChoices: { 'command-bay': { [MOTTO_CHOICE_ID]: ['No retreat'] } },
-    })
+    expect(update).toHaveBeenCalledWith(
+      'crawler',
+      baseCrawler.id,
+      {
+        bayChoices: { 'command-bay': { [MOTTO_CHOICE_ID]: ['No retreat'] } },
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('a bay whose NPC has no Motto choice renders a read-only dash', async () => {
@@ -396,7 +410,8 @@ describe('CrawlerSheet — crew facts (NpcInset)', () => {
       baseCrawler.id,
       'command-bay',
       { npcFacts: ['Hates synths', 'Owes a debt'] },
-      0
+      0,
+      LIVE_SHEET_MANUAL
     )
   })
 
@@ -420,7 +435,8 @@ describe('CrawlerSheet — crew facts (NpcInset)', () => {
       baseCrawler.id,
       'command-bay',
       { npcFacts: [] },
-      0
+      0,
+      LIVE_SHEET_MANUAL
     )
   })
 })

--- a/apps/itun/src/components/sheet/__tests__/CrawlerSheet-editable.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/CrawlerSheet-editable.test.tsx
@@ -24,6 +24,7 @@ import type { Crawler } from '../../../lib/schemas/crawler'
 import type { useEntityStore } from '../../../stores/entityStore'
 import { makeEntityStoreMock } from '../../__tests__/mockEntityStore'
 import { must } from '../../__tests__/must'
+import { LIVE_SHEET_MANUAL } from '../../../stores/surfaceProvenance'
 
 afterEach(() => {
   cleanup()
@@ -161,14 +162,20 @@ describe('CrawlerSheet — bay function/Repair actions (design §4.4, S12)', () 
     })
 
     // tech-2 crawler: 3 from tl2, then 2 from tl3 (TL+ scrap allowed).
-    expect(update).toHaveBeenCalledWith('crawler', fakeCrawler.id, {
-      scrapPool: { tl2: 0, tl3: 2 },
-    })
+    expect(update).toHaveBeenCalledWith(
+      'crawler',
+      fakeCrawler.id,
+      {
+        scrapPool: { tl2: 0, tl3: 2 },
+      },
+      LIVE_SHEET_MANUAL
+    )
     expect(updateCrawlerBay).toHaveBeenCalledWith(
       fakeCrawler.id,
       'command-bay',
       { condition: 'intact' },
-      0
+      0,
+      LIVE_SHEET_MANUAL
     )
   })
 
@@ -189,14 +196,20 @@ describe('CrawlerSheet — bay function/Repair actions (design §4.4, S12)', () 
       fireEvent.click(must(repair))
     })
 
-    expect(update).toHaveBeenCalledWith('crawler', broke.id, {
-      scrapPool: { tl2: 0 },
-    })
+    expect(update).toHaveBeenCalledWith(
+      'crawler',
+      broke.id,
+      {
+        scrapPool: { tl2: 0 },
+      },
+      LIVE_SHEET_MANUAL
+    )
     expect(updateCrawlerBay).toHaveBeenCalledWith(
       broke.id,
       'command-bay',
       { condition: 'intact' },
-      0
+      0,
+      LIVE_SHEET_MANUAL
     )
   })
 
@@ -221,7 +234,8 @@ describe('CrawlerSheet — bay function/Repair actions (design §4.4, S12)', () 
       fakeCrawler.id,
       'mech-bay',
       { condition: 'damaged' },
-      1
+      1,
+      LIVE_SHEET_MANUAL
     )
 
     // Command Bay (damaged, index 0) → back to Intact, not Destroyed.
@@ -235,7 +249,8 @@ describe('CrawlerSheet — bay function/Repair actions (design §4.4, S12)', () 
       fakeCrawler.id,
       'command-bay',
       { condition: 'intact' },
-      0
+      0,
+      LIVE_SHEET_MANUAL
     )
   })
 })

--- a/apps/itun/src/components/sheet/__tests__/CrawlerSheet-type.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/CrawlerSheet-type.test.tsx
@@ -23,6 +23,7 @@ import { CrawlerIdentityPanel } from '../CrawlerIdentity'
 import type { Crawler } from '../../../lib/schemas/crawler'
 import type { useEntityStore } from '../../../stores/entityStore'
 import { makeEntityStoreMock } from '../../__tests__/mockEntityStore'
+import { LIVE_SHEET_MANUAL } from '../../../stores/surfaceProvenance'
 
 afterEach(() => {
   cleanup()
@@ -190,9 +191,14 @@ describe('CrawlerIdentityPanel — type + ability cards', () => {
       fireEvent.blur(input)
     })
 
-    expect(update).toHaveBeenCalledWith('crawler', crawler.id, {
-      bayChoices: { [BATTLE_REF]: { [BATTLE_MOTTO_ID]: ['No retreat'] } },
-    })
+    expect(update).toHaveBeenCalledWith(
+      'crawler',
+      crawler.id,
+      {
+        bayChoices: { [BATTLE_REF]: { [BATTLE_MOTTO_ID]: ['No retreat'] } },
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('Augmented edge: hitPoints:0 NPC renders no HP block', async () => {

--- a/apps/itun/src/components/sheet/__tests__/MechSheet-system-cards.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/MechSheet-system-cards.test.tsx
@@ -24,6 +24,7 @@ import type { Mech } from '../../../lib/schemas/mech'
 import type { useEntityStore } from '../../../stores/entityStore'
 import { makeEntityStoreMock } from '../../__tests__/mockEntityStore'
 import { expandCards } from '../../__tests__/expandCards'
+import { LIVE_SHEET_MANUAL } from '../../../stores/surfaceProvenance'
 
 // MechSheet resolves system/module slugs against the reference data at render.
 beforeAll(async () => {
@@ -109,9 +110,14 @@ describe('MechSheet — system/module entity cards (plan 4.5)', () => {
       fireEvent.click(badge)
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('mech', mech.id, {
-      systemConditions: { [REAL_SYSTEM]: 'damaged' },
-    })
+    expect(updateSpy).toHaveBeenCalledWith(
+      'mech',
+      mech.id,
+      {
+        systemConditions: { [REAL_SYSTEM]: 'damaged' },
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('an unresolvable module slug falls back to plain text and still cycles', async () => {
@@ -127,9 +133,14 @@ describe('MechSheet — system/module entity cards (plan 4.5)', () => {
       fireEvent.click(badge)
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('mech', mech.id, {
-      moduleConditions: { 'totally-not-a-real-module': 'damaged' },
-    })
+    expect(updateSpy).toHaveBeenCalledWith(
+      'mech',
+      mech.id,
+      {
+        moduleConditions: { 'totally-not-a-real-module': 'damaged' },
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('a damaged status badge cycles on to destroyed', async () => {
@@ -145,8 +156,13 @@ describe('MechSheet — system/module entity cards (plan 4.5)', () => {
       fireEvent.click(badge)
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('mech', mech.id, {
-      systemConditions: { [REAL_SYSTEM]: 'destroyed' },
-    })
+    expect(updateSpy).toHaveBeenCalledWith(
+      'mech',
+      mech.id,
+      {
+        systemConditions: { [REAL_SYSTEM]: 'destroyed' },
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 })

--- a/apps/itun/src/components/sheet/__tests__/PilotSheet-abilities.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/PilotSheet-abilities.test.tsx
@@ -21,6 +21,7 @@ import type { Pilot } from '../../../lib/schemas/pilot'
 import type { useEntityStore } from '../../../stores/entityStore'
 import { makeEntityStoreMock } from '../../__tests__/mockEntityStore'
 import { expandCards } from '../../__tests__/expandCards'
+import { LIVE_SHEET_MANUAL } from '../../../stores/surfaceProvenance'
 
 beforeAll(async () => {
   // PilotSheet resolves abilities + their action AP costs from reference data,
@@ -97,7 +98,7 @@ describe('PilotSheet — spend AP (Slice D)', () => {
     })
 
     // 5 - 3 = 2
-    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, { currentAP: 2 })
+    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, { currentAP: 2 }, LIVE_SHEET_MANUAL)
   })
 
   test('spend clamps currentAP at 0 (never negative)', async () => {
@@ -111,7 +112,7 @@ describe('PilotSheet — spend AP (Slice D)', () => {
       fireEvent.click(screen.getByRole('button', { name: /spend 3 ap for talk shop/i }))
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, { currentAP: 0 })
+    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, { currentAP: 0 }, LIVE_SHEET_MANUAL)
   })
 
   test('spend button is disabled when AP is insufficient', async () => {
@@ -143,9 +144,14 @@ describe('PilotSheet — used/recharge toggle (Slice D)', () => {
       fireEvent.click(screen.getByRole('button', { name: /mark talk shop used/i }))
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, {
-      usedAbilities: [ABILITY_TALK_SHOP],
-    })
+    expect(updateSpy).toHaveBeenCalledWith(
+      'pilot',
+      pilot.id,
+      {
+        usedAbilities: [ABILITY_TALK_SHOP],
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('recharging removes the slug from usedAbilities', async () => {
@@ -159,9 +165,14 @@ describe('PilotSheet — used/recharge toggle (Slice D)', () => {
       fireEvent.click(screen.getByRole('button', { name: /recharge talk shop/i }))
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, {
-      usedAbilities: [],
-    })
+    expect(updateSpy).toHaveBeenCalledWith(
+      'pilot',
+      pilot.id,
+      {
+        usedAbilities: [],
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 })
 

--- a/apps/itun/src/components/sheet/__tests__/PilotSheet-conditions.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/PilotSheet-conditions.test.tsx
@@ -22,6 +22,7 @@ import type { EntityLookup } from '../Sheet'
 import type { SoftLinkStore } from '../../wiring/useSoftLinks'
 import type { Pilot } from '../../../lib/schemas/pilot'
 import type { useEntityStore } from '../../../stores/entityStore'
+import { LIVE_SHEET_MANUAL } from '../../../stores/surfaceProvenance'
 import {
   makeEntityStoreMock,
   makeEntityLookupMock,
@@ -127,9 +128,14 @@ describe('Pilot sheet — adding conditions (#254)', () => {
       fireEvent.keyDown(input, { key: 'Enter' })
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('pilot', basePilot.id, {
-      conditions: ['Exposed'],
-    })
+    expect(updateSpy).toHaveBeenCalledWith(
+      'pilot',
+      basePilot.id,
+      {
+        conditions: ['Exposed'],
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('appends to existing conditions rather than replacing', async () => {
@@ -148,9 +154,14 @@ describe('Pilot sheet — adding conditions (#254)', () => {
       fireEvent.keyDown(input, { key: 'Enter' })
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, {
-      conditions: ['Impaired', 'Exposed'],
-    })
+    expect(updateSpy).toHaveBeenCalledWith(
+      'pilot',
+      pilot.id,
+      {
+        conditions: ['Impaired', 'Exposed'],
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('does not add a blank condition', async () => {
@@ -204,9 +215,14 @@ describe('Pilot sheet — removing conditions (#254)', () => {
       fireEvent.click(removeButton)
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, {
-      conditions: ['Impaired'],
-    })
+    expect(updateSpy).toHaveBeenCalledWith(
+      'pilot',
+      pilot.id,
+      {
+        conditions: ['Impaired'],
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 })
 

--- a/apps/itun/src/components/sheet/__tests__/PilotSheet-equipment-choices.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/PilotSheet-equipment-choices.test.tsx
@@ -21,6 +21,7 @@ import { PilotSheet } from '../PilotSheet'
 import type { Pilot } from '../../../lib/schemas/pilot'
 import { makeEntityStoreMock } from '../../__tests__/mockEntityStore'
 import { expandCards } from '../../__tests__/expandCards'
+import { LIVE_SHEET_MANUAL } from '../../../stores/surfaceProvenance'
 
 // PilotSheet resolves equipment slugs via salvageunion-reference at render, and
 // the choice cards deep-link trait/keyword entities — preload 'all' so those
@@ -150,11 +151,16 @@ describe('PilotSheet — equipment choice cards', () => {
     })
 
     expect(updateMock).toHaveBeenCalledTimes(1)
-    expect(updateMock).toHaveBeenCalledWith('pilot', pilot.id, {
-      equipmentChoices: {
-        [SNIPER_ID]: { [WEAPON_TYPE_CHOICE_ID]: ['Ballistic'] },
+    expect(updateMock).toHaveBeenCalledWith(
+      'pilot',
+      pilot.id,
+      {
+        equipmentChoices: {
+          [SNIPER_ID]: { [WEAPON_TYPE_CHOICE_ID]: ['Ballistic'] },
+        },
       },
-    })
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('persisted selection renders as chosen (aria-pressed)', () => {

--- a/apps/itun/src/components/sheet/__tests__/PilotSheet-inventory.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/PilotSheet-inventory.test.tsx
@@ -19,6 +19,7 @@ import type { GenericInventoryEntry, Pilot } from '../../../lib/schemas/pilot'
 import type { useEntityStore } from '../../../stores/entityStore'
 import { makeEntityStoreMock } from '../../__tests__/mockEntityStore'
 import { expandCards } from '../../__tests__/expandCards'
+import { LIVE_SHEET_MANUAL } from '../../../stores/surfaceProvenance'
 
 beforeAll(async () => {
   await SalvageUnionReference.preload('all')
@@ -140,9 +141,14 @@ describe('PilotSheet — per-item uses counters (rules A14)', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Use First Aid Kit' }))
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, {
-      equipmentUses: { 'First Aid Kit': 1 },
-    })
+    expect(updateSpy).toHaveBeenCalledWith(
+      'pilot',
+      pilot.id,
+      {
+        equipmentUses: { 'First Aid Kit': 1 },
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('Use is disabled at 0; Restock refills to max', async () => {
@@ -163,9 +169,14 @@ describe('PilotSheet — per-item uses counters (rules A14)', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Restock First Aid Kit' }))
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, {
-      equipmentUses: { 'First Aid Kit': 3 },
-    })
+    expect(updateSpy).toHaveBeenCalledWith(
+      'pilot',
+      pilot.id,
+      {
+        equipmentUses: { 'First Aid Kit': 3 },
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('no uses affordance on items without a uses trait', () => {
@@ -191,9 +202,14 @@ describe('PilotSheet — generic inventory entries (plan S7)', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Add Scrap (3 slots)' }))
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, {
-      genericInventory: [expect.objectContaining({ name: 'Scrap', slotCost: 3 })],
-    })
+    expect(updateSpy).toHaveBeenCalledWith(
+      'pilot',
+      pilot.id,
+      {
+        genericInventory: [expect.objectContaining({ name: 'Scrap', slotCost: 3 })],
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('free-form add persists name, slot cost and qty', async () => {
@@ -217,15 +233,20 @@ describe('PilotSheet — generic inventory entries (plan S7)', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Add inventory item' }))
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, {
-      genericInventory: [
-        expect.objectContaining({
-          name: 'Salvaged Servo',
-          slotCost: 2,
-          qty: 2,
-        }),
-      ],
-    })
+    expect(updateSpy).toHaveBeenCalledWith(
+      'pilot',
+      pilot.id,
+      {
+        genericInventory: [
+          expect.objectContaining({
+            name: 'Salvaged Servo',
+            slotCost: 2,
+            qty: 2,
+          }),
+        ],
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('removing a generic entry filters it out', async () => {
@@ -238,9 +259,14 @@ describe('PilotSheet — generic inventory entries (plan S7)', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Remove Scrap' }))
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, {
-      genericInventory: [],
-    })
+    expect(updateSpy).toHaveBeenCalledWith(
+      'pilot',
+      pilot.id,
+      {
+        genericInventory: [],
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 })
 

--- a/apps/itun/src/components/sheet/__tests__/Sheet-pilot-hero.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/Sheet-pilot-hero.test.tsx
@@ -23,6 +23,7 @@ import type { EntityLookup } from '../Sheet'
 import type { SoftLinkStore } from '../../wiring/useSoftLinks'
 import type { Pilot } from '../../../lib/schemas/pilot'
 import type { useEntityStore } from '../../../stores/entityStore'
+import { LIVE_SHEET_MANUAL } from '../../../stores/surfaceProvenance'
 import {
   makeEntityStoreMock,
   makeEntityLookupMock,
@@ -119,7 +120,7 @@ describe('Pilot hero — HP/AP trackers', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Set HP to 7' }))
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, { currentHP: 6 })
+    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, { currentHP: 6 }, LIVE_SHEET_MANUAL)
   })
 
   test('clicking the top AP segment persists currentAP (clamped to derived max 5)', async () => {
@@ -132,7 +133,7 @@ describe('Pilot hero — HP/AP trackers', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Set AP to 5' }))
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, { currentAP: 5 })
+    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, { currentAP: 5 }, LIVE_SHEET_MANUAL)
   })
 
   test('injuries lower the derived max HP (10 − 1 minor − 2 major = 7)', () => {
@@ -174,9 +175,14 @@ describe('Pilot hero — TP tracker', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Increase Training Points' }))
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, {
-      trainingPoints: 3,
-    })
+    expect(updateSpy).toHaveBeenCalledWith(
+      'pilot',
+      pilot.id,
+      {
+        trainingPoints: 3,
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 })
 
@@ -194,9 +200,14 @@ describe('Pilot hero — identity used-toggles', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Mark motto used' }))
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, {
-      usedToggles: { motto: true },
-    })
+    expect(updateSpy).toHaveBeenCalledWith(
+      'pilot',
+      pilot.id,
+      {
+        usedToggles: { motto: true },
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('resetting a used flag merges with existing flags', async () => {
@@ -208,9 +219,14 @@ describe('Pilot hero — identity used-toggles', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Reset motto used' }))
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('pilot', pilot.id, {
-      usedToggles: { motto: false, keepsake: true },
-    })
+    expect(updateSpy).toHaveBeenCalledWith(
+      'pilot',
+      pilot.id,
+      {
+        usedToggles: { motto: false, keepsake: true },
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('readOnly: no toggle buttons, set flags render as static stamps', () => {

--- a/apps/itun/src/components/sheet/__tests__/condition-tracking.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/condition-tracking.test.tsx
@@ -23,6 +23,7 @@ import type { Pilot } from '../../../lib/schemas/pilot'
 import type { useEntityStore } from '../../../stores/entityStore'
 import { makeEntityStoreMock } from '../../__tests__/mockEntityStore'
 import { must } from '../../__tests__/must'
+import { LIVE_SHEET_MANUAL } from '../../../stores/surfaceProvenance'
 
 // PilotSheet resolves equipment/ability slugs; MechSheet resolves
 // system/module slugs, chassis stats and cargo caps at render — load all.
@@ -143,9 +144,14 @@ describe('MechSheet — system status badge (REQ-011 #240, plan 4.5)', () => {
       fireEvent.click(badge)
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('mech', mech.id, {
-      systemConditions: { 'plasma-torch': 'damaged' },
-    })
+    expect(updateSpy).toHaveBeenCalledWith(
+      'mech',
+      mech.id,
+      {
+        systemConditions: { 'plasma-torch': 'damaged' },
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('displayed condition reflects stored systemConditions value', () => {
@@ -195,9 +201,14 @@ describe('MechSheet — module status badge (REQ-011 #240, plan 4.5)', () => {
       fireEvent.click(badge)
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('mech', mech.id, {
-      moduleConditions: { 'reinforced-hull': 'damaged' },
-    })
+    expect(updateSpy).toHaveBeenCalledWith(
+      'mech',
+      mech.id,
+      {
+        moduleConditions: { 'reinforced-hull': 'damaged' },
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 })
 
@@ -217,9 +228,14 @@ describe('PilotSheet — equipment condition toggle (REQ-011 #240)', () => {
       fireEvent.click(toggle)
     })
 
-    expect(updateSpy).toHaveBeenCalledWith('pilot', fakePilot.id, {
-      equipmentConditions: { pistol: 'damaged' },
-    })
+    expect(updateSpy).toHaveBeenCalledWith(
+      'pilot',
+      fakePilot.id,
+      {
+        equipmentConditions: { pistol: 'damaged' },
+      },
+      LIVE_SHEET_MANUAL
+    )
   })
 
   test('displayed condition reflects stored equipmentConditions value', () => {
@@ -293,11 +309,16 @@ describe('MechSheet — condition merge reads live store, not stale prop (#240 r
 
     // The patch must include BOTH the prior store condition and the new one —
     // proving the merge base came from store.get, not the empty prop map.
-    expect(updateSpy).toHaveBeenCalledWith('mech', fakeMech.id, {
-      systemConditions: {
-        'prior-system': 'destroyed',
-        'plasma-torch': 'damaged',
+    expect(updateSpy).toHaveBeenCalledWith(
+      'mech',
+      fakeMech.id,
+      {
+        systemConditions: {
+          'prior-system': 'destroyed',
+          'plasma-torch': 'damaged',
+        },
       },
-    })
+      LIVE_SHEET_MANUAL
+    )
   })
 })

--- a/apps/itun/src/lib/wizard/applyCrawlerEdit.ts
+++ b/apps/itun/src/lib/wizard/applyCrawlerEdit.ts
@@ -25,6 +25,7 @@ import type { SURefCrawler } from 'salvageunion-reference'
 
 import type { Crawler } from '../schemas/crawler'
 import type { EntityState } from '../../stores/entityStore'
+import { WIZARD_TXN } from '../../stores/surfaceProvenance'
 import {
   crawlerFormCrewToPatches,
   defaultTypeNpcState,
@@ -57,7 +58,7 @@ export async function applyCrawlerCrewAndTypeEdit(
   const crewPatches = crawlerFormCrewToPatches(form)
   for (const [bayRef, patch] of Object.entries(crewPatches.bayPatches)) {
     if (Object.keys(patch).length === 0) continue
-    await storeState.updateCrawlerBay(crawlerId, bayRef, patch)
+    await storeState.updateCrawlerBay(crawlerId, bayRef, patch, undefined, WIZARD_TXN)
   }
 
   // Accumulate every crawler-RECORD field change into ONE atomic update.
@@ -86,6 +87,6 @@ export async function applyCrawlerCrewAndTypeEdit(
   }
 
   if (Object.keys(recordPatch).length > 0) {
-    await storeState.update('crawler', crawlerId, recordPatch)
+    await storeState.update('crawler', crawlerId, recordPatch, WIZARD_TXN)
   }
 }

--- a/apps/itun/src/stores/__tests__/entityStore-changeLog.test.ts
+++ b/apps/itun/src/stores/__tests__/entityStore-changeLog.test.ts
@@ -11,6 +11,7 @@ import { beforeEach, describe, expect, test } from 'bun:test'
 
 import { _clearAllStores, _resetDbSingleton, changeLog } from '../../lib/db/index'
 import { useEntityStore } from '../entityStore'
+import { DASHBOARD_TXN } from '../surfaceProvenance'
 
 const basePilotInput = {
   schemaVersion: 1 as const,
@@ -64,6 +65,57 @@ describe('Change Log — write-through chokepoint', () => {
     expect(entry.source).toBe('unknown')
     expect(entry.seq).toBeGreaterThan(0)
     expect(typeof entry.ts).toBe('number')
+  })
+
+  test('transfer() logs every updated entity — the chokepoint hole (ADR-022)', async () => {
+    // transfer() commits cross-entity writes in one IDB transaction, bypassing
+    // update(). Before this was wired it emitted nothing, so cargo stow/load
+    // and scrap hand-offs mutated entities with no provenance at all.
+    const pilot = await seedPilot()
+    await useEntityStore.getState().transfer({
+      updates: [{ type: 'pilot', id: pilot.id, patch: { callsign: 'Wraith' } }],
+    })
+
+    const entries = await changeLog.listForEntity(pilot.id)
+    expect(entries).toHaveLength(1)
+    const entry = entries[0]
+    if (!entry) throw new Error('expected a Change Log entry from transfer()')
+    expect(entry.field).toBe('callsign')
+    expect(entry.before).toBe('Ghost')
+    expect(entry.after).toBe('Wraith')
+  })
+
+  test('transfer() carries its provenance tag through to the entry', async () => {
+    const pilot = await seedPilot()
+    await useEntityStore
+      .getState()
+      .transfer(
+        { updates: [{ type: 'pilot', id: pilot.id, patch: { callsign: 'Wraith' } }] },
+        { kind: 'transaction', source: 'dashboard' }
+      )
+
+    const entry = (await changeLog.listForEntity(pilot.id))[0]
+    if (!entry) throw new Error('expected a Change Log entry from transfer()')
+    expect(entry.kind).toBe('transaction')
+    expect(entry.source).toBe('dashboard')
+  })
+
+  test('transfer() emits nothing for a patch that changes no field', async () => {
+    const pilot = await seedPilot()
+    await useEntityStore.getState().transfer({
+      updates: [{ type: 'pilot', id: pilot.id, patch: { callsign: 'Ghost' } }],
+    })
+    expect(await changeLog.listForEntity(pilot.id)).toHaveLength(0)
+  })
+
+  test("kind 'transaction' is reachable — it was defined but emitted nowhere", async () => {
+    const pilot = await seedPilot()
+    await useEntityStore.getState().update('pilot', pilot.id, { callsign: 'Wraith' }, DASHBOARD_TXN)
+
+    const entry = (await changeLog.listForEntity(pilot.id))[0]
+    if (!entry) throw new Error('expected a Change Log entry')
+    expect(entry.kind).toBe('transaction')
+    expect(entry.source).toBe('dashboard')
   })
 
   test('a multi-field update appends one entry per changed field', async () => {

--- a/apps/itun/src/stores/entityStore.ts
+++ b/apps/itun/src/stores/entityStore.ts
@@ -112,7 +112,9 @@ export type EntityState = {
      * index is patched when its bayRef matches; otherwise the first bayRef
      * match wins.
      */
-    index?: number
+    index?: number,
+    /** Change Log provenance for the resulting update (ADR-022). */
+    meta?: ChangeMeta
   ) => Promise<Crawler>
 
   /**
@@ -128,10 +130,13 @@ export type EntityState = {
    * stow/load, salvage hand-offs — where a partial write would duplicate or
    * destroy player data. Deletes cascade SoftLinks like delete().
    */
-  transfer: (ops: {
-    updates?: TransferUpdate[]
-    deletes?: { type: EntityType; id: string }[]
-  }) => Promise<void>
+  transfer: (
+    ops: {
+      updates?: TransferUpdate[]
+      deletes?: { type: EntityType; id: string }[]
+    },
+    meta?: ChangeMeta
+  ) => Promise<void>
 }
 
 /** One update inside a transfer() — the discriminant ties patch to type. */
@@ -363,17 +368,27 @@ export const useEntityStore = create<EntityState>((set, get) => ({
     return updated
   },
 
-  async transfer(ops) {
+  async transfer(ops, meta) {
     const updates = ops.updates ?? []
     const deletes = ops.deletes ?? []
     if (updates.length === 0 && deletes.length === 0) return
+
+    // Capture before-images BEFORE the write, exactly as update() does, so the
+    // Change Log can diff them in phase 4. Without this, cross-entity moves
+    // (cargo stow/load, scrap hand-offs) mutated entities with no provenance at
+    // all — the one hole in ADR-022's "every mutation is logged" chokepoint
+    // guarantee, since transfer() bypasses update().
+    const withBefore = updates.map((u) => ({ ...u, before: get().get(u.type, u.id) }))
 
     // Phase 1 — validate everything BEFORE touching disk. prepareUpdate
     // merges + strict-parses without writing, so a Zod failure on any patch
     // aborts the whole transfer with nothing changed.
     const prepared = await Promise.all(
-      updates.map(async (u) => ({
+      withBefore.map(async (u) => ({
         type: u.type,
+        id: u.id,
+        patch: u.patch,
+        before: u.before,
         record: await (
           dbStoreFor(u.type).prepareUpdate as (id: string, patch: object) => Promise<{ id: string }>
         )(u.id, u.patch),
@@ -427,9 +442,23 @@ export const useEntityStore = create<EntityState>((set, get) => ({
     if (pruned.size > 0 && !touched.has('softLink')) {
       publishStoreChange(STORE_NAMES.softLinks)
     }
+
+    // Phase 4 — provenance (ADR-022), mirroring update()'s awaited emit. One
+    // entry per changed field per updated entity. Deletes are not logged: the
+    // per-entity log goes with the entity.
+    for (const pu of prepared) {
+      await emitChangeLog(
+        pu.type,
+        pu.id,
+        pu.patch,
+        pu.before,
+        pu.record as EntityForType<typeof pu.type>,
+        meta
+      )
+    }
   },
 
-  async updateCrawlerBay(crawlerId, bayRef, patch, index) {
+  async updateCrawlerBay(crawlerId, bayRef, patch, index, meta) {
     // Read the freshest persisted record — NOT the in-memory copy — so two
     // tabs editing different bays merge instead of clobbering (plan 2.7).
     const fresh = await db.crawlers.get(crawlerId)
@@ -447,7 +476,7 @@ export const useEntityStore = create<EntityState>((set, get) => ({
       )
     }
     const next = bays.map((b, i) => (i === targetIndex ? { ...b, ...patch, bayRef } : b))
-    return get().update('crawler', crawlerId, { crawlerBays: next })
+    return get().update('crawler', crawlerId, { crawlerBays: next }, meta)
   },
 
   async delete(type, id) {

--- a/apps/itun/src/stores/surfaceProvenance.ts
+++ b/apps/itun/src/stores/surfaceProvenance.ts
@@ -1,0 +1,31 @@
+/**
+ * Per-surface Change Log provenance tags (ADR-022).
+ *
+ * `entityStore.update` / `.transfer` accept a `ChangeMeta`, but for a long
+ * stretch nothing passed one: `kind: 'transaction'` and every `source` value
+ * existed only in a doc comment on the store, so **every** entry persisted as
+ * `manual` / `unknown` — a Dashboard Push was indistinguishable from someone
+ * typing in a box, and the drawer's transaction badge could never render.
+ *
+ * These constants exist so the tag is declared once per surface rather than
+ * re-typed at ~50 call sites, where it would drift. Pick by the surface's
+ * enforcement mode (ADR-021), not by what the patch happens to touch:
+ *
+ * - **Guided Play** (Dashboard) and **Guided Creation** (Wizard) run enforced
+ *   lifecycle transactions → `transaction`.
+ * - **Free Edit** (Live Sheet) edits state directly → `manual`, or `override`
+ *   when pinning a quantitative cap.
+ */
+import type { ChangeMeta } from './entityStore'
+
+/** Guided Play — an enforced lifecycle transaction (use a system, Push, damage). */
+export const DASHBOARD_TXN: ChangeMeta = { kind: 'transaction', source: 'dashboard' }
+
+/** Guided Creation — an enforced creation-time transaction. */
+export const WIZARD_TXN: ChangeMeta = { kind: 'transaction', source: 'wizard' }
+
+/** Free Edit — a direct hand edit of entity state. */
+export const LIVE_SHEET_MANUAL: ChangeMeta = { kind: 'manual', source: 'live-sheet' }
+
+/** Free Edit — pinning or reverting a quantitative cap (ADR-022 stat override). */
+export const LIVE_SHEET_OVERRIDE: ChangeMeta = { kind: 'override', source: 'live-sheet' }

--- a/packages/salvageunion-reference/data/systems.json
+++ b/packages/salvageunion-reference/data/systems.json
@@ -728,6 +728,7 @@
     "techLevel": 3,
     "slotsRequired": 3,
     "salvageValue": 1,
+    "statBonus": { "structurePoints": 5 },
     "page": 173,
     "actions": ["Composite Armour"]
   },

--- a/packages/salvageunion-reference/lib/rules/derivedStats.test.ts
+++ b/packages/salvageunion-reference/lib/rules/derivedStats.test.ts
@@ -178,6 +178,7 @@ describe('mech derivation', () => {
 //   Transport Hold   -> statBonus.cargoCapacity = 4  (Core Book p.168)
 //   Heat Sink        -> statBonus.heatCapacity  = 1  (Core Book p.170)
 //   Capacitance Bank -> statBonus.energyPoints  = 2  (Core Book p.173)
+//   Composite Armour -> statBonus.structurePoints = 5  (Core Book p.173)
 // ---------------------------------------------------------------------------
 describe('installed system/module stat bonuses', () => {
   const bare = { chassisRef: 'no-such-chassis' }
@@ -194,6 +195,19 @@ describe('installed system/module stat bonuses', () => {
     // base heatCapacity 5 + 2 Heat Sinks (+1 each) = 7
     expect(mechMaxHeat(mech, chassis)).toBe(7)
     expect(installedStatBonus(mech, 'heatCapacity')).toBe(2)
+  })
+
+  it('applies Composite Armour +5 Max SP, per installed copy', () => {
+    // Its rules text -- "increases your Mech's Max SP by 5 for each Composite
+    // Armour System you have installed" -- is exactly the shape statBonus
+    // exists for, but the field was absent, so the system contributed nothing.
+    const one = { ...bare, systems: ['Composite Armour'] }
+    expect(installedStatBonus(one, 'structurePoints')).toBe(5)
+    expect(mechMaxSP(one, chassis)).toBe(15) // base 10 + 5
+
+    const two = { ...bare, systems: ['Composite Armour', 'Composite Armour'] }
+    expect(installedStatBonus(two, 'structurePoints')).toBe(10)
+    expect(mechMaxSP(two, chassis)).toBe(20) // base 10 + 5 + 5
   })
 
   it('adds installed bonuses on top of the hand-edited modifier', () => {


### PR DESCRIPTION
First execution slice of the **Rules Parity & Stat Provenance** goal (#597). Decisions in #596.

Draft while the rest of batch 1 (A3 override split, B1–B6 provenance panel) lands on this branch — keeping the batch to one PR.

## Three defects, all independent of the override split

**1. Composite Armour contributed nothing.** Its text — *"increases your Mech's Max SP by 5 for each Composite Armour System you have installed"* — is exactly the shape `statBonus.structurePoints` exists for. The field was simply absent. Now added, with a test covering per-copy stacking.

**2. `kind: 'transaction'` was emitted nowhere.** Defined in the schema, documented on `entityStore.update`, badged in `ChangeLogDrawer` — and passed by no call site. Every Dashboard lifecycle transaction (Push, Heat Check, take damage, activate) logged as an indistinguishable `manual` edit, so the drawer's transaction badge could never render.

**3. `source` was never passed at all** — every entry persisted as `'unknown'`.

Rather than re-typing a meta object at ~50 call sites, provenance is now a named per-surface constant (`stores/surfaceProvenance.ts`), picked by the surface's ADR-021 enforcement mode.

**4. `entityStore.transfer()` never logged.** It commits cross-entity writes in one IDB transaction, bypassing `update()` — so cargo stow/load and scrap hand-offs mutated entities with **no provenance at all**. The one real hole in ADR-022's chokepoint guarantee. It now captures before-images and emits per changed field exactly as `update()` does, and takes its own `ChangeMeta`.

## Verification

`bun run check:all` fully green: lint, format, typecheck, **4,800+ tests**, `validate:all`, knip, audit, tokens, styling.

Four new provenance tests pin the contract, including one asserting `kind: 'transaction'` is now reachable and one covering the `transfer()` hole directly.

## Note for review

The diff is wide but shallow — most of it is appending a provenance constant at call sites and to the test assertions that pin call shape. The behavioural changes are confined to `entityStore.ts`, `surfaceProvenance.ts`, and one data record.

Refs #597.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MT6q22Y1MtuCYHormXwQ4