### PR TITLE
fix(observability): point the CSP at Sentry's EU ingest region

### DIFF
--- a/apps/itun/netlify.toml
+++ b/apps/itun/netlify.toml
@@ -102,9 +102,13 @@
     # event before it leaves the page, so a provisioned DSN would report zero
     # errors and look healthy. Kept in lockstep with SENTRY_INGEST_HOST in
     # tools/check-observability.ts, which fails CI if this drifts. Wildcarded
-    # subdomain because the host encodes the Sentry org id; `us` is the default
-    # data region (an EU org uses `de`).
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://storage.ko-fi.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://ingesteer.services-prod.nsvcs.net https://*.ingest.us.sentry.io;"
+    # subdomain because the host encodes the Sentry org id.
+    #
+    # `de`, not `us`: this org is in Sentry's EU data region. A DSN issued in
+    # one region under a CSP written for the other is blocked in the browser and
+    # the project reports nothing — identical, from the outside, to "no errors".
+    # The nightly live probe now compares this against the DSN actually shipped.
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://storage.ko-fi.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://ingesteer.services-prod.nsvcs.net https://*.ingest.de.sentry.io;"
     X-DNS-Prefetch-Control = "on"
 
 [[headers]]

--- a/apps/srd/netlify.toml
+++ b/apps/srd/netlify.toml
@@ -85,8 +85,13 @@
     # failure mode is silent AND looks healthy (zero errors reported). Kept in
     # lockstep with SENTRY_INGEST_HOST in tools/check-observability.ts, which
     # fails CI if this drifts. Wildcarded subdomain because the host encodes the
-    # Sentry org id; `us` is the default data region (an EU org uses `de`).
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://storage.ko-fi.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://ingesteer.services-prod.nsvcs.net https://*.ingest.us.sentry.io;"
+    # Sentry org id.
+    #
+    # `de`, not `us`: this org is in Sentry's EU data region. A DSN issued in
+    # one region under a CSP written for the other is blocked in the browser and
+    # the project reports nothing — identical, from the outside, to "no errors".
+    # The nightly live probe now compares this against the DSN actually shipped.
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://storage.ko-fi.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://ingesteer.services-prod.nsvcs.net https://*.ingest.de.sentry.io;"
     X-DNS-Prefetch-Control = "on"
 
 # Astro hashed assets - immutable cache

--- a/tools/check-observability.ts
+++ b/tools/check-observability.ts
@@ -49,11 +49,23 @@ import { join } from 'node:path'
  * Wildcarded at the subdomain because the host encodes the Sentry org id
  * (`o<orgid>.ingest.<region>.sentry.io`); pinning the literal org would mean a
  * CSP edit every time a project moves org, and the wildcard is still tightly
- * scoped to Sentry's ingest domain. `us` is Sentry's default data region — an
- * EU-region org ingests at `*.ingest.de.sentry.io`, so this constant (and the
- * two netlify.toml CSPs that must match it) is the single place to change.
+ * scoped to Sentry's ingest domain.
+ *
+ * The REGION is the part that bites. This org is in the EU (`de`); Sentry's
+ * default is `us`, and a DSN issued in one region is silently unusable under a
+ * CSP written for the other — the beacon is blocked in the browser and the
+ * project simply reports nothing, which looks exactly like "no errors". This
+ * constant and the two netlify.toml CSPs must agree, and `checkLive` below also
+ * compares them against the host in the DSN actually shipped to production, so
+ * a region mismatch fails loudly instead of going quiet.
  */
-const SENTRY_INGEST_HOST = 'https://*.ingest.us.sentry.io'
+const SENTRY_INGEST_HOST = 'https://*.ingest.de.sentry.io'
+
+/** The `*.ingest.<region>.sentry.io` suffix implied by SENTRY_INGEST_HOST. */
+const SENTRY_INGEST_SUFFIX = SENTRY_INGEST_HOST.replace('https://*', '')
+
+/** A Sentry DSN as it appears inlined in a built bundle. */
+const DSN_IN_BUNDLE = /https:\/\/[0-9a-f]{16,}@([a-z0-9.-]+\.ingest\.[a-z0-9.-]*sentry\.io)\//i
 
 /** A marker that only appears once the Sentry SDK is really in a bundle. */
 const SDK_MARKER = /sentry/i
@@ -179,24 +191,45 @@ async function checkLive(app: BrowserApp): Promise<void> {
     return
   }
 
+  // The SDK and the inlined DSN can land in different chunks, so scan them all
+  // rather than returning on the first hit.
+  let sdkFoundIn: string | null = null
+  let dsnHost: string | null = null
+
   for (const url of urls) {
     try {
       const body = await (await fetch(url)).text()
-      if (SDK_MARKER.test(body)) {
-        console.log(`  [${app.name}] Sentry SDK present in ${url}`)
-        return
-      }
+      if (!sdkFoundIn && SDK_MARKER.test(body)) sdkFoundIn = url
+      if (!dsnHost) dsnHost = body.match(DSN_IN_BUNDLE)?.[1] ?? null
     } catch {
       // A single unreachable chunk is not proof of absence; keep looking.
     }
   }
 
-  fail(
-    app.name,
-    `Sentry SDK absent from all ${urls.length} script(s) served by ${app.productionUrl}.\n` +
-      `      The DSN (${app.dsnEnvVar}) is almost certainly unset on the Netlify site, so the\n` +
-      `      SDK was tree-shaken out of the build. Error tracking is DARK in production.`
-  )
+  if (!sdkFoundIn) {
+    fail(
+      app.name,
+      `Sentry SDK absent from all ${urls.length} script(s) served by ${app.productionUrl}.\n` +
+        `      The DSN (${app.dsnEnvVar}) is almost certainly unset on the Netlify site, so the\n` +
+        `      SDK was tree-shaken out of the build. Error tracking is DARK in production.`
+    )
+    return
+  }
+
+  console.log(`  [${app.name}] Sentry SDK present in ${sdkFoundIn}`)
+
+  // Region check. A DSN issued in one Sentry data region under a CSP written
+  // for the other yields a project that reports nothing at all — which is
+  // indistinguishable from "no errors happened". Compare what production is
+  // actually configured to talk to against what the CSP permits.
+  if (dsnHost && !dsnHost.endsWith(SENTRY_INGEST_SUFFIX)) {
+    fail(
+      app.name,
+      `DSN ships events to ${dsnHost}, but the CSP only allows ${SENTRY_INGEST_HOST}.\n` +
+        `      Every event will be blocked in the browser and the project will look silent.\n` +
+        `      Fix SENTRY_INGEST_HOST here and the connect-src in ${app.netlifyTomlPath}.`
+    )
+  }
 }
 
 const live = process.argv.includes('--live')


### PR DESCRIPTION
The Sentry org for these projects is in the **EU data region** — every DSN
issued for it ingests at `*.ingest.de.sentry.io`, not the `us` default the CSP
was written against in #601.

Left alone, this would have been the *worst* shape of the original bug rather
than a fix for it: the DSN provisioned, the SDK shipping, the app looking
correctly instrumented — and the browser blocking every single event at the CSP
before it left the page. The Sentry project reports nothing, which from the
outside is indistinguishable from "no errors are happening".

`SENTRY_INGEST_HOST` and both `netlify.toml` CSPs move to `de` together. The
static wiring check already fails CI if those three ever disagree.

## Closing the gap that made this possible

The static check can only prove the CSP matches a constant **in this repo**. It
has no way to know which region the real DSN belongs to, because the DSN lives
in the deploy environment — so a us/de mismatch was undetectable by
construction.

The `--live` probe now extracts the ingest host from the DSN actually inlined in
the production bundle and asserts the CSP permits it:

```
[itun] DSN ships events to o…ingest.us.sentry.io, but the CSP only allows
       https://*.ingest.de.sentry.io.
       Every event will be blocked in the browser and the project will look silent.
```

So the repo checks what it can prove statically, and the nightly probe checks
the half only production knows.

## Verification

- `git grep ingest.us.sentry` over tracked source: no matches.
- Static check passes; negative-tested by reverting the constant to `us`, which
  fails with the CSP mismatch message, then restored.
- `bun run check:all` green.
- The live region assertion is exercised for real once the DSNs deploy; until
  then production has no DSN to compare against.

## Follow-up in this same batch

All four DSNs are now stored in the `claude-agent` 1Password vault as
`sentry-dsn-{srd,itun,itun-functions,discord-bot}`, and the Netlify/Render env
vars are being set separately (not a code change).