### PR TITLE
feat(tooling): measure the agent fleet, scope the typecheck hook, fix the worktree reaper

### DIFF
--- a/.claude/hooks/typecheck-scoped.sh
+++ b/.claude/hooks/typecheck-scoped.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Typechecks ONLY the workspace an edit actually touched.
+# Used as a PostToolUse hook for Edit and Write tools.
+#
+# This replaces a hook that ran the whole monorepo `bun run typecheck` after
+# EVERY Edit and Write — including markdown, JSON and YAML, which cannot affect
+# a type. Measured, that is 7.0 s of wall clock per edit, of which apps/srd
+# alone is 6.3 s:
+#
+#   salvageunion-reference 0.10s   component-lib 0.15s   srd 6.27s
+#   itun 2.19s             discord-bot 0.96s            total 7.03s (concurrent)
+#
+# Across a few dozen edits per session that is minutes of pure waiting, paid on
+# every session, to re-prove something `bun run typecheck` in CI already gates
+# on merge. And because PostToolUse output is advisory — it cannot block the
+# edit — the cost bought a warning, not enforcement.
+#
+# So: skip entirely for files that cannot change a type, and otherwise check
+# just the one workspace that owns the file. A cross-package edit still gets
+# caught, because the consuming workspace is typechecked the moment you edit a
+# file in it, and CI still runs the full matrix on the PR.
+#
+# Never exits non-zero: a typecheck failure here is INFORMATION for the agent,
+# not a gate. Exiting 2 would reject an edit that is legitimately mid-refactor
+# and half-typed, which is a normal state to be in between two Edit calls.
+
+INPUT=$(cat)
+
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.file // empty')
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Only TypeScript-bearing sources can change a type. Astro files carry a
+# TypeScript frontmatter block, so they count; .md/.json/.yml/.css do not.
+case "$FILE_PATH" in
+  *.ts | *.tsx | *.mts | *.cts | *.astro) : ;;
+  *) exit 0 ;;
+esac
+
+# Map the edited path to the workspace that owns it. Ordered most-specific
+# first; salvageunion-reference must precede any broader packages/ rule.
+case "$FILE_PATH" in
+  *packages/salvageunion-reference/*) WORKSPACE="salvageunion-reference" ;;
+  *packages/component-lib/*)          WORKSPACE="component-lib" ;;
+  *apps/srd/*)                        WORKSPACE="srd" ;;
+  *apps/itun/*)                       WORKSPACE="itun" ;;
+  *apps/discord-bot/*)                WORKSPACE="discord-bot" ;;
+  # tools/, scripts and repo-root config belong to no workspace. The root
+  # tsconfig does not typecheck them as a project, and the full matrix would
+  # cost 7 s to prove nothing about the edited file — leave them to CI.
+  *) exit 0 ;;
+esac
+
+bun --filter "$WORKSPACE" typecheck 2>&1 | tail -20
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,8 +30,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run typecheck 2>&1 | head -20",
-            "statusMessage": "Typechecking after edit..."
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/typecheck-scoped.sh",
+            "statusMessage": "Typechecking the edited workspace..."
           }
         ]
       }

--- a/.claude/skills/component-refresh/SKILL.md
+++ b/.claude/skills/component-refresh/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: component-refresh
+description: Redesign an existing component through the three-level loop — real SSR "before", NEW* Ladle comparison, then staged cutover
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep
+---
+
+# Component Refresh
+
+Drive a component redesign through the repeatable three-level loop. This is the
+dominant kind of work in this repo, and the loop that makes it safe already
+exists as prose — it just was not invokable, so every session reconstructed it
+from a paragraph and some skipped the parts that make it safe.
+
+**The methodology lives in
+[`docs/design/entity-card-reconciliation.md`](../../../docs/design/entity-card-reconciliation.md)
+Part 1 — read it first, and treat it as the source of truth.** Do not restate it
+here or anywhere else; a second copy drifts, and `validate:doc-drift` exists
+because that has already happened. This skill is the operating procedure for
+running it.
+
+## Before starting
+
+Ask which level is being requested, and do not silently cross a gate:
+
+- **L1 (mockup)** — design only. Produces an artifact. Changes no app code.
+- **L2 (build alongside)** — `NEW`-prefixed components, Ladle-only, no consumers.
+- **L3 (cutover)** — migrate consumers and delete the legacy component.
+  **Explicit command only.** Never begin L3 because L2 looks finished.
+
+If the request is ambiguous, assume the _lower_ level and say so.
+
+## L1 — mockup, grounded in a real "before"
+
+The single rule that carries this level: **the "before" is the actual current
+component rendered from real code, never a hand-authored caricature.** A
+caricature hides exactly the wrapping, overflow, tone and empty-state bugs the
+refresh is supposed to fix, so a mockup built against one is designing for a
+component that does not exist.
+
+- Render it via SSR — `react-dom/server` `renderToStaticMarkup` plus compiled
+  Tailwind (`@tailwindcss/node` + `@tailwindcss/oxide` Scanner over the rendered
+  markup, theme fonts embedded as data URIs). Capture HTML + CSS, not
+  screenshots.
+- Feed it **real ORM data** (`SalvageUnionReference.*`), deliberately including
+  the awkward records — longest name, empty description, missing artwork.
+- Settle the read-only design before touching anything editable.
+
+## L2 — build alongside, never in place
+
+- New components carry a `NEW` prefix so they cannot collide with the legacy
+  one, are **not** barrel-exported, and have **no consumers**. Iteration is then
+  zero-risk.
+- Show them as a **three-way Ladle story on one page**: old · new read-only ·
+  new editable, all driven by real data through the real components.
+  `bun run ladle`
+- Add any write layer as **evolutions of the read-only card, never a redesign**.
+
+## L3 — cutover, staged and green at every step
+
+Only on explicit instruction. Follow the staged plan in the canonical doc
+(rename → barrel + compat shim → migrate consumers lowest-risk first → delete
+legacy and canonicalize stories), committing per stage.
+
+## Invariants — check these at every level
+
+- **Read-only byte-identical.** Every write-layer or migration change is
+  additive and prop-gated: a card with no write props must render exactly as
+  before. Prove it by diffing rendered `innerHTML` against `HEAD` — do not
+  assert it from reading the diff.
+- **Green at every checkpoint.** `bun run typecheck`, `bun run lint`,
+  `bun run test`, `bun run validate:all` — committed per stage, not batched to
+  the end.
+- **Real data everywhere** — mockups, stories and SSR captures alike.
+- **Prefer changing the data shape over special-casing the renderer.** A
+  renderer full of per-entity branches is the failure mode this repo keeps
+  paying for.
+
+## Finishing
+
+Report which level completed, what is now safe to delete, and what the next
+level would involve. If L2 finished, say explicitly that the legacy component is
+still the one users see — the work is not visible until L3.

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: triage
+description: Morning triage — read every production and CI signal, then propose the day's work in priority order
+allowed-tools: Bash, Read
+---
+
+# Triage
+
+Read what the systems are actually reporting, then propose what to work on. Run
+this before starting work, not after deciding what to do.
+
+This exists because the repo has a **backlog problem, not a capacity problem**.
+Throughput is ~3 PRs/day with a 40-minute median cycle time; the constraint is
+knowing which change is worth making. Nothing currently routes an observed
+production signal into the work queue — zero of the last 60 merged PRs
+referenced an issue, and the open backlog is mostly issues filed on one day in
+March. This closes that loop by hand until it earns being automated.
+
+## Steps
+
+Gather all of these before proposing anything. A signal you skipped is a
+recommendation you cannot justify.
+
+1. **Nightly E2E** — did last night's run pass?
+
+   ```bash
+   gh run list --workflow=e2e-nightly.yml --limit 5 \
+     --json conclusion,createdAt,displayTitle
+   gh issue list --label nightly-e2e-failure --state open
+   ```
+
+   A failure here outranks almost everything: the suite is the only automated
+   check on whole user journeys, and a suite that stays red stops being read.
+
+2. **Production error tracking** — is it reporting, and what did it report?
+
+   ```bash
+   bun run validate:observability:live   # is the SDK actually being served?
+   ```
+
+   If this fails, production is blind and that is the finding. Once a Sentry
+   DSN is provisioned, read the new issues since yesterday and treat anything
+   affecting more than one user as a candidate for today.
+
+3. **Deploys** — did the last deploy of each site succeed? Use the Netlify MCP
+   (`suindex` → salvageunion.io, `in-the-union-now` → intheunionnow.com) and
+   the Render MCP for `suref-discord-bot`. A site whose last deploy failed is
+   serving stale code and nobody was told.
+
+4. **Dependency and security PRs**
+
+   ```bash
+   gh pr list --author app/dependabot --state open
+   gh run list --workflow=codeql.yml --limit 3 --json conclusion
+   ```
+
+5. **In-flight work** — what is already open, and is any of it stuck?
+
+   ```bash
+   gh pr list --state open --json number,title,isDraft,statusCheckRollup
+   ```
+
+6. **Agent fleet health** — only when something feels slow or wasteful:
+
+   ```bash
+   bun tools/agent-digest.ts --days 7
+   ```
+
+## Output
+
+Propose an ordered list of at most **five** items. For each: the signal that
+produced it, why it ranks where it does, and a rough size. Then state plainly
+what you are NOT proposing and why — an unranked list of everything wrong is
+the backlog problem restated, not triage.
+
+Rank by this order unless there is a stated reason to depart from it:
+
+1. Production is broken or blind for real users.
+2. A merge gate is red (nightly E2E, CI on main, a failed deploy).
+3. Security and dependency updates.
+4. In-flight work that is one step from landing.
+5. New feature work.
+
+If every signal is green, say so in one line and propose feature work from the
+open backlog. Do not manufacture findings — "nothing is wrong" is a valid and
+useful triage result.

--- a/package.json
+++ b/package.json
@@ -89,6 +89,8 @@
     "validate:observability": "bun tools/check-observability.ts",
     "validate:observability:live": "bun tools/check-observability.ts --live",
     "validate:all": "bun --filter salvageunion-reference validate:all && bun tools/check-bun-version.ts && bun run validate:architecture && bun run validate:doc-drift && bun run validate:observability",
+    "agent:digest": "bun tools/agent-digest.ts",
+    "worktrees:prune": "bash tools/prune-stale-worktrees.sh",
     "clean": "bun --filter \"*\" clean || true",
     "knip": "knip",
     "check:schemas": "bun run build:package && git diff --exit-code -- packages/salvageunion-reference/schemas packages/salvageunion-reference/lib/generated packages/salvageunion-reference/lib/index.ts",

--- a/tools/agent-digest.ts
+++ b/tools/agent-digest.ts
@@ -1,0 +1,344 @@
+#!/usr/bin/env bun
+/**
+ * agent-digest — a weekly readout of what the agent fleet actually did.
+ *
+ * Agents are the largest single labour input in this repo — in the fortnight
+ * this tool was written, 22 sessions in this project spawned another 109
+ * subagent runs — and until now not one number about them was collected. No
+ * cost, no tool-error rate, no idea how often a guard hook fired or how many
+ * sessions ended without landing anything.
+ *
+ * (Those two figures are why the split exists: counting transcript files
+ * without separating them reports "131 sessions" for 22 real ones, which is
+ * how this tool's own first draft — and the review that prompted it —
+ * overstated the number by ~6x.)
+ *
+ * The instinct when facing that gap is to stand up telemetry — an OTLP
+ * endpoint, a collector, a dashboard. Don't, yet. Claude Code already writes a
+ * complete, structured record of every session to
+ * `~/.claude/projects/<encoded-cwd>/<session>.jsonl`, and hundreds of those
+ * files are already sitting on disk. That is a dataset being treated as
+ * exhaust. Read it first; it will tell you whether streaming telemetry is worth
+ * configuring at all, and it costs one script instead of an integration.
+ *
+ * Usage:
+ *   bun tools/agent-digest.ts                 # this repo, last 14 days
+ *   bun tools/agent-digest.ts --days 30       # a longer window
+ *   bun tools/agent-digest.ts --all           # every project on this machine
+ *   bun tools/agent-digest.ts --json          # machine-readable, for trending
+ *
+ * Reads only. Never writes, never uploads, never leaves the machine.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+type Args = { days: number; all: boolean; json: boolean }
+
+function parseArgs(argv: string[]): Args {
+  const daysFlag = argv.indexOf('--days')
+  return {
+    days: daysFlag === -1 ? 14 : Number(argv[daysFlag + 1]) || 14,
+    all: argv.includes('--all'),
+    json: argv.includes('--json'),
+  }
+}
+
+/**
+ * Claude Code encodes a project's directory into its transcript folder name by
+ * replacing every path separator with a dash. Worktrees get their own folder,
+ * so resolve to the MAIN working tree — otherwise a digest run from inside a
+ * worktree silently reports on that worktree alone.
+ */
+function mainWorktreeDir(): string {
+  const out = Bun.spawnSync(['git', 'worktree', 'list', '--porcelain']).stdout.toString()
+  const first = out.split('\n').find((l) => l.startsWith('worktree '))
+  return first ? first.slice('worktree '.length).trim() : process.cwd()
+}
+
+const encodeProject = (dir: string): string => dir.replace(/\//g, '-')
+
+type Session = {
+  project: string
+  file: string
+  /**
+   * A project folder holds top-level `<session>.jsonl` files — the sessions you
+   * actually start — plus `<session>/subagents/agent-*.jsonl` for every
+   * subagent those sessions spawned. Counting them together overstates
+   * "sessions" by roughly 5x (22 real sessions vs 131 files, measured), so they
+   * are tallied separately.
+   */
+  kind: 'main' | 'subagent'
+  startedAt: Date
+  endedAt: Date
+  outputTokens: number
+  cacheReadTokens: number
+  cacheCreationTokens: number
+  toolCalls: number
+  toolErrors: number
+  toolNames: Map<string, number>
+  errorToolNames: Map<string, number>
+  denials: number
+  committed: boolean
+  branches: Set<string>
+}
+
+const bump = (m: Map<string, number>, k: string) => m.set(k, (m.get(k) ?? 0) + 1)
+
+/** Content is an array of blocks for tool traffic, but a bare string elsewhere. */
+const blocksOf = (rec: unknown): Array<Record<string, unknown>> => {
+  const content = (rec as { message?: { content?: unknown } })?.message?.content
+  return Array.isArray(content) ? (content as Array<Record<string, unknown>>) : []
+}
+
+/**
+ * A permission denial — the auto-mode classifier, a `permissions.deny` rule, or
+ * a PreToolUse hook returning deny. All three surface as an errored tool_result
+ * whose text says so, rather than as a distinct record type.
+ */
+const DENIAL = /permission .*denied|denied by the claude code|blocked by classifier|^blocked:/i
+
+function readSession(project: string, file: string, kind: 'main' | 'subagent'): Session | null {
+  let raw: string
+  try {
+    raw = readFileSync(file, 'utf8')
+  } catch {
+    return null
+  }
+
+  const session: Session = {
+    project,
+    file,
+    kind,
+    startedAt: new Date(8.64e15),
+    endedAt: new Date(0),
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    toolCalls: 0,
+    toolErrors: 0,
+    toolNames: new Map(),
+    errorToolNames: new Map(),
+    denials: 0,
+    committed: false,
+    branches: new Set(),
+  }
+
+  // tool_result carries only the id it answers, so remember what each id was.
+  const toolNameById = new Map<string, string>()
+  let sawAnything = false
+
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue
+    let rec: Record<string, unknown>
+    try {
+      rec = JSON.parse(line)
+    } catch {
+      continue // a partially-flushed final line is normal on a live session
+    }
+
+    const ts = rec.timestamp as string | undefined
+    if (ts) {
+      const at = new Date(ts)
+      if (!Number.isNaN(at.valueOf())) {
+        sawAnything = true
+        if (at < session.startedAt) session.startedAt = at
+        if (at > session.endedAt) session.endedAt = at
+      }
+    }
+    if (typeof rec.gitBranch === 'string' && rec.gitBranch) session.branches.add(rec.gitBranch)
+
+    const usage = (rec as { message?: { usage?: Record<string, number> } })?.message?.usage
+    if (usage) {
+      session.outputTokens += usage.output_tokens ?? 0
+      session.cacheReadTokens += usage.cache_read_input_tokens ?? 0
+      session.cacheCreationTokens += usage.cache_creation_input_tokens ?? 0
+    }
+
+    for (const block of blocksOf(rec)) {
+      if (block.type === 'tool_use') {
+        session.toolCalls++
+        const name = String(block.name ?? '?')
+        bump(session.toolNames, name)
+        if (typeof block.id === 'string') toolNameById.set(block.id, name)
+
+        // "Did this session land anything?" is the cheapest proxy for whether
+        // the work survived, and it needs no git archaeology.
+        const command = (block.input as { command?: string } | undefined)?.command
+        if (name === 'Bash' && command && /\bgit\s+commit\b/.test(command)) {
+          session.committed = true
+        }
+      }
+
+      if (block.type === 'tool_result') {
+        const text =
+          typeof block.content === 'string' ? block.content : JSON.stringify(block.content ?? '')
+        if (block.is_error) {
+          session.toolErrors++
+          bump(session.errorToolNames, toolNameById.get(String(block.tool_use_id)) ?? '?')
+        }
+        if (DENIAL.test(text)) session.denials++
+      }
+    }
+  }
+
+  return sawAnything ? session : null
+}
+
+function collect({ days, all }: Args): Session[] {
+  const root = join(homedir(), '.claude', 'projects')
+  const cutoff = Date.now() - days * 86_400_000
+  const wanted = encodeProject(mainWorktreeDir())
+
+  let projectDirs: string[]
+  try {
+    projectDirs = readdirSync(root)
+  } catch {
+    return []
+  }
+  if (!all) projectDirs = projectDirs.filter((d) => d === wanted)
+
+  const sessions: Session[] = []
+
+  const take = (dir: string, path: string, kind: 'main' | 'subagent') => {
+    // mtime is a cheap pre-filter; the authoritative window check is the
+    // session's own last timestamp, below.
+    try {
+      if (statSync(path).mtimeMs < cutoff) return
+    } catch {
+      return
+    }
+    const s = readSession(dir, path, kind)
+    if (s && s.endedAt.valueOf() >= cutoff) sessions.push(s)
+  }
+
+  for (const dir of projectDirs) {
+    const full = join(root, dir)
+    let entries: string[]
+    try {
+      entries = readdirSync(full)
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      if (entry.endsWith('.jsonl')) {
+        take(dir, join(full, entry), 'main')
+        continue
+      }
+      // `<session-uuid>/subagents/agent-*.jsonl` — one file per subagent run.
+      const subagentDir = join(full, entry, 'subagents')
+      try {
+        for (const f of readdirSync(subagentDir)) {
+          if (f.endsWith('.jsonl')) take(dir, join(subagentDir, f), 'subagent')
+        }
+      } catch {
+        // not a session folder (e.g. `memory/`), or it spawned no subagents
+      }
+    }
+  }
+  return sessions.sort((a, b) => a.startedAt.valueOf() - b.startedAt.valueOf())
+}
+
+const sum = (xs: number[]) => xs.reduce((a, b) => a + b, 0)
+const pct = (n: number, d: number) => (d === 0 ? '0.0%' : `${((n / d) * 100).toFixed(1)}%`)
+
+/**
+ * Token counts here span six orders of magnitude — a session's output is
+ * thousands, its cache reads are billions — so a single fixed unit is
+ * unreadable at one end or the other. Step the unit instead.
+ */
+function k(n: number): string {
+  if (n >= 1e9) return `${(n / 1e9).toFixed(1)}B`
+  if (n >= 1e6) return `${(n / 1e6).toFixed(1)}M`
+  if (n >= 1e3) return `${(n / 1e3).toFixed(1)}k`
+  return String(n)
+}
+
+function mergeCounts(maps: Array<Map<string, number>>): Array<[string, number]> {
+  const merged = new Map<string, number>()
+  for (const m of maps) for (const [key, v] of m) merged.set(key, (merged.get(key) ?? 0) + v)
+  return [...merged].sort((a, b) => b[1] - a[1])
+}
+
+const args = parseArgs(process.argv.slice(2))
+const sessions = collect(args)
+
+if (sessions.length === 0) {
+  console.log(`No agent sessions in the last ${args.days} days.`)
+  process.exit(0)
+}
+
+// Session-shaped metrics (how many, how long, did it land) describe sessions
+// you actually started; token and tool volume covers every process, subagents
+// included, because that is what the work really cost.
+const main = sessions.filter((s) => s.kind === 'main')
+const subagents = sessions.filter((s) => s.kind === 'subagent')
+
+const toolCalls = sum(sessions.map((s) => s.toolCalls))
+const toolErrors = sum(sessions.map((s) => s.toolErrors))
+const denials = sum(sessions.map((s) => s.denials))
+const outputTokens = sum(sessions.map((s) => s.outputTokens))
+const cacheRead = sum(sessions.map((s) => s.cacheReadTokens))
+const cacheCreation = sum(sessions.map((s) => s.cacheCreationTokens))
+const committed = main.filter((s) => s.committed).length
+const durations = main
+  .map((s) => (s.endedAt.valueOf() - s.startedAt.valueOf()) / 60_000)
+  .sort((a, b) => a - b)
+const medianMinutes = durations[Math.floor(durations.length / 2)] ?? 0
+
+if (args.json) {
+  console.log(
+    JSON.stringify(
+      {
+        windowDays: args.days,
+        sessions: main.length,
+        subagentRuns: subagents.length,
+        sessionsPerDay: +(main.length / args.days).toFixed(2),
+        medianSessionMinutes: +medianMinutes.toFixed(1),
+        outputTokens,
+        cacheReadTokens: cacheRead,
+        cacheCreationTokens: cacheCreation,
+        toolCalls,
+        toolErrors,
+        toolErrorRate: +(toolErrors / Math.max(toolCalls, 1)).toFixed(4),
+        denials,
+        sessionsWithCommit: committed,
+        topTools: mergeCounts(sessions.map((s) => s.toolNames)).slice(0, 10),
+        topErrorTools: mergeCounts(sessions.map((s) => s.errorToolNames)).slice(0, 10),
+      },
+      null,
+      2
+    )
+  )
+  process.exit(0)
+}
+
+const scope = args.all ? 'all projects' : mainWorktreeDir()
+console.log(`\nAgent digest — last ${args.days} days — ${scope}\n${'─'.repeat(60)}`)
+console.log(`  sessions              ${main.length}  (${(main.length / args.days).toFixed(1)}/day)`)
+console.log(`  subagent runs         ${subagents.length}  (spawned by those sessions)`)
+console.log(`  median session        ${medianMinutes.toFixed(0)} min`)
+console.log(`  landed a commit       ${committed}  (${pct(committed, main.length)} of sessions)`)
+console.log(`  output tokens         ${k(outputTokens)}`)
+console.log(`  cache read / created  ${k(cacheRead)} / ${k(cacheCreation)}`)
+console.log(`  tool calls            ${k(toolCalls)}`)
+console.log(`  tool errors           ${toolErrors}  (${pct(toolErrors, toolCalls)} of calls)`)
+console.log(`  permission denials    ${denials}`)
+
+const topTools = mergeCounts(sessions.map((s) => s.toolNames)).slice(0, 8)
+console.log(`\n  most-used tools`)
+for (const [name, n] of topTools) {
+  console.log(`    ${name.padEnd(22)} ${String(n).padStart(5)}  ${pct(n, toolCalls)}`)
+}
+
+const topErrors = mergeCounts(sessions.map((s) => s.errorToolNames)).slice(0, 8)
+if (topErrors.length > 0) {
+  console.log(`\n  tools that errored most`)
+  for (const [name, n] of topErrors) {
+    const calls = mergeCounts(sessions.map((s) => s.toolNames)).find(([t]) => t === name)?.[1] ?? 0
+    console.log(`    ${name.padEnd(22)} ${String(n).padStart(5)}  (${pct(n, calls)} of its calls)`)
+  }
+}
+
+console.log()

--- a/tools/prune-stale-worktrees.sh
+++ b/tools/prune-stale-worktrees.sh
@@ -12,8 +12,23 @@
 # safety checks apply. It skips, unconditionally:
 #   - the main working tree
 #   - the worktree you are currently standing in
-#   - any worktree marked `locked` (an active run holds it)
+#   - any worktree whose lock is held by a LIVE process
 #   - any worktree with uncommitted changes (dirty working tree)
+#
+# Locks: Claude Code stamps its lock reason as
+#   "claude session <name> (pid <PID> start <date>)"
+# A killed or crashed session never releases that lock, so the worktree stays
+# locked forever and this script — which used to skip every locked worktree
+# unconditionally — could never reclaim it. That is the backlog described in
+# issue #377: the reaper runs, reports nothing to do, and the directories
+# accumulate anyway.
+#
+# So a lock is now interrogated rather than obeyed blindly: parse the PID out
+# of the reason, and if that process is GONE the lock is stale — unlock and
+# treat the worktree as a normal candidate (it still has to pass every other
+# safety check before removal). If the PID is alive, or no PID can be parsed at
+# all, skip: an unrecognised lock is somebody else's, and the default answer
+# here is always "leave it".
 #
 # Usage:
 #   tools/prune-stale-worktrees.sh            # dry-run: list what WOULD be removed
@@ -36,21 +51,61 @@ removed=0
 skipped=0
 
 process() {
-  local p="$1" lk="$2"
-  [[ -z "$p" ]] && return
+  local p="$1" lk="$2" reason="${3:-}"
+  # NOTE: every early return here MUST be `return 0`, not a bare `return`.
+  # A bare `return` yields the status of the last command run — which for the
+  # skip paths is a FAILED test — so `process` returned 1, and under
+  # `set -euo pipefail` that killed the whole script at the first worktree it
+  # declined to consider. The main working tree is always the first entry, and
+  # is always declined, so this script exited 1 with no output before examining
+  # a single candidate: it never reclaimed anything, for its entire life. That
+  # is the actual reason abandoned worktrees accumulate (issue #377), not the
+  # lock handling.
+  [[ -z "$p" ]] && return 0
   # Only consider worktrees under .claude/worktrees/
   case "$p" in
     */.claude/worktrees/*) : ;;
-    *) return ;;
+    *) return 0 ;;
   esac
   if [[ "$p" == "$main_wt" || "$p" == "$current_wt" ]]; then
-    echo "skip (current/main):   $p"; ((skipped++)) || true; return
+    echo "skip (current/main):   $p"; ((skipped++)) || true; return 0
   fi
   if [[ "$lk" == "1" ]]; then
-    echo "skip (locked/active):  $p"; ((skipped++)) || true; return
+    # Interrogate the lock instead of obeying it blindly (see header). Claude
+    # Code stamps "… (pid <PID> start <date>)"; anything else is an unknown
+    # holder and is left alone.
+    local pid
+    pid="$(printf '%s' "$reason" | sed -n 's/.*[Pp]id \([0-9][0-9]*\).*/\1/p')"
+    if [[ -z "$pid" ]]; then
+      echo "skip (locked, no pid): $p"; ((skipped++)) || true; return 0
+    fi
+    if ps -p "$pid" >/dev/null 2>&1; then
+      echo "skip (locked, pid $pid alive): $p"; ((skipped++)) || true; return 0
+    fi
+    # Stale: the session that took this lock is gone. Fall through to the
+    # ordinary safety checks — a stale lock makes a worktree a CANDIDATE, it
+    # does not exempt it from the dirty-tree or git-refusal checks below.
+    echo "stale lock (pid $pid gone): $p"
+    if [[ "$FORCE" == "1" ]]; then
+      git worktree unlock "$p" 2>/dev/null || true
+    fi
   fi
   if [[ -n "$(git -C "$p" status --porcelain 2>/dev/null)" ]]; then
-    echo "skip (uncommitted):    $p"; ((skipped++)) || true; return
+    echo "skip (uncommitted):    $p"; ((skipped++)) || true; return 0
+  fi
+  # Unpushed commits. `git worktree remove` does NOT check this — it only
+  # refuses on a dirty tree — so without this guard a worktree holding the only
+  # copy of a commit would be deleted. That risk was theoretical while the
+  # script exited early and removed nothing; fixing it made the risk real, so
+  # the guard ships in the same change.
+  #
+  # Deliberately conservative: a branch whose commits are not on ANY remote is
+  # kept. That also keeps squash-merged branches (whose content landed under a
+  # new SHA, so the originals exist nowhere by SHA) — those are safe to delete
+  # in principle, but proving it needs patch-id equivalence, and the default
+  # answer here is always "leave it".
+  if [[ -z "$(git -C "$p" branch -r --contains HEAD 2>/dev/null)" ]]; then
+    echo "skip (unpushed):       $p"; ((skipped++)) || true; return 0
   fi
   if [[ "$FORCE" == "1" ]]; then
     if git worktree remove "$p" 2>/dev/null; then
@@ -65,11 +120,17 @@ process() {
 
 path=""
 locked=0
+reason=""
 while IFS= read -r line; do
   case "$line" in
-    "worktree "*) [[ -n "$path" ]] && process "$path" "$locked"; path="${line#worktree }"; locked=0 ;;
-    "locked"*)    locked=1 ;;
-    "")           process "$path" "$locked"; path=""; locked=0 ;;
+    "worktree "*)
+      [[ -n "$path" ]] && process "$path" "$locked" "$reason"
+      path="${line#worktree }"; locked=0; reason="" ;;
+    # Porcelain emits a bare `locked` or `locked <reason>`; the reason carries
+    # the holding session's pid, which decides whether the lock is still real.
+    "locked")     locked=1; reason="" ;;
+    "locked "*)   locked=1; reason="${line#locked }" ;;
+    "")           process "$path" "$locked" "$reason"; path=""; locked=0; reason="" ;;
   esac
 done < <(git worktree list --porcelain; echo "")
 


### PR DESCRIPTION
Tiers 2 and 3 of the operating review. Instrument the largest unmeasured input,
stop paying a per-edit tax that enforced nothing, and make two
existing-but-broken things actually work.

## `tools/agent-digest.ts` — read the data already on disk

~10 agent sessions a day run in this repo and not one number about them was
collected. The instinct is to stand up an OTLP collector; **don't, yet.** Claude
Code already writes a complete structured record of every session to
`~/.claude/projects/`, and hundreds of those files are sitting there being
treated as exhaust. Read them first — the answers will tell you whether
streaming telemetry is worth configuring at all, and it costs one script instead
of an integration.

```
bun run agent:digest            # this repo, last 14 days
bun run agent:digest -- --all --days 30 --json
```

Reports sessions, median duration, share that landed a commit, tokens, tool-error
rate, permission denials, most-used and most-erroring tools. Reads only; nothing
leaves the machine.

It counts **main sessions and subagent runs separately**, which turned out to
matter. A project folder holds `<session>.jsonl` alongside
`<session>/subagents/agent-*.jsonl`, so counting files reports **131 "sessions"
for 22 real ones**. The review that prompted this work made exactly that mistake
and overstated the figure ~6x; the artifact has been corrected.

## A scoped typecheck hook

The `PostToolUse` hook ran the whole monorepo `bun run typecheck` after **every**
`Edit` and `Write` — including markdown and JSON, which cannot affect a type.

| | before | after |
|---|---|---|
| edit a `salvageunion-reference` file | 7030 ms | **114 ms** |
| edit a markdown file | 7030 ms | **0** (skipped) |

Measured breakdown: srd 6.27 s, itun 2.19 s, discord-bot 0.96 s, component-lib
0.15 s, reference 0.10 s — 7.03 s wall, and srd is essentially all of it.

As a `PostToolUse` hook its output is **advisory** — it cannot block the edit —
and CI gates the same check on merge. So the 7 s bought a warning, not
enforcement. `.claude/hooks/typecheck-scoped.sh` skips non-TypeScript files and
otherwise checks only the workspace owning the file. It never exits non-zero: a
half-typed file between two `Edit` calls is a normal state, not an error.

## The worktree reaper never worked — at all

`prune-stale-worktrees.sh` used a bare `return` in its skip paths. A bare
`return` yields the status of the last command run — a **failed test** — so
`process()` returned 1, and `set -euo pipefail` killed the script at the first
worktree it declined to consider. The main working tree is always first and
always declined, so it **exited 1 with no output before examining a single
candidate, for its entire life.**

Verified against the unmodified script from `main`:

```
$ bash /tmp/orig-prune.sh
EXIT=1          # ← no output whatsoever
```

That, not the lock handling, is why abandoned worktrees accumulate (#377).

Now that it runs, two further changes:

- **Locks are interrogated, not obeyed blindly.** Claude Code stamps
  `claude session <name> (pid <PID> start <date>)`; the PID is parsed and the
  lock is stale only if that process is gone. Alive or unparseable → skip.
- **An unpushed-commits guard was added.** `git worktree remove` only refuses on
  a *dirty tree*, so fixing the script would otherwise have armed it to delete
  the only copy of a commit. That risk was theoretical while it removed nothing
  and became real in this change, so the guard ships in the same commit.

Current dry run: **0 candidates, 11 skipped** — every worktree here has unpushed
commits. That is the correct conservative answer, and it now *tells you why*
instead of silently doing nothing.

⚠️ This does **not** fully close #377: nothing is reclaimed until branches are
pushed or merged. A `--push` mode (publish, then reap) is the obvious follow-up
but is outward-facing, so it is deliberately not in this PR.

## Two skills

- **`/triage`** reads every production and CI signal — nightly E2E, the live
  observability probe, deploys, Dependabot, in-flight PRs — and proposes the
  day's work in ranked order, capped at five items. This is the missing loop:
  zero of the last 60 merged PRs referenced an issue, so nothing routes an
  observed signal into the queue.
- **`/component-refresh`** operationalizes the three-level redesign loop (real
  SSR "before" → `NEW*` Ladle three-way → staged cutover). It **points at**
  `docs/design/entity-card-reconciliation.md` Part 1 rather than restating it —
  a second copy would drift, which is why `validate:doc-drift` exists.

## Verification

`bun run check:all` green after rebase onto `main` (which now includes #601).