### PR TITLE
feat(reference): abilities can declare stat contributions — Beefcake now applies

### DIFF
--- a/apps/itun/src/components/dashboard/ActiveItemBand.tsx
+++ b/apps/itun/src/components/dashboard/ActiveItemBand.tsx
@@ -82,6 +82,7 @@ export function ActiveItemBand({ mech, pilot, crawler, store }: ActiveItemBandPr
       mech={mech}
       store={s}
       hasPilot={pilot !== null}
+      pilotAbilities={pilot?.abilities}
       onDismount={() => setMount('pilot')}
     />
   )
@@ -135,18 +136,22 @@ function MechBand({
   mech,
   store,
   hasPilot,
+  pilotAbilities,
   onDismount,
 }: {
   mech: Mech
+  /** Beefcake raises the piloted MECH's Max SP and Cargo (ADR-029). */
+  pilotAbilities?: string[]
   store: PlayStore
   hasPilot: boolean
   onDismount: () => void
 }) {
   const chassis = resolveChassisRef(mech.chassisRef)
-  const maxSP = mechMaxSP(mech, chassis)
+  const piloting = { abilities: pilotAbilities }
+  const maxSP = mechMaxSP(mech, chassis, piloting)
   const maxEP = mechMaxEP(mech, chassis)
   const maxHeat = mechMaxHeat(mech, chassis)
-  const maxCargo = mechMaxCargo(mech, chassis)
+  const maxCargo = mechMaxCargo(mech, chassis, piloting)
   const sp = Math.min(mech.currentSP ?? maxSP, maxSP)
   const ep = Math.min(mech.currentEP ?? maxEP, maxEP)
   const heat = Math.min(mech.currentHeat ?? 0, maxHeat)
@@ -174,7 +179,7 @@ function MechBand({
   function doPush() {
     const m = fresh()
     const cap = mechMaxHeat(m, chassis)
-    const spMax = mechMaxSP(m, chassis)
+    const spMax = mechMaxSP(m, chassis, piloting)
     const { patch, effect, nextHeat, meltdown } = pushPatch({
       heat: Math.min(m.currentHeat ?? 0, cap),
       heatCap: cap,
@@ -188,7 +193,7 @@ function MechBand({
   function doHeatCheck() {
     const m = fresh()
     const cap = mechMaxHeat(m, chassis)
-    const spMax = mechMaxSP(m, chassis)
+    const spMax = mechMaxSP(m, chassis, piloting)
     const { patch, effect, meltdown } = heatCheckOncePatch({
       heat: Math.min(m.currentHeat ?? 0, cap),
       currentSP: Math.min(m.currentSP ?? spMax, spMax),
@@ -215,7 +220,7 @@ function MechBand({
     // Damage operates on the stored SP (authoritative); default to max only
     // when it was never set. The gauge, not this write, clamps for display.
     const { patch, effect } = mechDamagePatch({
-      currentSP: m.currentSP ?? mechMaxSP(m, chassis),
+      currentSP: m.currentSP ?? mechMaxSP(m, chassis, piloting),
       amount: dmg,
       vulnerable: m.vulnerable ?? false,
     })

--- a/apps/itun/src/components/dashboard/ActiveItemBand.tsx
+++ b/apps/itun/src/components/dashboard/ActiveItemBand.tsx
@@ -37,6 +37,7 @@ import { usePlayStateStore } from '../../stores/playStateStore'
 import { ActiveItemBand as ActiveItemBandView, CountStepper, StorageBay } from 'component-lib'
 import type { ActiveItemBandView as ActiveItemBandViewModel, BandButton } from 'component-lib'
 import { DASHBOARD_TXN } from '../../stores/surfaceProvenance'
+import { pilotingContext } from '../../lib/rules/pilotingContext'
 import {
   VENT_PATCH,
   critDamagePatch,
@@ -147,7 +148,7 @@ function MechBand({
   onDismount: () => void
 }) {
   const chassis = resolveChassisRef(mech.chassisRef)
-  const piloting = { abilities: pilotAbilities }
+  const piloting = pilotingContext(mech, pilotAbilities)
   const maxSP = mechMaxSP(mech, chassis, piloting)
   const maxEP = mechMaxEP(mech, chassis)
   const maxHeat = mechMaxHeat(mech, chassis)

--- a/apps/itun/src/components/dashboard/dialItems.ts
+++ b/apps/itun/src/components/dashboard/dialItems.ts
@@ -78,10 +78,18 @@ function pilotItem(pilot: Pilot): DialItem {
   }
 }
 
-function mechItem(mech: Mech): DialItem {
+/**
+ * Beefcake is a PILOT ability that raises the piloted MECH's Max SP and Cargo
+ * (ADR-029), so the mech dial cannot be derived from the mech alone.
+ */
+function mechItem(mech: Mech, pilot: Pilot | null): DialItem {
   const chassis = resolveChassisRef(mech.chassisRef)
-  const spParts = mechMaxSPParts(mech, chassis)
-  const heatParts = mechMaxHeatParts(mech, chassis)
+  const piloting = {
+    abilities: pilot?.abilities,
+    techLevel: typeof chassis?.techLevel === 'number' ? chassis.techLevel : undefined,
+  }
+  const spParts = mechMaxSPParts(mech, chassis, piloting)
+  const heatParts = mechMaxHeatParts(mech, chassis, piloting)
   const maxSP = spParts.total
   const maxHeat = heatParts.total
   const chassisLabel = `${chassis?.name ?? mech.chassisRef} chassis`
@@ -165,7 +173,7 @@ export function dialItems(args: {
   ]
   // The counterpart entities — everything NOT in the active row. In Downtime
   // the crawler is active, so the dial carries the mech + pilot instead.
-  if (mount !== 'mech') items.push(mechItem(mech))
+  if (mount !== 'mech') items.push(mechItem(mech, pilot))
   if (mount !== 'pilot' && pilot) items.push(pilotItem(pilot))
   if (mount !== 'downtime' && crawler) items.push(crawlerItem(crawler))
   items.push({

--- a/apps/itun/src/components/dashboard/dialItems.ts
+++ b/apps/itun/src/components/dashboard/dialItems.ts
@@ -25,6 +25,7 @@ import type { Pilot } from '../../lib/schemas/pilot'
 import type { MountState } from '../../stores/playStateStore'
 import type { DialItem as DialCellItem } from 'component-lib'
 import { linesFromBreakdown } from 'component-lib'
+import { pilotingContext } from '../../lib/rules/pilotingContext'
 
 export type DialItem = DialCellItem & { kind: DialKind }
 
@@ -84,10 +85,7 @@ function pilotItem(pilot: Pilot): DialItem {
  */
 function mechItem(mech: Mech, pilot: Pilot | null): DialItem {
   const chassis = resolveChassisRef(mech.chassisRef)
-  const piloting = {
-    abilities: pilot?.abilities,
-    techLevel: typeof chassis?.techLevel === 'number' ? chassis.techLevel : undefined,
-  }
+  const piloting = pilotingContext(mech, pilot?.abilities)
   const spParts = mechMaxSPParts(mech, chassis, piloting)
   const heatParts = mechMaxHeatParts(mech, chassis, piloting)
   const maxSP = spParts.total

--- a/apps/itun/src/components/sheet/MechSheet.tsx
+++ b/apps/itun/src/components/sheet/MechSheet.tsx
@@ -153,7 +153,7 @@ export function MechSheet({
 }: MechSheetProps) {
   const chassis = resolveChassis(mech, chassisOverride)
   const storeState = store()
-  const cargo = useCargo({ mech, crawler, store, readOnly })
+  const cargo = useCargo({ mech, crawler, store, readOnly, pilotAbilities })
   // Which collection's shared picker modal is open ('+ Add' — unified edit
   // language archetype B; always available, never rule-gated for now).
   const [picker, setPicker] = useState<ItemKind | null>(null)

--- a/apps/itun/src/components/sheet/MechSheet.tsx
+++ b/apps/itun/src/components/sheet/MechSheet.tsx
@@ -125,6 +125,13 @@ type MechSheetProps = {
    * its own, so this is passed straight through into the R4 section.
    */
   linkedUnits?: ReactNode
+  /**
+   * The assigned pilot's ability refs, handed down by SheetMech from
+   * `composition`. Beefcake is a PILOT ability that raises the piloted MECH's
+   * Max SP and Cargo, so a mech's maxima cannot be derived from the mech alone
+   * (ADR-029). Absent = unlinked, which correctly contributes nothing.
+   */
+  pilotAbilities?: string[]
 }
 
 function resolveChassis(mech: Mech, override?: ChassisLike | null): ChassisLike | null {
@@ -142,6 +149,7 @@ export function MechSheet({
   heroRef,
   crawler = null,
   linkedUnits,
+  pilotAbilities,
 }: MechSheetProps) {
   const chassis = resolveChassis(mech, chassisOverride)
   const storeState = store()
@@ -170,9 +178,19 @@ export function MechSheet({
   const [warningSubtitle, setWarningSubtitle] = useState<string | null>(null)
 
   // Derived maxima (plan 2.5): chassis stat + hand-edited modifiers.
-  const spParts = mechMaxSPParts(mech, chassis)
-  const epParts = mechMaxEPParts(mech, chassis)
-  const heatParts = mechMaxHeatParts(mech, chassis)
+  // Beefcake is a PILOT ability that raises the piloted MECH's Max SP and Cargo,
+  // so a mech's maxima cannot be derived from the mech alone (ADR-029).
+  // Beefcake is a PILOT ability that raises the piloted MECH (ADR-029), and its
+  // Max SP is "3+X where X is the Mech's Tech Level" — so the piloting context
+  // carries the chassis tech level. Non-numeric tech levels ('B'/'N' — Bio-Titan,
+  // Nanite) have no numeric scale and resolve to the flat part rather than a guess.
+  const pilotingChassis = resolveChassisRef(mech.chassisRef)
+  const chassisTl =
+    typeof pilotingChassis?.techLevel === 'number' ? pilotingChassis.techLevel : undefined
+  const piloting = { abilities: pilotAbilities, techLevel: chassisTl }
+  const spParts = mechMaxSPParts(mech, chassis, piloting)
+  const epParts = mechMaxEPParts(mech, chassis, piloting)
+  const heatParts = mechMaxHeatParts(mech, chassis, piloting)
   const maxSP = spParts.total
   const maxEP = epParts.total
   const heatCap = heatParts.total

--- a/apps/itun/src/components/sheet/MechSheet.tsx
+++ b/apps/itun/src/components/sheet/MechSheet.tsx
@@ -82,6 +82,7 @@ import { freshEntity } from './controlPrimitives'
 import type { SheetPatch } from './sheetViewProps'
 import { LIVE_SHEET_MANUAL, LIVE_SHEET_OVERRIDE } from '../../stores/surfaceProvenance'
 import { linesFromBreakdown } from 'component-lib'
+import { pilotingContext } from '../../lib/rules/pilotingContext'
 
 // Narrow subset of chassis data the stat derivations need
 type ChassisLike = {
@@ -180,14 +181,7 @@ export function MechSheet({
   // Derived maxima (plan 2.5): chassis stat + hand-edited modifiers.
   // Beefcake is a PILOT ability that raises the piloted MECH's Max SP and Cargo,
   // so a mech's maxima cannot be derived from the mech alone (ADR-029).
-  // Beefcake is a PILOT ability that raises the piloted MECH (ADR-029), and its
-  // Max SP is "3+X where X is the Mech's Tech Level" — so the piloting context
-  // carries the chassis tech level. Non-numeric tech levels ('B'/'N' — Bio-Titan,
-  // Nanite) have no numeric scale and resolve to the flat part rather than a guess.
-  const pilotingChassis = resolveChassisRef(mech.chassisRef)
-  const chassisTl =
-    typeof pilotingChassis?.techLevel === 'number' ? pilotingChassis.techLevel : undefined
-  const piloting = { abilities: pilotAbilities, techLevel: chassisTl }
+  const piloting = pilotingContext(mech, pilotAbilities)
   const spParts = mechMaxSPParts(mech, chassis, piloting)
   const epParts = mechMaxEPParts(mech, chassis, piloting)
   const heatParts = mechMaxHeatParts(mech, chassis, piloting)

--- a/apps/itun/src/components/sheet/ShareSnapshotScreen.tsx
+++ b/apps/itun/src/components/sheet/ShareSnapshotScreen.tsx
@@ -489,6 +489,16 @@ function SnapshotPreviewCard({ entity }: SnapshotPreviewCardProps) {
   if (isMech(entity)) {
     const mech = entity
     const chassis = resolveChassisRef(mech.chassisRef)
+    // KNOWN LIMITATION: no piloting context here. A snapshot is a frozen,
+    // BARE entity (ADR-004) — a shared mech carries no pilot — so pilot-sourced
+    // contributions (Beefcake's +3+X Max SP and +6 Cargo) cannot be resolved,
+    // and a shared mech reads lower than the same mech on its owner's sheet.
+    //
+    // Passing `{ abilities: undefined }` would not help: the data is genuinely
+    // absent, not merely unthreaded. The real fix is to freeze the DERIVED
+    // maxima into the snapshot payload at publish time, which is a payload
+    // change and a separate piece of work. Do not "fix" this by threading a
+    // pilot that does not exist here.
     const spParts = mechMaxSPParts(mech, chassis)
     const epParts = mechMaxEPParts(mech, chassis)
     const heatParts = mechMaxHeatParts(mech, chassis)

--- a/apps/itun/src/components/sheet/ShareSnapshotScreen.tsx
+++ b/apps/itun/src/components/sheet/ShareSnapshotScreen.tsx
@@ -55,6 +55,8 @@ import {
   pilotMaxHPParts,
 } from '../../lib/rules/derivedStats'
 import { useEntity } from '../../hooks/queries'
+import { useEntityStore } from '../../stores/entityStore'
+import { resolveSheetComposition } from './composition'
 import { captureMessage } from '../../lib/observability'
 import { deleteSnapshot, probeSnapshotService, publishSnapshot } from '../../lib/snapshot/client'
 import type { PublishResult, SnapshotPayload } from '../../lib/snapshot/client'
@@ -150,6 +152,19 @@ export function ShareSnapshotScreen({
 
   const entity = entityStore ? entityStore.get(kind, id) : liveEntity
 
+  // The assigned pilot's ability refs travel with a mech snapshot so
+  // pilot-sourced contributions resolve for a viewer (see handlePublish).
+  const store = useEntityStore.getState()
+  const pilotAbilities =
+    kind === 'mech'
+      ? resolveSheetComposition({
+          kind,
+          id,
+          links: store.list('softLink'),
+          store: entityStore ?? store,
+        }).pilot?.abilities
+      : undefined
+
   if (!entity) {
     return (
       <main className="mx-auto max-w-5xl p-6">
@@ -175,10 +190,20 @@ export function ShareSnapshotScreen({
     setCopied(false)
     setCopyError(null)
 
-    // Bare-entity snapshot payload (v1) — wired composition is post-beta.
+    // A snapshot shares a LIVE INSTANCE, so it must carry the context that
+    // instance's numbers depend on. Beefcake is a pilot ability that raises the
+    // piloted mech's Max SP and Cargo (ADR-029) — without the pilot's ability
+    // refs a shared mech would read LOWER than the same mech on its owner's
+    // sheet. (A mech PATTERN is the opposite case: a stateless build template
+    // with no pilot and no live instance, shared context-free — patterns do not
+    // go through this flow at all.)
+    //
+    // Additive to the v1 `{ kind, entity }` shape: older snapshots simply have
+    // no `context`, and the reader treats it as absent rather than empty.
     const payload: SnapshotPayload = {
       kind,
       entity,
+      ...(pilotAbilities ? { context: { pilotAbilities } } : {}),
     }
 
     try {
@@ -489,16 +514,10 @@ function SnapshotPreviewCard({ entity }: SnapshotPreviewCardProps) {
   if (isMech(entity)) {
     const mech = entity
     const chassis = resolveChassisRef(mech.chassisRef)
-    // KNOWN LIMITATION: no piloting context here. A snapshot is a frozen,
-    // BARE entity (ADR-004) — a shared mech carries no pilot — so pilot-sourced
-    // contributions (Beefcake's +3+X Max SP and +6 Cargo) cannot be resolved,
-    // and a shared mech reads lower than the same mech on its owner's sheet.
-    //
-    // Passing `{ abilities: undefined }` would not help: the data is genuinely
-    // absent, not merely unthreaded. The real fix is to freeze the DERIVED
-    // maxima into the snapshot payload at publish time, which is a payload
-    // change and a separate piece of work. Do not "fix" this by threading a
-    // pilot that does not exist here.
+    // This is the PUBLISH-time preview card, which shows the bare entity being
+    // published. The published snapshot itself carries the pilot's ability refs
+    // (see handlePublish) and the VIEWER resolves them, so a shared mech reads
+    // the same numbers as its owner's sheet.
     const spParts = mechMaxSPParts(mech, chassis)
     const epParts = mechMaxEPParts(mech, chassis)
     const heatParts = mechMaxHeatParts(mech, chassis)

--- a/apps/itun/src/components/sheet/Sheet.tsx
+++ b/apps/itun/src/components/sheet/Sheet.tsx
@@ -86,6 +86,20 @@ type SheetProps = {
   store?: typeof useEntityStore
   /** Hides publish + disables all stat editing (snapshot contexts). */
   readOnly?: boolean
+  /**
+   * Pilot ability refs to use instead of the composition's.
+   *
+   * A published snapshot shares a LIVE INSTANCE but carries a private read-only
+   * store with no pilot record and no soft-links, so the composition resolves
+   * `pilot: null` — and pilot-sourced contributions (Beefcake's +3+X Max SP and
+   * +6 Cargo, ADR-029) would silently vanish, making a shared mech read lower
+   * than the same mech on its owner's sheet.
+   *
+   * The snapshot payload carries the refs, and this passes them in explicitly
+   * rather than fabricating a pilot record — a synthetic pilot would surface in
+   * the Linked Units rail as a unit that was never shared.
+   */
+  pilotAbilities?: string[]
 }
 
 export function Sheet({
@@ -95,6 +109,7 @@ export function Sheet({
   softLinkStore,
   store = useEntityStore,
   readOnly = false,
+  pilotAbilities,
 }: SheetProps) {
   const storeState = store()
   const [changeLogOpen, setChangeLogOpen] = useState(false)
@@ -258,7 +273,7 @@ export function Sheet({
     resolved.kind === 'pilot' ? (
       <SheetPilot pilot={resolved.entity} {...common} />
     ) : resolved.kind === 'mech' ? (
-      <SheetMech mech={resolved.entity} {...common} />
+      <SheetMech mech={resolved.entity} pilotAbilitiesOverride={pilotAbilities} {...common} />
     ) : (
       <SheetCrawler crawler={resolved.entity} {...common} />
     )

--- a/apps/itun/src/components/sheet/SheetMech.tsx
+++ b/apps/itun/src/components/sheet/SheetMech.tsx
@@ -40,10 +40,13 @@ export function SheetMech({
   storeState,
 }: SheetMechProps) {
   const chassis = resolveChassisRef(mech.chassisRef)
-  const maxSP = mechMaxSP(mech, chassis)
+  // Beefcake raises the piloted MECH (ADR-029), so the condensed strip needs
+  // the same piloting context the body sheet uses or the two would disagree.
+  const piloting = { abilities: composition.pilot?.abilities }
+  const maxSP = mechMaxSP(mech, chassis, piloting)
   const maxEP = mechMaxEP(mech, chassis)
   const maxHeat = mechMaxHeat(mech, chassis)
-  const maxCargo = mechMaxCargo(mech, chassis)
+  const maxCargo = mechMaxCargo(mech, chassis, piloting)
   const cargoUsed = totalLotUnits(mech.cargoLots)
   const sp = Math.min(mech.currentSP ?? maxSP, maxSP)
   const ep = Math.min(mech.currentEP ?? maxEP, maxEP)

--- a/apps/itun/src/components/sheet/SheetMech.tsx
+++ b/apps/itun/src/components/sheet/SheetMech.tsx
@@ -25,6 +25,7 @@ import { RailCta } from './SheetRailParts'
 import { AppLink } from '../shared/AppLink'
 import { crawlerRailItems, mechStatusPill, pilotRailItems, rowStats } from './railStats'
 import type { SheetViewCommonProps } from './sheetViewProps'
+import { pilotingContext } from '../../lib/rules/pilotingContext'
 
 type SheetMechProps = SheetViewCommonProps & {
   mech: Mech
@@ -50,7 +51,7 @@ export function SheetMech({
   const chassis = resolveChassisRef(mech.chassisRef)
   // Beefcake raises the piloted MECH (ADR-029), so the condensed strip needs
   // the same piloting context the body sheet uses or the two would disagree.
-  const piloting = { abilities: pilotAbilitiesOverride ?? composition.pilot?.abilities }
+  const piloting = pilotingContext(mech, pilotAbilitiesOverride ?? composition.pilot?.abilities)
   const maxSP = mechMaxSP(mech, chassis, piloting)
   const maxEP = mechMaxEP(mech, chassis)
   const maxHeat = mechMaxHeat(mech, chassis)

--- a/apps/itun/src/components/sheet/SheetMech.tsx
+++ b/apps/itun/src/components/sheet/SheetMech.tsx
@@ -157,6 +157,7 @@ export function SheetMech({
           heroRef={heroRef}
           crawler={composition.crawler}
           linkedUnits={rail}
+          pilotAbilities={composition.pilot?.abilities}
         />
       )}
     />

--- a/apps/itun/src/components/sheet/SheetMech.tsx
+++ b/apps/itun/src/components/sheet/SheetMech.tsx
@@ -26,10 +26,18 @@ import { AppLink } from '../shared/AppLink'
 import { crawlerRailItems, mechStatusPill, pilotRailItems, rowStats } from './railStats'
 import type { SheetViewCommonProps } from './sheetViewProps'
 
-type SheetMechProps = SheetViewCommonProps & { mech: Mech }
+type SheetMechProps = SheetViewCommonProps & {
+  mech: Mech
+  /**
+   * Pilot ability refs to use instead of the composition's — supplied by a
+   * published snapshot, whose read-only store has no pilot record (ADR-029).
+   */
+  pilotAbilitiesOverride?: string[]
+}
 
 export function SheetMech({
   mech,
+  pilotAbilitiesOverride,
   composition,
   back,
   actions,
@@ -42,7 +50,7 @@ export function SheetMech({
   const chassis = resolveChassisRef(mech.chassisRef)
   // Beefcake raises the piloted MECH (ADR-029), so the condensed strip needs
   // the same piloting context the body sheet uses or the two would disagree.
-  const piloting = { abilities: composition.pilot?.abilities }
+  const piloting = { abilities: pilotAbilitiesOverride ?? composition.pilot?.abilities }
   const maxSP = mechMaxSP(mech, chassis, piloting)
   const maxEP = mechMaxEP(mech, chassis)
   const maxHeat = mechMaxHeat(mech, chassis)
@@ -160,7 +168,7 @@ export function SheetMech({
           heroRef={heroRef}
           crawler={composition.crawler}
           linkedUnits={rail}
-          pilotAbilities={composition.pilot?.abilities}
+          pilotAbilities={pilotAbilitiesOverride ?? composition.pilot?.abilities}
         />
       )}
     />

--- a/apps/itun/src/components/sheet/SnapshotSheet.tsx
+++ b/apps/itun/src/components/sheet/SnapshotSheet.tsx
@@ -38,9 +38,27 @@ type SnapshotSheetProps = {
   snapshot: Record<string, unknown>
 }
 
+/**
+ * Ability refs of the pilot this instance was published with.
+ *
+ * A snapshot shares a LIVE INSTANCE, and a live mech's maxima depend on its
+ * pilot: Beefcake raises the piloted mech's Max SP and Cargo (ADR-029). Without
+ * this a shared mech reads LOWER than the same mech on its owner's sheet.
+ *
+ * Absent on snapshots published before the field existed, and on kinds that have
+ * no piloting context — treated as "no contributions", never as an error.
+ */
+function parseContext(snapshot: Record<string, unknown>): string[] | undefined {
+  const context = snapshot.context
+  if (!isRecord(context)) return undefined
+  const refs = context.pilotAbilities
+  if (!Array.isArray(refs)) return undefined
+  return refs.filter((r): r is string => typeof r === 'string')
+}
+
 type ParseResult =
   | { ok: true; kind: 'pilot'; entity: Pilot }
-  | { ok: true; kind: 'mech'; entity: Mech }
+  | { ok: true; kind: 'mech'; entity: Mech; pilotAbilities?: string[] }
   | { ok: true; kind: 'crawler'; entity: Crawler }
   | { ok: false; reason: string }
 
@@ -75,7 +93,7 @@ function parseSnapshot(snapshot: Record<string, unknown>): ParseResult {
         reason: `Invalid mech data: ${parsed.error.message}`,
       }
     }
-    return { ok: true, kind: 'mech', entity: parsed.data }
+    return { ok: true, kind: 'mech', entity: parsed.data, pilotAbilities: parseContext(snapshot) }
   }
 
   if (kind === 'crawler') {
@@ -165,7 +183,13 @@ export function SnapshotSheet({ snapshot }: SnapshotSheetProps) {
         This is a read-only snapshot. Changes made in-game are not reflected here.
       </div>
 
-      <Sheet kind={result.kind} id={result.entity.id} store={store} readOnly />
+      <Sheet
+        kind={result.kind}
+        id={result.entity.id}
+        store={store}
+        pilotAbilities={result.kind === 'mech' ? result.pilotAbilities : undefined}
+        readOnly
+      />
     </div>
   )
 }

--- a/apps/itun/src/components/sheet/__tests__/Snapshot-pilot-context.test.ts
+++ b/apps/itun/src/components/sheet/__tests__/Snapshot-pilot-context.test.ts
@@ -1,0 +1,49 @@
+/**
+ * A snapshot shares a LIVE INSTANCE, so it must carry the context that
+ * instance's numbers depend on (ADR-029).
+ *
+ * Beefcake is a pilot ability that raises the piloted mech's Max SP and Cargo.
+ * A mech snapshot published without the pilot's ability refs would read LOWER
+ * for a viewer than the same mech on its owner's sheet.
+ *
+ * Contrast a mech PATTERN: a stateless build template with no pilot and no live
+ * instance. Patterns are shared context-free and never go through this flow.
+ */
+
+import { beforeAll, describe, expect, test } from 'bun:test'
+import { SalvageUnionReference } from 'salvageunion-reference'
+import {
+  abilityContributions,
+  mechMaxSPParts,
+  sumContributions,
+} from 'salvageunion-reference/rules'
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+describe('snapshot pilot context', () => {
+  test('a mech derives the SAME max SP with the pilot context as on the live sheet', () => {
+    const mech = { chassisRef: 'no-such-chassis' }
+    const chassis = { structurePoints: 20 }
+    const piloting = { abilities: ['Beefcake'], techLevel: 4 }
+
+    const ownersSheet = mechMaxSPParts(mech, chassis, piloting).total
+    // The viewer reconstructs the same context from the payload's `context`.
+    const viewer = mechMaxSPParts(mech, chassis, { abilities: ['Beefcake'], techLevel: 4 }).total
+
+    expect(viewer).toBe(ownersSheet)
+    expect(viewer).toBe(27)
+  })
+
+  test('dropping the context is exactly the under-count this guards against', () => {
+    const mech = { chassisRef: 'no-such-chassis' }
+    const chassis = { structurePoints: 20 }
+    const withPilot = mechMaxSPParts(mech, chassis, { abilities: ['Beefcake'], techLevel: 4 }).total
+    const without = mechMaxSPParts(mech, chassis).total
+    expect(withPilot - without).toBe(
+      sumContributions(abilityContributions(['Beefcake'], 'pilotedMech', 'structurePoints', 4))
+    )
+    expect(without).toBeLessThan(withPilot)
+  })
+})

--- a/apps/itun/src/components/sheet/pilotInventory.ts
+++ b/apps/itun/src/components/sheet/pilotInventory.ts
@@ -6,7 +6,8 @@
  *   - reference equipment: 1 slot, 2 when Heavy/Portable (ORM getInventorySlots)
  *   - unresolved slugs: counted at 1 so the total never lies low
  *   - generic entries: explicit slotCost × qty (Scrap = 3 per unit, plan S7)
- *   - capacity: base 6 + maxInventorySlotsModifier (Beefcake +4, rules A13)
+ *   - capacity: base 6 + maxInventorySlotsModifier + ability contributions
+ *     (Beefcake +4, rules A13 — now applied from the ability, not hand-entered)
  *
  * Uses accounting (rules A14): an item's max uses come from its `uses` trait
  * (on the equipment record or its matching action). `equipmentUses[slug]`
@@ -19,6 +20,7 @@ import { SalvageUnionReference, getInventorySlots, getTraits } from 'salvageunio
 import type { SURefEquipment } from 'salvageunion-reference'
 
 import type { GenericInventoryEntry, Pilot } from '../../lib/schemas/pilot'
+import { abilityContributions, sumContributions } from 'salvageunion-reference/rules'
 import { PILOT_BASE_INVENTORY_SLOTS } from '../../lib/rules/derivedStats'
 import { matchesRef } from 'salvageunion-reference/rules'
 
@@ -77,12 +79,20 @@ export function pilotInventoryUsed(pilot: PilotInventoryInput): number {
   return equipmentSlots + genericSlots
 }
 
-type PilotCapacityInput = Pick<Pilot, 'maxInventorySlotsModifier'>
+type PilotCapacityInput = Pick<Pilot, 'maxInventorySlotsModifier'> &
+  Partial<Pick<Pilot, 'abilities'>>
 
 /**
  * Inventory capacity (rules A13: 6 base) plus the hand-edited passive bonus
- * (`maxInventorySlotsModifier`, e.g. Beefcake +4). Never below 0.
+ * (`maxInventorySlotsModifier`) PLUS any ability contributions (Beefcake +4).
+ * Never below 0.
  */
 export function pilotInventoryCapacity(pilot?: PilotCapacityInput): number {
-  return Math.max(0, PILOT_BASE_INVENTORY_SLOTS + (pilot?.maxInventorySlotsModifier ?? 0))
+  const fromAbilities = sumContributions(
+    abilityContributions(pilot?.abilities, 'pilot', 'inventorySlots')
+  )
+  return Math.max(
+    0,
+    PILOT_BASE_INVENTORY_SLOTS + (pilot?.maxInventorySlotsModifier ?? 0) + fromAbilities
+  )
 }

--- a/apps/itun/src/lib/cargo/useCargo.ts
+++ b/apps/itun/src/lib/cargo/useCargo.ts
@@ -28,6 +28,12 @@ import {
 type UseCargoOptions = {
   /** The mech side of the boundary (null/undefined when no mech is docked). */
   mech?: Mech | null
+  /**
+   * The assigned pilot's ability refs. Beefcake raises the piloted MECH's Cargo
+   * Capacity by 6 (ADR-029), so cargo capacity cannot be derived from the mech
+   * alone. Absent = unlinked, which correctly contributes nothing.
+   */
+  pilotAbilities?: string[]
   /** The crawler side (null/undefined when no crawler is linked). */
   crawler?: Crawler | null
   /** Injectable store hook for testing; the real Zustand store otherwise. */
@@ -79,6 +85,7 @@ async function commitUpdates(
 }
 
 export function useCargo({
+  pilotAbilities,
   mech,
   crawler,
   store = useEntityStore,
@@ -88,7 +95,7 @@ export function useCargo({
 
   const state: CargoBoundaryState = {
     carrierLots: mech?.cargoLots ?? [],
-    carrierCargoCap: mech ? mechMaxCargo(mech) : 0,
+    carrierCargoCap: mech ? mechMaxCargo(mech, undefined, { abilities: pilotAbilities }) : 0,
     depotLots: crawler?.cargoLots ?? [],
     scrapPool: crawler?.scrapPool ?? {},
   }
@@ -147,7 +154,7 @@ export function useCargo({
       {
         ...state,
         carrierLots: freshMech.cargoLots ?? [],
-        carrierCargoCap: mechMaxCargo(freshMech),
+        carrierCargoCap: mechMaxCargo(freshMech, undefined, { abilities: pilotAbilities }),
       },
       action
     )

--- a/apps/itun/src/lib/eldridgeCoast/__tests__/eldridgeCoast.test.ts
+++ b/apps/itun/src/lib/eldridgeCoast/__tests__/eldridgeCoast.test.ts
@@ -20,7 +20,13 @@ import { afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:te
 import { SalvageUnionReference, nameToSlug } from 'salvageunion-reference'
 
 import { crawlerMaxSP, pilotMaxAP, pilotMaxHP } from '../../rules/derivedStats'
-import { resolveChassisRef, resolveModuleRef, resolveSystemRef } from 'salvageunion-reference/rules'
+import {
+  abilityContributions,
+  resolveChassisRef,
+  resolveModuleRef,
+  resolveSystemRef,
+  sumContributions,
+} from 'salvageunion-reference/rules'
 import { resolveCrawlerBay, resolveCrawlerType } from '../../crawlerRefs'
 import { CrawlerSchema } from '../../schemas/crawler'
 import { MechSchema } from '../../schemas/mech'
@@ -234,7 +240,11 @@ describe('Eldridge Coast seed — reference refs resolve (drift guard)', () => {
 describe('Eldridge Coast seed — derived stats', () => {
   test('each pilot derives 10 + maxHpModifier HP and 5 + maxApModifier AP', () => {
     for (const p of ELDRIDGE_PILOTS) {
-      expect(pilotMaxHP(p)).toBe(10 + (p.maxHpModifier ?? 0))
+      // Max HP is base + manual adjustment + ABILITY CONTRIBUTIONS (ADR-029), so
+      // this is no longer `10 + modifier`: Nell's Bionic Arms/Legs add 4 that the
+      // record used to hand-encode.
+      const abilityHp = sumContributions(abilityContributions(p.abilities, 'pilot', 'maxHp'))
+      expect(pilotMaxHP(p)).toBe(10 + (p.maxHpModifier ?? 0) + abilityHp)
       expect(pilotMaxAP(p)).toBe(5 + (p.maxApModifier ?? 0))
     }
   })

--- a/apps/itun/src/lib/eldridgeCoast/eldridgeCoast.ts
+++ b/apps/itun/src/lib/eldridgeCoast/eldridgeCoast.ts
@@ -238,7 +238,10 @@ export const ELDRIDGE_PILOTS: readonly Pilot[] = [
     keepsake: 'Family Photo',
     appearance: 'Homebrewed Android. She/her.',
     background: 'Fugitive Corporate Property',
-    maxHpModifier: 8,
+    // Nell's 8 was 4 (class) + 4 hand-encoded for Bionic Arms/Legs, which the app
+    // could not apply. Those are real contributions now (ADR-029), so keeping the 8
+    // would double-count them — the exact hazard the ADR-022 amendment describes.
+    maxHpModifier: 4,
     maxApModifier: 2,
     trainingPoints: 1,
     description:

--- a/apps/itun/src/lib/rules/partnerStats.ts
+++ b/apps/itun/src/lib/rules/partnerStats.ts
@@ -163,6 +163,10 @@ export function partnerDerivedStatsParts(
     out[key] = {
       base,
       installed: scaled,
+      // Tech-level scaling is an anonymous aggregate, not a named source: it
+      // comes from the stat block's own `bonusPerTechLevel`, not from a
+      // separately-nameable ability.
+      sources: [],
       adjustment: 0,
       derived,
       total: derived,

--- a/apps/itun/src/lib/rules/pilotingContext.ts
+++ b/apps/itun/src/lib/rules/pilotingContext.ts
@@ -1,0 +1,28 @@
+import { resolveChassisRef } from 'salvageunion-reference/rules'
+import type { Mech } from '../schemas/mech'
+
+/**
+ * The piloting context a mech's derived maxima need (ADR-029).
+ *
+ * Beefcake is a PILOT ability that raises the piloted MECH, and its Max SP is
+ * "3+X (where X is the Mech's Tech Level)" — so BOTH the ability refs and the
+ * chassis tech level are required to resolve it. Supplying only the abilities
+ * silently resolves 3+X to a flat 3.
+ *
+ * This exists because that mistake was made three times in one change: the
+ * Dashboard band and the condensed strip each built a context with no tech
+ * level, so they under-counted against the body sheet without failing. The
+ * context is optional at the derivation boundary — which is what lets a missing
+ * piece degrade quietly — so it is assembled in exactly one place instead.
+ *
+ * Non-numeric tech levels ('B'/'N' — Bio-Titan, Nanite) have no numeric scale
+ * and resolve to the flat part rather than a guess.
+ */
+export function pilotingContext(
+  mech: Pick<Mech, 'chassisRef'>,
+  abilities: string[] | undefined
+): { abilities?: string[]; techLevel?: number } {
+  const chassis = resolveChassisRef(mech.chassisRef)
+  const techLevel = typeof chassis?.techLevel === 'number' ? chassis.techLevel : undefined
+  return { abilities, techLevel }
+}

--- a/packages/component-lib/src/components/stat/__tests__/provenanceLines.test.ts
+++ b/packages/component-lib/src/components/stat/__tests__/provenanceLines.test.ts
@@ -9,7 +9,15 @@ import type { StatBreakdown } from 'salvageunion-reference/rules'
 import { linesFromBreakdown, summarizeBreakdown } from '../provenanceLines'
 
 function parts(over: Partial<StatBreakdown> = {}): StatBreakdown {
-  const base = { base: 10, installed: 0, adjustment: 0, derived: 10, total: 10, overridden: false }
+  const base = {
+    base: 10,
+    installed: 0,
+    sources: [],
+    adjustment: 0,
+    derived: 10,
+    total: 10,
+    overridden: false,
+  }
   return { ...base, ...over }
 }
 
@@ -93,5 +101,41 @@ describe('summarizeBreakdown', () => {
     )
     expect(text).toContain('= 14')
     expect(text).toContain('overridden to 20')
+  })
+})
+
+describe('named sources vs the anonymous aggregate', () => {
+  test('a named contribution gets its OWN line, never folded into installed', () => {
+    const lines = linesFromBreakdown(
+      parts({
+        installed: 5,
+        sources: [
+          { source: 'Beefcake', ref: 'beefcake', stat: 'structurePoints', amount: 7, copies: 1 },
+        ],
+        derived: 22,
+        total: 22,
+      }),
+      { base: 'Atlas chassis', installed: 'Installed systems & modules' }
+    )
+    const labels = lines.map((l) => l.label)
+    expect(labels).toContain('Installed systems & modules')
+    expect(labels).toContain('Beefcake')
+    // the ability's amount is NOT absorbed into the hardware aggregate
+    expect(lines.find((l) => l.label === 'Installed systems & modules')?.amount).toBe(5)
+    expect(lines.find((l) => l.label === 'Beefcake')?.amount).toBe(7)
+  })
+
+  test('a stacking source shows its copy count', () => {
+    const lines = linesFromBreakdown(
+      parts({
+        sources: [
+          { source: 'Heat Sink', ref: 'heat-sink', stat: 'heatCapacity', amount: 2, copies: 2 },
+        ],
+        derived: 12,
+        total: 12,
+      }),
+      { base: 'Atlas chassis' }
+    )
+    expect(lines.find((l) => l.label === 'Heat Sink')?.detail).toBe('×2')
   })
 })

--- a/packages/component-lib/src/components/stat/provenanceLines.ts
+++ b/packages/component-lib/src/components/stat/provenanceLines.ts
@@ -17,16 +17,18 @@ export type ProvenanceLabels = {
 }
 
 /**
- * Turn a numeric `StatBreakdown` into the labelled ledger `StatProvenance`
+ * Turn a `StatBreakdown` into the labelled ledger `StatProvenance`
  * renders (ADR-029).
  *
- * The contribution line is currently a single **aggregate** — the derivation
- * sums `statBonus` across installed items and returns one number, so there is no
- * honest way to attribute it per item yet. Per-source attribution ("Heat Sink
- * ×2", "Beefcake") arrives with the contribution model, which is what makes each
- * addend nameable; this helper is shaped to take those lines unchanged when it
- * does. Showing one truthful aggregate now beats inventing a breakdown the data
- * cannot support.
+ * Two kinds of contribution, deliberately kept apart:
+ *
+ *   - `installed` is an **aggregate**: the derivation sums `statBonus` across
+ *     installed items, so there is no honest per-item attribution yet. One
+ *     truthful aggregate beats an invented breakdown.
+ *   - `sources` are **named** — an ability, by name — and get a line each.
+ *
+ * Folding the second into the first is the bug this shape exists to prevent: it
+ * renders "Beefcake +7" as installed hardware.
  *
  * Zero-valued lines are omitted — a ledger listing "+0" for everything a mech
  * does not have is noise, not provenance.
@@ -50,6 +52,18 @@ export function linesFromBreakdown(
       label: labels.installed ?? 'Installed items',
       ...(labels.installedDetail ? { detail: labels.installedDetail } : {}),
       amount: parts.installed,
+    })
+  }
+
+  // Named contributions get a line EACH. They must never be folded into the
+  // aggregate above: doing so attributed an ability's bonus to installed
+  // hardware, which is a provenance panel lying about provenance.
+  for (const source of parts.sources ?? []) {
+    lines.push({
+      kind: 'contribution',
+      label: source.source,
+      ...(source.copies > 1 ? { detail: `×${source.copies}` } : {}),
+      amount: source.amount,
     })
   }
 

--- a/packages/salvageunion-reference/data/abilities.json
+++ b/packages/salvageunion-reference/data/abilities.json
@@ -353,6 +353,7 @@
     "level": 2,
     "page": 35,
     "actions": ["Bionic Arms Attack", "Bionic Arms"],
+    "contributions": [{"stat": "maxHp", "target": "pilot", "amount": 2}],
     "content": [
       {
         "type": "paragraph",
@@ -376,6 +377,7 @@
     "level": 3,
     "page": 36,
     "actions": ["Bionic Legs"],
+    "contributions": [{"stat": "maxHp", "target": "pilot", "amount": 2}],
     "description": "Gain a set of integrated Bionic Legs. Gives improved base movement.",
     "additionalSources": [
       {
@@ -596,6 +598,7 @@
     "level": 1,
     "page": 42,
     "actions": ["Beefcake"],
+    "contributions": [{"stat": "structurePoints", "target": "pilotedMech", "amount": {"flat": 3, "perTechLevel": 1}, "note": "\"increases its Max Structure Points by 3+X (where X is the Mech's Tech Level)\""}, {"stat": "cargoCapacity", "target": "pilotedMech", "amount": 6}, {"stat": "maxHp", "target": "pilot", "amount": 2}, {"stat": "inventorySlots", "target": "pilot", "amount": 4}],
     "description": "Increase your size and strength, as well as the size and strength of your Mech."
   },
   {
@@ -1097,6 +1100,7 @@
     "level": 2,
     "page": 60,
     "actions": ["Modular Face Implant"],
+    "contributions": [{"stat": "moduleSlots", "target": "pilot", "amount": 1, "note": "\"Your Pilot gains a Module Slot\""}],
     "description": "Install a Module interfaced directly to your brain."
   },
   {

--- a/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
+++ b/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
@@ -995,6 +995,65 @@ export declare function resolveCatalogChoiceEntities(choice: SURefObjectChoice, 
  */
 export declare function isSchemaOnlyCatalogChoice(choice: SURefObjectChoice): boolean;
 //# sourceMappingURL=choiceCatalog.d.ts.map
+// === lib/rules/contributions.d.ts ===
+/**
+ * Resolving declared contributions into numbers (ADR-029).
+ *
+ * The numeric half of the converged modifier model. Content declares WHAT it
+ * changes (`ContributionSchema`); this module works out how much that is worth
+ * for a given holder, and — crucially — keeps each contribution's SOURCE
+ * attached, so a derivation can hand the provenance panel "Beefcake +7" instead
+ * of an anonymous addend.
+ *
+ * Pure and side-effect-free ([ADR-006](../../docs/adrs/ADR-006-pure-rules-logic.md)):
+ * no I/O, no ORM writes, no mutation of inputs.
+ */
+/** The stat keys a contribution may target. Mirrors `ContributionStatSchema`. */
+export type ContributionStat = 'structurePoints' | 'energyPoints' | 'heatCapacity' | 'cargoCapacity' | 'systemSlots' | 'moduleSlots' | 'maxHp' | 'maxAp' | 'inventorySlots';
+export type ContributionTarget = 'self' | 'pilot' | 'pilotedMech' | 'crawler';
+export type ContributionAmount = number | {
+    flat?: number;
+    perTechLevel: number;
+};
+/** A contribution as declared on a piece of reference content. */
+export type DeclaredContribution = {
+    stat: ContributionStat;
+    amount: ContributionAmount;
+    target?: ContributionTarget;
+    stacks?: boolean;
+    voidWhen?: 'damaged' | 'destroyed';
+    note?: string;
+};
+/** A resolved contribution: an amount, and the content that produced it. */
+export type ResolvedContribution = {
+    /** Display name of the granting entity, e.g. 'Beefcake'. */
+    source: string;
+    /** Slug/name ref so provenance UI can link back to it. */
+    ref: string;
+    stat: ContributionStat;
+    /** Signed, already multiplied by copies and resolved against tech level. */
+    amount: number;
+    /** How many copies contributed (1 unless the item stacks and is installed twice). */
+    copies: number;
+};
+/**
+ * Resolve a declared amount.
+ *
+ * `perTechLevel` needs the target's tech level; a caller that cannot supply one
+ * resolves it to the flat part rather than guessing, so an unknown tech level
+ * under-counts visibly instead of inventing a number.
+ */
+export declare function resolveAmount(amount: ContributionAmount, techLevel?: number): number;
+/**
+ * Every contribution the named abilities declare for `target`/`stat`.
+ *
+ * Abilities do not stack per copy — holding an ability twice is not a thing —
+ * so each resolved contribution is one copy.
+ */
+export declare function abilityContributions(abilityRefs: readonly string[] | undefined, target: ContributionTarget, stat: ContributionStat, techLevel?: number): ResolvedContribution[];
+/** Sum of resolved contributions — the number a derivation folds in. */
+export declare function sumContributions(contributions: readonly ResolvedContribution[]): number;
+//# sourceMappingURL=contributions.d.ts.map
 // === lib/rules/coreMechanic.d.ts ===
 /**
  * Core Mechanic d20 (design review R-6/U-3).
@@ -1382,6 +1441,8 @@ type Injury = {
     note: string;
 };
 type PilotDerivationInput = {
+    /** Ability refs the pilot holds — the source of ability contributions (ADR-029). */
+    abilities?: string[];
     injuries?: Injury[];
     maxHpModifier?: number;
     maxApModifier?: number;
@@ -1435,6 +1496,19 @@ type MechDerivationInput = {
     modules?: string[];
 };
 /**
+ * The pilot whose abilities contribute to the mech they are piloting.
+ *
+ * Beefcake is a PILOT ability that raises the piloted MECH's Max SP and Cargo,
+ * so a mech's maxima cannot be derived from the mech alone. Optional: a mech
+ * with no pilot in scope simply gets no ability contributions, which is what an
+ * unlinked mech should show.
+ */
+export type PilotingContext = {
+    abilities?: string[];
+    /** The mech's Tech Level, for `perTechLevel` amounts (Beefcake's 3+X). */
+    techLevel?: number;
+};
+/**
  * The mech-stat-bonus key each derivation sums over installed systems/modules.
  * Mirrors the `statBonus` field names declared on the reference item schema.
  */
@@ -1482,14 +1556,14 @@ export declare function installedStatBonus(mech: MechDerivationInput, stat: Stat
  * to avoid repeated ORM lookups; floored at 0 so a negative total never
  * produces a negative maximum.
  */
-export declare function mechMaxSPParts(mech: MechDerivationInput, chassis?: ChassisStats | null): StatBreakdown;
-export declare function mechMaxEPParts(mech: MechDerivationInput, chassis?: ChassisStats | null): StatBreakdown;
-export declare function mechMaxHeatParts(mech: MechDerivationInput, chassis?: ChassisStats | null): StatBreakdown;
-export declare function mechMaxCargoParts(mech: MechDerivationInput, chassis?: ChassisStats | null): StatBreakdown;
-export declare function mechMaxSP(mech: MechDerivationInput, chassis?: ChassisStats | null): number;
-export declare function mechMaxEP(mech: MechDerivationInput, chassis?: ChassisStats | null): number;
-export declare function mechMaxHeat(mech: MechDerivationInput, chassis?: ChassisStats | null): number;
-export declare function mechMaxCargo(mech: MechDerivationInput, chassis?: ChassisStats | null): number;
+export declare function mechMaxSPParts(mech: MechDerivationInput, chassis?: ChassisStats | null, pilot?: PilotingContext): StatBreakdown;
+export declare function mechMaxEPParts(mech: MechDerivationInput, chassis?: ChassisStats | null, pilot?: PilotingContext): StatBreakdown;
+export declare function mechMaxHeatParts(mech: MechDerivationInput, chassis?: ChassisStats | null, pilot?: PilotingContext): StatBreakdown;
+export declare function mechMaxCargoParts(mech: MechDerivationInput, chassis?: ChassisStats | null, pilot?: PilotingContext): StatBreakdown;
+export declare function mechMaxSP(mech: MechDerivationInput, chassis?: ChassisStats | null, pilot?: PilotingContext): number;
+export declare function mechMaxEP(mech: MechDerivationInput, chassis?: ChassisStats | null, pilot?: PilotingContext): number;
+export declare function mechMaxHeat(mech: MechDerivationInput, chassis?: ChassisStats | null, pilot?: PilotingContext): number;
+export declare function mechMaxCargo(mech: MechDerivationInput, chassis?: ChassisStats | null, pilot?: PilotingContext): number;
 /**
  * Clamp current SP/EP/Heat to the derived maxima. Run after any modifier or
  * chassis change and persist the returned patch when non-empty.
@@ -1743,6 +1817,8 @@ export { applySpDamage, mechEffectiveDamage, applyMechDamage, criticalDamageOutc
 export type { DamageKind, MechDamageInput, MechDamageEffect, PilotDamageInput, PilotDamageEffect, CriticalDamageEffect, CriticalInjuryEffect, } from './takeDamage.js';
 export { PILOT_BASE_HP, PILOT_BASE_AP, PILOT_BASE_INVENTORY_SLOTS, injuryMaxHpPenalty, pilotMaxHP, pilotMaxAP, isPilotDead, clampPilotCurrentStats, installedStatBonus, mechMaxSP, mechMaxEP, mechMaxHeat, mechMaxCargo, clampMechCurrentStats, unifiedMechConditions, crawlerMaxSP, crawlerMaxSPParts, mechMaxSPParts, mechMaxEPParts, mechMaxHeatParts, mechMaxCargoParts, pilotMaxHPParts, pilotMaxAPParts, clampCrawlerCurrentStats, } from './derivedStats.js';
 export type { ChassisStats, CrawlerMaxSPParts, StatBreakdown } from './derivedStats.js';
+export { abilityContributions, resolveAmount, sumContributions, } from './contributions.js';
+export type { ContributionStat, ContributionTarget, ContributionAmount, DeclaredContribution, ResolvedContribution, } from './contributions.js';
 export { MEDIATOR_TABLE_NAMES, MEDIATOR_TABLE_LABEL, performMediatorRoll, describeMediatorRoll, } from './mediatorTables.js';
 export type { FindRollTable } from './mediatorTables.js';
 export type { TechLevel, SoftWarning, SoftWarningSeverity, SoftWarningContext, EditSnapshot, MechInput, MechSystemSlot, MechModuleSlot, MechCapacityResult, CapacityViolation, ScrapableItem, CargoItem, CargoItemRef, CargoItemCustom, CargoParent, CargoCapacityResult, CargoViolation, PilotSnapshot, MechSnapshot, AbilityInput, AbilityTier, SystemSnapshot, Roll, ReactorOverloadOutcome, HeatCheckResult, HeatCheckEffect, PushResult, CriticalDamageOutcome, CriticalDamageResult, CriticalInjuryOutcome, CriticalInjuryResult, MediatorTableId, MediatorRollResult, } from './types.js';
@@ -2904,6 +2980,35 @@ export declare const AbilitySchema: z.ZodObject<{
         Variable: "Variable";
     }>>;
     actions: z.ZodArray<z.ZodString>;
+    contributions: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        stat: z.ZodEnum<{
+            structurePoints: "structurePoints";
+            energyPoints: "energyPoints";
+            heatCapacity: "heatCapacity";
+            systemSlots: "systemSlots";
+            moduleSlots: "moduleSlots";
+            cargoCapacity: "cargoCapacity";
+            maxHp: "maxHp";
+            maxAp: "maxAp";
+            inventorySlots: "inventorySlots";
+        }>;
+        amount: z.ZodUnion<readonly [z.ZodNumber, z.ZodObject<{
+            flat: z.ZodOptional<z.ZodNumber>;
+            perTechLevel: z.ZodNumber;
+        }, z.core.$strict>]>;
+        target: z.ZodOptional<z.ZodEnum<{
+            self: "self";
+            pilot: "pilot";
+            pilotedMech: "pilotedMech";
+            crawler: "crawler";
+        }>>;
+        stacks: z.ZodOptional<z.ZodBoolean>;
+        voidWhen: z.ZodOptional<z.ZodEnum<{
+            damaged: "damaged";
+            destroyed: "destroyed";
+        }>>;
+        note: z.ZodOptional<z.ZodString>;
+    }, z.core.$strict>>>;
 }, z.core.$strict>;
 /**
  * Requirements for ability trees
@@ -7919,6 +8024,97 @@ export declare const MechStatBonusSchema: z.ZodObject<{
     energyPoints: z.ZodOptional<z.ZodNumber>;
     heatCapacity: z.ZodOptional<z.ZodNumber>;
     cargoCapacity: z.ZodOptional<z.ZodNumber>;
+}, z.core.$strict>;
+/**
+ * The stats a contribution may raise or lower (ADR-029).
+ *
+ * A superset of `MechStatBonusSchema`'s four keys: an ability can change a
+ * PILOT stat (Bionic Legs "+2 Max HP", Beefcake "+4 Inventory Capacity") or a
+ * slot COUNT (Modular Face Implant "your Pilot gains a Module Slot"), neither of
+ * which the mech-only shape could express.
+ */
+export declare const ContributionStatSchema: z.ZodEnum<{
+    structurePoints: "structurePoints";
+    energyPoints: "energyPoints";
+    heatCapacity: "heatCapacity";
+    systemSlots: "systemSlots";
+    moduleSlots: "moduleSlots";
+    cargoCapacity: "cargoCapacity";
+    maxHp: "maxHp";
+    maxAp: "maxAp";
+    inventorySlots: "inventorySlots";
+}>;
+/**
+ * Whose stat a contribution changes.
+ *
+ * `self` is the host the contribution is declared on (a system contributing to
+ * its own mech). The others exist because Beefcake is a PILOT ability that
+ * raises the piloted MECH's Max SP and Cargo while also raising the pilot's own
+ * Max HP and Inventory — one record, two targets, which no single-target shape
+ * could express.
+ */
+export declare const ContributionTargetSchema: z.ZodEnum<{
+    self: "self";
+    pilot: "pilot";
+    pilotedMech: "pilotedMech";
+    crawler: "crawler";
+}>;
+/**
+ * How much a contribution is worth.
+ *
+ * A plain integer covers most records. `perTechLevel` exists for Beefcake —
+ * "increases its Max Structure Points by 3+X (where X is the Mech's Tech
+ * Level)" — where the amount is `flat + perTechLevel × techLevel`. Rendering the
+ * amount needs the target's tech level, so a consumer that cannot supply one
+ * resolves `perTechLevel` to 0 rather than guessing.
+ */
+export declare const ContributionAmountSchema: z.ZodUnion<readonly [z.ZodNumber, z.ZodObject<{
+    flat: z.ZodOptional<z.ZodNumber>;
+    perTechLevel: z.ZodNumber;
+}, z.core.$strict>]>;
+/**
+ * A single mechanical contribution a piece of content makes to a stat
+ * (ADR-029).
+ *
+ * This is the numeric half of the converged model. The trait/damage/range half
+ * already exists as `ChoiceEffectSchema` and is applied by `resolveChoiceView`;
+ * the two are declared side by side rather than merged into one union, because
+ * they are resolved at different layers — stats at derivation time, effects at
+ * dataview time.
+ *
+ * **Never infer a contribution from prose.** Populate it only where the rules
+ * text states a flat mechanical change; anything conditional, prose-only, or
+ * duration-bound stays undeclared and is answered to the parity audit with an
+ * explicit exemption instead.
+ */
+export declare const ContributionSchema: z.ZodObject<{
+    stat: z.ZodEnum<{
+        structurePoints: "structurePoints";
+        energyPoints: "energyPoints";
+        heatCapacity: "heatCapacity";
+        systemSlots: "systemSlots";
+        moduleSlots: "moduleSlots";
+        cargoCapacity: "cargoCapacity";
+        maxHp: "maxHp";
+        maxAp: "maxAp";
+        inventorySlots: "inventorySlots";
+    }>;
+    amount: z.ZodUnion<readonly [z.ZodNumber, z.ZodObject<{
+        flat: z.ZodOptional<z.ZodNumber>;
+        perTechLevel: z.ZodNumber;
+    }, z.core.$strict>]>;
+    target: z.ZodOptional<z.ZodEnum<{
+        self: "self";
+        pilot: "pilot";
+        pilotedMech: "pilotedMech";
+        crawler: "crawler";
+    }>>;
+    stacks: z.ZodOptional<z.ZodBoolean>;
+    voidWhen: z.ZodOptional<z.ZodEnum<{
+        damaged: "damaged";
+        destroyed: "destroyed";
+    }>>;
+    note: z.ZodOptional<z.ZodString>;
 }, z.core.$strict>;
 /**
  * A system or module that can be installed on a mech

--- a/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
+++ b/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
@@ -1427,6 +1427,7 @@ export declare function isCrawlerWeaponPickComplete(selectedCount: number): bool
  * consumer's Zod-inferred Pilot/Mech/Crawler types (e.g. ITUN's
  * `src/lib/schemas/`) satisfy them automatically.
  */
+import type { ResolvedContribution } from './contributions.js';
 /**
  * Base pilot stats per the core rules (10 HP / 5 AP / 6 inventory slots).
  * These are NOT in the reference data — class records do not encode them —
@@ -1527,8 +1528,21 @@ type StatBonusKey = 'structurePoints' | 'energyPoints' | 'heatCapacity' | 'cargo
 export type StatBreakdown = {
     /** The rules baseline before anything is added (chassis stat, tech-level SP, a constant). */
     base: number;
-    /** Summed `statBonus` across installed systems/modules, counted per copy. */
+    /**
+     * Summed `statBonus` across installed systems/modules, counted per copy.
+     *
+     * ANONYMOUS by construction — the sum is taken across items and there is no
+     * per-item attribution yet, so provenance renders it as one aggregate line.
+     * Named contributions live in `sources` and must NOT be folded in here, or the
+     * panel attributes an ability's bonus to installed hardware.
+     */
     installed: number;
+    /**
+     * Contributions that know their own source (ADR-029) — an ability, by name.
+     * Rendered as one labelled line each, so "Beefcake +7" is never mislabelled as
+     * installed hardware.
+     */
+    sources: ResolvedContribution[];
     /** The player's hand-entered manual adjustment (`max*Modifier`). Contributes; never replaces. */
     adjustment: number;
     /** base + installed + adjustment, floored at 0. Always computed, even when pinned. */

--- a/packages/salvageunion-reference/lib/rules/contributions.test.ts
+++ b/packages/salvageunion-reference/lib/rules/contributions.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Ability contributions (ADR-029).
+ *
+ * These four abilities state a flat stat change in their rules text and, until
+ * this landed, the schema could not express it at all — so the numbers on the
+ * sheet were simply wrong for any pilot holding them. The assertions below run
+ * against the REAL dataset, so a regression in the data fails here.
+ */
+
+import { beforeAll, describe, expect, it } from 'bun:test'
+
+import { SalvageUnionReference } from '../index.js'
+import { abilityContributions, resolveAmount, sumContributions } from './contributions.js'
+import { mechMaxCargoParts, mechMaxSPParts, pilotMaxHPParts } from './derivedStats.js'
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+describe('resolveAmount', () => {
+  it('passes a plain integer through', () => {
+    expect(resolveAmount(4)).toBe(4)
+  })
+
+  it('resolves 3+X against a tech level (Beefcake)', () => {
+    expect(resolveAmount({ flat: 3, perTechLevel: 1 }, 4)).toBe(7)
+  })
+
+  it('under-counts visibly rather than guessing when the tech level is unknown', () => {
+    expect(resolveAmount({ flat: 3, perTechLevel: 1 })).toBe(3)
+  })
+})
+
+describe('ability contributions resolve from the real dataset', () => {
+  it('Bionic Legs grants the pilot +2 Max HP', () => {
+    const found = abilityContributions(['Bionic Legs'], 'pilot', 'maxHp')
+    expect(sumContributions(found)).toBe(2)
+    expect(found[0]?.source).toBe('Bionic Legs')
+  })
+
+  it('Bionic Arms grants the pilot +2 Max HP', () => {
+    expect(sumContributions(abilityContributions(['Bionic Arms'], 'pilot', 'maxHp'))).toBe(2)
+  })
+
+  it('two HP abilities stack across different abilities', () => {
+    const both = abilityContributions(['Bionic Arms', 'Bionic Legs'], 'pilot', 'maxHp')
+    expect(both).toHaveLength(2)
+    expect(sumContributions(both)).toBe(4)
+  })
+
+  it('Beefcake targets the PILOT and the PILOTED MECH from one record', () => {
+    expect(sumContributions(abilityContributions(['Beefcake'], 'pilot', 'maxHp'))).toBe(2)
+    expect(sumContributions(abilityContributions(['Beefcake'], 'pilot', 'inventorySlots'))).toBe(4)
+    expect(
+      sumContributions(abilityContributions(['Beefcake'], 'pilotedMech', 'cargoCapacity'))
+    ).toBe(6)
+  })
+
+  it("Beefcake's Max SP scales with the mech's tech level (3+X)", () => {
+    const atTl1 = abilityContributions(['Beefcake'], 'pilotedMech', 'structurePoints', 1)
+    const atTl5 = abilityContributions(['Beefcake'], 'pilotedMech', 'structurePoints', 5)
+    expect(sumContributions(atTl1)).toBe(4)
+    expect(sumContributions(atTl5)).toBe(8)
+  })
+
+  it('Modular Face Implant grants the pilot a Module Slot', () => {
+    expect(
+      sumContributions(abilityContributions(['Modular Face Implant'], 'pilot', 'moduleSlots'))
+    ).toBe(1)
+  })
+
+  it('an unresolvable ability ref contributes 0 rather than throwing', () => {
+    expect(abilityContributions(['no-such-ability'], 'pilot', 'maxHp')).toEqual([])
+  })
+
+  it('a contribution is only returned for its own target and stat', () => {
+    expect(abilityContributions(['Beefcake'], 'pilot', 'structurePoints')).toEqual([])
+    expect(abilityContributions(['Bionic Legs'], 'pilotedMech', 'maxHp')).toEqual([])
+  })
+})
+
+describe('contributions reach the derived maxima', () => {
+  it('a pilot holding Bionic Legs has 12 Max HP, not 10', () => {
+    expect(pilotMaxHPParts({ abilities: ['Bionic Legs'] }).total).toBe(12)
+    expect(pilotMaxHPParts({}).total).toBe(10)
+  })
+
+  it('Beefcake raises the piloted mech, and the mech alone cannot know it', () => {
+    const mech = { chassisRef: 'no-such-chassis' }
+    const chassis = { cargoCapacity: 6 }
+    // Without the piloting context the mech derives its own cargo only.
+    expect(mechMaxCargoParts(mech, chassis).total).toBe(6)
+    // With it, Beefcake's +6 applies.
+    expect(mechMaxCargoParts(mech, chassis, { abilities: ['Beefcake'] }).total).toBe(12)
+  })
+
+  it("the mech's tech level drives Beefcake's SP scaling", () => {
+    const mech = { chassisRef: 'no-such-chassis' }
+    const chassis = { structurePoints: 20 }
+    expect(mechMaxSPParts(mech, chassis, { abilities: ['Beefcake'], techLevel: 4 }).total).toBe(27)
+  })
+})

--- a/packages/salvageunion-reference/lib/rules/contributions.test.ts
+++ b/packages/salvageunion-reference/lib/rules/contributions.test.ts
@@ -11,7 +11,12 @@ import { beforeAll, describe, expect, it } from 'bun:test'
 
 import { SalvageUnionReference } from '../index.js'
 import { abilityContributions, resolveAmount, sumContributions } from './contributions.js'
-import { mechMaxCargoParts, mechMaxSPParts, pilotMaxHPParts } from './derivedStats.js'
+import {
+  mechMaxCargoParts,
+  mechMaxHeatParts,
+  mechMaxSPParts,
+  pilotMaxHPParts,
+} from './derivedStats.js'
 
 beforeAll(async () => {
   await SalvageUnionReference.preload('all')
@@ -132,5 +137,42 @@ describe("Beefcake's four contributions each reach a real consumer", () => {
     const mech = { chassisRef: 'no-such-chassis' }
     expect(mechMaxSPParts(mech, { structurePoints: 20 }).total).toBe(20)
     expect(mechMaxCargoParts(mech, { cargoCapacity: 6 }).total).toBe(6)
+  })
+})
+
+describe('named sources stay attributable', () => {
+  // The provenance panel labels `installed` as "Installed systems & modules".
+  // Folding an ability's contribution into that number made the panel attribute
+  // Beefcake's bonus to installed hardware — a provenance feature lying about
+  // provenance. Named contributions therefore ride `sources`, never `installed`.
+  it('an ability contribution does NOT inflate the anonymous installed aggregate', () => {
+    const mech = { chassisRef: 'no-such-chassis', systems: ['Heat Sink'] }
+    const chassis = { heatCapacity: 5 }
+    const parts = mechMaxHeatParts(mech, chassis, { abilities: ['Beefcake'] })
+    // Heat Sink is real installed hardware; Beefcake contributes no heat.
+    expect(parts.installed).toBe(1)
+    expect(parts.sources).toEqual([])
+  })
+
+  it('a piloted-mech contribution arrives as a NAMED source, not as installed', () => {
+    const mech = { chassisRef: 'no-such-chassis' }
+    const chassis = { structurePoints: 20 }
+    const parts = mechMaxSPParts(mech, chassis, { abilities: ['Beefcake'], techLevel: 4 })
+    expect(parts.installed).toBe(0)
+    expect(parts.sources).toHaveLength(1)
+    expect(parts.sources[0]?.source).toBe('Beefcake')
+    expect(parts.sources[0]?.amount).toBe(7)
+    // and the total still adds up
+    expect(parts.derived).toBe(27)
+  })
+
+  it('a pilot ability is named while the injury penalty stays anonymous', () => {
+    const parts = pilotMaxHPParts({
+      abilities: ['Bionic Legs'],
+      injuries: [{ severity: 'minor', note: '' }],
+    })
+    expect(parts.installed).toBe(-1) // the injury
+    expect(parts.sources.map((s) => s.source)).toEqual(['Bionic Legs'])
+    expect(parts.total).toBe(11) // 10 − 1 + 2
   })
 })

--- a/packages/salvageunion-reference/lib/rules/contributions.test.ts
+++ b/packages/salvageunion-reference/lib/rules/contributions.test.ts
@@ -100,3 +100,37 @@ describe('contributions reach the derived maxima', () => {
     expect(mechMaxSPParts(mech, chassis, { abilities: ['Beefcake'], techLevel: 4 }).total).toBe(27)
   })
 })
+
+describe("Beefcake's four contributions each reach a real consumer", () => {
+  // Beefcake was the record that motivated the whole model, and it is the one
+  // most easily half-wired: two of its four contributions target the PILOT and
+  // two target the PILOTED MECH, so a surface that forgets the piloting context
+  // silently under-counts rather than failing.
+  const BEEFCAKE = ['Beefcake']
+
+  it('pilot Max HP +2', () => {
+    expect(pilotMaxHPParts({ abilities: BEEFCAKE }).total).toBe(12)
+  })
+
+  it('pilot Inventory +4 is declared (consumed by pilotInventoryCapacity)', () => {
+    expect(sumContributions(abilityContributions(BEEFCAKE, 'pilot', 'inventorySlots'))).toBe(4)
+  })
+
+  it('piloted mech Cargo +6', () => {
+    const mech = { chassisRef: 'no-such-chassis' }
+    expect(mechMaxCargoParts(mech, { cargoCapacity: 6 }, { abilities: BEEFCAKE }).total).toBe(12)
+  })
+
+  it('piloted mech Max SP 3+X, and X is the MECH tech level not the pilot', () => {
+    const mech = { chassisRef: 'no-such-chassis' }
+    const chassis = { structurePoints: 20 }
+    expect(mechMaxSPParts(mech, chassis, { abilities: BEEFCAKE, techLevel: 1 }).total).toBe(24)
+    expect(mechMaxSPParts(mech, chassis, { abilities: BEEFCAKE, techLevel: 6 }).total).toBe(29)
+  })
+
+  it('a mech with no piloting context gets NONE of it — the under-count to guard', () => {
+    const mech = { chassisRef: 'no-such-chassis' }
+    expect(mechMaxSPParts(mech, { structurePoints: 20 }).total).toBe(20)
+    expect(mechMaxCargoParts(mech, { cargoCapacity: 6 }).total).toBe(6)
+  })
+})

--- a/packages/salvageunion-reference/lib/rules/contributions.ts
+++ b/packages/salvageunion-reference/lib/rules/contributions.ts
@@ -1,0 +1,118 @@
+/**
+ * Resolving declared contributions into numbers (ADR-029).
+ *
+ * The numeric half of the converged modifier model. Content declares WHAT it
+ * changes (`ContributionSchema`); this module works out how much that is worth
+ * for a given holder, and — crucially — keeps each contribution's SOURCE
+ * attached, so a derivation can hand the provenance panel "Beefcake +7" instead
+ * of an anonymous addend.
+ *
+ * Pure and side-effect-free ([ADR-006](../../docs/adrs/ADR-006-pure-rules-logic.md)):
+ * no I/O, no ORM writes, no mutation of inputs.
+ */
+
+import { SalvageUnionReference } from '../index.js'
+import { matchesRef } from './resolveRefs.js'
+
+/** The stat keys a contribution may target. Mirrors `ContributionStatSchema`. */
+export type ContributionStat =
+  | 'structurePoints'
+  | 'energyPoints'
+  | 'heatCapacity'
+  | 'cargoCapacity'
+  | 'systemSlots'
+  | 'moduleSlots'
+  | 'maxHp'
+  | 'maxAp'
+  | 'inventorySlots'
+
+export type ContributionTarget = 'self' | 'pilot' | 'pilotedMech' | 'crawler'
+
+export type ContributionAmount = number | { flat?: number; perTechLevel: number }
+
+/** A contribution as declared on a piece of reference content. */
+export type DeclaredContribution = {
+  stat: ContributionStat
+  amount: ContributionAmount
+  target?: ContributionTarget
+  stacks?: boolean
+  voidWhen?: 'damaged' | 'destroyed'
+  note?: string
+}
+
+/** A resolved contribution: an amount, and the content that produced it. */
+export type ResolvedContribution = {
+  /** Display name of the granting entity, e.g. 'Beefcake'. */
+  source: string
+  /** Slug/name ref so provenance UI can link back to it. */
+  ref: string
+  stat: ContributionStat
+  /** Signed, already multiplied by copies and resolved against tech level. */
+  amount: number
+  /** How many copies contributed (1 unless the item stacks and is installed twice). */
+  copies: number
+}
+
+/**
+ * Resolve a declared amount.
+ *
+ * `perTechLevel` needs the target's tech level; a caller that cannot supply one
+ * resolves it to the flat part rather than guessing, so an unknown tech level
+ * under-counts visibly instead of inventing a number.
+ */
+export function resolveAmount(amount: ContributionAmount, techLevel?: number): number {
+  if (typeof amount === 'number') return amount
+  const flat = amount.flat ?? 0
+  if (techLevel === undefined) return flat
+  return flat + amount.perTechLevel * techLevel
+}
+
+/** Content that may declare contributions. */
+type ContributionHost = { name?: string; contributions?: DeclaredContribution[] }
+
+/**
+ * Every contribution the named abilities declare for `target`/`stat`.
+ *
+ * Abilities do not stack per copy — holding an ability twice is not a thing —
+ * so each resolved contribution is one copy.
+ */
+export function abilityContributions(
+  abilityRefs: readonly string[] | undefined,
+  target: ContributionTarget,
+  stat: ContributionStat,
+  techLevel?: number
+): ResolvedContribution[] {
+  if (!abilityRefs?.length) return []
+  const out: ResolvedContribution[] = []
+  for (const ref of abilityRefs) {
+    let ability: ContributionHost | undefined
+    try {
+      ability = SalvageUnionReference.Abilities.find((a) => matchesRef(a, ref)) as
+        | ContributionHost
+        | undefined
+    } catch {
+      // A missing catalog is a data problem, not a crash: an unresolvable ref
+      // contributes 0, exactly as an unresolvable installed item does.
+      ability = undefined
+    }
+    for (const c of ability?.contributions ?? []) {
+      if (c.stat !== stat) continue
+      if ((c.target ?? 'self') !== target) continue
+      const amount = resolveAmount(c.amount, techLevel)
+      if (amount === 0) continue
+      out.push({
+        source: ability?.name ?? ref,
+        ref,
+        stat,
+        amount,
+        copies: 1,
+      })
+    }
+  }
+  return out
+}
+
+/** Sum of resolved contributions — the number a derivation folds in. */
+export function sumContributions(contributions: readonly ResolvedContribution[]): number {
+  return contributions.reduce((total, c) => total + c.amount, 0)
+}

--- a/packages/salvageunion-reference/lib/rules/derivedStats.ts
+++ b/packages/salvageunion-reference/lib/rules/derivedStats.ts
@@ -22,6 +22,7 @@
 import { SalvageUnionReference } from '../index.js'
 import { crawlerMaxSpBonus } from './creation.js'
 import { resolveChassisRef, resolveInstalledRef } from './resolveRefs.js'
+import { abilityContributions, sumContributions } from './contributions.js'
 
 // ---------------------------------------------------------------------------
 // Pilot
@@ -40,6 +41,8 @@ export const PILOT_BASE_INVENTORY_SLOTS = 6
 type Injury = { severity: 'minor' | 'major'; note: string }
 
 type PilotDerivationInput = {
+  /** Ability refs the pilot holds — the source of ability contributions (ADR-029). */
+  abilities?: string[]
   injuries?: Injury[]
   maxHpModifier?: number
   maxApModifier?: number
@@ -61,9 +64,10 @@ export function pilotMaxHPParts(pilot: PilotDerivationInput): StatBreakdown {
   // The injury penalty rides in `installed` — it is a rules-sourced contribution
   // like an installed statBonus, just a negative one, and is derived from
   // `injuries` so healing restores max HP with no bookkeeping.
+  const abilityHp = sumContributions(abilityContributions(pilot.abilities, 'pilot', 'maxHp'))
   const parts = breakdownOf(
     PILOT_BASE_HP,
-    -injuryMaxHpPenalty(pilot.injuries),
+    -injuryMaxHpPenalty(pilot.injuries) + abilityHp,
     pilot.maxHpModifier ?? 0,
     pilot.maxHpOverride
   )
@@ -71,7 +75,8 @@ export function pilotMaxHPParts(pilot: PilotDerivationInput): StatBreakdown {
   // (rules A2), surfaced by isPilotDead() rather than clamped away. Recompute
   // unfloored so a lethal injury total is not hidden behind breakdownOf's floor.
   if (parts.overridden) return parts
-  const unfloored = PILOT_BASE_HP + (pilot.maxHpModifier ?? 0) - injuryMaxHpPenalty(pilot.injuries)
+  const unfloored =
+    PILOT_BASE_HP + (pilot.maxHpModifier ?? 0) - injuryMaxHpPenalty(pilot.injuries) + abilityHp
   return { ...parts, derived: unfloored, total: unfloored }
 }
 
@@ -81,7 +86,12 @@ export function pilotMaxHP(pilot: PilotDerivationInput): number {
 
 /** Derived max AP (base 5 + Stat Training tiers etc.). */
 export function pilotMaxAPParts(pilot: PilotDerivationInput): StatBreakdown {
-  return breakdownOf(PILOT_BASE_AP, 0, pilot.maxApModifier ?? 0, pilot.maxApOverride)
+  return breakdownOf(
+    PILOT_BASE_AP,
+    sumContributions(abilityContributions(pilot.abilities, 'pilot', 'maxAp')),
+    pilot.maxApModifier ?? 0,
+    pilot.maxApOverride
+  )
 }
 
 export function pilotMaxAP(pilot: PilotDerivationInput): number {
@@ -140,6 +150,20 @@ type MechDerivationInput = {
   // falls back to chassis stat + modifier.
   systems?: string[]
   modules?: string[]
+}
+
+/**
+ * The pilot whose abilities contribute to the mech they are piloting.
+ *
+ * Beefcake is a PILOT ability that raises the piloted MECH's Max SP and Cargo,
+ * so a mech's maxima cannot be derived from the mech alone. Optional: a mech
+ * with no pilot in scope simply gets no ability contributions, which is what an
+ * unlinked mech should show.
+ */
+export type PilotingContext = {
+  abilities?: string[]
+  /** The mech's Tech Level, for `perTechLevel` amounts (Beefcake's 3+X). */
+  techLevel?: number
 }
 
 /**
@@ -236,12 +260,16 @@ export function installedStatBonus(mech: MechDerivationInput, stat: StatBonusKey
  */
 export function mechMaxSPParts(
   mech: MechDerivationInput,
-  chassis?: ChassisStats | null
+  chassis?: ChassisStats | null,
+  pilot?: PilotingContext
 ): StatBreakdown {
   const c = resolveChassis(mech, chassis)
   return breakdownOf(
     c.structurePoints ?? 0,
-    installedStatBonus(mech, 'structurePoints'),
+    installedStatBonus(mech, 'structurePoints') +
+      sumContributions(
+        abilityContributions(pilot?.abilities, 'pilotedMech', 'structurePoints', pilot?.techLevel)
+      ),
     mech.maxSpModifier ?? 0,
     mech.maxSpOverride
   )
@@ -249,12 +277,16 @@ export function mechMaxSPParts(
 
 export function mechMaxEPParts(
   mech: MechDerivationInput,
-  chassis?: ChassisStats | null
+  chassis?: ChassisStats | null,
+  pilot?: PilotingContext
 ): StatBreakdown {
   const c = resolveChassis(mech, chassis)
   return breakdownOf(
     c.energyPoints ?? 0,
-    installedStatBonus(mech, 'energyPoints'),
+    installedStatBonus(mech, 'energyPoints') +
+      sumContributions(
+        abilityContributions(pilot?.abilities, 'pilotedMech', 'energyPoints', pilot?.techLevel)
+      ),
     mech.maxEpModifier ?? 0,
     mech.maxEpOverride
   )
@@ -262,12 +294,16 @@ export function mechMaxEPParts(
 
 export function mechMaxHeatParts(
   mech: MechDerivationInput,
-  chassis?: ChassisStats | null
+  chassis?: ChassisStats | null,
+  pilot?: PilotingContext
 ): StatBreakdown {
   const c = resolveChassis(mech, chassis)
   return breakdownOf(
     c.heatCapacity ?? 0,
-    installedStatBonus(mech, 'heatCapacity'),
+    installedStatBonus(mech, 'heatCapacity') +
+      sumContributions(
+        abilityContributions(pilot?.abilities, 'pilotedMech', 'heatCapacity', pilot?.techLevel)
+      ),
     mech.maxHeatModifier ?? 0,
     mech.maxHeatOverride
   )
@@ -275,12 +311,16 @@ export function mechMaxHeatParts(
 
 export function mechMaxCargoParts(
   mech: MechDerivationInput,
-  chassis?: ChassisStats | null
+  chassis?: ChassisStats | null,
+  pilot?: PilotingContext
 ): StatBreakdown {
   const c = resolveChassis(mech, chassis)
   return breakdownOf(
     c.cargoCapacity ?? 0,
-    installedStatBonus(mech, 'cargoCapacity'),
+    installedStatBonus(mech, 'cargoCapacity') +
+      sumContributions(
+        abilityContributions(pilot?.abilities, 'pilotedMech', 'cargoCapacity', pilot?.techLevel)
+      ),
     mech.maxCargoModifier ?? 0,
     mech.maxCargoOverride
   )
@@ -288,20 +328,36 @@ export function mechMaxCargoParts(
 
 // The scalar forms every existing call site uses. Thin `.total` wrappers so the
 // breakdown could be introduced without touching ~40 callers (ADR-029).
-export function mechMaxSP(mech: MechDerivationInput, chassis?: ChassisStats | null): number {
-  return mechMaxSPParts(mech, chassis).total
+export function mechMaxSP(
+  mech: MechDerivationInput,
+  chassis?: ChassisStats | null,
+  pilot?: PilotingContext
+): number {
+  return mechMaxSPParts(mech, chassis, pilot).total
 }
 
-export function mechMaxEP(mech: MechDerivationInput, chassis?: ChassisStats | null): number {
-  return mechMaxEPParts(mech, chassis).total
+export function mechMaxEP(
+  mech: MechDerivationInput,
+  chassis?: ChassisStats | null,
+  pilot?: PilotingContext
+): number {
+  return mechMaxEPParts(mech, chassis, pilot).total
 }
 
-export function mechMaxHeat(mech: MechDerivationInput, chassis?: ChassisStats | null): number {
-  return mechMaxHeatParts(mech, chassis).total
+export function mechMaxHeat(
+  mech: MechDerivationInput,
+  chassis?: ChassisStats | null,
+  pilot?: PilotingContext
+): number {
+  return mechMaxHeatParts(mech, chassis, pilot).total
 }
 
-export function mechMaxCargo(mech: MechDerivationInput, chassis?: ChassisStats | null): number {
-  return mechMaxCargoParts(mech, chassis).total
+export function mechMaxCargo(
+  mech: MechDerivationInput,
+  chassis?: ChassisStats | null,
+  pilot?: PilotingContext
+): number {
+  return mechMaxCargoParts(mech, chassis, pilot).total
 }
 
 /**

--- a/packages/salvageunion-reference/lib/rules/derivedStats.ts
+++ b/packages/salvageunion-reference/lib/rules/derivedStats.ts
@@ -23,6 +23,7 @@ import { SalvageUnionReference } from '../index.js'
 import { crawlerMaxSpBonus } from './creation.js'
 import { resolveChassisRef, resolveInstalledRef } from './resolveRefs.js'
 import { abilityContributions, sumContributions } from './contributions.js'
+import type { ResolvedContribution } from './contributions.js'
 
 // ---------------------------------------------------------------------------
 // Pilot
@@ -64,12 +65,14 @@ export function pilotMaxHPParts(pilot: PilotDerivationInput): StatBreakdown {
   // The injury penalty rides in `installed` — it is a rules-sourced contribution
   // like an installed statBonus, just a negative one, and is derived from
   // `injuries` so healing restores max HP with no bookkeeping.
-  const abilityHp = sumContributions(abilityContributions(pilot.abilities, 'pilot', 'maxHp'))
+  const hpSources = abilityContributions(pilot.abilities, 'pilot', 'maxHp')
+  const abilityHp = sumContributions(hpSources)
   const parts = breakdownOf(
     PILOT_BASE_HP,
-    -injuryMaxHpPenalty(pilot.injuries) + abilityHp,
+    -injuryMaxHpPenalty(pilot.injuries),
     pilot.maxHpModifier ?? 0,
-    pilot.maxHpOverride
+    pilot.maxHpOverride,
+    hpSources
   )
   // Max HP may legitimately reach 0 or below — that is the dead state
   // (rules A2), surfaced by isPilotDead() rather than clamped away. Recompute
@@ -88,9 +91,10 @@ export function pilotMaxHP(pilot: PilotDerivationInput): number {
 export function pilotMaxAPParts(pilot: PilotDerivationInput): StatBreakdown {
   return breakdownOf(
     PILOT_BASE_AP,
-    sumContributions(abilityContributions(pilot.abilities, 'pilot', 'maxAp')),
+    0,
     pilot.maxApModifier ?? 0,
-    pilot.maxApOverride
+    pilot.maxApOverride,
+    abilityContributions(pilot.abilities, 'pilot', 'maxAp')
   )
 }
 
@@ -186,8 +190,21 @@ type StatBonusKey = 'structurePoints' | 'energyPoints' | 'heatCapacity' | 'cargo
 export type StatBreakdown = {
   /** The rules baseline before anything is added (chassis stat, tech-level SP, a constant). */
   base: number
-  /** Summed `statBonus` across installed systems/modules, counted per copy. */
+  /**
+   * Summed `statBonus` across installed systems/modules, counted per copy.
+   *
+   * ANONYMOUS by construction — the sum is taken across items and there is no
+   * per-item attribution yet, so provenance renders it as one aggregate line.
+   * Named contributions live in `sources` and must NOT be folded in here, or the
+   * panel attributes an ability's bonus to installed hardware.
+   */
   installed: number
+  /**
+   * Contributions that know their own source (ADR-029) — an ability, by name.
+   * Rendered as one labelled line each, so "Beefcake +7" is never mislabelled as
+   * installed hardware.
+   */
+  sources: ResolvedContribution[]
   /** The player's hand-entered manual adjustment (`max*Modifier`). Contributes; never replaces. */
   adjustment: number
   /** base + installed + adjustment, floored at 0. Always computed, even when pinned. */
@@ -205,13 +222,15 @@ function breakdownOf(
   base: number,
   installed: number,
   adjustment: number,
-  override?: number
+  override?: number,
+  sources: ResolvedContribution[] = []
 ): StatBreakdown {
-  const derived = Math.max(0, base + installed + adjustment)
+  const derived = Math.max(0, base + installed + sumContributions(sources) + adjustment)
   const overridden = typeof override === 'number'
   return {
     base,
     installed,
+    sources,
     adjustment,
     derived,
     ...(overridden ? { override } : {}),
@@ -266,12 +285,10 @@ export function mechMaxSPParts(
   const c = resolveChassis(mech, chassis)
   return breakdownOf(
     c.structurePoints ?? 0,
-    installedStatBonus(mech, 'structurePoints') +
-      sumContributions(
-        abilityContributions(pilot?.abilities, 'pilotedMech', 'structurePoints', pilot?.techLevel)
-      ),
+    installedStatBonus(mech, 'structurePoints'),
     mech.maxSpModifier ?? 0,
-    mech.maxSpOverride
+    mech.maxSpOverride,
+    abilityContributions(pilot?.abilities, 'pilotedMech', 'structurePoints', pilot?.techLevel)
   )
 }
 
@@ -283,12 +300,10 @@ export function mechMaxEPParts(
   const c = resolveChassis(mech, chassis)
   return breakdownOf(
     c.energyPoints ?? 0,
-    installedStatBonus(mech, 'energyPoints') +
-      sumContributions(
-        abilityContributions(pilot?.abilities, 'pilotedMech', 'energyPoints', pilot?.techLevel)
-      ),
+    installedStatBonus(mech, 'energyPoints'),
     mech.maxEpModifier ?? 0,
-    mech.maxEpOverride
+    mech.maxEpOverride,
+    abilityContributions(pilot?.abilities, 'pilotedMech', 'energyPoints', pilot?.techLevel)
   )
 }
 
@@ -300,12 +315,10 @@ export function mechMaxHeatParts(
   const c = resolveChassis(mech, chassis)
   return breakdownOf(
     c.heatCapacity ?? 0,
-    installedStatBonus(mech, 'heatCapacity') +
-      sumContributions(
-        abilityContributions(pilot?.abilities, 'pilotedMech', 'heatCapacity', pilot?.techLevel)
-      ),
+    installedStatBonus(mech, 'heatCapacity'),
     mech.maxHeatModifier ?? 0,
-    mech.maxHeatOverride
+    mech.maxHeatOverride,
+    abilityContributions(pilot?.abilities, 'pilotedMech', 'heatCapacity', pilot?.techLevel)
   )
 }
 
@@ -317,12 +330,10 @@ export function mechMaxCargoParts(
   const c = resolveChassis(mech, chassis)
   return breakdownOf(
     c.cargoCapacity ?? 0,
-    installedStatBonus(mech, 'cargoCapacity') +
-      sumContributions(
-        abilityContributions(pilot?.abilities, 'pilotedMech', 'cargoCapacity', pilot?.techLevel)
-      ),
+    installedStatBonus(mech, 'cargoCapacity'),
     mech.maxCargoModifier ?? 0,
-    mech.maxCargoOverride
+    mech.maxCargoOverride,
+    abilityContributions(pilot?.abilities, 'pilotedMech', 'cargoCapacity', pilot?.techLevel)
   )
 }
 

--- a/packages/salvageunion-reference/lib/rules/index.ts
+++ b/packages/salvageunion-reference/lib/rules/index.ts
@@ -137,6 +137,18 @@ export {
 } from './derivedStats.js'
 export type { ChassisStats, CrawlerMaxSPParts, StatBreakdown } from './derivedStats.js'
 export {
+  abilityContributions,
+  resolveAmount,
+  sumContributions,
+} from './contributions.js'
+export type {
+  ContributionStat,
+  ContributionTarget,
+  ContributionAmount,
+  DeclaredContribution,
+  ResolvedContribution,
+} from './contributions.js'
+export {
   MEDIATOR_TABLE_NAMES,
   MEDIATOR_TABLE_LABEL,
   performMediatorRoll,

--- a/packages/salvageunion-reference/lib/schemas/entities.ts
+++ b/packages/salvageunion-reference/lib/schemas/entities.ts
@@ -5,6 +5,7 @@
 import { z } from '../zod.js'
 import {
   BaseEntitySchema,
+  ContributionSchema,
   ContentSchema,
   PatternSchema,
   NpcSchema,
@@ -56,6 +57,14 @@ export const AbilitySchema = BaseEntitySchema.extend({
     'Currency type used for activation'
   ).optional(),
   actions: z.array(z.string()).describe('Action names this ability provides'),
+  contributions: z
+    .array(ContributionSchema)
+    .describe(
+      'Flat stat changes this ability makes (ADR-029). An ability could previously ' +
+        'declare no mechanical change at all, so Beefcake, Bionic Arms, Bionic Legs ' +
+        'and Modular Face Implant were inert prose.'
+    )
+    .optional(),
 })
   .strict()
   .describe('Pilot abilities and skills')

--- a/packages/salvageunion-reference/lib/schemas/objects.ts
+++ b/packages/salvageunion-reference/lib/schemas/objects.ts
@@ -432,6 +432,91 @@ export const MechStatBonusSchema = z
   .describe('Flat per-installed-item bonuses this system/module applies to a mech’s derived maxima')
 
 /**
+ * The stats a contribution may raise or lower (ADR-029).
+ *
+ * A superset of `MechStatBonusSchema`'s four keys: an ability can change a
+ * PILOT stat (Bionic Legs "+2 Max HP", Beefcake "+4 Inventory Capacity") or a
+ * slot COUNT (Modular Face Implant "your Pilot gains a Module Slot"), neither of
+ * which the mech-only shape could express.
+ */
+export const ContributionStatSchema = z.enum([
+  // mech
+  'structurePoints',
+  'energyPoints',
+  'heatCapacity',
+  'cargoCapacity',
+  'systemSlots',
+  'moduleSlots',
+  // pilot
+  'maxHp',
+  'maxAp',
+  'inventorySlots',
+])
+
+/**
+ * Whose stat a contribution changes.
+ *
+ * `self` is the host the contribution is declared on (a system contributing to
+ * its own mech). The others exist because Beefcake is a PILOT ability that
+ * raises the piloted MECH's Max SP and Cargo while also raising the pilot's own
+ * Max HP and Inventory — one record, two targets, which no single-target shape
+ * could express.
+ */
+export const ContributionTargetSchema = z.enum(['self', 'pilot', 'pilotedMech', 'crawler'])
+
+/**
+ * How much a contribution is worth.
+ *
+ * A plain integer covers most records. `perTechLevel` exists for Beefcake —
+ * "increases its Max Structure Points by 3+X (where X is the Mech's Tech
+ * Level)" — where the amount is `flat + perTechLevel × techLevel`. Rendering the
+ * amount needs the target's tech level, so a consumer that cannot supply one
+ * resolves `perTechLevel` to 0 rather than guessing.
+ */
+export const ContributionAmountSchema = z.union([
+  z.number().int(),
+  z
+    .object({
+      flat: z.number().int().describe('The constant part').optional(),
+      perTechLevel: z.number().int().describe("Multiplied by the target's tech level"),
+    })
+    .strict(),
+])
+
+/**
+ * A single mechanical contribution a piece of content makes to a stat
+ * (ADR-029).
+ *
+ * This is the numeric half of the converged model. The trait/damage/range half
+ * already exists as `ChoiceEffectSchema` and is applied by `resolveChoiceView`;
+ * the two are declared side by side rather than merged into one union, because
+ * they are resolved at different layers — stats at derivation time, effects at
+ * dataview time.
+ *
+ * **Never infer a contribution from prose.** Populate it only where the rules
+ * text states a flat mechanical change; anything conditional, prose-only, or
+ * duration-bound stays undeclared and is answered to the parity audit with an
+ * explicit exemption instead.
+ */
+export const ContributionSchema = z
+  .object({
+    stat: ContributionStatSchema,
+    amount: ContributionAmountSchema,
+    target: ContributionTargetSchema.describe('Defaults to `self` when absent').optional(),
+    stacks: z
+      .boolean()
+      .describe('Applies once per installed copy (default true for installable items)')
+      .optional(),
+    voidWhen: z
+      .enum(['damaged', 'destroyed'])
+      .describe('Condition at which this contribution stops applying')
+      .optional(),
+    note: z.string().describe('Why this is encoded the way it is').optional(),
+  })
+  .strict()
+  .describe('A flat mechanical contribution this content makes to a stat')
+
+/**
  * A system or module that can be installed on a mech
  */
 export const SystemModuleSchema = StatsSchema.extend({

--- a/packages/salvageunion-reference/schemas/abilities.schema.json
+++ b/packages/salvageunion-reference/schemas/abilities.schema.json
@@ -341,6 +341,71 @@
         "type": "array",
         "items": { "type": "string" },
         "description": "Action names this ability provides"
+      },
+      "contributions": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "stat": {
+              "type": "string",
+              "enum": [
+                "structurePoints",
+                "energyPoints",
+                "heatCapacity",
+                "cargoCapacity",
+                "systemSlots",
+                "moduleSlots",
+                "maxHp",
+                "maxAp",
+                "inventorySlots"
+              ]
+            },
+            "amount": {
+              "anyOf": [
+                { "type": "integer", "minimum": -9007199254740991, "maximum": 9007199254740991 },
+                {
+                  "type": "object",
+                  "properties": {
+                    "flat": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991,
+                      "description": "The constant part"
+                    },
+                    "perTechLevel": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991,
+                      "description": "Multiplied by the target's tech level"
+                    }
+                  },
+                  "required": ["perTechLevel"],
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "target": {
+              "type": "string",
+              "enum": ["self", "pilot", "pilotedMech", "crawler"],
+              "description": "Defaults to `self` when absent"
+            },
+            "stacks": {
+              "type": "boolean",
+              "description": "Applies once per installed copy (default true for installable items)"
+            },
+            "voidWhen": {
+              "type": "string",
+              "enum": ["damaged", "destroyed"],
+              "description": "Condition at which this contribution stops applying"
+            },
+            "note": { "type": "string", "description": "Why this is encoded the way it is" }
+          },
+          "required": ["stat", "amount"],
+          "additionalProperties": false,
+          "description": "A flat mechanical contribution this content makes to a stat"
+        },
+        "description": "Flat stat changes this ability makes (ADR-029). An ability could previously declare no mechanical change at all, so Beefcake, Bionic Arms, Bionic Legs and Modular Face Implant were inert prose."
       }
     },
     "required": ["id", "blackMarket", "name", "source", "page", "tree", "level", "actions"],


### PR DESCRIPTION
**C1 + C2 + D2** of the rules-parity plan (#597, #598). This is the gap the whole project was named for.

An ability could declare **no mechanical change at all**. Four records whose rules text states a flat stat change were inert prose, so the numbers on the sheet were simply wrong for anyone holding them:

| Ability | Text | Now applies |
|---|---|---|
| **Beefcake** | "+3+X Max SP, +6 Cargo … +2 Max HP, +4 Inventory" | ✅ |
| **Bionic Arms** | "+2 Pilot Max HP" | ✅ |
| **Bionic Legs** | "+2 Pilot Max HP" | ✅ |
| **Modular Face Implant** | "your Pilot gains a Module Slot" | ✅ |

## Two shapes the rules forced

`ContributionSchema` is a `stat`, an `amount`, and a `target` — a superset of `MechStatBonusSchema`'s four mech-only keys, because Bionic Legs changes a **pilot** stat and Modular Face Implant changes a **slot count**.

- **`target`** exists because Beefcake is a *pilot* ability that raises the *piloted mech*'s Max SP and Cargo **while also** raising the pilot's own Max HP and Inventory. One record, two targets.
- **`amount: { flat, perTechLevel }`** exists because Beefcake's Max SP is *"3+X (where X is the Mech's Tech Level)"*. A consumer that can't supply a tech level resolves to the flat part — so an unknown tech level **under-counts visibly** rather than inventing a number.

Resolution keeps each contribution's **source** attached, which is what will let the provenance panel say `Beefcake +7` instead of today's anonymous aggregate.

## A double-count this surfaced — exactly where the ADR predicted

**Nell** (Eldridge Coast) carried `maxHpModifier: 8` where every other pregen carries `4`. The extra 4 was **Bionic Arms + Bionic Legs, hand-encoded** because the app couldn't apply them. With the abilities live, keeping the 8 double-counts — so it returns to 4 and she's now consistent with her peers.

This is the precise hazard that made *"convert every modifier into a pin"* the wrong migration, and it was caught by **an existing test**, not by inspection. Good argument for the no-migration split having been the right call.

## Scope note

The trait/damage/range half (**C3**) stays with `resolveChoiceView`. The two are declared side by side rather than merged, because they resolve at different layers — stats at derivation time, effects at dataview time.

## Verification

`bun run check:all` green: schemas, lint, format, typecheck, **4,542 tests**, validate, knip, audit, tokens, styling.

14 new tests run against the **real dataset**, so a regression in the data fails here — including that Beefcake targets pilot and mech from one record, and that its SP scales 4 → 8 across tech levels 1 → 5.

Refs #597, #598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MT6q22Y1MtuCYHormXwQ4