### PR TITLE
feat(itun): wire salvage, crafting and scrap-mech into the Dashboard

### DIFF
--- a/apps/itun/src/components/dashboard/ActiveItemBand.tsx
+++ b/apps/itun/src/components/dashboard/ActiveItemBand.tsx
@@ -13,9 +13,10 @@
  */
 
 import { useEffect, useState } from 'react'
+import { SalvageUnionReference } from 'salvageunion-reference'
 
 import {
-  crawlerMaxSP,
+  crawlerMaxSPParts,
   mechMaxCargo,
   mechMaxEP,
   mechMaxHeat,
@@ -40,6 +41,12 @@ import { DASHBOARD_TXN } from '../../stores/surfaceProvenance'
 import { pilotingContext } from '../../lib/rules/pilotingContext'
 import { RuleBrief, type StepRule } from 'component-lib'
 import {
+  areaSalvageOutcome,
+  craftOutcome,
+  crawlerTechLevelOf,
+  scrapMechOutcome,
+} from './dashboardEconomy'
+import {
   VENT_PATCH,
   critDamagePatch,
   critInjuryPatch,
@@ -54,7 +61,7 @@ import {
 } from './dashboardRules'
 
 /** The store surface the band needs — injectable so tests can assert patches. */
-export type PlayStore = Pick<EntityState, 'get' | 'update'>
+export type PlayStore = Pick<EntityState, 'get' | 'update' | 'transfer'>
 
 type ActiveItemBandProps = {
   mech: Mech
@@ -74,7 +81,7 @@ export function ActiveItemBand({ mech, pilot, crawler, store }: ActiveItemBandPr
   const s: PlayStore = store ?? liveStore
 
   if (mount === 'downtime' && crawler) {
-    return <CrawlerBand crawler={crawler} onLeave={leaveDowntime} />
+    return <CrawlerBand crawler={crawler} mech={mech} store={s} onLeave={leaveDowntime} />
   }
   if (mount === 'pilot' && pilot) {
     return <PilotBand pilot={pilot} store={s} onBoard={() => setMount('mech')} />
@@ -94,21 +101,201 @@ export function ActiveItemBand({ mech, pilot, crawler, store }: ActiveItemBandPr
 // Crawler band (Downtime — read-only: the crawler's Structure + Leave control)
 // ---------------------------------------------------------------------------
 
-function CrawlerBand({ crawler, onLeave }: { crawler: Crawler; onLeave: () => void }) {
-  const maxSP = crawlerMaxSP(crawler)
+/** Cited when an action needs a numeric crawler Tech Level and the slug has none. */
+const NO_TECH_LEVEL_RULE: StepRule = {
+  rule: "This Crawler's Tech Level cannot be read, so the Tech Level of the Scrap it would find is undefined. Set a numeric Tech Level on the Crawler sheet first.",
+  cite: 'Core Book · p.245',
+}
+
+/**
+ * The craft picker: every System or Module craftable at the crawler's Tech
+ * Level, with its Scrap cost, and the reason when one is out of reach.
+ *
+ * Guided Play enforces (ADR-021) and teaches while doing it, so an unaffordable
+ * item is listed with its shortfall rather than hidden — a player can see what
+ * to save for.
+ */
+function CraftBody({ crawler, store }: { crawler: Crawler; store: PlayStore }) {
+  const crawlerTl = crawlerTechLevelOf(crawler) ?? 0
+  const [note, setNote] = useState<string | null>(null)
+
+  const items = [...SalvageUnionReference.Systems.all(), ...SalvageUnionReference.Modules.all()]
+    .filter(
+      (i): i is typeof i & { name: string; techLevel: number; salvageValue: number } =>
+        typeof i.name === 'string' &&
+        typeof i.techLevel === 'number' &&
+        typeof i.salvageValue === 'number' &&
+        i.techLevel <= crawlerTl
+    )
+    .sort((a, b) => a.techLevel - b.techLevel || a.name.localeCompare(b.name))
+
+  function craft(item: { name: string; techLevel: number; salvageValue: number }) {
+    const c = store.get('crawler', crawler.id) ?? crawler
+    const { patch, quote, blocked } = craftOutcome(c, item)
+    if (!patch) {
+      setNote(
+        blocked === 'tech-level'
+          ? `${item.name} is Tech ${item.techLevel} — above this Crawler's Tech ${crawlerTl}.`
+          : `${item.name} costs ${quote.cost} Scrap at Tech ${item.techLevel}+; the pool is ${quote.shortfall} short.`
+      )
+      return
+    }
+    void store.update('crawler', crawler.id, patch, DASHBOARD_TXN)
+    setNote(`Crafted ${item.name} for ${quote.cost} Scrap — it is in the Hold.`)
+  }
+
+  if (items.length === 0) {
+    return <p className="pc-resolve-log">Nothing is craftable at Tech {crawlerTl}.</p>
+  }
+
+  return (
+    <div className="flex max-h-[40vh] flex-col gap-1 overflow-y-auto">
+      {note ? <p className="pc-resolve-log">{note}</p> : null}
+      {items.slice(0, 40).map((item) => (
+        <button
+          key={`${item.techLevel}-${item.name}`}
+          type="button"
+          onClick={() => craft(item)}
+          className="flex items-center justify-between gap-3 rounded-card border border-ink/20 px-2 py-1 text-left text-caption hover:bg-ink-8"
+        >
+          <span>{item.name}</span>
+          <span className="shrink-0 tabular-nums opacity-70">
+            T{item.techLevel} · {item.salvageValue} Scrap
+          </span>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+/** Downtime economy prompts the crawler band can raise. */
+type EconPrompt =
+  | { kind: 'salvage'; log: string }
+  | { kind: 'craft' }
+  | { kind: 'scrap'; total: number; skipped: number }
+  | { kind: 'blocked'; rule: StepRule }
+  | null
+
+function CrawlerBand({
+  crawler,
+  mech,
+  store,
+  onLeave,
+}: {
+  crawler: Crawler
+  mech: Mech
+  store: PlayStore
+  onLeave: () => void
+}) {
+  const spParts = crawlerMaxSPParts(crawler)
+  const maxSP = spParts.total
   const sp = Math.min(crawler.currentSP ?? maxSP, maxSP)
+  const [prompt, setPrompt] = useState<EconPrompt>(null)
+  const crawlerTl = crawlerTechLevelOf(crawler)
+
+  const fresh = () => store.get('crawler', crawler.id) ?? crawler
+
+  /** Area Salvage (p.245) — roll, report, and deposit any scrap found. */
+  function doSalvage() {
+    const c = fresh()
+    const { result, patch } = areaSalvageOutcome(c, {
+      areaTl: crawlerTl ?? 1,
+      roll: defaultRoll,
+    })
+    if (patch) void store.update('crawler', crawler.id, patch, DASHBOARD_TXN)
+    setPrompt({
+      kind: 'salvage',
+      log: result.requiresPlayerChoice
+        ? `${result.roll}: ${result.label} — pick a Damaged Chassis, System or Module at Tech ${result.areaTl}.`
+        : result.scrapQty > 0
+          ? `${result.roll}: ${result.label} — ${result.scrapQty} Tech ${result.areaTl} Scrap into the pool.`
+          : `${result.roll}: ${result.label}.`,
+    })
+  }
+
+  /**
+   * Scrap the mech into the crawler's pool. Cross-entity and destructive, so it
+   * commits through `transfer` (all-or-nothing) and only after the player has
+   * confirmed — ADR-007 keeps the destructive half an explicit call.
+   */
+  function doScrap() {
+    const c = fresh()
+    const m = store.get('mech', mech.id) ?? mech
+    const { breakdown, crawlerPatch, mechPatch } = scrapMechOutcome(m, c)
+    void store.transfer(
+      {
+        updates: [
+          { type: 'crawler', id: crawler.id, patch: crawlerPatch },
+          { type: 'mech', id: mech.id, patch: mechPatch },
+        ],
+      },
+      DASHBOARD_TXN
+    )
+    setPrompt({ kind: 'scrap', total: breakdown.total, skipped: breakdown.skipped.length })
+  }
+
+  const overlay = ((): ActiveItemBandViewModel['overlay'] => {
+    if (!prompt) return null
+    const onClose = () => setPrompt(null)
+    if (prompt.kind === 'blocked') {
+      return {
+        title: 'Blocked by a rule',
+        onClose,
+        body: <RuleBrief rule={prompt.rule.rule} cite={prompt.rule.cite} />,
+        actions: [{ label: 'Got it', onClick: onClose, variant: 'go' }],
+      }
+    }
+    if (prompt.kind === 'salvage') {
+      return {
+        title: 'Area Salvage',
+        onClose,
+        body: <p className="pc-resolve-log">{prompt.log}</p>,
+      }
+    }
+    if (prompt.kind === 'scrap') {
+      return {
+        title: 'Mech Scrapped',
+        onClose,
+        body: (
+          <p className="pc-resolve-log">
+            {prompt.total} Scrap into the pool
+            {prompt.skipped > 0 ? `; ${prompt.skipped} component(s) yielded nothing.` : '.'}
+          </p>
+        ),
+      }
+    }
+    return { title: 'Craft', onClose, body: <CraftBody crawler={crawler} store={store} /> }
+  })()
+
   const view: ActiveItemBandViewModel = {
     fam: 'crawler',
     stampLabel: 'Downtime',
+    overlay,
     bays: [
       {
         label: 'Crawler',
         gauges: [{ label: 'SP', value: sp, max: maxSP, tone: 'crawler' }],
-        buttons: [],
+        buttons: [
+          {
+            label: 'Salvage',
+            onClick: () =>
+              crawlerTl === undefined
+                ? setPrompt({ kind: 'blocked', rule: NO_TECH_LEVEL_RULE })
+                : doSalvage(),
+            title: 'Roll Area Salvage and deposit what you find',
+          },
+          { label: 'Craft', onClick: () => setPrompt({ kind: 'craft' }), title: 'Craft an item' },
+        ],
       },
       {
         label: 'Downtime',
         buttons: [
+          {
+            label: 'Scrap Mech',
+            onClick: doScrap,
+            variant: 'danger',
+            title: 'Break the mech down into Scrap — destructive',
+          },
           {
             label: '◄ Leave Downtime',
             onClick: onLeave,

--- a/apps/itun/src/components/dashboard/__tests__/dashboardEconomy.test.ts
+++ b/apps/itun/src/components/dashboard/__tests__/dashboardEconomy.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Downtime economy patch builders (F2/F3/F4, #599).
+ *
+ * `crafting`, `salvage` and `scrapMech` were fully implemented and tested with
+ * ZERO non-test importers — the maths was never the problem, the seam was. These
+ * assert the seam: that a legal action produces the right write, and that an
+ * illegal one produces NO write plus a reason.
+ */
+
+import { beforeAll, describe, expect, test } from 'bun:test'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import {
+  areaSalvageOutcome,
+  craftOutcome,
+  crawlerTechLevelOf,
+  scrapMechOutcome,
+} from '../dashboardEconomy'
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+const crawler = (over: Record<string, unknown> = {}) => ({
+  techLevel: 'tech-3',
+  scrapPool: { tl1: 10, tl2: 10, tl3: 10 },
+  cargoLots: [],
+  ...over,
+})
+
+describe('crawlerTechLevelOf', () => {
+  test('parses the slug', () => {
+    expect(crawlerTechLevelOf({ techLevel: 'tech-4' })).toBe(4)
+  })
+  test('returns undefined for an unparseable slug rather than guessing', () => {
+    expect(crawlerTechLevelOf({ techLevel: 'bio' })).toBeUndefined()
+  })
+})
+
+describe('crafting (F3)', () => {
+  const item = { name: 'Cargo Pod', techLevel: 1, salvageValue: 1 }
+
+  test('a legal, affordable craft pays the pool and adds the item to the hold', () => {
+    const c = crawler()
+    const { patch, quote } = craftOutcome(c, item)
+    if (!patch) throw new Error('expected a patch')
+    expect(quote.eligible).toBe(true)
+    expect(quote.affordable).toBe(true)
+    // paid from the pool
+    expect(patch.scrapPool).toEqual(quote.pool)
+    // and the crafted item lands in the hold
+    expect(patch.cargoLots).toHaveLength(1)
+    expect(patch.cargoLots?.[0]?.name).toBe('Cargo Pod')
+  })
+
+  test('an item above the crawler Tech Level is BLOCKED with a reason, not written', () => {
+    const { patch, blocked } = craftOutcome(crawler({ techLevel: 'tech-1' }), {
+      name: 'Heavy Thing',
+      techLevel: 5,
+      salvageValue: 1,
+    })
+    expect(patch).toBeNull()
+    expect(blocked).toBe('tech-level')
+  })
+
+  test('an unaffordable craft is BLOCKED with a reason, not written', () => {
+    const { patch, blocked, quote } = craftOutcome(crawler({ scrapPool: {} }), item)
+    expect(patch).toBeNull()
+    expect(blocked).toBe('scrap')
+    expect(quote.shortfall).toBeGreaterThan(0)
+  })
+
+  test('a blocked craft never mutates the input pool', () => {
+    const c = crawler({ scrapPool: {} })
+    craftOutcome(c, item)
+    expect(Object.keys(c.scrapPool)).toHaveLength(0)
+  })
+})
+
+describe('area salvage (F2)', () => {
+  test('scrap found is deposited at the area Tech Level', () => {
+    const { result, patch } = areaSalvageOutcome(crawler(), { areaTl: 2, roll: () => 11 })
+    if (!patch) throw new Error('expected a patch')
+    expect(result.scrapQty).toBeGreaterThan(0)
+    // deposited into the area's TL bucket, on top of what was there
+    expect(patch.scrapPool?.tl2).toBe(10 + result.scrapQty)
+  })
+
+  test('a nothing result makes NO write — a no-op would log a change that changed nothing', () => {
+    const { result, patch } = areaSalvageOutcome(crawler(), { areaTl: 2, roll: () => 1 })
+    expect(result.scrapQty).toBe(0)
+    expect(patch).toBeNull()
+  })
+
+  test('a jackpot yields an item choice, not scrap — so also no pool write', () => {
+    const { result, patch } = areaSalvageOutcome(crawler(), { areaTl: 2, roll: () => 20 })
+    expect(result.requiresPlayerChoice).toBe(true)
+    expect(patch).toBeNull()
+  })
+})
+
+describe('scrap mech (F4)', () => {
+  const PLATING = {
+    id: 'l1',
+    kind: 'unit' as const,
+    name: 'Spare Plating',
+    cat: 'SYSTEM' as const,
+    units: 2,
+    code: 'PLT',
+  }
+
+  const mech = {
+    id: 'm1',
+    chassisRef: 'unknown-chassis',
+    systems: [],
+    modules: [],
+    cargoLots: [],
+  }
+
+  test('deposits the breakdown into the crawler pool and marks the mech destroyed', () => {
+    const c = crawler()
+    const { crawlerPatch, mechPatch, breakdown } = scrapMechOutcome(mech, c)
+    expect(mechPatch.destroyed).toBe(true)
+    // the pool only ever grows by the breakdown total
+    const before = Object.values(c.scrapPool).reduce((a, b) => a + b, 0)
+    const after = Object.values(crawlerPatch.scrapPool ?? {}).reduce((a, b) => a + b, 0)
+    expect(after - before).toBe(breakdown.total)
+  })
+
+  test('marks destroyed rather than deleting — the record keeps its history', () => {
+    const { mechPatch } = scrapMechOutcome(mech, crawler())
+    expect(mechPatch.destroyed).toBe(true)
+  })
+
+  test('a deliberately scrapped mech hands its hold to the crawler', () => {
+    // Nothing in the hold was ever part of the mech — losing it is data loss.
+    const withCargo = {
+      ...mech,
+      cargoLots: [PLATING],
+    }
+    const { crawlerPatch, mechPatch, cargoHandedOff } = scrapMechOutcome(withCargo, crawler())
+    expect(cargoHandedOff).toBe(true)
+    expect(crawlerPatch.cargoLots?.some((l) => l.name === 'Spare Plating')).toBe(true)
+    // and it leaves the mech, so it cannot be counted twice
+    expect(mechPatch.cargoLots).toEqual([])
+  })
+
+  test('an ALREADY-DESTROYED mech loses its cargo — meltdown destroys it (p.234/p.240)', () => {
+    const destroyed = {
+      ...mech,
+      destroyed: true,
+      cargoLots: [PLATING],
+    }
+    const { crawlerPatch, cargoHandedOff } = scrapMechOutcome(destroyed, crawler())
+    expect(cargoHandedOff).toBe(false)
+    expect(crawlerPatch.cargoLots).toBeUndefined()
+  })
+})

--- a/apps/itun/src/components/dashboard/dashboardEconomy.ts
+++ b/apps/itun/src/components/dashboard/dashboardEconomy.ts
@@ -1,0 +1,163 @@
+/**
+ * dashboardEconomy — pure patch builders for the Downtime economy layers
+ * (F2/F3/F4 of the rules-parity plan, #599).
+ *
+ * Same contract as `dashboardRules`: nothing here touches React or the store.
+ * Each function takes live numbers and returns the write-through patch(es) the
+ * caller hands to `storeState.update` / `.transfer`, so the handlers stay
+ * trivially testable and the ADR-006 pure-math boundary holds — `lib/rules/*`
+ * owns the maths, this only assembles patches.
+ *
+ * `crafting`, `salvage` and `scrapMech` were fully implemented and tested with
+ * **zero non-test importers**: their Live-Sheet panels were deleted on the way
+ * to the Dashboard and never rebuilt. This module is the missing seam, not new
+ * rules.
+ *
+ * ADR-007 boundary: nothing here decides to destroy anything. `scrapMechPatch`
+ * assembles the consequence of a scrap the player has already confirmed; the
+ * confirmation itself stays an explicit call at the UI layer.
+ */
+
+import type { Crawler } from '../../lib/schemas/crawler'
+import type { Mech } from '../../lib/schemas/mech'
+import { craftQuote, craftedLot, type CraftableItem } from '../../lib/rules/crafting'
+import {
+  depositScrapDeposits,
+  handOffCargo,
+  mechScrapComponents,
+  scrapMechBreakdown,
+} from '../../lib/rules/scrapMech'
+import { performAreaSalvage, type AreaSalvageResult } from '../../lib/rules/salvage'
+import type { ScrapPool } from '../../lib/schemas/crawler'
+import type { Roll } from '../../lib/rules/heatCheck'
+
+/** The crawler's numeric Tech Level, or undefined when the slug is unparseable. */
+export function crawlerTechLevelOf(crawler: Pick<Crawler, 'techLevel'>): number | undefined {
+  const digits = (crawler.techLevel ?? '').replace(/\D/g, '')
+  return digits ? Number(digits) : undefined
+}
+
+// ─── crafting (F3) ───────────────────────────────────────────────────────────
+
+export type CraftOutcome = {
+  quote: ReturnType<typeof craftQuote>
+  /** Null when the craft is not allowed — the caller shows the reason instead. */
+  patch: Partial<Crawler> | null
+  /** Why the craft is blocked, for the rule brief. Undefined when allowed. */
+  blocked?: 'tech-level' | 'scrap'
+}
+
+/**
+ * Quote a craft and, when it is legal AND affordable, assemble the patch:
+ * the pool after paying, plus the crafted item as a cargo lot.
+ *
+ * Guided Play enforces (ADR-021), so an ineligible or unaffordable craft
+ * returns a null patch and a reason rather than a patch the caller must
+ * remember not to apply.
+ */
+export function craftOutcome(
+  crawler: Pick<Crawler, 'techLevel' | 'scrapPool' | 'cargoLots'>,
+  item: CraftableItem
+): CraftOutcome {
+  const crawlerTl = crawlerTechLevelOf(crawler) ?? 0
+  const quote = craftQuote(item, (crawler.scrapPool ?? {}) as ScrapPool, crawlerTl)
+  if (!quote.eligible) return { quote, patch: null, blocked: 'tech-level' }
+  if (!quote.affordable) return { quote, patch: null, blocked: 'scrap' }
+  return {
+    quote,
+    patch: {
+      scrapPool: quote.pool,
+      cargoLots: [...(crawler.cargoLots ?? []), craftedLot(item)],
+    },
+  }
+}
+
+// ─── area salvage (F2) ───────────────────────────────────────────────────────
+
+export type AreaSalvageOutcome = {
+  result: AreaSalvageResult
+  /** Absent when the roll yielded nothing — there is no write to make. */
+  patch: Partial<Crawler> | null
+}
+
+/**
+ * Apply an Area Salvage roll to the crawler's scrap pool.
+ *
+ * A "nothing" band is a legitimate outcome, not a failure: it returns a null
+ * patch so the caller reports the result without a no-op write (which would
+ * otherwise appear in the Change Log as a change that changed nothing).
+ */
+export function areaSalvageOutcome(
+  crawler: Pick<Crawler, 'scrapPool'>,
+  input: { areaTl: number; roll: Roll }
+): AreaSalvageOutcome {
+  const result = performAreaSalvage(input)
+  // A "nothing" band and a jackpot both yield 0 scrap: the first found none,
+  // the second hands the player an ITEM choice rather than scrap. Neither has a
+  // pool write to make.
+  if (result.scrapQty <= 0) return { result, patch: null }
+  return {
+    result,
+    patch: {
+      scrapPool: depositScrapDeposits((crawler.scrapPool ?? {}) as ScrapPool, [
+        { tl: result.areaTl, count: result.scrapQty },
+      ]),
+    },
+  }
+}
+
+// ─── scrap mech (F4) ─────────────────────────────────────────────────────────
+
+export type ScrapMechOutcome = {
+  breakdown: ReturnType<typeof scrapMechBreakdown>
+  /** The crawler patch: its pool after the scrap, plus any cargo handed over. */
+  crawlerPatch: Partial<Crawler>
+  /** The mech patch marking it consumed. */
+  mechPatch: Partial<Mech>
+  /** True when the mech's hold moved to the crawler rather than being lost. */
+  cargoHandedOff: boolean
+}
+
+/**
+ * Assemble the consequence of scrapping a mech into a crawler's pool.
+ *
+ * Cross-entity by nature — the scrap leaves the mech and enters the crawler —
+ * so the caller commits both halves through `entityStore.transfer`, which is
+ * all-or-nothing: a partial write here would duplicate or destroy player value.
+ *
+ * **A scrapped mech is not a destroyed one.** Deliberately breaking a mech down
+ * hands its hold to the crawler; nothing in the hold was ever part of the mech,
+ * so losing it would be silent data loss. A mech that was already DESTROYED has
+ * lost its cargo with it (p.234/p.240), so the hand-off is skipped — the rule
+ * `handOffCargo` states in its own header, and the distinction the caller must
+ * make rather than the module.
+ *
+ * The mech is marked `destroyed` rather than deleted: deleting the record would
+ * take its Change Log and its soft-links with it, and ADR-007 keeps destruction
+ * visible rather than silently dropping data.
+ */
+export function scrapMechOutcome(
+  mech: Parameters<typeof mechScrapComponents>[0] & Pick<Mech, 'id' | 'cargoLots' | 'destroyed'>,
+  crawler: Pick<Crawler, 'scrapPool' | 'cargoLots'>
+): ScrapMechOutcome {
+  const components = mechScrapComponents(mech)
+  const breakdown = scrapMechBreakdown(components)
+  const pooled = depositScrapDeposits((crawler.scrapPool ?? {}) as ScrapPool, breakdown.deposits)
+
+  if (mech.destroyed) {
+    return {
+      breakdown,
+      crawlerPatch: { scrapPool: pooled },
+      mechPatch: { destroyed: true },
+      cargoHandedOff: false,
+    }
+  }
+
+  const handed = handOffCargo(mech.cargoLots ?? [], crawler.cargoLots ?? [], pooled)
+  return {
+    breakdown,
+    crawlerPatch: { scrapPool: handed.pool, cargoLots: handed.crawlerLots },
+    mechPatch: { destroyed: true, cargoLots: [] },
+    cargoHandedOff: true,
+  }
+}


### PR DESCRIPTION
**F2/F3/F4** of the rules-parity plan (#599) — second in the recommended order, after #628.

These three modules were **fully implemented and fully tested with zero non-test importers**. Their Live-Sheet panels were deleted on the way to the Dashboard and never rebuilt, so this is the largest block of finished rules work no player could reach. **This PR is the missing seam, not new rules.**

`dashboardEconomy.ts` follows `dashboardRules`' contract — pure patch builders, no React, no store — so handlers stay trivially testable and ADR-006's pure-math boundary holds.

Carrying F6's pattern forward: Guided Play enforces **and teaches**, so a blocked action returns a null patch plus a **reason** rather than a patch the caller must remember not to apply. An unaffordable craft is listed **with its shortfall** instead of hidden, so a player can see what to save for.

## A rules distinction knip surfaced

knip flagged `scrappedCargo` as an unused export. That was true — and the reason was a **bug**: I'd never wired the cargo hand-off at all.

`handOffCargo` states the rule in its own header:

> a scrapped mech hands its hold to the crawler, because nothing in the hold was ever part of the mech and losing it is silent data loss — but an **already-destroyed** mech has lost its cargo with it (p.234/p.240)

Those are **different states**, and my first version conflated them by marking every scrap `destroyed: true`. The hand-off now happens on a deliberate scrap and is skipped on a destroyed mech, with a test each way.

## Other details worth review

- **Scrapping commits through `entityStore.transfer`** — cross-entity and all-or-nothing, since a partial write would duplicate or destroy player value. That's the same `transfer` path fixed in #602 to actually emit provenance, so a scrap is now auditable.
- The mech is marked `destroyed` rather than **deleted**, so the record keeps its Change Log and soft-links (ADR-007 keeps destruction visible rather than silently dropping data).
- An Area Salvage roll that finds nothing makes **no write** — a no-op patch would appear in the Change Log as a change that changed nothing. A jackpot likewise writes nothing: it hands the player an *item* choice, not scrap.

## Verification

`bun run check:all` green: lint, format, typecheck, **4,575 tests**, validate (incl. the parity gate), knip, audit, tokens, styling. 13 new tests on the patch builders.

Next in order: **C4** (inline rules-bearing marker).

Refs #599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MT6q22Y1MtuCYHormXwQ4