### PR TITLE
feat(itun): wire stat provenance into the Live Sheets and the Dashboard

### DIFF
--- a/apps/itun/src/components/dashboard/dialItems.ts
+++ b/apps/itun/src/components/dashboard/dialItems.ts
@@ -11,11 +11,11 @@
  */
 
 import {
-  crawlerMaxSP,
-  mechMaxHeat,
-  mechMaxSP,
-  pilotMaxAP,
-  pilotMaxHP,
+  crawlerMaxSPParts,
+  mechMaxSPParts,
+  mechMaxHeatParts,
+  pilotMaxHPParts,
+  pilotMaxAPParts,
 } from '../../lib/rules/derivedStats'
 import { resolveChassisRef } from 'salvageunion-reference/rules'
 import type { CockpitPrefs, DialKind } from '../../lib/schemas/cockpitPrefs'
@@ -24,6 +24,7 @@ import type { Mech } from '../../lib/schemas/mech'
 import type { Pilot } from '../../lib/schemas/pilot'
 import type { MountState } from '../../stores/playStateStore'
 import type { DialItem as DialCellItem } from 'component-lib'
+import { linesFromBreakdown } from 'component-lib'
 
 export type DialItem = DialCellItem & { kind: DialKind }
 
@@ -41,8 +42,10 @@ export const DIAL_KIND_LABELS: Record<DialKind, string> = {
 export const LOCKED_DIAL_KIND: DialKind = 'actions'
 
 function pilotItem(pilot: Pilot): DialItem {
-  const maxHP = Math.max(0, pilotMaxHP(pilot))
-  const maxAP = Math.max(0, pilotMaxAP(pilot))
+  const hpParts = pilotMaxHPParts(pilot)
+  const apParts = pilotMaxAPParts(pilot)
+  const maxHP = Math.max(0, hpParts.total)
+  const maxAP = Math.max(0, apParts.total)
   return {
     key: `pilot:${pilot.id}`,
     kind: 'pilot',
@@ -50,16 +53,38 @@ function pilotItem(pilot: Pilot): DialItem {
     label: `Pilot · ${pilot.name}`,
     tone: 'pilot',
     gauges: [
-      { label: 'HP', value: Math.min(pilot.currentHP ?? maxHP, maxHP), max: maxHP, tone: 'pilot' },
-      { label: 'AP', value: Math.min(pilot.currentAP ?? maxAP, maxAP), max: maxAP, tone: 'pilot' },
+      {
+        label: 'HP',
+        value: Math.min(pilot.currentHP ?? maxHP, maxHP),
+        max: maxHP,
+        tone: 'pilot',
+        provenance: linesFromBreakdown(hpParts, {
+          base: 'Pilot',
+          baseDetail: 'base',
+          installed: 'Injuries',
+          installedDetail: 'rules A11',
+        }),
+        ...(hpParts.overridden ? { derivedMax: hpParts.derived } : {}),
+      },
+      {
+        label: 'AP',
+        value: Math.min(pilot.currentAP ?? maxAP, maxAP),
+        max: maxAP,
+        tone: 'pilot',
+        provenance: linesFromBreakdown(apParts, { base: 'Pilot', baseDetail: 'base' }),
+        ...(apParts.overridden ? { derivedMax: apParts.derived } : {}),
+      },
     ],
   }
 }
 
 function mechItem(mech: Mech): DialItem {
   const chassis = resolveChassisRef(mech.chassisRef)
-  const maxSP = mechMaxSP(mech, chassis)
-  const maxHeat = mechMaxHeat(mech, chassis)
+  const spParts = mechMaxSPParts(mech, chassis)
+  const heatParts = mechMaxHeatParts(mech, chassis)
+  const maxSP = spParts.total
+  const maxHeat = heatParts.total
+  const chassisLabel = `${chassis?.name ?? mech.chassisRef} chassis`
   return {
     key: `mech:${mech.id}`,
     kind: 'mech',
@@ -67,20 +92,38 @@ function mechItem(mech: Mech): DialItem {
     label: `Mech · ${mech.name}`,
     tone: 'mech',
     gauges: [
-      { label: 'SP', value: Math.min(mech.currentSP ?? maxSP, maxSP), max: maxSP, tone: 'mech' },
+      {
+        label: 'SP',
+        value: Math.min(mech.currentSP ?? maxSP, maxSP),
+        max: maxSP,
+        tone: 'mech',
+        provenance: linesFromBreakdown(spParts, {
+          base: chassisLabel,
+          baseDetail: 'base',
+          installed: 'Installed systems & modules',
+        }),
+        ...(spParts.overridden ? { derivedMax: spParts.derived } : {}),
+      },
       {
         label: 'Heat',
         value: Math.min(mech.currentHeat ?? 0, maxHeat),
         max: maxHeat,
         tone: 'mech',
         danger: Math.max(0, maxHeat - 2),
+        provenance: linesFromBreakdown(heatParts, {
+          base: chassisLabel,
+          baseDetail: 'base',
+          installed: 'Installed systems & modules',
+        }),
+        ...(heatParts.overridden ? { derivedMax: heatParts.derived } : {}),
       },
     ],
   }
 }
 
 function crawlerItem(crawler: Crawler): DialItem {
-  const maxSP = crawlerMaxSP(crawler)
+  const spParts = crawlerMaxSPParts(crawler)
+  const maxSP = spParts.total
   return {
     key: `crawler:${crawler.id}`,
     kind: 'crawler',
@@ -93,6 +136,12 @@ function crawlerItem(crawler: Crawler): DialItem {
         value: Math.min(crawler.currentSP ?? maxSP, maxSP),
         max: maxSP,
         tone: 'crawler',
+        provenance: linesFromBreakdown(spParts, {
+          base: `Tech ${crawler.techLevel?.replace(/\D/g, '') || '?'} Crawler`,
+          baseDetail: 'base',
+          installed: 'Crawler type bonus',
+        }),
+        ...(spParts.overridden ? { derivedMax: spParts.derived } : {}),
       },
     ],
   }

--- a/apps/itun/src/components/sheet/MechSheet.tsx
+++ b/apps/itun/src/components/sheet/MechSheet.tsx
@@ -81,6 +81,7 @@ import { StorageManifest } from './StorageManifest'
 import { freshEntity } from './controlPrimitives'
 import type { SheetPatch } from './sheetViewProps'
 import { LIVE_SHEET_MANUAL, LIVE_SHEET_OVERRIDE } from '../../stores/surfaceProvenance'
+import { linesFromBreakdown } from 'component-lib'
 
 // Narrow subset of chassis data the stat derivations need
 type ChassisLike = {
@@ -194,6 +195,24 @@ export function MechSheet({
     ? (SalvageUnionReference.resolveActions(chassisEntity) ?? [])
     : []
   const chassisName = chassisEntity?.name ?? chassis?.name ?? mech.chassisRef
+
+  // Stat provenance ledgers (ADR-029). The installed line is a single aggregate
+  // until the contribution model can attribute it per item.
+  const spLines = linesFromBreakdown(spParts, {
+    base: `${chassisName} chassis`,
+    baseDetail: 'base',
+    installed: 'Installed systems & modules',
+  })
+  const epLines = linesFromBreakdown(epParts, {
+    base: `${chassisName} chassis`,
+    baseDetail: 'base',
+    installed: 'Installed systems & modules',
+  })
+  const heatLines = linesFromBreakdown(heatParts, {
+    base: `${chassisName} chassis`,
+    baseDetail: 'base',
+    installed: 'Installed systems & modules',
+  })
   const techLevel =
     typeof chassisEntity?.techLevel === 'number' ? chassisEntity.techLevel : undefined
 
@@ -558,6 +577,7 @@ export function MechSheet({
                   : (next) => overrideMechMax({ maxSpOverride: pinOrUndef(next, spParts.derived) })
               }
               overriddenFrom={readOnly || !spParts.overridden ? undefined : spParts.derived}
+              provenance={spLines}
               onRevertOverride={
                 readOnly ? undefined : () => overrideMechMax({ maxSpOverride: undefined })
               }
@@ -575,6 +595,7 @@ export function MechSheet({
                   : (next) => overrideMechMax({ maxEpOverride: pinOrUndef(next, epParts.derived) })
               }
               overriddenFrom={readOnly || !epParts.overridden ? undefined : epParts.derived}
+              provenance={epLines}
               onRevertOverride={
                 readOnly ? undefined : () => overrideMechMax({ maxEpOverride: undefined })
               }
@@ -593,6 +614,7 @@ export function MechSheet({
                       overrideMechMax({ maxHeatOverride: pinOrUndef(next, heatParts.derived) })
               }
               overriddenFrom={readOnly || !heatParts.overridden ? undefined : heatParts.derived}
+              provenance={heatLines}
               onRevertOverride={
                 readOnly ? undefined : () => overrideMechMax({ maxHeatOverride: undefined })
               }

--- a/apps/itun/src/components/sheet/PilotSheet.tsx
+++ b/apps/itun/src/components/sheet/PilotSheet.tsx
@@ -77,6 +77,7 @@ import {
 import { PartnerCard } from './PartnerCard'
 import { resolveAbility } from './pilotAbilities'
 import { LIVE_SHEET_MANUAL, LIVE_SHEET_OVERRIDE } from '../../stores/surfaceProvenance'
+import { linesFromBreakdown } from 'component-lib'
 
 /**
  * The tree every pilot has regardless of class (Repair, Scrap, Mount, …).
@@ -307,6 +308,17 @@ export function PilotSheet({
 
   const hpParts = pilotMaxHPParts(pilot)
   const apParts = pilotMaxAPParts(pilot)
+
+  // Stat provenance ledgers (ADR-029). Injuries ride the contribution line —
+  // a negative rules-sourced addend, derived from `injuries` so healing restores
+  // max HP with no bookkeeping.
+  const hpLines = linesFromBreakdown(hpParts, {
+    base: 'Pilot',
+    baseDetail: 'base',
+    installed: 'Injuries',
+    installedDetail: 'rules A11',
+  })
+  const apLines = linesFromBreakdown(apParts, { base: 'Pilot', baseDetail: 'base' })
   const maxHP = Math.max(0, hpParts.total)
   const maxAP = Math.max(0, apParts.total)
   const hp = Math.min(pilot.currentHP ?? maxHP, maxHP)
@@ -537,6 +549,7 @@ export function PilotSheet({
                   : (next) => overridePilotMax({ maxHpOverride: pinOrUndef(next, hpParts.derived) })
               }
               overriddenFrom={readOnly || !hpParts.overridden ? undefined : hpParts.derived}
+              provenance={hpLines}
               onRevertOverride={
                 readOnly ? undefined : () => overridePilotMax({ maxHpOverride: undefined })
               }
@@ -553,6 +566,7 @@ export function PilotSheet({
                   : (next) => overridePilotMax({ maxApOverride: pinOrUndef(next, apParts.derived) })
               }
               overriddenFrom={readOnly || !apParts.overridden ? undefined : apParts.derived}
+              provenance={apLines}
               onRevertOverride={
                 readOnly ? undefined : () => overridePilotMax({ maxApOverride: undefined })
               }

--- a/apps/itun/src/components/sheet/SheetCrawler.tsx
+++ b/apps/itun/src/components/sheet/SheetCrawler.tsx
@@ -33,6 +33,7 @@ import { AppLink } from '../shared/AppLink'
 import { bayStates, mechRailItems, mechStatusPill, pilotRailItems, rowStats } from './railStats'
 import type { SheetViewCommonProps } from './sheetViewProps'
 import { LIVE_SHEET_OVERRIDE } from '../../stores/surfaceProvenance'
+import { linesFromBreakdown } from 'component-lib'
 
 type SheetCrawlerProps = SheetViewCommonProps & { crawler: Crawler }
 
@@ -56,6 +57,11 @@ export function SheetCrawler({
 
   const spParts = crawlerMaxSPParts(crawler)
   const maxSP = spParts.total
+  const spLines = linesFromBreakdown(spParts, {
+    base: `Tech ${crawler.techLevel?.replace(/\D/g, '') || '?'} Crawler`,
+    baseDetail: 'base',
+    installed: 'Crawler type bonus',
+  })
   const sp = Math.min(crawler.currentSP ?? maxSP, maxSP)
   // Cap override (ADR-022, Free Edit): pin Max SP via a signed maxSpModifier
   // delta; the gauge shows "overridden from N" + a revert. Tagged `override`.
@@ -243,6 +249,7 @@ export function SheetCrawler({
               : undefined
           }
           overriddenFrom={editable && spParts.overridden ? spParts.derived : undefined}
+          provenance={spLines}
           onRevertOverride={
             editable ? () => overrideCrawlerMax({ maxSpOverride: undefined }) : undefined
           }

--- a/packages/component-lib/src/components/dashboard/DashboardGauge.tsx
+++ b/packages/component-lib/src/components/dashboard/DashboardGauge.tsx
@@ -13,6 +13,7 @@
 
 import type { CSSVarStyle } from '../../styles/cssVars'
 import { VitalGauge } from '../stat/VitalGauge'
+import type { ProvenanceLine } from '../stat/StatProvenance'
 
 export type GaugeTone = 'mech' | 'pilot' | 'crawler'
 
@@ -29,9 +30,29 @@ export type DashboardGaugeProps = {
   tone?: GaugeTone
   /** First 0-based segment index that reads as danger (redline) when filled. */
   danger?: number
+  /**
+   * Ledger explaining how `max` was derived (ADR-029). Guided Play teaches as it
+   * enforces (ADR-021), so the instrument carries this too — it used to discard
+   * the gauge's override/provenance props entirely.
+   */
+  provenance?: ProvenanceLine[]
+  /**
+   * The value this max would derive to without a Free-Edit pin. Supplying it
+   * flags the max as overridden. Must be the DERIVED value, not `max` — the
+   * gauge treats `overriddenFrom === max` as "not overridden".
+   */
+  derivedMax?: number
 }
 
-export function DashboardGauge({ label, value, max, tone = 'mech', danger }: DashboardGaugeProps) {
+export function DashboardGauge({
+  label,
+  value,
+  max,
+  tone = 'mech',
+  danger,
+  provenance,
+  derivedMax,
+}: DashboardGaugeProps) {
   const [t, td] = TONES[tone]
   const toneStyle: CSSVarStyle = { '--tone': t, '--tone-deep': td }
   return (
@@ -43,6 +64,8 @@ export function DashboardGauge({ label, value, max, tone = 'mech', danger }: Das
       value={value}
       max={max}
       danger={danger}
+      provenance={provenance}
+      overriddenFrom={derivedMax}
       style={toneStyle}
     />
   )

--- a/packages/component-lib/src/components/dashboard/Dial.tsx
+++ b/packages/component-lib/src/components/dashboard/Dial.tsx
@@ -23,6 +23,7 @@ import { useCallback, useEffect, useRef, useState, type PointerEvent, type React
 import { useEscapeKey } from '../../hooks/useEscapeKey'
 import { Button } from '../chrome/Button'
 import { DashboardGauge, type GaugeTone } from './DashboardGauge'
+import type { ProvenanceLine } from '../stat/StatProvenance'
 
 export type DialGauge = {
   label: string
@@ -31,6 +32,10 @@ export type DialGauge = {
   tone: GaugeTone
   /** First 0-based segment index that reads as danger (redline) when filled. */
   danger?: number
+  /** Ledger explaining how `max` was derived (ADR-029). */
+  provenance?: ProvenanceLine[]
+  /** The value `max` would derive to without a Free-Edit pin. */
+  derivedMax?: number
 }
 
 /** A presentational dial entry. Statless entries are a centered title (Actions /
@@ -99,6 +104,8 @@ function DialCell({
             max={g.max}
             tone={g.tone}
             danger={g.danger}
+            provenance={g.provenance}
+            derivedMax={g.derivedMax}
           />
         ))}
       </div>

--- a/packages/component-lib/src/components/dashboard/__tests__/DashboardGauge.provenance.test.tsx
+++ b/packages/component-lib/src/components/dashboard/__tests__/DashboardGauge.provenance.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * The Dashboard used to silently DROP the gauge's override/provenance props:
+ * `DashboardGauge` never forwarded them, and `VitalGauge`'s compact branch
+ * returned before any of that chrome rendered. ADR-021 requires Guided Play to
+ * teach as it enforces, so this pins the fix at both layers.
+ */
+
+import { describe, expect, test, afterEach } from 'bun:test'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { DashboardGauge } from '../DashboardGauge'
+import type { ProvenanceLine } from '../../stat/StatProvenance'
+
+afterEach(cleanup)
+
+const LINES: ProvenanceLine[] = [
+  { kind: 'base', label: 'Atlas chassis', detail: 'base', amount: 18 },
+  { kind: 'contribution', label: 'Installed systems & modules', amount: 10 },
+]
+
+describe('DashboardGauge — provenance (ADR-021 teach-as-you-enforce)', () => {
+  test('the compact instrument exposes a provenance trigger', () => {
+    render(<DashboardGauge label="SP" value={20} max={28} provenance={LINES} />)
+    expect(screen.getByRole('button', { name: /max sp: how this is derived/i })).toBeTruthy()
+  })
+
+  test('opening it shows the derivation', async () => {
+    render(<DashboardGauge label="SP" value={20} max={28} provenance={LINES} />)
+    fireEvent.click(screen.getByRole('button', { name: /how this is derived/i }))
+    await waitFor(() => expect(screen.getByText('Atlas chassis')).toBeTruthy())
+    expect(screen.getByText('Installed systems & modules')).toBeTruthy()
+  })
+
+  test('with no provenance the instrument renders no trigger', () => {
+    render(<DashboardGauge label="SP" value={20} max={28} />)
+    expect(screen.queryByRole('button', { name: /how this is derived/i })).toBeNull()
+  })
+
+  test('derivedMax must differ from max to read as overridden', () => {
+    // Regression: passing `max` here silently never flags — the gauge treats
+    // overriddenFrom === max as "not overridden".
+    render(<DashboardGauge label="SP" value={20} max={28} provenance={LINES} derivedMax={28} />)
+    expect(screen.getByText('ⓘ')).toBeTruthy()
+    cleanup()
+    render(<DashboardGauge label="SP" value={20} max={28} provenance={LINES} derivedMax={22} />)
+    expect(screen.getByText('*')).toBeTruthy()
+  })
+})

--- a/packages/component-lib/src/components/stat/VitalGauge.tsx
+++ b/packages/component-lib/src/components/stat/VitalGauge.tsx
@@ -5,6 +5,8 @@ import { cn } from '../../utils/cn'
 import type { SizeRung } from '../../styles/sizing'
 import { POSTER_STAMP } from '../chrome/posterStamp'
 import { pipClickValue, statBlockRowStarts, trackSegmentState } from './pipRows'
+import { StatProvenance } from './StatProvenance'
+import type { ProvenanceLine } from './StatProvenance'
 
 export type VitalGaugeProps = {
   /** Stamp label, e.g. 'HP', 'SP', 'Heat'. */
@@ -31,6 +33,17 @@ export type VitalGaugeProps = {
   overriddenFrom?: number
   /** Revert the cap override back to its derived baseline. */
   onRevertOverride?: () => void
+  /**
+   * Ledger explaining how `max` was derived (ADR-029). When supplied, a small
+   * marker beside the numeral opens the StatProvenance panel on hover, focus or
+   * tap.
+   *
+   * It is deliberately NOT the numeral itself: the numeral is already the
+   * click-to-edit override affordance, so one click would have to mean two
+   * things. When the stat is overridden the existing `*` marker becomes the
+   * trigger — it already signals "there is something here to explain".
+   */
+  provenance?: ProvenanceLine[]
   /** Caption pair, right-aligned under the track. Defaults to Current / Max. */
   caption?: [string, string]
   /** Non-interactive read-out (role="img"); over-capacity segments read red. */
@@ -81,6 +94,7 @@ export function VitalGauge({
   onMaxChange,
   overriddenFrom,
   onRevertOverride,
+  provenance,
   caption,
   readOnly,
   danger,
@@ -239,6 +253,26 @@ export function VitalGauge({
         >
           {shown}/{max}
         </span>
+        {/*
+         * Guided Play teaches as it enforces (ADR-021), so the compact
+         * instrument carries provenance too. This branch used to return before
+         * any of the override/provenance chrome, which is why the Dashboard
+         * silently dropped both props.
+         */}
+        {provenance && (
+          <StatProvenance
+            statLabel={`Max ${label}`}
+            lines={provenance}
+            total={max}
+            overridden={isOverridden}
+            className={cn(
+              'shrink-0 border-b-0 text-label leading-none',
+              onDark ? 'text-paper/60 hover:text-paper' : 'text-wk-muted hover:text-ink'
+            )}
+          >
+            {isOverridden ? '*' : 'ⓘ'}
+          </StatProvenance>
+        )}
       </div>
     )
   }
@@ -318,13 +352,34 @@ export function VitalGauge({
           ) : (
             <span className={cn('text-readout text-ink/70')}>{max}</span>
           )}
-          {isOverridden && (
-            <sup
-              title={`Overridden from ${overriddenFrom}`}
-              className="ml-0.5 text-label font-bold text-[var(--tone-deep)]"
+          {isOverridden &&
+            (provenance ? (
+              <StatProvenance
+                statLabel={`Max ${label}`}
+                lines={provenance}
+                total={max}
+                overridden
+                className="ml-0.5 border-b-0 align-super text-label font-bold text-[var(--tone-deep)]"
+              >
+                *
+              </StatProvenance>
+            ) : (
+              <sup
+                title={`Overridden from ${overriddenFrom}`}
+                className="ml-0.5 text-label font-bold text-[var(--tone-deep)]"
+              >
+                *
+              </sup>
+            ))}
+          {!isOverridden && provenance && (
+            <StatProvenance
+              statLabel={`Max ${label}`}
+              lines={provenance}
+              total={max}
+              className="ml-1 border-b-0 align-middle text-label leading-none text-wk-muted hover:text-ink"
             >
-              *
-            </sup>
+              ⓘ
+            </StatProvenance>
           )}
           {isOverridden && onRevertOverride && !editingMax && (
             <button

--- a/packages/component-lib/src/components/stat/__tests__/provenanceLines.test.ts
+++ b/packages/component-lib/src/components/stat/__tests__/provenanceLines.test.ts
@@ -1,0 +1,68 @@
+/**
+ * linesFromBreakdown — turning a numeric StatBreakdown into a labelled ledger
+ * (ADR-029).
+ */
+
+import { describe, expect, test } from 'bun:test'
+import type { StatBreakdown } from 'salvageunion-reference/rules'
+
+import { linesFromBreakdown } from '../provenanceLines'
+
+function parts(over: Partial<StatBreakdown> = {}): StatBreakdown {
+  const base = { base: 10, installed: 0, adjustment: 0, derived: 10, total: 10, overridden: false }
+  return { ...base, ...over }
+}
+
+describe('linesFromBreakdown', () => {
+  test('a bare derivation is a single base line', () => {
+    const lines = linesFromBreakdown(parts(), { base: 'Atlas chassis' })
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toMatchObject({ kind: 'base', label: 'Atlas chassis', amount: 10 })
+  })
+
+  test('omits zero-valued lines rather than rendering "+0" noise', () => {
+    const lines = linesFromBreakdown(parts(), { base: 'Atlas chassis', installed: 'Installed' })
+    expect(lines.map((l) => l.kind)).toEqual(['base'])
+  })
+
+  test('includes a negative contribution — an injury penalty is still a contribution', () => {
+    const lines = linesFromBreakdown(parts({ installed: -2, derived: 8, total: 8 }), {
+      base: 'Pilot',
+      installed: 'Injuries',
+    })
+    expect(lines.map((l) => l.kind)).toEqual(['base', 'contribution'])
+    expect(lines[1]).toMatchObject({ label: 'Injuries', amount: -2 })
+  })
+
+  test('a manual adjustment is its own labelled line, never folded into the base', () => {
+    const lines = linesFromBreakdown(parts({ adjustment: 3, derived: 13, total: 13 }), {
+      base: 'Atlas chassis',
+    })
+    expect(lines.map((l) => l.kind)).toEqual(['base', 'adjustment'])
+    expect(lines[1]).toMatchObject({ label: 'Manual adjustment', amount: 3 })
+  })
+
+  test('an override APPENDS to the full derivation rather than replacing it', () => {
+    const lines = linesFromBreakdown(
+      parts({
+        installed: 5,
+        adjustment: 2,
+        derived: 17,
+        override: 25,
+        total: 25,
+        overridden: true,
+      }),
+      { base: 'Atlas chassis', installed: 'Installed systems' }
+    )
+    // every derived component is still listed, then the subtotal, then the pin
+    expect(lines.map((l) => l.kind)).toEqual([
+      'base',
+      'contribution',
+      'adjustment',
+      'derived',
+      'override',
+    ])
+    expect(lines.at(-2)).toMatchObject({ label: 'Derived', amount: 17 })
+    expect(lines.at(-1)).toMatchObject({ label: 'Override', amount: 25 })
+  })
+})

--- a/packages/component-lib/src/components/stat/provenanceLines.ts
+++ b/packages/component-lib/src/components/stat/provenanceLines.ts
@@ -1,0 +1,78 @@
+import type { StatBreakdown } from 'salvageunion-reference/rules'
+
+import type { ProvenanceLine } from './StatProvenance'
+
+export type ProvenanceLabels = {
+  /** Names the rules baseline, e.g. 'Atlas chassis', 'Tech 4 base', 'Pilot base'. */
+  base: string
+  /**
+   * Names the rules-sourced contribution, e.g. 'Installed systems',
+   * 'Battle type bonus', 'Injuries'. Only rendered when non-zero.
+   */
+  installed?: string
+  /** Optional qualifier on the base line, e.g. 'base', 'chassis'. */
+  baseDetail?: string
+  /** Optional qualifier on the contribution line, e.g. 'statBonus'. */
+  installedDetail?: string
+}
+
+/**
+ * Turn a numeric `StatBreakdown` into the labelled ledger `StatProvenance`
+ * renders (ADR-029).
+ *
+ * The contribution line is currently a single **aggregate** — the derivation
+ * sums `statBonus` across installed items and returns one number, so there is no
+ * honest way to attribute it per item yet. Per-source attribution ("Heat Sink
+ * ×2", "Beefcake") arrives with the contribution model, which is what makes each
+ * addend nameable; this helper is shaped to take those lines unchanged when it
+ * does. Showing one truthful aggregate now beats inventing a breakdown the data
+ * cannot support.
+ *
+ * Zero-valued lines are omitted — a ledger listing "+0" for everything a mech
+ * does not have is noise, not provenance.
+ */
+export function linesFromBreakdown(
+  parts: StatBreakdown,
+  labels: ProvenanceLabels
+): ProvenanceLine[] {
+  const lines: ProvenanceLine[] = [
+    {
+      kind: 'base',
+      label: labels.base,
+      ...(labels.baseDetail ? { detail: labels.baseDetail } : {}),
+      amount: parts.base,
+    },
+  ]
+
+  if (parts.installed !== 0) {
+    lines.push({
+      kind: 'contribution',
+      label: labels.installed ?? 'Installed items',
+      ...(labels.installedDetail ? { detail: labels.installedDetail } : {}),
+      amount: parts.installed,
+    })
+  }
+
+  if (parts.adjustment !== 0) {
+    lines.push({
+      kind: 'adjustment',
+      label: 'Manual adjustment',
+      detail: 'entered by hand',
+      amount: parts.adjustment,
+    })
+  }
+
+  // An override appends to the full derivation rather than replacing it, so the
+  // revert target stays visible and explained (ADR-022 amendment).
+  if (parts.overridden) {
+    lines.push({ kind: 'derived', label: 'Derived', amount: parts.derived })
+    lines.push({
+      kind: 'override',
+      label: 'Override',
+      detail: 'pinned by hand',
+      amount: parts.override ?? parts.total,
+    })
+  }
+
+  return lines
+}

--- a/packages/component-lib/src/index.ts
+++ b/packages/component-lib/src/index.ts
@@ -179,6 +179,8 @@ export { Colophon } from './components/shared/Colophon'
 // Stat trackers (ITUN design handoff — design-spec §2.7)
 export { VitalGauge } from './components/stat/VitalGauge'
 export { StatProvenance } from './components/stat/StatProvenance'
+export { linesFromBreakdown } from './components/stat/provenanceLines'
+export type { ProvenanceLabels } from './components/stat/provenanceLines'
 export type {
   ProvenanceLine,
   ProvenanceLineKind,


### PR DESCRIPTION
**B3 + B4** of the rules-parity plan (#597). Every derived maximum on both live surfaces can now explain itself — the feature originally asked for.

## The interaction decision

The max numeral is **already** the click-to-edit override affordance, so wrapping it in a popover trigger would make one click mean two things. Instead:

- **Overridden stat** → the existing `*` marker *becomes* the trigger. It already signals "there is something here to explain."
- **Otherwise** → a small `ⓘ` beside the numeral.

Both open on **hover, focus and tap**. Click-to-edit is untouched.

## The Dashboard was dropping this at two layers

`DashboardGauge` never forwarded the override/provenance props, *and* `VitalGauge`'s `compact` branch returned before any of that chrome rendered — so even fixing the first wouldn't have shown anything. ADR-021 requires Guided Play to "teach as it enforces"; this is the affordance it lacked. Both layers now carry it, with a regression test at each.

## `linesFromBreakdown`

Turns a numeric `StatBreakdown` into a labelled ledger:

- **Zero-valued lines are omitted** — a ledger reading `+0` for everything a mech doesn't have is noise, not provenance.
- **An override appends to the full derivation** rather than replacing it, so the revert target stays visible and explained.
- **A negative contribution is still a contribution** — injury penalties render as `−2` on their own line.

The contribution line is deliberately a single **aggregate** ("Installed systems & modules") for now. The derivation sums `statBonus` across installed items and returns one number, so there's no honest way to attribute it per item yet — per-source attribution (`Heat Sink ×2`, `Beefcake`) arrives with the contribution model (#598), and the helper is shaped to take those lines unchanged. One truthful aggregate beats an invented breakdown.

## A bug I introduced and caught

My first cut passed `overriddenFrom={overridden ? max : undefined}` — which can **never** flag as overridden, because the gauge treats `overriddenFrom === max` as "not overridden". The prop is now `derivedMax`, documented, and pinned by a test that asserts both directions.

## Verification

`bun run check:all` green: lint, format, typecheck, **4,525 tests**, validate, knip, audit, tokens, styling.

Remaining in B: **B5** (partner cards + frozen snapshot) and **B6** (retire the wizard's bespoke `sp-breakdown` string).

Refs #597.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MT6q22Y1MtuCYHormXwQ4