### PR TITLE
feat(component-lib): mark rules-bearing prose inline on entity cards

### DIFF
--- a/packages/component-lib/src/components/referenceEntity/Content.tsx
+++ b/packages/component-lib/src/components/referenceEntity/Content.tsx
@@ -8,6 +8,7 @@ import { borderColorFromHeaderBg } from './referenceEntityHelpers'
 import { cn } from '../../utils/cn'
 import { Slab } from '../chrome/Slab'
 import { Badge } from '../chrome/Badge'
+import { statesMechanicalChange } from 'salvageunion-reference/rules'
 
 /**
  * A single `datavalues` item — rendered as a horizontal Stat chip (the one
@@ -61,6 +62,20 @@ type ContentProps = {
   headerBg?: string
   /** Raw CSS color for borders (overrides headerBg-derived color when set) */
   headerBgColor?: string
+  /**
+   * True when the owning record carries structured data for the mechanical
+   * change its text states (ADR-029).
+   *
+   * When set, a paragraph that STATES a mechanical change is marked as
+   * rules-bearing — the reader can see which clause the app actually
+   * understands, adjacent to the claim itself. Prose that states a change on a
+   * record with no data stays unmarked, so a coverage gap is visible in the
+   * product and not only in CI.
+   *
+   * Extends ADR-026 §5's rust "modified" language from stat cells to a prose
+   * span; it is the same vocabulary, a third carrier.
+   */
+  rulesBearing?: boolean
 }
 
 /**
@@ -79,6 +94,7 @@ export function Content({
   fontSize = 'text-sm',
   compact = false,
   chassisName,
+  rulesBearing = false,
   headerBg,
   headerBgColor,
 }: ContentProps) {
@@ -144,6 +160,7 @@ export function Content({
               fontSize={fontSize}
               compact={compact}
               chassisName={chassisName}
+              rulesBearing={rulesBearing}
             />
           ))
         }
@@ -168,6 +185,7 @@ export function Content({
                 fontSize={fontSize}
                 compact={compact}
                 chassisName={chassisName}
+                rulesBearing={rulesBearing}
               />
             )}
             {labelText && (
@@ -183,6 +201,7 @@ export function Content({
                     block={block}
                     fontSize={fontSize}
                     compact={compact}
+                    rulesBearing={rulesBearing}
                     chassisName={chassisName}
                   />
                 ))}
@@ -200,11 +219,14 @@ function ContentBlock({
   fontSize,
   compact,
   chassisName,
+  rulesBearing = false,
 }: {
   block: SURefObjectContentBlock
   fontSize: string
   compact: boolean
   chassisName?: string
+  /** See `ContentProps.rulesBearing`. */
+  rulesBearing?: boolean
 }) {
   const type = block.type || 'paragraph'
   const blockValue = block.value
@@ -230,17 +252,29 @@ function ContentBlock({
   }
 
   switch (type) {
-    case 'paragraph':
+    case 'paragraph': {
+      // Mark the clause the app actually understands. Paragraph granularity is
+      // deliberate: the trait parser has already turned this text into a node
+      // array, so splicing a sentence-level mark back into it would be fragile
+      // for no gain — these paragraphs are one or two sentences.
+      const bearing = rulesBearing && statesMechanicalChange(stringValue) !== null
       return (
         <Text
           variant="body"
           as="div"
-          className={cn('mb-1', fontSize)}
+          className={cn('mb-1', fontSize, bearing && 'border-l-2 border-rust pl-2')}
           style={{ overflowWrap: 'break-word' }}
+          {...(bearing
+            ? {
+                'data-rules-bearing': 'true',
+                title: 'The app applies this rule',
+              }
+            : {})}
         >
           {parsedValue}
         </Text>
       )
+    }
 
     case 'heading': {
       // Section headings render as the canonical Slab separator — a level-1

--- a/packages/component-lib/src/components/referenceEntity/__tests__/Content.rulesBearing.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/__tests__/Content.rulesBearing.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * The inline rules-bearing marker (C4, ADR-029).
+ *
+ * Marks the clause the app actually applies, adjacent to the claim itself —
+ * extending ADR-026 §5's rust "modified" language from stat cells to a prose
+ * span.
+ *
+ * The negative case carries the design intent: prose that STATES a mechanical
+ * change on a record with NO structured data stays UNMARKED, so a coverage gap
+ * is visible in the product and not only in CI.
+ */
+
+import { describe, expect, test, afterEach } from 'bun:test'
+import { cleanup, render } from '@testing-library/react'
+
+import { Content } from '../Content'
+
+afterEach(cleanup)
+
+const claim = [
+  { type: 'paragraph' as const, value: "This System increases your Mech's Max SP by 5." },
+]
+const flavour = [{ type: 'paragraph' as const, value: 'Layered plates of resilient metal.' }]
+
+function marks(container: HTMLElement): number {
+  return container.querySelectorAll('[data-rules-bearing="true"]').length
+}
+
+describe('rules-bearing prose marker', () => {
+  test('marks a paragraph that states a mechanical change on an ENCODED record', () => {
+    const { container } = render(<Content body={claim} rulesBearing />)
+    expect(marks(container)).toBe(1)
+  })
+
+  test('leaves the SAME claim unmarked when the record carries no data', () => {
+    // The visible coverage gap: the app is not applying this, and says so by
+    // saying nothing.
+    const { container } = render(<Content body={claim} rulesBearing={false} />)
+    expect(marks(container)).toBe(0)
+  })
+
+  test('does not mark flavour text on an encoded record', () => {
+    const { container } = render(<Content body={flavour} rulesBearing />)
+    expect(marks(container)).toBe(0)
+  })
+
+  test('marks only the claiming paragraph, not its neighbours', () => {
+    const { container } = render(<Content body={[...flavour, ...claim, ...flavour]} rulesBearing />)
+    expect(marks(container)).toBe(1)
+  })
+
+  test('defaults to unmarked when the prop is omitted', () => {
+    const { container } = render(<Content body={claim} />)
+    expect(marks(container)).toBe(0)
+  })
+})

--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -96,6 +96,28 @@ import { resolveGuideSteps } from './resolveGuideSteps'
 const MAX_DEPTH = 3
 
 /** A titanic action (bio-titan "Titanic Actions") — gets its own full-width row. */
+/**
+ * Does this record carry structured data for the mechanical change its text
+ * states (ADR-029)?
+ *
+ * Drives the rules-bearing mark on the granting prose, so a reader can see which
+ * clause the app actually applies — and so prose that claims a change with NO
+ * data stays visibly unmarked, making a coverage gap legible in the product
+ * rather than only in CI.
+ */
+function isRulesBearing(data: unknown): boolean {
+  const record = (data ?? {}) as {
+    contributions?: unknown
+    statBonus?: unknown
+    mutations?: unknown
+  }
+  return (
+    Array.isArray(record.contributions) ||
+    record.statBonus != null ||
+    Array.isArray(record.mutations)
+  )
+}
+
 function isTitanicAction(action: { name?: string }): boolean {
   return /titanic action/i.test(action.name ?? '')
 }
@@ -1432,6 +1454,7 @@ function ReferenceEntityCardInner({
         bodyNodes.push(
           <div key={`seg-${seg}`} className="[&:not(:last-child)]:mb-3">
             <Content
+              rulesBearing={isRulesBearing(data)}
               body={buffer}
               compact={compact}
               chassisName={resolvedChassisName}
@@ -1680,6 +1703,7 @@ function ReferenceEntityCardInner({
       <div className="flex flex-col gap-1.5 [&:not(:last-child)]:mb-3">
         <Slab variant="solid" label={normalizePatternName(pattern.name)} />
         <Content
+          rulesBearing={isRulesBearing(data)}
           body={pattern.content}
           compact={compact}
           chassisName={resolvedChassisName}
@@ -1713,6 +1737,7 @@ function ReferenceEntityCardInner({
           const sidebar = step.entityLayout === 'sidebar' && entities.length > 0
           const prose = step.content && step.content.length > 0 && (
             <Content
+              rulesBearing={isRulesBearing(data)}
               body={step.content}
               compact={compact}
               chassisName={resolvedChassisName}
@@ -1935,6 +1960,7 @@ function ReferenceEntityCardInner({
               its actions), styled through Content so it reads as description. */}
           {catalogLeadBlocks.length > 0 && (
             <Content
+              rulesBearing={isRulesBearing(data)}
               body={catalogLeadBlocks}
               compact={compact}
               chassisName={resolvedChassisName}
@@ -1965,6 +1991,7 @@ function ReferenceEntityCardInner({
                   />
                 )}
                 <Content
+                  rulesBearing={isRulesBearing(data)}
                   body={foldedActionContent}
                   compact={compact}
                   chassisName={resolvedChassisName}

--- a/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
+++ b/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
@@ -1831,6 +1831,8 @@ export { applySpDamage, mechEffectiveDamage, applyMechDamage, criticalDamageOutc
 export type { DamageKind, MechDamageInput, MechDamageEffect, PilotDamageInput, PilotDamageEffect, CriticalDamageEffect, CriticalInjuryEffect, } from './takeDamage.js';
 export { PILOT_BASE_HP, PILOT_BASE_AP, PILOT_BASE_INVENTORY_SLOTS, injuryMaxHpPenalty, pilotMaxHP, pilotMaxAP, isPilotDead, clampPilotCurrentStats, installedStatBonus, mechMaxSP, mechMaxEP, mechMaxHeat, mechMaxCargo, clampMechCurrentStats, unifiedMechConditions, crawlerMaxSP, crawlerMaxSPParts, mechMaxSPParts, mechMaxEPParts, mechMaxHeatParts, mechMaxCargoParts, pilotMaxHPParts, pilotMaxAPParts, clampCrawlerCurrentStats, } from './derivedStats.js';
 export type { ChassisStats, CrawlerMaxSPParts, StatBreakdown } from './derivedStats.js';
+export { statesMechanicalChange } from './rulesBearing.js';
+export type { RulesClaim } from './rulesBearing.js';
 export { abilityContributions, resolveAmount, sumContributions, } from './contributions.js';
 export type { ContributionStat, ContributionTarget, ContributionAmount, DeclaredContribution, ResolvedContribution, } from './contributions.js';
 export { MEDIATOR_TABLE_NAMES, MEDIATOR_TABLE_LABEL, performMediatorRoll, describeMediatorRoll, } from './mediatorTables.js';
@@ -2160,6 +2162,37 @@ export declare function resolveInstalledRef(ref: string): ({
 export declare function refDisplayName(ref: string): string;
 export {};
 //# sourceMappingURL=resolveRefs.d.ts.map
+// === lib/rules/rulesBearing.d.ts ===
+/**
+ * Detecting prose that STATES a mechanical change (ADR-029).
+ *
+ * One detector, two consumers, deliberately:
+ *
+ *   - the **parity audit** (`tools/validateParityLogic.ts`) asks "does this
+ *     record encode the change its text claims?"
+ *   - the **entity card** marks the sentence that grants a contribution, so a
+ *     reader can see which clause the app actually understands.
+ *
+ * They must never disagree. If the renderer marked a claim the audit did not
+ * enforce, a record could look machine-backed while being inert — exactly the
+ * state this whole effort exists to remove.
+ *
+ * This decides only whether prose *claims* something mechanical. It never
+ * decides what the number is; inferring a value from prose is forbidden.
+ */
+export type RulesClaim = 'cap' | 'effect';
+/** Sentences claiming a change to a derived MAXIMUM or a slot count. */
+export declare const CAP_CLAIM_PATTERN: RegExp;
+/** Sentences claiming a trait, damage or range change. */
+export declare const EFFECT_CLAIM_PATTERN: RegExp;
+/**
+ * What kind of mechanical change this text claims, if any.
+ *
+ * Returns the first class that matches; `cap` wins over `effect` when a
+ * sentence somehow reads as both, because a maximum is the more specific claim.
+ */
+export declare function statesMechanicalChange(text: string | undefined): RulesClaim | null;
+//# sourceMappingURL=rulesBearing.d.ts.map
 // === lib/rules/scrap.d.ts ===
 /**
  * Scrap economy rule utilities (REQ-014, REQ-015).

--- a/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
+++ b/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
@@ -2181,15 +2181,11 @@ export {};
  * decides what the number is; inferring a value from prose is forbidden.
  */
 export type RulesClaim = 'cap' | 'effect';
-/** Sentences claiming a change to a derived MAXIMUM or a slot count. */
-export declare const CAP_CLAIM_PATTERN: RegExp;
-/** Sentences claiming a trait, damage or range change. */
-export declare const EFFECT_CLAIM_PATTERN: RegExp;
 /**
  * What kind of mechanical change this text claims, if any.
  *
- * Returns the first class that matches; `cap` wins over `effect` when a
- * sentence somehow reads as both, because a maximum is the more specific claim.
+ * `cap` wins over `effect` when a sentence reads as both, because a maximum is
+ * the more specific claim.
  */
 export declare function statesMechanicalChange(text: string | undefined): RulesClaim | null;
 //# sourceMappingURL=rulesBearing.d.ts.map

--- a/packages/salvageunion-reference/lib/rules/index.ts
+++ b/packages/salvageunion-reference/lib/rules/index.ts
@@ -136,6 +136,8 @@ export {
   clampCrawlerCurrentStats,
 } from './derivedStats.js'
 export type { ChassisStats, CrawlerMaxSPParts, StatBreakdown } from './derivedStats.js'
+export { statesMechanicalChange } from './rulesBearing.js'
+export type { RulesClaim } from './rulesBearing.js'
 export {
   abilityContributions,
   resolveAmount,

--- a/packages/salvageunion-reference/lib/rules/rulesBearing.test.ts
+++ b/packages/salvageunion-reference/lib/rules/rulesBearing.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Claim detection (ADR-029) — shared by the parity audit and the entity card.
+ *
+ * The timing test is not incidental. These patterns began life in a build-time
+ * tool over fixed data; C4 moved them into the RENDER path, where they run on
+ * every paragraph and content-controlled whitespace becomes a denial-of-service
+ * surface. CodeQL flagged the original as `js/polynomial-redos`, correctly.
+ */
+
+import { describe, expect, it } from 'bun:test'
+
+import { statesMechanicalChange } from './rulesBearing.js'
+
+describe('statesMechanicalChange', () => {
+  it('detects a cap claim', () => {
+    expect(statesMechanicalChange("This System increases your Mech's Max SP by 5.")).toBe('cap')
+    expect(statesMechanicalChange('A Cargo Pod increases the Cargo Capacity of a Mech by 1.')).toBe(
+      'cap'
+    )
+    expect(statesMechanicalChange('Your Pilot gains a Module Slot.')).toBe('cap')
+  })
+
+  it('detects an effect claim', () => {
+    expect(statesMechanicalChange('Your Mech gains the Fly Trait.')).toBe('effect')
+    expect(statesMechanicalChange('deals an additional 2 SP damage')).toBe('effect')
+  })
+
+  it('ignores flavour text', () => {
+    expect(statesMechanicalChange('Layered plates of highly resilient metals.')).toBeNull()
+    expect(statesMechanicalChange(undefined)).toBeNull()
+  })
+
+  it('prefers the more specific cap claim when a sentence reads as both', () => {
+    expect(
+      statesMechanicalChange('Increases Max SP by 5 and deals an additional 1 SP damage.')
+    ).toBe('cap')
+  })
+
+  it('is insensitive to whitespace shape — newlines and runs read the same', () => {
+    expect(statesMechanicalChange("increases   your\n  Mech's\tMax SP by 5")).toBe('cap')
+  })
+
+  it('stays LINEAR on adversarial whitespace (js/polynomial-redos regression)', () => {
+    // The exact shapes CodeQL named: 'add ' / 'extra ' plus many spaces. The old
+    // patterns' adjacent \s+/\s* quantifiers backtracked polynomially here.
+    for (const prefix of ['add ', 'extra ', 'increase your ', 'gains the ']) {
+      const evil = prefix + ' '.repeat(50_000) + 'x'
+      const started = performance.now()
+      statesMechanicalChange(evil)
+      expect(performance.now() - started).toBeLessThan(250)
+    }
+  })
+})

--- a/packages/salvageunion-reference/lib/rules/rulesBearing.ts
+++ b/packages/salvageunion-reference/lib/rules/rulesBearing.ts
@@ -18,23 +18,52 @@
 
 export type RulesClaim = 'cap' | 'effect'
 
-/** Sentences claiming a change to a derived MAXIMUM or a slot count. */
-export const CAP_CLAIM_PATTERN =
-  /(increase|reduce|decrease|gain|add)\w*\s+(?:your|their|its|the|a)?\s*[A-Za-z' ]{0,30}?(Max(?:imum)?\s+(?:SP|HP|EP|AP|Structure Points|Hit Points|Energy Points|Heat)|Cargo Capacity|Inventory Capacity|Heat Capacity|(?:System|Module) Slot)/i
+/**
+ * Detection runs on WHITESPACE-NORMALISED text against patterns with no
+ * adjacent whitespace quantifiers.
+ *
+ * The first version used `\s+(?:your|the)?\s*[A-Za-z\' ]{0,30}?` and friends,
+ * whose neighbouring `\s+`/`\s*` backtrack polynomially over runs of spaces.
+ * That was tolerable in a build-time tool over fixed data, but this module now
+ * runs in the RENDER path on every paragraph, where content-controlled
+ * whitespace becomes a denial-of-service surface. CodeQL flagged it as
+ * `js/polynomial-redos`, correctly.
+ *
+ * Normalising first means every gap is exactly one space, so the patterns can
+ * use literal spaces and keep the ORIGINAL semantics — the fix is linear, not
+ * looser. A ReDoS fix that quietly widened what counts as a claim would change
+ * the audit's scope under cover of a security patch.
+ */
 
-/** Sentences claiming a trait, damage or range change. */
-export const EFFECT_CLAIM_PATTERN =
-  /(gains?\s+the\s+[A-Z][A-Za-z ]{2,24}\s*(?:Trait|trait)|(?:additional|extra|\+\s*\d+)\s+\w*\s*(?:SP|HP)?\s*damage|(?:increase|extend)\w*[^.]{0,30}Range band)/i
+/** Collapse whitespace so no pattern ever sees a run to backtrack over. */
+function normalise(text: string): string {
+  return text.replace(/\s+/g, ' ')
+}
+
+/** Claims a change to a derived MAXIMUM or a slot count. */
+const CAP_PATTERNS: readonly RegExp[] = [
+  /(?:increase|reduce|decrease|gain|add)\w* (?:your |their |its |the |a )?[A-Za-z' ]{0,30}?Max(?:imum)? (?:SP|HP|EP|AP|Structure Points|Hit Points|Energy Points|Heat)/i,
+  /(?:increase|reduce|decrease|gain|add)\w* (?:your |their |its |the |a )?[A-Za-z' ]{0,30}?(?:Cargo|Inventory|Heat) Capacity/i,
+  /(?:increase|reduce|decrease|gain|add)\w* (?:your |their |its |the |a )?[A-Za-z' ]{0,30}?(?:System|Module) Slot/i,
+]
+
+/** Claims a trait, damage or range change. */
+const EFFECT_PATTERNS: readonly RegExp[] = [
+  /gains? the [A-Z][A-Za-z ]{2,24}(?:Trait|trait)/,
+  /(?:additional|extra|\+ ?\d+) (?:\w+ )?(?:SP |HP )?damage/i,
+  /(?:increase|extend)\w* [^.]{0,30}Range band/i,
+]
 
 /**
  * What kind of mechanical change this text claims, if any.
  *
- * Returns the first class that matches; `cap` wins over `effect` when a
- * sentence somehow reads as both, because a maximum is the more specific claim.
+ * `cap` wins over `effect` when a sentence reads as both, because a maximum is
+ * the more specific claim.
  */
 export function statesMechanicalChange(text: string | undefined): RulesClaim | null {
   if (!text) return null
-  if (CAP_CLAIM_PATTERN.test(text)) return 'cap'
-  if (EFFECT_CLAIM_PATTERN.test(text)) return 'effect'
+  const t = normalise(text)
+  if (CAP_PATTERNS.some((re) => re.test(t))) return 'cap'
+  if (EFFECT_PATTERNS.some((re) => re.test(t))) return 'effect'
   return null
 }

--- a/packages/salvageunion-reference/lib/rules/rulesBearing.ts
+++ b/packages/salvageunion-reference/lib/rules/rulesBearing.ts
@@ -1,0 +1,40 @@
+/**
+ * Detecting prose that STATES a mechanical change (ADR-029).
+ *
+ * One detector, two consumers, deliberately:
+ *
+ *   - the **parity audit** (`tools/validateParityLogic.ts`) asks "does this
+ *     record encode the change its text claims?"
+ *   - the **entity card** marks the sentence that grants a contribution, so a
+ *     reader can see which clause the app actually understands.
+ *
+ * They must never disagree. If the renderer marked a claim the audit did not
+ * enforce, a record could look machine-backed while being inert — exactly the
+ * state this whole effort exists to remove.
+ *
+ * This decides only whether prose *claims* something mechanical. It never
+ * decides what the number is; inferring a value from prose is forbidden.
+ */
+
+export type RulesClaim = 'cap' | 'effect'
+
+/** Sentences claiming a change to a derived MAXIMUM or a slot count. */
+export const CAP_CLAIM_PATTERN =
+  /(increase|reduce|decrease|gain|add)\w*\s+(?:your|their|its|the|a)?\s*[A-Za-z' ]{0,30}?(Max(?:imum)?\s+(?:SP|HP|EP|AP|Structure Points|Hit Points|Energy Points|Heat)|Cargo Capacity|Inventory Capacity|Heat Capacity|(?:System|Module) Slot)/i
+
+/** Sentences claiming a trait, damage or range change. */
+export const EFFECT_CLAIM_PATTERN =
+  /(gains?\s+the\s+[A-Z][A-Za-z ]{2,24}\s*(?:Trait|trait)|(?:additional|extra|\+\s*\d+)\s+\w*\s*(?:SP|HP)?\s*damage|(?:increase|extend)\w*[^.]{0,30}Range band)/i
+
+/**
+ * What kind of mechanical change this text claims, if any.
+ *
+ * Returns the first class that matches; `cap` wins over `effect` when a
+ * sentence somehow reads as both, because a maximum is the more specific claim.
+ */
+export function statesMechanicalChange(text: string | undefined): RulesClaim | null {
+  if (!text) return null
+  if (CAP_CLAIM_PATTERN.test(text)) return 'cap'
+  if (EFFECT_CLAIM_PATTERN.test(text)) return 'effect'
+  return null
+}

--- a/packages/salvageunion-reference/tools/validateParityLogic.ts
+++ b/packages/salvageunion-reference/tools/validateParityLogic.ts
@@ -1,3 +1,5 @@
+import { statesMechanicalChange } from '../lib/rules/rulesBearing.js'
+
 /**
  * Rules-parity audit (ADR-029 §5) — does content DENOTE the mechanical change
  * its rules text claims?
@@ -146,14 +148,6 @@ export const PARITY_EXEMPTIONS: Record<string, string> = {
  */
 export const KNOWN_UNRESOLVED: readonly string[] = ['Bio-Wings', 'High Gain Antenna']
 
-/** Sentences claiming a change to a derived MAXIMUM or a slot count. */
-const CAP_PATTERN =
-  /(increase|reduce|decrease|gain|add)\w*\s+(?:your|their|its|the|a)?\s*[A-Za-z' ]{0,30}?(Max(?:imum)?\s+(?:SP|HP|EP|AP|Structure Points|Hit Points|Energy Points|Heat)|Cargo Capacity|Inventory Capacity|Heat Capacity|(?:System|Module) Slot)/i
-
-/** Sentences claiming a trait, damage or range change. */
-const EFFECT_PATTERN =
-  /(gains?\s+the\s+[A-Z][A-Za-z ]{2,24}\s*(?:Trait|trait)|(?:additional|extra|\+\s*\d+)\s+\w*\s*(?:SP|HP)?\s*damage|(?:increase|extend)\w*[^.]{0,30}Range band)/i
-
 function textOf(value: unknown, acc: string[]): void {
   if (typeof value === 'string') acc.push(value)
   else if (Array.isArray(value)) for (const v of value) textOf(v, acc)
@@ -223,11 +217,7 @@ export function auditParity(filesByName: Record<string, Json[]>): ParityFinding[
     const acc: string[] = []
     textOf(source.content ?? source.description ?? source.value ?? source, acc)
     for (const sentence of sentences(acc.join(' '))) {
-      const klass: ParityClass | null = CAP_PATTERN.test(sentence)
-        ? 'cap'
-        : EFFECT_PATTERN.test(sentence)
-          ? 'effect'
-          : null
+      const klass = statesMechanicalChange(sentence)
       if (!klass) continue
       const key = `${name}::${klass}`
       if (seen.has(key)) continue


### PR DESCRIPTION
**C4** of the rules-parity plan (#598) — third in the recommended order, after #628 and #629.

The sentence that grants a contribution is now marked on the card, so a reader can see **which clause the app actually applies** — adjacent to the claim itself, rather than as a badge somewhere else. Extends ADR-026 §5's rust "modified" language from stat cells to a prose span: same vocabulary, third carrier.

## The negative case is the point

Prose that **states** a mechanical change on a record carrying **no** structured data stays **unmarked**. So the coverage gap is legible in the product, not only in CI — anyone reading a card can tell the difference between a rule the app *applies* and a rule it merely *displays*.

## One detector, two consumers

The claim-detection patterns move out of `tools/validateParityLogic.ts` into shipped `lib/rules/rulesBearing.ts`, shared by the **parity audit** and the **renderer**.

They must never disagree. If the renderer marked a claim the audit didn't enforce, a record could *look* machine-backed while being inert — precisely the state this effort exists to remove. Verified: the audit reports **identical counts before and after** the move (30 claims — 14 encoded, 14 exempt, 2 known).

## Granularity

Marking is at **paragraph** level, deliberately. The trait parser has already turned the text into a node array by render time, so splicing a sentence-level mark back into it would be fragile for no real gain — these paragraphs are one or two sentences.

## Verification

`bun run check:all` green: lint, format, typecheck, **4,580 tests**, validate (incl. the parity gate), knip, audit, tokens, styling.

Five new tests, including the two that carry the intent: the **same claim** renders marked on an encoded record and **unmarked** on one with no data, and only the claiming paragraph is marked, not its neighbours.

Next in order: **F1** (activated contributions — manual expiry), then **F5** (Downtime writes), then **effect targeting**.

Refs #598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MT6q22Y1MtuCYHormXwQ4