### PR TITLE
feat(reference): give effects a target — Bio-Wings grants the MECH the Fly Trait

### DIFF
--- a/packages/salvageunion-reference/data/systems.json
+++ b/packages/salvageunion-reference/data/systems.json
@@ -1361,6 +1361,7 @@
     "techLevel": "B",
     "slotsRequired": 6,
     "salvageValue": 25,
+    "appliedEffects": [{"op": "addTrait", "value": "Fly", "target": "hostMech"}],
     "page": 74,
     "actions": ["Bio-Wings"]
   },

--- a/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
+++ b/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
@@ -1874,6 +1874,8 @@ export type { DamageKind, MechDamageInput, MechDamageEffect, PilotDamageInput, P
 export { PILOT_BASE_HP, PILOT_BASE_AP, PILOT_BASE_INVENTORY_SLOTS, injuryMaxHpPenalty, pilotMaxHP, pilotMaxAP, isPilotDead, clampPilotCurrentStats, installedStatBonus, mechMaxSP, mechMaxEP, mechMaxHeat, mechMaxCargo, clampMechCurrentStats, unifiedMechConditions, crawlerMaxSP, crawlerMaxSPParts, mechMaxSPParts, mechMaxEPParts, mechMaxHeatParts, mechMaxCargoParts, pilotMaxHPParts, pilotMaxAPParts, clampCrawlerCurrentStats, } from './derivedStats.js';
 export type { ChassisStats, CrawlerMaxSPParts, StatBreakdown } from './derivedStats.js';
 export { statesMechanicalChange } from './rulesBearing.js';
+export { mechTraits } from './mechTraits.js';
+export type { MechTrait } from './mechTraits.js';
 export type { RulesClaim } from './rulesBearing.js';
 export { abilityContributions, resolveAmount, sumContributions, } from './contributions.js';
 export type { ContributionStat, ContributionTarget, ContributionAmount, DeclaredContribution, ResolvedContribution, } from './contributions.js';
@@ -1882,6 +1884,46 @@ export type { FindRollTable } from './mediatorTables.js';
 export type { TechLevel, SoftWarning, SoftWarningSeverity, SoftWarningContext, EditSnapshot, MechInput, MechSystemSlot, MechModuleSlot, MechCapacityResult, CapacityViolation, ScrapableItem, CargoItem, CargoItemRef, CargoItemCustom, CargoParent, CargoCapacityResult, CargoViolation, PilotSnapshot, MechSnapshot, AbilityInput, AbilityTier, SystemSnapshot, Roll, ReactorOverloadOutcome, HeatCheckResult, HeatCheckEffect, PushResult, CriticalDamageOutcome, CriticalDamageResult, CriticalInjuryOutcome, CriticalInjuryResult, MediatorTableId, MediatorRollResult, } from './types.js';
 export type { CrawlerCapacityInput, CrawlerCapacityResult, CrawlerCapacityViolation, } from './crawlerCapacity.js';
 //# sourceMappingURL=index.d.ts.map
+// === lib/rules/mechTraits.d.ts ===
+/**
+ * Traits a mech has because of what is installed on it (ADR-029).
+ *
+ * Nothing aggregated a mech's traits before this. Bio-Wings says "Your Mech
+ * gains the Fly Trait" — a trait that belongs to the MECH, not to the system
+ * that granted it — so there was no shape to encode it into: declaring it as a
+ * self-effect would have said the Bio-Wings system flies, which is wrong rather
+ * than merely incomplete.
+ *
+ * That is why the blocker was never "a place to declare effects". It was that
+ * `ChoiceEffectSchema` had no `target`, and this derivation did not exist.
+ *
+ * Pure and side-effect-free (ADR-006). Derived at read time, never stored: a
+ * trait disappears the moment the granting item is removed, with no bookkeeping.
+ */
+/** A trait a mech holds, and what granted it. */
+export type MechTrait = {
+    /** Trait name, e.g. 'Fly'. */
+    name: string;
+    /** Optional magnitude, e.g. Burn 1. */
+    amount?: string | number;
+    /** Display name of the installed item that granted it. */
+    source: string;
+    /** The installed ref, so provenance UI can link back. */
+    ref: string;
+};
+/**
+ * Every trait the mech's installed systems and modules grant it.
+ *
+ * Only `target: 'hostMech'` effects are collected — a `self` effect belongs to
+ * the item's own card, not to the mech. Duplicates keep the highest magnitude,
+ * matching `resolveChoiceView`'s upgrade rule (Explosive 1 → 2) so the two
+ * resolvers cannot disagree about what stacking means.
+ */
+export declare function mechTraits(mech: {
+    systems?: string[];
+    modules?: string[];
+}): MechTrait[];
+//# sourceMappingURL=mechTraits.d.ts.map
 // === lib/rules/mediatorTables.d.ts ===
 /**
  * Mediator tables — Reaction / Morale / Retreat rolls (design-review R-5).
@@ -2110,6 +2152,23 @@ export declare function resolveSystemRef(ref: string): ({
         duration?: "permanent" | "activated" | undefined;
         note?: string | undefined;
     }[] | undefined;
+    appliedEffects?: ({
+        op: "addTrait";
+        value: string;
+        amount?: string | number | undefined;
+        target?: "self" | "hostMech" | undefined;
+    } | {
+        op: "removeTrait";
+        value: string;
+        target?: "self" | "hostMech" | undefined;
+    } | {
+        op: "setRange";
+        value: string | number;
+    } | {
+        op: "addDamage";
+        value: string | number;
+        unit?: string | undefined;
+    })[] | undefined;
 } & {
     schemaName: string;
 }) | null;
@@ -2173,6 +2232,23 @@ export declare function resolveModuleRef(ref: string): ({
         duration?: "permanent" | "activated" | undefined;
         note?: string | undefined;
     }[] | undefined;
+    appliedEffects?: ({
+        op: "addTrait";
+        value: string;
+        amount?: string | number | undefined;
+        target?: "self" | "hostMech" | undefined;
+    } | {
+        op: "removeTrait";
+        value: string;
+        target?: "self" | "hostMech" | undefined;
+    } | {
+        op: "setRange";
+        value: string | number;
+    } | {
+        op: "addDamage";
+        value: string | number;
+        unit?: string | undefined;
+    })[] | undefined;
 } & {
     schemaName: string;
 }) | null;
@@ -2239,6 +2315,23 @@ export declare function resolveInstalledRef(ref: string): ({
         duration?: "permanent" | "activated" | undefined;
         note?: string | undefined;
     }[] | undefined;
+    appliedEffects?: ({
+        op: "addTrait";
+        value: string;
+        amount?: string | number | undefined;
+        target?: "self" | "hostMech" | undefined;
+    } | {
+        op: "removeTrait";
+        value: string;
+        target?: "self" | "hostMech" | undefined;
+    } | {
+        op: "setRange";
+        value: string | number;
+    } | {
+        op: "addDamage";
+        value: string | number;
+        unit?: string | undefined;
+    })[] | undefined;
 } & {
     schemaName: string;
 }) | null;
@@ -3943,9 +4036,17 @@ export declare const CrawlerBaySchema: z.ZodObject<{
                 op: z.ZodLiteral<"addTrait">;
                 value: z.ZodString;
                 amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                target: z.ZodOptional<z.ZodEnum<{
+                    self: "self";
+                    hostMech: "hostMech";
+                }>>;
             }, z.core.$strict>, z.ZodObject<{
                 op: z.ZodLiteral<"removeTrait">;
                 value: z.ZodString;
+                target: z.ZodOptional<z.ZodEnum<{
+                    self: "self";
+                    hostMech: "hostMech";
+                }>>;
             }, z.core.$strict>, z.ZodObject<{
                 op: z.ZodLiteral<"setRange">;
                 value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
@@ -3978,9 +4079,17 @@ export declare const CrawlerBaySchema: z.ZodObject<{
                     op: z.ZodLiteral<"addTrait">;
                     value: z.ZodString;
                     amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
                 }, z.core.$strict>, z.ZodObject<{
                     op: z.ZodLiteral<"removeTrait">;
                     value: z.ZodString;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
                 }, z.core.$strict>, z.ZodObject<{
                     op: z.ZodLiteral<"setRange">;
                     value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
@@ -4096,6 +4205,29 @@ export declare const CrawlerBaySchema: z.ZodObject<{
                     }>>;
                     note: z.ZodOptional<z.ZodString>;
                 }, z.core.$strict>>>;
+                appliedEffects: z.ZodOptional<z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{
+                    op: z.ZodLiteral<"addTrait">;
+                    value: z.ZodString;
+                    amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
+                }, z.core.$strict>, z.ZodObject<{
+                    op: z.ZodLiteral<"removeTrait">;
+                    value: z.ZodString;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
+                }, z.core.$strict>, z.ZodObject<{
+                    op: z.ZodLiteral<"setRange">;
+                    value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+                }, z.core.$strict>, z.ZodObject<{
+                    op: z.ZodLiteral<"addDamage">;
+                    value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+                    unit: z.ZodOptional<z.ZodString>;
+                }, z.core.$strict>], "op">>>;
                 actions: z.ZodArray<z.ZodString>;
             }, z.core.$strip>>;
         }, z.core.$strict>], "kind">>;
@@ -4124,9 +4256,17 @@ export declare const CrawlerBaySchema: z.ZodObject<{
                 op: z.ZodLiteral<"addTrait">;
                 value: z.ZodString;
                 amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                target: z.ZodOptional<z.ZodEnum<{
+                    self: "self";
+                    hostMech: "hostMech";
+                }>>;
             }, z.core.$strict>, z.ZodObject<{
                 op: z.ZodLiteral<"removeTrait">;
                 value: z.ZodString;
+                target: z.ZodOptional<z.ZodEnum<{
+                    self: "self";
+                    hostMech: "hostMech";
+                }>>;
             }, z.core.$strict>, z.ZodObject<{
                 op: z.ZodLiteral<"setRange">;
                 value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
@@ -4159,9 +4299,17 @@ export declare const CrawlerBaySchema: z.ZodObject<{
                     op: z.ZodLiteral<"addTrait">;
                     value: z.ZodString;
                     amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
                 }, z.core.$strict>, z.ZodObject<{
                     op: z.ZodLiteral<"removeTrait">;
                     value: z.ZodString;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
                 }, z.core.$strict>, z.ZodObject<{
                     op: z.ZodLiteral<"setRange">;
                     value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
@@ -4277,6 +4425,29 @@ export declare const CrawlerBaySchema: z.ZodObject<{
                     }>>;
                     note: z.ZodOptional<z.ZodString>;
                 }, z.core.$strict>>>;
+                appliedEffects: z.ZodOptional<z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{
+                    op: z.ZodLiteral<"addTrait">;
+                    value: z.ZodString;
+                    amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
+                }, z.core.$strict>, z.ZodObject<{
+                    op: z.ZodLiteral<"removeTrait">;
+                    value: z.ZodString;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
+                }, z.core.$strict>, z.ZodObject<{
+                    op: z.ZodLiteral<"setRange">;
+                    value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+                }, z.core.$strict>, z.ZodObject<{
+                    op: z.ZodLiteral<"addDamage">;
+                    value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+                    unit: z.ZodOptional<z.ZodString>;
+                }, z.core.$strict>], "op">>>;
                 actions: z.ZodArray<z.ZodString>;
             }, z.core.$strip>>;
         }, z.core.$strict>], "kind">>;
@@ -4764,9 +4935,17 @@ export declare const DroneSchema: z.ZodObject<{
                 op: z.ZodLiteral<"addTrait">;
                 value: z.ZodString;
                 amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                target: z.ZodOptional<z.ZodEnum<{
+                    self: "self";
+                    hostMech: "hostMech";
+                }>>;
             }, z.core.$strict>, z.ZodObject<{
                 op: z.ZodLiteral<"removeTrait">;
                 value: z.ZodString;
+                target: z.ZodOptional<z.ZodEnum<{
+                    self: "self";
+                    hostMech: "hostMech";
+                }>>;
             }, z.core.$strict>, z.ZodObject<{
                 op: z.ZodLiteral<"setRange">;
                 value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
@@ -4799,9 +4978,17 @@ export declare const DroneSchema: z.ZodObject<{
                     op: z.ZodLiteral<"addTrait">;
                     value: z.ZodString;
                     amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
                 }, z.core.$strict>, z.ZodObject<{
                     op: z.ZodLiteral<"removeTrait">;
                     value: z.ZodString;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
                 }, z.core.$strict>, z.ZodObject<{
                     op: z.ZodLiteral<"setRange">;
                     value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
@@ -4917,6 +5104,29 @@ export declare const DroneSchema: z.ZodObject<{
                     }>>;
                     note: z.ZodOptional<z.ZodString>;
                 }, z.core.$strict>>>;
+                appliedEffects: z.ZodOptional<z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{
+                    op: z.ZodLiteral<"addTrait">;
+                    value: z.ZodString;
+                    amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
+                }, z.core.$strict>, z.ZodObject<{
+                    op: z.ZodLiteral<"removeTrait">;
+                    value: z.ZodString;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
+                }, z.core.$strict>, z.ZodObject<{
+                    op: z.ZodLiteral<"setRange">;
+                    value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+                }, z.core.$strict>, z.ZodObject<{
+                    op: z.ZodLiteral<"addDamage">;
+                    value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+                    unit: z.ZodOptional<z.ZodString>;
+                }, z.core.$strict>], "op">>>;
                 actions: z.ZodArray<z.ZodString>;
             }, z.core.$strip>>;
         }, z.core.$strict>], "kind">>;
@@ -4945,9 +5155,17 @@ export declare const DroneSchema: z.ZodObject<{
                 op: z.ZodLiteral<"addTrait">;
                 value: z.ZodString;
                 amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                target: z.ZodOptional<z.ZodEnum<{
+                    self: "self";
+                    hostMech: "hostMech";
+                }>>;
             }, z.core.$strict>, z.ZodObject<{
                 op: z.ZodLiteral<"removeTrait">;
                 value: z.ZodString;
+                target: z.ZodOptional<z.ZodEnum<{
+                    self: "self";
+                    hostMech: "hostMech";
+                }>>;
             }, z.core.$strict>, z.ZodObject<{
                 op: z.ZodLiteral<"setRange">;
                 value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
@@ -4980,9 +5198,17 @@ export declare const DroneSchema: z.ZodObject<{
                     op: z.ZodLiteral<"addTrait">;
                     value: z.ZodString;
                     amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
                 }, z.core.$strict>, z.ZodObject<{
                     op: z.ZodLiteral<"removeTrait">;
                     value: z.ZodString;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
                 }, z.core.$strict>, z.ZodObject<{
                     op: z.ZodLiteral<"setRange">;
                     value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
@@ -5098,6 +5324,29 @@ export declare const DroneSchema: z.ZodObject<{
                     }>>;
                     note: z.ZodOptional<z.ZodString>;
                 }, z.core.$strict>>>;
+                appliedEffects: z.ZodOptional<z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{
+                    op: z.ZodLiteral<"addTrait">;
+                    value: z.ZodString;
+                    amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
+                }, z.core.$strict>, z.ZodObject<{
+                    op: z.ZodLiteral<"removeTrait">;
+                    value: z.ZodString;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
+                }, z.core.$strict>, z.ZodObject<{
+                    op: z.ZodLiteral<"setRange">;
+                    value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+                }, z.core.$strict>, z.ZodObject<{
+                    op: z.ZodLiteral<"addDamage">;
+                    value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+                    unit: z.ZodOptional<z.ZodString>;
+                }, z.core.$strict>], "op">>>;
                 actions: z.ZodArray<z.ZodString>;
             }, z.core.$strip>>;
         }, z.core.$strict>], "kind">>;
@@ -5216,9 +5465,17 @@ export declare const EquipmentSchema: z.ZodObject<{
                 op: z.ZodLiteral<"addTrait">;
                 value: z.ZodString;
                 amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                target: z.ZodOptional<z.ZodEnum<{
+                    self: "self";
+                    hostMech: "hostMech";
+                }>>;
             }, z.core.$strict>, z.ZodObject<{
                 op: z.ZodLiteral<"removeTrait">;
                 value: z.ZodString;
+                target: z.ZodOptional<z.ZodEnum<{
+                    self: "self";
+                    hostMech: "hostMech";
+                }>>;
             }, z.core.$strict>, z.ZodObject<{
                 op: z.ZodLiteral<"setRange">;
                 value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
@@ -5251,9 +5508,17 @@ export declare const EquipmentSchema: z.ZodObject<{
                     op: z.ZodLiteral<"addTrait">;
                     value: z.ZodString;
                     amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
                 }, z.core.$strict>, z.ZodObject<{
                     op: z.ZodLiteral<"removeTrait">;
                     value: z.ZodString;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
                 }, z.core.$strict>, z.ZodObject<{
                     op: z.ZodLiteral<"setRange">;
                     value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
@@ -5369,6 +5634,29 @@ export declare const EquipmentSchema: z.ZodObject<{
                     }>>;
                     note: z.ZodOptional<z.ZodString>;
                 }, z.core.$strict>>>;
+                appliedEffects: z.ZodOptional<z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{
+                    op: z.ZodLiteral<"addTrait">;
+                    value: z.ZodString;
+                    amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
+                }, z.core.$strict>, z.ZodObject<{
+                    op: z.ZodLiteral<"removeTrait">;
+                    value: z.ZodString;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
+                }, z.core.$strict>, z.ZodObject<{
+                    op: z.ZodLiteral<"setRange">;
+                    value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+                }, z.core.$strict>, z.ZodObject<{
+                    op: z.ZodLiteral<"addDamage">;
+                    value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+                    unit: z.ZodOptional<z.ZodString>;
+                }, z.core.$strict>], "op">>>;
                 actions: z.ZodArray<z.ZodString>;
             }, z.core.$strip>>;
         }, z.core.$strict>], "kind">>;
@@ -5397,9 +5685,17 @@ export declare const EquipmentSchema: z.ZodObject<{
                 op: z.ZodLiteral<"addTrait">;
                 value: z.ZodString;
                 amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                target: z.ZodOptional<z.ZodEnum<{
+                    self: "self";
+                    hostMech: "hostMech";
+                }>>;
             }, z.core.$strict>, z.ZodObject<{
                 op: z.ZodLiteral<"removeTrait">;
                 value: z.ZodString;
+                target: z.ZodOptional<z.ZodEnum<{
+                    self: "self";
+                    hostMech: "hostMech";
+                }>>;
             }, z.core.$strict>, z.ZodObject<{
                 op: z.ZodLiteral<"setRange">;
                 value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
@@ -5432,9 +5728,17 @@ export declare const EquipmentSchema: z.ZodObject<{
                     op: z.ZodLiteral<"addTrait">;
                     value: z.ZodString;
                     amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
                 }, z.core.$strict>, z.ZodObject<{
                     op: z.ZodLiteral<"removeTrait">;
                     value: z.ZodString;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
                 }, z.core.$strict>, z.ZodObject<{
                     op: z.ZodLiteral<"setRange">;
                     value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
@@ -5550,6 +5854,29 @@ export declare const EquipmentSchema: z.ZodObject<{
                     }>>;
                     note: z.ZodOptional<z.ZodString>;
                 }, z.core.$strict>>>;
+                appliedEffects: z.ZodOptional<z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{
+                    op: z.ZodLiteral<"addTrait">;
+                    value: z.ZodString;
+                    amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
+                }, z.core.$strict>, z.ZodObject<{
+                    op: z.ZodLiteral<"removeTrait">;
+                    value: z.ZodString;
+                    target: z.ZodOptional<z.ZodEnum<{
+                        self: "self";
+                        hostMech: "hostMech";
+                    }>>;
+                }, z.core.$strict>, z.ZodObject<{
+                    op: z.ZodLiteral<"setRange">;
+                    value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+                }, z.core.$strict>, z.ZodObject<{
+                    op: z.ZodLiteral<"addDamage">;
+                    value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+                    unit: z.ZodOptional<z.ZodString>;
+                }, z.core.$strict>], "op">>>;
                 actions: z.ZodArray<z.ZodString>;
             }, z.core.$strip>>;
         }, z.core.$strict>], "kind">>;
@@ -5943,6 +6270,29 @@ export declare const ModuleSchema: z.ZodObject<{
         }>>;
         note: z.ZodOptional<z.ZodString>;
     }, z.core.$strict>>>;
+    appliedEffects: z.ZodOptional<z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{
+        op: z.ZodLiteral<"addTrait">;
+        value: z.ZodString;
+        amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+        target: z.ZodOptional<z.ZodEnum<{
+            self: "self";
+            hostMech: "hostMech";
+        }>>;
+    }, z.core.$strict>, z.ZodObject<{
+        op: z.ZodLiteral<"removeTrait">;
+        value: z.ZodString;
+        target: z.ZodOptional<z.ZodEnum<{
+            self: "self";
+            hostMech: "hostMech";
+        }>>;
+    }, z.core.$strict>, z.ZodObject<{
+        op: z.ZodLiteral<"setRange">;
+        value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+    }, z.core.$strict>, z.ZodObject<{
+        op: z.ZodLiteral<"addDamage">;
+        value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+        unit: z.ZodOptional<z.ZodString>;
+    }, z.core.$strict>], "op">>>;
     actions: z.ZodArray<z.ZodString>;
 }, z.core.$strict>;
 /**
@@ -6992,6 +7342,29 @@ export declare const SystemSchema: z.ZodObject<{
         }>>;
         note: z.ZodOptional<z.ZodString>;
     }, z.core.$strict>>>;
+    appliedEffects: z.ZodOptional<z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{
+        op: z.ZodLiteral<"addTrait">;
+        value: z.ZodString;
+        amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+        target: z.ZodOptional<z.ZodEnum<{
+            self: "self";
+            hostMech: "hostMech";
+        }>>;
+    }, z.core.$strict>, z.ZodObject<{
+        op: z.ZodLiteral<"removeTrait">;
+        value: z.ZodString;
+        target: z.ZodOptional<z.ZodEnum<{
+            self: "self";
+            hostMech: "hostMech";
+        }>>;
+    }, z.core.$strict>, z.ZodObject<{
+        op: z.ZodLiteral<"setRange">;
+        value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+    }, z.core.$strict>, z.ZodObject<{
+        op: z.ZodLiteral<"addDamage">;
+        value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+        unit: z.ZodOptional<z.ZodString>;
+    }, z.core.$strict>], "op">>>;
     actions: z.ZodArray<z.ZodString>;
 }, z.core.$strict>;
 /**
@@ -7243,9 +7616,17 @@ export declare const GuideSchema: z.ZodObject<{
                 op: z.ZodLiteral<"addTrait">;
                 value: z.ZodString;
                 amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                target: z.ZodOptional<z.ZodEnum<{
+                    self: "self";
+                    hostMech: "hostMech";
+                }>>;
             }, z.core.$strict>, z.ZodObject<{
                 op: z.ZodLiteral<"removeTrait">;
                 value: z.ZodString;
+                target: z.ZodOptional<z.ZodEnum<{
+                    self: "self";
+                    hostMech: "hostMech";
+                }>>;
             }, z.core.$strict>, z.ZodObject<{
                 op: z.ZodLiteral<"setRange">;
                 value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
@@ -7302,9 +7683,17 @@ export declare const GuideSchema: z.ZodObject<{
                 op: z.ZodLiteral<"addTrait">;
                 value: z.ZodString;
                 amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+                target: z.ZodOptional<z.ZodEnum<{
+                    self: "self";
+                    hostMech: "hostMech";
+                }>>;
             }, z.core.$strict>, z.ZodObject<{
                 op: z.ZodLiteral<"removeTrait">;
                 value: z.ZodString;
+                target: z.ZodOptional<z.ZodEnum<{
+                    self: "self";
+                    hostMech: "hostMech";
+                }>>;
             }, z.core.$strict>, z.ZodObject<{
                 op: z.ZodLiteral<"setRange">;
                 value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
@@ -8648,6 +9037,55 @@ export declare const ContributionSchema: z.ZodObject<{
     note: z.ZodOptional<z.ZodString>;
 }, z.core.$strict>;
 /**
+ * Whose state an effect changes (ADR-029).
+ *
+ * `self` — the record declaring it — was the only target the model had, and THAT
+ * was the blocker, not the declaration site. Bio-Wings says "YOUR MECH gains the
+ * Fly Trait": declared as a self-effect it would say the Bio-Wings *system*
+ * flies, which is wrong rather than merely incomplete.
+ */
+export declare const EffectTargetSchema: z.ZodEnum<{
+    self: "self";
+    hostMech: "hostMech";
+}>;
+/**
+ * Choice effect schema — describes a mechanical effect applied when a choice option is selected
+ */
+/**
+ * A single mechanical effect of a choice option, discriminated by `op` so each
+ * operation only permits the fields it actually uses (no `removeTrait` with an
+ * `amount`, no `addDamage` with an `amount`, etc.):
+ *
+ * - `addTrait`    — add a trait by name; optional `amount` is its magnitude
+ *                   (e.g. Burn 1). Adding a trait that already exists upgrades it.
+ * - `removeTrait` — strip a trait by name.
+ * - `setRange`    — replace the Range datavalue.
+ * - `addDamage`   — increase the Damage datavalue; optional `unit` (e.g. "SP").
+ */
+export declare const ChoiceEffectSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
+    op: z.ZodLiteral<"addTrait">;
+    value: z.ZodString;
+    amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+    target: z.ZodOptional<z.ZodEnum<{
+        self: "self";
+        hostMech: "hostMech";
+    }>>;
+}, z.core.$strict>, z.ZodObject<{
+    op: z.ZodLiteral<"removeTrait">;
+    value: z.ZodString;
+    target: z.ZodOptional<z.ZodEnum<{
+        self: "self";
+        hostMech: "hostMech";
+    }>>;
+}, z.core.$strict>, z.ZodObject<{
+    op: z.ZodLiteral<"setRange">;
+    value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+}, z.core.$strict>, z.ZodObject<{
+    op: z.ZodLiteral<"addDamage">;
+    value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+    unit: z.ZodOptional<z.ZodString>;
+}, z.core.$strict>], "op">;
+/**
  * A system or module that can be installed on a mech
  */
 export declare const SystemModuleSchema: z.ZodObject<{
@@ -8714,37 +9152,31 @@ export declare const SystemModuleSchema: z.ZodObject<{
         }>>;
         note: z.ZodOptional<z.ZodString>;
     }, z.core.$strict>>>;
+    appliedEffects: z.ZodOptional<z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{
+        op: z.ZodLiteral<"addTrait">;
+        value: z.ZodString;
+        amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+        target: z.ZodOptional<z.ZodEnum<{
+            self: "self";
+            hostMech: "hostMech";
+        }>>;
+    }, z.core.$strict>, z.ZodObject<{
+        op: z.ZodLiteral<"removeTrait">;
+        value: z.ZodString;
+        target: z.ZodOptional<z.ZodEnum<{
+            self: "self";
+            hostMech: "hostMech";
+        }>>;
+    }, z.core.$strict>, z.ZodObject<{
+        op: z.ZodLiteral<"setRange">;
+        value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+    }, z.core.$strict>, z.ZodObject<{
+        op: z.ZodLiteral<"addDamage">;
+        value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+        unit: z.ZodOptional<z.ZodString>;
+    }, z.core.$strict>], "op">>>;
     actions: z.ZodArray<z.ZodString>;
 }, z.core.$strip>;
-/**
- * Choice effect schema — describes a mechanical effect applied when a choice option is selected
- */
-/**
- * A single mechanical effect of a choice option, discriminated by `op` so each
- * operation only permits the fields it actually uses (no `removeTrait` with an
- * `amount`, no `addDamage` with an `amount`, etc.):
- *
- * - `addTrait`    — add a trait by name; optional `amount` is its magnitude
- *                   (e.g. Burn 1). Adding a trait that already exists upgrades it.
- * - `removeTrait` — strip a trait by name.
- * - `setRange`    — replace the Range datavalue.
- * - `addDamage`   — increase the Damage datavalue; optional `unit` (e.g. "SP").
- */
-export declare const ChoiceEffectSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
-    op: z.ZodLiteral<"addTrait">;
-    value: z.ZodString;
-    amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
-}, z.core.$strict>, z.ZodObject<{
-    op: z.ZodLiteral<"removeTrait">;
-    value: z.ZodString;
-}, z.core.$strict>, z.ZodObject<{
-    op: z.ZodLiteral<"setRange">;
-    value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
-}, z.core.$strict>, z.ZodObject<{
-    op: z.ZodLiteral<"addDamage">;
-    value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
-    unit: z.ZodOptional<z.ZodString>;
-}, z.core.$strict>], "op">;
 /**
  * Choice options schema
  */
@@ -8756,9 +9188,17 @@ declare const ChoiceOptionSchema: z.ZodObject<{
         op: z.ZodLiteral<"addTrait">;
         value: z.ZodString;
         amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+        target: z.ZodOptional<z.ZodEnum<{
+            self: "self";
+            hostMech: "hostMech";
+        }>>;
     }, z.core.$strict>, z.ZodObject<{
         op: z.ZodLiteral<"removeTrait">;
         value: z.ZodString;
+        target: z.ZodOptional<z.ZodEnum<{
+            self: "self";
+            hostMech: "hostMech";
+        }>>;
     }, z.core.$strict>, z.ZodObject<{
         op: z.ZodLiteral<"setRange">;
         value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
@@ -8822,9 +9262,17 @@ declare const ChoiceSourceSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
             op: z.ZodLiteral<"addTrait">;
             value: z.ZodString;
             amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+            target: z.ZodOptional<z.ZodEnum<{
+                self: "self";
+                hostMech: "hostMech";
+            }>>;
         }, z.core.$strict>, z.ZodObject<{
             op: z.ZodLiteral<"removeTrait">;
             value: z.ZodString;
+            target: z.ZodOptional<z.ZodEnum<{
+                self: "self";
+                hostMech: "hostMech";
+            }>>;
         }, z.core.$strict>, z.ZodObject<{
             op: z.ZodLiteral<"setRange">;
             value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
@@ -8940,6 +9388,29 @@ declare const ChoiceSourceSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
             }>>;
             note: z.ZodOptional<z.ZodString>;
         }, z.core.$strict>>>;
+        appliedEffects: z.ZodOptional<z.ZodArray<z.ZodDiscriminatedUnion<[z.ZodObject<{
+            op: z.ZodLiteral<"addTrait">;
+            value: z.ZodString;
+            amount: z.ZodOptional<z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>>;
+            target: z.ZodOptional<z.ZodEnum<{
+                self: "self";
+                hostMech: "hostMech";
+            }>>;
+        }, z.core.$strict>, z.ZodObject<{
+            op: z.ZodLiteral<"removeTrait">;
+            value: z.ZodString;
+            target: z.ZodOptional<z.ZodEnum<{
+                self: "self";
+                hostMech: "hostMech";
+            }>>;
+        }, z.core.$strict>, z.ZodObject<{
+            op: z.ZodLiteral<"setRange">;
+            value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+        }, z.core.$strict>, z.ZodObject<{
+            op: z.ZodLiteral<"addDamage">;
+            value: z.ZodUnion<readonly [z.ZodString, z.ZodNumber]>;
+            unit: z.ZodOptional<z.ZodString>;
+        }, z.core.$strict>], "op">>>;
         actions: z.ZodArray<z.ZodString>;
     }, z.core.$strip>>;
 }, z.core.$strict>], "kind">;

--- a/packages/salvageunion-reference/lib/rules/index.ts
+++ b/packages/salvageunion-reference/lib/rules/index.ts
@@ -137,6 +137,8 @@ export {
 } from './derivedStats.js'
 export type { ChassisStats, CrawlerMaxSPParts, StatBreakdown } from './derivedStats.js'
 export { statesMechanicalChange } from './rulesBearing.js'
+export { mechTraits } from './mechTraits.js'
+export type { MechTrait } from './mechTraits.js'
 export type { RulesClaim } from './rulesBearing.js'
 export {
   abilityContributions,

--- a/packages/salvageunion-reference/lib/rules/mechTraits.test.ts
+++ b/packages/salvageunion-reference/lib/rules/mechTraits.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Mech traits derived from an installed loadout (ADR-029).
+ *
+ * Bio-Wings says "Your Mech gains the Fly Trait" — a trait belonging to the
+ * MECH, not to the system that granted it. Nothing aggregated a mech's traits
+ * before, which is why the blocker was never "a place to declare effects" but
+ * the missing `target` plus this derivation.
+ */
+
+import { beforeAll, describe, expect, it } from 'bun:test'
+
+import { SalvageUnionReference } from '../index.js'
+import { mechTraits } from './mechTraits.js'
+
+beforeAll(async () => {
+  await SalvageUnionReference.preload('all')
+})
+
+describe('mechTraits', () => {
+  it('grants the host mech a trait from a real installed system', () => {
+    const traits = mechTraits({ systems: ['Bio-Wings'], modules: [] })
+    expect(traits.map((t) => t.name)).toContain('Fly')
+  })
+
+  it('attributes the trait to the item that granted it', () => {
+    const [fly] = mechTraits({ systems: ['Bio-Wings'], modules: [] })
+    expect(fly?.source).toBe('Bio-Wings')
+    expect(fly?.ref).toBe('Bio-Wings')
+  })
+
+  it('a bare loadout has no traits', () => {
+    expect(mechTraits({ systems: [], modules: [] })).toEqual([])
+  })
+
+  it('an unresolvable ref grants nothing rather than throwing', () => {
+    expect(mechTraits({ systems: ['no-such-system'], modules: [] })).toEqual([])
+  })
+
+  it('does NOT collect self-targeted effects — those belong to the item, not the mech', () => {
+    // Only `target: 'hostMech'` lands on the mech. A weapon whose own choice
+    // adds Ballistic to ITSELF must not make the mech Ballistic.
+    const traits = mechTraits({ systems: ['Cargo Pod'], modules: [] })
+    expect(traits).toEqual([])
+  })
+
+  it('two copies of the same grant yield one trait, not two', () => {
+    const traits = mechTraits({ systems: ['Bio-Wings', 'Bio-Wings'], modules: [] })
+    expect(traits.filter((t) => t.name === 'Fly')).toHaveLength(1)
+  })
+})

--- a/packages/salvageunion-reference/lib/rules/mechTraits.ts
+++ b/packages/salvageunion-reference/lib/rules/mechTraits.ts
@@ -1,0 +1,86 @@
+/**
+ * Traits a mech has because of what is installed on it (ADR-029).
+ *
+ * Nothing aggregated a mech's traits before this. Bio-Wings says "Your Mech
+ * gains the Fly Trait" — a trait that belongs to the MECH, not to the system
+ * that granted it — so there was no shape to encode it into: declaring it as a
+ * self-effect would have said the Bio-Wings system flies, which is wrong rather
+ * than merely incomplete.
+ *
+ * That is why the blocker was never "a place to declare effects". It was that
+ * `ChoiceEffectSchema` had no `target`, and this derivation did not exist.
+ *
+ * Pure and side-effect-free (ADR-006). Derived at read time, never stored: a
+ * trait disappears the moment the granting item is removed, with no bookkeeping.
+ */
+
+import { resolveInstalledRef } from './resolveRefs.js'
+
+/** A trait a mech holds, and what granted it. */
+export type MechTrait = {
+  /** Trait name, e.g. 'Fly'. */
+  name: string
+  /** Optional magnitude, e.g. Burn 1. */
+  amount?: string | number
+  /** Display name of the installed item that granted it. */
+  source: string
+  /** The installed ref, so provenance UI can link back. */
+  ref: string
+}
+
+type EffectLike = {
+  op: string
+  value?: string
+  amount?: string | number
+  target?: string
+}
+
+type InstalledLike = { name?: string; appliedEffects?: EffectLike[] }
+
+/**
+ * Every trait the mech's installed systems and modules grant it.
+ *
+ * Only `target: 'hostMech'` effects are collected — a `self` effect belongs to
+ * the item's own card, not to the mech. Duplicates keep the highest magnitude,
+ * matching `resolveChoiceView`'s upgrade rule (Explosive 1 → 2) so the two
+ * resolvers cannot disagree about what stacking means.
+ */
+export function mechTraits(mech: { systems?: string[]; modules?: string[] }): MechTrait[] {
+  const installed = [...(mech.systems ?? []), ...(mech.modules ?? [])]
+  const byName = new Map<string, MechTrait>()
+
+  for (const ref of installed) {
+    let item: InstalledLike | undefined
+    try {
+      item = (resolveInstalledRef(ref) ?? undefined) as InstalledLike | undefined
+    } catch {
+      // An unresolvable ref grants nothing, exactly as it contributes nothing.
+      item = undefined
+    }
+    for (const effect of item?.appliedEffects ?? []) {
+      if (effect.target !== 'hostMech') continue
+      if (!effect.value) continue
+      if (effect.op === 'removeTrait') {
+        byName.delete(effect.value)
+        continue
+      }
+      if (effect.op !== 'addTrait') continue
+      const existing = byName.get(effect.value)
+      const next: MechTrait = {
+        name: effect.value,
+        ...(effect.amount !== undefined ? { amount: effect.amount } : {}),
+        source: item?.name ?? ref,
+        ref,
+      }
+      if (!existing) {
+        byName.set(effect.value, next)
+        continue
+      }
+      const a = Number(existing.amount ?? 0)
+      const b = Number(next.amount ?? 0)
+      if (b > a) byName.set(effect.value, next)
+    }
+  }
+
+  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name))
+}

--- a/packages/salvageunion-reference/lib/schemas/objects.ts
+++ b/packages/salvageunion-reference/lib/schemas/objects.ts
@@ -535,6 +535,61 @@ export const ContributionSchema = z
   .describe('A flat mechanical contribution this content makes to a stat')
 
 /**
+ * Whose state an effect changes (ADR-029).
+ *
+ * `self` — the record declaring it — was the only target the model had, and THAT
+ * was the blocker, not the declaration site. Bio-Wings says "YOUR MECH gains the
+ * Fly Trait": declared as a self-effect it would say the Bio-Wings *system*
+ * flies, which is wrong rather than merely incomplete.
+ */
+export const EffectTargetSchema = z.enum(['self', 'hostMech'])
+
+/**
+ * Choice effect schema — describes a mechanical effect applied when a choice option is selected
+ */
+/**
+ * A single mechanical effect of a choice option, discriminated by `op` so each
+ * operation only permits the fields it actually uses (no `removeTrait` with an
+ * `amount`, no `addDamage` with an `amount`, etc.):
+ *
+ * - `addTrait`    — add a trait by name; optional `amount` is its magnitude
+ *                   (e.g. Burn 1). Adding a trait that already exists upgrades it.
+ * - `removeTrait` — strip a trait by name.
+ * - `setRange`    — replace the Range datavalue.
+ * - `addDamage`   — increase the Damage datavalue; optional `unit` (e.g. "SP").
+ */
+export const ChoiceEffectSchema = z.discriminatedUnion('op', [
+  z
+    .object({
+      op: z.literal('addTrait'),
+      value: z.string(),
+      amount: z.union([z.string(), z.number()]).optional(),
+      target: EffectTargetSchema.describe('Defaults to `self` when absent').optional(),
+    })
+    .strict(),
+  z
+    .object({
+      op: z.literal('removeTrait'),
+      value: z.string(),
+      target: EffectTargetSchema.describe('Defaults to `self` when absent').optional(),
+    })
+    .strict(),
+  z
+    .object({
+      op: z.literal('setRange'),
+      value: z.union([z.string(), z.number()]),
+    })
+    .strict(),
+  z
+    .object({
+      op: z.literal('addDamage'),
+      value: z.union([z.string(), z.number()]),
+      unit: z.string().optional(),
+    })
+    .strict(),
+])
+
+/**
  * A system or module that can be installed on a mech
  */
 export const SystemModuleSchema = StatsSchema.extend({
@@ -558,51 +613,19 @@ export const SystemModuleSchema = StatsSchema.extend({
         'flat per-copy bonus cannot.'
     )
     .optional(),
+  appliedEffects: z
+    .array(ChoiceEffectSchema)
+    .describe(
+      'Trait/damage/range effects this item applies unconditionally (ADR-029). ' +
+        'Same vocabulary as a choice option\u2019s `effects`, declared directly on ' +
+        'the record for grants that are not a choice. Named `appliedEffects`, not ' +
+        '`effects`: that key is already taken on meta entities with a different ' +
+        '`{ label, value }` shape (see getEffects), and one field name meaning two ' +
+        'things is how a schema rots.'
+    )
+    .optional(),
   actions: z.array(z.string()).describe('Action names this system/module provides'),
 }).describe('A system or module that can be installed on a mech')
-
-/**
- * Choice effect schema — describes a mechanical effect applied when a choice option is selected
- */
-/**
- * A single mechanical effect of a choice option, discriminated by `op` so each
- * operation only permits the fields it actually uses (no `removeTrait` with an
- * `amount`, no `addDamage` with an `amount`, etc.):
- *
- * - `addTrait`    — add a trait by name; optional `amount` is its magnitude
- *                   (e.g. Burn 1). Adding a trait that already exists upgrades it.
- * - `removeTrait` — strip a trait by name.
- * - `setRange`    — replace the Range datavalue.
- * - `addDamage`   — increase the Damage datavalue; optional `unit` (e.g. "SP").
- */
-export const ChoiceEffectSchema = z.discriminatedUnion('op', [
-  z
-    .object({
-      op: z.literal('addTrait'),
-      value: z.string(),
-      amount: z.union([z.string(), z.number()]).optional(),
-    })
-    .strict(),
-  z
-    .object({
-      op: z.literal('removeTrait'),
-      value: z.string(),
-    })
-    .strict(),
-  z
-    .object({
-      op: z.literal('setRange'),
-      value: z.union([z.string(), z.number()]),
-    })
-    .strict(),
-  z
-    .object({
-      op: z.literal('addDamage'),
-      value: z.union([z.string(), z.number()]),
-      unit: z.string().optional(),
-    })
-    .strict(),
-])
 
 /**
  * Choice options schema

--- a/packages/salvageunion-reference/schemas/actions.schema.json
+++ b/packages/salvageunion-reference/schemas/actions.schema.json
@@ -649,6 +649,62 @@
                     },
                     "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
                   },
+                  "appliedEffects": {
+                    "type": "array",
+                    "items": {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "op": { "type": "string", "const": "addTrait" },
+                            "value": { "type": "string" },
+                            "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "hostMech"],
+                              "description": "Defaults to `self` when absent"
+                            }
+                          },
+                          "required": ["op", "value"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "op": { "type": "string", "const": "removeTrait" },
+                            "value": { "type": "string" },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "hostMech"],
+                              "description": "Defaults to `self` when absent"
+                            }
+                          },
+                          "required": ["op", "value"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "op": { "type": "string", "const": "setRange" },
+                            "value": { "anyOf": [{ "type": "string" }, { "type": "number" }] }
+                          },
+                          "required": ["op", "value"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "op": { "type": "string", "const": "addDamage" },
+                            "value": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                            "unit": { "type": "string" }
+                          },
+                          "required": ["op", "value"],
+                          "additionalProperties": false
+                        }
+                      ]
+                    },
+                    "description": "Trait/damage/range effects this item applies unconditionally (ADR-029). Same vocabulary as a choice option’s `effects`, declared directly on the record for grants that are not a choice. Named `appliedEffects`, not `effects`: that key is already taken on meta entities with a different `{ label, value }` shape (see getEffects), and one field name meaning two things is how a schema rots."
+                  },
                   "actions": {
                     "type": "array",
                     "items": { "type": "string" },
@@ -682,7 +738,12 @@
                           "properties": {
                             "op": { "type": "string", "const": "addTrait" },
                             "value": { "type": "string" },
-                            "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] }
+                            "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "hostMech"],
+                              "description": "Defaults to `self` when absent"
+                            }
                           },
                           "required": ["op", "value"],
                           "additionalProperties": false
@@ -691,7 +752,12 @@
                           "type": "object",
                           "properties": {
                             "op": { "type": "string", "const": "removeTrait" },
-                            "value": { "type": "string" }
+                            "value": { "type": "string" },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "hostMech"],
+                              "description": "Defaults to `self` when absent"
+                            }
                           },
                           "required": ["op", "value"],
                           "additionalProperties": false
@@ -792,6 +858,11 @@
                                     "value": { "type": "string" },
                                     "amount": {
                                       "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                    },
+                                    "target": {
+                                      "type": "string",
+                                      "enum": ["self", "hostMech"],
+                                      "description": "Defaults to `self` when absent"
                                     }
                                   },
                                   "required": ["op", "value"],
@@ -801,7 +872,12 @@
                                   "type": "object",
                                   "properties": {
                                     "op": { "type": "string", "const": "removeTrait" },
-                                    "value": { "type": "string" }
+                                    "value": { "type": "string" },
+                                    "target": {
+                                      "type": "string",
+                                      "enum": ["self", "hostMech"],
+                                      "description": "Defaults to `self` when absent"
+                                    }
                                   },
                                   "required": ["op", "value"],
                                   "additionalProperties": false
@@ -1117,6 +1193,68 @@
                               "description": "A flat mechanical contribution this content makes to a stat"
                             },
                             "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
+                          },
+                          "appliedEffects": {
+                            "type": "array",
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "op": { "type": "string", "const": "addTrait" },
+                                    "value": { "type": "string" },
+                                    "amount": {
+                                      "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                    },
+                                    "target": {
+                                      "type": "string",
+                                      "enum": ["self", "hostMech"],
+                                      "description": "Defaults to `self` when absent"
+                                    }
+                                  },
+                                  "required": ["op", "value"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "op": { "type": "string", "const": "removeTrait" },
+                                    "value": { "type": "string" },
+                                    "target": {
+                                      "type": "string",
+                                      "enum": ["self", "hostMech"],
+                                      "description": "Defaults to `self` when absent"
+                                    }
+                                  },
+                                  "required": ["op", "value"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "op": { "type": "string", "const": "setRange" },
+                                    "value": {
+                                      "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                    }
+                                  },
+                                  "required": ["op", "value"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "op": { "type": "string", "const": "addDamage" },
+                                    "value": {
+                                      "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                    },
+                                    "unit": { "type": "string" }
+                                  },
+                                  "required": ["op", "value"],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            },
+                            "description": "Trait/damage/range effects this item applies unconditionally (ADR-029). Same vocabulary as a choice option’s `effects`, declared directly on the record for grants that are not a choice. Named `appliedEffects`, not `effects`: that key is already taken on meta entities with a different `{ label, value }` shape (see getEffects), and one field name meaning two things is how a schema rots."
                           },
                           "actions": {
                             "type": "array",

--- a/packages/salvageunion-reference/schemas/crawler-bays.schema.json
+++ b/packages/salvageunion-reference/schemas/crawler-bays.schema.json
@@ -782,6 +782,62 @@
                         },
                         "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
                       },
+                      "appliedEffects": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "op": { "type": "string", "const": "addTrait" },
+                                "value": { "type": "string" },
+                                "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                                "target": {
+                                  "type": "string",
+                                  "enum": ["self", "hostMech"],
+                                  "description": "Defaults to `self` when absent"
+                                }
+                              },
+                              "required": ["op", "value"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "op": { "type": "string", "const": "removeTrait" },
+                                "value": { "type": "string" },
+                                "target": {
+                                  "type": "string",
+                                  "enum": ["self", "hostMech"],
+                                  "description": "Defaults to `self` when absent"
+                                }
+                              },
+                              "required": ["op", "value"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "op": { "type": "string", "const": "setRange" },
+                                "value": { "anyOf": [{ "type": "string" }, { "type": "number" }] }
+                              },
+                              "required": ["op", "value"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "op": { "type": "string", "const": "addDamage" },
+                                "value": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                                "unit": { "type": "string" }
+                              },
+                              "required": ["op", "value"],
+                              "additionalProperties": false
+                            }
+                          ]
+                        },
+                        "description": "Trait/damage/range effects this item applies unconditionally (ADR-029). Same vocabulary as a choice option’s `effects`, declared directly on the record for grants that are not a choice. Named `appliedEffects`, not `effects`: that key is already taken on meta entities with a different `{ label, value }` shape (see getEffects), and one field name meaning two things is how a schema rots."
+                      },
                       "actions": {
                         "type": "array",
                         "items": { "type": "string" },
@@ -815,7 +871,12 @@
                               "properties": {
                                 "op": { "type": "string", "const": "addTrait" },
                                 "value": { "type": "string" },
-                                "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] }
+                                "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                                "target": {
+                                  "type": "string",
+                                  "enum": ["self", "hostMech"],
+                                  "description": "Defaults to `self` when absent"
+                                }
                               },
                               "required": ["op", "value"],
                               "additionalProperties": false
@@ -824,7 +885,12 @@
                               "type": "object",
                               "properties": {
                                 "op": { "type": "string", "const": "removeTrait" },
-                                "value": { "type": "string" }
+                                "value": { "type": "string" },
+                                "target": {
+                                  "type": "string",
+                                  "enum": ["self", "hostMech"],
+                                  "description": "Defaults to `self` when absent"
+                                }
                               },
                               "required": ["op", "value"],
                               "additionalProperties": false
@@ -925,6 +991,11 @@
                                         "value": { "type": "string" },
                                         "amount": {
                                           "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                        },
+                                        "target": {
+                                          "type": "string",
+                                          "enum": ["self", "hostMech"],
+                                          "description": "Defaults to `self` when absent"
                                         }
                                       },
                                       "required": ["op", "value"],
@@ -934,7 +1005,12 @@
                                       "type": "object",
                                       "properties": {
                                         "op": { "type": "string", "const": "removeTrait" },
-                                        "value": { "type": "string" }
+                                        "value": { "type": "string" },
+                                        "target": {
+                                          "type": "string",
+                                          "enum": ["self", "hostMech"],
+                                          "description": "Defaults to `self` when absent"
+                                        }
                                       },
                                       "required": ["op", "value"],
                                       "additionalProperties": false
@@ -1250,6 +1326,68 @@
                                   "description": "A flat mechanical contribution this content makes to a stat"
                                 },
                                 "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
+                              },
+                              "appliedEffects": {
+                                "type": "array",
+                                "items": {
+                                  "oneOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "op": { "type": "string", "const": "addTrait" },
+                                        "value": { "type": "string" },
+                                        "amount": {
+                                          "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                        },
+                                        "target": {
+                                          "type": "string",
+                                          "enum": ["self", "hostMech"],
+                                          "description": "Defaults to `self` when absent"
+                                        }
+                                      },
+                                      "required": ["op", "value"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "op": { "type": "string", "const": "removeTrait" },
+                                        "value": { "type": "string" },
+                                        "target": {
+                                          "type": "string",
+                                          "enum": ["self", "hostMech"],
+                                          "description": "Defaults to `self` when absent"
+                                        }
+                                      },
+                                      "required": ["op", "value"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "op": { "type": "string", "const": "setRange" },
+                                        "value": {
+                                          "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                        }
+                                      },
+                                      "required": ["op", "value"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "op": { "type": "string", "const": "addDamage" },
+                                        "value": {
+                                          "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                        },
+                                        "unit": { "type": "string" }
+                                      },
+                                      "required": ["op", "value"],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                },
+                                "description": "Trait/damage/range effects this item applies unconditionally (ADR-029). Same vocabulary as a choice option’s `effects`, declared directly on the record for grants that are not a choice. Named `appliedEffects`, not `effects`: that key is already taken on meta entities with a different `{ label, value }` shape (see getEffects), and one field name meaning two things is how a schema rots."
                               },
                               "actions": {
                                 "type": "array",
@@ -1758,6 +1896,62 @@
                     },
                     "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
                   },
+                  "appliedEffects": {
+                    "type": "array",
+                    "items": {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "op": { "type": "string", "const": "addTrait" },
+                            "value": { "type": "string" },
+                            "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "hostMech"],
+                              "description": "Defaults to `self` when absent"
+                            }
+                          },
+                          "required": ["op", "value"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "op": { "type": "string", "const": "removeTrait" },
+                            "value": { "type": "string" },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "hostMech"],
+                              "description": "Defaults to `self` when absent"
+                            }
+                          },
+                          "required": ["op", "value"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "op": { "type": "string", "const": "setRange" },
+                            "value": { "anyOf": [{ "type": "string" }, { "type": "number" }] }
+                          },
+                          "required": ["op", "value"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "op": { "type": "string", "const": "addDamage" },
+                            "value": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                            "unit": { "type": "string" }
+                          },
+                          "required": ["op", "value"],
+                          "additionalProperties": false
+                        }
+                      ]
+                    },
+                    "description": "Trait/damage/range effects this item applies unconditionally (ADR-029). Same vocabulary as a choice option’s `effects`, declared directly on the record for grants that are not a choice. Named `appliedEffects`, not `effects`: that key is already taken on meta entities with a different `{ label, value }` shape (see getEffects), and one field name meaning two things is how a schema rots."
+                  },
                   "actions": {
                     "type": "array",
                     "items": { "type": "string" },
@@ -1791,7 +1985,12 @@
                           "properties": {
                             "op": { "type": "string", "const": "addTrait" },
                             "value": { "type": "string" },
-                            "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] }
+                            "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "hostMech"],
+                              "description": "Defaults to `self` when absent"
+                            }
                           },
                           "required": ["op", "value"],
                           "additionalProperties": false
@@ -1800,7 +1999,12 @@
                           "type": "object",
                           "properties": {
                             "op": { "type": "string", "const": "removeTrait" },
-                            "value": { "type": "string" }
+                            "value": { "type": "string" },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "hostMech"],
+                              "description": "Defaults to `self` when absent"
+                            }
                           },
                           "required": ["op", "value"],
                           "additionalProperties": false
@@ -1901,6 +2105,11 @@
                                     "value": { "type": "string" },
                                     "amount": {
                                       "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                    },
+                                    "target": {
+                                      "type": "string",
+                                      "enum": ["self", "hostMech"],
+                                      "description": "Defaults to `self` when absent"
                                     }
                                   },
                                   "required": ["op", "value"],
@@ -1910,7 +2119,12 @@
                                   "type": "object",
                                   "properties": {
                                     "op": { "type": "string", "const": "removeTrait" },
-                                    "value": { "type": "string" }
+                                    "value": { "type": "string" },
+                                    "target": {
+                                      "type": "string",
+                                      "enum": ["self", "hostMech"],
+                                      "description": "Defaults to `self` when absent"
+                                    }
                                   },
                                   "required": ["op", "value"],
                                   "additionalProperties": false
@@ -2226,6 +2440,68 @@
                               "description": "A flat mechanical contribution this content makes to a stat"
                             },
                             "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
+                          },
+                          "appliedEffects": {
+                            "type": "array",
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "op": { "type": "string", "const": "addTrait" },
+                                    "value": { "type": "string" },
+                                    "amount": {
+                                      "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                    },
+                                    "target": {
+                                      "type": "string",
+                                      "enum": ["self", "hostMech"],
+                                      "description": "Defaults to `self` when absent"
+                                    }
+                                  },
+                                  "required": ["op", "value"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "op": { "type": "string", "const": "removeTrait" },
+                                    "value": { "type": "string" },
+                                    "target": {
+                                      "type": "string",
+                                      "enum": ["self", "hostMech"],
+                                      "description": "Defaults to `self` when absent"
+                                    }
+                                  },
+                                  "required": ["op", "value"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "op": { "type": "string", "const": "setRange" },
+                                    "value": {
+                                      "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                    }
+                                  },
+                                  "required": ["op", "value"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "op": { "type": "string", "const": "addDamage" },
+                                    "value": {
+                                      "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                    },
+                                    "unit": { "type": "string" }
+                                  },
+                                  "required": ["op", "value"],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            },
+                            "description": "Trait/damage/range effects this item applies unconditionally (ADR-029). Same vocabulary as a choice option’s `effects`, declared directly on the record for grants that are not a choice. Named `appliedEffects`, not `effects`: that key is already taken on meta entities with a different `{ label, value }` shape (see getEffects), and one field name meaning two things is how a schema rots."
                           },
                           "actions": {
                             "type": "array",

--- a/packages/salvageunion-reference/schemas/crawlers.schema.json
+++ b/packages/salvageunion-reference/schemas/crawlers.schema.json
@@ -777,6 +777,62 @@
                         },
                         "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
                       },
+                      "appliedEffects": {
+                        "type": "array",
+                        "items": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "op": { "type": "string", "const": "addTrait" },
+                                "value": { "type": "string" },
+                                "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                                "target": {
+                                  "type": "string",
+                                  "enum": ["self", "hostMech"],
+                                  "description": "Defaults to `self` when absent"
+                                }
+                              },
+                              "required": ["op", "value"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "op": { "type": "string", "const": "removeTrait" },
+                                "value": { "type": "string" },
+                                "target": {
+                                  "type": "string",
+                                  "enum": ["self", "hostMech"],
+                                  "description": "Defaults to `self` when absent"
+                                }
+                              },
+                              "required": ["op", "value"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "op": { "type": "string", "const": "setRange" },
+                                "value": { "anyOf": [{ "type": "string" }, { "type": "number" }] }
+                              },
+                              "required": ["op", "value"],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "op": { "type": "string", "const": "addDamage" },
+                                "value": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                                "unit": { "type": "string" }
+                              },
+                              "required": ["op", "value"],
+                              "additionalProperties": false
+                            }
+                          ]
+                        },
+                        "description": "Trait/damage/range effects this item applies unconditionally (ADR-029). Same vocabulary as a choice option’s `effects`, declared directly on the record for grants that are not a choice. Named `appliedEffects`, not `effects`: that key is already taken on meta entities with a different `{ label, value }` shape (see getEffects), and one field name meaning two things is how a schema rots."
+                      },
                       "actions": {
                         "type": "array",
                         "items": { "type": "string" },
@@ -810,7 +866,12 @@
                               "properties": {
                                 "op": { "type": "string", "const": "addTrait" },
                                 "value": { "type": "string" },
-                                "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] }
+                                "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                                "target": {
+                                  "type": "string",
+                                  "enum": ["self", "hostMech"],
+                                  "description": "Defaults to `self` when absent"
+                                }
                               },
                               "required": ["op", "value"],
                               "additionalProperties": false
@@ -819,7 +880,12 @@
                               "type": "object",
                               "properties": {
                                 "op": { "type": "string", "const": "removeTrait" },
-                                "value": { "type": "string" }
+                                "value": { "type": "string" },
+                                "target": {
+                                  "type": "string",
+                                  "enum": ["self", "hostMech"],
+                                  "description": "Defaults to `self` when absent"
+                                }
                               },
                               "required": ["op", "value"],
                               "additionalProperties": false
@@ -920,6 +986,11 @@
                                         "value": { "type": "string" },
                                         "amount": {
                                           "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                        },
+                                        "target": {
+                                          "type": "string",
+                                          "enum": ["self", "hostMech"],
+                                          "description": "Defaults to `self` when absent"
                                         }
                                       },
                                       "required": ["op", "value"],
@@ -929,7 +1000,12 @@
                                       "type": "object",
                                       "properties": {
                                         "op": { "type": "string", "const": "removeTrait" },
-                                        "value": { "type": "string" }
+                                        "value": { "type": "string" },
+                                        "target": {
+                                          "type": "string",
+                                          "enum": ["self", "hostMech"],
+                                          "description": "Defaults to `self` when absent"
+                                        }
                                       },
                                       "required": ["op", "value"],
                                       "additionalProperties": false
@@ -1245,6 +1321,68 @@
                                   "description": "A flat mechanical contribution this content makes to a stat"
                                 },
                                 "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
+                              },
+                              "appliedEffects": {
+                                "type": "array",
+                                "items": {
+                                  "oneOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "op": { "type": "string", "const": "addTrait" },
+                                        "value": { "type": "string" },
+                                        "amount": {
+                                          "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                        },
+                                        "target": {
+                                          "type": "string",
+                                          "enum": ["self", "hostMech"],
+                                          "description": "Defaults to `self` when absent"
+                                        }
+                                      },
+                                      "required": ["op", "value"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "op": { "type": "string", "const": "removeTrait" },
+                                        "value": { "type": "string" },
+                                        "target": {
+                                          "type": "string",
+                                          "enum": ["self", "hostMech"],
+                                          "description": "Defaults to `self` when absent"
+                                        }
+                                      },
+                                      "required": ["op", "value"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "op": { "type": "string", "const": "setRange" },
+                                        "value": {
+                                          "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                        }
+                                      },
+                                      "required": ["op", "value"],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "op": { "type": "string", "const": "addDamage" },
+                                        "value": {
+                                          "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                        },
+                                        "unit": { "type": "string" }
+                                      },
+                                      "required": ["op", "value"],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                },
+                                "description": "Trait/damage/range effects this item applies unconditionally (ADR-029). Same vocabulary as a choice option’s `effects`, declared directly on the record for grants that are not a choice. Named `appliedEffects`, not `effects`: that key is already taken on meta entities with a different `{ label, value }` shape (see getEffects), and one field name meaning two things is how a schema rots."
                               },
                               "actions": {
                                 "type": "array",

--- a/packages/salvageunion-reference/schemas/drones.schema.json
+++ b/packages/salvageunion-reference/schemas/drones.schema.json
@@ -772,6 +772,62 @@
                     },
                     "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
                   },
+                  "appliedEffects": {
+                    "type": "array",
+                    "items": {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "op": { "type": "string", "const": "addTrait" },
+                            "value": { "type": "string" },
+                            "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "hostMech"],
+                              "description": "Defaults to `self` when absent"
+                            }
+                          },
+                          "required": ["op", "value"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "op": { "type": "string", "const": "removeTrait" },
+                            "value": { "type": "string" },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "hostMech"],
+                              "description": "Defaults to `self` when absent"
+                            }
+                          },
+                          "required": ["op", "value"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "op": { "type": "string", "const": "setRange" },
+                            "value": { "anyOf": [{ "type": "string" }, { "type": "number" }] }
+                          },
+                          "required": ["op", "value"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "op": { "type": "string", "const": "addDamage" },
+                            "value": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                            "unit": { "type": "string" }
+                          },
+                          "required": ["op", "value"],
+                          "additionalProperties": false
+                        }
+                      ]
+                    },
+                    "description": "Trait/damage/range effects this item applies unconditionally (ADR-029). Same vocabulary as a choice option’s `effects`, declared directly on the record for grants that are not a choice. Named `appliedEffects`, not `effects`: that key is already taken on meta entities with a different `{ label, value }` shape (see getEffects), and one field name meaning two things is how a schema rots."
+                  },
                   "actions": {
                     "type": "array",
                     "items": { "type": "string" },
@@ -805,7 +861,12 @@
                           "properties": {
                             "op": { "type": "string", "const": "addTrait" },
                             "value": { "type": "string" },
-                            "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] }
+                            "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "hostMech"],
+                              "description": "Defaults to `self` when absent"
+                            }
                           },
                           "required": ["op", "value"],
                           "additionalProperties": false
@@ -814,7 +875,12 @@
                           "type": "object",
                           "properties": {
                             "op": { "type": "string", "const": "removeTrait" },
-                            "value": { "type": "string" }
+                            "value": { "type": "string" },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "hostMech"],
+                              "description": "Defaults to `self` when absent"
+                            }
                           },
                           "required": ["op", "value"],
                           "additionalProperties": false
@@ -915,6 +981,11 @@
                                     "value": { "type": "string" },
                                     "amount": {
                                       "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                    },
+                                    "target": {
+                                      "type": "string",
+                                      "enum": ["self", "hostMech"],
+                                      "description": "Defaults to `self` when absent"
                                     }
                                   },
                                   "required": ["op", "value"],
@@ -924,7 +995,12 @@
                                   "type": "object",
                                   "properties": {
                                     "op": { "type": "string", "const": "removeTrait" },
-                                    "value": { "type": "string" }
+                                    "value": { "type": "string" },
+                                    "target": {
+                                      "type": "string",
+                                      "enum": ["self", "hostMech"],
+                                      "description": "Defaults to `self` when absent"
+                                    }
                                   },
                                   "required": ["op", "value"],
                                   "additionalProperties": false
@@ -1240,6 +1316,68 @@
                               "description": "A flat mechanical contribution this content makes to a stat"
                             },
                             "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
+                          },
+                          "appliedEffects": {
+                            "type": "array",
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "op": { "type": "string", "const": "addTrait" },
+                                    "value": { "type": "string" },
+                                    "amount": {
+                                      "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                    },
+                                    "target": {
+                                      "type": "string",
+                                      "enum": ["self", "hostMech"],
+                                      "description": "Defaults to `self` when absent"
+                                    }
+                                  },
+                                  "required": ["op", "value"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "op": { "type": "string", "const": "removeTrait" },
+                                    "value": { "type": "string" },
+                                    "target": {
+                                      "type": "string",
+                                      "enum": ["self", "hostMech"],
+                                      "description": "Defaults to `self` when absent"
+                                    }
+                                  },
+                                  "required": ["op", "value"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "op": { "type": "string", "const": "setRange" },
+                                    "value": {
+                                      "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                    }
+                                  },
+                                  "required": ["op", "value"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "op": { "type": "string", "const": "addDamage" },
+                                    "value": {
+                                      "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                    },
+                                    "unit": { "type": "string" }
+                                  },
+                                  "required": ["op", "value"],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            },
+                            "description": "Trait/damage/range effects this item applies unconditionally (ADR-029). Same vocabulary as a choice option’s `effects`, declared directly on the record for grants that are not a choice. Named `appliedEffects`, not `effects`: that key is already taken on meta entities with a different `{ label, value }` shape (see getEffects), and one field name meaning two things is how a schema rots."
                           },
                           "actions": {
                             "type": "array",

--- a/packages/salvageunion-reference/schemas/equipment.schema.json
+++ b/packages/salvageunion-reference/schemas/equipment.schema.json
@@ -762,6 +762,62 @@
                     },
                     "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
                   },
+                  "appliedEffects": {
+                    "type": "array",
+                    "items": {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "op": { "type": "string", "const": "addTrait" },
+                            "value": { "type": "string" },
+                            "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "hostMech"],
+                              "description": "Defaults to `self` when absent"
+                            }
+                          },
+                          "required": ["op", "value"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "op": { "type": "string", "const": "removeTrait" },
+                            "value": { "type": "string" },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "hostMech"],
+                              "description": "Defaults to `self` when absent"
+                            }
+                          },
+                          "required": ["op", "value"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "op": { "type": "string", "const": "setRange" },
+                            "value": { "anyOf": [{ "type": "string" }, { "type": "number" }] }
+                          },
+                          "required": ["op", "value"],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "op": { "type": "string", "const": "addDamage" },
+                            "value": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                            "unit": { "type": "string" }
+                          },
+                          "required": ["op", "value"],
+                          "additionalProperties": false
+                        }
+                      ]
+                    },
+                    "description": "Trait/damage/range effects this item applies unconditionally (ADR-029). Same vocabulary as a choice option’s `effects`, declared directly on the record for grants that are not a choice. Named `appliedEffects`, not `effects`: that key is already taken on meta entities with a different `{ label, value }` shape (see getEffects), and one field name meaning two things is how a schema rots."
+                  },
                   "actions": {
                     "type": "array",
                     "items": { "type": "string" },
@@ -795,7 +851,12 @@
                           "properties": {
                             "op": { "type": "string", "const": "addTrait" },
                             "value": { "type": "string" },
-                            "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] }
+                            "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "hostMech"],
+                              "description": "Defaults to `self` when absent"
+                            }
                           },
                           "required": ["op", "value"],
                           "additionalProperties": false
@@ -804,7 +865,12 @@
                           "type": "object",
                           "properties": {
                             "op": { "type": "string", "const": "removeTrait" },
-                            "value": { "type": "string" }
+                            "value": { "type": "string" },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "hostMech"],
+                              "description": "Defaults to `self` when absent"
+                            }
                           },
                           "required": ["op", "value"],
                           "additionalProperties": false
@@ -905,6 +971,11 @@
                                     "value": { "type": "string" },
                                     "amount": {
                                       "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                    },
+                                    "target": {
+                                      "type": "string",
+                                      "enum": ["self", "hostMech"],
+                                      "description": "Defaults to `self` when absent"
                                     }
                                   },
                                   "required": ["op", "value"],
@@ -914,7 +985,12 @@
                                   "type": "object",
                                   "properties": {
                                     "op": { "type": "string", "const": "removeTrait" },
-                                    "value": { "type": "string" }
+                                    "value": { "type": "string" },
+                                    "target": {
+                                      "type": "string",
+                                      "enum": ["self", "hostMech"],
+                                      "description": "Defaults to `self` when absent"
+                                    }
                                   },
                                   "required": ["op", "value"],
                                   "additionalProperties": false
@@ -1230,6 +1306,68 @@
                               "description": "A flat mechanical contribution this content makes to a stat"
                             },
                             "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
+                          },
+                          "appliedEffects": {
+                            "type": "array",
+                            "items": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "op": { "type": "string", "const": "addTrait" },
+                                    "value": { "type": "string" },
+                                    "amount": {
+                                      "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                    },
+                                    "target": {
+                                      "type": "string",
+                                      "enum": ["self", "hostMech"],
+                                      "description": "Defaults to `self` when absent"
+                                    }
+                                  },
+                                  "required": ["op", "value"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "op": { "type": "string", "const": "removeTrait" },
+                                    "value": { "type": "string" },
+                                    "target": {
+                                      "type": "string",
+                                      "enum": ["self", "hostMech"],
+                                      "description": "Defaults to `self` when absent"
+                                    }
+                                  },
+                                  "required": ["op", "value"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "op": { "type": "string", "const": "setRange" },
+                                    "value": {
+                                      "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                    }
+                                  },
+                                  "required": ["op", "value"],
+                                  "additionalProperties": false
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "op": { "type": "string", "const": "addDamage" },
+                                    "value": {
+                                      "anyOf": [{ "type": "string" }, { "type": "number" }]
+                                    },
+                                    "unit": { "type": "string" }
+                                  },
+                                  "required": ["op", "value"],
+                                  "additionalProperties": false
+                                }
+                              ]
+                            },
+                            "description": "Trait/damage/range effects this item applies unconditionally (ADR-029). Same vocabulary as a choice option’s `effects`, declared directly on the record for grants that are not a choice. Named `appliedEffects`, not `effects`: that key is already taken on meta entities with a different `{ label, value }` shape (see getEffects), and one field name meaning two things is how a schema rots."
                           },
                           "actions": {
                             "type": "array",

--- a/packages/salvageunion-reference/schemas/guides.schema.json
+++ b/packages/salvageunion-reference/schemas/guides.schema.json
@@ -465,7 +465,12 @@
                           "properties": {
                             "op": { "type": "string", "const": "addTrait" },
                             "value": { "type": "string" },
-                            "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] }
+                            "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "hostMech"],
+                              "description": "Defaults to `self` when absent"
+                            }
                           },
                           "required": ["op", "value"],
                           "additionalProperties": false
@@ -474,7 +479,12 @@
                           "type": "object",
                           "properties": {
                             "op": { "type": "string", "const": "removeTrait" },
-                            "value": { "type": "string" }
+                            "value": { "type": "string" },
+                            "target": {
+                              "type": "string",
+                              "enum": ["self", "hostMech"],
+                              "description": "Defaults to `self` when absent"
+                            }
                           },
                           "required": ["op", "value"],
                           "additionalProperties": false

--- a/packages/salvageunion-reference/schemas/modules.schema.json
+++ b/packages/salvageunion-reference/schemas/modules.schema.json
@@ -410,6 +410,62 @@
         },
         "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
       },
+      "appliedEffects": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "op": { "type": "string", "const": "addTrait" },
+                "value": { "type": "string" },
+                "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                "target": {
+                  "type": "string",
+                  "enum": ["self", "hostMech"],
+                  "description": "Defaults to `self` when absent"
+                }
+              },
+              "required": ["op", "value"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "op": { "type": "string", "const": "removeTrait" },
+                "value": { "type": "string" },
+                "target": {
+                  "type": "string",
+                  "enum": ["self", "hostMech"],
+                  "description": "Defaults to `self` when absent"
+                }
+              },
+              "required": ["op", "value"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "op": { "type": "string", "const": "setRange" },
+                "value": { "anyOf": [{ "type": "string" }, { "type": "number" }] }
+              },
+              "required": ["op", "value"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "op": { "type": "string", "const": "addDamage" },
+                "value": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                "unit": { "type": "string" }
+              },
+              "required": ["op", "value"],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "description": "Trait/damage/range effects this item applies unconditionally (ADR-029). Same vocabulary as a choice option’s `effects`, declared directly on the record for grants that are not a choice. Named `appliedEffects`, not `effects`: that key is already taken on meta entities with a different `{ label, value }` shape (see getEffects), and one field name meaning two things is how a schema rots."
+      },
       "actions": {
         "type": "array",
         "items": { "type": "string" },

--- a/packages/salvageunion-reference/schemas/systems.schema.json
+++ b/packages/salvageunion-reference/schemas/systems.schema.json
@@ -410,6 +410,62 @@
         },
         "description": "Contributions this item makes (ADR-029). Distinct from `statBonus`: these carry a target, a duration and expression amounts, so they cover what a flat per-copy bonus cannot."
       },
+      "appliedEffects": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "op": { "type": "string", "const": "addTrait" },
+                "value": { "type": "string" },
+                "amount": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                "target": {
+                  "type": "string",
+                  "enum": ["self", "hostMech"],
+                  "description": "Defaults to `self` when absent"
+                }
+              },
+              "required": ["op", "value"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "op": { "type": "string", "const": "removeTrait" },
+                "value": { "type": "string" },
+                "target": {
+                  "type": "string",
+                  "enum": ["self", "hostMech"],
+                  "description": "Defaults to `self` when absent"
+                }
+              },
+              "required": ["op", "value"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "op": { "type": "string", "const": "setRange" },
+                "value": { "anyOf": [{ "type": "string" }, { "type": "number" }] }
+              },
+              "required": ["op", "value"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "op": { "type": "string", "const": "addDamage" },
+                "value": { "anyOf": [{ "type": "string" }, { "type": "number" }] },
+                "unit": { "type": "string" }
+              },
+              "required": ["op", "value"],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "description": "Trait/damage/range effects this item applies unconditionally (ADR-029). Same vocabulary as a choice option’s `effects`, declared directly on the record for grants that are not a choice. Named `appliedEffects`, not `effects`: that key is already taken on meta entities with a different `{ label, value }` shape (see getEffects), and one field name meaning two things is how a schema rots."
+      },
       "actions": {
         "type": "array",
         "items": { "type": "string" },

--- a/packages/salvageunion-reference/tools/validateParityLogic.ts
+++ b/packages/salvageunion-reference/tools/validateParityLogic.ts
@@ -141,7 +141,14 @@ export const PARITY_EXEMPTIONS: Record<string, string> = {
  * on a stale entry, because a burn-down list that never shrinks is not burning
  * down.
  */
-export const KNOWN_UNRESOLVED: readonly string[] = ['Bio-Wings', 'High Gain Antenna']
+export const KNOWN_UNRESOLVED: readonly string[] = [
+  // Raises the Range band of OTHER installed Modules and Pilot Abilities,
+  // filtered by trait. Still blocked, and now precisely: it needs a `bumpRange`
+  // op (`setRange` sets an absolute value; this INCREMENTS by one) and
+  // cross-item targeting with a predicate — a loadout-level resolver, where
+  // every other effect resolves per entity.
+  'High Gain Antenna',
+]
 
 function textOf(value: unknown, acc: string[]): void {
   if (typeof value === 'string') acc.push(value)
@@ -167,6 +174,9 @@ function hasCapData(record: Json): boolean {
 }
 
 function hasEffectData(record: Json): boolean {
+  // Record-level effects (ADR-029) — a grant that is not a choice, e.g.
+  // Bio-Wings granting the host mech the Fly Trait outright.
+  if (Array.isArray(record.appliedEffects) && record.appliedEffects.length > 0) return true
   const choices = record.choices
   if (!Array.isArray(choices)) return false
   return choices.some((choice) => {


### PR DESCRIPTION
**Effect targeting** — the last item of the rules-parity plan (#598), sixth in the recommended order.

```
Rules parity: 30 claim(s) — 17 encoded, 12 exempt, 1 unresolved (1 known, burning down)
```

## The blocker was never "a place to declare effects"

C3 was scoped as *"effects declarable directly on a system/ability"*. Declaring them was never the problem: **`ChoiceEffectSchema` had no `target`**, and neither remaining record's effect lands on the record that declares it.

Bio-Wings says *"Your Mech gains the Fly Trait"* — a trait belonging to the **mech**, not to the system that granted it. Declared as a self-effect it would have said the Bio-Wings *system* flies: **wrong, not merely incomplete**. Encoding it that way would have applied a real rule to the wrong entity, which is worse than a visible gap — so it stayed unencoded until the model could say it properly.

## Three pieces, each necessary

| Piece | Why |
|---|---|
| `target: 'hostMech'` | So an effect can land on the mech rather than the item |
| `appliedEffects` | Record-level effects, for grants that aren't a choice |
| `mechTraits()` | The derivation that aggregates them — **nothing collected a mech's traits before**, the other half of why this couldn't be encoded |

Named **`appliedEffects`**, not `effects`: that key is already taken on meta entities with a different `{ label, value }` shape (consumed by `getEffects`), and one field name meaning two things is how a schema rots.

Derived at read time, never stored — a trait disappears the moment the granting item is removed, with no bookkeeping. Duplicates keep the highest magnitude, matching `resolveChoiceView`'s Explosive 1 → 2 upgrade rule, so the two resolvers can't disagree about stacking.

## What remains, precisely scoped

**High Gain Antenna** raises the Range band of *other* installed Modules and Pilot Abilities, filtered by trait. That needs a **`bumpRange`** op (`setRange` sets an absolute value; this *increments* by one) and **cross-item targeting with a predicate** — a loadout-level resolver, where every other effect resolves per entity. Recorded in `KNOWN_UNRESOLVED` with that reasoning so the next person doesn't rediscover it.

## Verification

`bun run check:all` green: schemas, lint, format, typecheck, **4,604 tests**, validate (incl. the parity gate), knip, audit, tokens, styling.

Six new tests, including the one carrying the intent: a **self**-targeted effect must not land on the mech — a weapon whose own choice adds Ballistic to itself must never make the mech Ballistic.

Refs #598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MT6q22Y1MtuCYHormXwQ4