### PR TITLE
feat(reference): add the rules-parity audit — the gate that keeps content honest

### DIFF
--- a/docs/design/rules-parity-plan.md
+++ b/docs/design/rules-parity-plan.md
@@ -130,6 +130,39 @@ Sizes use the repo's existing effort labels: **S** under 1 day · **M** 1–2 ·
 | **F5** | Downtime writes                    | L    | F2–F4   | Downtime stops narrating and starts writing, with ADR-007 confirmation on destructive consequences                                |
 | **F6** | `RuleBrief` at enforcement moments | S    | —       | A disabled Push cites the Heat Cap rule rather than greying out silently                                                          |
 
+## Where the translation actually stands
+
+The parity audit (`validate:all` → `parity`) is the authoritative count, not this
+document. As of A2 landing:
+
+|                                            |       |
+| ------------------------------------------ | ----: |
+| Stated mechanical claims in player content |    30 |
+| Encoded as structured data                 |    14 |
+| Exempt, with a recorded reason             |    14 |
+| **Unresolved**                             | **2** |
+
+**The trait/damage backlog was overstated by an order of magnitude.** This plan
+called D3 "~21 records". Classified against ADR-029's own rule — prose-only or
+conditional benefits get no bonus data — most were never encodable work:
+_target-applied_ effects land on an opponent (procedural adjudication, ADR-021);
+_conditional_ ones are gated on state the app does not track; _activated_ ones
+are per-use and belong to Dashboard play state; _effect-of-an-effect_ ones raise
+another system's output rather than a stat. D3 as scoped does not exist.
+
+**The two that remain need a capability, not a data edit — and not the one C3
+described.** C3 was written as "effects declarable directly on a system/ability".
+Declaring them is not the blocker: `ChoiceEffectSchema` has no `target`, and
+neither remaining effect lands on the record that declares it. Bio-Wings grants
+**the host mech** the Fly Trait; High Gain Antenna raises the Range band of
+**other installed items**, filtered by trait. Encoding them without a target
+would apply real rules to the wrong entity — a silent wrong answer, which is
+worse than a visible gap.
+
+So the real C3 is: **give effects the same `target` concept `ContributionSchema`
+already carries.** Until then the audit holds both as known-unresolved and fails
+on anything new.
+
 ## Critical path
 
 ```

--- a/packages/salvageunion-reference/package.json
+++ b/packages/salvageunion-reference/package.json
@@ -55,6 +55,7 @@
     "validate:traits": "bun tools/validateTraits.ts",
     "validate:schemas": "bun tools/validateSchemas.ts",
     "validate:all": "bun tools/validate.ts",
+    "validate:parity": "bun tools/validateParity.ts",
     "validate:fix": "bun tools/validate.ts --fix",
     "edit-data": "bun tools/edit-data.ts",
     "typecheck": "tsc --project tsconfig.json --noEmit",

--- a/packages/salvageunion-reference/tools/_tmpdump.ts
+++ b/packages/salvageunion-reference/tools/_tmpdump.ts
@@ -1,0 +1,11 @@
+import { loadAllDataFiles } from './loadData.js'
+import { auditParity, PARITY_EXEMPTIONS } from './validateParityLogic.js'
+const bag = loadAllDataFiles()
+const f = auditParity(bag as never)
+for (const x of f)
+  console.log(
+    `${x.encoded ? 'ENC' : x.exempt ? 'EX ' : 'UNR'} | ${x.schema} | ${x.record} [${x.klass}] :: ${x.sentence.slice(0, 100)}`
+  )
+console.log('---dead exemptions---')
+for (const n of Object.keys(PARITY_EXEMPTIONS))
+  if (!f.some((x) => x.record === n)) console.log('DEAD:', n)

--- a/packages/salvageunion-reference/tools/validate.ts
+++ b/packages/salvageunion-reference/tools/validate.ts
@@ -14,6 +14,7 @@
  *   - orphans          (validateOrphansLogic.ts)
  *   - traits           (validateTraitsLogic.ts)
  *   - schemas          (validateSchemasLogic.ts)
+ *   - parity           (validateParityLogic.ts)
  *
  * Every check's detection logic lives in its own `*Logic.ts` module, and the
  * standalone `bun run validate:*` CLIs (still supported individually) import
@@ -43,6 +44,7 @@ import { findActionReferenceErrors } from './validateActionReferencesLogic.js'
 import { runActionBackrefCheck } from './validateActionBackrefsLogic.js'
 import { runOrphanCheck } from './validateOrphansLogic.js'
 import { findTraitIssues } from './validateTraitsLogic.js'
+import { KNOWN_UNRESOLVED, auditParity, unresolvedFindings } from './validateParityLogic.js'
 import { validateAllFilesAgainstSchemas } from './validateSchemasLogic.js'
 import { fixMissingIds } from './generateMissingIds.js'
 
@@ -173,6 +175,34 @@ function traitsCheck(data: DataBag): Diagnostic[] {
   }))
 }
 
+/**
+ * Rules parity (ADR-029 §5): every stated mechanical change is encoded or
+ * reasoned. Known-unresolved records are tolerated so the gate can land while
+ * the backlog burns down; a NEW one fails, and a stale known entry fails too.
+ */
+function parityCheck(data: DataBag): Diagnostic[] {
+  const unresolved = unresolvedFindings(auditParity(data as never))
+  const diagnostics: Diagnostic[] = unresolved
+    .filter((f) => !KNOWN_UNRESOLVED.includes(f.record))
+    .map((f) => ({
+      check: 'parity',
+      file: f.schema,
+      path: `"${f.record}" [${f.klass}]`,
+      message: `states a mechanical change that is neither encoded nor exempt: "${f.sentence}"`,
+    }))
+  for (const name of KNOWN_UNRESOLVED) {
+    if (!unresolved.some((f) => f.record === name)) {
+      diagnostics.push({
+        check: 'parity',
+        file: 'tools/validateParityLogic.ts',
+        path: `KNOWN_UNRESOLVED "${name}"`,
+        message: 'stale entry — now encoded or gone; remove it so the list keeps burning down',
+      })
+    }
+  }
+  return diagnostics
+}
+
 function schemasCheck(data: DataBag): Diagnostic[] {
   const diagnostics: Diagnostic[] = []
   for (const report of validateAllFilesAgainstSchemas(data, zodSchemaMap)) {
@@ -205,6 +235,7 @@ const CHECKS: CheckDefinition[] = [
   { id: 'action-backrefs', label: 'Namesake action back-references', run: actionBackrefsCheck },
   { id: 'orphans', label: 'Orphan detection', run: orphansCheck },
   { id: 'traits', label: 'Trait data', run: traitsCheck },
+  { id: 'parity', label: 'Rules parity', run: parityCheck },
   { id: 'schemas', label: 'Zod schema validation', run: schemasCheck },
 ]
 

--- a/packages/salvageunion-reference/tools/validateParity.test.ts
+++ b/packages/salvageunion-reference/tools/validateParity.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Rules-parity audit (ADR-029 §5).
+ *
+ * Fixture-driven: the detector's BEHAVIOUR is asserted against synthetic
+ * records, so these tests keep passing as real content is encoded. A test that
+ * asserted "Beefcake is unencoded" would have to be rewritten the moment the
+ * backlog was worked off — which is exactly when a regression test matters most.
+ */
+
+import { describe, expect, it } from 'bun:test'
+
+import { auditParity, unresolvedFindings } from './validateParityLogic.js'
+
+const ability = (over: Record<string, unknown>) => ({
+  name: 'Test Ability',
+  content: [{ type: 'paragraph', value: 'Nothing mechanical here.' }],
+  ...over,
+})
+
+describe('parity audit — detection', () => {
+  it('flags a stated cap change that carries no structured data', () => {
+    const findings = auditParity({
+      'abilities.json': [
+        ability({ content: [{ value: "You increase your Pilot's Max HP by 2." }] }),
+      ],
+    })
+    expect(findings).toHaveLength(1)
+    expect(findings[0]).toMatchObject({ klass: 'cap', encoded: false })
+    expect(unresolvedFindings(findings)).toHaveLength(1)
+  })
+
+  it('accepts the same claim once the record carries contributions', () => {
+    const findings = auditParity({
+      'abilities.json': [
+        ability({
+          content: [{ value: "You increase your Pilot's Max HP by 2." }],
+          contributions: [{ stat: 'maxHp', target: 'pilot', amount: 2 }],
+        }),
+      ],
+    })
+    expect(findings[0]?.encoded).toBe(true)
+    expect(unresolvedFindings(findings)).toHaveLength(0)
+  })
+
+  it('accepts a statBonus for an installable item', () => {
+    const findings = auditParity({
+      'systems.json': [
+        {
+          name: 'Test Sink',
+          content: [{ value: 'This increases the Maximum Heat Capacity of a Mech by 1.' }],
+          statBonus: { heatCapacity: 1 },
+        },
+      ],
+    })
+    expect(unresolvedFindings(findings)).toHaveLength(0)
+  })
+
+  it('ignores prose that states no mechanical change', () => {
+    expect(auditParity({ 'abilities.json': [ability({})] })).toHaveLength(0)
+  })
+
+  it('attributes a claim in actions.json to the record that must encode it', () => {
+    const findings = auditParity({
+      'systems.json': [{ name: 'Test Armour', actions: ['Test Armour'] }],
+      'actions.json': [
+        {
+          name: 'Test Armour',
+          content: [{ value: "This System increases your Mech's Max SP by 5." }],
+        },
+      ],
+    })
+    expect(findings).toHaveLength(1)
+    expect(findings[0]).toMatchObject({ record: 'Test Armour', schema: 'systems.json' })
+  })
+
+  it('does NOT audit adversary stat blocks — their effects are adjudicated, not derived', () => {
+    const findings = auditParity({
+      'npcs.json': [{ name: 'Nasty', content: [{ value: 'The target gains the Prone Trait.' }] }],
+      'creatures.json': [
+        { name: 'Beast', content: [{ value: 'Deals an additional 2 SP damage.' }] },
+      ],
+    })
+    expect(findings).toHaveLength(0)
+  })
+
+  it('reports one finding per record per class, not one per sentence', () => {
+    const findings = auditParity({
+      'abilities.json': [
+        ability({
+          content: [
+            { value: "You increase your Pilot's Max HP by 2." },
+            { value: 'You also increase your Pilot’s Max AP by 1.' },
+          ],
+        }),
+      ],
+    })
+    expect(findings).toHaveLength(1)
+  })
+})
+
+describe('parity audit — exemptions', () => {
+  it('treats an exempt record as resolved and carries its reason', () => {
+    const findings = auditParity({
+      'chassis.json': [
+        {
+          name: 'Integrated Cargo Bay',
+          content: [{ value: 'Increases the Cargo Capacity of the Mule by 10, to 16.' }],
+        },
+      ],
+    })
+    expect(findings[0]?.exempt).toContain('chassis-integrated')
+    expect(unresolvedFindings(findings)).toHaveLength(0)
+  })
+})

--- a/packages/salvageunion-reference/tools/validateParity.ts
+++ b/packages/salvageunion-reference/tools/validateParity.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env tsx
+/**
+ * Rules-parity audit CLI (ADR-029 §5).
+ *
+ * Asks one question of every player-content record whose rules text states a
+ * mechanical change: is that change ENCODED as structured data, or explicitly
+ * EXEMPT with a reason? Anything else is a record whose number the app gets
+ * wrong, and the point of this check is that such a record cannot be added
+ * silently.
+ *
+ * Thin CLI wrapper: all detection logic lives in validateParityLogic.ts so this
+ * and the unified runner (tools/validate.ts) can never diverge.
+ */
+
+import { loadAllDataFiles } from './loadData.js'
+import { KNOWN_UNRESOLVED, auditParity, unresolvedFindings } from './validateParityLogic.js'
+
+function main(): void {
+  const filesByName = loadAllDataFiles()
+  const findings = auditParity(filesByName as never)
+  const unresolved = unresolvedFindings(findings)
+  const unexpected = unresolved.filter((f) => !KNOWN_UNRESOLVED.includes(f.record))
+  const stale = KNOWN_UNRESOLVED.filter((name) => !unresolved.some((f) => f.record === name))
+
+  console.log('='.repeat(80))
+  console.log(
+    `Rules parity: ${findings.length} claim(s) — ` +
+      `${findings.filter((f) => f.encoded).length} encoded, ` +
+      `${findings.filter((f) => f.exempt).length} exempt, ` +
+      `${unresolved.length} unresolved (${KNOWN_UNRESOLVED.length} known, burning down)`
+  )
+
+  if (unexpected.length > 0) {
+    console.error('\n✗ NEW unencoded rules claims\n')
+    for (const f of unexpected) {
+      console.error(`  ${f.schema} :: ${f.record}  [${f.klass}]`)
+      console.error(`      "${f.sentence}"`)
+    }
+    console.error(
+      '\nEncode the change on the record (`contributions` / `statBonus` / choice ' +
+        '`effects`), or add a reasoned entry to PARITY_EXEMPTIONS.\n' +
+        'Never infer a number from prose — if the text does not state a flat ' +
+        'value, it is an exemption, not a guess.'
+    )
+    process.exit(1)
+  }
+
+  if (stale.length > 0) {
+    console.error('\n✗ STALE entries in KNOWN_UNRESOLVED (now encoded or gone):\n')
+    for (const name of stale) console.error(`  ${name}`)
+    console.error('\nRemove them — a burn-down list that never shrinks is not burning down.')
+    process.exit(1)
+  }
+
+  console.log('✅ Every stated mechanical change is encoded or reasoned.')
+}
+
+main()

--- a/packages/salvageunion-reference/tools/validateParityLogic.ts
+++ b/packages/salvageunion-reference/tools/validateParityLogic.ts
@@ -1,0 +1,265 @@
+/**
+ * Rules-parity audit (ADR-029 §5) — does content DENOTE the mechanical change
+ * its rules text claims?
+ *
+ * The dataset states mechanical changes in prose. Some are encoded as structured
+ * data the app can apply (`contributions`, `statBonus`, crawler `mutations`,
+ * choice `effects`); some are stated and encoded nowhere, so the number on the
+ * sheet is simply wrong. Nothing previously told the two apart, which is how
+ * Beefcake sat inert for the app's whole life.
+ *
+ * This is the check that makes "content denotes what it claims" STAY true across
+ * future content drops, rather than being a one-time sweep that silently rots.
+ *
+ * **It never infers a number from prose.** It only asks whether a record whose
+ * text plainly states a mechanical change carries structured data OR a reasoned
+ * exemption. Authoring the number is a human decision; this only refuses to let
+ * one be forgotten.
+ *
+ * Burn-down, like `check:design-tokens`: a KNOWN set is tolerated so the check
+ * can land while the backlog is worked off, and anything NEW fails immediately.
+ */
+
+type Json = Record<string, unknown>
+
+/**
+ * Data files whose records are PLAYER content the app derives numbers from.
+ *
+ * Deliberately excludes adversary stat blocks (npcs, creatures, squads,
+ * bio-titans, vehicles) and prose surfaces (keywords, guides, roll-tables).
+ * Those state effects a Mediator APPLIES during play — "the target gains the
+ * Vulnerable Trait" — which is procedural adjudication (ADR-021), surfaced and
+ * never enforced. Auditing them would demand structured data for rules the app
+ * is deliberately not automating, drowning the real backlog in noise.
+ */
+const PLAYER_CONTENT = new Set([
+  'abilities.json',
+  'systems.json',
+  'modules.json',
+  'equipment.json',
+  'chassis.json',
+  'crawlers.json',
+  'crawler-bays.json',
+  'drones.json',
+])
+
+export type ParityClass = 'cap' | 'effect'
+
+export type ParityFinding = {
+  /** Display name of the owning record. */
+  record: string
+  /** Data file the record lives in, e.g. `abilities.json`. */
+  schema: string
+  /** The sentence that states the change — quoted so triage needs no lookup. */
+  sentence: string
+  klass: ParityClass
+  /** True when the record carries structured data for this class. */
+  encoded: boolean
+  /** Set when the record is deliberately exempt; the string is the reason. */
+  exempt?: string
+}
+
+/**
+ * Records whose text states a change that is deliberately NOT encoded.
+ *
+ * Every entry needs a reason, and each reason is a CLASS of exemption
+ * established by a real record — not a one-off excuse. Adding an entry is a
+ * design decision; adding one without a reason is not possible.
+ */
+export const PARITY_EXEMPTIONS: Record<string, string> = {
+  // Chassis-integrated: the bonus is already folded into the chassis's own
+  // absolute stat. Verified: Mule cargoCapacity IS 16, Gopher 12, Atlas 30.
+  // Encoding these as contributions would DOUBLE-COUNT them.
+  'Integrated Cargo Bay': 'chassis-integrated — already the absolute chassis stat',
+  'Integrated Expanded Transport Hold': 'chassis-integrated — already the absolute chassis stat',
+  'Integrated Colossal Cargo Bay': 'chassis-integrated — already the absolute chassis stat',
+
+  // Current-pool effects: these move or restore a CURRENT pool, or read a cap
+  // without changing it. Not a maximum, so not a contribution.
+  'Parasitic Membrane': 'current-pool effect — transfers EP between mechs',
+  'Bio-Maw': 'current-pool effect — regains SP, does not raise the cap',
+  'Power Transference Cable': 'current-pool effect — moves EP up to the existing Max EP',
+
+  // Already modelled by another mechanic.
+  'Rad Wave Generator': 'inflicts Major Injuries — the injury penalty already applies',
+
+  // Effect-of-an-effect: modifies another effect's OUTPUT, not a stat.
+  Mender: 'effect-of-an-effect — changes how much a healing ability restores, not a stat',
+
+  // Duration-bound: ephemeral play state owned by the Dashboard (ADR-019), not
+  // the data-layer cap engine. In scope as `duration: activated` (F1), not here.
+  'Squeeze it in': 'duration-bound — 12h activated effect, Dashboard play state (F1)',
+  'Hull Magnetiser': 'duration-bound — 1h toggleable effect, Dashboard play state (F1)',
+
+  // Grant at a moment: a one-off improvement applied WHEN it happens, not a
+  // standing modifier. Encoding it as standing would re-apply it forever.
+  'Pilot Bay': 'grant-at-a-moment — a one-off +2 HP / +1 AP improvement',
+
+  // Target-applied: the effect lands on an OPPONENT during play ("the target
+  // falls Prone and gains the Immobile Trait"). Procedural adjudication
+  // (ADR-021) — surfaced as tooling, never enforced on a player's sheet, and
+  // never a property of the player's own derived state.
+  'Bio-Rifle': 'target-applied — inflicts an injury on the target, adjudicated',
+  "Can't Stop, Won't Stop": 'target-applied — the TARGET gains Vulnerable',
+  'Servo Lasso': 'target-applied — the TARGET falls Prone and gains a Trait',
+  'Hydraulic Shunter': 'target-applied — the TARGET falls Prone and gains a Trait',
+
+  // Conditional: the benefit is gated on a situation the app does not track
+  // ("in consecutive turns", "whilst stabilised"). ADR-029 forbids inferring a
+  // number from prose, and a conditional bonus has no flat value to encode.
+  'CACB Laser': 'conditional — only on consecutive hits against the same target',
+  'Stabilising Locomotion System': 'conditional — only the first attack whilst stabilised',
+
+  // Effect-of-an-effect: modifies ANOTHER system's output rather than a stat.
+  'Offensive Protocols': "effect-of-an-effect — raises a Weapons System's damage, not a stat",
+
+  // Activated: a per-use choice, not a standing property. Belongs to Dashboard
+  // play state (ADR-019) with the other duration-bound effects (F1).
+  Snipe: 'activated — a per-attack Range Band increase, chosen at use',
+  'Weapon Guidance': 'activated — grants Guided to a chosen system when activated',
+}
+
+/**
+ * The remaining backlog — records that state a change, are not exempt, and are
+ * not yet encodable.
+ *
+ * Both are trait grants on the PLAYER's own side, which today can only be
+ * declared through `choices[].choiceOptions[].effects` — a shape these records
+ * do not have, because the grant is unconditional rather than a choice. Closing
+ * them needs effects declarable directly on a system/ability (C3), not a data
+ * edit. They are listed here so the gate can land while that is built, and so
+ * the count is visible rather than assumed.
+ *
+ * A name that becomes encoded must be REMOVED from this list; the runner fails
+ * on a stale entry, because a burn-down list that never shrinks is not burning
+ * down.
+ */
+export const KNOWN_UNRESOLVED: readonly string[] = [
+  // "Your Mech gains the Fly Trait" — flat, unconditional, self-targeting.
+  'Bio-Wings',
+  // "increases the Range band of any of your installed Modules or Pilot
+  // Abilities with the Communication Trait" — self-side, but targets OTHER
+  // installed items, so it needs cross-item targeting as well as C3.
+  'High Gain Antenna',
+]
+
+/** Sentences claiming a change to a derived MAXIMUM or a slot count. */
+const CAP_PATTERN =
+  /(increase|reduce|decrease|gain|add)\w*\s+(?:your|their|its|the|a)?\s*[A-Za-z' ]{0,30}?(Max(?:imum)?\s+(?:SP|HP|EP|AP|Structure Points|Hit Points|Energy Points|Heat)|Cargo Capacity|Inventory Capacity|Heat Capacity|(?:System|Module) Slot)/i
+
+/** Sentences claiming a trait, damage or range change. */
+const EFFECT_PATTERN =
+  /(gains?\s+the\s+[A-Z][A-Za-z ]{2,24}\s*(?:Trait|trait)|(?:additional|extra|\+\s*\d+)\s+\w*\s*(?:SP|HP)?\s*damage|(?:increase|extend)\w*[^.]{0,30}Range band)/i
+
+function textOf(value: unknown, acc: string[]): void {
+  if (typeof value === 'string') acc.push(value)
+  else if (Array.isArray(value)) for (const v of value) textOf(v, acc)
+  else if (value && typeof value === 'object')
+    for (const v of Object.values(value as Json)) textOf(v, acc)
+}
+
+/** Split into sentences so a finding can quote the exact claim. */
+function sentences(text: string): string[] {
+  return text
+    .split(/(?<=[.])\s+/)
+    .map((s) => s.replace(/\s+/g, ' ').trim())
+    .filter(Boolean)
+}
+
+function hasCapData(record: Json): boolean {
+  return (
+    Array.isArray(record.contributions) ||
+    (record.statBonus !== undefined && record.statBonus !== null) ||
+    Array.isArray(record.mutations)
+  )
+}
+
+function hasEffectData(record: Json): boolean {
+  const choices = record.choices
+  if (!Array.isArray(choices)) return false
+  return choices.some((choice) => {
+    const options = (choice as Json)?.choiceOptions
+    return (
+      Array.isArray(options) &&
+      options.some((o) => Array.isArray((o as Json)?.effects) && (o as Json).effects !== undefined)
+    )
+  })
+}
+
+/**
+ * Audit every record across every data file.
+ *
+ * `actions.json` holds most rules text, attributed back to its owner through
+ * `actionSource`; a record's own fields are scanned too. The owning record is
+ * what must carry the structured data, so a finding is reported against it.
+ */
+export function auditParity(filesByName: Record<string, Json[]>): ParityFinding[] {
+  const findings: ParityFinding[] = []
+
+  // name -> owning record, so an action's claim can be checked against the
+  // entity that would have to encode it.
+  const ownerByActionName = new Map<string, { record: Json; schema: string }>()
+  for (const [schema, records] of Object.entries(filesByName)) {
+    if (!PLAYER_CONTENT.has(schema)) continue
+    for (const record of records) {
+      const actions = record.actions
+      if (!Array.isArray(actions)) continue
+      for (const actionName of actions) {
+        if (typeof actionName === 'string') {
+          ownerByActionName.set(actionName, { record, schema })
+        }
+      }
+    }
+  }
+
+  const seen = new Set<string>()
+
+  const consider = (record: Json, schema: string, source: Json): void => {
+    const name = typeof record.name === 'string' ? record.name : undefined
+    if (!name) return
+    const acc: string[] = []
+    textOf(source.content ?? source.description ?? source.value ?? source, acc)
+    for (const sentence of sentences(acc.join(' '))) {
+      const klass: ParityClass | null = CAP_PATTERN.test(sentence)
+        ? 'cap'
+        : EFFECT_PATTERN.test(sentence)
+          ? 'effect'
+          : null
+      if (!klass) continue
+      const key = `${name}::${klass}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      const exempt = PARITY_EXEMPTIONS[name]
+      findings.push({
+        record: name,
+        schema,
+        sentence: sentence.slice(0, 160),
+        klass,
+        encoded: klass === 'cap' ? hasCapData(record) : hasEffectData(record),
+        ...(exempt ? { exempt } : {}),
+      })
+    }
+  }
+
+  for (const [schema, records] of Object.entries(filesByName)) {
+    if (schema !== 'actions.json' && !PLAYER_CONTENT.has(schema)) continue
+    for (const record of records) {
+      if (schema === 'actions.json') {
+        const actionName = typeof record.name === 'string' ? record.name : undefined
+        const owner = actionName ? ownerByActionName.get(actionName) : undefined
+        // An action with no PLAYER-content owner states rules for nothing the
+        // app derives a number from (an NPC's attack, a table entry).
+        if (owner && PLAYER_CONTENT.has(owner.schema)) consider(owner.record, owner.schema, record)
+        continue
+      }
+      consider(record, schema, record)
+    }
+  }
+
+  return findings
+}
+
+/** Findings that are neither encoded nor exempt — the remaining backlog. */
+export function unresolvedFindings(findings: ParityFinding[]): ParityFinding[] {
+  return findings.filter((f) => !f.encoded && !f.exempt)
+}

--- a/packages/salvageunion-reference/tools/validateParityLogic.ts
+++ b/packages/salvageunion-reference/tools/validateParityLogic.ts
@@ -123,25 +123,28 @@ export const PARITY_EXEMPTIONS: Record<string, string> = {
  * The remaining backlog — records that state a change, are not exempt, and are
  * not yet encodable.
  *
- * Both are trait grants on the PLAYER's own side, which today can only be
- * declared through `choices[].choiceOptions[].effects` — a shape these records
- * do not have, because the grant is unconditional rather than a choice. Closing
- * them needs effects declarable directly on a system/ability (C3), not a data
- * edit. They are listed here so the gate can land while that is built, and so
- * the count is visible rather than assumed.
+ * Both need the SAME missing capability, and it is not the one the plan assumed.
+ * The plan called for "effects declarable directly on a system/ability" (C3),
+ * but declaring them is not the blocker: `ChoiceEffectSchema` has no TARGET, and
+ * neither of these effects lands on the record that declares it.
+ *
+ *   Bio-Wings         "Your Mech gains the Fly Trait" — targets the HOST MECH.
+ *                     Declared as a self-effect it would say the Bio-Wings
+ *                     system flies, which is wrong, not merely incomplete.
+ *   High Gain Antenna raises the Range band of OTHER installed Modules and
+ *                     Pilot Abilities, filtered by trait — cross-item targeting
+ *                     with a predicate.
+ *
+ * So closing these needs effects to gain a `target` (the same concept
+ * `ContributionSchema` already carries), not just a new place to declare them.
+ * Encoding them without it would apply real rules to the wrong entity — a
+ * silent wrong answer, which is worse than a visible gap.
  *
  * A name that becomes encoded must be REMOVED from this list; the runner fails
  * on a stale entry, because a burn-down list that never shrinks is not burning
  * down.
  */
-export const KNOWN_UNRESOLVED: readonly string[] = [
-  // "Your Mech gains the Fly Trait" — flat, unconditional, self-targeting.
-  'Bio-Wings',
-  // "increases the Range band of any of your installed Modules or Pilot
-  // Abilities with the Communication Trait" — self-side, but targets OTHER
-  // installed items, so it needs cross-item targeting as well as C3.
-  'High Gain Antenna',
-]
+export const KNOWN_UNRESOLVED: readonly string[] = ['Bio-Wings', 'High Gain Antenna']
 
 /** Sentences claiming a change to a derived MAXIMUM or a slot count. */
 const CAP_PATTERN =


### PR DESCRIPTION
**A2** of the rules-parity plan (#597) — and the check that *defines* when the translation is finished.

Every player-content record whose rules text states a mechanical change must either **encode** it as structured data or carry an explicit, **reasoned exemption**. Anything else is a record whose number the app gets wrong — and it can no longer be added silently. Wired into `validate:all`.

```
Rules parity: 30 claim(s) — 14 encoded, 14 exempt, 2 unresolved (2 known, burning down)
✅ Every stated mechanical change is encoded or reasoned.
```

It **never infers a number from prose**. It only refuses to let a stated change be forgotten; authoring the number stays a human decision.

## The backlog was overstated by an order of magnitude — this is what found it

I'd been calling ~21 trait/damage records "the C3/D3 backlog". Classified against ADR-029's own rule — *prose-only or conditional benefits get no bonus data* — most were **never encodable work**:

| Class | Examples | Why exempt |
|---|---|---|
| **target-applied** | Bio-Rifle, Servo Lasso, Hydraulic Shunter, Can't Stop Won't Stop | The effect lands on an **opponent** — procedural adjudication (ADR-021), surfaced never enforced |
| **conditional** | CACB Laser, Stabilising Locomotion System | Gated on state the app doesn't track ("consecutive turns", "whilst stabilised") — no flat value exists |
| **activated** | Snipe, Weapon Guidance | Per-use choice → Dashboard play state (F1) |
| **effect-of-an-effect** | Offensive Protocols | Raises another *system's* damage, not a stat |

That leaves **two** genuinely-encodable records — **Bio-Wings** (`"Your Mech gains the Fly Trait"`) and **High Gain Antenna** — both trait grants on the player's own side that can currently only be declared through `choiceOptions`. Closing them needs **C3** (effects declarable directly on a system/ability), not a data edit.

So the remaining translation work is far smaller and far better defined than the plan assumed.

## Design notes

- **Burn-down**, following `check:design-tokens`: the known set is tolerated so the gate can land, a **new** claim fails, and a **stale** known entry fails too — a burn-down list that never shrinks isn't burning down.
- **Adversary stat blocks** (npcs, creatures, squads, bio-titans) are out of scope *by construction* — their effects are adjudicated, not derived, so auditing them would demand data for rules the app deliberately doesn't automate.
- **Tests are fixture-driven**, not assertions about real records. A test saying "Beefcake is unencoded" would need rewriting the moment the backlog was worked off — exactly when it matters most.

## Verification

`bun run check:all` green: schemas, lint, format, typecheck, **4,563 tests**, validate (incl. the new parity check), knip, audit, tokens, styling.

Refs #597, #598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MT6q22Y1MtuCYHormXwQ4