### PR TITLE
fix(itun): spend Dashboard EP/AP/SP from the full pool, not from zero

### DIFF
--- a/apps/itun/src/components/dashboard/ActionsDeck.tsx
+++ b/apps/itun/src/components/dashboard/ActionsDeck.tsx
@@ -25,7 +25,7 @@ import type { ActionsDeckView as ActionsDeckViewModel, DeckRow } from 'component
 import { CORE_ROLL_BANDS, describePushOutcome, performCoreRoll } from '../../lib/rules/coreMechanic'
 import type { CoreRollResult } from '../../lib/rules/coreMechanic'
 import { defaultRoll } from '../../lib/rules/heatCheck'
-import { mechMaxHeat } from '../../lib/rules/derivedStats'
+import { mechMaxEP, mechMaxHeat, mechMaxSP, pilotMaxAP } from '../../lib/rules/derivedStats'
 import { canActivateAction, resolveChassisRef } from 'salvageunion-reference/rules'
 import type { Mech } from '../../lib/schemas/mech'
 import type { Pilot } from '../../lib/schemas/pilot'
@@ -133,9 +133,14 @@ export function ActionsDeck({ mech, pilot, mount = 'mech', store }: ActionsDeckP
     if (effCurrency === 'AP') {
       if (!pilot) return
       const fresh = s.get('pilot', pilot.id) ?? pilot
+      // An unrecorded live stat means UNSPENT, not empty — a pilot who has never
+      // spent AP is at full AP. Defaulting to 0 here banked the spend against an
+      // empty pool and wrote AP 0 on the first activation. The stored value stays
+      // authoritative when present (same rule as ActiveItemBand's damage write):
+      // never clamp it here, since an unresolved ref makes the max 0.
       const patch = pilotActivationPatch({
         apCost: economy.epCost,
-        currentAP: fresh.currentAP ?? 0,
+        currentAP: fresh.currentAP ?? pilotMaxAP(fresh),
       })
       if (Object.keys(patch).length > 0) void s.update('pilot', pilot.id, patch, DASHBOARD_TXN)
       setActivated(true)
@@ -147,7 +152,8 @@ export function ActionsDeck({ mech, pilot, mount = 'mech', store }: ActionsDeckP
     const patch = activationPatch({
       slug: action.slug,
       economy,
-      currentEP: fresh.currentEP ?? 0,
+      // Unrecorded EP means a mech that has never spent any — full, not empty.
+      currentEP: fresh.currentEP ?? mechMaxEP(fresh, chassis),
       currentHeat: fresh.currentHeat ?? 0,
       heatCap,
       prevUses: fresh.itemUses,
@@ -186,7 +192,9 @@ export function ActionsDeck({ mech, pilot, mount = 'mech', store }: ActionsDeckP
     const { patch, effect, nextHeat } = pushPatch({
       heat: Math.min(fresh.currentHeat ?? 0, cap),
       heatCap: cap,
-      currentSP: fresh.currentSP ?? 0,
+      // Unrecorded SP means undamaged. At 0 an Overheat wrote the mech straight
+      // to SP 0 — one hit from destroyed — without it ever having taken damage.
+      currentSP: fresh.currentSP ?? mechMaxSP(fresh, chassis),
       roll: defaultRoll,
     })
     void s.update('mech', mech.id, patch, DASHBOARD_TXN)

--- a/apps/itun/src/components/dashboard/__tests__/ActionsDeck.test.tsx
+++ b/apps/itun/src/components/dashboard/__tests__/ActionsDeck.test.tsx
@@ -17,6 +17,8 @@ import { SalvageUnionReference } from 'salvageunion-reference'
 
 import type { Mech } from '../../../lib/schemas/mech'
 import type { Pilot } from '../../../lib/schemas/pilot'
+import { resolveChassisRef } from 'salvageunion-reference/rules'
+import { mechMaxEP, mechMaxHeat, mechMaxSP, pilotMaxAP } from '../../../lib/rules/derivedStats'
 import { itemEconomy, resolveModule, resolveSystem } from '../../sheet/mechItemRules'
 import { ActionsDeck } from '../ActionsDeck'
 import { hasCurrencyChoice, hasVariableHot, hotHeatFor } from '../dashboardRules'
@@ -390,5 +392,116 @@ describe('ActionsDeck', () => {
     expect(ability.actionNames.some((n) => labels.includes(n))).toBe(true)
     // The mech is left behind — none of its actions are reachable on foot.
     expect(mechActionNames().some((n) => labels.includes(n))).toBe(false)
+  })
+})
+
+/**
+ * An UNRECORDED live stat means unspent/undamaged, not empty. The deck's three
+ * write paths each defaulted the missing value to 0, so the first Activate or
+ * Push on a mech (or pilot) that had never had the field written banked the
+ * spend against an empty pool and stored EP 0 / AP 0 / SP 0 — a record that
+ * displayed full everywhere else, because every read path defaults to the max.
+ *
+ * These use a REAL chassis: `unknown-chassis` (used above) derives a max of 0,
+ * which would make the assertions pass under the old behaviour too.
+ */
+describe('ActionsDeck — unrecorded live stats default to full, not empty', () => {
+  const CHASSIS = 'Leviathan'
+
+  test('Activate spends EP from the full pool when EP was never stored', () => {
+    const mech = mechFixture({
+      id: 'm1',
+      name: 'Rig',
+      chassisRef: CHASSIS,
+      systems: [costedSystemId],
+      currentHeat: 0,
+    })
+    expect(mech.currentEP).toBeUndefined()
+    const { store, calls } = stubStore(mech)
+    const { container } = renderDeck(mech, store)
+    const { epCost } = clickPrimaryAction(container)
+    fireEvent.click(screen.getByText('Activate'))
+
+    const epMax = mechMaxEP(mech, resolveChassisRef(CHASSIS))
+    expect(epMax).toBeGreaterThan(epCost)
+    expect(calls).toHaveLength(1)
+    // Previously Math.max(0, 0 - epCost) === 0 — the mech's EP was zeroed.
+    expect(calls[0]?.patch.currentEP).toBe(epMax - epCost)
+  })
+
+  test('Activate spends AP from the full pool when AP was never stored', () => {
+    const mod = epApModule as { id: string; actionName: string }
+    expect(mod).toBeTruthy()
+    const mech = mechFixture({
+      id: 'm1',
+      name: 'Rig',
+      chassisRef: CHASSIS,
+      modules: [mod.id],
+      currentHeat: 0,
+    })
+    const pilot = pilotFixture({ id: 'p1', name: 'Vex' })
+    expect(pilot.currentAP).toBeUndefined()
+    const calls: Call[] = []
+    const store: PlayStore = makeEntityStoreMock({
+      get: (type, id) =>
+        type === 'mech' && id === mech.id
+          ? mech
+          : type === 'pilot' && id === pilot.id
+            ? pilot
+            : null,
+      update: async (type, id, patch) => {
+        calls.push({ type, id, patch })
+        return mech
+      },
+    }).getState()
+    const { container } = render(
+      <EntityHrefProvider value={() => undefined}>
+        <ActionsDeck mech={mech} pilot={pilot} mount="mech" store={store} />
+      </EntityHrefProvider>
+    )
+    clickActionByName(container, mod.actionName)
+    fireEvent.click(screen.getByLabelText('1 AP'))
+    fireEvent.click(screen.getByText('Activate'))
+
+    const apMax = pilotMaxAP(pilot)
+    expect(apMax).toBeGreaterThan(1)
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.type).toBe('pilot')
+    // Previously Math.max(0, 0 - 1) === 0 — the pilot's AP was zeroed.
+    expect(calls[0]?.patch.currentAP).toBe(apMax - 1)
+  })
+
+  test('Push damages SP from the full pool when SP was never stored', () => {
+    // Leviathan is SP 76 / Heat Cap 18. Starting at Heat 17 every Push clamps to
+    // the cap, so the Heat Check overloads on any d20 except a natural 20 (90%)
+    // and the 11-19 Overheat band (45%) then writes SP — ~40% of pushes. Over 80
+    // pushes at least one SP write is a certainty for any practical purpose.
+    // The damage is Heat-sized, so the expected write is 76 - 18 = 58, never 0.
+    const mech = mechFixture({
+      id: 'm1',
+      name: 'Rig',
+      chassisRef: CHASSIS,
+      systems: [costedSystemId],
+      currentHeat: 17,
+    })
+    expect(mech.currentSP).toBeUndefined()
+    const chassis = resolveChassisRef(CHASSIS)
+    const spMax = mechMaxSP(mech, chassis)
+    const heatAtCheck = mechMaxHeat(mech, chassis)
+    expect(spMax).toBeGreaterThan(heatAtCheck)
+
+    const { store, calls } = stubStore(mech)
+    const { container } = renderDeck(mech, store)
+    clickPrimaryAction(container)
+    fireEvent.click(screen.getByText('Roll')) // Push stays disabled until a roll exists
+    for (let i = 0; i < 80; i += 1) fireEvent.click(screen.getByText('Push'))
+
+    const spWrites = calls
+      .map((c) => c.patch.currentSP)
+      .filter((v): v is number => typeof v === 'number')
+    expect(spWrites.length).toBeGreaterThan(0)
+    // Previously every one of these was Math.max(0, 0 - heat) === 0: an undamaged
+    // mech recorded at SP 0, one hit from destroyed.
+    for (const v of spWrites) expect(v).toBe(spMax - heatAtCheck)
   })
 })


### PR DESCRIPTION
Follow-up to #588 — the same defect class, on the other live stats. Flagged in that PR's review as a single SP line; the sweep turned up **three**, and unlike #588 these are all **write** paths.

## The rule being violated

Across ~30 sites the app treats an unrecorded live stat as *unspent / undamaged* and falls back to the derived maximum. `ActionsDeck.tsx` was the only file defaulting to `0`:

| call | was | for an entity with the field unset |
|---|---|---|
| `pilotActivationPatch` | `currentAP ?? 0` | `Math.max(0, 0 - cost)` → stores **AP 0** |
| `activationPatch` | `currentEP ?? 0` | `Math.max(0, 0 - cost)` → stores **EP 0** |
| `pushPatch` | `currentSP ?? 0` | `performHeatCheck` Overheat → `max(0, 0 - heat)` → stores **SP 0** |

Because every *read* path defaults to the max, the record kept displaying full while holding `0`. The next read-modify-write made the zero permanent. The SP case is the worst: a mech that had never taken damage gets recorded one hit from destroyed after a single Push.

This only affects entities whose field was never written — a fresh entity, or one predating the field. An entity that has taken damage or spent EP has the value stored and was always handled correctly.

## Fix

All three fall back to the derived maximum (`mechMaxEP` / `mechMaxSP` / `pilotMaxAP`).

The stored value stays authoritative and is deliberately **not** clamped here. I tried `Math.min(stored ?? max, max)` first, to mirror `ActiveItemBand`'s display reads — it's wrong for a write path: an unresolved `chassisRef` derives a max of `0`, so it would zero a real stored value. `ActiveItemBand.applyDamage` already documents the correct rule ("Damage operates on the stored SP (authoritative); default to max only when it was never set").

## Tests

Three cases, each asserting the **written patch**, not the rendering.

They use a real chassis (Leviathan). This matters: the existing deck tests use `chassisRef: 'unknown-chassis'`, whose derived maxima are `0` — under that fixture the old and new code are indistinguishable, so a test written against it would pass either way.

The Push case can't inject a roll (`doPush` closes over `defaultRoll`, and this suite deliberately avoids `mock.module`), so it's set up so the dice barely matter: at Heat 17 on an 18-cap chassis every Push clamps to cap, overloading on any d20 but a natural 20, and ~40% of pushes write SP. It asserts every observed SP write equals `76 - 18 = 58` and that at least one occurred across 80 pushes — P(no write) ≈ 1e-18. Whole file runs in ~0.5s.

## Verification

`bun run check:all` exit 0 — lint, format, typecheck, 1291 itun tests, validate:all, knip, audit, token/styling.

One note on the test run: an earlier full-suite run showed 3 failures in `sheet-soft-warnings` and `ShareSnapshotScreen`. They pass in isolation, pass on a re-run of the full suite, touch none of this code, and are timeouts under load — pre-existing flakes, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAxZfRPrgJq8U9mm4b2LzE