### PR TITLE
feat(itun): Game templates — the Starter Set arrives unclaimed

### DIFF
--- a/apps/itun/convex/__tests__/account.test.ts
+++ b/apps/itun/convex/__tests__/account.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, test } from 'bun:test'
+
+import { api } from '../_generated/api'
+import type { Id } from '../_generated/dataModel'
+import { testConvex } from './harness'
+
+/**
+ * Account management, and in particular the promise D27 makes:
+ * **a campaign never dies because one person quit.**
+ *
+ * Deletion is the operation with no undo, so the cases below are less about
+ * "does it delete" and more about "does it delete *only* the right things" —
+ * the crew's Game, the communal crawler, and other people's characters all
+ * have to survive somebody exercising their right to be forgotten.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+async function seedPilot(t: Ctx, gameId: Id<'games'> | null, ownerId: Id<'users'> | null) {
+  return await t.run(
+    async (ctx) =>
+      await ctx.db.insert('pilots', { gameId, ownerId, body: { callsign: 'X' }, updatedAt: 1 })
+  )
+}
+
+describe('profile', () => {
+  test('displayName falls back to the Discord name when unset', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Roach-Boy')
+    await u.as.mutation(api.account.updateProfile, { displayName: null })
+
+    const me = await u.as.query(api.account.me, {})
+    // Cleared means "fall back", not "blank" — a nameless owner chip is worse
+    // than a stale one.
+    expect(me?.displayName).toBe('Roach-Boy')
+  })
+
+  test('a set displayName overrides the Discord name', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Roach-Boy')
+    await u.as.mutation(api.account.updateProfile, { displayName: '  Beefcake  ' })
+
+    const me = await u.as.query(api.account.me, {})
+    expect(me?.displayName).toBe('Beefcake')
+  })
+
+  test('an anonymous caller has no profile to read', async () => {
+    const t = testConvex()
+    await expect(t.query(api.account.me, {})).rejects.toThrow(/not signed in/i)
+  })
+})
+
+describe('export is scoped to what you own', () => {
+  test('excludes a crewmate pilot you can merely see', async () => {
+    const t = testConvex()
+    const owner = await makeUser(t, 'Owner')
+    const other = await makeUser(t, 'Other')
+    const gameId = await owner.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await owner.as.mutation(api.invites.create, { gameId })
+    await other.as.mutation(api.invites.redeem, { code })
+
+    await seedPilot(t, gameId, owner.userId)
+    await seedPilot(t, gameId, other.userId)
+
+    const mine = await owner.as.query(api.account.exportMine, {})
+    // Readable inside a Game is not the same as yours to take away.
+    expect(mine.pilots).toHaveLength(1)
+  })
+})
+
+describe('deleteAccount — the campaign survives', () => {
+  test('Organizer passes to the longest-standing remaining member', async () => {
+    const t = testConvex()
+    const organizer = await makeUser(t, 'Organizer')
+    const early = await makeUser(t, 'Early')
+    const late = await makeUser(t, 'Late')
+
+    const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await early.as.mutation(api.invites.redeem, { code })
+    await late.as.mutation(api.invites.redeem, { code })
+
+    // Make the ordering unambiguous rather than relying on clock resolution.
+    await t.run(async (ctx) => {
+      for (const m of await ctx.db.query('memberships').collect()) {
+        if (m.userId === early.userId) await ctx.db.patch(m._id, { joinedAt: 100 })
+        if (m.userId === late.userId) await ctx.db.patch(m._id, { joinedAt: 200 })
+      }
+    })
+
+    await organizer.as.mutation(api.account.deleteAccount, {})
+
+    const roster = await early.as.query(api.games.members, { gameId })
+    const organizers = roster.filter((m) => m.organizer)
+    expect(organizers).toHaveLength(1)
+    expect(organizers[0]?.userId).toBe(early.userId)
+  })
+
+  test('the Game and the communal crawler survive', async () => {
+    const t = testConvex()
+    const organizer = await makeUser(t, 'Organizer')
+    const player = await makeUser(t, 'Player')
+    const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await player.as.mutation(api.invites.redeem, { code })
+
+    const crawlerId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('crawlers', { gameId, body: { name: '#430' }, updatedAt: 1 })
+    )
+
+    await organizer.as.mutation(api.account.deleteAccount, {})
+
+    const game = await t.run(async (ctx) => await ctx.db.get(gameId))
+    const crawler = await t.run(async (ctx) => await ctx.db.get(crawlerId))
+    expect(game).not.toBeNull()
+    // The crawler belongs to the table, not to whoever set the Game up.
+    expect(crawler).not.toBeNull()
+  })
+
+  test("another member's pilot is untouched", async () => {
+    const t = testConvex()
+    const organizer = await makeUser(t, 'Organizer')
+    const player = await makeUser(t, 'Player')
+    const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await player.as.mutation(api.invites.redeem, { code })
+
+    const theirs = await seedPilot(t, gameId, player.userId)
+    await organizer.as.mutation(api.account.deleteAccount, {})
+
+    const pilot = await t.run(async (ctx) => await ctx.db.get(theirs))
+    expect(pilot).not.toBeNull()
+    expect(pilot?.ownerId).toBe(player.userId)
+  })
+
+  test('the departing account’s own entities go, in a Game and on the shelf alike', async () => {
+    const t = testConvex()
+    const organizer = await makeUser(t, 'Organizer')
+    const player = await makeUser(t, 'Player')
+    const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await player.as.mutation(api.invites.redeem, { code })
+
+    const inGame = await seedPilot(t, gameId, organizer.userId)
+    const onShelf = await seedPilot(t, null, organizer.userId)
+
+    await organizer.as.mutation(api.account.deleteAccount, {})
+
+    expect(await t.run(async (ctx) => await ctx.db.get(inGame))).toBeNull()
+    expect(await t.run(async (ctx) => await ctx.db.get(onShelf))).toBeNull()
+  })
+
+  test('the last member out takes the Game with them', async () => {
+    const t = testConvex()
+    const solo = await makeUser(t, 'Solo')
+    const gameId = await solo.as.mutation(api.games.create, { name: 'Alone' })
+    const crawlerId = await t.run(
+      async (ctx) => await ctx.db.insert('crawlers', { gameId, body: {}, updatedAt: 1 })
+    )
+    const unclaimed = await seedPilot(t, gameId, null)
+
+    await solo.as.mutation(api.account.deleteAccount, {})
+
+    // An empty Game is not a campaign anybody can come back to, and its
+    // unclaimed entities have no shelf to fall back to.
+    expect(await t.run(async (ctx) => await ctx.db.get(gameId))).toBeNull()
+    expect(await t.run(async (ctx) => await ctx.db.get(crawlerId))).toBeNull()
+    expect(await t.run(async (ctx) => await ctx.db.get(unclaimed))).toBeNull()
+  })
+
+  test('the user row and its auth rows are gone', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Gone')
+
+    // A session with a refresh token hanging off it — the ordering hazard.
+    await t.run(async (ctx) => {
+      const sessionId = await ctx.db.insert('authSessions', {
+        userId: u.userId,
+        expirationTime: Date.now() + 1000,
+      })
+      await ctx.db.insert('authRefreshTokens', {
+        sessionId,
+        expirationTime: Date.now() + 1000,
+      })
+      await ctx.db.insert('authAccounts', {
+        userId: u.userId,
+        provider: 'discord',
+        providerAccountId: 'abc123',
+      })
+    })
+
+    await u.as.mutation(api.account.deleteAccount, {})
+
+    const left = await t.run(async (ctx) => ({
+      user: await ctx.db.get(u.userId),
+      sessions: (await ctx.db.query('authSessions').collect()).length,
+      tokens: (await ctx.db.query('authRefreshTokens').collect()).length,
+      accounts: (await ctx.db.query('authAccounts').collect()).length,
+    }))
+
+    expect(left.user).toBeNull()
+    expect(left.sessions).toBe(0)
+    // Refresh tokens are keyed by session, not user — they are the rows most
+    // likely to be left behind pointing at something deleted.
+    expect(left.tokens).toBe(0)
+    expect(left.accounts).toBe(0)
+  })
+})

--- a/apps/itun/convex/__tests__/harness.ts
+++ b/apps/itun/convex/__tests__/harness.ts
@@ -22,6 +22,7 @@ const modules = {
   // map, so these two are required even though no test imports them directly.
   './_generated/api.js': () => import('../_generated/api'),
   './_generated/server.js': () => import('../_generated/server'),
+  './account.ts': () => import('../account'),
   './games.ts': () => import('../games'),
   './invites.ts': () => import('../invites'),
   './ownership.ts': () => import('../ownership'),

--- a/apps/itun/convex/__tests__/harness.ts
+++ b/apps/itun/convex/__tests__/harness.ts
@@ -26,6 +26,7 @@ const modules = {
   './games.ts': () => import('../games'),
   './invites.ts': () => import('../invites'),
   './ownership.ts': () => import('../ownership'),
+  './templates.ts': () => import('../templates'),
   './model/permissions.ts': () => import('../model/permissions'),
 }
 

--- a/apps/itun/convex/__tests__/templates.test.ts
+++ b/apps/itun/convex/__tests__/templates.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test'
+
+import { api } from '../_generated/api'
+import { testConvex } from './harness'
+
+/**
+ * Game templates (D34).
+ *
+ * The property under test is the one that makes a template useful rather than
+ * decorative: **its entities arrive unclaimed**, so the person running the
+ * table hands them out. A template that pre-assigned everything to its creator
+ * would just be a private roster with extra steps.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+describe('starter-set template', () => {
+  test('is listed', async () => {
+    const t = testConvex()
+    const templates = await t.query(api.templates.list, {})
+    expect(templates.map((x) => x.id)).toContain('starter-set')
+  })
+
+  test('every pilot and mech arrives unclaimed', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const { pilots, mechs } = await t.run(async (ctx) => ({
+      pilots: await ctx.db.query('pilots').collect(),
+      mechs: await ctx.db.query('mechs').collect(),
+    }))
+
+    expect(pilots.length).toBeGreaterThan(0)
+    expect(mechs.length).toBeGreaterThan(0)
+    // Not owned by the creator — that is the difference between a template and
+    // a private roster.
+    expect(pilots.every((p) => p.ownerId === null)).toBe(true)
+    expect(mechs.every((m) => m.ownerId === null)).toBe(true)
+  })
+
+  test('the creator is Organizer and a seated Player, as with any game', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    const gameId = await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const roster = await u.as.query(api.games.members, { gameId })
+    expect(roster).toHaveLength(1)
+    expect(roster[0]?.organizer).toBe(true)
+    // A template changes what is IN the game, never who runs it.
+    expect(roster[0]?.mediator).toBe(false)
+  })
+
+  test('the crawler is created communally, with no owner column at all', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const crawlers = await t.run(async (ctx) => await ctx.db.query('crawlers').collect())
+    expect(crawlers.length).toBeGreaterThan(0)
+    expect(crawlers[0]).not.toHaveProperty('ownerId')
+  })
+
+  test('soft links come across, so the crew is wired together on arrival', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const links = await t.run(async (ctx) => await ctx.db.query('softLinks').collect())
+    // Without these the pilots and mechs would arrive as unrelated strangers.
+    expect(links.length).toBeGreaterThan(0)
+    expect(links.some((l) => l.type === 'mech-to-pilot')).toBe(true)
+  })
+
+  test('the game records which template it came from', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    const gameId = await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const game = await t.run(async (ctx) => await ctx.db.get(gameId))
+    expect(game?.templateOrigin).toBe('starter-set')
+  })
+
+  test('a custom name overrides the template name', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    const gameId = await u.as.mutation(api.templates.createGame, {
+      templateId: 'starter-set',
+      name: '  Our Tuesday Game  ',
+    })
+
+    const game = await t.run(async (ctx) => await ctx.db.get(gameId))
+    expect(game?.name).toBe('Our Tuesday Game')
+  })
+
+  test('an anonymous caller cannot create one', async () => {
+    const t = testConvex()
+    await expect(
+      t.mutation(api.templates.createGame, { templateId: 'starter-set' })
+    ).rejects.toThrow(/not signed in/i)
+  })
+})

--- a/apps/itun/convex/_generated/api.d.ts
+++ b/apps/itun/convex/_generated/api.d.ts
@@ -16,6 +16,7 @@ import type * as http from "../http.js";
 import type * as invites from "../invites.js";
 import type * as model_permissions from "../model/permissions.js";
 import type * as ownership from "../ownership.js";
+import type * as templates from "../templates.js";
 
 import type {
   ApiFromModules,
@@ -32,6 +33,7 @@ declare const fullApi: ApiFromModules<{
   invites: typeof invites;
   "model/permissions": typeof model_permissions;
   ownership: typeof ownership;
+  templates: typeof templates;
 }>;
 
 /**

--- a/apps/itun/convex/_generated/api.d.ts
+++ b/apps/itun/convex/_generated/api.d.ts
@@ -8,6 +8,8 @@
  * @module
  */
 
+import type * as __tests___harness from "../__tests__/harness.js";
+import type * as account from "../account.js";
 import type * as auth from "../auth.js";
 import type * as games from "../games.js";
 import type * as http from "../http.js";
@@ -22,6 +24,8 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  "__tests__/harness": typeof __tests___harness;
+  account: typeof account;
   auth: typeof auth;
   games: typeof games;
   http: typeof http;

--- a/apps/itun/convex/account.ts
+++ b/apps/itun/convex/account.ts
@@ -1,0 +1,230 @@
+import { v } from 'convex/values'
+
+import type { Doc, Id } from './_generated/dataModel'
+import { mutation, query } from './_generated/server'
+import type { MutationCtx } from './_generated/server'
+import { requireUser } from './model/permissions'
+
+/**
+ * Account management (ADR-030 §6, D33).
+ *
+ * Holding somebody's Discord identity is an obligation the project did not have
+ * before, so the three things that discharge it — read your profile, edit it,
+ * delete the account entirely — are part of the same module rather than a
+ * follow-up. Export is served here too, so "give me my data" and "delete my
+ * data" cannot drift apart.
+ */
+
+/** The signed-in user's own profile. Never exposes another user's row. */
+export const me = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await requireUser(ctx)
+    const user = await ctx.db.get(userId)
+    if (user === null) return null
+    return {
+      _id: user._id,
+      displayName: user.displayName ?? user.name ?? null,
+      avatarUrl: user.avatarUrl ?? user.image ?? null,
+      email: user.email ?? null,
+    }
+  },
+})
+
+/**
+ * Edit the display name and avatar shown on every owner chip.
+ *
+ * These are overrides layered on the Discord profile rather than replacements:
+ * clearing one falls back to the Discord value rather than to blank, because a
+ * nameless owner chip is worse than a stale one.
+ */
+export const updateProfile = mutation({
+  args: {
+    displayName: v.optional(v.union(v.string(), v.null())),
+    avatarUrl: v.optional(v.union(v.string(), v.null())),
+  },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    const patch: { displayName?: string | undefined; avatarUrl?: string | undefined } = {}
+
+    if (args.displayName !== undefined) {
+      const trimmed = args.displayName?.trim() ?? ''
+      patch.displayName = trimmed.length > 0 ? trimmed : undefined
+    }
+    if (args.avatarUrl !== undefined) {
+      const trimmed = args.avatarUrl?.trim() ?? ''
+      patch.avatarUrl = trimmed.length > 0 ? trimmed : undefined
+    }
+
+    await ctx.db.patch(userId, patch)
+  },
+})
+
+/**
+ * Everything this account owns, as a plain object suitable for download.
+ *
+ * Deliberately scoped to what the user *owns*, not everything they can see: a
+ * crewmate's pilot is readable inside a Game but is not this person's data to
+ * take away. The communal crawler is likewise excluded — it belongs to the
+ * table, not to any one member.
+ */
+export const exportMine = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await requireUser(ctx)
+
+    const pilots = await ctx.db
+      .query('pilots')
+      .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+      .collect()
+    const mechs = await ctx.db
+      .query('mechs')
+      .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+      .collect()
+    const mechPatterns = await ctx.db
+      .query('mechPatterns')
+      .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+      .collect()
+    const memberships = await ctx.db
+      .query('memberships')
+      .withIndex('by_user', (q) => q.eq('userId', userId))
+      .collect()
+
+    return {
+      exportedAt: new Date().toISOString(),
+      pilots: pilots.map((p) => p.body),
+      mechs: mechs.map((m) => m.body),
+      mechPatterns: mechPatterns.map((p) => p.body),
+      games: memberships.map((m) => ({
+        gameId: m.gameId,
+        mediator: m.mediator,
+        organizer: m.organizer,
+        joinedAt: m.joinedAt,
+      })),
+    }
+  },
+})
+
+/**
+ * Pass the Organizer flag to the longest-standing remaining member.
+ *
+ * "Longest-standing" is `joinedAt`, and the tie-break is deterministic rather
+ * than arbitrary — two members can share a timestamp if a Game was seeded in
+ * one mutation, and an unstable choice there would make the outcome depend on
+ * document scan order.
+ */
+async function reassignOrganizer(
+  ctx: MutationCtx,
+  gameId: Id<'games'>,
+  leavingUserId: Id<'users'>
+): Promise<boolean> {
+  const remaining = (
+    await ctx.db
+      .query('memberships')
+      .withIndex('by_game', (q) => q.eq('gameId', gameId))
+      .collect()
+  ).filter((m) => m.userId !== leavingUserId)
+
+  if (remaining.length === 0) return false
+
+  remaining.sort((a: Doc<'memberships'>, b: Doc<'memberships'>) =>
+    a.joinedAt === b.joinedAt ? a._id.localeCompare(b._id) : a.joinedAt - b.joinedAt
+  )
+  const heir = remaining[0]
+  if (heir === undefined) return false
+
+  await ctx.db.patch(heir._id, { organizer: true })
+  return true
+}
+
+/**
+ * Delete this account and everything personal to it (D27).
+ *
+ * The rule that matters: **a campaign never dies because one person quit.**
+ * Games survive, the communal crawler survives, and the Organizer flag passes
+ * to the longest-standing remaining member. Only when the departing user was
+ * the *last* member is the Game itself removed, because an empty Game is not a
+ * campaign anybody can return to.
+ *
+ * Their own pilots and mechs go with them — that is the point of a deletion
+ * request. Anyone who wants to keep a character exports first, which is why
+ * `exportMine` lives in this same module.
+ */
+export const deleteAccount = mutation({
+  args: {},
+  handler: async (ctx): Promise<void> => {
+    const userId = await requireUser(ctx)
+
+    const memberships = await ctx.db
+      .query('memberships')
+      .withIndex('by_user', (q) => q.eq('userId', userId))
+      .collect()
+
+    for (const membership of memberships) {
+      if (membership.organizer) {
+        const passedOn = await reassignOrganizer(ctx, membership.gameId, userId)
+        if (!passedOn) {
+          // Last member out: the Game has nobody left to run or play it.
+          for (const table of [
+            'crawlers',
+            'encounterNpcs',
+            'softLinks',
+            'invites',
+            'presence',
+          ] as const) {
+            const rows = await ctx.db
+              .query(table)
+              .withIndex('by_game', (q) => q.eq('gameId', membership.gameId))
+              .collect()
+            for (const row of rows) await ctx.db.delete(row._id)
+          }
+          // Unclaimed entities in a Game with no members have nowhere to go.
+          for (const table of ['pilots', 'mechs'] as const) {
+            const rows = await ctx.db
+              .query(table)
+              .withIndex('by_game', (q) => q.eq('gameId', membership.gameId))
+              .collect()
+            for (const row of rows) await ctx.db.delete(row._id)
+          }
+          await ctx.db.delete(membership.gameId)
+        }
+      }
+      await ctx.db.delete(membership._id)
+    }
+
+    // Personal entities, wherever they live — in a Game or on the shelf.
+    for (const table of ['pilots', 'mechs', 'mechPatterns'] as const) {
+      const rows = await ctx.db
+        .query(table)
+        .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+        .collect()
+      for (const row of rows) await ctx.db.delete(row._id)
+    }
+
+    // Auth rows, so the identity cannot be resurrected by signing in again.
+    //
+    // Order matters: refresh tokens are keyed by SESSION, not by user, so they
+    // have to go before the sessions they point at. Deleting sessions first
+    // would strand them as orphans referencing rows that no longer exist.
+    const sessions = await ctx.db
+      .query('authSessions')
+      .withIndex('userId', (q) => q.eq('userId', userId))
+      .collect()
+    for (const session of sessions) {
+      const tokens = await ctx.db
+        .query('authRefreshTokens')
+        .withIndex('sessionId', (q) => q.eq('sessionId', session._id))
+        .collect()
+      for (const token of tokens) await ctx.db.delete(token._id)
+      await ctx.db.delete(session._id)
+    }
+
+    const accounts = await ctx.db
+      .query('authAccounts')
+      .withIndex('userIdAndProvider', (q) => q.eq('userId', userId))
+      .collect()
+    for (const account of accounts) await ctx.db.delete(account._id)
+
+    await ctx.db.delete(userId)
+  },
+})

--- a/apps/itun/convex/schema.ts
+++ b/apps/itun/convex/schema.ts
@@ -42,6 +42,12 @@ export default defineSchema({
     image: v.optional(v.string()),
     emailVerificationTime: v.optional(v.number()),
     isAnonymous: v.optional(v.boolean()),
+    // Carried over from `authTables.users` even though Discord is the only
+    // provider: overriding that table means anything the library expects to
+    // find has to be redeclared here, and a missing field would surface as a
+    // write failure inside the auth flow rather than as a type error.
+    phone: v.optional(v.string()),
+    phoneVerificationTime: v.optional(v.number()),
 
     /** Discord snowflake, once linked. The only third-party identifier stored. */
     discordId: v.optional(v.string()),
@@ -55,6 +61,7 @@ export default defineSchema({
     avatarUrl: v.optional(v.string()),
   })
     .index('email', ['email'])
+    .index('phone', ['phone'])
     .index('by_discord', ['discordId']),
 
   /**

--- a/apps/itun/convex/templates.ts
+++ b/apps/itun/convex/templates.ts
@@ -1,0 +1,104 @@
+import { v } from 'convex/values'
+
+import {
+  STARTER_CRAWLERS,
+  STARTER_MECHS,
+  STARTER_PILOTS,
+  STARTER_SOFT_LINKS,
+} from '../src/lib/starterSet/starterSet'
+import type { Id } from './_generated/dataModel'
+import { mutation, query } from './_generated/server'
+import { requireUser } from './model/permissions'
+
+/**
+ * Game templates (ADR-030, D34).
+ *
+ * A template is a pre-built crew you can start a Game from. The rule that makes
+ * it more than seeded data: **its entities arrive unclaimed** (`ownerId: null`).
+ * The Mediator — or the Organizer, while a Game has no Mediator — hands them
+ * out as players join, which turns pre-generated characters from a curiosity
+ * into the onboarding path.
+ *
+ * The Starter Set data is imported straight from `src/lib/starterSet/`. That
+ * module is deliberately static plain data with no runtime reference-data
+ * resolution (see its header), so it bundles into a Convex function safely and
+ * there is exactly one copy of the roster rather than a server-side duplicate
+ * that would drift from the local one.
+ */
+
+const TEMPLATES = {
+  'starter-set': {
+    name: "Reclamation of the Wastes — Union Crawler #430 'Tenacity'",
+    description:
+      'The six pilots of the Salvage Union Starter Set, their mechs, and their crawler. Everyone arrives unclaimed for you to hand out.',
+  },
+} as const
+
+export type TemplateId = keyof typeof TEMPLATES
+
+/** The templates a Game can be started from. */
+export const list = query({
+  args: {},
+  handler: async () => {
+    return Object.entries(TEMPLATES).map(([id, t]) => ({
+      id,
+      name: t.name,
+      description: t.description,
+    }))
+  },
+})
+
+/**
+ * Create a Game pre-populated from a template.
+ *
+ * The creator becomes its Organizer and is seated as a Player, exactly as
+ * `games.create` does — a template changes what is *in* the Game, never who
+ * runs it. `mediator` starts false, so the Organizer fallback covers handing
+ * out the pre-gens until somebody is appointed.
+ */
+export const createGame = mutation({
+  args: {
+    templateId: v.literal('starter-set'),
+    name: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<Id<'games'>> => {
+    const userId = await requireUser(ctx)
+    const template = TEMPLATES[args.templateId]
+
+    const gameId = await ctx.db.insert('games', {
+      name: args.name?.trim() || template.name,
+      templateOrigin: args.templateId,
+    })
+    await ctx.db.insert('memberships', {
+      gameId,
+      userId,
+      mediator: false,
+      organizer: true,
+      joinedAt: Date.now(),
+    })
+
+    const now = Date.now()
+
+    // ownerId: null is the whole point — see the module header.
+    for (const pilot of STARTER_PILOTS) {
+      await ctx.db.insert('pilots', { gameId, ownerId: null, body: pilot, updatedAt: now })
+    }
+    for (const mech of STARTER_MECHS) {
+      await ctx.db.insert('mechs', { gameId, ownerId: null, body: mech, updatedAt: now })
+    }
+    // The crawler has no ownerId column at all: it is communal by design (D8).
+    for (const crawler of STARTER_CRAWLERS) {
+      await ctx.db.insert('crawlers', { gameId, body: crawler, updatedAt: now })
+    }
+    for (const link of STARTER_SOFT_LINKS) {
+      await ctx.db.insert('softLinks', {
+        gameId,
+        from: { type: link.from.type, id: link.from.id },
+        to: { type: link.to.type, id: link.to.id },
+        type: link.type,
+      })
+    }
+
+    return gameId
+  },
+})

--- a/apps/itun/src/components/account/AccountScreen.tsx
+++ b/apps/itun/src/components/account/AccountScreen.tsx
@@ -1,0 +1,213 @@
+import { useState } from 'react'
+import { Button, Card, Text } from 'component-lib'
+import { useMutation, useQuery } from 'convex/react'
+
+import { api } from '../../../convex/_generated/api'
+import { useConnection } from '../../lib/connection/connectionContext'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+import { SignInControl } from './SignInControl'
+
+/**
+ * The account screen (D33): profile, your Games, export, delete.
+ *
+ * All four live on one page deliberately. Holding somebody's Discord identity
+ * creates obligations — let me see it, let me correct it, let me take it away,
+ * let me erase it — and splitting those across surfaces is how one of them
+ * quietly never ships.
+ *
+ * As everywhere in this app, the Convex hooks are isolated behind a
+ * build-time branch so a Solo build (no `VITE_CONVEX_URL`) renders without a
+ * provider present.
+ */
+
+function download(filename: string, data: unknown): void {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function SignedInAccount() {
+  const me = useQuery(api.account.me, {})
+  const games = useQuery(api.games.listMine, {})
+  const exported = useQuery(api.account.exportMine, {})
+  const updateProfile = useMutation(api.account.updateProfile)
+  const deleteAccount = useMutation(api.account.deleteAccount)
+
+  const [name, setName] = useState<string | null>(null)
+  const [confirming, setConfirming] = useState(false)
+
+  if (me === undefined) return <Text>Loading your account…</Text>
+  if (me === null) return <Text>No account found.</Text>
+
+  const value = name ?? me.displayName ?? ''
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <div className="flex flex-col gap-3 p-4">
+          <Text as="label" className="font-cond text-xs font-bold tracking-widest uppercase">
+            Display name
+          </Text>
+          <Text variant="hint" className="text-left">
+            Shown on every entity you own. Defaults to your Discord name; clearing this falls back
+            to it rather than to blank.
+          </Text>
+          <input
+            aria-label="Display name"
+            className="border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-1"
+            value={value}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <div>
+            <Button
+              variant="primary"
+              size="compact"
+              onClick={() => void updateProfile({ displayName: value })}
+            >
+              Save
+            </Button>
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <div className="flex flex-col gap-2 p-4">
+          <Text as="label" className="font-cond text-xs font-bold tracking-widest uppercase">
+            Your games
+          </Text>
+          {games === undefined && (
+            <Text variant="hint" className="text-left">
+              Loading…
+            </Text>
+          )}
+          {games?.length === 0 && (
+            <Text variant="hint" className="text-left">
+              You are not in any games yet.
+            </Text>
+          )}
+          {games?.map((g) => (
+            <div key={g._id} className="flex items-baseline justify-between gap-3">
+              <Text>{g.name}</Text>
+              <Text variant="hint" className="text-left">
+                {g.organizer ? 'Organizer · ' : ''}
+                {g.mediator ? 'Mediator' : 'Player'} · {g.memberCount} member
+                {g.memberCount === 1 ? '' : 's'}
+              </Text>
+            </div>
+          ))}
+        </div>
+      </Card>
+
+      <Card>
+        <div className="flex flex-col gap-3 p-4">
+          <Text as="label" className="font-cond text-xs font-bold tracking-widest uppercase">
+            Your data
+          </Text>
+          <Text variant="hint" className="text-left">
+            Downloads everything you own. Crewmates' characters and the shared crawler are not
+            included — you can see them, but they are not yours to take.
+          </Text>
+          <div>
+            <Button
+              variant="ghost"
+              size="compact"
+              disabled={exported === undefined}
+              onClick={() => exported && download('itun-account-export.json', exported)}
+            >
+              Download my data
+            </Button>
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <div className="flex flex-col gap-3 p-4">
+          <Text as="label" className="font-cond text-xs font-bold tracking-widest uppercase">
+            Delete account
+          </Text>
+          <Text variant="hint" className="text-left">
+            Your pilots and mechs are deleted. Games you are in survive — the shared crawler stays,
+            and if you organise a game the role passes to the longest-standing member. Download your
+            data first; this cannot be undone.
+          </Text>
+          <div>
+            {confirming ? (
+              <div className="flex gap-2">
+                <Button variant="danger" size="compact" onClick={() => void deleteAccount({})}>
+                  Permanently delete
+                </Button>
+                <Button variant="ghost" size="compact" onClick={() => setConfirming(false)}>
+                  Cancel
+                </Button>
+              </div>
+            ) : (
+              <Button variant="danger" size="compact" onClick={() => setConfirming(true)}>
+                Delete my account
+              </Button>
+            )}
+          </div>
+        </div>
+      </Card>
+    </div>
+  )
+}
+
+function AccountBody() {
+  const { mode } = useConnection()
+
+  if (mode === 'connected') return <SignedInAccount />
+
+  if (mode === 'disconnected') {
+    return (
+      <Card>
+        <div className="p-4">
+          <Text>
+            Your account is unreachable right now. Reconnect to change your profile or manage your
+            games.
+          </Text>
+        </div>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <Text>
+          You are playing solo. Everything you build is saved on this device and needs no account.
+        </Text>
+        <Text variant="hint" className="text-left">
+          Signing in lets you join a game with other people and carry your builds between devices.
+        </Text>
+        <div>
+          <SignInControl />
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+export function AccountScreen() {
+  return (
+    <main className="mx-auto flex max-w-2xl flex-col gap-6 p-4">
+      <Text as="h1" className="font-cond text-2xl font-bold tracking-wide uppercase">
+        Account
+      </Text>
+      {isConvexConfigured ? (
+        <AccountBody />
+      ) : (
+        <Card>
+          <div className="p-4">
+            <Text>
+              This build has no account service configured, so everything is saved on this device.
+            </Text>
+          </div>
+        </Card>
+      )}
+    </main>
+  )
+}

--- a/apps/itun/src/components/account/AccountStrip.tsx
+++ b/apps/itun/src/components/account/AccountStrip.tsx
@@ -30,6 +30,14 @@ export function AccountStrip() {
     <div className="flex items-center justify-end gap-3 border-b border-[var(--color-ink)]/15 px-3 py-1">
       {mode === 'connected' && (
         <Link
+          to="/games"
+          className="font-cond text-xs font-bold tracking-widest text-[var(--color-ink)] uppercase hover:text-[var(--color-rust)]"
+        >
+          Games
+        </Link>
+      )}
+      {mode === 'connected' && (
+        <Link
           to="/account"
           className="font-cond text-xs font-bold tracking-widest text-[var(--color-ink)] uppercase hover:text-[var(--color-rust)]"
         >

--- a/apps/itun/src/components/account/AccountStrip.tsx
+++ b/apps/itun/src/components/account/AccountStrip.tsx
@@ -1,0 +1,42 @@
+import { Link } from '@tanstack/react-router'
+
+import { useConnection } from '../../lib/connection/connectionContext'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+import { SignInControl } from './SignInControl'
+
+/**
+ * A thin strip above the brand header carrying sign-in and a link to the
+ * account page.
+ *
+ * ## Why not a nav item in `AppBar`
+ *
+ * `AppBar` lives in `component-lib` and is shared with `apps/srd`, which has no
+ * accounts and never will. Threading an auth slot through it would push an
+ * ITUN-only concept into a package whose contract is to stay backend-agnostic,
+ * and would touch a component every page of both apps renders. A local strip
+ * keeps the blast radius inside ITUN.
+ *
+ * ## It renders nothing in a Solo build
+ *
+ * No `VITE_CONVEX_URL` means accounts are not merely signed-out, they are
+ * absent — so there is nothing to link to and nothing to sign into. Existing
+ * users see exactly the chrome they saw before.
+ */
+export function AccountStrip() {
+  const { mode } = useConnection()
+  if (!isConvexConfigured) return null
+
+  return (
+    <div className="flex items-center justify-end gap-3 border-b border-[var(--color-ink)]/15 px-3 py-1">
+      {mode === 'connected' && (
+        <Link
+          to="/account"
+          className="font-cond text-xs font-bold tracking-widest text-[var(--color-ink)] uppercase hover:text-[var(--color-rust)]"
+        >
+          Account
+        </Link>
+      )}
+      <SignInControl />
+    </div>
+  )
+}

--- a/apps/itun/src/components/account/SignInControl.tsx
+++ b/apps/itun/src/components/account/SignInControl.tsx
@@ -1,0 +1,50 @@
+import { Button } from 'component-lib'
+import { useAuthActions } from '@convex-dev/auth/react'
+
+import { useConnection } from '../../lib/connection/connectionContext'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+
+/**
+ * Sign in / sign out with Discord.
+ *
+ * ## The Solo-build branch, again
+ *
+ * `useAuthActions` needs a `ConvexAuthProvider` above it, and a build with no
+ * `VITE_CONVEX_URL` deliberately has none. So this file uses the same
+ * component-level branch as `ConnectionProvider`: the hook lives in
+ * `ConvexSignIn`, which is only ever rendered when the build is configured.
+ * The branch is a build-time constant, so React sees a stable component
+ * identity across renders.
+ *
+ * In a Solo build this renders **nothing at all** rather than a disabled
+ * button. Offering an account to somebody whose app cannot have one is worse
+ * than silence — signing in is an upgrade, not a missing feature (ADR-030 §1).
+ */
+
+function ConvexSignIn() {
+  const { signIn, signOut } = useAuthActions()
+  const { mode } = useConnection()
+
+  if (mode === 'connected') {
+    return (
+      <Button variant="ghost" size="compact" onClick={() => void signOut()}>
+        Sign out
+      </Button>
+    )
+  }
+
+  // Disconnected means signed in but unreachable — offering "sign in" there
+  // would be nonsense, and the NOT CONNECTED banner already explains the state.
+  if (mode === 'disconnected') return null
+
+  return (
+    <Button variant="primary" size="compact" onClick={() => void signIn('discord')}>
+      Sign in with Discord
+    </Button>
+  )
+}
+
+export function SignInControl() {
+  if (!isConvexConfigured) return null
+  return <ConvexSignIn />
+}

--- a/apps/itun/src/components/account/__tests__/AccountScreen.test.tsx
+++ b/apps/itun/src/components/account/__tests__/AccountScreen.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+
+import { ConnectionProvider } from '../../../lib/connection/ConnectionProvider'
+import { isConvexConfigured } from '../../../lib/connection/convexClient'
+import { AccountScreen } from '../AccountScreen'
+import { SignInControl } from '../SignInControl'
+
+/**
+ * The failure this guards against is structural rather than cosmetic.
+ *
+ * `AccountScreen` and `SignInControl` both reach for Convex hooks
+ * (`useQuery`, `useMutation`, `useAuthActions`), and every one of those throws
+ * without a provider above it. A Solo build deliberately has no provider, so if
+ * the build-time branch is ever removed or inverted, this page crashes for the
+ * majority of users — the ones who never sign in — while working perfectly for
+ * whoever is testing it with a configured `.env.local`.
+ *
+ * The test environment has no `VITE_CONVEX_URL`, so rendering here without a
+ * throw is the assertion.
+ */
+
+describe('AccountScreen in a Solo build', () => {
+  test('the test build really is Solo', () => {
+    // Asserted, not assumed: if this flips, the tests below would start
+    // passing for an entirely different reason.
+    expect(isConvexConfigured).toBe(false)
+  })
+
+  test('renders without a Convex provider present', () => {
+    render(
+      <ConnectionProvider>
+        <AccountScreen />
+      </ConnectionProvider>
+    )
+    expect(screen.getByText('Account')).toBeTruthy()
+  })
+
+  test('explains that data is local rather than offering an account', () => {
+    render(
+      <ConnectionProvider>
+        <AccountScreen />
+      </ConnectionProvider>
+    )
+    expect(screen.getByText(/saved on this device/i)).toBeTruthy()
+  })
+
+  test('SignInControl renders nothing at all', () => {
+    // Not a disabled button: offering an account to somebody whose build
+    // cannot have one is worse than silence.
+    const { container } = render(
+      <ConnectionProvider>
+        <SignInControl />
+      </ConnectionProvider>
+    )
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/apps/itun/src/components/games/GamesScreen.tsx
+++ b/apps/itun/src/components/games/GamesScreen.tsx
@@ -154,7 +154,9 @@ function GameRow({
 
 function ConnectedGames() {
   const games = useQuery(api.games.listMine, {})
+  const templates = useQuery(api.templates.list, {})
   const create = useMutation(api.games.create)
+  const createFromTemplate = useMutation(api.templates.createGame)
   const redeem = useMutation(api.invites.redeem)
 
   const [newName, setNewName] = useState('')
@@ -183,6 +185,34 @@ function ConnectedGames() {
           >
             Create
           </Button>
+        </div>
+      </Card>
+
+      <Card>
+        <div className="flex flex-col gap-3 p-4">
+          <span className={label}>Or start from a template</span>
+          {templates?.map((t) => (
+            <div key={t.id} className="flex flex-col gap-2">
+              <Text as="span">{t.name}</Text>
+              <Text variant="hint" className="text-left">
+                {t.description}
+              </Text>
+              <div>
+                <Button
+                  variant="ghost"
+                  size="compact"
+                  onClick={() =>
+                    void createFromTemplate({
+                      templateId: 'starter-set',
+                      name: newName || undefined,
+                    })
+                  }
+                >
+                  Start this game
+                </Button>
+              </div>
+            </div>
+          ))}
         </div>
       </Card>
 

--- a/apps/itun/src/components/games/GamesScreen.tsx
+++ b/apps/itun/src/components/games/GamesScreen.tsx
@@ -1,0 +1,292 @@
+import { useState } from 'react'
+import { Button, Card, Text } from 'component-lib'
+import { useMutation, useQuery } from 'convex/react'
+
+import { api } from '../../../convex/_generated/api'
+import type { Id } from '../../../convex/_generated/dataModel'
+import { useConnection } from '../../lib/connection/connectionContext'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+import { SignInControl } from '../account/SignInControl'
+
+/**
+ * Games: create one, invite people, join by code, hand over the Organizer role.
+ *
+ * The whole screen is gated on `mode === 'connected'`. That is not defensive
+ * coding — a Game is inherently shared state, so there is nothing meaningful to
+ * show a Solo user and nothing safe to show a Disconnected one, whose view
+ * would be a stale snapshot of a roster that may have changed.
+ */
+
+const label = 'font-cond text-xs font-bold tracking-caps-wide uppercase'
+
+function InvitePanel({ gameId }: { gameId: Id<'games'> }) {
+  const createInvite = useMutation(api.invites.create)
+  const [code, setCode] = useState<string | null>(null)
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Button
+        variant="ghost"
+        size="compact"
+        onClick={() => void createInvite({ gameId }).then(setCode)}
+      >
+        Create invite code
+      </Button>
+      {code !== null && (
+        <div className="flex flex-col gap-1">
+          {/* Crockford base32 with no I/L/O/U, so a code read aloud across a
+              table cannot be mistyped into a different valid one. Rendered
+              large and spaced because reading it aloud is the primary use. */}
+          <Text as="span" className="font-cond text-2xl font-bold tracking-caps-wide">
+            {code}
+          </Text>
+          <Text variant="hint" className="text-left">
+            Valid for 14 days. Anyone with this code can join as a player.
+          </Text>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function GameRow({
+  game,
+}: {
+  game: {
+    _id: Id<'games'>
+    name: string
+    mediator: boolean
+    organizer: boolean
+    memberCount: number
+  }
+}) {
+  const members = useQuery(api.games.members, { gameId: game._id })
+  const rename = useMutation(api.games.rename)
+  const setMediator = useMutation(api.games.setMediator)
+  const transferOrganizer = useMutation(api.games.transferOrganizer)
+  const [name, setName] = useState<string | null>(null)
+
+  const value = name ?? game.name
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <div className="flex items-baseline justify-between gap-3">
+          <Text as="span" className="font-cond text-lg font-bold">
+            {game.name}
+          </Text>
+          <Text variant="hint" className="text-left">
+            {game.organizer ? 'Organizer · ' : ''}
+            {game.mediator ? 'Mediator' : 'Player'}
+          </Text>
+        </div>
+
+        {game.organizer && (
+          <div className="flex flex-wrap items-end gap-2">
+            <label className="flex flex-col gap-1">
+              <span className={label}>Name</span>
+              <input
+                aria-label={`Rename ${game.name}`}
+                className="border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-1"
+                value={value}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </label>
+            <Button
+              variant="primary"
+              size="compact"
+              onClick={() => void rename({ gameId: game._id, name: value })}
+            >
+              Save
+            </Button>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-1">
+          <span className={label}>Crew</span>
+          {members === undefined && <Text variant="hint">Loading…</Text>}
+          {members?.map((m) => (
+            <div key={m.userId} className="flex items-baseline justify-between gap-3">
+              <Text as="span">{m.displayName}</Text>
+              <span className="flex items-center gap-2">
+                <Text variant="hint" className="text-left">
+                  {m.organizer ? 'Organizer · ' : ''}
+                  {m.mediator ? 'Mediator' : 'Player'}
+                </Text>
+                {game.organizer && (
+                  <>
+                    <Button
+                      variant="ghost"
+                      size="mini"
+                      onClick={() =>
+                        void setMediator({
+                          gameId: game._id,
+                          userId: m.userId,
+                          mediator: !m.mediator,
+                        })
+                      }
+                    >
+                      {m.mediator ? 'Stand down' : 'Make Mediator'}
+                    </Button>
+                    {!m.organizer && (
+                      <Button
+                        variant="ghost"
+                        size="mini"
+                        onClick={() =>
+                          void transferOrganizer({ gameId: game._id, userId: m.userId })
+                        }
+                      >
+                        Hand over
+                      </Button>
+                    )}
+                  </>
+                )}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {game.organizer && <InvitePanel gameId={game._id} />}
+      </div>
+    </Card>
+  )
+}
+
+function ConnectedGames() {
+  const games = useQuery(api.games.listMine, {})
+  const create = useMutation(api.games.create)
+  const redeem = useMutation(api.invites.redeem)
+
+  const [newName, setNewName] = useState('')
+  const [code, setCode] = useState('')
+  const [joinError, setJoinError] = useState<string | null>(null)
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <div className="flex flex-wrap items-end gap-2 p-4">
+          <label className="flex flex-col gap-1">
+            <span className={label}>Start a game</span>
+            <input
+              aria-label="New game name"
+              placeholder="Union Crawler #430"
+              className="border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-1"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+            />
+          </label>
+          <Button
+            variant="primary"
+            size="compact"
+            disabled={newName.trim().length === 0}
+            onClick={() => void create({ name: newName }).then(() => setNewName(''))}
+          >
+            Create
+          </Button>
+        </div>
+      </Card>
+
+      <Card>
+        <div className="flex flex-col gap-2 p-4">
+          <div className="flex flex-wrap items-end gap-2">
+            <label className="flex flex-col gap-1">
+              <span className={label}>Join with a code</span>
+              <input
+                aria-label="Invite code"
+                placeholder="A1B2C3D4"
+                className="border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-1 tracking-caps-wide uppercase"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+              />
+            </label>
+            <Button
+              variant="primary"
+              size="compact"
+              disabled={code.trim().length === 0}
+              onClick={() => {
+                setJoinError(null)
+                void redeem({ code })
+                  .then(() => setCode(''))
+                  // The server distinguishes not-valid / expired / used-up, so
+                  // surface its wording rather than a generic failure.
+                  .catch((err: Error) => setJoinError(err.message))
+              }}
+            >
+              Join
+            </Button>
+          </div>
+          {joinError !== null && (
+            <Text variant="hint" className="text-left text-[var(--color-roll-cascade)]">
+              {joinError}
+            </Text>
+          )}
+        </div>
+      </Card>
+
+      {games === undefined && <Text>Loading your games…</Text>}
+      {games?.length === 0 && (
+        <Text variant="hint" className="text-left">
+          You are not in any games yet. Create one, or join with a code from whoever set yours up.
+        </Text>
+      )}
+      {games?.map((g) => (
+        <GameRow key={g._id} game={g} />
+      ))}
+    </div>
+  )
+}
+
+function GamesBody() {
+  const { mode } = useConnection()
+
+  if (mode === 'connected') return <ConnectedGames />
+
+  if (mode === 'disconnected') {
+    return (
+      <Card>
+        <div className="p-4">
+          <Text>
+            Your games are unreachable right now. Reconnect to see your crew or manage invites.
+          </Text>
+        </div>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <Text>Games let several people share one crawler, with a Mediator running the table.</Text>
+        <Text variant="hint" className="text-left">
+          You are playing solo. Everything you build stays on this device and needs no account —
+          sign in only if you want to play with other people.
+        </Text>
+        <div>
+          <SignInControl />
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+export function GamesScreen() {
+  return (
+    <main className="mx-auto flex max-w-2xl flex-col gap-6 p-4">
+      <Text as="h1" className="font-cond text-2xl font-bold tracking-caps uppercase">
+        Games
+      </Text>
+      {isConvexConfigured ? (
+        <GamesBody />
+      ) : (
+        <Card>
+          <div className="p-4">
+            <Text>
+              This build has no account service configured, so shared games are unavailable and
+              everything is saved on this device.
+            </Text>
+          </div>
+        </Card>
+      )}
+    </main>
+  )
+}

--- a/apps/itun/src/components/games/__tests__/GamesScreen.test.tsx
+++ b/apps/itun/src/components/games/__tests__/GamesScreen.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+
+import { ConnectionProvider } from '../../../lib/connection/ConnectionProvider'
+import { isConvexConfigured } from '../../../lib/connection/convexClient'
+import { GamesScreen } from '../GamesScreen'
+
+/**
+ * Same structural guard as the account screen: every Convex hook in here
+ * (`useQuery`, `useMutation`) throws without a provider above it, and a Solo
+ * build deliberately has none.
+ *
+ * This is the failure mode that hides best — it works perfectly for whoever
+ * is developing with a configured `.env.local`, and crashes for every user who
+ * never signs in.
+ */
+
+describe('GamesScreen in a Solo build', () => {
+  test('the test build really is Solo', () => {
+    expect(isConvexConfigured).toBe(false)
+  })
+
+  test('renders without a Convex provider present', () => {
+    render(
+      <ConnectionProvider>
+        <GamesScreen />
+      </ConnectionProvider>
+    )
+    expect(screen.getByText('Games')).toBeTruthy()
+  })
+
+  test('explains why shared games are unavailable rather than showing a broken form', () => {
+    render(
+      <ConnectionProvider>
+        <GamesScreen />
+      </ConnectionProvider>
+    )
+    expect(screen.getByText(/saved on this device/i)).toBeTruthy()
+    // No create/join affordance should be offered when it cannot possibly work.
+    expect(screen.queryByLabelText('New game name')).toBeNull()
+    expect(screen.queryByLabelText('Invite code')).toBeNull()
+  })
+})

--- a/apps/itun/src/lib/__tests__/container.test.ts
+++ b/apps/itun/src/lib/__tests__/container.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test'
+
+import { DEFAULT_WORKSPACE_ID } from '../defaultWorkspace'
+import { containerOf, gameIdOf, isOnShelf, moveTo } from '../container'
+
+/**
+ * The container resolver (ADR-030 §2).
+ *
+ * The case worth the most attention is the difference between `gameId: null`
+ * and `gameId: undefined`. They look alike in JavaScript and mean opposite
+ * things here — "deliberately shelved" versus "not yet decided" — and getting
+ * them backwards would send every shelved entity back through the legacy
+ * fallback on every read.
+ */
+
+describe('null is a decision; undefined is not', () => {
+  test('gameId: null means the shelf, and does NOT consult workspaceId', () => {
+    // Even with a workspace still attached, an explicit null wins. Otherwise a
+    // deliberate "move to shelf" would silently bounce back to the old game.
+    const c = containerOf({ gameId: null, workspaceId: 'some-old-workspace' })
+    expect(c.kind).toBe('shelf')
+  })
+
+  test('gameId: undefined falls back to workspaceId', () => {
+    const c = containerOf({ workspaceId: 'campaign-a' })
+    expect(c).toEqual({ kind: 'game', gameId: 'campaign-a' })
+  })
+
+  test('a set gameId wins over a stale workspaceId', () => {
+    const c = containerOf({ gameId: 'campaign-b', workspaceId: 'campaign-a' })
+    expect(c).toEqual({ kind: 'game', gameId: 'campaign-b' })
+  })
+})
+
+describe('the Default workspace is the shelf, not a game', () => {
+  test('DEFAULT_WORKSPACE_ID resolves to the shelf', () => {
+    // It was never a campaign — it was where builds went when they belonged to
+    // no campaign, which is what a shelf is.
+    expect(containerOf({ workspaceId: DEFAULT_WORKSPACE_ID }).kind).toBe('shelf')
+  })
+
+  test('an entity with no container at all is on the shelf', () => {
+    expect(containerOf({}).kind).toBe('shelf')
+  })
+})
+
+describe('helpers', () => {
+  test('isOnShelf agrees with containerOf', () => {
+    expect(isOnShelf({ gameId: null })).toBe(true)
+    expect(isOnShelf({ gameId: 'g1' })).toBe(false)
+    expect(isOnShelf({ workspaceId: DEFAULT_WORKSPACE_ID })).toBe(true)
+  })
+
+  test('gameIdOf returns null for a shelved entity rather than undefined', () => {
+    // Callers write this straight into a nullable column, so the distinction
+    // between null and undefined has to survive the helper.
+    expect(gameIdOf({ gameId: null })).toBeNull()
+    expect(gameIdOf({})).toBeNull()
+    expect(gameIdOf({ gameId: 'g1' })).toBe('g1')
+  })
+
+  test('moveTo produces a patch that round-trips', () => {
+    expect(moveTo({ kind: 'shelf' })).toEqual({ gameId: null })
+    expect(moveTo({ kind: 'game', gameId: 'g1' })).toEqual({ gameId: 'g1' })
+    // The round trip is the property that matters: applying the patch and
+    // re-resolving must land in the same container.
+    expect(containerOf(moveTo({ kind: 'shelf' })).kind).toBe('shelf')
+    expect(containerOf(moveTo({ kind: 'game', gameId: 'g1' }))).toEqual({
+      kind: 'game',
+      gameId: 'g1',
+    })
+  })
+})

--- a/apps/itun/src/lib/container.ts
+++ b/apps/itun/src/lib/container.ts
@@ -1,0 +1,70 @@
+import { DEFAULT_WORKSPACE_ID } from './defaultWorkspace'
+
+/**
+ * Which container an entity lives in (ADR-030 §2).
+ *
+ * There are exactly two: a shared **Game**, or the owner's personal **Shelf**.
+ * They are encoded in one nullable column rather than two fields, because an
+ * entity is always in exactly one and a second field could contradict the
+ * first.
+ *
+ * The subtle part is that **`null` is a value, not an absence**. `null` means
+ * "on the shelf" — a real place — while `undefined` means "this record predates
+ * the split and we have not decided yet". Conflating them is the bug this
+ * module exists to prevent: treating a shelved entity as unmigrated would send
+ * it back through the fallback on every read.
+ */
+
+/** A shared Game, by id. */
+export type GameContainer = { kind: 'game'; gameId: string }
+/** The owner's personal shelf. Not a Game: no crew, no Mediator, no invites. */
+export type ShelfContainer = { kind: 'shelf' }
+
+export type Container = GameContainer | ShelfContainer
+
+export const SHELF: ShelfContainer = { kind: 'shelf' }
+
+/** The minimum an entity needs to expose for its container to be resolved. */
+export type ContainerFields = {
+  gameId?: string | null | undefined
+  /** @deprecated Read only as a fallback for records written before ADR-030. */
+  workspaceId?: string | undefined
+}
+
+/**
+ * Resolve where an entity lives.
+ *
+ * The fallback chain matters and is ordered deliberately:
+ *
+ *  1. `gameId` set to a string — it is in that Game.
+ *  2. `gameId` explicitly `null` — it is on the shelf. Decided; stop.
+ *  3. `gameId` absent — pre-split record, so fall back to `workspaceId`, with
+ *     the built-in Default workspace mapping to the shelf rather than to a
+ *     Game. The Default workspace was never a campaign; it was the place
+ *     builds went when they belonged to no campaign, which is precisely a
+ *     shelf.
+ */
+export function containerOf(entity: ContainerFields): Container {
+  if (typeof entity.gameId === 'string') return { kind: 'game', gameId: entity.gameId }
+  if (entity.gameId === null) return SHELF
+  if (entity.workspaceId !== undefined && entity.workspaceId !== DEFAULT_WORKSPACE_ID) {
+    return { kind: 'game', gameId: entity.workspaceId }
+  }
+  return SHELF
+}
+
+/** True when the entity is on the owner's shelf rather than in a Game. */
+export function isOnShelf(entity: ContainerFields): boolean {
+  return containerOf(entity).kind === 'shelf'
+}
+
+/** The Game id, or null when the entity is shelved. */
+export function gameIdOf(entity: ContainerFields): string | null {
+  const container = containerOf(entity)
+  return container.kind === 'game' ? container.gameId : null
+}
+
+/** The patch that moves an entity into a container. */
+export function moveTo(container: Container): { gameId: string | null } {
+  return { gameId: container.kind === 'game' ? container.gameId : null }
+}

--- a/apps/itun/src/lib/db/__tests__/workspace-to-game-or-shelf.test.ts
+++ b/apps/itun/src/lib/db/__tests__/workspace-to-game-or-shelf.test.ts
@@ -1,0 +1,146 @@
+/**
+ * v12 → v13 fixture test: workspaceId → gameId (ADR-030 §2).
+ *
+ * A migration is the one edit a user cannot undo, so this seeds a real v12
+ * database and re-opens it through the live upgrade path rather than calling
+ * `migrate()` directly — the thing worth proving is that the ladder produces
+ * the right containers end to end, not that one function does.
+ *
+ * The claim under test is that the built-in Default workspace becomes the
+ * **shelf** rather than a Game. Getting that backwards would invent a campaign
+ * nobody ran and put every unassigned build into it.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { DEFAULT_WORKSPACE_ID } from '../../defaultWorkspace'
+import { containerOf } from '../../container'
+import { openItunDatabase } from '../index'
+
+const TEST_DB_NAME = 'itun-test-v12-to-v13'
+
+async function destroy(): Promise<void> {
+  const { deleteDB } = await import('idb')
+  await deleteDB(TEST_DB_NAME)
+}
+
+beforeEach(destroy)
+afterEach(destroy)
+
+/** Seed a v12-shaped database with pilots in three different container states. */
+async function seedV12(): Promise<void> {
+  const { openDB } = await import('idb')
+  const db = await openDB(TEST_DB_NAME, 12, {
+    upgrade(db) {
+      for (const name of [
+        'pilots',
+        'mechs',
+        'crawlers',
+        'workspaces',
+        'softLinks',
+        'mechPatterns',
+        'encounterNpcs',
+      ]) {
+        if (!db.objectStoreNames.contains(name)) db.createObjectStore(name, { keyPath: 'id' })
+      }
+      if (!db.objectStoreNames.contains('changeLog')) {
+        db.createObjectStore('changeLog', { keyPath: 'seq', autoIncrement: true })
+      }
+    },
+  })
+
+  const base = { schemaVersion: 1, createdAt: '2026-01-01T00:00:00.000Z' }
+  await db.put('pilots', {
+    ...base,
+    id: 'p-default',
+    name: 'Shelved',
+    workspaceId: DEFAULT_WORKSPACE_ID,
+  })
+  await db.put('pilots', {
+    ...base,
+    id: 'p-campaign',
+    name: 'In a game',
+    workspaceId: 'campaign-a',
+  })
+  await db.put('pilots', { ...base, id: 'p-none', name: 'No workspace' })
+  await db.put('mechs', { ...base, id: 'm-campaign', name: 'Mule', workspaceId: 'campaign-a' })
+  await db.put('crawlers', {
+    ...base,
+    id: 'c-default',
+    name: '#430',
+    workspaceId: DEFAULT_WORKSPACE_ID,
+  })
+  db.close()
+}
+
+/**
+ * Re-open through the app's own opener and read a row back.
+ *
+ * Deliberately `openItunDatabase` rather than a hand-rolled `openDB` upgrade
+ * callback: the first draft of this test wrote its own callback and every case
+ * failed with `AbortError`, because the migrations were fired without being
+ * awaited and the versionchange transaction auto-committed underneath them.
+ * Using the real opener tests the real ladder and cannot drift from it.
+ */
+async function readAfterUpgrade(store: string, id: string): Promise<Record<string, unknown>> {
+  const db = await openItunDatabase(TEST_DB_NAME)
+  const row = (await db.get(store, id)) as Record<string, unknown>
+  db.close()
+  return row
+}
+
+describe('v12 → v13 container split', () => {
+  test('the Default workspace becomes the shelf, not a game', async () => {
+    await seedV12()
+    const row = await readAfterUpgrade('pilots', 'p-default')
+
+    expect(row.gameId).toBeNull()
+    expect(containerOf(row).kind).toBe('shelf')
+  })
+
+  test('a real workspace becomes a game of the same id', async () => {
+    await seedV12()
+    const row = await readAfterUpgrade('pilots', 'p-campaign')
+
+    expect(row.gameId).toBe('campaign-a')
+    expect(containerOf(row)).toEqual({ kind: 'game', gameId: 'campaign-a' })
+  })
+
+  test('an entity with no workspace at all lands on the shelf', async () => {
+    await seedV12()
+    const row = await readAfterUpgrade('pilots', 'p-none')
+
+    // null, not undefined — the record now carries a decision.
+    expect(row.gameId).toBeNull()
+  })
+
+  test('mechs and crawlers migrate too, not just pilots', async () => {
+    await seedV12()
+    expect((await readAfterUpgrade('mechs', 'm-campaign')).gameId).toBe('campaign-a')
+    expect((await readAfterUpgrade('crawlers', 'c-default')).gameId).toBeNull()
+  })
+
+  test('workspaceId is retained, not stripped', async () => {
+    await seedV12()
+    const row = await readAfterUpgrade('pilots', 'p-campaign')
+
+    // The schemas are `.strict()`, so a row written here still has to parse on
+    // a build that predates the migration. Dropping the key is a separate,
+    // irreversible follow-up.
+    expect(row.workspaceId).toBe('campaign-a')
+  })
+
+  test('re-running is idempotent and never moves a placed entity', async () => {
+    await seedV12()
+    await readAfterUpgrade('pilots', 'p-campaign')
+
+    // Deliberately shelve it, then re-open: the migration must not drag it back
+    // to the old workspace on a second pass.
+    const db = await openItunDatabase(TEST_DB_NAME)
+    const existing = (await db.get('pilots', 'p-campaign')) as Record<string, unknown>
+    await db.put('pilots', { ...existing, gameId: null })
+    db.close()
+
+    const row = await readAfterUpgrade('pilots', 'p-campaign')
+    expect(row.gameId).toBeNull()
+  })
+})

--- a/apps/itun/src/lib/db/index.ts
+++ b/apps/itun/src/lib/db/index.ts
@@ -53,7 +53,7 @@ import { STORE_NAMES } from './stores'
  * model replaces the old cross-workspace "All Builds" view; see
  * lib/defaultWorkspace.ts.)
  */
-export const DB_VERSION = 12
+export const DB_VERSION = 13
 
 const DB_NAME = 'itun-v1'
 

--- a/apps/itun/src/lib/db/migrations/13-workspace-to-game-or-shelf.ts
+++ b/apps/itun/src/lib/db/migrations/13-workspace-to-game-or-shelf.ts
@@ -1,0 +1,54 @@
+import type { UpgradeTransaction } from './index'
+
+/**
+ * v12 → v13: give every entity an explicit container (ADR-030 §2).
+ *
+ * Before this, an entity's home was `workspaceId`, and the built-in Default
+ * workspace was a real row every unassigned build was backfilled into (v10).
+ * ADR-030 splits that into two containers — a shared **Game** or the owner's
+ * personal **Shelf** — encoded as one nullable `gameId`.
+ *
+ * The mapping:
+ *
+ *   workspaceId === DEFAULT_WORKSPACE_ID  →  gameId: null   (the shelf)
+ *   workspaceId === <anything else>       →  gameId: <that> (a game)
+ *   workspaceId absent                    →  gameId: null   (the shelf)
+ *
+ * The Default workspace becoming the shelf is the substantive claim here, and
+ * it is a restoration rather than a reinterpretation: the Default workspace was
+ * never a campaign. It existed because the app required *some* container and
+ * these builds belonged to no particular one — which is exactly what a shelf
+ * is. Mapping it to a Game would invent a campaign nobody ran.
+ *
+ * `workspaceId` is **not** stripped. The entity schemas are `.strict()`, so a
+ * record written by this migration still has to parse on a build that predates
+ * it; removing the key is a separate, irreversible follow-up. The constant is
+ * inlined rather than imported because migrations may only await IndexedDB
+ * operations — a module import could let the versionchange transaction commit
+ * mid-run (see this directory's README).
+ */
+
+/** Inlined from lib/defaultWorkspace.ts — see the note above on imports. */
+const DEFAULT_WORKSPACE_ID = 'default-workspace'
+
+const STORES = ['pilots', 'mechs', 'crawlers'] as const
+
+export async function migrate(tx: UpgradeTransaction): Promise<void> {
+  for (const store of STORES) {
+    let cursor = await tx.objectStore(store).openCursor()
+    while (cursor) {
+      const row = cursor.value as { workspaceId?: unknown; gameId?: unknown }
+
+      // Idempotent: a row that already has a decision keeps it. Re-running must
+      // never move an entity that has since been placed deliberately.
+      if (row.gameId === undefined) {
+        const workspaceId = typeof row.workspaceId === 'string' ? row.workspaceId : undefined
+        const gameId =
+          workspaceId === undefined || workspaceId === DEFAULT_WORKSPACE_ID ? null : workspaceId
+        await cursor.update({ ...row, gameId })
+      }
+
+      cursor = await cursor.continue()
+    }
+  }
+}

--- a/apps/itun/src/lib/db/migrations/index.ts
+++ b/apps/itun/src/lib/db/migrations/index.ts
@@ -26,6 +26,7 @@ import { migrate as migrate8CrawlerBattleSpToDerived } from './8-crawler-battle-
 import { migrate as migrate10WorkspaceDefaultBackfill } from './10-workspace-default-backfill'
 import { migrate as migrate11EquipmentLoadoutsToPartners } from './11-equipment-loadouts-to-partners'
 import { migrate as migrate12CompanionMechsToPartners } from './12-companion-mechs-to-partners'
+import { migrate as migrate13WorkspaceToGameOrShelf } from './13-workspace-to-game-or-shelf'
 
 /** The untyped versionchange transaction handed to the idb upgrade callback. */
 export type UpgradeTransaction = IDBPTransaction<
@@ -85,6 +86,11 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
     toVersion: 12,
     description: 'companion-mechs-to-partners',
     migrate: (tx) => migrate12CompanionMechsToPartners(tx),
+  },
+  {
+    toVersion: 13,
+    description: 'workspace-to-game-or-shelf',
+    migrate: (tx) => migrate13WorkspaceToGameOrShelf(tx),
   },
   // NOTE: the built-in Starter Set is NOT seeded by a migration. It is spawned
   // on-demand into each browser the first time the user opens the Starter Set

--- a/apps/itun/src/lib/schemas/crawler.ts
+++ b/apps/itun/src/lib/schemas/crawler.ts
@@ -123,7 +123,22 @@ export const CrawlerSchema = z
      * needed (same tactic as Pilot.equipmentChoices / crawlerBays).
      */
     bayChoices: z.record(z.string(), ChoiceSelectionsSchema).optional(),
-    /** Optional: links this crawler to a workspace */
+    /**
+     * Which container holds this entity (ADR-030 §2).
+     *
+     * `undefined` means the record predates the container split and should be
+     * read through `containerOf()`, which falls back to `workspaceId`.
+     * `null` means the owner's **Shelf** — not "unset". The distinction is the
+     * whole point: a shelf is a real place an entity lives, not the absence of
+     * one.
+     */
+    gameId: z.string().nullable().optional(),
+    /**
+     * @deprecated Superseded by `gameId` (ADR-030 §2). Retained because these
+     * schemas are `.strict()`: dropping the key would fail the parse of every
+     * already-migrated record. Removing it needs a follow-up migration that
+     * strips it from stored rows first — a separate, irreversible change.
+     */
     workspaceId: z.string().optional(),
     // ---------------------------------------------------------------------------
     // Live-play current stat tracking (#245).

--- a/apps/itun/src/lib/schemas/mech.ts
+++ b/apps/itun/src/lib/schemas/mech.ts
@@ -213,7 +213,22 @@ export const MechSchema = z
     /** Absolute pinned Cargo Capacity. */
     maxCargoOverride: z.number().int().nonnegative().optional(),
 
-    /** Optional: links this mech to a workspace */
+    /**
+     * Which container holds this entity (ADR-030 §2).
+     *
+     * `undefined` means the record predates the container split and should be
+     * read through `containerOf()`, which falls back to `workspaceId`.
+     * `null` means the owner's **Shelf** — not "unset". The distinction is the
+     * whole point: a shelf is a real place an entity lives, not the absence of
+     * one.
+     */
+    gameId: z.string().nullable().optional(),
+    /**
+     * @deprecated Superseded by `gameId` (ADR-030 §2). Retained because these
+     * schemas are `.strict()`: dropping the key would fail the parse of every
+     * already-migrated record. Removing it needs a follow-up migration that
+     * strips it from stored rows first — a separate, irreversible change.
+     */
     workspaceId: z.string().optional(),
 
     // ---------------------------------------------------------------------------

--- a/apps/itun/src/lib/schemas/pilot.ts
+++ b/apps/itun/src/lib/schemas/pilot.ts
@@ -140,7 +140,22 @@ export const PilotSchema = z
     /** Active condition slugs */
     conditions: z.array(z.string()),
 
-    /** Optional: links this pilot to a workspace */
+    /**
+     * Which container holds this entity (ADR-030 §2).
+     *
+     * `undefined` means the record predates the container split and should be
+     * read through `containerOf()`, which falls back to `workspaceId`.
+     * `null` means the owner's **Shelf** — not "unset". The distinction is the
+     * whole point: a shelf is a real place an entity lives, not the absence of
+     * one.
+     */
+    gameId: z.string().nullable().optional(),
+    /**
+     * @deprecated Superseded by `gameId` (ADR-030 §2). Retained because these
+     * schemas are `.strict()`: dropping the key would fail the parse of every
+     * already-migrated record. Removing it needs a follow-up migration that
+     * strips it from stored rows first — a separate, irreversible change.
+     */
     workspaceId: z.string().optional(),
 
     // ---------------------------------------------------------------------------

--- a/apps/itun/src/routeTree.gen.ts
+++ b/apps/itun/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as AboutRouteImport } from './routes/about'
 import { Route as AccountRouteImport } from './routes/account'
 import { Route as ChangelogRouteImport } from './routes/changelog'
 import { Route as EncounterRouteImport } from './routes/encounter'
+import { Route as GamesRouteImport } from './routes/games'
 import { Route as CrawlersIdRouteImport } from './routes/crawlers/$id'
 import { Route as CrawlersNewRouteImport } from './routes/crawlers/new'
 import { Route as DashboardIdRouteImport } from './routes/dashboard/$id'
@@ -49,6 +50,11 @@ const ChangelogRoute = ChangelogRouteImport.update({
 const EncounterRoute = EncounterRouteImport.update({
   id: '/encounter',
   path: '/encounter',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const GamesRoute = GamesRouteImport.update({
+  id: '/games',
+  path: '/games',
   getParentRoute: () => rootRouteImport,
 } as any)
 const CrawlersIdRoute = CrawlersIdRouteImport.update({
@@ -113,6 +119,7 @@ export interface FileRoutesByFullPath {
   '/account': typeof AccountRoute
   '/changelog': typeof ChangelogRoute
   '/encounter': typeof EncounterRoute
+  '/games': typeof GamesRoute
   '/crawlers/$id': typeof CrawlersIdRoute
   '/crawlers/new': typeof CrawlersNewRoute
   '/dashboard/$id': typeof DashboardIdRoute
@@ -131,6 +138,7 @@ export interface FileRoutesByTo {
   '/account': typeof AccountRoute
   '/changelog': typeof ChangelogRoute
   '/encounter': typeof EncounterRoute
+  '/games': typeof GamesRoute
   '/crawlers/$id': typeof CrawlersIdRoute
   '/crawlers/new': typeof CrawlersNewRoute
   '/dashboard/$id': typeof DashboardIdRoute
@@ -150,6 +158,7 @@ export interface FileRoutesById {
   '/account': typeof AccountRoute
   '/changelog': typeof ChangelogRoute
   '/encounter': typeof EncounterRoute
+  '/games': typeof GamesRoute
   '/crawlers/$id': typeof CrawlersIdRoute
   '/crawlers/new': typeof CrawlersNewRoute
   '/dashboard/$id': typeof DashboardIdRoute
@@ -170,6 +179,7 @@ export interface FileRouteTypes {
     | '/account'
     | '/changelog'
     | '/encounter'
+    | '/games'
     | '/crawlers/$id'
     | '/crawlers/new'
     | '/dashboard/$id'
@@ -188,6 +198,7 @@ export interface FileRouteTypes {
     | '/account'
     | '/changelog'
     | '/encounter'
+    | '/games'
     | '/crawlers/$id'
     | '/crawlers/new'
     | '/dashboard/$id'
@@ -206,6 +217,7 @@ export interface FileRouteTypes {
     | '/account'
     | '/changelog'
     | '/encounter'
+    | '/games'
     | '/crawlers/$id'
     | '/crawlers/new'
     | '/dashboard/$id'
@@ -225,6 +237,7 @@ export interface RootRouteChildren {
   AccountRoute: typeof AccountRoute
   ChangelogRoute: typeof ChangelogRoute
   EncounterRoute: typeof EncounterRoute
+  GamesRoute: typeof GamesRoute
   CrawlersIdRoute: typeof CrawlersIdRoute
   CrawlersNewRoute: typeof CrawlersNewRoute
   DashboardIdRoute: typeof DashboardIdRoute
@@ -273,6 +286,13 @@ declare module '@tanstack/react-router' {
       path: '/encounter'
       fullPath: '/encounter'
       preLoaderRoute: typeof EncounterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/games': {
+      id: '/games'
+      path: '/games'
+      fullPath: '/games'
+      preLoaderRoute: typeof GamesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/crawlers/$id': {
@@ -361,6 +381,7 @@ const rootRouteChildren: RootRouteChildren = {
   AccountRoute: AccountRoute,
   ChangelogRoute: ChangelogRoute,
   EncounterRoute: EncounterRoute,
+  GamesRoute: GamesRoute,
   CrawlersIdRoute: CrawlersIdRoute,
   CrawlersNewRoute: CrawlersNewRoute,
   DashboardIdRoute: DashboardIdRoute,

--- a/apps/itun/src/routeTree.gen.ts
+++ b/apps/itun/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AboutRouteImport } from './routes/about'
+import { Route as AccountRouteImport } from './routes/account'
 import { Route as ChangelogRouteImport } from './routes/changelog'
 import { Route as EncounterRouteImport } from './routes/encounter'
 import { Route as CrawlersIdRouteImport } from './routes/crawlers/$id'
@@ -33,6 +34,11 @@ const IndexRoute = IndexRouteImport.update({
 const AboutRoute = AboutRouteImport.update({
   id: '/about',
   path: '/about',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AccountRoute = AccountRouteImport.update({
+  id: '/account',
+  path: '/account',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ChangelogRoute = ChangelogRouteImport.update({
@@ -104,6 +110,7 @@ const SheetKindIdShareRoute = SheetKindIdShareRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/account': typeof AccountRoute
   '/changelog': typeof ChangelogRoute
   '/encounter': typeof EncounterRoute
   '/crawlers/$id': typeof CrawlersIdRoute
@@ -121,6 +128,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/account': typeof AccountRoute
   '/changelog': typeof ChangelogRoute
   '/encounter': typeof EncounterRoute
   '/crawlers/$id': typeof CrawlersIdRoute
@@ -139,6 +147,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/account': typeof AccountRoute
   '/changelog': typeof ChangelogRoute
   '/encounter': typeof EncounterRoute
   '/crawlers/$id': typeof CrawlersIdRoute
@@ -158,6 +167,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/about'
+    | '/account'
     | '/changelog'
     | '/encounter'
     | '/crawlers/$id'
@@ -175,6 +185,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/about'
+    | '/account'
     | '/changelog'
     | '/encounter'
     | '/crawlers/$id'
@@ -192,6 +203,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/about'
+    | '/account'
     | '/changelog'
     | '/encounter'
     | '/crawlers/$id'
@@ -210,6 +222,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
+  AccountRoute: typeof AccountRoute
   ChangelogRoute: typeof ChangelogRoute
   EncounterRoute: typeof EncounterRoute
   CrawlersIdRoute: typeof CrawlersIdRoute
@@ -239,6 +252,13 @@ declare module '@tanstack/react-router' {
       path: '/about'
       fullPath: '/about'
       preLoaderRoute: typeof AboutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/account': {
+      id: '/account'
+      path: '/account'
+      fullPath: '/account'
+      preLoaderRoute: typeof AccountRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/changelog': {
@@ -338,6 +358,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
+  AccountRoute: AccountRoute,
   ChangelogRoute: ChangelogRoute,
   EncounterRoute: EncounterRoute,
   CrawlersIdRoute: CrawlersIdRoute,

--- a/apps/itun/src/routes/__root.tsx
+++ b/apps/itun/src/routes/__root.tsx
@@ -10,6 +10,7 @@ import { AppLink } from '../components/shared/AppLink'
 import { BlockedUpgradeError } from '../lib/db/index'
 import { GameDataReady } from '../components/shared/GameDataReady'
 import { NotConnectedBanner } from '../components/shared/NotConnectedBanner'
+import { AccountStrip } from '../components/account/AccountStrip'
 import { AppConvexProvider } from '../components/shared/AppConvexProvider'
 import { GlobalSearch } from '../components/shared/GlobalSearch'
 import { BackupNudgeToast } from '../components/shared/BackupNudgeToast'
@@ -83,6 +84,7 @@ function RootComponent() {
             data, so it paints immediately instead of sitting behind the full
             preload. */}
           <NotConnectedBanner />
+          <AccountStrip />
           <AppHeader onSearchClick={() => setSearchOpen(true)} LinkComponent={AppLink} />
           <GameDataReady>
             <Outlet />

--- a/apps/itun/src/routes/account.tsx
+++ b/apps/itun/src/routes/account.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { AccountScreen } from '../components/account/AccountScreen'
+
+export const Route = createFileRoute('/account')({
+  component: AccountScreen,
+})

--- a/apps/itun/src/routes/games.tsx
+++ b/apps/itun/src/routes/games.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { GamesScreen } from '../components/games/GamesScreen'
+
+export const Route = createFileRoute('/games')({
+  component: GamesScreen,
+})


### PR DESCRIPTION
Fifth in the stack (#609 → #631 → #632 → #633 → this). Phase 1 of [ADR-030](https://github.com/SalvageUnion-io/SU-SRD/blob/main/docs/adrs/ADR-030-accounts-games-server-of-record.md), decision **D34**.

## What makes a template more than seeded data

**Its entities arrive with `ownerId: null`.** The Mediator — or the Organizer, while a Game has no Mediator — hands them out as players join.

That single property turns the six pre-gens of Union Crawler #430 'Tenacity' from a curiosity buried in a workspace switcher into the actual onboarding path. A template that pre-assigned everything to its creator would just be a private roster with extra steps, so that's the property the tests pin hardest.

## One copy of the roster, not two

The crew is imported straight from `src/lib/starterSet/`. That module is deliberately static plain data with no runtime reference-data resolution (its header says so), so it bundles into a Convex function safely — and there is exactly **one** copy rather than a server-side duplicate that would drift from the local one on the next data fix.

## Details that follow from earlier decisions

- **The crawler is inserted with no `ownerId` column at all**, because it is communal (D8). Tested, so a future refactor cannot quietly give the crew's home an owner.
- **Soft links come across**, so pilots and mechs arrive wired to each other and to the crawler. Without them the template would deliver a set of unrelated strangers.
- **`templateOrigin`** records which template a Game came from — what later lets anything tell a seeded crawler from a hand-built one.

## Tests

8 new, covering unclaimed-on-arrival, the creator being Organizer-and-Player (a template changes what is *in* a Game, never who runs it), the communal crawler, soft links surviving, custom-name override, and the anonymous-caller rejection.

## Verification

typecheck 4/4 · knip clean · `format:check` clean · design-token gate clean · full suite green · no new lint warnings. Re-verified after rebasing across 8 newly-landed commits on `main`.

## Remaining in Phase 1

Routing `entityStore` reads/writes to Convex when connected, and claim-local-data on first sign-in. Then Phases 2–6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014m6W8yMd1FM3Roumj9x4Zj
