### PR TITLE
docs: resolve duplicate ADR-028, index the missing partners ADR

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -100,7 +100,8 @@ Read the matching ADR before proposing alternatives.
 | [ADR-025](adrs/ADR-025-reference-versioned-releases-surface-gate.md) | Versioned internal releases + public-surface (TS + schema) gate for the ref; partially supersedes ADR-014       |
 | [ADR-026](adrs/ADR-026-entity-card-design-rules.md)                  | **Entity card design rules** — one renderer, choice/stat-atom/modified-stats/tech-level rules (built)           |
 | [ADR-027](adrs/ADR-027-partners-owned-by-host.md)                    | Partners are owned by their host entity                                                                         |
-| [ADR-028](adrs/ADR-028-contribution-model-and-stat-provenance.md)    | **Proposed** — one contribution model for caps/traits/damage + stat provenance; amends ADR-022's overrides      |
+| [ADR-028](adrs/ADR-028-partners-render-in-place.md)                  | Partners render in place as reference entities; supersedes ADR-027                                              |
+| [ADR-029](adrs/ADR-029-contribution-model-and-stat-provenance.md)    | **Proposed** — one contribution model for caps/traits/damage + stat provenance; amends ADR-022's overrides      |
 
 > ADR-021 is the governing decision for rules enforcement and takes precedence
 > over prior ADRs where they conflict on _how hard a rule is enforced on which

--- a/docs/adrs/ADR-022-provenance-log-and-overrides.md
+++ b/docs/adrs/ADR-022-provenance-log-and-overrides.md
@@ -14,7 +14,7 @@ model this ADR serves.
 in the same field the rules derivation reads. See
 [Amendment](#amendment-2026-07-overrides-become-absolute-pins); the amendment is a
 hard prerequisite for
-[ADR-028](ADR-028-contribution-model-and-stat-provenance.md).
+[ADR-029](ADR-029-contribution-model-and-stat-provenance.md).
 
 ## Context
 
@@ -133,7 +133,7 @@ is why hand-entering Beefcake works at all, and why the Eldridge Coast pregens
 write these fields directly).
 
 The consequence is blocking. The moment a contribution applies automatically
-([ADR-028](ADR-028-contribution-model-and-stat-provenance.md)), it must not be
+([ADR-029](ADR-029-contribution-model-and-stat-provenance.md)), it must not be
 written there — or a **rules-legal bonus renders as a hand override**, complete
 with an "overridden from N" callout and an offer to revert it. The sheet would
 actively lie. No data backfill can proceed until this is separated.

--- a/docs/adrs/ADR-029-contribution-model-and-stat-provenance.md
+++ b/docs/adrs/ADR-029-contribution-model-and-stat-provenance.md
@@ -1,4 +1,4 @@
-# ADR-028: Unified Contribution Model & Stat Provenance
+# ADR-029: Unified Contribution Model & Stat Provenance
 
 ## Status
 

--- a/docs/design/rules-parity-plan.md
+++ b/docs/design/rules-parity-plan.md
@@ -1,7 +1,7 @@
 # Rules Parity & Stat Provenance — Delivery Plan
 
 > **Decisions live in the ADRs, not here.**
-> [ADR-028](../adrs/ADR-028-contribution-model-and-stat-provenance.md) (the
+> [ADR-029](../adrs/ADR-029-contribution-model-and-stat-provenance.md) (the
 > contribution model + provenance) and the
 > [ADR-022 amendment](../adrs/ADR-022-provenance-log-and-overrides.md#amendment-2026-07-overrides-become-absolute-pins)
 > (overrides become absolute pins) are authoritative. This document is the
@@ -54,7 +54,7 @@ Two traps worth carrying into the work, both verified:
 | Scope                  | **Full contextual parity** — all six phases below                                                                                                          |
 | Migration              | **Convert every `max*Modifier` to an absolute pin.** Lossless; no displayed number changes. Accepted cost: some sheets gain an override marker they lacked |
 | Model                  | **Converge the two engines** into one contribution vocabulary; widen where effects may be _declared_, leave `resolveChoiceView`'s application logic alone  |
-| Process                | **ADR-022 amendment + new ADR-028**, both before code                                                                                                      |
+| Process                | **ADR-022 amendment + new ADR-029**, both before code                                                                                                      |
 | Duration-bound effects | **In scope**, as `duration: activated` contributions applied only by the Dashboard against ephemeral play state (ADR-019)                                  |
 | Order                  | **Provenance first** (A→B), then the model and data (C→D), then Dashboard wiring (F)                                                                       |
 | Surfaces               | Live Sheet, Dashboard, **partner cards, Frozen snapshot, wizard previews, entity reference cards**                                                         |
@@ -67,7 +67,7 @@ Sizes use the repo's existing effort labels: **S** under 1 day · **M** 1–2 ·
 
 | ID     | Unit                        | Size | Depends | Done when                                                                                                                                                                                 |
 | ------ | --------------------------- | ---- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **A1** | ADR-022 amendment + ADR-028 | S    | —       | Both merged; `docs/README.md` index updated                                                                                                                                               |
+| **A1** | ADR-022 amendment + ADR-029 | S    | —       | Both merged; `docs/README.md` index updated                                                                                                                                               |
 | **A2** | Parity audit + CI gate      | M    | A1      | Scans every record stating a mechanical change; asserts a contribution or a reasoned exemption; names record + sentence on failure. Advisory for one week, then blocking                  |
 | **A3** | Absolute-pin overrides      | L    | A1      | `max*Override` replaces the six delta fields; IDB migration lossless (property test: no displayed maximum changes); `VitalGauge` reads an explicit `overridden` flag, never a subtraction |
 


### PR DESCRIPTION
Two ADRs both claimed **028** on `main`:

| File | Landed | Disposition |
| --- | --- | --- |
| `ADR-028-partners-render-in-place.md` | #590, 00:35 | **keeps 028** (first claim) |
| `ADR-028-contribution-model-and-stat-provenance.md` | #596, 01:15 | renumbered to **029** |

Every inbound reference to the contribution-model ADR moves with it — `docs/README.md`, `docs/design/rules-parity-plan.md` (3 spots), and the two links from `ADR-022`.

## Second bug, found while fixing the first

`docs/README.md`'s ADR index had **no row for the partners ADR at all**. It was never added when #590 landed, so the governing decision for how partners render was missing from the one table that is supposed to list every ADR. Added.

## Verification

- No duplicate ADR numbers remain — `ls docs/adrs | sed -E 's/(ADR-[0-9]+).*/\1/' | sort | uniq -d` returns empty
- Every ADR-to-ADR markdown link under `docs/` resolves to a file that exists — checked by script, 0 broken
- `format:check` (the CI gate) passes

The bare `ADR-028` references left in `ADR-027` and in `apps/itun/src/**` are correct as-is — all of them refer to partners.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014m6W8yMd1FM3Roumj9x4Zj