### PR TITLE
fix(observability): probe the CSP production SERVES, not the one this repo declares

### DIFF
--- a/tools/check-observability.ts
+++ b/tools/check-observability.ts
@@ -61,9 +61,6 @@ import { join } from 'node:path'
  */
 const SENTRY_INGEST_HOST = 'https://*.ingest.de.sentry.io'
 
-/** The `*.ingest.<region>.sentry.io` suffix implied by SENTRY_INGEST_HOST. */
-const SENTRY_INGEST_SUFFIX = SENTRY_INGEST_HOST.replace('https://*', '')
-
 /** A Sentry DSN as it appears inlined in a built bundle. */
 const DSN_IN_BUNDLE = /https:\/\/[0-9a-f]{16,}@([a-z0-9.-]+\.ingest\.[a-z0-9.-]*sentry\.io)\//i
 
@@ -119,11 +116,30 @@ function read(path: string): string | null {
  * Returns null when the file declares no CSP at all (which is itself a finding
  * for an app that ships one).
  */
+function connectSrcOfPolicy(policy: string): string | null {
+  const directive = policy.split(';').find((d) => d.trim().startsWith('connect-src'))
+  return directive ? directive.trim() : null
+}
+
 function connectSrcOf(toml: string): string | null {
   const csp = toml.match(/Content-Security-Policy\s*=\s*"([^"]*)"/)
-  if (!csp) return null
-  const directive = csp[1].split(';').find((d) => d.trim().startsWith('connect-src'))
-  return directive ? directive.trim() : null
+  return csp ? connectSrcOfPolicy(csp[1]) : null
+}
+
+/**
+ * Would this `connect-src` actually let a beacon reach `host`? Handles the two
+ * source forms that matter here — an exact origin and a leftmost-subdomain
+ * wildcard — rather than string-matching a constant, so the answer is about the
+ * policy being served rather than about what this repo believes it declared.
+ */
+function connectSrcPermits(connectSrc: string, host: string): boolean {
+  return connectSrc
+    .split(/\s+/)
+    .slice(1) // drop the "connect-src" directive name itself
+    .some((source) => {
+      const bare = source.replace(/^https?:\/\//, '').replace(/\/$/, '')
+      return bare.startsWith('*.') ? host.endsWith(bare.slice(1)) : bare === host
+    })
 }
 
 function checkStatic(app: BrowserApp): void {
@@ -173,12 +189,18 @@ function scriptUrls(html: string, origin: string): string[] {
 
 async function checkLive(app: BrowserApp): Promise<void> {
   let html: string
+  // The CSP as ACTUALLY SERVED. Checking the repo's own constant here would be
+  // circular — the whole point of a live probe is to test the deployed truth,
+  // and a CSP can lag a merge, be overridden in the Netlify UI, or come from a
+  // _headers file this repo never sees.
+  let servedCsp: string | null = null
   try {
     const res = await fetch(app.productionUrl, { redirect: 'follow' })
     if (!res.ok) {
       fail(app.name, `production fetch failed: HTTP ${res.status} ${app.productionUrl}`)
       return
     }
+    servedCsp = res.headers.get('content-security-policy')
     html = await res.text()
   } catch (error) {
     fail(app.name, `production unreachable (${app.productionUrl}): ${String(error)}`)
@@ -218,18 +240,38 @@ async function checkLive(app: BrowserApp): Promise<void> {
 
   console.log(`  [${app.name}] Sentry SDK present in ${sdkFoundIn}`)
 
-  // Region check. A DSN issued in one Sentry data region under a CSP written
-  // for the other yields a project that reports nothing at all — which is
-  // indistinguishable from "no errors happened". Compare what production is
-  // actually configured to talk to against what the CSP permits.
-  if (dsnHost && !dsnHost.endsWith(SENTRY_INGEST_SUFFIX)) {
+  // The end-to-end assertion: does the CSP production is SERVING actually let
+  // the DSN production is SHIPPING send anything? A mismatch (most easily a
+  // us/de region slip) yields a project that reports nothing at all, which is
+  // indistinguishable from "no errors happened" — the failure this whole file
+  // exists to make loud.
+  //
+  // Verified against the real thing: with a `de` DSN deployed under the old
+  // `us` CSP, an earlier version of this probe that compared the DSN to
+  // SENTRY_INGEST_HOST (a constant in THIS repo) reported OK, because the repo
+  // constant had already been updated while production had not. Comparing
+  // against the served header is what catches it.
+  if (!dsnHost) {
+    console.log(`  [${app.name}] no DSN inlined in the bundle — skipping CSP reachability check`)
+    return
+  }
+  const servedConnectSrc = servedCsp ? connectSrcOfPolicy(servedCsp) : null
+  if (!servedConnectSrc) {
+    fail(app.name, `production serves no CSP connect-src; cannot confirm Sentry is reachable`)
+    return
+  }
+  if (!connectSrcPermits(servedConnectSrc, dsnHost)) {
     fail(
       app.name,
-      `DSN ships events to ${dsnHost}, but the CSP only allows ${SENTRY_INGEST_HOST}.\n` +
-        `      Every event will be blocked in the browser and the project will look silent.\n` +
-        `      Fix SENTRY_INGEST_HOST here and the connect-src in ${app.netlifyTomlPath}.`
+      `production ships a DSN pointing at ${dsnHost}, but the CSP it SERVES does not\n` +
+        `      permit that origin, so every event is blocked in the browser and the Sentry\n` +
+        `      project looks silent.\n` +
+        `      served: ${servedConnectSrc}\n` +
+        `      expected to allow: ${SENTRY_INGEST_HOST}`
     )
+    return
   }
+  console.log(`  [${app.name}] served CSP permits ${dsnHost}`)
 }
 
 const live = process.argv.includes('--live')


### PR DESCRIPTION
The live probe compared the DSN's ingest host against `SENTRY_INGEST_HOST` — a
constant **in this repo**. That is circular, and it produced a false PASS
against real production the moment it mattered.

## What actually happened

Observed, not hypothesised:

1. #607 changed the constant and both `netlify.toml` CSPs from `us` to `de`, and merged.
2. The Netlify sites had not redeployed yet — so they were still **serving** the
   `us` CSP while already **shipping** a `de` DSN.
3. Every event was therefore blocked in the browser and Sentry was silent.
4. The probe read the repo's already-correct constant, matched it against the
   DSN, and reported:

```
✓ observability probe OK
```

The precise failure this file exists to make loud, green-lit by the check meant
to catch it.

A live probe that consults the repo cannot see a deploy that hasn't happened, a
CSP overridden in the Netlify UI, or one coming from a `_headers` file this repo
never sees.

## The fix

Read the `content-security-policy` **response header** from production and ask
whether that policy actually permits the host the shipped DSN points at — via a
real source-list matcher (exact origin, or leftmost-subdomain wildcard) rather
than a string compare against a constant.

Against the identical production state it now correctly fails:

```
✗ observability probe failed:
  [srd] production ships a DSN pointing at o4511811110764544.ingest.de.sentry.io,
      but the CSP it SERVES does not permit that origin, so every event is blocked
      in the browser and the Sentry project looks silent.
      served: connect-src 'self' https://ingesteer.services-prod.nsvcs.net https://*.ingest.us.sentry.io
      expected to allow: https://*.ingest.de.sentry.io
```

Exit code 1, confirmed separately from the pipeline.

## Division of labour, now clean

| check | runs | proves |
|---|---|---|
| static | every PR | the **repo** is internally consistent (module ↔ entry ↔ CSP ↔ constant) |
| `--live` | nightly | the **deployment** actually works — and consults nothing but the deployment |

Also drops the now-unused `SENTRY_INGEST_SUFFIX`.

`bun run check:all` green; static check still exits 0, live probe exits 1 against
current production (correctly, until the `de` CSP finishes deploying).