### PR TITLE
feat(itun): a blocked Push teaches the rule instead of greying out

### DIFF
--- a/apps/itun/src/components/dashboard/ActiveItemBand.tsx
+++ b/apps/itun/src/components/dashboard/ActiveItemBand.tsx
@@ -38,6 +38,7 @@ import { ActiveItemBand as ActiveItemBandView, CountStepper, StorageBay } from '
 import type { ActiveItemBandView as ActiveItemBandViewModel, BandButton } from 'component-lib'
 import { DASHBOARD_TXN } from '../../stores/surfaceProvenance'
 import { pilotingContext } from '../../lib/rules/pilotingContext'
+import { RuleBrief, type StepRule } from 'component-lib'
 import {
   VENT_PATCH,
   critDamagePatch,
@@ -133,6 +134,19 @@ type MechPrompt =
   | { kind: 'storage' }
   | null
 
+/**
+ * Rules a blocked Guided-Play control explains when the player reaches for it
+ * (ADR-021 — the guided modes teach as they enforce).
+ *
+ * Paraphrased with a citation, matching the wizards' RuleBrief contract; the
+ * numbers are interpolated so the brief describes THIS mech's situation rather
+ * than the rule in the abstract.
+ */
+const PUSH_RULE = (heat: number, cap: number): StepRule => ({
+  rule: `Pushing adds 2 Heat before the roll, and a Mech can never exceed its Heat Cap. This Mech is at ${heat}/${cap} Heat, so a Push would take it past the Cap — vent or take a Heat Check first.`,
+  cite: 'Quick Ref · p.233',
+})
+
 function MechBand({
   mech,
   store,
@@ -176,6 +190,9 @@ function MechBand({
 
   // Quick Ref p.233 — can't Push if +2 Heat would exceed the Heat Cap.
   const pushLocked = heat + 2 > maxHeat
+
+  // The rule a blocked control explains when the player reaches for it.
+  const [blocked, setBlocked] = useState<StepRule | null>(null)
 
   function doPush() {
     const m = fresh()
@@ -255,6 +272,25 @@ function MechBand({
   }
 
   const overlay = ((): ActiveItemBandViewModel['overlay'] => {
+    if (blocked) {
+      return {
+        title: 'Blocked by a rule',
+        onClose: () => setBlocked(null),
+        // Keep the gauge the rule is ABOUT on screen while explaining it —
+        // the number and the reason belong together.
+        gauges: [
+          {
+            label: 'Heat',
+            value: heat,
+            max: maxHeat,
+            tone: 'mech',
+            danger: Math.max(0, maxHeat - 2),
+          },
+        ],
+        body: <RuleBrief rule={blocked.rule} cite={blocked.cite} />,
+        actions: [{ label: 'Got it', onClick: () => setBlocked(null), variant: 'go' }],
+      }
+    }
     if (!prompt) return null
     const onClose = () => setPrompt(null)
     if (prompt.kind === 'reactor') {
@@ -360,11 +396,14 @@ function MechBand({
         buttons: [
           {
             label: 'Push',
-            onClick: doPush,
-            disabled: pushLocked,
+            // Guided Play teaches as it enforces (ADR-021). A blocked Push used
+            // to grey out with a hover title — unreachable on touch, and it
+            // taught nothing at the moment the rule actually bit. It now stays
+            // pressable and opens the rule instead of performing the action.
+            onClick: pushLocked ? () => setBlocked(PUSH_RULE(heat, maxHeat)) : doPush,
             variant: 'go',
             title: pushLocked
-              ? `Can't Push at Heat ${heat}/${maxHeat} — +2 would exceed the Heat Cap (p.233).`
+              ? `Can't Push at Heat ${heat}/${maxHeat} — why?`
               : '+2 Heat, then a Heat Check',
           },
           {

--- a/apps/itun/src/components/dashboard/__tests__/ActiveItemBand.rules.test.tsx
+++ b/apps/itun/src/components/dashboard/__tests__/ActiveItemBand.rules.test.tsx
@@ -95,3 +95,45 @@ describe('ActiveItemBand rules buttons', () => {
     expect(usePlayStateStore.getState().mount).toBe('pilot')
   })
 })
+
+describe('blocked controls teach the rule (F6, ADR-021)', () => {
+  // Guided Play "teaches as it enforces". A blocked Push used to grey out with a
+  // hover title — unreachable on touch, and it taught nothing at the moment the
+  // rule actually bit.
+  const hotMech = mechFixture({
+    id: 'm-hot',
+    name: 'Iron Mongrel',
+    chassisRef: 'unknown-chassis',
+    currentSP: 10,
+    // heatCapacity resolves to 0 for an unknown chassis, so any heat is over cap
+    currentHeat: 0,
+    maxHeatOverride: 4,
+  })
+
+  test('a Push that would exceed the Heat Cap explains itself instead of greying out', () => {
+    const blocked = { ...hotMech, currentHeat: 3 } // 3 + 2 > 4
+    const { store, calls } = stubStore([blocked])
+    render(<ActiveItemBand mech={blocked} pilot={null} store={store} />)
+
+    const push = screen.getByRole('button', { name: /push/i })
+    expect(push.hasAttribute('disabled')).toBe(false)
+
+    fireEvent.click(push)
+
+    // It teaches rather than acting: the rule is shown and NOTHING is written.
+    expect(screen.getByText(/Heat Cap/i)).toBeTruthy()
+    expect(screen.getByText(/Quick Ref/i)).toBeTruthy()
+    expect(calls).toHaveLength(0)
+  })
+
+  test('a legal Push still performs the action, not the explanation', () => {
+    const ok = { ...hotMech, currentHeat: 0 } // 0 + 2 <= 4
+    const { store, calls } = stubStore([ok])
+    render(<ActiveItemBand mech={ok} pilot={null} store={store} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /push/i }))
+
+    expect(screen.queryByText(/Quick Ref/i)).toBeNull()
+    expect(calls.length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
**F6** of the rules-parity plan (#599) — first of the recommended order.

ADR-021 requires Guided Play to *teach as it enforces*. `RuleBrief` existed but appeared **only in the three wizards**, never in `components/dashboard/` — so the Dashboard enforced without ever explaining.

## The change

A Push that would exceed the Heat Cap used to **disable the button and put the reason in a `title`**. That taught nothing at the moment the rule actually bit, and a hover title is **unreachable on touch** — the enforcement was invisible exactly where it mattered.

The button now stays pressable and, when blocked, opens the band overlay with the rule and its citation *instead of* performing the action:

> **The Rule** — Pushing adds 2 Heat before the roll, and a Mech can never exceed its Heat Cap. This Mech is at 3/4 Heat, so a Push would take it past the Cap — vent or take a Heat Check first.
> *Quick Ref · p.233*

Two details that follow existing precedent rather than inventing anything:

- The **Heat gauge stays on screen** beside the explanation, so the number the rule is *about* and the reason are visible together. That's the same reasoning the overlay's `gauges` field already encodes for Take Damage.
- The brief **interpolates the mech's actual Heat and Cap**, so it describes *this* situation rather than the rule in the abstract.

Reuses `RuleBrief` and the existing `BandOverlay` contract — no dashboard-local variant.

## Verification

`bun run check:all` green: lint, format, typecheck, **4,565 tests**, validate (incl. the parity gate), knip, audit, tokens, styling.

Two new tests pin **both** directions: a blocked Push shows the rule and writes **nothing**, and a legal Push still performs the action without showing the explanation.

Next in order: **F2/F3/F4** — wiring salvage, crafting and scrap-mech, which are fully implemented and tested with zero non-test importers.

Refs #599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MT6q22Y1MtuCYHormXwQ4