### PR TITLE
fix(observability): make the nightly probe trustworthy — retries + name it in the report

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -295,6 +295,7 @@ jobs:
         env:
           ITUN_RESULT: ${{ needs.e2e-itun.result }}
           SRD_RESULT: ${{ needs.e2e-srd.result }}
+          PROBE_RESULT: ${{ needs.observability-probe.result }}
         with:
           script: |
             const label = 'nightly-e2e-failure'
@@ -303,9 +304,18 @@ jobs:
             // always means "hit timeout-minutes", which reads very differently
             // from 'failure' (assertions failed) and points at a hang rather
             // than a broken expectation.
+            // observability-probe MUST appear here, not just in `needs:` and the
+            // `if:`. It can open this issue on its own, and without a line of its
+            // own the issue would read "e2e-itun: success, e2e-srd: success" while
+            // still being filed — an alarm that refuses to say what tripped it.
+            // Omitted entirely when skipped (the OBSERVABILITY_PROBE variable is
+            // off), so the report never lists a job that did not run.
             const results = [
               ['e2e-itun', process.env.ITUN_RESULT],
               ['e2e-srd', process.env.SRD_RESULT],
+              ...(process.env.PROBE_RESULT && process.env.PROBE_RESULT !== 'skipped'
+                ? [['observability-probe', process.env.PROBE_RESULT]]
+                : []),
             ]
             const body = [
               `Nightly E2E (\`e2e-nightly.yml\`) did not pass on \`${context.ref}\`.`,

--- a/tools/check-observability.ts
+++ b/tools/check-observability.ts
@@ -179,6 +179,37 @@ function checkStatic(app: BrowserApp): void {
   }
 }
 
+/**
+ * Fetch, retrying transient network failures.
+ *
+ * This probe talks to the public internet from a CI runner, where a dropped
+ * socket or a momentary 5xx is ordinary weather — and a failure here OPENS A
+ * TRACKING ISSUE. The first real nightly run proved the point: it reported
+ * "production unreachable … The socket connection was closed unexpectedly"
+ * against a site that was demonstrably up seconds earlier.
+ *
+ * A probe that cries wolf teaches you to stop reading it, which is precisely
+ * the failure this file exists to prevent — so a verdict of "production is
+ * dark" has to survive several attempts before it is worth waking anyone.
+ *
+ * Retries only what is plausibly transient: network errors and 5xx. A 4xx is a
+ * real answer from a working server and is returned immediately.
+ */
+async function fetchWithRetry(url: string, attempts = 4): Promise<Response> {
+  let lastError: unknown = new Error('no attempt made')
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      const res = await fetch(url, { redirect: 'follow' })
+      if (res.status < 500) return res
+      lastError = new Error(`HTTP ${res.status}`)
+    } catch (error) {
+      lastError = error
+    }
+    if (attempt < attempts - 1) await Bun.sleep(1000 * 2 ** attempt)
+  }
+  throw lastError
+}
+
 /** Absolute-ises every `<script src>` the served HTML references. */
 function scriptUrls(html: string, origin: string): string[] {
   const re = /<script[^>]+src=["']([^"']+)["']/g
@@ -195,7 +226,7 @@ async function checkLive(app: BrowserApp): Promise<void> {
   // _headers file this repo never sees.
   let servedCsp: string | null = null
   try {
-    const res = await fetch(app.productionUrl, { redirect: 'follow' })
+    const res = await fetchWithRetry(app.productionUrl)
     if (!res.ok) {
       fail(app.name, `production fetch failed: HTTP ${res.status} ${app.productionUrl}`)
       return
@@ -220,7 +251,7 @@ async function checkLive(app: BrowserApp): Promise<void> {
 
   for (const url of urls) {
     try {
-      const body = await (await fetch(url)).text()
+      const body = await (await fetchWithRetry(url)).text()
       if (!sdkFoundIn && SDK_MARKER.test(body)) sdkFoundIn = url
       if (!dsnHost) dsnHost = body.match(DSN_IN_BUNDLE)?.[1] ?? null
     } catch {


### PR DESCRIPTION
Two defects the **first real nightly run** exposed in the probe I shipped. Both
share a theme: an alarm you can't trust is worse than no alarm, which is exactly
the condition this work set out to fix.

## 1. It cried wolf on ordinary internet weather

The run reported:

```
✗ [srd] production unreachable (https://salvageunion.io):
      The socket connection was closed unexpectedly
```

against a site that was demonstrably up seconds earlier and is up now. One
dropped TCP connection from the CI runner, and the probe declared production
dark — **and this job's failure opens a tracking issue.**

Both the page fetch and every chunk fetch now go through `fetchWithRetry`:
4 attempts, exponential backoff (1s, 2s, 4s — ~7s worst case, measured against
an unresolvable host). It retries only what is plausibly transient (network
errors, 5xx); a 4xx is a real answer from a working server and returns
immediately, so a genuinely missing page still fails fast.

This does not weaken the check — a production that is actually dark fails all
four attempts and still reports. Only the single-blip false positive goes away.

## 2. The issue it opens never said the probe was why

`observability-probe` was wired into `needs:` and into `notify-failure`'s
condition, so it can file the issue on its own — but it was never added to the
results list the issue body prints. The real run showed it:

```
- e2e-itun: failure
- e2e-srd: failure
```

No mention of the probe, though it had also failed. And in the case that matters
most — **production dark while both suites pass** — the issue would have been
filed stating every job succeeded.

The probe now gets its own line, and is omitted when skipped (variable off), so
the report never lists a job that didn't run. Verified across all three states:

| state | reported |
|---|---|
| probe skipped | `e2e-itun`, `e2e-srd` |
| probe failed, suites green | `e2e-itun`, `e2e-srd`, **`observability-probe: failure`** |
| all failed | all three |

## Verification

- `validate:observability:live` passes against current production (SDK present
  + served CSP permits the DSN, both sites).
- Backoff measured: ~7s against an unresolvable host, matching 1+2+4.
- Workflow YAML parses; `notify-failure` env now carries `PROBE_RESULT`.
- `bun run check:all` green.