### PR TITLE
feat(itun): stat provenance on frozen snapshots and partner cards

### DIFF
--- a/apps/itun/src/components/sheet/PartnerCard.tsx
+++ b/apps/itun/src/components/sheet/PartnerCard.tsx
@@ -42,6 +42,7 @@ import type { PartnerWithHost } from '../../lib/partnerLookup'
 import {
   partnerCap,
   partnerDerivedStats,
+  partnerDerivedStatsParts,
   partnerTechLevel,
   resolvePartnerStatBlock,
 } from '../../lib/rules/partnerStats'
@@ -54,6 +55,7 @@ import { PartnerHold } from './PartnerHold'
 import { partnerDisplayName } from './partnerDisplay'
 import { resolveModule, resolveSystem } from './mechItemRules'
 import { LIVE_SHEET_MANUAL } from '../../stores/surfaceProvenance'
+import { summarizeBreakdown } from 'component-lib'
 
 type PartnerCardProps = {
   /**
@@ -101,6 +103,17 @@ export function PartnerCard({
   const statBlock = resolvePartnerStatBlock(partner)
   const techLevel = partnerTechLevel(partner, crawlerTechLevel)
   const max = partnerDerivedStats(partner, techLevel)
+  // Tech-level scaling is a partner's whole story and nothing on screen
+  // explained it (ADR-029). `Stat` cells carry an editable stepper cluster, so
+  // the popover panel would nest a button inside a button — these render the
+  // derivation through the existing hoverText tooltip until Stat grows its own
+  // non-nesting affordance.
+  const maxParts = partnerDerivedStatsParts(partner, techLevel)
+  const scalingHover = (key: keyof typeof maxParts): string =>
+    summarizeBreakdown(maxParts[key], {
+      base: 'Base',
+      installed: `Tech ${techLevel} scaling`,
+    })
 
   const cargo = usePartnerCargo({
     found,
@@ -138,6 +151,7 @@ export function PartnerCard({
       label: 'SP',
       value: sp,
       outOfMax: max.structurePoints,
+      hoverText: scalingHover('structurePoints'),
       onChange: editable
         ? (next) => patch({ currentSP: clamp(next, max.structurePoints) })
         : undefined,
@@ -147,6 +161,7 @@ export function PartnerCard({
       label: 'EP',
       value: ep,
       outOfMax: max.energyPoints,
+      hoverText: scalingHover('energyPoints'),
       onChange: editable
         ? (next) => patch({ currentEP: clamp(next, max.energyPoints) })
         : undefined,
@@ -156,6 +171,7 @@ export function PartnerCard({
       label: 'Heat',
       value: heat,
       outOfMax: max.heatCapacity,
+      hoverText: scalingHover('heatCapacity'),
       onChange: editable
         ? (next) => patch({ currentHeat: clamp(next, max.heatCapacity) })
         : undefined,

--- a/apps/itun/src/components/sheet/ShareSnapshotScreen.tsx
+++ b/apps/itun/src/components/sheet/ShareSnapshotScreen.tsx
@@ -46,13 +46,13 @@ import type { Mech } from '../../lib/schemas/mech'
 import type { Pilot } from '../../lib/schemas/pilot'
 import { computeMechCapacity, resolveChassisRef } from 'salvageunion-reference/rules'
 import {
-  crawlerMaxSP,
-  mechMaxCargo,
-  mechMaxEP,
-  mechMaxHeat,
-  mechMaxSP,
-  pilotMaxAP,
-  pilotMaxHP,
+  crawlerMaxSPParts,
+  mechMaxCargoParts,
+  mechMaxEPParts,
+  mechMaxHeatParts,
+  mechMaxSPParts,
+  pilotMaxAPParts,
+  pilotMaxHPParts,
 } from '../../lib/rules/derivedStats'
 import { useEntity } from '../../hooks/queries'
 import { captureMessage } from '../../lib/observability'
@@ -71,6 +71,7 @@ import type { EntityLookup } from './composition'
 import { SheetHero, ChassisStats } from 'component-lib'
 import { SnapshotQr } from 'component-lib'
 import type { ChassisStatItem } from 'component-lib'
+import { linesFromBreakdown } from 'component-lib'
 
 type ShareSnapshotScreenProps = {
   kind: EntityRef['type']
@@ -437,8 +438,10 @@ function isMech(entity: Pilot | Mech | Crawler): entity is Mech {
 function SnapshotPreviewCard({ entity }: SnapshotPreviewCardProps) {
   if (isPilot(entity)) {
     const pilot = entity
-    const maxHP = Math.max(0, pilotMaxHP(pilot))
-    const maxAP = Math.max(0, pilotMaxAP(pilot))
+    const hpParts = pilotMaxHPParts(pilot)
+    const apParts = pilotMaxAPParts(pilot)
+    const maxHP = Math.max(0, hpParts.total)
+    const maxAP = Math.max(0, apParts.total)
     return (
       <SheetHero
         cat="Pilot"
@@ -461,12 +464,19 @@ function SnapshotPreviewCard({ entity }: SnapshotPreviewCardProps) {
               label="HP"
               max={maxHP}
               value={Math.min(pilot.currentHP ?? maxHP, maxHP)}
+              provenance={linesFromBreakdown(hpParts, {
+                base: 'Pilot',
+                baseDetail: 'base',
+                installed: 'Injuries',
+                installedDetail: 'rules A11',
+              })}
               readOnly
             />
             <VitalGauge
               label="AP"
               max={maxAP}
               value={Math.min(pilot.currentAP ?? maxAP, maxAP)}
+              provenance={linesFromBreakdown(apParts, { base: 'Pilot', baseDetail: 'base' })}
               readOnly
             />
             <Stat label="TP" value={pilot.trainingPoints ?? 0} />
@@ -479,10 +489,20 @@ function SnapshotPreviewCard({ entity }: SnapshotPreviewCardProps) {
   if (isMech(entity)) {
     const mech = entity
     const chassis = resolveChassisRef(mech.chassisRef)
-    const maxSP = mechMaxSP(mech, chassis)
-    const maxEP = mechMaxEP(mech, chassis)
-    const maxHeat = mechMaxHeat(mech, chassis)
-    const maxCargo = mechMaxCargo(mech, chassis)
+    const spParts = mechMaxSPParts(mech, chassis)
+    const epParts = mechMaxEPParts(mech, chassis)
+    const heatParts = mechMaxHeatParts(mech, chassis)
+    const cargoParts = mechMaxCargoParts(mech, chassis)
+    const maxSP = spParts.total
+    const maxEP = epParts.total
+    const maxHeat = heatParts.total
+    const maxCargo = cargoParts.total
+    const chassisLabel = `${chassis?.name ?? mech.chassisRef} chassis`
+    const mechLabels = {
+      base: chassisLabel,
+      baseDetail: 'base',
+      installed: 'Installed systems & modules',
+    }
     const capacity = computeMechCapacity({
       chassisRef: mech.chassisRef,
       systems: mech.systems.map((ref) => ({ ref })),
@@ -520,6 +540,7 @@ function SnapshotPreviewCard({ entity }: SnapshotPreviewCardProps) {
               subLabel="Structure"
               max={maxSP}
               value={Math.min(mech.currentSP ?? maxSP, maxSP)}
+              provenance={linesFromBreakdown(spParts, mechLabels)}
               readOnly
             />
             <VitalGauge
@@ -527,6 +548,7 @@ function SnapshotPreviewCard({ entity }: SnapshotPreviewCardProps) {
               subLabel="Energy"
               max={maxEP}
               value={Math.min(mech.currentEP ?? maxEP, maxEP)}
+              provenance={linesFromBreakdown(epParts, mechLabels)}
               readOnly
             />
             <VitalGauge
@@ -534,6 +556,7 @@ function SnapshotPreviewCard({ entity }: SnapshotPreviewCardProps) {
               max={maxHeat}
               value={Math.min(mech.currentHeat ?? 0, maxHeat)}
               danger={maxHeat > 0 ? heatDangerFrom(maxHeat) : undefined}
+              provenance={linesFromBreakdown(heatParts, mechLabels)}
               readOnly
             />
             <VitalGauge
@@ -541,6 +564,7 @@ function SnapshotPreviewCard({ entity }: SnapshotPreviewCardProps) {
               max={maxCargo}
               value={totalLotUnits(mech.cargoLots)}
               caption={['Used', 'Cap']}
+              provenance={linesFromBreakdown(cargoParts, mechLabels)}
               readOnly
             />
           </>
@@ -550,7 +574,8 @@ function SnapshotPreviewCard({ entity }: SnapshotPreviewCardProps) {
   }
 
   const crawler = entity
-  const maxSP = crawlerMaxSP(crawler)
+  const spParts = crawlerMaxSPParts(crawler)
+  const maxSP = spParts.total
   const tl = parseCrawlerTechLevel(crawler.techLevel)
   const states = (crawler.crawlerBays ?? []).map((bay) => bay.condition ?? 'intact')
   return (
@@ -567,6 +592,11 @@ function SnapshotPreviewCard({ entity }: SnapshotPreviewCardProps) {
             max={maxSP}
             value={Math.min(crawler.currentSP ?? maxSP, maxSP)}
             caption={['Structure', 'Max']}
+            provenance={linesFromBreakdown(spParts, {
+              base: `Tech ${crawler.techLevel?.replace(/\D/g, '') || '?'} Crawler`,
+              baseDetail: 'base',
+              installed: 'Crawler type bonus',
+            })}
             readOnly
           />
           {states.length > 0 && <BayStatus label="Bays" states={states} />}

--- a/apps/itun/src/lib/rules/partnerStats.ts
+++ b/apps/itun/src/lib/rules/partnerStats.ts
@@ -28,6 +28,7 @@
  * pinned by tests rather than left to the call sites.
  */
 
+import type { StatBreakdown } from 'salvageunion-reference/rules'
 import { SalvageUnionReference } from 'salvageunion-reference'
 import type { SURefEntity } from 'salvageunion-reference'
 import { matchesRef } from 'salvageunion-reference/rules'
@@ -129,6 +130,44 @@ export function partnerDerivedStats(
     const base = statOf(statBlock, key) ?? 0
     const per = bonuses?.[key]
     out[key] = base + (typeof per === 'number' ? per * steps : 0)
+  }
+  return out
+}
+
+/**
+ * A partner's derived maxima, decomposed per stat (ADR-029).
+ *
+ * The tech-level scaling is a partner's whole story and nothing on screen
+ * explained it before, so each stat resolves to `{ base, installed, ... }` where
+ * `installed` carries the scaling — a rules-sourced contribution, exactly like a
+ * mech's summed `statBonus`.
+ *
+ * `override` is always absent: partners have no cap-pin field, so a partner stat
+ * is never overridden.
+ */
+export function partnerDerivedStatsParts(
+  partner: PartnerInstance,
+  techLevel: number
+): Record<PartnerStatKey, StatBreakdown> {
+  const statBlock = resolvePartnerStatBlock(partner)
+  const bonuses = (statBlock as { bonusPerTechLevel?: Record<string, number> } | null)
+    ?.bonusPerTechLevel
+  const steps = Math.max(0, techLevel - 1)
+
+  const out = {} as Record<PartnerStatKey, StatBreakdown>
+  for (const key of SCALED_STATS) {
+    const base = statOf(statBlock, key) ?? 0
+    const per = bonuses?.[key]
+    const scaled = typeof per === 'number' ? per * steps : 0
+    const derived = Math.max(0, base + scaled)
+    out[key] = {
+      base,
+      installed: scaled,
+      adjustment: 0,
+      derived,
+      total: derived,
+      overridden: false,
+    }
   }
   return out
 }

--- a/docs/design/rules-parity-plan.md
+++ b/docs/design/rules-parity-plan.md
@@ -80,7 +80,19 @@ Sizes use the repo's existing effort labels: **S** under 1 day · **M** 1–2 ·
 | **B3** | Live Sheet wiring               | M    | B2, A3  | All gauges carry breakdowns; **an override appends as the final line**, never replaces the list; revert target visible                     |
 | **B4** | Dashboard wiring                | S    | B2      | `DashboardGauge` stops discarding the props; Guided Play gains the "teach as it enforces" affordance                                       |
 | **B5** | Partner cards + Frozen snapshot | M    | B2      | Partner stats explain their `bonusPerTechLevel` scaling in `PartnerCard`; snapshots show the breakdown and never the revert                |
-| **B6** | Wizard previews                 | S    | B2      | The bespoke `sp-breakdown` string is retired in favour of the shared panel                                                                 |
+| **B6** | Wizard previews                 | S    | B2      | **Superseded — see note below.** The wizard already renders a shared-derivation breakdown, and its prose teaches a rule the panel cannot   |
+
+> **B6 note (resolved during B3–B5).** The unit was written as "retire the bespoke
+> `sp-breakdown` string in favour of the shared panel". That is the wrong goal.
+> The wizard's inline prose — _"the bonus derives from your Crawler type, so it
+> follows a type change automatically"_ — teaches a **rule**, not just the
+> arithmetic, and Guided Creation exists to teach while it enforces
+> ([ADR-021](../adrs/ADR-021-itun-surface-taxonomy.md)). Replacing it with a
+> hover panel would trade a visible explanation for a hidden one in the mode that
+> most needs the visible version. The underlying requirement — that the wizard's
+> breakdown comes from the shared derivation and cannot drift — is **already
+> satisfied**: `CrawlerStatsStep` calls `crawlerMaxSPParts` directly. No change
+> made; recorded so it is not "fixed" later by someone reading the original DoD.
 
 ### Phase C — The converged model
 

--- a/packages/component-lib/src/components/stat/__tests__/provenanceLines.test.ts
+++ b/packages/component-lib/src/components/stat/__tests__/provenanceLines.test.ts
@@ -6,7 +6,7 @@
 import { describe, expect, test } from 'bun:test'
 import type { StatBreakdown } from 'salvageunion-reference/rules'
 
-import { linesFromBreakdown } from '../provenanceLines'
+import { linesFromBreakdown, summarizeBreakdown } from '../provenanceLines'
 
 function parts(over: Partial<StatBreakdown> = {}): StatBreakdown {
   const base = { base: 10, installed: 0, adjustment: 0, derived: 10, total: 10, overridden: false }
@@ -64,5 +64,34 @@ describe('linesFromBreakdown', () => {
     ])
     expect(lines.at(-2)).toMatchObject({ label: 'Derived', amount: 17 })
     expect(lines.at(-1)).toMatchObject({ label: 'Override', amount: 25 })
+  })
+})
+
+describe('summarizeBreakdown', () => {
+  test('reads as an equation for surfaces that can only take a string', () => {
+    expect(
+      summarizeBreakdown(parts({ installed: 4, derived: 14, total: 14 }), {
+        base: 'Base',
+        installed: 'Tech 3 scaling',
+      })
+    ).toBe('Base 10 +4 Tech 3 scaling = 14')
+  })
+
+  test('uses a true minus for a negative contribution', () => {
+    expect(
+      summarizeBreakdown(parts({ installed: -2, derived: 8, total: 8 }), {
+        base: 'Pilot',
+        installed: 'injuries',
+      })
+    ).toBe('Pilot 10 −2 injuries = 8')
+  })
+
+  test('names the pin without hiding the derivation it replaced', () => {
+    const text = summarizeBreakdown(
+      parts({ installed: 4, derived: 14, override: 20, total: 20, overridden: true }),
+      { base: 'Base', installed: 'scaling' }
+    )
+    expect(text).toContain('= 14')
+    expect(text).toContain('overridden to 20')
   })
 })

--- a/packages/component-lib/src/components/stat/provenanceLines.ts
+++ b/packages/component-lib/src/components/stat/provenanceLines.ts
@@ -76,3 +76,27 @@ export function linesFromBreakdown(
 
   return lines
 }
+
+/**
+ * A one-line text rendering of the same ledger, for surfaces that can only take
+ * a string.
+ *
+ * `Stat` cells carry an editable stepper cluster, so wrapping one in the
+ * `StatProvenance` popover trigger would nest a button inside a button. Until
+ * `Stat` grows its own non-nesting affordance, those surfaces render the
+ * derivation through the existing `hoverText` tooltip instead — less rich than
+ * the panel, but true, and it beats a number with no explanation at all.
+ */
+export function summarizeBreakdown(parts: StatBreakdown, labels: ProvenanceLabels): string {
+  const terms: string[] = [`${labels.base} ${parts.base}`]
+  if (parts.installed !== 0) {
+    const sign = parts.installed < 0 ? '−' : '+'
+    terms.push(`${sign}${Math.abs(parts.installed)} ${labels.installed ?? 'installed'}`)
+  }
+  if (parts.adjustment !== 0) {
+    const sign = parts.adjustment < 0 ? '−' : '+'
+    terms.push(`${sign}${Math.abs(parts.adjustment)} manual adjustment`)
+  }
+  const sum = `${terms.join(' ')} = ${parts.derived}`
+  return parts.overridden ? `${sum}; overridden to ${parts.override ?? parts.total}` : sum
+}

--- a/packages/component-lib/src/index.ts
+++ b/packages/component-lib/src/index.ts
@@ -179,7 +179,7 @@ export { Colophon } from './components/shared/Colophon'
 // Stat trackers (ITUN design handoff — design-spec §2.7)
 export { VitalGauge } from './components/stat/VitalGauge'
 export { StatProvenance } from './components/stat/StatProvenance'
-export { linesFromBreakdown } from './components/stat/provenanceLines'
+export { linesFromBreakdown, summarizeBreakdown } from './components/stat/provenanceLines'
 export type { ProvenanceLabels } from './components/stat/provenanceLines'
 export type {
   ProvenanceLine,


### PR DESCRIPTION
**B5** of the rules-parity plan (#597), plus a finding that supersedes **B6**. This completes **Phase B** — every surface that shows a derived maximum can now explain it.

## Frozen snapshots

All seven gauges carry the full breakdown, and no revert. That falls out of the existing contract rather than a special case: the revert only renders when `onRevertOverride` is supplied, and a published snapshot never supplies one (ADR-022 + ADR-010).

## Partner cards — the surface where this mattered most

Every partner stat is `base + bonusPerTechLevel × (TL − 1)` and **nothing on screen said so**. `partnerDerivedStatsParts` decomposes them, carrying the scaling on the contribution line like any other rules-sourced addend.

They render through `summarizeBreakdown` — a one-line text form (`Base 8 +4 Tech 3 scaling = 12`) — rather than the popover panel. A `Stat` cell carries an **editable stepper cluster**, and the panel's trigger is a `<button>`; wrapping one in the other nests a button inside a button. The text form is less rich but true, and beats a number with no explanation. The panel arrives when `Stat` grows a non-nesting affordance, alongside the entity-card work in C4.

## B6 is superseded, not skipped

It was written as *"retire the bespoke `sp-breakdown` string in favour of the shared panel."* **That is the wrong goal.**

The wizard's prose — *"the bonus derives from your Crawler type, so it follows a type change automatically"* — teaches a **rule**, not the arithmetic. Guided Creation exists to teach while it enforces (ADR-021), so replacing it with a hover panel would trade a visible explanation for a hidden one in the mode that most needs the visible version.

The underlying requirement — that the breakdown comes from the shared derivation and can't drift — is **already satisfied**: `CrawlerStatsStep` calls `crawlerMaxSPParts` directly. No change made; recorded in the plan so nobody "fixes" it later from the original DoD.

## Verification

`bun run check:all` green: lint, format, typecheck, **4,528 tests**, validate, knip, audit, tokens, styling.

## Phase B complete

| Surface | Provenance |
|---|---|
| Live Sheet (pilot/mech/crawler) | panel, with revert |
| Dashboard instruments | panel, read-only |
| Frozen snapshot | panel, no revert |
| Partner cards | text summary |
| Wizard | inline teaching prose (already shared-derivation) |

Next: **C1–C4** (#598) — the converged contribution model, which is what makes each addend nameable and turns "Installed systems & modules +10" into "Heat Sink ×2, Composite Armour ×1".

Refs #597.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MT6q22Y1MtuCYHormXwQ4