### PR TITLE
feat(itun): activated contributions with manual expiry — Squeeze It In, Hull Magnetiser

### DIFF
--- a/apps/itun/src/components/dashboard/ActiveItemBand.tsx
+++ b/apps/itun/src/components/dashboard/ActiveItemBand.tsx
@@ -34,6 +34,7 @@ import type { Mech } from '../../lib/schemas/mech'
 import type { Pilot } from '../../lib/schemas/pilot'
 import { useEntityStore } from '../../stores/entityStore'
 import type { EntityState } from '../../stores/entityStore'
+import { activatableEffects } from './dashboardEffects'
 import { usePlayStateStore } from '../../stores/playStateStore'
 import { ActiveItemBand as ActiveItemBandView, CountStepper, StorageBay } from 'component-lib'
 import type { ActiveItemBandView as ActiveItemBandViewModel, BandButton } from 'component-lib'
@@ -349,7 +350,12 @@ function MechBand({
   onDismount: () => void
 }) {
   const chassis = resolveChassisRef(mech.chassisRef)
-  const piloting = pilotingContext(mech, pilotAbilities)
+  const activeEffects = usePlayStateStore((st) => st.activeEffects)
+  const toggleEffect = usePlayStateStore((st) => st.toggleEffect)
+  const piloting = { ...pilotingContext(mech, pilotAbilities), active: activeEffects }
+  // What this mech/pilot could switch on (F1). Manual expiry: the table keeps
+  // time, the app keeps state.
+  const activatable = activatableEffects(mech, pilotAbilities)
   const maxSP = mechMaxSP(mech, chassis, piloting)
   const maxEP = mechMaxEP(mech, chassis)
   const maxHeat = mechMaxHeat(mech, chassis)
@@ -625,6 +631,20 @@ function MechBand({
           },
         ],
       },
+      ...(activatable.length > 0
+        ? [
+            {
+              label: 'Effects',
+              buttons: activatable.map((e) => ({
+                label: `${activeEffects[e.ref] ? '\u25CF' : '\u25CB'} ${e.name}`,
+                onClick: () => toggleEffect(e.ref),
+                title: activeEffects[e.ref]
+                  ? `${e.name} is active — click to end it`
+                  : `${e.name}: ${e.summary}`,
+              })),
+            },
+          ]
+        : []),
       {
         label: 'Egress',
         buttons: [

--- a/apps/itun/src/components/dashboard/__tests__/dashboardEffects.test.ts
+++ b/apps/itun/src/components/dashboard/__tests__/dashboardEffects.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Activated-effect enumeration (F1, ADR-029).
+ *
+ * Manual expiry by design: Salvage Union states real durations, but the app has
+ * no play clock and inventing one would put wall-time into the data layer and
+ * make a sheet's numbers change while nobody is looking. The table keeps time;
+ * the app keeps state.
+ */
+
+import { beforeAll, describe, expect, test } from 'bun:test'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+import { activatableEffects } from '../dashboardEffects'
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+describe('activatableEffects', () => {
+  test('finds an activated contribution on an installed module', () => {
+    const found = activatableEffects({ systems: [], modules: ['Hull Magnetiser'] }, undefined)
+    expect(found.map((e) => e.name)).toContain('Hull Magnetiser')
+  })
+
+  test('finds an activated contribution on a pilot ability', () => {
+    const found = activatableEffects({ systems: [], modules: [] }, ['Squeeze it in'])
+    expect(found.map((e) => e.name)).toContain('Squeeze it in')
+  })
+
+  test('ignores PERMANENT contributions — they need no switch', () => {
+    // Beefcake and Heat Sink apply whenever held/installed.
+    const found = activatableEffects({ systems: ['Heat Sink'], modules: [] }, ['Beefcake'])
+    expect(found).toHaveLength(0)
+  })
+
+  test('de-duplicates by ref so two copies list one toggle', () => {
+    const found = activatableEffects(
+      { systems: [], modules: ['Hull Magnetiser', 'Hull Magnetiser'] },
+      undefined
+    )
+    expect(found).toHaveLength(1)
+  })
+
+  test('summarises a fromStat amount without inventing a number', () => {
+    const [effect] = activatableEffects({ systems: [], modules: ['Hull Magnetiser'] }, undefined)
+    expect(effect?.summary).toContain('systemSlots')
+  })
+
+  test('an empty loadout offers nothing to switch on', () => {
+    expect(activatableEffects({ systems: [], modules: [] }, [])).toEqual([])
+  })
+})

--- a/apps/itun/src/components/dashboard/dashboardEffects.ts
+++ b/apps/itun/src/components/dashboard/dashboardEffects.ts
@@ -1,0 +1,75 @@
+/**
+ * Activated contributions a mech/pilot can switch on (F1, ADR-029).
+ *
+ * `duration: 'activated'` contributions apply only while the player has them
+ * on. **Manual expiry by design**: Salvage Union states real durations ("this
+ * effect lasts for 1 hour"), but the app has no play clock, and inventing one
+ * would put wall-time into the data layer and make a sheet's numbers change
+ * while nobody is looking. The table keeps time; the app keeps state — the same
+ * division ADR-001's honour system already relies on.
+ *
+ * Pure: this only enumerates what COULD be switched on. Whether it is on lives
+ * in ephemeral play state (ADR-019), never on the entity.
+ */
+
+import { SalvageUnionReference } from 'salvageunion-reference'
+import { matchesRef } from 'salvageunion-reference/rules'
+
+import type { Mech } from '../../lib/schemas/mech'
+
+export type ActivatableEffect = {
+  /** The declaring record's ref — the key play state toggles on. */
+  ref: string
+  /** Display name. */
+  name: string
+  /** One line describing what switching it on does. */
+  summary: string
+}
+
+type WithContributions = {
+  name?: string
+  contributions?: Array<{ stat: string; amount: unknown; duration?: string }>
+}
+
+function describe(c: { stat: string; amount: unknown }): string {
+  const stat = c.stat === 'cargoCapacity' ? 'Cargo Capacity' : c.stat
+  if (typeof c.amount === 'number') return `+${c.amount} ${stat}`
+  if (c.amount && typeof c.amount === 'object' && 'fromStat' in c.amount) {
+    return `${stat} by this Mech's ${String((c.amount as { fromStat: string }).fromStat)}`
+  }
+  return `changes ${stat}`
+}
+
+function activatedOf(record: WithContributions | undefined, ref: string): ActivatableEffect[] {
+  return (record?.contributions ?? [])
+    .filter((c) => c.duration === 'activated')
+    .map((c) => ({ ref, name: record?.name ?? ref, summary: describe(c) }))
+}
+
+/**
+ * Every activated contribution reachable from this mech's installed loadout and
+ * its pilot's abilities, de-duplicated by ref.
+ */
+export function activatableEffects(
+  mech: Pick<Mech, 'systems' | 'modules'>,
+  pilotAbilities: string[] | undefined
+): ActivatableEffect[] {
+  const out = new Map<string, ActivatableEffect>()
+
+  const installed = [...(mech.systems ?? []), ...(mech.modules ?? [])]
+  for (const ref of installed) {
+    const item =
+      (SalvageUnionReference.Systems.find((s) => matchesRef(s, ref)) as WithContributions) ??
+      (SalvageUnionReference.Modules.find((m) => matchesRef(m, ref)) as WithContributions)
+    for (const e of activatedOf(item, ref)) out.set(e.ref, e)
+  }
+
+  for (const ref of pilotAbilities ?? []) {
+    const ability = SalvageUnionReference.Abilities.find((a) =>
+      matchesRef(a, ref)
+    ) as WithContributions
+    for (const e of activatedOf(ability, ref)) out.set(e.ref, e)
+  }
+
+  return [...out.values()].sort((a, b) => a.name.localeCompare(b.name))
+}

--- a/apps/itun/src/stores/playStateStore.ts
+++ b/apps/itun/src/stores/playStateStore.ts
@@ -43,7 +43,24 @@ type PlayState = {
    *  active Item band should open its Take-Damage overlay (pre-armed) for the
    *  player to confirm. Consumed (reset) by the band once it opens the overlay. */
   damagePromptArmed: boolean
+  /**
+   * Which `duration: 'activated'` contributions are switched on, keyed by the
+   * declaring record's ref (ADR-029 / F1).
+   *
+   * **Manual expiry by design.** Salvage Union states real durations ("this
+   * effect lasts for 1 hour"), but the app has no play clock and inventing one
+   * would put wall-time into the data layer and make a sheet's numbers change
+   * while nobody is looking. The table keeps time; the app keeps state — the
+   * same division ADR-001's honour system already relies on.
+   *
+   * Ephemeral like the rest of this store: an activated effect never persists
+   * onto the entity, so it can never leak into a live sheet or a shared
+   * snapshot (ADR-019).
+   */
+  activeEffects: Record<string, boolean>
   setMount: (mount: MountState) => void
+  /** Switch an activated contribution on or off. */
+  toggleEffect: (ref: string) => void
   setWheel: (wheel: number) => void
   /** Set the self-declared engagement range band. */
   setRange: (range: RangeBand) => void
@@ -69,7 +86,10 @@ export const usePlayStateStore = create<PlayState>((set) => ({
   dtStep: 0,
   dtDone: {},
   damagePromptArmed: false,
+  activeEffects: {},
   setMount: (mount) => set({ mount }),
+  toggleEffect: (ref) =>
+    set((s) => ({ activeEffects: { ...s.activeEffects, [ref]: !s.activeEffects[ref] } })),
   setWheel: (wheel) => set({ wheel }),
   setRange: (range) => set({ range }),
   armDamagePrompt: () => set({ damagePromptArmed: true }),

--- a/packages/salvageunion-reference/data/abilities.json
+++ b/packages/salvageunion-reference/data/abilities.json
@@ -445,6 +445,7 @@
     "level": 1,
     "page": 40,
     "actions": ["Squeeze it in"],
+    "contributions": [{"stat": "cargoCapacity", "target": "pilotedMech", "amount": 4, "duration": "activated", "stacks": true, "note": "\"temporarily increase the Cargo Capacity of a Mech in Range by 4\" — manual expiry"}],
     "description": "Temporarily increase the cargo capacity of a Mech.",
     "additionalSources": [
       {

--- a/packages/salvageunion-reference/data/modules.json
+++ b/packages/salvageunion-reference/data/modules.json
@@ -262,6 +262,7 @@
     "techLevel": 2,
     "slotsRequired": 1,
     "salvageValue": 2,
+    "contributions": [{"stat": "cargoCapacity", "target": "self", "amount": {"fromStat": "systemSlots"}, "duration": "activated", "note": "\"increases your Mech's Cargo Capacity by its System Slot Value\" — manual expiry"}],
     "page": 194,
     "actions": ["Hull Magnetiser"],
     "additionalSources": [

--- a/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
+++ b/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
@@ -1014,6 +1014,8 @@ export type ContributionTarget = 'self' | 'pilot' | 'pilotedMech' | 'crawler';
 export type ContributionAmount = number | {
     flat?: number;
     perTechLevel: number;
+} | {
+    fromStat: ContributionStat;
 };
 /** A contribution as declared on a piece of reference content. */
 export type DeclaredContribution = {
@@ -1022,6 +1024,8 @@ export type DeclaredContribution = {
     target?: ContributionTarget;
     stacks?: boolean;
     voidWhen?: 'damaged' | 'destroyed';
+    /** `activated` applies only while switched on in Guided Play (ADR-019). */
+    duration?: 'permanent' | 'activated';
     note?: string;
 };
 /** A resolved contribution: an amount, and the content that produced it. */
@@ -1043,16 +1047,44 @@ export type ResolvedContribution = {
  * resolves it to the flat part rather than guessing, so an unknown tech level
  * under-counts visibly instead of inventing a number.
  */
-export declare function resolveAmount(amount: ContributionAmount, techLevel?: number): number;
+export declare function resolveAmount(amount: ContributionAmount, techLevel?: number, stats?: Partial<Record<ContributionStat, number>>): number;
 /**
  * Every contribution the named abilities declare for `target`/`stat`.
  *
  * Abilities do not stack per copy — holding an ability twice is not a thing —
  * so each resolved contribution is one copy.
  */
-export declare function abilityContributions(abilityRefs: readonly string[] | undefined, target: ContributionTarget, stat: ContributionStat, techLevel?: number): ResolvedContribution[];
+/**
+ * Which `duration: 'activated'` contributions are currently switched on.
+ *
+ * Manual expiry by design: a player toggles an activated effect on and off.
+ * Salvage Union states real durations ("this effect lasts for 1 hour"), but the
+ * app has no play clock and inventing one would put time into the data layer —
+ * so the table keeps time and the app keeps state, which is the same division
+ * ADR-001's honour system already relies on.
+ *
+ * Ephemeral (ADR-019): this lives in play state and is never persisted.
+ */
+export type ActiveEffects = Readonly<Record<string, boolean>>;
+export declare function abilityContributions(abilityRefs: readonly string[] | undefined, target: ContributionTarget, stat: ContributionStat, techLevel?: number, active?: ActiveEffects, stats?: Partial<Record<ContributionStat, number>>): ResolvedContribution[];
 /** Sum of resolved contributions — the number a derivation folds in. */
 export declare function sumContributions(contributions: readonly ResolvedContribution[]): number;
+/**
+ * Contributions declared by the mech's own installed systems and modules.
+ *
+ * Distinct from `statBonus`, which is a flat per-copy number with no target,
+ * duration or expression. An installed item's contribution targets `self` — the
+ * host mech — so `target` is not consulted here.
+ *
+ * `stats` supplies the host's own values for `fromStat` amounts: Hull
+ * Magnetiser raises Cargo "by its System Slot Value", a number that changes
+ * with the chassis and so cannot be written as a constant.
+ */
+export declare function installedContributions(installedRefs: readonly string[] | undefined, stat: ContributionStat, options?: {
+    techLevel?: number;
+    active?: ActiveEffects;
+    stats?: Partial<Record<ContributionStat, number>>;
+}): ResolvedContribution[];
 //# sourceMappingURL=contributions.d.ts.map
 // === lib/rules/coreMechanic.d.ts ===
 /**
@@ -1427,6 +1459,7 @@ export declare function isCrawlerWeaponPickComplete(selectedCount: number): bool
  * consumer's Zod-inferred Pilot/Mech/Crawler types (e.g. ITUN's
  * `src/lib/schemas/`) satisfy them automatically.
  */
+import type { ActiveEffects } from './contributions.js';
 import type { ResolvedContribution } from './contributions.js';
 /**
  * Base pilot stats per the core rules (10 HP / 5 AP / 6 inventory slots).
@@ -1482,6 +1515,9 @@ export type ChassisStats = {
     energyPoints?: number;
     heatCapacity?: number;
     cargoCapacity?: number;
+    /** Slot counts — read by `fromStat` contributions (Hull Magnetiser). */
+    systemSlots?: number;
+    moduleSlots?: number;
 };
 type MechDerivationInput = {
     chassisRef: string;
@@ -1508,6 +1544,12 @@ export type PilotingContext = {
     abilities?: string[];
     /** The mech's Tech Level, for `perTechLevel` amounts (Beefcake's 3+X). */
     techLevel?: number;
+    /**
+     * Which `duration: 'activated'` contributions are switched on right now
+     * (F1). Ephemeral play state, never persisted — an activated effect that is
+     * off contributes nothing, exactly as if it were absent.
+     */
+    active?: ActiveEffects;
 };
 /**
  * The mech-stat-bonus key each derivation sums over installed systems/modules.
@@ -2054,6 +2096,20 @@ export declare function resolveSystemRef(ref: string): ({
         heatCapacity?: number | undefined;
         cargoCapacity?: number | undefined;
     } | undefined;
+    contributions?: {
+        stat: "structurePoints" | "energyPoints" | "heatCapacity" | "systemSlots" | "moduleSlots" | "cargoCapacity" | "maxHp" | "maxAp" | "inventorySlots";
+        amount: number | {
+            perTechLevel: number;
+            flat?: number | undefined;
+        } | {
+            fromStat: "structurePoints" | "energyPoints" | "heatCapacity" | "systemSlots" | "moduleSlots" | "cargoCapacity" | "maxHp" | "maxAp" | "inventorySlots";
+        };
+        target?: "self" | "pilot" | "pilotedMech" | "crawler" | undefined;
+        stacks?: boolean | undefined;
+        voidWhen?: "damaged" | "destroyed" | undefined;
+        duration?: "permanent" | "activated" | undefined;
+        note?: string | undefined;
+    }[] | undefined;
 } & {
     schemaName: string;
 }) | null;
@@ -2103,6 +2159,20 @@ export declare function resolveModuleRef(ref: string): ({
         heatCapacity?: number | undefined;
         cargoCapacity?: number | undefined;
     } | undefined;
+    contributions?: {
+        stat: "structurePoints" | "energyPoints" | "heatCapacity" | "systemSlots" | "moduleSlots" | "cargoCapacity" | "maxHp" | "maxAp" | "inventorySlots";
+        amount: number | {
+            perTechLevel: number;
+            flat?: number | undefined;
+        } | {
+            fromStat: "structurePoints" | "energyPoints" | "heatCapacity" | "systemSlots" | "moduleSlots" | "cargoCapacity" | "maxHp" | "maxAp" | "inventorySlots";
+        };
+        target?: "self" | "pilot" | "pilotedMech" | "crawler" | undefined;
+        stacks?: boolean | undefined;
+        voidWhen?: "damaged" | "destroyed" | undefined;
+        duration?: "permanent" | "activated" | undefined;
+        note?: string | undefined;
+    }[] | undefined;
 } & {
     schemaName: string;
 }) | null;
@@ -2155,6 +2225,20 @@ export declare function resolveInstalledRef(ref: string): ({
         heatCapacity?: number | undefined;
         cargoCapacity?: number | undefined;
     } | undefined;
+    contributions?: {
+        stat: "structurePoints" | "energyPoints" | "heatCapacity" | "systemSlots" | "moduleSlots" | "cargoCapacity" | "maxHp" | "maxAp" | "inventorySlots";
+        amount: number | {
+            perTechLevel: number;
+            flat?: number | undefined;
+        } | {
+            fromStat: "structurePoints" | "energyPoints" | "heatCapacity" | "systemSlots" | "moduleSlots" | "cargoCapacity" | "maxHp" | "maxAp" | "inventorySlots";
+        };
+        target?: "self" | "pilot" | "pilotedMech" | "crawler" | undefined;
+        stacks?: boolean | undefined;
+        voidWhen?: "damaged" | "destroyed" | undefined;
+        duration?: "permanent" | "activated" | undefined;
+        note?: string | undefined;
+    }[] | undefined;
 } & {
     schemaName: string;
 }) | null;
@@ -3038,6 +3122,18 @@ export declare const AbilitySchema: z.ZodObject<{
         amount: z.ZodUnion<readonly [z.ZodNumber, z.ZodObject<{
             flat: z.ZodOptional<z.ZodNumber>;
             perTechLevel: z.ZodNumber;
+        }, z.core.$strict>, z.ZodObject<{
+            fromStat: z.ZodEnum<{
+                structurePoints: "structurePoints";
+                energyPoints: "energyPoints";
+                heatCapacity: "heatCapacity";
+                systemSlots: "systemSlots";
+                moduleSlots: "moduleSlots";
+                cargoCapacity: "cargoCapacity";
+                maxHp: "maxHp";
+                maxAp: "maxAp";
+                inventorySlots: "inventorySlots";
+            }>;
         }, z.core.$strict>]>;
         target: z.ZodOptional<z.ZodEnum<{
             self: "self";
@@ -3049,6 +3145,10 @@ export declare const AbilitySchema: z.ZodObject<{
         voidWhen: z.ZodOptional<z.ZodEnum<{
             damaged: "damaged";
             destroyed: "destroyed";
+        }>>;
+        duration: z.ZodOptional<z.ZodEnum<{
+            permanent: "permanent";
+            activated: "activated";
         }>>;
         note: z.ZodOptional<z.ZodString>;
     }, z.core.$strict>>>;
@@ -3951,6 +4051,51 @@ export declare const CrawlerBaySchema: z.ZodObject<{
                     heatCapacity: z.ZodOptional<z.ZodNumber>;
                     cargoCapacity: z.ZodOptional<z.ZodNumber>;
                 }, z.core.$strict>>;
+                contributions: z.ZodOptional<z.ZodArray<z.ZodObject<{
+                    stat: z.ZodEnum<{
+                        structurePoints: "structurePoints";
+                        energyPoints: "energyPoints";
+                        heatCapacity: "heatCapacity";
+                        systemSlots: "systemSlots";
+                        moduleSlots: "moduleSlots";
+                        cargoCapacity: "cargoCapacity";
+                        maxHp: "maxHp";
+                        maxAp: "maxAp";
+                        inventorySlots: "inventorySlots";
+                    }>;
+                    amount: z.ZodUnion<readonly [z.ZodNumber, z.ZodObject<{
+                        flat: z.ZodOptional<z.ZodNumber>;
+                        perTechLevel: z.ZodNumber;
+                    }, z.core.$strict>, z.ZodObject<{
+                        fromStat: z.ZodEnum<{
+                            structurePoints: "structurePoints";
+                            energyPoints: "energyPoints";
+                            heatCapacity: "heatCapacity";
+                            systemSlots: "systemSlots";
+                            moduleSlots: "moduleSlots";
+                            cargoCapacity: "cargoCapacity";
+                            maxHp: "maxHp";
+                            maxAp: "maxAp";
+                            inventorySlots: "inventorySlots";
+                        }>;
+                    }, z.core.$strict>]>;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        pilot: "pilot";
+                        pilotedMech: "pilotedMech";
+                        crawler: "crawler";
+                    }>>;
+                    stacks: z.ZodOptional<z.ZodBoolean>;
+                    voidWhen: z.ZodOptional<z.ZodEnum<{
+                        damaged: "damaged";
+                        destroyed: "destroyed";
+                    }>>;
+                    duration: z.ZodOptional<z.ZodEnum<{
+                        permanent: "permanent";
+                        activated: "activated";
+                    }>>;
+                    note: z.ZodOptional<z.ZodString>;
+                }, z.core.$strict>>>;
                 actions: z.ZodArray<z.ZodString>;
             }, z.core.$strip>>;
         }, z.core.$strict>], "kind">>;
@@ -4087,6 +4232,51 @@ export declare const CrawlerBaySchema: z.ZodObject<{
                     heatCapacity: z.ZodOptional<z.ZodNumber>;
                     cargoCapacity: z.ZodOptional<z.ZodNumber>;
                 }, z.core.$strict>>;
+                contributions: z.ZodOptional<z.ZodArray<z.ZodObject<{
+                    stat: z.ZodEnum<{
+                        structurePoints: "structurePoints";
+                        energyPoints: "energyPoints";
+                        heatCapacity: "heatCapacity";
+                        systemSlots: "systemSlots";
+                        moduleSlots: "moduleSlots";
+                        cargoCapacity: "cargoCapacity";
+                        maxHp: "maxHp";
+                        maxAp: "maxAp";
+                        inventorySlots: "inventorySlots";
+                    }>;
+                    amount: z.ZodUnion<readonly [z.ZodNumber, z.ZodObject<{
+                        flat: z.ZodOptional<z.ZodNumber>;
+                        perTechLevel: z.ZodNumber;
+                    }, z.core.$strict>, z.ZodObject<{
+                        fromStat: z.ZodEnum<{
+                            structurePoints: "structurePoints";
+                            energyPoints: "energyPoints";
+                            heatCapacity: "heatCapacity";
+                            systemSlots: "systemSlots";
+                            moduleSlots: "moduleSlots";
+                            cargoCapacity: "cargoCapacity";
+                            maxHp: "maxHp";
+                            maxAp: "maxAp";
+                            inventorySlots: "inventorySlots";
+                        }>;
+                    }, z.core.$strict>]>;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        pilot: "pilot";
+                        pilotedMech: "pilotedMech";
+                        crawler: "crawler";
+                    }>>;
+                    stacks: z.ZodOptional<z.ZodBoolean>;
+                    voidWhen: z.ZodOptional<z.ZodEnum<{
+                        damaged: "damaged";
+                        destroyed: "destroyed";
+                    }>>;
+                    duration: z.ZodOptional<z.ZodEnum<{
+                        permanent: "permanent";
+                        activated: "activated";
+                    }>>;
+                    note: z.ZodOptional<z.ZodString>;
+                }, z.core.$strict>>>;
                 actions: z.ZodArray<z.ZodString>;
             }, z.core.$strip>>;
         }, z.core.$strict>], "kind">>;
@@ -4682,6 +4872,51 @@ export declare const DroneSchema: z.ZodObject<{
                     heatCapacity: z.ZodOptional<z.ZodNumber>;
                     cargoCapacity: z.ZodOptional<z.ZodNumber>;
                 }, z.core.$strict>>;
+                contributions: z.ZodOptional<z.ZodArray<z.ZodObject<{
+                    stat: z.ZodEnum<{
+                        structurePoints: "structurePoints";
+                        energyPoints: "energyPoints";
+                        heatCapacity: "heatCapacity";
+                        systemSlots: "systemSlots";
+                        moduleSlots: "moduleSlots";
+                        cargoCapacity: "cargoCapacity";
+                        maxHp: "maxHp";
+                        maxAp: "maxAp";
+                        inventorySlots: "inventorySlots";
+                    }>;
+                    amount: z.ZodUnion<readonly [z.ZodNumber, z.ZodObject<{
+                        flat: z.ZodOptional<z.ZodNumber>;
+                        perTechLevel: z.ZodNumber;
+                    }, z.core.$strict>, z.ZodObject<{
+                        fromStat: z.ZodEnum<{
+                            structurePoints: "structurePoints";
+                            energyPoints: "energyPoints";
+                            heatCapacity: "heatCapacity";
+                            systemSlots: "systemSlots";
+                            moduleSlots: "moduleSlots";
+                            cargoCapacity: "cargoCapacity";
+                            maxHp: "maxHp";
+                            maxAp: "maxAp";
+                            inventorySlots: "inventorySlots";
+                        }>;
+                    }, z.core.$strict>]>;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        pilot: "pilot";
+                        pilotedMech: "pilotedMech";
+                        crawler: "crawler";
+                    }>>;
+                    stacks: z.ZodOptional<z.ZodBoolean>;
+                    voidWhen: z.ZodOptional<z.ZodEnum<{
+                        damaged: "damaged";
+                        destroyed: "destroyed";
+                    }>>;
+                    duration: z.ZodOptional<z.ZodEnum<{
+                        permanent: "permanent";
+                        activated: "activated";
+                    }>>;
+                    note: z.ZodOptional<z.ZodString>;
+                }, z.core.$strict>>>;
                 actions: z.ZodArray<z.ZodString>;
             }, z.core.$strip>>;
         }, z.core.$strict>], "kind">>;
@@ -4818,6 +5053,51 @@ export declare const DroneSchema: z.ZodObject<{
                     heatCapacity: z.ZodOptional<z.ZodNumber>;
                     cargoCapacity: z.ZodOptional<z.ZodNumber>;
                 }, z.core.$strict>>;
+                contributions: z.ZodOptional<z.ZodArray<z.ZodObject<{
+                    stat: z.ZodEnum<{
+                        structurePoints: "structurePoints";
+                        energyPoints: "energyPoints";
+                        heatCapacity: "heatCapacity";
+                        systemSlots: "systemSlots";
+                        moduleSlots: "moduleSlots";
+                        cargoCapacity: "cargoCapacity";
+                        maxHp: "maxHp";
+                        maxAp: "maxAp";
+                        inventorySlots: "inventorySlots";
+                    }>;
+                    amount: z.ZodUnion<readonly [z.ZodNumber, z.ZodObject<{
+                        flat: z.ZodOptional<z.ZodNumber>;
+                        perTechLevel: z.ZodNumber;
+                    }, z.core.$strict>, z.ZodObject<{
+                        fromStat: z.ZodEnum<{
+                            structurePoints: "structurePoints";
+                            energyPoints: "energyPoints";
+                            heatCapacity: "heatCapacity";
+                            systemSlots: "systemSlots";
+                            moduleSlots: "moduleSlots";
+                            cargoCapacity: "cargoCapacity";
+                            maxHp: "maxHp";
+                            maxAp: "maxAp";
+                            inventorySlots: "inventorySlots";
+                        }>;
+                    }, z.core.$strict>]>;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        pilot: "pilot";
+                        pilotedMech: "pilotedMech";
+                        crawler: "crawler";
+                    }>>;
+                    stacks: z.ZodOptional<z.ZodBoolean>;
+                    voidWhen: z.ZodOptional<z.ZodEnum<{
+                        damaged: "damaged";
+                        destroyed: "destroyed";
+                    }>>;
+                    duration: z.ZodOptional<z.ZodEnum<{
+                        permanent: "permanent";
+                        activated: "activated";
+                    }>>;
+                    note: z.ZodOptional<z.ZodString>;
+                }, z.core.$strict>>>;
                 actions: z.ZodArray<z.ZodString>;
             }, z.core.$strip>>;
         }, z.core.$strict>], "kind">>;
@@ -5044,6 +5324,51 @@ export declare const EquipmentSchema: z.ZodObject<{
                     heatCapacity: z.ZodOptional<z.ZodNumber>;
                     cargoCapacity: z.ZodOptional<z.ZodNumber>;
                 }, z.core.$strict>>;
+                contributions: z.ZodOptional<z.ZodArray<z.ZodObject<{
+                    stat: z.ZodEnum<{
+                        structurePoints: "structurePoints";
+                        energyPoints: "energyPoints";
+                        heatCapacity: "heatCapacity";
+                        systemSlots: "systemSlots";
+                        moduleSlots: "moduleSlots";
+                        cargoCapacity: "cargoCapacity";
+                        maxHp: "maxHp";
+                        maxAp: "maxAp";
+                        inventorySlots: "inventorySlots";
+                    }>;
+                    amount: z.ZodUnion<readonly [z.ZodNumber, z.ZodObject<{
+                        flat: z.ZodOptional<z.ZodNumber>;
+                        perTechLevel: z.ZodNumber;
+                    }, z.core.$strict>, z.ZodObject<{
+                        fromStat: z.ZodEnum<{
+                            structurePoints: "structurePoints";
+                            energyPoints: "energyPoints";
+                            heatCapacity: "heatCapacity";
+                            systemSlots: "systemSlots";
+                            moduleSlots: "moduleSlots";
+                            cargoCapacity: "cargoCapacity";
+                            maxHp: "maxHp";
+                            maxAp: "maxAp";
+                            inventorySlots: "inventorySlots";
+                        }>;
+                    }, z.core.$strict>]>;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        pilot: "pilot";
+                        pilotedMech: "pilotedMech";
+                        crawler: "crawler";
+                    }>>;
+                    stacks: z.ZodOptional<z.ZodBoolean>;
+                    voidWhen: z.ZodOptional<z.ZodEnum<{
+                        damaged: "damaged";
+                        destroyed: "destroyed";
+                    }>>;
+                    duration: z.ZodOptional<z.ZodEnum<{
+                        permanent: "permanent";
+                        activated: "activated";
+                    }>>;
+                    note: z.ZodOptional<z.ZodString>;
+                }, z.core.$strict>>>;
                 actions: z.ZodArray<z.ZodString>;
             }, z.core.$strip>>;
         }, z.core.$strict>], "kind">>;
@@ -5180,6 +5505,51 @@ export declare const EquipmentSchema: z.ZodObject<{
                     heatCapacity: z.ZodOptional<z.ZodNumber>;
                     cargoCapacity: z.ZodOptional<z.ZodNumber>;
                 }, z.core.$strict>>;
+                contributions: z.ZodOptional<z.ZodArray<z.ZodObject<{
+                    stat: z.ZodEnum<{
+                        structurePoints: "structurePoints";
+                        energyPoints: "energyPoints";
+                        heatCapacity: "heatCapacity";
+                        systemSlots: "systemSlots";
+                        moduleSlots: "moduleSlots";
+                        cargoCapacity: "cargoCapacity";
+                        maxHp: "maxHp";
+                        maxAp: "maxAp";
+                        inventorySlots: "inventorySlots";
+                    }>;
+                    amount: z.ZodUnion<readonly [z.ZodNumber, z.ZodObject<{
+                        flat: z.ZodOptional<z.ZodNumber>;
+                        perTechLevel: z.ZodNumber;
+                    }, z.core.$strict>, z.ZodObject<{
+                        fromStat: z.ZodEnum<{
+                            structurePoints: "structurePoints";
+                            energyPoints: "energyPoints";
+                            heatCapacity: "heatCapacity";
+                            systemSlots: "systemSlots";
+                            moduleSlots: "moduleSlots";
+                            cargoCapacity: "cargoCapacity";
+                            maxHp: "maxHp";
+                            maxAp: "maxAp";
+                            inventorySlots: "inventorySlots";
+                        }>;
+                    }, z.core.$strict>]>;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        pilot: "pilot";
+                        pilotedMech: "pilotedMech";
+                        crawler: "crawler";
+                    }>>;
+                    stacks: z.ZodOptional<z.ZodBoolean>;
+                    voidWhen: z.ZodOptional<z.ZodEnum<{
+                        damaged: "damaged";
+                        destroyed: "destroyed";
+                    }>>;
+                    duration: z.ZodOptional<z.ZodEnum<{
+                        permanent: "permanent";
+                        activated: "activated";
+                    }>>;
+                    note: z.ZodOptional<z.ZodString>;
+                }, z.core.$strict>>>;
                 actions: z.ZodArray<z.ZodString>;
             }, z.core.$strip>>;
         }, z.core.$strict>], "kind">>;
@@ -5528,6 +5898,51 @@ export declare const ModuleSchema: z.ZodObject<{
         heatCapacity: z.ZodOptional<z.ZodNumber>;
         cargoCapacity: z.ZodOptional<z.ZodNumber>;
     }, z.core.$strict>>;
+    contributions: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        stat: z.ZodEnum<{
+            structurePoints: "structurePoints";
+            energyPoints: "energyPoints";
+            heatCapacity: "heatCapacity";
+            systemSlots: "systemSlots";
+            moduleSlots: "moduleSlots";
+            cargoCapacity: "cargoCapacity";
+            maxHp: "maxHp";
+            maxAp: "maxAp";
+            inventorySlots: "inventorySlots";
+        }>;
+        amount: z.ZodUnion<readonly [z.ZodNumber, z.ZodObject<{
+            flat: z.ZodOptional<z.ZodNumber>;
+            perTechLevel: z.ZodNumber;
+        }, z.core.$strict>, z.ZodObject<{
+            fromStat: z.ZodEnum<{
+                structurePoints: "structurePoints";
+                energyPoints: "energyPoints";
+                heatCapacity: "heatCapacity";
+                systemSlots: "systemSlots";
+                moduleSlots: "moduleSlots";
+                cargoCapacity: "cargoCapacity";
+                maxHp: "maxHp";
+                maxAp: "maxAp";
+                inventorySlots: "inventorySlots";
+            }>;
+        }, z.core.$strict>]>;
+        target: z.ZodOptional<z.ZodEnum<{
+            self: "self";
+            pilot: "pilot";
+            pilotedMech: "pilotedMech";
+            crawler: "crawler";
+        }>>;
+        stacks: z.ZodOptional<z.ZodBoolean>;
+        voidWhen: z.ZodOptional<z.ZodEnum<{
+            damaged: "damaged";
+            destroyed: "destroyed";
+        }>>;
+        duration: z.ZodOptional<z.ZodEnum<{
+            permanent: "permanent";
+            activated: "activated";
+        }>>;
+        note: z.ZodOptional<z.ZodString>;
+    }, z.core.$strict>>>;
     actions: z.ZodArray<z.ZodString>;
 }, z.core.$strict>;
 /**
@@ -6532,6 +6947,51 @@ export declare const SystemSchema: z.ZodObject<{
         heatCapacity: z.ZodOptional<z.ZodNumber>;
         cargoCapacity: z.ZodOptional<z.ZodNumber>;
     }, z.core.$strict>>;
+    contributions: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        stat: z.ZodEnum<{
+            structurePoints: "structurePoints";
+            energyPoints: "energyPoints";
+            heatCapacity: "heatCapacity";
+            systemSlots: "systemSlots";
+            moduleSlots: "moduleSlots";
+            cargoCapacity: "cargoCapacity";
+            maxHp: "maxHp";
+            maxAp: "maxAp";
+            inventorySlots: "inventorySlots";
+        }>;
+        amount: z.ZodUnion<readonly [z.ZodNumber, z.ZodObject<{
+            flat: z.ZodOptional<z.ZodNumber>;
+            perTechLevel: z.ZodNumber;
+        }, z.core.$strict>, z.ZodObject<{
+            fromStat: z.ZodEnum<{
+                structurePoints: "structurePoints";
+                energyPoints: "energyPoints";
+                heatCapacity: "heatCapacity";
+                systemSlots: "systemSlots";
+                moduleSlots: "moduleSlots";
+                cargoCapacity: "cargoCapacity";
+                maxHp: "maxHp";
+                maxAp: "maxAp";
+                inventorySlots: "inventorySlots";
+            }>;
+        }, z.core.$strict>]>;
+        target: z.ZodOptional<z.ZodEnum<{
+            self: "self";
+            pilot: "pilot";
+            pilotedMech: "pilotedMech";
+            crawler: "crawler";
+        }>>;
+        stacks: z.ZodOptional<z.ZodBoolean>;
+        voidWhen: z.ZodOptional<z.ZodEnum<{
+            damaged: "damaged";
+            destroyed: "destroyed";
+        }>>;
+        duration: z.ZodOptional<z.ZodEnum<{
+            permanent: "permanent";
+            activated: "activated";
+        }>>;
+        note: z.ZodOptional<z.ZodString>;
+    }, z.core.$strict>>>;
     actions: z.ZodArray<z.ZodString>;
 }, z.core.$strict>;
 /**
@@ -8114,6 +8574,18 @@ export declare const ContributionTargetSchema: z.ZodEnum<{
 export declare const ContributionAmountSchema: z.ZodUnion<readonly [z.ZodNumber, z.ZodObject<{
     flat: z.ZodOptional<z.ZodNumber>;
     perTechLevel: z.ZodNumber;
+}, z.core.$strict>, z.ZodObject<{
+    fromStat: z.ZodEnum<{
+        structurePoints: "structurePoints";
+        energyPoints: "energyPoints";
+        heatCapacity: "heatCapacity";
+        systemSlots: "systemSlots";
+        moduleSlots: "moduleSlots";
+        cargoCapacity: "cargoCapacity";
+        maxHp: "maxHp";
+        maxAp: "maxAp";
+        inventorySlots: "inventorySlots";
+    }>;
 }, z.core.$strict>]>;
 /**
  * A single mechanical contribution a piece of content makes to a stat
@@ -8145,6 +8617,18 @@ export declare const ContributionSchema: z.ZodObject<{
     amount: z.ZodUnion<readonly [z.ZodNumber, z.ZodObject<{
         flat: z.ZodOptional<z.ZodNumber>;
         perTechLevel: z.ZodNumber;
+    }, z.core.$strict>, z.ZodObject<{
+        fromStat: z.ZodEnum<{
+            structurePoints: "structurePoints";
+            energyPoints: "energyPoints";
+            heatCapacity: "heatCapacity";
+            systemSlots: "systemSlots";
+            moduleSlots: "moduleSlots";
+            cargoCapacity: "cargoCapacity";
+            maxHp: "maxHp";
+            maxAp: "maxAp";
+            inventorySlots: "inventorySlots";
+        }>;
     }, z.core.$strict>]>;
     target: z.ZodOptional<z.ZodEnum<{
         self: "self";
@@ -8156,6 +8640,10 @@ export declare const ContributionSchema: z.ZodObject<{
     voidWhen: z.ZodOptional<z.ZodEnum<{
         damaged: "damaged";
         destroyed: "destroyed";
+    }>>;
+    duration: z.ZodOptional<z.ZodEnum<{
+        permanent: "permanent";
+        activated: "activated";
     }>>;
     note: z.ZodOptional<z.ZodString>;
 }, z.core.$strict>;
@@ -8181,6 +8669,51 @@ export declare const SystemModuleSchema: z.ZodObject<{
         heatCapacity: z.ZodOptional<z.ZodNumber>;
         cargoCapacity: z.ZodOptional<z.ZodNumber>;
     }, z.core.$strict>>;
+    contributions: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        stat: z.ZodEnum<{
+            structurePoints: "structurePoints";
+            energyPoints: "energyPoints";
+            heatCapacity: "heatCapacity";
+            systemSlots: "systemSlots";
+            moduleSlots: "moduleSlots";
+            cargoCapacity: "cargoCapacity";
+            maxHp: "maxHp";
+            maxAp: "maxAp";
+            inventorySlots: "inventorySlots";
+        }>;
+        amount: z.ZodUnion<readonly [z.ZodNumber, z.ZodObject<{
+            flat: z.ZodOptional<z.ZodNumber>;
+            perTechLevel: z.ZodNumber;
+        }, z.core.$strict>, z.ZodObject<{
+            fromStat: z.ZodEnum<{
+                structurePoints: "structurePoints";
+                energyPoints: "energyPoints";
+                heatCapacity: "heatCapacity";
+                systemSlots: "systemSlots";
+                moduleSlots: "moduleSlots";
+                cargoCapacity: "cargoCapacity";
+                maxHp: "maxHp";
+                maxAp: "maxAp";
+                inventorySlots: "inventorySlots";
+            }>;
+        }, z.core.$strict>]>;
+        target: z.ZodOptional<z.ZodEnum<{
+            self: "self";
+            pilot: "pilot";
+            pilotedMech: "pilotedMech";
+            crawler: "crawler";
+        }>>;
+        stacks: z.ZodOptional<z.ZodBoolean>;
+        voidWhen: z.ZodOptional<z.ZodEnum<{
+            damaged: "damaged";
+            destroyed: "destroyed";
+        }>>;
+        duration: z.ZodOptional<z.ZodEnum<{
+            permanent: "permanent";
+            activated: "activated";
+        }>>;
+        note: z.ZodOptional<z.ZodString>;
+    }, z.core.$strict>>>;
     actions: z.ZodArray<z.ZodString>;
 }, z.core.$strip>;
 /**
@@ -8362,6 +8895,51 @@ declare const ChoiceSourceSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
             heatCapacity: z.ZodOptional<z.ZodNumber>;
             cargoCapacity: z.ZodOptional<z.ZodNumber>;
         }, z.core.$strict>>;
+        contributions: z.ZodOptional<z.ZodArray<z.ZodObject<{
+            stat: z.ZodEnum<{
+                structurePoints: "structurePoints";
+                energyPoints: "energyPoints";
+                heatCapacity: "heatCapacity";
+                systemSlots: "systemSlots";
+                moduleSlots: "moduleSlots";
+                cargoCapacity: "cargoCapacity";
+                maxHp: "maxHp";
+                maxAp: "maxAp";
+                inventorySlots: "inventorySlots";
+            }>;
+            amount: z.ZodUnion<readonly [z.ZodNumber, z.ZodObject<{
+                flat: z.ZodOptional<z.ZodNumber>;
+                perTechLevel: z.ZodNumber;
+            }, z.core.$strict>, z.ZodObject<{
+                fromStat: z.ZodEnum<{
+                    structurePoints: "structurePoints";
+                    energyPoints: "energyPoints";
+                    heatCapacity: "heatCapacity";
+                    systemSlots: "systemSlots";
+                    moduleSlots: "moduleSlots";
+                    cargoCapacity: "cargoCapacity";
+                    maxHp: "maxHp";
+                    maxAp: "maxAp";
+                    inventorySlots: "inventorySlots";
+                }>;
+            }, z.core.$strict>]>;
+            target: z.ZodOptional<z.ZodEnum<{
+                self: "self";
+                pilot: "pilot";
+                pilotedMech: "pilotedMech";
+                crawler: "crawler";
+            }>>;
+            stacks: z.ZodOptional<z.ZodBoolean>;
+            voidWhen: z.ZodOptional<z.ZodEnum<{
+                damaged: "damaged";
+                destroyed: "destroyed";
+            }>>;
+            duration: z.ZodOptional<z.ZodEnum<{
+                permanent: "permanent";
+                activated: "activated";
+            }>>;
+            note: z.ZodOptional<z.ZodString>;
+        }, z.core.$strict>>>;
         actions: z.ZodArray<z.ZodString>;
     }, z.core.$strip>>;
 }, z.core.$strict>], "kind">;

--- a/packages/salvageunion-reference/lib/rules/contributions.test.ts
+++ b/packages/salvageunion-reference/lib/rules/contributions.test.ts
@@ -176,3 +176,52 @@ describe('named sources stay attributable', () => {
     expect(parts.total).toBe(11) // 10 − 1 + 2
   })
 })
+
+describe('activated contributions — manual expiry (F1)', () => {
+  // Salvage Union states real durations ("lasts for 1 hour"), but the app has no
+  // play clock: inventing one would put wall-time into the data layer and make a
+  // sheet's numbers change while nobody is looking. The table keeps time, the
+  // app keeps state — so an activated effect applies only while switched on.
+  const mech = { chassisRef: 'no-such-chassis', modules: ['Hull Magnetiser'] }
+  const chassis = { cargoCapacity: 6, systemSlots: 15 }
+
+  it('an activated ability contributes NOTHING while switched off', () => {
+    expect(
+      sumContributions(abilityContributions(['Squeeze it in'], 'pilotedMech', 'cargoCapacity'))
+    ).toBe(0)
+  })
+
+  it('and contributes once switched on', () => {
+    const on = abilityContributions(['Squeeze it in'], 'pilotedMech', 'cargoCapacity', undefined, {
+      'Squeeze it in': true,
+    })
+    expect(sumContributions(on)).toBe(4)
+    expect(on[0]?.source).toBe('Squeeze it in')
+  })
+
+  it('a permanent contribution is unaffected by the active map', () => {
+    expect(
+      sumContributions(abilityContributions(['Bionic Legs'], 'pilot', 'maxHp', undefined, {}))
+    ).toBe(2)
+  })
+
+  it("Hull Magnetiser resolves its amount FROM the mech's System Slot Value", () => {
+    // "increases your Mech's Cargo Capacity by its System Slot Value" — a number
+    // that changes with the chassis, so it cannot be written as a constant.
+    const off = mechMaxCargoParts(mech, chassis)
+    expect(off.total).toBe(6)
+
+    const on = mechMaxCargoParts(mech, chassis, { active: { 'Hull Magnetiser': true } })
+    expect(on.total).toBe(6 + 15)
+    expect(on.sources[0]?.source).toBe('Hull Magnetiser')
+  })
+
+  it('a fromStat amount with no stat available resolves to 0, never a guess', () => {
+    const on = mechMaxCargoParts(
+      mech,
+      { cargoCapacity: 6 },
+      { active: { 'Hull Magnetiser': true } }
+    )
+    expect(on.total).toBe(6)
+  })
+})

--- a/packages/salvageunion-reference/lib/rules/contributions.ts
+++ b/packages/salvageunion-reference/lib/rules/contributions.ts
@@ -12,7 +12,7 @@
  */
 
 import { SalvageUnionReference } from '../index.js'
-import { matchesRef } from './resolveRefs.js'
+import { matchesRef, resolveInstalledRef } from './resolveRefs.js'
 
 /** The stat keys a contribution may target. Mirrors `ContributionStatSchema`. */
 export type ContributionStat =
@@ -28,7 +28,10 @@ export type ContributionStat =
 
 export type ContributionTarget = 'self' | 'pilot' | 'pilotedMech' | 'crawler'
 
-export type ContributionAmount = number | { flat?: number; perTechLevel: number }
+export type ContributionAmount =
+  | number
+  | { flat?: number; perTechLevel: number }
+  | { fromStat: ContributionStat }
 
 /** A contribution as declared on a piece of reference content. */
 export type DeclaredContribution = {
@@ -37,6 +40,8 @@ export type DeclaredContribution = {
   target?: ContributionTarget
   stacks?: boolean
   voidWhen?: 'damaged' | 'destroyed'
+  /** `activated` applies only while switched on in Guided Play (ADR-019). */
+  duration?: 'permanent' | 'activated'
   note?: string
 }
 
@@ -60,8 +65,17 @@ export type ResolvedContribution = {
  * resolves it to the flat part rather than guessing, so an unknown tech level
  * under-counts visibly instead of inventing a number.
  */
-export function resolveAmount(amount: ContributionAmount, techLevel?: number): number {
+export function resolveAmount(
+  amount: ContributionAmount,
+  techLevel?: number,
+  stats?: Partial<Record<ContributionStat, number>>
+): number {
   if (typeof amount === 'number') return amount
+  if ('fromStat' in amount) {
+    // The amount IS another of the target's stats (Hull Magnetiser: Cargo by
+    // System Slot Value). An unknown stat resolves to 0 rather than a guess.
+    return stats?.[amount.fromStat] ?? 0
+  }
   const flat = amount.flat ?? 0
   if (techLevel === undefined) return flat
   return flat + amount.perTechLevel * techLevel
@@ -76,11 +90,32 @@ type ContributionHost = { name?: string; contributions?: DeclaredContribution[] 
  * Abilities do not stack per copy — holding an ability twice is not a thing —
  * so each resolved contribution is one copy.
  */
+/**
+ * Which `duration: 'activated'` contributions are currently switched on.
+ *
+ * Manual expiry by design: a player toggles an activated effect on and off.
+ * Salvage Union states real durations ("this effect lasts for 1 hour"), but the
+ * app has no play clock and inventing one would put time into the data layer —
+ * so the table keeps time and the app keeps state, which is the same division
+ * ADR-001's honour system already relies on.
+ *
+ * Ephemeral (ADR-019): this lives in play state and is never persisted.
+ */
+export type ActiveEffects = Readonly<Record<string, boolean>>
+
+/** True when a contribution applies right now. */
+function isLive(c: DeclaredContribution, ref: string, active: ActiveEffects | undefined): boolean {
+  if ((c.duration ?? 'permanent') === 'permanent') return true
+  return active?.[ref] === true
+}
+
 export function abilityContributions(
   abilityRefs: readonly string[] | undefined,
   target: ContributionTarget,
   stat: ContributionStat,
-  techLevel?: number
+  techLevel?: number,
+  active?: ActiveEffects,
+  stats?: Partial<Record<ContributionStat, number>>
 ): ResolvedContribution[] {
   if (!abilityRefs?.length) return []
   const out: ResolvedContribution[] = []
@@ -98,7 +133,8 @@ export function abilityContributions(
     for (const c of ability?.contributions ?? []) {
       if (c.stat !== stat) continue
       if ((c.target ?? 'self') !== target) continue
-      const amount = resolveAmount(c.amount, techLevel)
+      if (!isLive(c, ref, active)) continue
+      const amount = resolveAmount(c.amount, techLevel, stats)
       if (amount === 0) continue
       out.push({
         source: ability?.name ?? ref,
@@ -115,4 +151,57 @@ export function abilityContributions(
 /** Sum of resolved contributions — the number a derivation folds in. */
 export function sumContributions(contributions: readonly ResolvedContribution[]): number {
   return contributions.reduce((total, c) => total + c.amount, 0)
+}
+
+/**
+ * Contributions declared by the mech's own installed systems and modules.
+ *
+ * Distinct from `statBonus`, which is a flat per-copy number with no target,
+ * duration or expression. An installed item's contribution targets `self` — the
+ * host mech — so `target` is not consulted here.
+ *
+ * `stats` supplies the host's own values for `fromStat` amounts: Hull
+ * Magnetiser raises Cargo "by its System Slot Value", a number that changes
+ * with the chassis and so cannot be written as a constant.
+ */
+export function installedContributions(
+  installedRefs: readonly string[] | undefined,
+  stat: ContributionStat,
+  options?: {
+    techLevel?: number
+    active?: ActiveEffects
+    stats?: Partial<Record<ContributionStat, number>>
+  }
+): ResolvedContribution[] {
+  if (!installedRefs?.length) return []
+  const counted = new Map<string, number>()
+  for (const ref of installedRefs) counted.set(ref, (counted.get(ref) ?? 0) + 1)
+
+  const out: ResolvedContribution[] = []
+  for (const [ref, copies] of counted) {
+    let item: ContributionHost | undefined
+    try {
+      item = (resolveInstalledRef(ref) ?? undefined) as ContributionHost | undefined
+    } catch {
+      item = undefined
+    }
+    for (const c of item?.contributions ?? []) {
+      if (c.stat !== stat) continue
+      if ((c.target ?? 'self') !== 'self') continue
+      if (!isLive(c, ref, options?.active)) continue
+      const each = resolveAmount(c.amount, options?.techLevel, options?.stats)
+      // `stacks` defaults TRUE for an installed item — two Heat Sinks are two
+      // Heat Sinks — matching statBonus's per-copy semantics.
+      const amount = c.stacks === false ? each : each * copies
+      if (amount === 0) continue
+      out.push({
+        source: item?.name ?? ref,
+        ref,
+        stat,
+        amount,
+        copies: c.stacks === false ? 1 : copies,
+      })
+    }
+  }
+  return out
 }

--- a/packages/salvageunion-reference/lib/rules/derivedStats.ts
+++ b/packages/salvageunion-reference/lib/rules/derivedStats.ts
@@ -22,7 +22,8 @@
 import { SalvageUnionReference } from '../index.js'
 import { crawlerMaxSpBonus } from './creation.js'
 import { resolveChassisRef, resolveInstalledRef } from './resolveRefs.js'
-import { abilityContributions, sumContributions } from './contributions.js'
+import { abilityContributions, installedContributions, sumContributions } from './contributions.js'
+import type { ActiveEffects } from './contributions.js'
 import type { ResolvedContribution } from './contributions.js'
 
 // ---------------------------------------------------------------------------
@@ -137,6 +138,9 @@ export type ChassisStats = {
   energyPoints?: number
   heatCapacity?: number
   cargoCapacity?: number
+  /** Slot counts — read by `fromStat` contributions (Hull Magnetiser). */
+  systemSlots?: number
+  moduleSlots?: number
 }
 
 type MechDerivationInput = {
@@ -168,6 +172,12 @@ export type PilotingContext = {
   abilities?: string[]
   /** The mech's Tech Level, for `perTechLevel` amounts (Beefcake's 3+X). */
   techLevel?: number
+  /**
+   * Which `duration: 'activated'` contributions are switched on right now
+   * (F1). Ephemeral play state, never persisted — an activated effect that is
+   * off contributes nothing, exactly as if it were absent.
+   */
+  active?: ActiveEffects
 }
 
 /**
@@ -288,7 +298,24 @@ export function mechMaxSPParts(
     installedStatBonus(mech, 'structurePoints'),
     mech.maxSpModifier ?? 0,
     mech.maxSpOverride,
-    abilityContributions(pilot?.abilities, 'pilotedMech', 'structurePoints', pilot?.techLevel)
+    [
+      ...abilityContributions(
+        pilot?.abilities,
+        'pilotedMech',
+        'structurePoints',
+        pilot?.techLevel,
+        pilot?.active
+      ),
+      ...installedContributions(
+        [...(mech.systems ?? []), ...(mech.modules ?? [])],
+        'structurePoints',
+        {
+          techLevel: pilot?.techLevel,
+          active: pilot?.active,
+          stats: { systemSlots: c.systemSlots ?? 0, moduleSlots: c.moduleSlots ?? 0 },
+        }
+      ),
+    ]
   )
 }
 
@@ -303,7 +330,24 @@ export function mechMaxEPParts(
     installedStatBonus(mech, 'energyPoints'),
     mech.maxEpModifier ?? 0,
     mech.maxEpOverride,
-    abilityContributions(pilot?.abilities, 'pilotedMech', 'energyPoints', pilot?.techLevel)
+    [
+      ...abilityContributions(
+        pilot?.abilities,
+        'pilotedMech',
+        'energyPoints',
+        pilot?.techLevel,
+        pilot?.active
+      ),
+      ...installedContributions(
+        [...(mech.systems ?? []), ...(mech.modules ?? [])],
+        'energyPoints',
+        {
+          techLevel: pilot?.techLevel,
+          active: pilot?.active,
+          stats: { systemSlots: c.systemSlots ?? 0, moduleSlots: c.moduleSlots ?? 0 },
+        }
+      ),
+    ]
   )
 }
 
@@ -318,7 +362,24 @@ export function mechMaxHeatParts(
     installedStatBonus(mech, 'heatCapacity'),
     mech.maxHeatModifier ?? 0,
     mech.maxHeatOverride,
-    abilityContributions(pilot?.abilities, 'pilotedMech', 'heatCapacity', pilot?.techLevel)
+    [
+      ...abilityContributions(
+        pilot?.abilities,
+        'pilotedMech',
+        'heatCapacity',
+        pilot?.techLevel,
+        pilot?.active
+      ),
+      ...installedContributions(
+        [...(mech.systems ?? []), ...(mech.modules ?? [])],
+        'heatCapacity',
+        {
+          techLevel: pilot?.techLevel,
+          active: pilot?.active,
+          stats: { systemSlots: c.systemSlots ?? 0, moduleSlots: c.moduleSlots ?? 0 },
+        }
+      ),
+    ]
   )
 }
 
@@ -333,7 +394,24 @@ export function mechMaxCargoParts(
     installedStatBonus(mech, 'cargoCapacity'),
     mech.maxCargoModifier ?? 0,
     mech.maxCargoOverride,
-    abilityContributions(pilot?.abilities, 'pilotedMech', 'cargoCapacity', pilot?.techLevel)
+    [
+      ...abilityContributions(
+        pilot?.abilities,
+        'pilotedMech',
+        'cargoCapacity',
+        pilot?.techLevel,
+        pilot?.active
+      ),
+      ...installedContributions(
+        [...(mech.systems ?? []), ...(mech.modules ?? [])],
+        'cargoCapacity',
+        {
+          techLevel: pilot?.techLevel,
+          active: pilot?.active,
+          stats: { systemSlots: c.systemSlots ?? 0, moduleSlots: c.moduleSlots ?? 0 },
+        }
+      ),
+    ]
   )
 }
 

--- a/packages/salvageunion-reference/lib/schemas/objects.ts
+++ b/packages/salvageunion-reference/lib/schemas/objects.ts
@@ -481,6 +481,16 @@ export const ContributionAmountSchema = z.union([
       perTechLevel: z.number().int().describe("Multiplied by the target's tech level"),
     })
     .strict(),
+  z
+    .object({
+      /**
+       * The amount IS another of the target's stats. Hull Magnetiser increases
+       * Cargo Capacity "by its System Slot Value" — a number that changes with
+       * the chassis, so it cannot be written as a constant.
+       */
+      fromStat: ContributionStatSchema,
+    })
+    .strict(),
 ])
 
 /**
@@ -511,6 +521,14 @@ export const ContributionSchema = z
       .enum(['damaged', 'destroyed'])
       .describe('Condition at which this contribution stops applying')
       .optional(),
+    duration: z
+      .enum(['permanent', 'activated'])
+      .describe(
+        'Permanent (default) applies whenever held/installed. `activated` applies ' +
+          'only while the player has switched it on in Guided Play — ephemeral ' +
+          'play state (ADR-019), never persisted on the entity.'
+      )
+      .optional(),
     note: z.string().describe('Why this is encoded the way it is').optional(),
   })
   .strict()
@@ -532,6 +550,14 @@ export const SystemModuleSchema = StatsSchema.extend({
   statBonus: MechStatBonusSchema.describe(
     'Explicit flat bonuses this item applies to the host mech’s derived maxima, summed per installed copy'
   ).optional(),
+  contributions: z
+    .array(ContributionSchema)
+    .describe(
+      'Contributions this item makes (ADR-029). Distinct from `statBonus`: these ' +
+        'carry a target, a duration and expression amounts, so they cover what a ' +
+        'flat per-copy bonus cannot.'
+    )
+    .optional(),
   actions: z.array(z.string()).describe('Action names this system/module provides'),
 }).describe('A system or module that can be installed on a mech')
 

--- a/packages/salvageunion-reference/schemas/abilities.schema.json
+++ b/packages/salvageunion-reference/schemas/abilities.schema.json
@@ -382,6 +382,27 @@
                   },
                   "required": ["perTechLevel"],
                   "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "fromStat": {
+                      "type": "string",
+                      "enum": [
+                        "structurePoints",
+                        "energyPoints",
+                        "heatCapacity",
+                        "cargoCapacity",
+                        "systemSlots",
+                        "moduleSlots",
+                        "maxHp",
+                        "maxAp",
+                        "inventorySlots"
+                      ]
+                    }
+                  },
+                  "required": ["fromStat"],
+                  "additionalProperties": false
                 }
               ]
             },
@@ -398,6 +419,11 @@
               "type": "string",
               "enum": ["damaged", "destroyed"],
               "description": "Condition at which this contribution stops applying"
+            },
+            "duration": {
+              "type": "string",
+              "enum": ["permanent", "activated"],
+              "description": "Permanent (default) applies whenever held/installed. `activated` applies only while the player has switched it on in Guided Play — ephemeral play state (ADR-019), never persisted on the entity."
             },
             "note": { "type": "string", "description": "Why this is encoded the way it is" }
           },

--- a/packages/salvageunion-reference/schemas/actions.schema.json
+++ b/packages/salvageunion-reference/schemas/actions.schema.json
@@ -551,6 +551,104 @@
                     "additionalProperties": false,
                     "description": "Explicit flat bonuses this item applies to the host mech’s derived maxima, summed per installed copy"
                   },
+                  "contributions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "stat": {
+                          "type": "string",
+                          "enum": [
+                            "structurePoints",
+                            "energyPoints",
+                            "heatCapacity",
+                            "cargoCapacity",
+                            "systemSlots",
+                            "moduleSlots",
+                            "maxHp",
+                            "maxAp",
+                            "inventorySlots"
+                          ]
+                        },
+                        "amount": {
+                          "anyOf": [
+                            {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "flat": {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991,
+                                  "description": "The constant part"
+                                },
+                                "perTechLevel": {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991,
+                                  "description": "Multiplied by the target's tech level"
+                                }
+                              },
+                              "required": ["perTechLevel"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "fromStat": {
+                                  "type": "string",
+                                  "enum": [
+                                    "structurePoints",
+                                    "energyPoints",
+                                    "heatCapacity",
+                                    "cargoCapacity",
+                                    "systemSlots",
+                                    "moduleSlots",
+                                    "maxHp",
+                                    "maxAp",
+                                    "inventorySlots"
+                                  ]
+                                }
+                              },
+                              "required": ["fromStat"],
+                              "additionalProperties": false
+                            }
+                          ]
+                        },
+                        "target": {
+                          "type": "string",
+                          "enum": ["self", "pilot", "pilotedMech", "crawler"],
+                          "description": "Defaults to `self` when absent"
+                        },
+                        "stacks": {
+                          "type": "boolean",
+                          "description": "Applies once per installed copy (default true for installable items)"
+                        },
+                        "voidWhen": {
+                          "type": "string",
+                          "enum": ["damaged", "destroyed"],
+                          "description": "Condition at which this contribution stops applying"
+                        },
+                        "duration": {
+                          "type": "string",
+                          "enum": ["permanent", "activated"],
+                          "description": "Permanent (default) applies whenever held/installed. `activated` applies only while the player has switched it on in Guided Play — ephemeral play state (ADR-019), never persisted on the entity."
+                        },
+                        "note": {
+                          "type": "string",
+                          "description": "Why this is encoded the way it is"
+                        }
+                      },
+                      "required": ["stat", "amount"],
+                      "additionalProperties": false,
+                      "description": "A flat mechanical contribution this content makes to a stat"
+                    },
+                    "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
+                  },
                   "actions": {
                     "type": "array",
                     "items": { "type": "string" },
@@ -921,6 +1019,104 @@
                             },
                             "additionalProperties": false,
                             "description": "Explicit flat bonuses this item applies to the host mech’s derived maxima, summed per installed copy"
+                          },
+                          "contributions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "stat": {
+                                  "type": "string",
+                                  "enum": [
+                                    "structurePoints",
+                                    "energyPoints",
+                                    "heatCapacity",
+                                    "cargoCapacity",
+                                    "systemSlots",
+                                    "moduleSlots",
+                                    "maxHp",
+                                    "maxAp",
+                                    "inventorySlots"
+                                  ]
+                                },
+                                "amount": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer",
+                                      "minimum": -9007199254740991,
+                                      "maximum": 9007199254740991
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "flat": {
+                                          "type": "integer",
+                                          "minimum": -9007199254740991,
+                                          "maximum": 9007199254740991,
+                                          "description": "The constant part"
+                                        },
+                                        "perTechLevel": {
+                                          "type": "integer",
+                                          "minimum": -9007199254740991,
+                                          "maximum": 9007199254740991,
+                                          "description": "Multiplied by the target's tech level"
+                                        }
+                                      },
+                                      "required": ["perTechLevel"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "fromStat": {
+                                          "type": "string",
+                                          "enum": [
+                                            "structurePoints",
+                                            "energyPoints",
+                                            "heatCapacity",
+                                            "cargoCapacity",
+                                            "systemSlots",
+                                            "moduleSlots",
+                                            "maxHp",
+                                            "maxAp",
+                                            "inventorySlots"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["fromStat"],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                },
+                                "target": {
+                                  "type": "string",
+                                  "enum": ["self", "pilot", "pilotedMech", "crawler"],
+                                  "description": "Defaults to `self` when absent"
+                                },
+                                "stacks": {
+                                  "type": "boolean",
+                                  "description": "Applies once per installed copy (default true for installable items)"
+                                },
+                                "voidWhen": {
+                                  "type": "string",
+                                  "enum": ["damaged", "destroyed"],
+                                  "description": "Condition at which this contribution stops applying"
+                                },
+                                "duration": {
+                                  "type": "string",
+                                  "enum": ["permanent", "activated"],
+                                  "description": "Permanent (default) applies whenever held/installed. `activated` applies only while the player has switched it on in Guided Play — ephemeral play state (ADR-019), never persisted on the entity."
+                                },
+                                "note": {
+                                  "type": "string",
+                                  "description": "Why this is encoded the way it is"
+                                }
+                              },
+                              "required": ["stat", "amount"],
+                              "additionalProperties": false,
+                              "description": "A flat mechanical contribution this content makes to a stat"
+                            },
+                            "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
                           },
                           "actions": {
                             "type": "array",

--- a/packages/salvageunion-reference/schemas/crawler-bays.schema.json
+++ b/packages/salvageunion-reference/schemas/crawler-bays.schema.json
@@ -684,6 +684,104 @@
                         "additionalProperties": false,
                         "description": "Explicit flat bonuses this item applies to the host mech’s derived maxima, summed per installed copy"
                       },
+                      "contributions": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "stat": {
+                              "type": "string",
+                              "enum": [
+                                "structurePoints",
+                                "energyPoints",
+                                "heatCapacity",
+                                "cargoCapacity",
+                                "systemSlots",
+                                "moduleSlots",
+                                "maxHp",
+                                "maxAp",
+                                "inventorySlots"
+                              ]
+                            },
+                            "amount": {
+                              "anyOf": [
+                                {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "flat": {
+                                      "type": "integer",
+                                      "minimum": -9007199254740991,
+                                      "maximum": 9007199254740991,
+                                      "description": "The constant part"
+                                    },
+                                    "perTechLevel": {
+                                      "type": "integer",
+                                      "minimum": -9007199254740991,
+                                      "maximum": 9007199254740991,
+                                      "description": "Multiplied by the target's tech level"
+                                    }
+                                  },
+                                  "required": ["perTechLevel"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "fromStat": {
+                                      "type": "string",
+                                      "enum": [
+                                        "structurePoints",
+                                        "energyPoints",
+                                        "heatCapacity",
+                                        "cargoCapacity",
+                                        "systemSlots",
+                                        "moduleSlots",
+                                        "maxHp",
+                                        "maxAp",
+                                        "inventorySlots"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["fromStat"],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "pilot", "pilotedMech", "crawler"],
+                              "description": "Defaults to `self` when absent"
+                            },
+                            "stacks": {
+                              "type": "boolean",
+                              "description": "Applies once per installed copy (default true for installable items)"
+                            },
+                            "voidWhen": {
+                              "type": "string",
+                              "enum": ["damaged", "destroyed"],
+                              "description": "Condition at which this contribution stops applying"
+                            },
+                            "duration": {
+                              "type": "string",
+                              "enum": ["permanent", "activated"],
+                              "description": "Permanent (default) applies whenever held/installed. `activated` applies only while the player has switched it on in Guided Play — ephemeral play state (ADR-019), never persisted on the entity."
+                            },
+                            "note": {
+                              "type": "string",
+                              "description": "Why this is encoded the way it is"
+                            }
+                          },
+                          "required": ["stat", "amount"],
+                          "additionalProperties": false,
+                          "description": "A flat mechanical contribution this content makes to a stat"
+                        },
+                        "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
+                      },
                       "actions": {
                         "type": "array",
                         "items": { "type": "string" },
@@ -1054,6 +1152,104 @@
                                 },
                                 "additionalProperties": false,
                                 "description": "Explicit flat bonuses this item applies to the host mech’s derived maxima, summed per installed copy"
+                              },
+                              "contributions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "stat": {
+                                      "type": "string",
+                                      "enum": [
+                                        "structurePoints",
+                                        "energyPoints",
+                                        "heatCapacity",
+                                        "cargoCapacity",
+                                        "systemSlots",
+                                        "moduleSlots",
+                                        "maxHp",
+                                        "maxAp",
+                                        "inventorySlots"
+                                      ]
+                                    },
+                                    "amount": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer",
+                                          "minimum": -9007199254740991,
+                                          "maximum": 9007199254740991
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "flat": {
+                                              "type": "integer",
+                                              "minimum": -9007199254740991,
+                                              "maximum": 9007199254740991,
+                                              "description": "The constant part"
+                                            },
+                                            "perTechLevel": {
+                                              "type": "integer",
+                                              "minimum": -9007199254740991,
+                                              "maximum": 9007199254740991,
+                                              "description": "Multiplied by the target's tech level"
+                                            }
+                                          },
+                                          "required": ["perTechLevel"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "fromStat": {
+                                              "type": "string",
+                                              "enum": [
+                                                "structurePoints",
+                                                "energyPoints",
+                                                "heatCapacity",
+                                                "cargoCapacity",
+                                                "systemSlots",
+                                                "moduleSlots",
+                                                "maxHp",
+                                                "maxAp",
+                                                "inventorySlots"
+                                              ]
+                                            }
+                                          },
+                                          "required": ["fromStat"],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "target": {
+                                      "type": "string",
+                                      "enum": ["self", "pilot", "pilotedMech", "crawler"],
+                                      "description": "Defaults to `self` when absent"
+                                    },
+                                    "stacks": {
+                                      "type": "boolean",
+                                      "description": "Applies once per installed copy (default true for installable items)"
+                                    },
+                                    "voidWhen": {
+                                      "type": "string",
+                                      "enum": ["damaged", "destroyed"],
+                                      "description": "Condition at which this contribution stops applying"
+                                    },
+                                    "duration": {
+                                      "type": "string",
+                                      "enum": ["permanent", "activated"],
+                                      "description": "Permanent (default) applies whenever held/installed. `activated` applies only while the player has switched it on in Guided Play — ephemeral play state (ADR-019), never persisted on the entity."
+                                    },
+                                    "note": {
+                                      "type": "string",
+                                      "description": "Why this is encoded the way it is"
+                                    }
+                                  },
+                                  "required": ["stat", "amount"],
+                                  "additionalProperties": false,
+                                  "description": "A flat mechanical contribution this content makes to a stat"
+                                },
+                                "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
                               },
                               "actions": {
                                 "type": "array",
@@ -1464,6 +1660,104 @@
                     "additionalProperties": false,
                     "description": "Explicit flat bonuses this item applies to the host mech’s derived maxima, summed per installed copy"
                   },
+                  "contributions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "stat": {
+                          "type": "string",
+                          "enum": [
+                            "structurePoints",
+                            "energyPoints",
+                            "heatCapacity",
+                            "cargoCapacity",
+                            "systemSlots",
+                            "moduleSlots",
+                            "maxHp",
+                            "maxAp",
+                            "inventorySlots"
+                          ]
+                        },
+                        "amount": {
+                          "anyOf": [
+                            {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "flat": {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991,
+                                  "description": "The constant part"
+                                },
+                                "perTechLevel": {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991,
+                                  "description": "Multiplied by the target's tech level"
+                                }
+                              },
+                              "required": ["perTechLevel"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "fromStat": {
+                                  "type": "string",
+                                  "enum": [
+                                    "structurePoints",
+                                    "energyPoints",
+                                    "heatCapacity",
+                                    "cargoCapacity",
+                                    "systemSlots",
+                                    "moduleSlots",
+                                    "maxHp",
+                                    "maxAp",
+                                    "inventorySlots"
+                                  ]
+                                }
+                              },
+                              "required": ["fromStat"],
+                              "additionalProperties": false
+                            }
+                          ]
+                        },
+                        "target": {
+                          "type": "string",
+                          "enum": ["self", "pilot", "pilotedMech", "crawler"],
+                          "description": "Defaults to `self` when absent"
+                        },
+                        "stacks": {
+                          "type": "boolean",
+                          "description": "Applies once per installed copy (default true for installable items)"
+                        },
+                        "voidWhen": {
+                          "type": "string",
+                          "enum": ["damaged", "destroyed"],
+                          "description": "Condition at which this contribution stops applying"
+                        },
+                        "duration": {
+                          "type": "string",
+                          "enum": ["permanent", "activated"],
+                          "description": "Permanent (default) applies whenever held/installed. `activated` applies only while the player has switched it on in Guided Play — ephemeral play state (ADR-019), never persisted on the entity."
+                        },
+                        "note": {
+                          "type": "string",
+                          "description": "Why this is encoded the way it is"
+                        }
+                      },
+                      "required": ["stat", "amount"],
+                      "additionalProperties": false,
+                      "description": "A flat mechanical contribution this content makes to a stat"
+                    },
+                    "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
+                  },
                   "actions": {
                     "type": "array",
                     "items": { "type": "string" },
@@ -1834,6 +2128,104 @@
                             },
                             "additionalProperties": false,
                             "description": "Explicit flat bonuses this item applies to the host mech’s derived maxima, summed per installed copy"
+                          },
+                          "contributions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "stat": {
+                                  "type": "string",
+                                  "enum": [
+                                    "structurePoints",
+                                    "energyPoints",
+                                    "heatCapacity",
+                                    "cargoCapacity",
+                                    "systemSlots",
+                                    "moduleSlots",
+                                    "maxHp",
+                                    "maxAp",
+                                    "inventorySlots"
+                                  ]
+                                },
+                                "amount": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer",
+                                      "minimum": -9007199254740991,
+                                      "maximum": 9007199254740991
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "flat": {
+                                          "type": "integer",
+                                          "minimum": -9007199254740991,
+                                          "maximum": 9007199254740991,
+                                          "description": "The constant part"
+                                        },
+                                        "perTechLevel": {
+                                          "type": "integer",
+                                          "minimum": -9007199254740991,
+                                          "maximum": 9007199254740991,
+                                          "description": "Multiplied by the target's tech level"
+                                        }
+                                      },
+                                      "required": ["perTechLevel"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "fromStat": {
+                                          "type": "string",
+                                          "enum": [
+                                            "structurePoints",
+                                            "energyPoints",
+                                            "heatCapacity",
+                                            "cargoCapacity",
+                                            "systemSlots",
+                                            "moduleSlots",
+                                            "maxHp",
+                                            "maxAp",
+                                            "inventorySlots"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["fromStat"],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                },
+                                "target": {
+                                  "type": "string",
+                                  "enum": ["self", "pilot", "pilotedMech", "crawler"],
+                                  "description": "Defaults to `self` when absent"
+                                },
+                                "stacks": {
+                                  "type": "boolean",
+                                  "description": "Applies once per installed copy (default true for installable items)"
+                                },
+                                "voidWhen": {
+                                  "type": "string",
+                                  "enum": ["damaged", "destroyed"],
+                                  "description": "Condition at which this contribution stops applying"
+                                },
+                                "duration": {
+                                  "type": "string",
+                                  "enum": ["permanent", "activated"],
+                                  "description": "Permanent (default) applies whenever held/installed. `activated` applies only while the player has switched it on in Guided Play — ephemeral play state (ADR-019), never persisted on the entity."
+                                },
+                                "note": {
+                                  "type": "string",
+                                  "description": "Why this is encoded the way it is"
+                                }
+                              },
+                              "required": ["stat", "amount"],
+                              "additionalProperties": false,
+                              "description": "A flat mechanical contribution this content makes to a stat"
+                            },
+                            "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
                           },
                           "actions": {
                             "type": "array",

--- a/packages/salvageunion-reference/schemas/crawlers.schema.json
+++ b/packages/salvageunion-reference/schemas/crawlers.schema.json
@@ -679,6 +679,104 @@
                         "additionalProperties": false,
                         "description": "Explicit flat bonuses this item applies to the host mech’s derived maxima, summed per installed copy"
                       },
+                      "contributions": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "stat": {
+                              "type": "string",
+                              "enum": [
+                                "structurePoints",
+                                "energyPoints",
+                                "heatCapacity",
+                                "cargoCapacity",
+                                "systemSlots",
+                                "moduleSlots",
+                                "maxHp",
+                                "maxAp",
+                                "inventorySlots"
+                              ]
+                            },
+                            "amount": {
+                              "anyOf": [
+                                {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "flat": {
+                                      "type": "integer",
+                                      "minimum": -9007199254740991,
+                                      "maximum": 9007199254740991,
+                                      "description": "The constant part"
+                                    },
+                                    "perTechLevel": {
+                                      "type": "integer",
+                                      "minimum": -9007199254740991,
+                                      "maximum": 9007199254740991,
+                                      "description": "Multiplied by the target's tech level"
+                                    }
+                                  },
+                                  "required": ["perTechLevel"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "fromStat": {
+                                      "type": "string",
+                                      "enum": [
+                                        "structurePoints",
+                                        "energyPoints",
+                                        "heatCapacity",
+                                        "cargoCapacity",
+                                        "systemSlots",
+                                        "moduleSlots",
+                                        "maxHp",
+                                        "maxAp",
+                                        "inventorySlots"
+                                      ]
+                                    }
+                                  },
+                                  "required": ["fromStat"],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "pilot", "pilotedMech", "crawler"],
+                              "description": "Defaults to `self` when absent"
+                            },
+                            "stacks": {
+                              "type": "boolean",
+                              "description": "Applies once per installed copy (default true for installable items)"
+                            },
+                            "voidWhen": {
+                              "type": "string",
+                              "enum": ["damaged", "destroyed"],
+                              "description": "Condition at which this contribution stops applying"
+                            },
+                            "duration": {
+                              "type": "string",
+                              "enum": ["permanent", "activated"],
+                              "description": "Permanent (default) applies whenever held/installed. `activated` applies only while the player has switched it on in Guided Play — ephemeral play state (ADR-019), never persisted on the entity."
+                            },
+                            "note": {
+                              "type": "string",
+                              "description": "Why this is encoded the way it is"
+                            }
+                          },
+                          "required": ["stat", "amount"],
+                          "additionalProperties": false,
+                          "description": "A flat mechanical contribution this content makes to a stat"
+                        },
+                        "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
+                      },
                       "actions": {
                         "type": "array",
                         "items": { "type": "string" },
@@ -1049,6 +1147,104 @@
                                 },
                                 "additionalProperties": false,
                                 "description": "Explicit flat bonuses this item applies to the host mech’s derived maxima, summed per installed copy"
+                              },
+                              "contributions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "stat": {
+                                      "type": "string",
+                                      "enum": [
+                                        "structurePoints",
+                                        "energyPoints",
+                                        "heatCapacity",
+                                        "cargoCapacity",
+                                        "systemSlots",
+                                        "moduleSlots",
+                                        "maxHp",
+                                        "maxAp",
+                                        "inventorySlots"
+                                      ]
+                                    },
+                                    "amount": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer",
+                                          "minimum": -9007199254740991,
+                                          "maximum": 9007199254740991
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "flat": {
+                                              "type": "integer",
+                                              "minimum": -9007199254740991,
+                                              "maximum": 9007199254740991,
+                                              "description": "The constant part"
+                                            },
+                                            "perTechLevel": {
+                                              "type": "integer",
+                                              "minimum": -9007199254740991,
+                                              "maximum": 9007199254740991,
+                                              "description": "Multiplied by the target's tech level"
+                                            }
+                                          },
+                                          "required": ["perTechLevel"],
+                                          "additionalProperties": false
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "fromStat": {
+                                              "type": "string",
+                                              "enum": [
+                                                "structurePoints",
+                                                "energyPoints",
+                                                "heatCapacity",
+                                                "cargoCapacity",
+                                                "systemSlots",
+                                                "moduleSlots",
+                                                "maxHp",
+                                                "maxAp",
+                                                "inventorySlots"
+                                              ]
+                                            }
+                                          },
+                                          "required": ["fromStat"],
+                                          "additionalProperties": false
+                                        }
+                                      ]
+                                    },
+                                    "target": {
+                                      "type": "string",
+                                      "enum": ["self", "pilot", "pilotedMech", "crawler"],
+                                      "description": "Defaults to `self` when absent"
+                                    },
+                                    "stacks": {
+                                      "type": "boolean",
+                                      "description": "Applies once per installed copy (default true for installable items)"
+                                    },
+                                    "voidWhen": {
+                                      "type": "string",
+                                      "enum": ["damaged", "destroyed"],
+                                      "description": "Condition at which this contribution stops applying"
+                                    },
+                                    "duration": {
+                                      "type": "string",
+                                      "enum": ["permanent", "activated"],
+                                      "description": "Permanent (default) applies whenever held/installed. `activated` applies only while the player has switched it on in Guided Play — ephemeral play state (ADR-019), never persisted on the entity."
+                                    },
+                                    "note": {
+                                      "type": "string",
+                                      "description": "Why this is encoded the way it is"
+                                    }
+                                  },
+                                  "required": ["stat", "amount"],
+                                  "additionalProperties": false,
+                                  "description": "A flat mechanical contribution this content makes to a stat"
+                                },
+                                "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
                               },
                               "actions": {
                                 "type": "array",

--- a/packages/salvageunion-reference/schemas/drones.schema.json
+++ b/packages/salvageunion-reference/schemas/drones.schema.json
@@ -674,6 +674,104 @@
                     "additionalProperties": false,
                     "description": "Explicit flat bonuses this item applies to the host mech’s derived maxima, summed per installed copy"
                   },
+                  "contributions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "stat": {
+                          "type": "string",
+                          "enum": [
+                            "structurePoints",
+                            "energyPoints",
+                            "heatCapacity",
+                            "cargoCapacity",
+                            "systemSlots",
+                            "moduleSlots",
+                            "maxHp",
+                            "maxAp",
+                            "inventorySlots"
+                          ]
+                        },
+                        "amount": {
+                          "anyOf": [
+                            {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "flat": {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991,
+                                  "description": "The constant part"
+                                },
+                                "perTechLevel": {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991,
+                                  "description": "Multiplied by the target's tech level"
+                                }
+                              },
+                              "required": ["perTechLevel"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "fromStat": {
+                                  "type": "string",
+                                  "enum": [
+                                    "structurePoints",
+                                    "energyPoints",
+                                    "heatCapacity",
+                                    "cargoCapacity",
+                                    "systemSlots",
+                                    "moduleSlots",
+                                    "maxHp",
+                                    "maxAp",
+                                    "inventorySlots"
+                                  ]
+                                }
+                              },
+                              "required": ["fromStat"],
+                              "additionalProperties": false
+                            }
+                          ]
+                        },
+                        "target": {
+                          "type": "string",
+                          "enum": ["self", "pilot", "pilotedMech", "crawler"],
+                          "description": "Defaults to `self` when absent"
+                        },
+                        "stacks": {
+                          "type": "boolean",
+                          "description": "Applies once per installed copy (default true for installable items)"
+                        },
+                        "voidWhen": {
+                          "type": "string",
+                          "enum": ["damaged", "destroyed"],
+                          "description": "Condition at which this contribution stops applying"
+                        },
+                        "duration": {
+                          "type": "string",
+                          "enum": ["permanent", "activated"],
+                          "description": "Permanent (default) applies whenever held/installed. `activated` applies only while the player has switched it on in Guided Play — ephemeral play state (ADR-019), never persisted on the entity."
+                        },
+                        "note": {
+                          "type": "string",
+                          "description": "Why this is encoded the way it is"
+                        }
+                      },
+                      "required": ["stat", "amount"],
+                      "additionalProperties": false,
+                      "description": "A flat mechanical contribution this content makes to a stat"
+                    },
+                    "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
+                  },
                   "actions": {
                     "type": "array",
                     "items": { "type": "string" },
@@ -1044,6 +1142,104 @@
                             },
                             "additionalProperties": false,
                             "description": "Explicit flat bonuses this item applies to the host mech’s derived maxima, summed per installed copy"
+                          },
+                          "contributions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "stat": {
+                                  "type": "string",
+                                  "enum": [
+                                    "structurePoints",
+                                    "energyPoints",
+                                    "heatCapacity",
+                                    "cargoCapacity",
+                                    "systemSlots",
+                                    "moduleSlots",
+                                    "maxHp",
+                                    "maxAp",
+                                    "inventorySlots"
+                                  ]
+                                },
+                                "amount": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer",
+                                      "minimum": -9007199254740991,
+                                      "maximum": 9007199254740991
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "flat": {
+                                          "type": "integer",
+                                          "minimum": -9007199254740991,
+                                          "maximum": 9007199254740991,
+                                          "description": "The constant part"
+                                        },
+                                        "perTechLevel": {
+                                          "type": "integer",
+                                          "minimum": -9007199254740991,
+                                          "maximum": 9007199254740991,
+                                          "description": "Multiplied by the target's tech level"
+                                        }
+                                      },
+                                      "required": ["perTechLevel"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "fromStat": {
+                                          "type": "string",
+                                          "enum": [
+                                            "structurePoints",
+                                            "energyPoints",
+                                            "heatCapacity",
+                                            "cargoCapacity",
+                                            "systemSlots",
+                                            "moduleSlots",
+                                            "maxHp",
+                                            "maxAp",
+                                            "inventorySlots"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["fromStat"],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                },
+                                "target": {
+                                  "type": "string",
+                                  "enum": ["self", "pilot", "pilotedMech", "crawler"],
+                                  "description": "Defaults to `self` when absent"
+                                },
+                                "stacks": {
+                                  "type": "boolean",
+                                  "description": "Applies once per installed copy (default true for installable items)"
+                                },
+                                "voidWhen": {
+                                  "type": "string",
+                                  "enum": ["damaged", "destroyed"],
+                                  "description": "Condition at which this contribution stops applying"
+                                },
+                                "duration": {
+                                  "type": "string",
+                                  "enum": ["permanent", "activated"],
+                                  "description": "Permanent (default) applies whenever held/installed. `activated` applies only while the player has switched it on in Guided Play — ephemeral play state (ADR-019), never persisted on the entity."
+                                },
+                                "note": {
+                                  "type": "string",
+                                  "description": "Why this is encoded the way it is"
+                                }
+                              },
+                              "required": ["stat", "amount"],
+                              "additionalProperties": false,
+                              "description": "A flat mechanical contribution this content makes to a stat"
+                            },
+                            "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
                           },
                           "actions": {
                             "type": "array",

--- a/packages/salvageunion-reference/schemas/equipment.schema.json
+++ b/packages/salvageunion-reference/schemas/equipment.schema.json
@@ -664,6 +664,104 @@
                     "additionalProperties": false,
                     "description": "Explicit flat bonuses this item applies to the host mech’s derived maxima, summed per installed copy"
                   },
+                  "contributions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "stat": {
+                          "type": "string",
+                          "enum": [
+                            "structurePoints",
+                            "energyPoints",
+                            "heatCapacity",
+                            "cargoCapacity",
+                            "systemSlots",
+                            "moduleSlots",
+                            "maxHp",
+                            "maxAp",
+                            "inventorySlots"
+                          ]
+                        },
+                        "amount": {
+                          "anyOf": [
+                            {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "flat": {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991,
+                                  "description": "The constant part"
+                                },
+                                "perTechLevel": {
+                                  "type": "integer",
+                                  "minimum": -9007199254740991,
+                                  "maximum": 9007199254740991,
+                                  "description": "Multiplied by the target's tech level"
+                                }
+                              },
+                              "required": ["perTechLevel"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "fromStat": {
+                                  "type": "string",
+                                  "enum": [
+                                    "structurePoints",
+                                    "energyPoints",
+                                    "heatCapacity",
+                                    "cargoCapacity",
+                                    "systemSlots",
+                                    "moduleSlots",
+                                    "maxHp",
+                                    "maxAp",
+                                    "inventorySlots"
+                                  ]
+                                }
+                              },
+                              "required": ["fromStat"],
+                              "additionalProperties": false
+                            }
+                          ]
+                        },
+                        "target": {
+                          "type": "string",
+                          "enum": ["self", "pilot", "pilotedMech", "crawler"],
+                          "description": "Defaults to `self` when absent"
+                        },
+                        "stacks": {
+                          "type": "boolean",
+                          "description": "Applies once per installed copy (default true for installable items)"
+                        },
+                        "voidWhen": {
+                          "type": "string",
+                          "enum": ["damaged", "destroyed"],
+                          "description": "Condition at which this contribution stops applying"
+                        },
+                        "duration": {
+                          "type": "string",
+                          "enum": ["permanent", "activated"],
+                          "description": "Permanent (default) applies whenever held/installed. `activated` applies only while the player has switched it on in Guided Play — ephemeral play state (ADR-019), never persisted on the entity."
+                        },
+                        "note": {
+                          "type": "string",
+                          "description": "Why this is encoded the way it is"
+                        }
+                      },
+                      "required": ["stat", "amount"],
+                      "additionalProperties": false,
+                      "description": "A flat mechanical contribution this content makes to a stat"
+                    },
+                    "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
+                  },
                   "actions": {
                     "type": "array",
                     "items": { "type": "string" },
@@ -1034,6 +1132,104 @@
                             },
                             "additionalProperties": false,
                             "description": "Explicit flat bonuses this item applies to the host mech’s derived maxima, summed per installed copy"
+                          },
+                          "contributions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "stat": {
+                                  "type": "string",
+                                  "enum": [
+                                    "structurePoints",
+                                    "energyPoints",
+                                    "heatCapacity",
+                                    "cargoCapacity",
+                                    "systemSlots",
+                                    "moduleSlots",
+                                    "maxHp",
+                                    "maxAp",
+                                    "inventorySlots"
+                                  ]
+                                },
+                                "amount": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer",
+                                      "minimum": -9007199254740991,
+                                      "maximum": 9007199254740991
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "flat": {
+                                          "type": "integer",
+                                          "minimum": -9007199254740991,
+                                          "maximum": 9007199254740991,
+                                          "description": "The constant part"
+                                        },
+                                        "perTechLevel": {
+                                          "type": "integer",
+                                          "minimum": -9007199254740991,
+                                          "maximum": 9007199254740991,
+                                          "description": "Multiplied by the target's tech level"
+                                        }
+                                      },
+                                      "required": ["perTechLevel"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "fromStat": {
+                                          "type": "string",
+                                          "enum": [
+                                            "structurePoints",
+                                            "energyPoints",
+                                            "heatCapacity",
+                                            "cargoCapacity",
+                                            "systemSlots",
+                                            "moduleSlots",
+                                            "maxHp",
+                                            "maxAp",
+                                            "inventorySlots"
+                                          ]
+                                        }
+                                      },
+                                      "required": ["fromStat"],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                },
+                                "target": {
+                                  "type": "string",
+                                  "enum": ["self", "pilot", "pilotedMech", "crawler"],
+                                  "description": "Defaults to `self` when absent"
+                                },
+                                "stacks": {
+                                  "type": "boolean",
+                                  "description": "Applies once per installed copy (default true for installable items)"
+                                },
+                                "voidWhen": {
+                                  "type": "string",
+                                  "enum": ["damaged", "destroyed"],
+                                  "description": "Condition at which this contribution stops applying"
+                                },
+                                "duration": {
+                                  "type": "string",
+                                  "enum": ["permanent", "activated"],
+                                  "description": "Permanent (default) applies whenever held/installed. `activated` applies only while the player has switched it on in Guided Play — ephemeral play state (ADR-019), never persisted on the entity."
+                                },
+                                "note": {
+                                  "type": "string",
+                                  "description": "Why this is encoded the way it is"
+                                }
+                              },
+                              "required": ["stat", "amount"],
+                              "additionalProperties": false,
+                              "description": "A flat mechanical contribution this content makes to a stat"
+                            },
+                            "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
                           },
                           "actions": {
                             "type": "array",

--- a/packages/salvageunion-reference/schemas/modules.schema.json
+++ b/packages/salvageunion-reference/schemas/modules.schema.json
@@ -319,6 +319,97 @@
         "additionalProperties": false,
         "description": "Explicit flat bonuses this item applies to the host mech’s derived maxima, summed per installed copy"
       },
+      "contributions": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "stat": {
+              "type": "string",
+              "enum": [
+                "structurePoints",
+                "energyPoints",
+                "heatCapacity",
+                "cargoCapacity",
+                "systemSlots",
+                "moduleSlots",
+                "maxHp",
+                "maxAp",
+                "inventorySlots"
+              ]
+            },
+            "amount": {
+              "anyOf": [
+                { "type": "integer", "minimum": -9007199254740991, "maximum": 9007199254740991 },
+                {
+                  "type": "object",
+                  "properties": {
+                    "flat": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991,
+                      "description": "The constant part"
+                    },
+                    "perTechLevel": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991,
+                      "description": "Multiplied by the target's tech level"
+                    }
+                  },
+                  "required": ["perTechLevel"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "fromStat": {
+                      "type": "string",
+                      "enum": [
+                        "structurePoints",
+                        "energyPoints",
+                        "heatCapacity",
+                        "cargoCapacity",
+                        "systemSlots",
+                        "moduleSlots",
+                        "maxHp",
+                        "maxAp",
+                        "inventorySlots"
+                      ]
+                    }
+                  },
+                  "required": ["fromStat"],
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "target": {
+              "type": "string",
+              "enum": ["self", "pilot", "pilotedMech", "crawler"],
+              "description": "Defaults to `self` when absent"
+            },
+            "stacks": {
+              "type": "boolean",
+              "description": "Applies once per installed copy (default true for installable items)"
+            },
+            "voidWhen": {
+              "type": "string",
+              "enum": ["damaged", "destroyed"],
+              "description": "Condition at which this contribution stops applying"
+            },
+            "duration": {
+              "type": "string",
+              "enum": ["permanent", "activated"],
+              "description": "Permanent (default) applies whenever held/installed. `activated` applies only while the player has switched it on in Guided Play — ephemeral play state (ADR-019), never persisted on the entity."
+            },
+            "note": { "type": "string", "description": "Why this is encoded the way it is" }
+          },
+          "required": ["stat", "amount"],
+          "additionalProperties": false,
+          "description": "A flat mechanical contribution this content makes to a stat"
+        },
+        "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
+      },
       "actions": {
         "type": "array",
         "items": { "type": "string" },

--- a/packages/salvageunion-reference/schemas/systems.schema.json
+++ b/packages/salvageunion-reference/schemas/systems.schema.json
@@ -319,6 +319,97 @@
         "additionalProperties": false,
         "description": "Explicit flat bonuses this item applies to the host mech’s derived maxima, summed per installed copy"
       },
+      "contributions": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "stat": {
+              "type": "string",
+              "enum": [
+                "structurePoints",
+                "energyPoints",
+                "heatCapacity",
+                "cargoCapacity",
+                "systemSlots",
+                "moduleSlots",
+                "maxHp",
+                "maxAp",
+                "inventorySlots"
+              ]
+            },
+            "amount": {
+              "anyOf": [
+                { "type": "integer", "minimum": -9007199254740991, "maximum": 9007199254740991 },
+                {
+                  "type": "object",
+                  "properties": {
+                    "flat": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991,
+                      "description": "The constant part"
+                    },
+                    "perTechLevel": {
+                      "type": "integer",
+                      "minimum": -9007199254740991,
+                      "maximum": 9007199254740991,
+                      "description": "Multiplied by the target's tech level"
+                    }
+                  },
+                  "required": ["perTechLevel"],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "fromStat": {
+                      "type": "string",
+                      "enum": [
+                        "structurePoints",
+                        "energyPoints",
+                        "heatCapacity",
+                        "cargoCapacity",
+                        "systemSlots",
+                        "moduleSlots",
+                        "maxHp",
+                        "maxAp",
+                        "inventorySlots"
+                      ]
+                    }
+                  },
+                  "required": ["fromStat"],
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "target": {
+              "type": "string",
+              "enum": ["self", "pilot", "pilotedMech", "crawler"],
+              "description": "Defaults to `self` when absent"
+            },
+            "stacks": {
+              "type": "boolean",
+              "description": "Applies once per installed copy (default true for installable items)"
+            },
+            "voidWhen": {
+              "type": "string",
+              "enum": ["damaged", "destroyed"],
+              "description": "Condition at which this contribution stops applying"
+            },
+            "duration": {
+              "type": "string",
+              "enum": ["permanent", "activated"],
+              "description": "Permanent (default) applies whenever held/installed. `activated` applies only while the player has switched it on in Guided Play — ephemeral play state (ADR-019), never persisted on the entity."
+            },
+            "note": { "type": "string", "description": "Why this is encoded the way it is" }
+          },
+          "required": ["stat", "amount"],
+          "additionalProperties": false,
+          "description": "A flat mechanical contribution this content makes to a stat"
+        },
+        "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
+      },
       "actions": {
         "type": "array",
         "items": { "type": "string" },

--- a/packages/salvageunion-reference/tools/validateParityLogic.ts
+++ b/packages/salvageunion-reference/tools/validateParityLogic.ts
@@ -88,11 +88,6 @@ export const PARITY_EXEMPTIONS: Record<string, string> = {
   // Effect-of-an-effect: modifies another effect's OUTPUT, not a stat.
   Mender: 'effect-of-an-effect — changes how much a healing ability restores, not a stat',
 
-  // Duration-bound: ephemeral play state owned by the Dashboard (ADR-019), not
-  // the data-layer cap engine. In scope as `duration: activated` (F1), not here.
-  'Squeeze it in': 'duration-bound — 12h activated effect, Dashboard play state (F1)',
-  'Hull Magnetiser': 'duration-bound — 1h toggleable effect, Dashboard play state (F1)',
-
   // Grant at a moment: a one-off improvement applied WHEN it happens, not a
   // standing modifier. Encoding it as standing would re-apply it forever.
   'Pilot Bay': 'grant-at-a-moment — a one-off +2 HP / +1 AP improvement',


### PR DESCRIPTION
**F1** of the rules-parity plan (#599) — fourth in the recommended order, after #628, #629, #630.

The last two duration-bound records move from *"exempt with a reason"* to **genuinely applied**:

```
Rules parity: 30 claim(s) — 16 encoded, 12 exempt, 2 unresolved   (was 14 / 14 / 2)
```

## Manual expiry, by decision

Salvage Union states real durations — *"this effect lasts for 1 hour"*, *"for 12 hours"* — but the app has **no play clock**. Inventing one would put wall-time into the data layer and make a sheet's numbers change while nobody is looking.

The table keeps time; the app keeps state — the same division ADR-001's honour system already relies on. A player switches an effect on and off.

The switch lives in `playStateStore`, **ephemeral** (ADR-019), so an activated effect can never persist onto the entity and never leaks into a live sheet or a shared snapshot.

## Two schema additions, each forced by a real record

| Addition | Why |
|---|---|
| `duration: 'activated'` | Applies only while switched on. `permanent` (default) applies whenever held or installed. |
| `amount: { fromStat }` | The amount **is** another of the target's stats. Hull Magnetiser raises Cargo *"by its System Slot Value"* — a number that changes with the chassis, so it cannot be a constant. An unavailable stat resolves to **0, never a guess**. |

`installedContributions` is the systems/modules counterpart to `abilityContributions`, and is deliberately distinct from `statBonus`: that's a flat per-copy number with no target, duration or expression — exactly what Hull Magnetiser can't be expressed as. Per-copy stacking defaults to true, matching `statBonus` semantics.

## UI

The mech band grows an **Effects** bay listing only what this loadout and pilot can actually switch on, so a permanent contribution never offers a pointless switch.

## Verification

`bun run check:all` green: schemas, lint, format, typecheck, **4,593 tests**, validate (incl. the parity gate), knip, audit, tokens, styling.

Tests cover both directions of the gate (off contributes nothing, on contributes), that a permanent contribution is unaffected by the active map, that Hull Magnetiser resolves from the chassis slot value, and that a `fromStat` with no stat available resolves to 0.

Next: **F5** (Downtime writes), then **effect targeting**.

Refs #599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MT6q22Y1MtuCYHormXwQ4