### PR TITLE
feat(itun): Mediator server layer — NPC tray and presence (Phase 3)

### DIFF
--- a/apps/itun/CHANGELOG.md
+++ b/apps/itun/CHANGELOG.md
@@ -4,82 +4,71 @@ Maintained by release-please (see ADR-024).
 
 ## [0.7.0](https://github.com/SalvageUnion-io/SU-SRD/compare/itun-v0.6.0...itun-v0.7.0) (2026-07-28)
 
-
 ### Features
 
-* **component-lib:** make the roll-table title its own table picker ([#592](https://github.com/SalvageUnion-io/SU-SRD/issues/592)) ([18f315a](https://github.com/SalvageUnion-io/SU-SRD/commit/18f315ac0501f00f52db63181dbf383d66909245))
-* **itun:** render partners in place, delete the partner sheet ([#590](https://github.com/SalvageUnion-io/SU-SRD/issues/590)) ([33ddccd](https://github.com/SalvageUnion-io/SU-SRD/commit/33ddccd79c6b9db417dff0384f27188d3fe0b67f))
-* **itun:** render the SRD home page in the Dashboard SRD Explorer ([#593](https://github.com/SalvageUnion-io/SU-SRD/issues/593)) ([05906b6](https://github.com/SalvageUnion-io/SU-SRD/commit/05906b629fe97708f5c9faf8e638e29033e363e9))
+- **component-lib:** make the roll-table title its own table picker ([#592](https://github.com/SalvageUnion-io/SU-SRD/issues/592)) ([18f315a](https://github.com/SalvageUnion-io/SU-SRD/commit/18f315ac0501f00f52db63181dbf383d66909245))
+- **itun:** render partners in place, delete the partner sheet ([#590](https://github.com/SalvageUnion-io/SU-SRD/issues/590)) ([33ddccd](https://github.com/SalvageUnion-io/SU-SRD/commit/33ddccd79c6b9db417dff0384f27188d3fe0b67f))
+- **itun:** render the SRD home page in the Dashboard SRD Explorer ([#593](https://github.com/SalvageUnion-io/SU-SRD/issues/593)) ([05906b6](https://github.com/SalvageUnion-io/SU-SRD/commit/05906b629fe97708f5c9faf8e638e29033e363e9))
 
 ## [0.6.0](https://github.com/SalvageUnion-io/SU-SRD/compare/itun-v0.5.0...itun-v0.6.0) (2026-07-28)
 
-
 ### Features
 
-* **itun:** show the Actions deck as one catalog-tile grid, mech + pilot ([#591](https://github.com/SalvageUnion-io/SU-SRD/issues/591)) ([f8979b0](https://github.com/SalvageUnion-io/SU-SRD/commit/f8979b04b8d804c4c464bd596c0b31074d8f4769))
-
+- **itun:** show the Actions deck as one catalog-tile grid, mech + pilot ([#591](https://github.com/SalvageUnion-io/SU-SRD/issues/591)) ([f8979b0](https://github.com/SalvageUnion-io/SU-SRD/commit/f8979b04b8d804c4c464bd596c0b31074d8f4769))
 
 ### Bug Fixes
 
-* **itun:** start Heat at zero, never at capacity ([#588](https://github.com/SalvageUnion-io/SU-SRD/issues/588)) ([67cebf2](https://github.com/SalvageUnion-io/SU-SRD/commit/67cebf2901aff7bfda198e55f49c10a3f7442f3f))
+- **itun:** start Heat at zero, never at capacity ([#588](https://github.com/SalvageUnion-io/SU-SRD/issues/588)) ([67cebf2](https://github.com/SalvageUnion-io/SU-SRD/commit/67cebf2901aff7bfda198e55f49c10a3f7442f3f))
 
 ## [0.5.0](https://github.com/SalvageUnion-io/SU-SRD/compare/itun-v0.4.1...itun-v0.5.0) (2026-07-25)
 
-
 ### Features
 
-* **itun:** live-sheet redesign — card/slab containers, folding, and a crew-shaped crawler ([#561](https://github.com/SalvageUnion-io/SU-SRD/issues/561)) ([b180c24](https://github.com/SalvageUnion-io/SU-SRD/commit/b180c244ab7b8d8df39512ed3805b80661efc22a))
-* Partner Sheets — statted drones/companions owned by a pilot or a mech ([#578](https://github.com/SalvageUnion-io/SU-SRD/issues/578)) ([7ee4d1b](https://github.com/SalvageUnion-io/SU-SRD/commit/7ee4d1b45e11d44f90da0c90dad82e08a1edca30))
+- **itun:** live-sheet redesign — card/slab containers, folding, and a crew-shaped crawler ([#561](https://github.com/SalvageUnion-io/SU-SRD/issues/561)) ([b180c24](https://github.com/SalvageUnion-io/SU-SRD/commit/b180c244ab7b8d8df39512ed3805b80661efc22a))
+- Partner Sheets — statted drones/companions owned by a pilot or a mech ([#578](https://github.com/SalvageUnion-io/SU-SRD/issues/578)) ([7ee4d1b](https://github.com/SalvageUnion-io/SU-SRD/commit/7ee4d1b45e11d44f90da0c90dad82e08a1edca30))
 
 ## [0.4.1](https://github.com/SalvageUnion-io/SU-SRD/compare/itun-v0.4.0...itun-v0.4.1) (2026-07-24)
 
-
 ### Bug Fixes
 
-* **reference:** resolve data-inspection findings — dead flags, enum, null-marker, redundant fields ([#555](https://github.com/SalvageUnion-io/SU-SRD/issues/555)) ([2658095](https://github.com/SalvageUnion-io/SU-SRD/commit/2658095793f18341538cd977d328aca98a7861cb))
+- **reference:** resolve data-inspection findings — dead flags, enum, null-marker, redundant fields ([#555](https://github.com/SalvageUnion-io/SU-SRD/issues/555)) ([2658095](https://github.com/SalvageUnion-io/SU-SRD/commit/2658095793f18341538cd977d328aca98a7861cb))
 
 ## [0.4.0](https://github.com/SalvageUnion-io/SU-SRD/compare/itun-v0.3.1...itun-v0.4.0) (2026-07-24)
 
-
 ### Features
 
-* **dashboard:** lay the Actions deck out as a masonry grid ([#549](https://github.com/SalvageUnion-io/SU-SRD/issues/549)) ([49fc203](https://github.com/SalvageUnion-io/SU-SRD/commit/49fc203e54bf35c0e90423544d4184981bd06a68))
-
+- **dashboard:** lay the Actions deck out as a masonry grid ([#549](https://github.com/SalvageUnion-io/SU-SRD/issues/549)) ([49fc203](https://github.com/SalvageUnion-io/SU-SRD/commit/49fc203e54bf35c0e90423544d4184981bd06a68))
 
 ### Bug Fixes
 
-* **ci:** unbreak the nightly e2e suite, its alerting, and the routeTree drift ([#548](https://github.com/SalvageUnion-io/SU-SRD/issues/548)) ([5fd242a](https://github.com/SalvageUnion-io/SU-SRD/commit/5fd242a0aafd427ab80000f4235b6e1ee62c7712))
-* **live-sheets:** black-on-black titles + Workshop Manual redesign (mockup for sign-off) ([#554](https://github.com/SalvageUnion-io/SU-SRD/issues/554)) ([cf5f3ed](https://github.com/SalvageUnion-io/SU-SRD/commit/cf5f3ed45a0127ac6b5f82966dfd6eed539e203f))
+- **ci:** unbreak the nightly e2e suite, its alerting, and the routeTree drift ([#548](https://github.com/SalvageUnion-io/SU-SRD/issues/548)) ([5fd242a](https://github.com/SalvageUnion-io/SU-SRD/commit/5fd242a0aafd427ab80000f4235b6e1ee62c7712))
+- **live-sheets:** black-on-black titles + Workshop Manual redesign (mockup for sign-off) ([#554](https://github.com/SalvageUnion-io/SU-SRD/issues/554)) ([cf5f3ed](https://github.com/SalvageUnion-io/SU-SRD/commit/cf5f3ed45a0127ac6b5f82966dfd6eed539e203f))
 
 ## [0.3.1](https://github.com/SalvageUnion-io/SU-SRD/compare/itun-v0.3.0...itun-v0.3.1) (2026-07-23)
 
-
 ### Performance Improvements
 
-* **itun:** route-level code splitting + a PR-blocking bundle budget ([#543](https://github.com/SalvageUnion-io/SU-SRD/issues/543)) ([e75b1e9](https://github.com/SalvageUnion-io/SU-SRD/commit/e75b1e9ec427bc8c714cb3cad0efb8b9961a9fdb))
+- **itun:** route-level code splitting + a PR-blocking bundle budget ([#543](https://github.com/SalvageUnion-io/SU-SRD/issues/543)) ([e75b1e9](https://github.com/SalvageUnion-io/SU-SRD/commit/e75b1e9ec427bc8c714cb3cad0efb8b9961a9fdb))
 
 ## [0.3.0](https://github.com/SalvageUnion-io/SU-SRD/compare/itun-v0.2.0...itun-v0.3.0) (2026-07-23)
 
-
 ### Features
 
-* **itun:** make the mech hold and crawler Storage Bay independently usable ([#536](https://github.com/SalvageUnion-io/SU-SRD/issues/536)) ([ba911f3](https://github.com/SalvageUnion-io/SU-SRD/commit/ba911f3ad084ea411d42c46cc0f85d5a0c7f6043))
+- **itun:** make the mech hold and crawler Storage Bay independently usable ([#536](https://github.com/SalvageUnion-io/SU-SRD/issues/536)) ([ba911f3](https://github.com/SalvageUnion-io/SU-SRD/commit/ba911f3ad084ea411d42c46cc0f85d5a0c7f6043))
 
 ## [0.2.0](https://github.com/SalvageUnion-io/SU-SRD/compare/itun-v0.1.0...itun-v0.2.0) (2026-07-23)
 
-
 ### Features
 
-* shared about-page colophon + slab section heads on the back pages ([#524](https://github.com/SalvageUnion-io/SU-SRD/issues/524)) ([652e5fc](https://github.com/SalvageUnion-io/SU-SRD/commit/652e5fcdbd107d7eb3fa422d21441924114d2b97))
-
+- shared about-page colophon + slab section heads on the back pages ([#524](https://github.com/SalvageUnion-io/SU-SRD/issues/524)) ([652e5fc](https://github.com/SalvageUnion-io/SU-SRD/commit/652e5fcdbd107d7eb3fa422d21441924114d2b97))
 
 ### Bug Fixes
 
-* **reference:** correct three pattern names and add two missing book patterns ([#523](https://github.com/SalvageUnion-io/SU-SRD/issues/523)) ([736b1b8](https://github.com/SalvageUnion-io/SU-SRD/commit/736b1b8a04736215f63e0eca7831214f290d91ca))
-* **reference:** give every mech pattern its own verified source + page ([#529](https://github.com/SalvageUnion-io/SU-SRD/issues/529)) ([578a12f](https://github.com/SalvageUnion-io/SU-SRD/commit/578a12f8a7267bd49559b7dd67448463e7c20d77))
+- **reference:** correct three pattern names and add two missing book patterns ([#523](https://github.com/SalvageUnion-io/SU-SRD/issues/523)) ([736b1b8](https://github.com/SalvageUnion-io/SU-SRD/commit/736b1b8a04736215f63e0eca7831214f290d91ca))
+- **reference:** give every mech pattern its own verified source + page ([#529](https://github.com/SalvageUnion-io/SU-SRD/issues/529)) ([578a12f](https://github.com/SalvageUnion-io/SU-SRD/commit/578a12f8a7267bd49559b7dd67448463e7c20d77))
 
 ## 0.1.0 (2026-07-18)
 
 ### Features
 
-* Initial in-app changelog.
+- Initial in-app changelog.

--- a/apps/itun/convex/__tests__/account.test.ts
+++ b/apps/itun/convex/__tests__/account.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, test } from 'bun:test'
+
+import { api } from '../_generated/api'
+import type { Id } from '../_generated/dataModel'
+import { testConvex } from './harness'
+
+/**
+ * Account management, and in particular the promise D27 makes:
+ * **a campaign never dies because one person quit.**
+ *
+ * Deletion is the operation with no undo, so the cases below are less about
+ * "does it delete" and more about "does it delete *only* the right things" —
+ * the crew's Game, the communal crawler, and other people's characters all
+ * have to survive somebody exercising their right to be forgotten.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+async function seedPilot(t: Ctx, gameId: Id<'games'> | null, ownerId: Id<'users'> | null) {
+  return await t.run(
+    async (ctx) =>
+      await ctx.db.insert('pilots', { gameId, ownerId, body: { callsign: 'X' }, updatedAt: 1 })
+  )
+}
+
+describe('profile', () => {
+  test('displayName falls back to the Discord name when unset', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Roach-Boy')
+    await u.as.mutation(api.account.updateProfile, { displayName: null })
+
+    const me = await u.as.query(api.account.me, {})
+    // Cleared means "fall back", not "blank" — a nameless owner chip is worse
+    // than a stale one.
+    expect(me?.displayName).toBe('Roach-Boy')
+  })
+
+  test('a set displayName overrides the Discord name', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Roach-Boy')
+    await u.as.mutation(api.account.updateProfile, { displayName: '  Beefcake  ' })
+
+    const me = await u.as.query(api.account.me, {})
+    expect(me?.displayName).toBe('Beefcake')
+  })
+
+  test('an anonymous caller has no profile to read', async () => {
+    const t = testConvex()
+    await expect(t.query(api.account.me, {})).rejects.toThrow(/not signed in/i)
+  })
+})
+
+describe('export is scoped to what you own', () => {
+  test('excludes a crewmate pilot you can merely see', async () => {
+    const t = testConvex()
+    const owner = await makeUser(t, 'Owner')
+    const other = await makeUser(t, 'Other')
+    const gameId = await owner.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await owner.as.mutation(api.invites.create, { gameId })
+    await other.as.mutation(api.invites.redeem, { code })
+
+    await seedPilot(t, gameId, owner.userId)
+    await seedPilot(t, gameId, other.userId)
+
+    const mine = await owner.as.query(api.account.exportMine, {})
+    // Readable inside a Game is not the same as yours to take away.
+    expect(mine.pilots).toHaveLength(1)
+  })
+})
+
+describe('deleteAccount — the campaign survives', () => {
+  test('Organizer passes to the longest-standing remaining member', async () => {
+    const t = testConvex()
+    const organizer = await makeUser(t, 'Organizer')
+    const early = await makeUser(t, 'Early')
+    const late = await makeUser(t, 'Late')
+
+    const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await early.as.mutation(api.invites.redeem, { code })
+    await late.as.mutation(api.invites.redeem, { code })
+
+    // Make the ordering unambiguous rather than relying on clock resolution.
+    await t.run(async (ctx) => {
+      for (const m of await ctx.db.query('memberships').collect()) {
+        if (m.userId === early.userId) await ctx.db.patch(m._id, { joinedAt: 100 })
+        if (m.userId === late.userId) await ctx.db.patch(m._id, { joinedAt: 200 })
+      }
+    })
+
+    await organizer.as.mutation(api.account.deleteAccount, {})
+
+    const roster = await early.as.query(api.games.members, { gameId })
+    const organizers = roster.filter((m) => m.organizer)
+    expect(organizers).toHaveLength(1)
+    expect(organizers[0]?.userId).toBe(early.userId)
+  })
+
+  test('the Game and the communal crawler survive', async () => {
+    const t = testConvex()
+    const organizer = await makeUser(t, 'Organizer')
+    const player = await makeUser(t, 'Player')
+    const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await player.as.mutation(api.invites.redeem, { code })
+
+    const crawlerId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('crawlers', { gameId, body: { name: '#430' }, updatedAt: 1 })
+    )
+
+    await organizer.as.mutation(api.account.deleteAccount, {})
+
+    const game = await t.run(async (ctx) => await ctx.db.get(gameId))
+    const crawler = await t.run(async (ctx) => await ctx.db.get(crawlerId))
+    expect(game).not.toBeNull()
+    // The crawler belongs to the table, not to whoever set the Game up.
+    expect(crawler).not.toBeNull()
+  })
+
+  test("another member's pilot is untouched", async () => {
+    const t = testConvex()
+    const organizer = await makeUser(t, 'Organizer')
+    const player = await makeUser(t, 'Player')
+    const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await player.as.mutation(api.invites.redeem, { code })
+
+    const theirs = await seedPilot(t, gameId, player.userId)
+    await organizer.as.mutation(api.account.deleteAccount, {})
+
+    const pilot = await t.run(async (ctx) => await ctx.db.get(theirs))
+    expect(pilot).not.toBeNull()
+    expect(pilot?.ownerId).toBe(player.userId)
+  })
+
+  test('the departing account’s own entities go, in a Game and on the shelf alike', async () => {
+    const t = testConvex()
+    const organizer = await makeUser(t, 'Organizer')
+    const player = await makeUser(t, 'Player')
+    const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await player.as.mutation(api.invites.redeem, { code })
+
+    const inGame = await seedPilot(t, gameId, organizer.userId)
+    const onShelf = await seedPilot(t, null, organizer.userId)
+
+    await organizer.as.mutation(api.account.deleteAccount, {})
+
+    expect(await t.run(async (ctx) => await ctx.db.get(inGame))).toBeNull()
+    expect(await t.run(async (ctx) => await ctx.db.get(onShelf))).toBeNull()
+  })
+
+  test('the last member out takes the Game with them', async () => {
+    const t = testConvex()
+    const solo = await makeUser(t, 'Solo')
+    const gameId = await solo.as.mutation(api.games.create, { name: 'Alone' })
+    const crawlerId = await t.run(
+      async (ctx) => await ctx.db.insert('crawlers', { gameId, body: {}, updatedAt: 1 })
+    )
+    const unclaimed = await seedPilot(t, gameId, null)
+
+    await solo.as.mutation(api.account.deleteAccount, {})
+
+    // An empty Game is not a campaign anybody can come back to, and its
+    // unclaimed entities have no shelf to fall back to.
+    expect(await t.run(async (ctx) => await ctx.db.get(gameId))).toBeNull()
+    expect(await t.run(async (ctx) => await ctx.db.get(crawlerId))).toBeNull()
+    expect(await t.run(async (ctx) => await ctx.db.get(unclaimed))).toBeNull()
+  })
+
+  test('the user row and its auth rows are gone', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Gone')
+
+    // A session with a refresh token hanging off it — the ordering hazard.
+    await t.run(async (ctx) => {
+      const sessionId = await ctx.db.insert('authSessions', {
+        userId: u.userId,
+        expirationTime: Date.now() + 1000,
+      })
+      await ctx.db.insert('authRefreshTokens', {
+        sessionId,
+        expirationTime: Date.now() + 1000,
+      })
+      await ctx.db.insert('authAccounts', {
+        userId: u.userId,
+        provider: 'discord',
+        providerAccountId: 'abc123',
+      })
+    })
+
+    await u.as.mutation(api.account.deleteAccount, {})
+
+    const left = await t.run(async (ctx) => ({
+      user: await ctx.db.get(u.userId),
+      sessions: (await ctx.db.query('authSessions').collect()).length,
+      tokens: (await ctx.db.query('authRefreshTokens').collect()).length,
+      accounts: (await ctx.db.query('authAccounts').collect()).length,
+    }))
+
+    expect(left.user).toBeNull()
+    expect(left.sessions).toBe(0)
+    // Refresh tokens are keyed by session, not user — they are the rows most
+    // likely to be left behind pointing at something deleted.
+    expect(left.tokens).toBe(0)
+    expect(left.accounts).toBe(0)
+  })
+})

--- a/apps/itun/convex/__tests__/appId.test.ts
+++ b/apps/itun/convex/__tests__/appId.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from 'bun:test'
+
+import { api } from '../_generated/api'
+import { testConvex } from './harness'
+
+/**
+ * Addressing server rows by the client's own app id.
+ *
+ * This exists because the first write-mirroring attempt could not work at all:
+ * Convex mints its own `_id`, so a client holding only its local UUID had
+ * nothing to address a row by. Creates mirrored and edits silently no-opped —
+ * a mirror that looked synced and was not.
+ *
+ * The cases below pin the two properties that fix it: **an edit finds its row**,
+ * and **a missing row is created rather than dropped**, which is what makes the
+ * mirror converge for entities built while Solo and claimed afterwards.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+function pilotBody(over: Record<string, unknown> = {}) {
+  return {
+    id: 'local-uuid-1',
+    schemaVersion: 1,
+    name: 'Roach-Boy',
+    callsign: 'Roach-Boy',
+    classRef: 'salvager',
+    abilities: [],
+    equipment: [],
+    motto: '',
+    keepsake: '',
+    appearance: '',
+    conditions: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...over,
+  }
+}
+
+describe('upsertByAppId', () => {
+  test('creates when no row carries that app id', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    // The Solo-then-claim path: the entity exists locally long before the
+    // server has ever heard of it.
+    await u.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'local-uuid-1',
+      gameId: null,
+      body: pilotBody(),
+    })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.appId).toBe('local-uuid-1')
+  })
+
+  test('a second write updates rather than duplicating', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    await u.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'local-uuid-1',
+      gameId: null,
+      body: pilotBody(),
+    })
+    await u.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'local-uuid-1',
+      gameId: null,
+      body: pilotBody({ name: 'Renamed' }),
+    })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    // The bug this replaces: an edit that could not find its row. One row, new
+    // name — not two rows, and not a silent no-op.
+    expect(rows).toHaveLength(1)
+    expect((rows[0]?.body as { name: string } | undefined)?.name).toBe('Renamed')
+  })
+
+  test("cannot overwrite another player's row that happens to share an app id", async () => {
+    const t = testConvex()
+    const owner = await makeUser(t, 'Owner')
+    const other = await makeUser(t, 'Other')
+
+    await owner.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'local-uuid-1',
+      gameId: null,
+      body: pilotBody(),
+    })
+
+    // Addressing by a client-supplied id must not become a way to write
+    // somebody else's data by guessing theirs.
+    await expect(
+      other.as.mutation(api.entities.upsertByAppId, {
+        table: 'pilots',
+        appId: 'local-uuid-1',
+        gameId: null,
+        body: pilotBody({ name: 'Hijacked' }),
+      })
+    ).rejects.toThrow(/another player/i)
+  })
+
+  test('a malformed body is still rejected', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    await expect(
+      u.as.mutation(api.entities.upsertByAppId, {
+        table: 'pilots',
+        appId: 'local-uuid-1',
+        gameId: null,
+        body: { nonsense: true },
+      })
+    ).rejects.toThrow(/invalid pilots payload/i)
+  })
+})
+
+describe('removeByAppId', () => {
+  test('deletes the addressed row', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    await u.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'local-uuid-1',
+      gameId: null,
+      body: pilotBody(),
+    })
+
+    await u.as.mutation(api.entities.removeByAppId, { table: 'pilots', appId: 'local-uuid-1' })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(0)
+  })
+
+  test('a row that is already gone is not an error', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    // The mirror is fire-and-forget and may retry or arrive out of order; a
+    // delete of something already deleted must be a no-op, not a throw.
+    await u.as.mutation(api.entities.removeByAppId, { table: 'pilots', appId: 'never-existed' })
+  })
+
+  test("cannot delete another player's row", async () => {
+    const t = testConvex()
+    const owner = await makeUser(t, 'Owner')
+    const other = await makeUser(t, 'Other')
+    await owner.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'local-uuid-1',
+      gameId: null,
+      body: pilotBody(),
+    })
+
+    await expect(
+      other.as.mutation(api.entities.removeByAppId, { table: 'pilots', appId: 'local-uuid-1' })
+    ).rejects.toThrow(/another player/i)
+  })
+})

--- a/apps/itun/convex/__tests__/crew.test.ts
+++ b/apps/itun/convex/__tests__/crew.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from 'bun:test'
+
+import { api } from '../_generated/api'
+import { testConvex } from './harness'
+
+/**
+ * Crew visibility (D12).
+ *
+ * The privacy boundary is what these tests are for. "Every member sees every
+ * crewmate" is easy to get right; the cases that matter are the two things that
+ * must stay *out* — a non-member seeing anything at all, and a shelved entity
+ * (which belongs to one person and to no crew) being reachable through a
+ * Game-scoped read.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+async function seedGame(t: Ctx) {
+  const organizer = await makeUser(t, 'Organizer')
+  const player = await makeUser(t, 'Beefcake')
+  const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+  const code = await organizer.as.mutation(api.invites.create, { gameId })
+  await player.as.mutation(api.invites.redeem, { code })
+  return { organizer, player, gameId }
+}
+
+describe('vitals', () => {
+  test('shows every crewmate, with owner names resolved', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    await t.run(async (ctx) => {
+      await ctx.db.insert('pilots', {
+        gameId,
+        ownerId: player.userId,
+        body: { callsign: 'Roach-Boy', currentHp: 7, currentAp: 3 },
+        updatedAt: 1,
+      })
+    })
+
+    const crew = await organizer.as.query(api.crew.vitals, { gameId })
+    expect(crew.pilots).toHaveLength(1)
+    expect(crew.pilots[0]?.name).toBe('Roach-Boy')
+    expect(crew.pilots[0]?.currentHp).toBe(7)
+    // The chip needs a name, not just an id.
+    expect(crew.pilots[0]?.ownerName).toBe('Beefcake')
+  })
+
+  test('an unclaimed pilot has a null owner name rather than a missing row', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    await t.run(async (ctx) => {
+      await ctx.db.insert('pilots', {
+        gameId,
+        ownerId: null,
+        body: { callsign: 'Pre-gen' },
+        updatedAt: 1,
+      })
+    })
+
+    const crew = await organizer.as.query(api.crew.vitals, { gameId })
+    // Unclaimed pre-gens must still appear — they are what the Mediator hands
+    // out, so hiding them would hide the onboarding path.
+    expect(crew.pilots).toHaveLength(1)
+    expect(crew.pilots[0]?.ownerId).toBeNull()
+    expect(crew.pilots[0]?.ownerName).toBeNull()
+  })
+
+  test('a missing numeric field reads as null, not NaN or zero', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    await t.run(async (ctx) => {
+      await ctx.db.insert('pilots', { gameId, ownerId: null, body: {}, updatedAt: 1 })
+    })
+
+    const crew = await organizer.as.query(api.crew.vitals, { gameId })
+    // Bodies are opaque, so the projection must not trust their shape. Zero
+    // would render as "dead" on a vitals strip, which is worse than blank.
+    expect(crew.pilots[0]?.currentHp).toBeNull()
+  })
+
+  test('a non-member gets nothing', async () => {
+    const t = testConvex()
+    const { gameId } = await seedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+
+    await expect(outsider.as.query(api.crew.vitals, { gameId })).rejects.toThrow(/not a member/i)
+  })
+})
+
+describe('readEntity', () => {
+  test("a member can read a crewmate's sheet", async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    const pilotId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('pilots', {
+          gameId,
+          ownerId: player.userId,
+          body: { callsign: 'Roach-Boy' },
+          updatedAt: 1,
+        })
+    )
+
+    // "Lean over and look at their sheet", which is what a table does.
+    const seen = await organizer.as.query(api.crew.readEntity, {
+      table: 'pilots',
+      entityId: pilotId,
+    })
+    expect(seen).not.toBeNull()
+    expect((seen?.body as { callsign: string } | undefined)?.callsign).toBe('Roach-Boy')
+  })
+
+  test('a non-member cannot', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+    const pilotId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('pilots', {
+          gameId,
+          ownerId: player.userId,
+          body: {},
+          updatedAt: 1,
+        })
+    )
+
+    await expect(
+      outsider.as.query(api.crew.readEntity, { table: 'pilots', entityId: pilotId })
+    ).rejects.toThrow(/not a member/i)
+  })
+
+  test('a shelved entity is not reachable through this query at all', async () => {
+    const t = testConvex()
+    const { organizer, player } = await seedGame(t)
+    const shelved = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('pilots', {
+          gameId: null,
+          ownerId: player.userId,
+          body: { callsign: 'Private draft' },
+          updatedAt: 1,
+        })
+    )
+
+    // A shelf belongs to one person and to no crew. There is no membership that
+    // could grant access, so the answer is "nothing here" rather than a check
+    // that might one day be loosened.
+    const seen = await organizer.as.query(api.crew.readEntity, {
+      table: 'pilots',
+      entityId: shelved,
+    })
+    expect(seen).toBeNull()
+  })
+})

--- a/apps/itun/convex/__tests__/entities.test.ts
+++ b/apps/itun/convex/__tests__/entities.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, test } from 'bun:test'
+
+import { api } from '../_generated/api'
+import type { Id } from '../_generated/dataModel'
+import { testConvex } from './harness'
+
+/**
+ * Entity reads and writes against the server of record.
+ *
+ * Two properties carry the weight here:
+ *
+ *  1. **Every write Zod-parses first.** The schema stores bodies as `v.any()`
+ *     so the Zod schemas stay the single source of truth, which means Convex
+ *     itself cannot reject a malformed body — the mutation must. If that check
+ *     is ever dropped, nothing else in the system will notice until a corrupt
+ *     row reaches a sheet and blanks it.
+ *  2. **Reading is per-Game, writing is per-entity.** Any member sees the whole
+ *     crew (which is what makes vitals and drill-in possible), but nobody
+ *     writes a crewmate's sheet — a Mediator wanting to change one goes through
+ *     a proposal, not a privileged write path.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+/**
+ * A minimal body that satisfies PilotSchema.
+ *
+ * Derived by probing the real schema rather than guessed — the first draft of
+ * this fixture invented fields (`currentHp`, `trainingPoints`, `abilityRefs`)
+ * that do not exist on it and omitted required ones (`classRef`, `motto`,
+ * `keepsake`, `appearance`), so every case failed at the parse step.
+ */
+function pilotBody(over: Record<string, unknown> = {}) {
+  return {
+    id: 'p1',
+    schemaVersion: 1,
+    name: 'Roach-Boy',
+    callsign: 'Roach-Boy',
+    classRef: 'salvager',
+    abilities: [],
+    equipment: [],
+    motto: '',
+    keepsake: '',
+    appearance: '',
+    conditions: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...over,
+  }
+}
+
+async function seedGame(t: Ctx) {
+  const organizer = await makeUser(t, 'Organizer')
+  const player = await makeUser(t, 'Player')
+  const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+  const code = await organizer.as.mutation(api.invites.create, { gameId })
+  await player.as.mutation(api.invites.redeem, { code })
+  return { organizer, player, gameId }
+}
+
+describe('every write Zod-parses first', () => {
+  test('a malformed pilot body is rejected, not stored', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    await expect(
+      u.as.mutation(api.entities.create, {
+        table: 'pilots',
+        gameId: null,
+        body: { nonsense: true },
+      })
+    ).rejects.toThrow(/invalid pilots payload/i)
+
+    // Nothing partial left behind.
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(0)
+  })
+
+  test('a well-formed pilot body is stored', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    await u.as.mutation(api.entities.create, { table: 'pilots', gameId: null, body: pilotBody() })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.gameId).toBeNull()
+    expect(rows[0]?.ownerId).toBe(u.userId)
+  })
+})
+
+describe('reading is per-game, writing is per-entity', () => {
+  test('a member sees the whole crew, including entities they do not own', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    await player.as.mutation(api.entities.create, { table: 'pilots', gameId, body: pilotBody() })
+
+    const seen = await organizer.as.query(api.entities.listForGame, { gameId })
+    // This is what makes crew vitals and read-only drill-in possible.
+    expect(seen.pilots).toHaveLength(1)
+  })
+
+  test('a non-member sees nothing', async () => {
+    const t = testConvex()
+    const { gameId } = await seedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+
+    await expect(outsider.as.query(api.entities.listForGame, { gameId })).rejects.toThrow(
+      /not a member/i
+    )
+  })
+
+  test("a crewmate cannot write another player's pilot", async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    const pilotId = await player.as.mutation(api.entities.create, {
+      table: 'pilots',
+      gameId,
+      body: pilotBody(),
+    })
+
+    await expect(
+      organizer.as.mutation(api.entities.update, {
+        table: 'pilots',
+        entityId: pilotId,
+        body: pilotBody({ name: 'Hijacked' }),
+      })
+    ).rejects.toThrow(/another player/i)
+  })
+
+  test('an unclaimed entity cannot be edited until it is assigned', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const pilotId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('pilots', {
+          gameId,
+          ownerId: null,
+          body: pilotBody(),
+          updatedAt: 1,
+        })
+    )
+
+    // Editing an unclaimed pre-gen would let anyone quietly take it without
+    // going through assignment, which is the act the Change Log records.
+    await expect(
+      organizer.as.mutation(api.entities.update, {
+        table: 'pilots',
+        entityId: pilotId,
+        body: pilotBody({ name: 'Mine now' }),
+      })
+    ).rejects.toThrow(/unclaimed/i)
+  })
+
+  test('the owner can write their own', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedGame(t)
+    const pilotId = await player.as.mutation(api.entities.create, {
+      table: 'pilots',
+      gameId,
+      body: pilotBody(),
+    })
+
+    await player.as.mutation(api.entities.update, {
+      table: 'pilots',
+      entityId: pilotId,
+      body: pilotBody({ name: 'Renamed' }),
+    })
+
+    const row = await t.run(async (ctx) => await ctx.db.get(pilotId as Id<'pilots'>))
+    expect(row).not.toBeNull()
+    expect((row?.body as { name: string } | undefined)?.name).toBe('Renamed')
+  })
+})
+
+describe('the crawler is communal and merges per field', () => {
+  test('two members editing different fields do not clobber each other', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    const crawlerId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('crawlers', {
+          gameId,
+          // Shape probed against CrawlerSchema, not guessed: techLevel is a
+          // STRING here, there is no `modules` key, and `systems` is required.
+          body: {
+            id: 'c1',
+            schemaVersion: 1,
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            name: '#430',
+            techLevel: '1',
+            systems: [],
+          },
+          updatedAt: 1,
+        })
+    )
+
+    await organizer.as.mutation(api.entities.patchCrawler, {
+      crawlerId,
+      patch: { name: 'Tenacity' },
+    })
+    await player.as.mutation(api.entities.patchCrawler, { crawlerId, patch: { techLevel: '2' } })
+
+    const row = await t.run(async (ctx) => await ctx.db.get(crawlerId))
+    const body = row?.body as { name: string; techLevel: string; id: string }
+
+    // Both survive. A full-body write would have discarded whichever member
+    // lost the race — on exactly the night it matters, during Downtime.
+    expect(body.name).toBe('Tenacity')
+    expect(body.techLevel).toBe('2')
+    expect(body.id).toBe('c1')
+  })
+
+  test('a non-member cannot touch the crawler', async () => {
+    const t = testConvex()
+    const { gameId } = await seedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+    const crawlerId = await t.run(
+      async (ctx) => await ctx.db.insert('crawlers', { gameId, body: {}, updatedAt: 1 })
+    )
+
+    await expect(
+      outsider.as.mutation(api.entities.patchCrawler, { crawlerId, patch: { scrap: 999 } })
+    ).rejects.toThrow(/not a member/i)
+  })
+})
+
+describe('claiming local data on first sign-in', () => {
+  test('everything lands on the shelf, never in a game', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    const result = await u.as.mutation(api.entities.claimLocal, {
+      pilots: [pilotBody(), pilotBody({ id: 'p2' })],
+      mechs: [],
+    })
+
+    expect(result.claimed).toBe(2)
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    // Guessing a Game for a build that has no relationship to any crew would be
+    // worse than making the person place it deliberately.
+    expect(rows.every((r) => r.gameId === null)).toBe(true)
+  })
+
+  test('one corrupt record is skipped rather than costing the whole roster', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    const result = await u.as.mutation(api.entities.claimLocal, {
+      pilots: [pilotBody(), { totally: 'broken' }, pilotBody({ id: 'p3' })],
+      mechs: [],
+    })
+
+    expect(result.claimed).toBe(2)
+    expect(result.skipped).toBe(1)
+  })
+
+  test('an anonymous caller cannot claim', async () => {
+    const t = testConvex()
+    await expect(t.mutation(api.entities.claimLocal, { pilots: [], mechs: [] })).rejects.toThrow(
+      /not signed in/i
+    )
+  })
+})

--- a/apps/itun/convex/__tests__/harness.ts
+++ b/apps/itun/convex/__tests__/harness.ts
@@ -22,6 +22,7 @@ const modules = {
   // map, so these two are required even though no test imports them directly.
   './_generated/api.js': () => import('../_generated/api'),
   './_generated/server.js': () => import('../_generated/server'),
+  './account.ts': () => import('../account'),
   './games.ts': () => import('../games'),
   './invites.ts': () => import('../invites'),
   './ownership.ts': () => import('../ownership'),

--- a/apps/itun/convex/__tests__/harness.ts
+++ b/apps/itun/convex/__tests__/harness.ts
@@ -26,6 +26,7 @@ const modules = {
   './crew.ts': () => import('../crew'),
   './entities.ts': () => import('../entities'),
   './games.ts': () => import('../games'),
+  './mediator.ts': () => import('../mediator'),
   './invites.ts': () => import('../invites'),
   './ownership.ts': () => import('../ownership'),
   './templates.ts': () => import('../templates'),

--- a/apps/itun/convex/__tests__/harness.ts
+++ b/apps/itun/convex/__tests__/harness.ts
@@ -26,6 +26,7 @@ const modules = {
   './games.ts': () => import('../games'),
   './invites.ts': () => import('../invites'),
   './ownership.ts': () => import('../ownership'),
+  './templates.ts': () => import('../templates'),
   './model/permissions.ts': () => import('../model/permissions'),
 }
 

--- a/apps/itun/convex/__tests__/harness.ts
+++ b/apps/itun/convex/__tests__/harness.ts
@@ -23,6 +23,7 @@ const modules = {
   './_generated/api.js': () => import('../_generated/api'),
   './_generated/server.js': () => import('../_generated/server'),
   './account.ts': () => import('../account'),
+  './entities.ts': () => import('../entities'),
   './games.ts': () => import('../games'),
   './invites.ts': () => import('../invites'),
   './ownership.ts': () => import('../ownership'),

--- a/apps/itun/convex/__tests__/harness.ts
+++ b/apps/itun/convex/__tests__/harness.ts
@@ -23,6 +23,7 @@ const modules = {
   './_generated/api.js': () => import('../_generated/api'),
   './_generated/server.js': () => import('../_generated/server'),
   './account.ts': () => import('../account'),
+  './crew.ts': () => import('../crew'),
   './entities.ts': () => import('../entities'),
   './games.ts': () => import('../games'),
   './invites.ts': () => import('../invites'),

--- a/apps/itun/convex/__tests__/mediator.test.ts
+++ b/apps/itun/convex/__tests__/mediator.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from 'bun:test'
+
+import { api } from '../_generated/api'
+import { PRESENCE_WINDOW_MS } from '../mediator'
+import { testConvex } from './harness'
+
+/**
+ * The Mediator surface's server layer.
+ *
+ * The NPC tray is the only genuinely secret thing in a Game, so most of these
+ * tests are about it staying that way. A player who can read prepared
+ * opposition can read the encounter before it happens — the one leak that
+ * changes how the game is *played*, rather than merely who can edit what.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+/** A Game where `organizer` also mediates, plus a plain player. */
+async function seedMediatedGame(t: Ctx) {
+  const organizer = await makeUser(t, 'Mediator')
+  const player = await makeUser(t, 'Player')
+  const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+  const code = await organizer.as.mutation(api.invites.create, { gameId })
+  await player.as.mutation(api.invites.redeem, { code })
+  await organizer.as.mutation(api.games.setMediator, {
+    gameId,
+    userId: organizer.userId,
+    mediator: true,
+  })
+  return { mediator: organizer, player, gameId }
+}
+
+describe('the NPC tray is Mediator-only', () => {
+  test('the Mediator can read it', async () => {
+    const t = testConvex()
+    const { mediator, gameId } = await seedMediatedGame(t)
+    await mediator.as.mutation(api.mediator.addNpc, { gameId, body: { name: 'Wretch' } })
+
+    const rows = await mediator.as.query(api.mediator.npcs, { gameId })
+    expect(rows).toHaveLength(1)
+  })
+
+  test('a player in the same game cannot', async () => {
+    const t = testConvex()
+    const { mediator, player, gameId } = await seedMediatedGame(t)
+    await mediator.as.mutation(api.mediator.addNpc, { gameId, body: { name: 'Wretch' } })
+
+    // Membership is not enough here, unlike everywhere else in the app.
+    await expect(player.as.query(api.mediator.npcs, { gameId })).rejects.toThrow(/mediator/i)
+  })
+
+  test('a player cannot add, edit or remove one', async () => {
+    const t = testConvex()
+    const { mediator, player, gameId } = await seedMediatedGame(t)
+    const npcId = await mediator.as.mutation(api.mediator.addNpc, { gameId, body: { name: 'A' } })
+
+    await expect(
+      player.as.mutation(api.mediator.addNpc, { gameId, body: { name: 'B' } })
+    ).rejects.toThrow(/mediator/i)
+    await expect(
+      player.as.mutation(api.mediator.updateNpc, { npcId, body: { name: 'C' } })
+    ).rejects.toThrow(/mediator/i)
+    await expect(player.as.mutation(api.mediator.removeNpc, { npcId })).rejects.toThrow(/mediator/i)
+  })
+
+  test('an Organizer who does not mediate cannot read it either', async () => {
+    const t = testConvex()
+    const organizer = await makeUser(t, 'Organizer')
+    const gm = await makeUser(t, 'GM')
+    const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await gm.as.mutation(api.invites.redeem, { code })
+    await organizer.as.mutation(api.games.setMediator, {
+      gameId,
+      userId: gm.userId,
+      mediator: true,
+    })
+
+    // The Organizer flag is administrative and confers no content authority —
+    // reading prepared opposition is very much content.
+    await expect(organizer.as.query(api.mediator.npcs, { gameId })).rejects.toThrow(/mediator/i)
+  })
+})
+
+describe('presence', () => {
+  test('a heartbeat upserts rather than appending', async () => {
+    const t = testConvex()
+    const { mediator, gameId } = await seedMediatedGame(t)
+
+    await mediator.as.mutation(api.mediator.heartbeat, { gameId })
+    await mediator.as.mutation(api.mediator.heartbeat, { gameId })
+    await mediator.as.mutation(api.mediator.heartbeat, { gameId })
+
+    // Otherwise a long session grows presence without bound.
+    const rows = await t.run(async (ctx) => await ctx.db.query('presence').collect())
+    expect(rows).toHaveLength(1)
+  })
+
+  test('present is computed from lastSeen, not stored', async () => {
+    const t = testConvex()
+    const { mediator, gameId } = await seedMediatedGame(t)
+    await mediator.as.mutation(api.mediator.heartbeat, { gameId })
+
+    // Backdate past the window: nothing had to turn a flag off.
+    await t.run(async (ctx) => {
+      for (const row of await ctx.db.query('presence').collect()) {
+        await ctx.db.patch(row._id, { lastSeen: Date.now() - PRESENCE_WINDOW_MS - 1000 })
+      }
+    })
+
+    const rows = await mediator.as.query(api.mediator.presence, { gameId })
+    // A stored boolean needs something to clear it, and every such mechanism
+    // can fail in a way that leaves somebody present forever.
+    expect(rows[0]?.present).toBe(false)
+  })
+
+  test('any member may heartbeat and read presence', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedMediatedGame(t)
+    await player.as.mutation(api.mediator.heartbeat, { gameId })
+
+    // Presence is not privileged: a Mediator needs to see players arrive
+    // exactly as much as players need to see each other.
+    const rows = await player.as.query(api.mediator.presence, { gameId })
+    expect(rows.some((r) => r.userId === player.userId && r.present)).toBe(true)
+  })
+
+  test('a non-member cannot heartbeat into a game they are not in', async () => {
+    const t = testConvex()
+    const { gameId } = await seedMediatedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+
+    await expect(outsider.as.mutation(api.mediator.heartbeat, { gameId })).rejects.toThrow(
+      /not a member/i
+    )
+  })
+})
+
+describe('amMediator', () => {
+  test('true for the Mediator, false for a player', async () => {
+    const t = testConvex()
+    const { mediator, player, gameId } = await seedMediatedGame(t)
+    expect(await mediator.as.query(api.mediator.amMediator, { gameId })).toBe(true)
+    expect(await player.as.query(api.mediator.amMediator, { gameId })).toBe(false)
+  })
+
+  test('false rather than a throw for a non-member', async () => {
+    const t = testConvex()
+    const { gameId } = await seedMediatedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+
+    // "Can I mediate this" is a reasonable question for anyone to ask, and a
+    // surface gating itself on the answer should not have to catch.
+    expect(await outsider.as.query(api.mediator.amMediator, { gameId })).toBe(false)
+  })
+})

--- a/apps/itun/convex/__tests__/templates.test.ts
+++ b/apps/itun/convex/__tests__/templates.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test'
+
+import { api } from '../_generated/api'
+import { testConvex } from './harness'
+
+/**
+ * Game templates (D34).
+ *
+ * The property under test is the one that makes a template useful rather than
+ * decorative: **its entities arrive unclaimed**, so the person running the
+ * table hands them out. A template that pre-assigned everything to its creator
+ * would just be a private roster with extra steps.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+describe('starter-set template', () => {
+  test('is listed', async () => {
+    const t = testConvex()
+    const templates = await t.query(api.templates.list, {})
+    expect(templates.map((x) => x.id)).toContain('starter-set')
+  })
+
+  test('every pilot and mech arrives unclaimed', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const { pilots, mechs } = await t.run(async (ctx) => ({
+      pilots: await ctx.db.query('pilots').collect(),
+      mechs: await ctx.db.query('mechs').collect(),
+    }))
+
+    expect(pilots.length).toBeGreaterThan(0)
+    expect(mechs.length).toBeGreaterThan(0)
+    // Not owned by the creator — that is the difference between a template and
+    // a private roster.
+    expect(pilots.every((p) => p.ownerId === null)).toBe(true)
+    expect(mechs.every((m) => m.ownerId === null)).toBe(true)
+  })
+
+  test('the creator is Organizer and a seated Player, as with any game', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    const gameId = await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const roster = await u.as.query(api.games.members, { gameId })
+    expect(roster).toHaveLength(1)
+    expect(roster[0]?.organizer).toBe(true)
+    // A template changes what is IN the game, never who runs it.
+    expect(roster[0]?.mediator).toBe(false)
+  })
+
+  test('the crawler is created communally, with no owner column at all', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const crawlers = await t.run(async (ctx) => await ctx.db.query('crawlers').collect())
+    expect(crawlers.length).toBeGreaterThan(0)
+    expect(crawlers[0]).not.toHaveProperty('ownerId')
+  })
+
+  test('soft links come across, so the crew is wired together on arrival', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const links = await t.run(async (ctx) => await ctx.db.query('softLinks').collect())
+    // Without these the pilots and mechs would arrive as unrelated strangers.
+    expect(links.length).toBeGreaterThan(0)
+    expect(links.some((l) => l.type === 'mech-to-pilot')).toBe(true)
+  })
+
+  test('the game records which template it came from', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    const gameId = await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const game = await t.run(async (ctx) => await ctx.db.get(gameId))
+    expect(game?.templateOrigin).toBe('starter-set')
+  })
+
+  test('a custom name overrides the template name', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    const gameId = await u.as.mutation(api.templates.createGame, {
+      templateId: 'starter-set',
+      name: '  Our Tuesday Game  ',
+    })
+
+    const game = await t.run(async (ctx) => await ctx.db.get(gameId))
+    expect(game?.name).toBe('Our Tuesday Game')
+  })
+
+  test('an anonymous caller cannot create one', async () => {
+    const t = testConvex()
+    await expect(
+      t.mutation(api.templates.createGame, { templateId: 'starter-set' })
+    ).rejects.toThrow(/not signed in/i)
+  })
+})

--- a/apps/itun/convex/_generated/api.d.ts
+++ b/apps/itun/convex/_generated/api.d.ts
@@ -16,6 +16,7 @@ import type * as http from "../http.js";
 import type * as invites from "../invites.js";
 import type * as model_permissions from "../model/permissions.js";
 import type * as ownership from "../ownership.js";
+import type * as templates from "../templates.js";
 
 import type {
   ApiFromModules,
@@ -32,6 +33,7 @@ declare const fullApi: ApiFromModules<{
   invites: typeof invites;
   "model/permissions": typeof model_permissions;
   ownership: typeof ownership;
+  templates: typeof templates;
 }>;
 
 /**

--- a/apps/itun/convex/_generated/api.d.ts
+++ b/apps/itun/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as __tests___harness from "../__tests__/harness.js";
 import type * as account from "../account.js";
 import type * as auth from "../auth.js";
+import type * as crew from "../crew.js";
 import type * as entities from "../entities.js";
 import type * as games from "../games.js";
 import type * as http from "../http.js";
@@ -29,6 +30,7 @@ declare const fullApi: ApiFromModules<{
   "__tests__/harness": typeof __tests___harness;
   account: typeof account;
   auth: typeof auth;
+  crew: typeof crew;
   entities: typeof entities;
   games: typeof games;
   http: typeof http;

--- a/apps/itun/convex/_generated/api.d.ts
+++ b/apps/itun/convex/_generated/api.d.ts
@@ -16,6 +16,7 @@ import type * as entities from "../entities.js";
 import type * as games from "../games.js";
 import type * as http from "../http.js";
 import type * as invites from "../invites.js";
+import type * as mediator from "../mediator.js";
 import type * as model_permissions from "../model/permissions.js";
 import type * as ownership from "../ownership.js";
 import type * as templates from "../templates.js";
@@ -35,6 +36,7 @@ declare const fullApi: ApiFromModules<{
   games: typeof games;
   http: typeof http;
   invites: typeof invites;
+  mediator: typeof mediator;
   "model/permissions": typeof model_permissions;
   ownership: typeof ownership;
   templates: typeof templates;

--- a/apps/itun/convex/_generated/api.d.ts
+++ b/apps/itun/convex/_generated/api.d.ts
@@ -8,6 +8,8 @@
  * @module
  */
 
+import type * as __tests___harness from "../__tests__/harness.js";
+import type * as account from "../account.js";
 import type * as auth from "../auth.js";
 import type * as games from "../games.js";
 import type * as http from "../http.js";
@@ -22,6 +24,8 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  "__tests__/harness": typeof __tests___harness;
+  account: typeof account;
   auth: typeof auth;
   games: typeof games;
   http: typeof http;

--- a/apps/itun/convex/_generated/api.d.ts
+++ b/apps/itun/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as __tests___harness from "../__tests__/harness.js";
 import type * as account from "../account.js";
 import type * as auth from "../auth.js";
+import type * as entities from "../entities.js";
 import type * as games from "../games.js";
 import type * as http from "../http.js";
 import type * as invites from "../invites.js";
@@ -28,6 +29,7 @@ declare const fullApi: ApiFromModules<{
   "__tests__/harness": typeof __tests___harness;
   account: typeof account;
   auth: typeof auth;
+  entities: typeof entities;
   games: typeof games;
   http: typeof http;
   invites: typeof invites;

--- a/apps/itun/convex/account.ts
+++ b/apps/itun/convex/account.ts
@@ -1,0 +1,230 @@
+import { v } from 'convex/values'
+
+import type { Doc, Id } from './_generated/dataModel'
+import { mutation, query } from './_generated/server'
+import type { MutationCtx } from './_generated/server'
+import { requireUser } from './model/permissions'
+
+/**
+ * Account management (ADR-030 §6, D33).
+ *
+ * Holding somebody's Discord identity is an obligation the project did not have
+ * before, so the three things that discharge it — read your profile, edit it,
+ * delete the account entirely — are part of the same module rather than a
+ * follow-up. Export is served here too, so "give me my data" and "delete my
+ * data" cannot drift apart.
+ */
+
+/** The signed-in user's own profile. Never exposes another user's row. */
+export const me = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await requireUser(ctx)
+    const user = await ctx.db.get(userId)
+    if (user === null) return null
+    return {
+      _id: user._id,
+      displayName: user.displayName ?? user.name ?? null,
+      avatarUrl: user.avatarUrl ?? user.image ?? null,
+      email: user.email ?? null,
+    }
+  },
+})
+
+/**
+ * Edit the display name and avatar shown on every owner chip.
+ *
+ * These are overrides layered on the Discord profile rather than replacements:
+ * clearing one falls back to the Discord value rather than to blank, because a
+ * nameless owner chip is worse than a stale one.
+ */
+export const updateProfile = mutation({
+  args: {
+    displayName: v.optional(v.union(v.string(), v.null())),
+    avatarUrl: v.optional(v.union(v.string(), v.null())),
+  },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    const patch: { displayName?: string | undefined; avatarUrl?: string | undefined } = {}
+
+    if (args.displayName !== undefined) {
+      const trimmed = args.displayName?.trim() ?? ''
+      patch.displayName = trimmed.length > 0 ? trimmed : undefined
+    }
+    if (args.avatarUrl !== undefined) {
+      const trimmed = args.avatarUrl?.trim() ?? ''
+      patch.avatarUrl = trimmed.length > 0 ? trimmed : undefined
+    }
+
+    await ctx.db.patch(userId, patch)
+  },
+})
+
+/**
+ * Everything this account owns, as a plain object suitable for download.
+ *
+ * Deliberately scoped to what the user *owns*, not everything they can see: a
+ * crewmate's pilot is readable inside a Game but is not this person's data to
+ * take away. The communal crawler is likewise excluded — it belongs to the
+ * table, not to any one member.
+ */
+export const exportMine = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await requireUser(ctx)
+
+    const pilots = await ctx.db
+      .query('pilots')
+      .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+      .collect()
+    const mechs = await ctx.db
+      .query('mechs')
+      .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+      .collect()
+    const mechPatterns = await ctx.db
+      .query('mechPatterns')
+      .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+      .collect()
+    const memberships = await ctx.db
+      .query('memberships')
+      .withIndex('by_user', (q) => q.eq('userId', userId))
+      .collect()
+
+    return {
+      exportedAt: new Date().toISOString(),
+      pilots: pilots.map((p) => p.body),
+      mechs: mechs.map((m) => m.body),
+      mechPatterns: mechPatterns.map((p) => p.body),
+      games: memberships.map((m) => ({
+        gameId: m.gameId,
+        mediator: m.mediator,
+        organizer: m.organizer,
+        joinedAt: m.joinedAt,
+      })),
+    }
+  },
+})
+
+/**
+ * Pass the Organizer flag to the longest-standing remaining member.
+ *
+ * "Longest-standing" is `joinedAt`, and the tie-break is deterministic rather
+ * than arbitrary — two members can share a timestamp if a Game was seeded in
+ * one mutation, and an unstable choice there would make the outcome depend on
+ * document scan order.
+ */
+async function reassignOrganizer(
+  ctx: MutationCtx,
+  gameId: Id<'games'>,
+  leavingUserId: Id<'users'>
+): Promise<boolean> {
+  const remaining = (
+    await ctx.db
+      .query('memberships')
+      .withIndex('by_game', (q) => q.eq('gameId', gameId))
+      .collect()
+  ).filter((m) => m.userId !== leavingUserId)
+
+  if (remaining.length === 0) return false
+
+  remaining.sort((a: Doc<'memberships'>, b: Doc<'memberships'>) =>
+    a.joinedAt === b.joinedAt ? a._id.localeCompare(b._id) : a.joinedAt - b.joinedAt
+  )
+  const heir = remaining[0]
+  if (heir === undefined) return false
+
+  await ctx.db.patch(heir._id, { organizer: true })
+  return true
+}
+
+/**
+ * Delete this account and everything personal to it (D27).
+ *
+ * The rule that matters: **a campaign never dies because one person quit.**
+ * Games survive, the communal crawler survives, and the Organizer flag passes
+ * to the longest-standing remaining member. Only when the departing user was
+ * the *last* member is the Game itself removed, because an empty Game is not a
+ * campaign anybody can return to.
+ *
+ * Their own pilots and mechs go with them — that is the point of a deletion
+ * request. Anyone who wants to keep a character exports first, which is why
+ * `exportMine` lives in this same module.
+ */
+export const deleteAccount = mutation({
+  args: {},
+  handler: async (ctx): Promise<void> => {
+    const userId = await requireUser(ctx)
+
+    const memberships = await ctx.db
+      .query('memberships')
+      .withIndex('by_user', (q) => q.eq('userId', userId))
+      .collect()
+
+    for (const membership of memberships) {
+      if (membership.organizer) {
+        const passedOn = await reassignOrganizer(ctx, membership.gameId, userId)
+        if (!passedOn) {
+          // Last member out: the Game has nobody left to run or play it.
+          for (const table of [
+            'crawlers',
+            'encounterNpcs',
+            'softLinks',
+            'invites',
+            'presence',
+          ] as const) {
+            const rows = await ctx.db
+              .query(table)
+              .withIndex('by_game', (q) => q.eq('gameId', membership.gameId))
+              .collect()
+            for (const row of rows) await ctx.db.delete(row._id)
+          }
+          // Unclaimed entities in a Game with no members have nowhere to go.
+          for (const table of ['pilots', 'mechs'] as const) {
+            const rows = await ctx.db
+              .query(table)
+              .withIndex('by_game', (q) => q.eq('gameId', membership.gameId))
+              .collect()
+            for (const row of rows) await ctx.db.delete(row._id)
+          }
+          await ctx.db.delete(membership.gameId)
+        }
+      }
+      await ctx.db.delete(membership._id)
+    }
+
+    // Personal entities, wherever they live — in a Game or on the shelf.
+    for (const table of ['pilots', 'mechs', 'mechPatterns'] as const) {
+      const rows = await ctx.db
+        .query(table)
+        .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+        .collect()
+      for (const row of rows) await ctx.db.delete(row._id)
+    }
+
+    // Auth rows, so the identity cannot be resurrected by signing in again.
+    //
+    // Order matters: refresh tokens are keyed by SESSION, not by user, so they
+    // have to go before the sessions they point at. Deleting sessions first
+    // would strand them as orphans referencing rows that no longer exist.
+    const sessions = await ctx.db
+      .query('authSessions')
+      .withIndex('userId', (q) => q.eq('userId', userId))
+      .collect()
+    for (const session of sessions) {
+      const tokens = await ctx.db
+        .query('authRefreshTokens')
+        .withIndex('sessionId', (q) => q.eq('sessionId', session._id))
+        .collect()
+      for (const token of tokens) await ctx.db.delete(token._id)
+      await ctx.db.delete(session._id)
+    }
+
+    const accounts = await ctx.db
+      .query('authAccounts')
+      .withIndex('userIdAndProvider', (q) => q.eq('userId', userId))
+      .collect()
+    for (const account of accounts) await ctx.db.delete(account._id)
+
+    await ctx.db.delete(userId)
+  },
+})

--- a/apps/itun/convex/crew.ts
+++ b/apps/itun/convex/crew.ts
@@ -1,0 +1,107 @@
+import { v } from 'convex/values'
+
+import { query } from './_generated/server'
+import { requireMember, requireUser } from './model/permissions'
+
+/**
+ * Crew visibility inside a Game (ADR-030 §5, D12).
+ *
+ * Every member sees every crewmate's **vitals** live, and can drill into a
+ * crewmate's full sheet **read-only**. What stays hidden is the Mediator's
+ * prepared opposition — that is the one thing a player must not be able to
+ * read, and it is simply not queried here.
+ *
+ * ## Why vitals are a separate, narrow query
+ *
+ * The crew strip re-renders on every point of damage anyone takes. Serving it
+ * from `entities.listForGame` would push every crewmate's full sheet — loadouts,
+ * abilities, cargo — down the wire on each change, for a row that shows four
+ * numbers. A narrow projection keeps the hot path small and, just as usefully,
+ * makes the privacy boundary legible: this query returns what a crewmate is
+ * *entitled* to see at a glance, and nothing more.
+ */
+
+/** The four numbers a crew strip shows, plus who the row belongs to. */
+export const vitals = query({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args) => {
+    await requireMember(ctx, args.gameId)
+    const viewerId = await requireUser(ctx)
+
+    const [pilots, mechs, members] = await Promise.all([
+      ctx.db
+        .query('pilots')
+        .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+        .collect(),
+      ctx.db
+        .query('mechs')
+        .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+        .collect(),
+      ctx.db
+        .query('memberships')
+        .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+        .collect(),
+    ])
+
+    const names = new Map<string, string>()
+    for (const m of members) {
+      const user = await ctx.db.get(m.userId)
+      names.set(m.userId, user?.displayName ?? user?.name ?? 'Crewmate')
+    }
+
+    /** Read a numeric field off an opaque body without trusting its shape. */
+    const num = (body: unknown, key: string): number | null => {
+      const value = (body as Record<string, unknown> | null)?.[key]
+      return typeof value === 'number' ? value : null
+    }
+
+    return {
+      viewerId,
+      pilots: pilots.map((p) => ({
+        _id: p._id,
+        appId: p.appId ?? null,
+        ownerId: p.ownerId,
+        ownerName: p.ownerId === null ? null : (names.get(p.ownerId) ?? null),
+        name: ((p.body as Record<string, unknown> | null)?.callsign as string) ?? 'Pilot',
+        currentHp: num(p.body, 'currentHp'),
+        currentAp: num(p.body, 'currentAp'),
+      })),
+      mechs: mechs.map((m) => ({
+        _id: m._id,
+        appId: m.appId ?? null,
+        ownerId: m.ownerId,
+        ownerName: m.ownerId === null ? null : (names.get(m.ownerId) ?? null),
+        name: ((m.body as Record<string, unknown> | null)?.name as string) ?? 'Mech',
+        currentSp: num(m.body, 'currentSp'),
+        currentHeat: num(m.body, 'currentHeat'),
+      })),
+    }
+  },
+})
+
+/**
+ * A crewmate's full sheet, read-only.
+ *
+ * Membership is the whole check — inside a Game you may read any crewmate's
+ * pilot or mech, which is what "lean over and look at their sheet" means at a
+ * physical table. There is no write counterpart to this query anywhere; a
+ * Mediator who wants to change what they are reading proposes instead (D7).
+ */
+export const readEntity = query({
+  args: {
+    table: v.union(v.literal('pilots'), v.literal('mechs')),
+    entityId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const doc = await ctx.db.get(args.entityId as never)
+    if (doc === null) return null
+
+    const row = doc as unknown as { gameId: string | null; ownerId: string | null; body: unknown }
+    // A shelved entity has no Game to be a member of; it is private to its
+    // owner, and this query is deliberately not the way to reach one.
+    if (row.gameId === null) return null
+
+    await requireMember(ctx, row.gameId as never)
+    return { ownerId: row.ownerId, body: row.body }
+  },
+})

--- a/apps/itun/convex/entities.ts
+++ b/apps/itun/convex/entities.ts
@@ -145,6 +145,8 @@ export const create = mutation({
   args: {
     table: OWNABLE,
     gameId: v.union(v.id('games'), v.null()),
+    /** The local UUID this row mirrors, so later edits can address it. */
+    appId: v.optional(v.string()),
     body: v.any(),
   },
   handler: async (ctx, args): Promise<Id<'pilots'> | Id<'mechs'>> => {
@@ -155,6 +157,7 @@ export const create = mutation({
     return await ctx.db.insert(args.table, {
       gameId: args.gameId,
       ownerId: userId,
+      appId: args.appId,
       body,
       updatedAt: Date.now(),
     })
@@ -268,5 +271,73 @@ export const claimLocal = mutation({
     }
 
     return { claimed, skipped }
+  },
+})
+
+/**
+ * Look a row up by the app-level UUID the client holds.
+ *
+ * This is the whole point of the `appId` column: a client that only knows its
+ * local UUID can still address the server row, so updates and deletes work
+ * without a mapping table. One indexed lookup, not a scan.
+ */
+async function byAppId(
+  ctx: MutationCtx,
+  table: OwnableTable,
+  appId: string
+): Promise<Doc<'pilots'> | Doc<'mechs'> | null> {
+  return (await ctx.db
+    .query(table)
+    .withIndex('by_app_id', (q) => q.eq('appId', appId))
+    .unique()) as Doc<'pilots'> | Doc<'mechs'> | null
+}
+
+/**
+ * Mirror a local write to the server of record, addressed by app id.
+ *
+ * Upsert rather than update: the row may not exist yet if the entity was
+ * created while Solo and the account was claimed afterwards. Treating a missing
+ * row as "create it" is what makes the mirror converge instead of silently
+ * dropping the first edit after a claim.
+ */
+export const upsertByAppId = mutation({
+  args: {
+    table: OWNABLE,
+    appId: v.string(),
+    gameId: v.union(v.id('games'), v.null()),
+    body: v.any(),
+  },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    await assertGameMemberOrShelfOwner(ctx, args.gameId, userId)
+    const body = parseBody(args.table, args.body)
+
+    const existing = await byAppId(ctx, args.table, args.appId)
+    if (existing === null) {
+      await ctx.db.insert(args.table, {
+        gameId: args.gameId,
+        ownerId: userId,
+        appId: args.appId,
+        body,
+        updatedAt: Date.now(),
+      })
+      return
+    }
+
+    assertMayWrite(existing, userId)
+    await ctx.db.patch(existing._id, { body, updatedAt: Date.now() })
+  },
+})
+
+/** Delete by app id. A row that is already gone is not an error. */
+export const removeByAppId = mutation({
+  args: { table: OWNABLE, appId: v.string() },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    const existing = await byAppId(ctx, args.table, args.appId)
+    if (existing === null) return
+
+    assertMayWrite(existing, userId)
+    await ctx.db.delete(existing._id)
   },
 })

--- a/apps/itun/convex/entities.ts
+++ b/apps/itun/convex/entities.ts
@@ -1,0 +1,272 @@
+import { v } from 'convex/values'
+
+import { CrawlerSchema } from '../src/lib/schemas/crawler'
+import { MechSchema } from '../src/lib/schemas/mech'
+import { PilotSchema } from '../src/lib/schemas/pilot'
+import type { Doc, Id } from './_generated/dataModel'
+import { mutation, query } from './_generated/server'
+import type { MutationCtx, QueryCtx } from './_generated/server'
+import { NotAuthorized, getMembership, requireMember, requireUser } from './model/permissions'
+
+/**
+ * Entity reads and writes against the server of record (ADR-030 §1).
+ *
+ * ## Every write Zod-parses before it persists
+ *
+ * The schema stores entity bodies as `v.any()` so the Zod schemas in
+ * `src/lib/schemas/` stay the single source of truth rather than being forked
+ * into a second, hand-maintained set of Convex validators. The price of that is
+ * stated plainly in the schema header: **Convex cannot reject a malformed body,
+ * so the mutation has to.** These functions are where that obligation is paid.
+ *
+ * ## What you may read, and what you may write
+ *
+ * Reading is per-Game: any member sees every pilot and mech in it, which is
+ * what makes crew vitals and read-only drill-in possible (D12).
+ *
+ * Writing is per-*entity*: only the owner writes their own pilot, and nobody
+ * writes a crewmate's. A Mediator wanting to change someone else's sheet goes
+ * through a proposal (D7), not through here — there is deliberately no
+ * privileged write path in this module.
+ *
+ * The crawler is the exception on both axes, because it is communal (D8): any
+ * member may write it, resolved by field-level merge rather than
+ * last-write-wins, since the scrap pool and cargo lots are genuinely contended
+ * during Downtime.
+ */
+
+const OWNABLE = v.union(v.literal('pilots'), v.literal('mechs'))
+type OwnableTable = 'pilots' | 'mechs'
+
+const PARSERS = {
+  pilots: PilotSchema,
+  mechs: MechSchema,
+} as const
+
+/** Parse a body against its Zod schema, or throw with a legible reason. */
+function parseBody(table: OwnableTable, body: unknown): unknown {
+  const result = PARSERS[table].safeParse(body)
+  if (!result.success) {
+    throw new Error(`Invalid ${table} payload: ${result.error.issues[0]?.message ?? 'unknown'}`)
+  }
+  return result.data
+}
+
+/**
+ * Who may write an entity.
+ *
+ * Synchronous and ctx-free on purpose: the answer depends only on the row's
+ * own `ownerId`. There is deliberately no lookup that could grant a Mediator a
+ * privileged write here — changing someone else's sheet goes through a
+ * proposal (D7), and giving this function a ctx would invite exactly that.
+ */
+function assertMayWrite(doc: Doc<'pilots'> | Doc<'mechs'>, userId: Id<'users'>): void {
+  if (doc.ownerId === userId) return
+  if (doc.ownerId === null) {
+    throw new NotAuthorized(
+      'That entity is unclaimed — it must be assigned before it can be edited'
+    )
+  }
+  throw new NotAuthorized("You cannot edit another player's entity")
+}
+
+async function assertGameMemberOrShelfOwner(
+  ctx: QueryCtx | MutationCtx,
+  gameId: Id<'games'> | null,
+  userId: Id<'users'>
+): Promise<void> {
+  if (gameId === null) return
+  const membership = await getMembership(ctx, gameId, userId)
+  if (membership === null) throw new NotAuthorized('Not a member of this game')
+}
+
+/** Everything in a Game the caller can see: all pilots and mechs, plus the crawler. */
+export const listForGame = query({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args) => {
+    await requireMember(ctx, args.gameId)
+
+    const [pilots, mechs, crawlers, softLinks] = await Promise.all([
+      ctx.db
+        .query('pilots')
+        .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+        .collect(),
+      ctx.db
+        .query('mechs')
+        .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+        .collect(),
+      ctx.db
+        .query('crawlers')
+        .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+        .collect(),
+      ctx.db
+        .query('softLinks')
+        .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+        .collect(),
+    ])
+
+    return {
+      pilots: pilots.map((p) => ({ _id: p._id, ownerId: p.ownerId, body: p.body })),
+      mechs: mechs.map((m) => ({ _id: m._id, ownerId: m.ownerId, body: m.body })),
+      crawlers: crawlers.map((c) => ({ _id: c._id, body: c.body })),
+      softLinks: softLinks.map((l) => ({ _id: l._id, from: l.from, to: l.to, type: l.type })),
+    }
+  },
+})
+
+/** The caller's own shelf — entities that belong to them and to no Game. */
+export const listShelf = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await requireUser(ctx)
+
+    const pilots = (
+      await ctx.db
+        .query('pilots')
+        .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+        .collect()
+    ).filter((p) => p.gameId === null)
+    const mechs = (
+      await ctx.db
+        .query('mechs')
+        .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+        .collect()
+    ).filter((m) => m.gameId === null)
+
+    return {
+      pilots: pilots.map((p) => ({ _id: p._id, body: p.body })),
+      mechs: mechs.map((m) => ({ _id: m._id, body: m.body })),
+    }
+  },
+})
+
+/** Create an entity, on the caller's shelf or in a Game they belong to. */
+export const create = mutation({
+  args: {
+    table: OWNABLE,
+    gameId: v.union(v.id('games'), v.null()),
+    body: v.any(),
+  },
+  handler: async (ctx, args): Promise<Id<'pilots'> | Id<'mechs'>> => {
+    const userId = await requireUser(ctx)
+    await assertGameMemberOrShelfOwner(ctx, args.gameId, userId)
+    const body = parseBody(args.table, args.body)
+
+    return await ctx.db.insert(args.table, {
+      gameId: args.gameId,
+      ownerId: userId,
+      body,
+      updatedAt: Date.now(),
+    })
+  },
+})
+
+/** Replace an entity's body. Owner only — see the module header. */
+export const update = mutation({
+  args: {
+    table: OWNABLE,
+    entityId: v.string(),
+    body: v.any(),
+  },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    const doc = await ctx.db.get(args.entityId as Id<'pilots'> | Id<'mechs'>)
+    if (doc === null) throw new Error('That entity no longer exists')
+
+    assertMayWrite(doc as Doc<'pilots'> | Doc<'mechs'>, userId)
+    const body = parseBody(args.table, args.body)
+
+    await ctx.db.patch(doc._id, { body, updatedAt: Date.now() })
+  },
+})
+
+export const remove = mutation({
+  args: { table: OWNABLE, entityId: v.string() },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    const doc = await ctx.db.get(args.entityId as Id<'pilots'> | Id<'mechs'>)
+    if (doc === null) return
+
+    assertMayWrite(doc as Doc<'pilots'> | Doc<'mechs'>, userId)
+    await ctx.db.delete(doc._id)
+  },
+})
+
+/**
+ * Write the communal crawler with a **field-level merge** (D19).
+ *
+ * Last-write-wins would be wrong here in a way that shows up on exactly the
+ * night it matters: during Downtime the whole crew touches the crawler within
+ * the same few minutes, and a full-body write would silently discard whichever
+ * member happened to lose the race. Merging per top-level field means two
+ * people editing different things both succeed, and only a genuine same-field
+ * collision contends.
+ */
+export const patchCrawler = mutation({
+  args: {
+    crawlerId: v.id('crawlers'),
+    patch: v.any(),
+  },
+  handler: async (ctx, args): Promise<void> => {
+    const doc = await ctx.db.get(args.crawlerId)
+    if (doc === null) throw new Error('That crawler no longer exists')
+
+    // Communal: membership is the whole check. No ownerId to consult.
+    await requireMember(ctx, doc.gameId)
+
+    const merged = { ...(doc.body as Record<string, unknown>), ...(args.patch as object) }
+    const result = CrawlerSchema.safeParse(merged)
+    if (!result.success) {
+      throw new Error(`Invalid crawler payload: ${result.error.issues[0]?.message ?? 'unknown'}`)
+    }
+
+    await ctx.db.patch(args.crawlerId, { body: result.data, updatedAt: Date.now() })
+  },
+})
+
+/**
+ * Upload local entities into this account on first sign-in (D11).
+ *
+ * Everything lands on the **shelf**, never straight into a Game. A person
+ * signing in for the first time has local builds with no relationship to any
+ * crew, and guessing one would be worse than making them place it deliberately.
+ *
+ * Bodies are Zod-parsed like any other write, and a row that fails is **skipped
+ * rather than aborting the claim**. A single corrupt local record should not
+ * cost somebody their whole roster — the count of skipped rows comes back so
+ * the UI can say what did not make it.
+ */
+export const claimLocal = mutation({
+  args: {
+    pilots: v.array(v.any()),
+    mechs: v.array(v.any()),
+  },
+  handler: async (ctx, args): Promise<{ claimed: number; skipped: number }> => {
+    const userId = await requireUser(ctx)
+    const now = Date.now()
+    let claimed = 0
+    let skipped = 0
+
+    for (const [table, rows] of [
+      ['pilots', args.pilots],
+      ['mechs', args.mechs],
+    ] as const) {
+      for (const body of rows) {
+        const parsed = PARSERS[table].safeParse(body)
+        if (!parsed.success) {
+          skipped += 1
+          continue
+        }
+        await ctx.db.insert(table, {
+          gameId: null,
+          ownerId: userId,
+          body: parsed.data,
+          updatedAt: now,
+        })
+        claimed += 1
+      }
+    }
+
+    return { claimed, skipped }
+  },
+})

--- a/apps/itun/convex/mediator.ts
+++ b/apps/itun/convex/mediator.ts
@@ -1,0 +1,151 @@
+import { v } from 'convex/values'
+
+import { mutation, query } from './_generated/server'
+import type { Id } from './_generated/dataModel'
+import { requireMediator, requireMember, requireUser } from './model/permissions'
+
+/**
+ * The Mediator surface's server layer (ADR-030 §6, Phase 3).
+ *
+ * ## The NPC tray is the one genuinely secret thing
+ *
+ * Everything else in a Game is readable by every member — that is what makes a
+ * crew a crew. Prepared opposition is the exception, and it is the *only*
+ * exception, so these queries gate on `requireMediator` rather than
+ * `requireMember`. A player who can read the NPC tray can read the encounter
+ * before it happens, which is the one leak that changes how the game is played
+ * rather than merely who can edit what.
+ *
+ * ## Presence is deliberately not a subscription to everything
+ *
+ * "Who is at the table right now" is a heartbeat, not a stream of activity.
+ * Storing a `lastSeen` and letting readers decide what counts as present keeps
+ * it cheap and avoids inventing an online/offline state the app would then have
+ * to keep truthful.
+ */
+
+/** How long since a heartbeat before somebody stops counting as at the table. */
+export const PRESENCE_WINDOW_MS = 90_000
+
+/** The Mediator's prepared opposition. Mediator-only, by design. */
+export const npcs = query({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args) => {
+    await requireMediator(ctx, args.gameId)
+    const rows = await ctx.db
+      .query('encounterNpcs')
+      .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+      .collect()
+    return rows.map((r) => ({ _id: r._id, body: r.body }))
+  },
+})
+
+export const addNpc = mutation({
+  args: { gameId: v.id('games'), body: v.any() },
+  handler: async (ctx, args): Promise<Id<'encounterNpcs'>> => {
+    await requireMediator(ctx, args.gameId)
+    return await ctx.db.insert('encounterNpcs', { gameId: args.gameId, body: args.body })
+  },
+})
+
+export const updateNpc = mutation({
+  args: { npcId: v.id('encounterNpcs'), body: v.any() },
+  handler: async (ctx, args): Promise<void> => {
+    const doc = await ctx.db.get(args.npcId)
+    if (doc === null) return
+    await requireMediator(ctx, doc.gameId)
+    await ctx.db.patch(args.npcId, { body: args.body })
+  },
+})
+
+export const removeNpc = mutation({
+  args: { npcId: v.id('encounterNpcs') },
+  handler: async (ctx, args): Promise<void> => {
+    const doc = await ctx.db.get(args.npcId)
+    if (doc === null) return
+    await requireMediator(ctx, doc.gameId)
+    await ctx.db.delete(args.npcId)
+  },
+})
+
+/**
+ * Record that the caller is at the table.
+ *
+ * Upserts one row per (game, member) rather than appending, so presence cannot
+ * grow without bound during a long session. Any member may heartbeat — presence
+ * is not privileged information, and a Mediator needs to see players arrive
+ * exactly as much as players need to see each other.
+ */
+export const heartbeat = mutation({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args): Promise<void> => {
+    const membership = await requireMember(ctx, args.gameId)
+    const existing = await ctx.db
+      .query('presence')
+      .withIndex('by_game_user', (q) => q.eq('gameId', args.gameId).eq('userId', membership.userId))
+      .unique()
+
+    if (existing === null) {
+      await ctx.db.insert('presence', {
+        gameId: args.gameId,
+        userId: membership.userId,
+        lastSeen: Date.now(),
+      })
+      return
+    }
+    await ctx.db.patch(existing._id, { lastSeen: Date.now() })
+  },
+})
+
+/**
+ * Who is at the table.
+ *
+ * `present` is computed at read time from `lastSeen` rather than stored. A
+ * stored boolean would need something to turn it off — a timer, a disconnect
+ * hook — and every one of those can fail in a way that leaves somebody
+ * permanently "present" long after they closed the tab.
+ */
+export const presence = query({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args) => {
+    await requireMember(ctx, args.gameId)
+    const now = Date.now()
+
+    const rows = await ctx.db
+      .query('presence')
+      .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+      .collect()
+
+    return await Promise.all(
+      rows.map(async (r) => {
+        const user = await ctx.db.get(r.userId)
+        return {
+          userId: r.userId,
+          displayName: user?.displayName ?? user?.name ?? 'Crewmate',
+          lastSeen: r.lastSeen,
+          present: now - r.lastSeen < PRESENCE_WINDOW_MS,
+        }
+      })
+    )
+  },
+})
+
+/**
+ * Whether the caller mediates this Game.
+ *
+ * A plain query rather than something derived client-side from the roster, so
+ * a surface can gate itself on one authoritative answer instead of
+ * reconstructing the rule. Returns false rather than throwing for a
+ * non-member — "can I mediate this" is a reasonable question for anyone to ask.
+ */
+export const amMediator = query({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args): Promise<boolean> => {
+    const userId = await requireUser(ctx)
+    const membership = await ctx.db
+      .query('memberships')
+      .withIndex('by_game_user', (q) => q.eq('gameId', args.gameId).eq('userId', userId))
+      .unique()
+    return membership?.mediator ?? false
+  },
+})

--- a/apps/itun/convex/schema.ts
+++ b/apps/itun/convex/schema.ts
@@ -42,6 +42,12 @@ export default defineSchema({
     image: v.optional(v.string()),
     emailVerificationTime: v.optional(v.number()),
     isAnonymous: v.optional(v.boolean()),
+    // Carried over from `authTables.users` even though Discord is the only
+    // provider: overriding that table means anything the library expects to
+    // find has to be redeclared here, and a missing field would surface as a
+    // write failure inside the auth flow rather than as a type error.
+    phone: v.optional(v.string()),
+    phoneVerificationTime: v.optional(v.number()),
 
     /** Discord snowflake, once linked. The only third-party identifier stored. */
     discordId: v.optional(v.string()),
@@ -55,6 +61,7 @@ export default defineSchema({
     avatarUrl: v.optional(v.string()),
   })
     .index('email', ['email'])
+    .index('phone', ['phone'])
     .index('by_discord', ['discordId']),
 
   /**

--- a/apps/itun/convex/schema.ts
+++ b/apps/itun/convex/schema.ts
@@ -110,20 +110,48 @@ export default defineSchema({
   pilots: defineTable({
     gameId: v.union(v.id('games'), v.null()),
     ownerId: v.union(v.id('users'), v.null()),
+    /**
+     * The app-level UUID this row mirrors (ADR-030 §1).
+     *
+     * Convex mints its own `_id`, so a client holding only the local UUID has
+     * nothing to address a row by — which is what made an earlier
+     * write-mirroring attempt unworkable for updates and deletes. Carrying the
+     * app id as an indexed column gives one cheap lookup per write instead of
+     * a mapping table, and keeps `_id` idiomatic for everything server-side.
+     *
+     * Optional because rows created server-side (Game templates) have no local
+     * counterpart until somebody claims them.
+     */
+    appId: v.optional(v.string()),
     body: v.any(),
     updatedAt: v.number(),
   })
     .index('by_game', ['gameId'])
-    .index('by_owner', ['ownerId']),
+    .index('by_owner', ['ownerId'])
+    .index('by_app_id', ['appId']),
 
   mechs: defineTable({
     gameId: v.union(v.id('games'), v.null()),
     ownerId: v.union(v.id('users'), v.null()),
+    /**
+     * The app-level UUID this row mirrors (ADR-030 §1).
+     *
+     * Convex mints its own `_id`, so a client holding only the local UUID has
+     * nothing to address a row by — which is what made an earlier
+     * write-mirroring attempt unworkable for updates and deletes. Carrying the
+     * app id as an indexed column gives one cheap lookup per write instead of
+     * a mapping table, and keeps `_id` idiomatic for everything server-side.
+     *
+     * Optional because rows created server-side (Game templates) have no local
+     * counterpart until somebody claims them.
+     */
+    appId: v.optional(v.string()),
     body: v.any(),
     updatedAt: v.number(),
   })
     .index('by_game', ['gameId'])
-    .index('by_owner', ['ownerId']),
+    .index('by_owner', ['ownerId'])
+    .index('by_app_id', ['appId']),
 
   /**
    * The crawler is communal (D8) — no `ownerId` at all, and any member of the
@@ -133,9 +161,13 @@ export default defineSchema({
    */
   crawlers: defineTable({
     gameId: v.id('games'),
+    /** See `pilots.appId` — same reason, same lookup path. */
+    appId: v.optional(v.string()),
     body: v.any(),
     updatedAt: v.number(),
-  }).index('by_game', ['gameId']),
+  })
+    .index('by_game', ['gameId'])
+    .index('by_app_id', ['appId']),
 
   /** 'mech-to-pilot' | 'pilot-to-crawler'. EntityRef is NOT widened (ADR-027). */
   softLinks: defineTable({

--- a/apps/itun/convex/templates.ts
+++ b/apps/itun/convex/templates.ts
@@ -1,0 +1,104 @@
+import { v } from 'convex/values'
+
+import {
+  STARTER_CRAWLERS,
+  STARTER_MECHS,
+  STARTER_PILOTS,
+  STARTER_SOFT_LINKS,
+} from '../src/lib/starterSet/starterSet'
+import type { Id } from './_generated/dataModel'
+import { mutation, query } from './_generated/server'
+import { requireUser } from './model/permissions'
+
+/**
+ * Game templates (ADR-030, D34).
+ *
+ * A template is a pre-built crew you can start a Game from. The rule that makes
+ * it more than seeded data: **its entities arrive unclaimed** (`ownerId: null`).
+ * The Mediator — or the Organizer, while a Game has no Mediator — hands them
+ * out as players join, which turns pre-generated characters from a curiosity
+ * into the onboarding path.
+ *
+ * The Starter Set data is imported straight from `src/lib/starterSet/`. That
+ * module is deliberately static plain data with no runtime reference-data
+ * resolution (see its header), so it bundles into a Convex function safely and
+ * there is exactly one copy of the roster rather than a server-side duplicate
+ * that would drift from the local one.
+ */
+
+const TEMPLATES = {
+  'starter-set': {
+    name: "Reclamation of the Wastes — Union Crawler #430 'Tenacity'",
+    description:
+      'The six pilots of the Salvage Union Starter Set, their mechs, and their crawler. Everyone arrives unclaimed for you to hand out.',
+  },
+} as const
+
+export type TemplateId = keyof typeof TEMPLATES
+
+/** The templates a Game can be started from. */
+export const list = query({
+  args: {},
+  handler: async () => {
+    return Object.entries(TEMPLATES).map(([id, t]) => ({
+      id,
+      name: t.name,
+      description: t.description,
+    }))
+  },
+})
+
+/**
+ * Create a Game pre-populated from a template.
+ *
+ * The creator becomes its Organizer and is seated as a Player, exactly as
+ * `games.create` does — a template changes what is *in* the Game, never who
+ * runs it. `mediator` starts false, so the Organizer fallback covers handing
+ * out the pre-gens until somebody is appointed.
+ */
+export const createGame = mutation({
+  args: {
+    templateId: v.literal('starter-set'),
+    name: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<Id<'games'>> => {
+    const userId = await requireUser(ctx)
+    const template = TEMPLATES[args.templateId]
+
+    const gameId = await ctx.db.insert('games', {
+      name: args.name?.trim() || template.name,
+      templateOrigin: args.templateId,
+    })
+    await ctx.db.insert('memberships', {
+      gameId,
+      userId,
+      mediator: false,
+      organizer: true,
+      joinedAt: Date.now(),
+    })
+
+    const now = Date.now()
+
+    // ownerId: null is the whole point — see the module header.
+    for (const pilot of STARTER_PILOTS) {
+      await ctx.db.insert('pilots', { gameId, ownerId: null, body: pilot, updatedAt: now })
+    }
+    for (const mech of STARTER_MECHS) {
+      await ctx.db.insert('mechs', { gameId, ownerId: null, body: mech, updatedAt: now })
+    }
+    // The crawler has no ownerId column at all: it is communal by design (D8).
+    for (const crawler of STARTER_CRAWLERS) {
+      await ctx.db.insert('crawlers', { gameId, body: crawler, updatedAt: now })
+    }
+    for (const link of STARTER_SOFT_LINKS) {
+      await ctx.db.insert('softLinks', {
+        gameId,
+        from: { type: link.from.type, id: link.from.id },
+        to: { type: link.to.type, id: link.to.id },
+        type: link.type,
+      })
+    }
+
+    return gameId
+  },
+})

--- a/apps/itun/src/components/account/AccountScreen.tsx
+++ b/apps/itun/src/components/account/AccountScreen.tsx
@@ -1,0 +1,213 @@
+import { useState } from 'react'
+import { Button, Card, Text } from 'component-lib'
+import { useMutation, useQuery } from 'convex/react'
+
+import { api } from '../../../convex/_generated/api'
+import { useConnection } from '../../lib/connection/connectionContext'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+import { SignInControl } from './SignInControl'
+
+/**
+ * The account screen (D33): profile, your Games, export, delete.
+ *
+ * All four live on one page deliberately. Holding somebody's Discord identity
+ * creates obligations — let me see it, let me correct it, let me take it away,
+ * let me erase it — and splitting those across surfaces is how one of them
+ * quietly never ships.
+ *
+ * As everywhere in this app, the Convex hooks are isolated behind a
+ * build-time branch so a Solo build (no `VITE_CONVEX_URL`) renders without a
+ * provider present.
+ */
+
+function download(filename: string, data: unknown): void {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function SignedInAccount() {
+  const me = useQuery(api.account.me, {})
+  const games = useQuery(api.games.listMine, {})
+  const exported = useQuery(api.account.exportMine, {})
+  const updateProfile = useMutation(api.account.updateProfile)
+  const deleteAccount = useMutation(api.account.deleteAccount)
+
+  const [name, setName] = useState<string | null>(null)
+  const [confirming, setConfirming] = useState(false)
+
+  if (me === undefined) return <Text>Loading your account…</Text>
+  if (me === null) return <Text>No account found.</Text>
+
+  const value = name ?? me.displayName ?? ''
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <div className="flex flex-col gap-3 p-4">
+          <Text as="label" className="font-cond text-xs font-bold tracking-widest uppercase">
+            Display name
+          </Text>
+          <Text variant="hint" className="text-left">
+            Shown on every entity you own. Defaults to your Discord name; clearing this falls back
+            to it rather than to blank.
+          </Text>
+          <input
+            aria-label="Display name"
+            className="border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-1"
+            value={value}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <div>
+            <Button
+              variant="primary"
+              size="compact"
+              onClick={() => void updateProfile({ displayName: value })}
+            >
+              Save
+            </Button>
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <div className="flex flex-col gap-2 p-4">
+          <Text as="label" className="font-cond text-xs font-bold tracking-widest uppercase">
+            Your games
+          </Text>
+          {games === undefined && (
+            <Text variant="hint" className="text-left">
+              Loading…
+            </Text>
+          )}
+          {games?.length === 0 && (
+            <Text variant="hint" className="text-left">
+              You are not in any games yet.
+            </Text>
+          )}
+          {games?.map((g) => (
+            <div key={g._id} className="flex items-baseline justify-between gap-3">
+              <Text>{g.name}</Text>
+              <Text variant="hint" className="text-left">
+                {g.organizer ? 'Organizer · ' : ''}
+                {g.mediator ? 'Mediator' : 'Player'} · {g.memberCount} member
+                {g.memberCount === 1 ? '' : 's'}
+              </Text>
+            </div>
+          ))}
+        </div>
+      </Card>
+
+      <Card>
+        <div className="flex flex-col gap-3 p-4">
+          <Text as="label" className="font-cond text-xs font-bold tracking-widest uppercase">
+            Your data
+          </Text>
+          <Text variant="hint" className="text-left">
+            Downloads everything you own. Crewmates' characters and the shared crawler are not
+            included — you can see them, but they are not yours to take.
+          </Text>
+          <div>
+            <Button
+              variant="ghost"
+              size="compact"
+              disabled={exported === undefined}
+              onClick={() => exported && download('itun-account-export.json', exported)}
+            >
+              Download my data
+            </Button>
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <div className="flex flex-col gap-3 p-4">
+          <Text as="label" className="font-cond text-xs font-bold tracking-widest uppercase">
+            Delete account
+          </Text>
+          <Text variant="hint" className="text-left">
+            Your pilots and mechs are deleted. Games you are in survive — the shared crawler stays,
+            and if you organise a game the role passes to the longest-standing member. Download your
+            data first; this cannot be undone.
+          </Text>
+          <div>
+            {confirming ? (
+              <div className="flex gap-2">
+                <Button variant="danger" size="compact" onClick={() => void deleteAccount({})}>
+                  Permanently delete
+                </Button>
+                <Button variant="ghost" size="compact" onClick={() => setConfirming(false)}>
+                  Cancel
+                </Button>
+              </div>
+            ) : (
+              <Button variant="danger" size="compact" onClick={() => setConfirming(true)}>
+                Delete my account
+              </Button>
+            )}
+          </div>
+        </div>
+      </Card>
+    </div>
+  )
+}
+
+function AccountBody() {
+  const { mode } = useConnection()
+
+  if (mode === 'connected') return <SignedInAccount />
+
+  if (mode === 'disconnected') {
+    return (
+      <Card>
+        <div className="p-4">
+          <Text>
+            Your account is unreachable right now. Reconnect to change your profile or manage your
+            games.
+          </Text>
+        </div>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <Text>
+          You are playing solo. Everything you build is saved on this device and needs no account.
+        </Text>
+        <Text variant="hint" className="text-left">
+          Signing in lets you join a game with other people and carry your builds between devices.
+        </Text>
+        <div>
+          <SignInControl />
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+export function AccountScreen() {
+  return (
+    <main className="mx-auto flex max-w-2xl flex-col gap-6 p-4">
+      <Text as="h1" className="font-cond text-2xl font-bold tracking-wide uppercase">
+        Account
+      </Text>
+      {isConvexConfigured ? (
+        <AccountBody />
+      ) : (
+        <Card>
+          <div className="p-4">
+            <Text>
+              This build has no account service configured, so everything is saved on this device.
+            </Text>
+          </div>
+        </Card>
+      )}
+    </main>
+  )
+}

--- a/apps/itun/src/components/account/AccountStrip.tsx
+++ b/apps/itun/src/components/account/AccountStrip.tsx
@@ -30,6 +30,14 @@ export function AccountStrip() {
     <div className="flex items-center justify-end gap-3 border-b border-[var(--color-ink)]/15 px-3 py-1">
       {mode === 'connected' && (
         <Link
+          to="/games"
+          className="font-cond text-xs font-bold tracking-widest text-[var(--color-ink)] uppercase hover:text-[var(--color-rust)]"
+        >
+          Games
+        </Link>
+      )}
+      {mode === 'connected' && (
+        <Link
           to="/account"
           className="font-cond text-xs font-bold tracking-widest text-[var(--color-ink)] uppercase hover:text-[var(--color-rust)]"
         >

--- a/apps/itun/src/components/account/AccountStrip.tsx
+++ b/apps/itun/src/components/account/AccountStrip.tsx
@@ -1,0 +1,42 @@
+import { Link } from '@tanstack/react-router'
+
+import { useConnection } from '../../lib/connection/connectionContext'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+import { SignInControl } from './SignInControl'
+
+/**
+ * A thin strip above the brand header carrying sign-in and a link to the
+ * account page.
+ *
+ * ## Why not a nav item in `AppBar`
+ *
+ * `AppBar` lives in `component-lib` and is shared with `apps/srd`, which has no
+ * accounts and never will. Threading an auth slot through it would push an
+ * ITUN-only concept into a package whose contract is to stay backend-agnostic,
+ * and would touch a component every page of both apps renders. A local strip
+ * keeps the blast radius inside ITUN.
+ *
+ * ## It renders nothing in a Solo build
+ *
+ * No `VITE_CONVEX_URL` means accounts are not merely signed-out, they are
+ * absent — so there is nothing to link to and nothing to sign into. Existing
+ * users see exactly the chrome they saw before.
+ */
+export function AccountStrip() {
+  const { mode } = useConnection()
+  if (!isConvexConfigured) return null
+
+  return (
+    <div className="flex items-center justify-end gap-3 border-b border-[var(--color-ink)]/15 px-3 py-1">
+      {mode === 'connected' && (
+        <Link
+          to="/account"
+          className="font-cond text-xs font-bold tracking-widest text-[var(--color-ink)] uppercase hover:text-[var(--color-rust)]"
+        >
+          Account
+        </Link>
+      )}
+      <SignInControl />
+    </div>
+  )
+}

--- a/apps/itun/src/components/account/SignInControl.tsx
+++ b/apps/itun/src/components/account/SignInControl.tsx
@@ -1,0 +1,50 @@
+import { Button } from 'component-lib'
+import { useAuthActions } from '@convex-dev/auth/react'
+
+import { useConnection } from '../../lib/connection/connectionContext'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+
+/**
+ * Sign in / sign out with Discord.
+ *
+ * ## The Solo-build branch, again
+ *
+ * `useAuthActions` needs a `ConvexAuthProvider` above it, and a build with no
+ * `VITE_CONVEX_URL` deliberately has none. So this file uses the same
+ * component-level branch as `ConnectionProvider`: the hook lives in
+ * `ConvexSignIn`, which is only ever rendered when the build is configured.
+ * The branch is a build-time constant, so React sees a stable component
+ * identity across renders.
+ *
+ * In a Solo build this renders **nothing at all** rather than a disabled
+ * button. Offering an account to somebody whose app cannot have one is worse
+ * than silence — signing in is an upgrade, not a missing feature (ADR-030 §1).
+ */
+
+function ConvexSignIn() {
+  const { signIn, signOut } = useAuthActions()
+  const { mode } = useConnection()
+
+  if (mode === 'connected') {
+    return (
+      <Button variant="ghost" size="compact" onClick={() => void signOut()}>
+        Sign out
+      </Button>
+    )
+  }
+
+  // Disconnected means signed in but unreachable — offering "sign in" there
+  // would be nonsense, and the NOT CONNECTED banner already explains the state.
+  if (mode === 'disconnected') return null
+
+  return (
+    <Button variant="primary" size="compact" onClick={() => void signIn('discord')}>
+      Sign in with Discord
+    </Button>
+  )
+}
+
+export function SignInControl() {
+  if (!isConvexConfigured) return null
+  return <ConvexSignIn />
+}

--- a/apps/itun/src/components/account/__tests__/AccountScreen.test.tsx
+++ b/apps/itun/src/components/account/__tests__/AccountScreen.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+
+import { ConnectionProvider } from '../../../lib/connection/ConnectionProvider'
+import { isConvexConfigured } from '../../../lib/connection/convexClient'
+import { AccountScreen } from '../AccountScreen'
+import { SignInControl } from '../SignInControl'
+
+/**
+ * The failure this guards against is structural rather than cosmetic.
+ *
+ * `AccountScreen` and `SignInControl` both reach for Convex hooks
+ * (`useQuery`, `useMutation`, `useAuthActions`), and every one of those throws
+ * without a provider above it. A Solo build deliberately has no provider, so if
+ * the build-time branch is ever removed or inverted, this page crashes for the
+ * majority of users — the ones who never sign in — while working perfectly for
+ * whoever is testing it with a configured `.env.local`.
+ *
+ * The test environment has no `VITE_CONVEX_URL`, so rendering here without a
+ * throw is the assertion.
+ */
+
+describe('AccountScreen in a Solo build', () => {
+  test('the test build really is Solo', () => {
+    // Asserted, not assumed: if this flips, the tests below would start
+    // passing for an entirely different reason.
+    expect(isConvexConfigured).toBe(false)
+  })
+
+  test('renders without a Convex provider present', () => {
+    render(
+      <ConnectionProvider>
+        <AccountScreen />
+      </ConnectionProvider>
+    )
+    expect(screen.getByText('Account')).toBeTruthy()
+  })
+
+  test('explains that data is local rather than offering an account', () => {
+    render(
+      <ConnectionProvider>
+        <AccountScreen />
+      </ConnectionProvider>
+    )
+    expect(screen.getByText(/saved on this device/i)).toBeTruthy()
+  })
+
+  test('SignInControl renders nothing at all', () => {
+    // Not a disabled button: offering an account to somebody whose build
+    // cannot have one is worse than silence.
+    const { container } = render(
+      <ConnectionProvider>
+        <SignInControl />
+      </ConnectionProvider>
+    )
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/apps/itun/src/components/games/GamesScreen.tsx
+++ b/apps/itun/src/components/games/GamesScreen.tsx
@@ -154,7 +154,9 @@ function GameRow({
 
 function ConnectedGames() {
   const games = useQuery(api.games.listMine, {})
+  const templates = useQuery(api.templates.list, {})
   const create = useMutation(api.games.create)
+  const createFromTemplate = useMutation(api.templates.createGame)
   const redeem = useMutation(api.invites.redeem)
 
   const [newName, setNewName] = useState('')
@@ -183,6 +185,34 @@ function ConnectedGames() {
           >
             Create
           </Button>
+        </div>
+      </Card>
+
+      <Card>
+        <div className="flex flex-col gap-3 p-4">
+          <span className={label}>Or start from a template</span>
+          {templates?.map((t) => (
+            <div key={t.id} className="flex flex-col gap-2">
+              <Text as="span">{t.name}</Text>
+              <Text variant="hint" className="text-left">
+                {t.description}
+              </Text>
+              <div>
+                <Button
+                  variant="ghost"
+                  size="compact"
+                  onClick={() =>
+                    void createFromTemplate({
+                      templateId: 'starter-set',
+                      name: newName || undefined,
+                    })
+                  }
+                >
+                  Start this game
+                </Button>
+              </div>
+            </div>
+          ))}
         </div>
       </Card>
 

--- a/apps/itun/src/components/games/GamesScreen.tsx
+++ b/apps/itun/src/components/games/GamesScreen.tsx
@@ -1,0 +1,292 @@
+import { useState } from 'react'
+import { Button, Card, Text } from 'component-lib'
+import { useMutation, useQuery } from 'convex/react'
+
+import { api } from '../../../convex/_generated/api'
+import type { Id } from '../../../convex/_generated/dataModel'
+import { useConnection } from '../../lib/connection/connectionContext'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+import { SignInControl } from '../account/SignInControl'
+
+/**
+ * Games: create one, invite people, join by code, hand over the Organizer role.
+ *
+ * The whole screen is gated on `mode === 'connected'`. That is not defensive
+ * coding — a Game is inherently shared state, so there is nothing meaningful to
+ * show a Solo user and nothing safe to show a Disconnected one, whose view
+ * would be a stale snapshot of a roster that may have changed.
+ */
+
+const label = 'font-cond text-xs font-bold tracking-caps-wide uppercase'
+
+function InvitePanel({ gameId }: { gameId: Id<'games'> }) {
+  const createInvite = useMutation(api.invites.create)
+  const [code, setCode] = useState<string | null>(null)
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Button
+        variant="ghost"
+        size="compact"
+        onClick={() => void createInvite({ gameId }).then(setCode)}
+      >
+        Create invite code
+      </Button>
+      {code !== null && (
+        <div className="flex flex-col gap-1">
+          {/* Crockford base32 with no I/L/O/U, so a code read aloud across a
+              table cannot be mistyped into a different valid one. Rendered
+              large and spaced because reading it aloud is the primary use. */}
+          <Text as="span" className="font-cond text-2xl font-bold tracking-caps-wide">
+            {code}
+          </Text>
+          <Text variant="hint" className="text-left">
+            Valid for 14 days. Anyone with this code can join as a player.
+          </Text>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function GameRow({
+  game,
+}: {
+  game: {
+    _id: Id<'games'>
+    name: string
+    mediator: boolean
+    organizer: boolean
+    memberCount: number
+  }
+}) {
+  const members = useQuery(api.games.members, { gameId: game._id })
+  const rename = useMutation(api.games.rename)
+  const setMediator = useMutation(api.games.setMediator)
+  const transferOrganizer = useMutation(api.games.transferOrganizer)
+  const [name, setName] = useState<string | null>(null)
+
+  const value = name ?? game.name
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <div className="flex items-baseline justify-between gap-3">
+          <Text as="span" className="font-cond text-lg font-bold">
+            {game.name}
+          </Text>
+          <Text variant="hint" className="text-left">
+            {game.organizer ? 'Organizer · ' : ''}
+            {game.mediator ? 'Mediator' : 'Player'}
+          </Text>
+        </div>
+
+        {game.organizer && (
+          <div className="flex flex-wrap items-end gap-2">
+            <label className="flex flex-col gap-1">
+              <span className={label}>Name</span>
+              <input
+                aria-label={`Rename ${game.name}`}
+                className="border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-1"
+                value={value}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </label>
+            <Button
+              variant="primary"
+              size="compact"
+              onClick={() => void rename({ gameId: game._id, name: value })}
+            >
+              Save
+            </Button>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-1">
+          <span className={label}>Crew</span>
+          {members === undefined && <Text variant="hint">Loading…</Text>}
+          {members?.map((m) => (
+            <div key={m.userId} className="flex items-baseline justify-between gap-3">
+              <Text as="span">{m.displayName}</Text>
+              <span className="flex items-center gap-2">
+                <Text variant="hint" className="text-left">
+                  {m.organizer ? 'Organizer · ' : ''}
+                  {m.mediator ? 'Mediator' : 'Player'}
+                </Text>
+                {game.organizer && (
+                  <>
+                    <Button
+                      variant="ghost"
+                      size="mini"
+                      onClick={() =>
+                        void setMediator({
+                          gameId: game._id,
+                          userId: m.userId,
+                          mediator: !m.mediator,
+                        })
+                      }
+                    >
+                      {m.mediator ? 'Stand down' : 'Make Mediator'}
+                    </Button>
+                    {!m.organizer && (
+                      <Button
+                        variant="ghost"
+                        size="mini"
+                        onClick={() =>
+                          void transferOrganizer({ gameId: game._id, userId: m.userId })
+                        }
+                      >
+                        Hand over
+                      </Button>
+                    )}
+                  </>
+                )}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {game.organizer && <InvitePanel gameId={game._id} />}
+      </div>
+    </Card>
+  )
+}
+
+function ConnectedGames() {
+  const games = useQuery(api.games.listMine, {})
+  const create = useMutation(api.games.create)
+  const redeem = useMutation(api.invites.redeem)
+
+  const [newName, setNewName] = useState('')
+  const [code, setCode] = useState('')
+  const [joinError, setJoinError] = useState<string | null>(null)
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <div className="flex flex-wrap items-end gap-2 p-4">
+          <label className="flex flex-col gap-1">
+            <span className={label}>Start a game</span>
+            <input
+              aria-label="New game name"
+              placeholder="Union Crawler #430"
+              className="border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-1"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+            />
+          </label>
+          <Button
+            variant="primary"
+            size="compact"
+            disabled={newName.trim().length === 0}
+            onClick={() => void create({ name: newName }).then(() => setNewName(''))}
+          >
+            Create
+          </Button>
+        </div>
+      </Card>
+
+      <Card>
+        <div className="flex flex-col gap-2 p-4">
+          <div className="flex flex-wrap items-end gap-2">
+            <label className="flex flex-col gap-1">
+              <span className={label}>Join with a code</span>
+              <input
+                aria-label="Invite code"
+                placeholder="A1B2C3D4"
+                className="border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-1 tracking-caps-wide uppercase"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+              />
+            </label>
+            <Button
+              variant="primary"
+              size="compact"
+              disabled={code.trim().length === 0}
+              onClick={() => {
+                setJoinError(null)
+                void redeem({ code })
+                  .then(() => setCode(''))
+                  // The server distinguishes not-valid / expired / used-up, so
+                  // surface its wording rather than a generic failure.
+                  .catch((err: Error) => setJoinError(err.message))
+              }}
+            >
+              Join
+            </Button>
+          </div>
+          {joinError !== null && (
+            <Text variant="hint" className="text-left text-[var(--color-roll-cascade)]">
+              {joinError}
+            </Text>
+          )}
+        </div>
+      </Card>
+
+      {games === undefined && <Text>Loading your games…</Text>}
+      {games?.length === 0 && (
+        <Text variant="hint" className="text-left">
+          You are not in any games yet. Create one, or join with a code from whoever set yours up.
+        </Text>
+      )}
+      {games?.map((g) => (
+        <GameRow key={g._id} game={g} />
+      ))}
+    </div>
+  )
+}
+
+function GamesBody() {
+  const { mode } = useConnection()
+
+  if (mode === 'connected') return <ConnectedGames />
+
+  if (mode === 'disconnected') {
+    return (
+      <Card>
+        <div className="p-4">
+          <Text>
+            Your games are unreachable right now. Reconnect to see your crew or manage invites.
+          </Text>
+        </div>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <Text>Games let several people share one crawler, with a Mediator running the table.</Text>
+        <Text variant="hint" className="text-left">
+          You are playing solo. Everything you build stays on this device and needs no account —
+          sign in only if you want to play with other people.
+        </Text>
+        <div>
+          <SignInControl />
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+export function GamesScreen() {
+  return (
+    <main className="mx-auto flex max-w-2xl flex-col gap-6 p-4">
+      <Text as="h1" className="font-cond text-2xl font-bold tracking-caps uppercase">
+        Games
+      </Text>
+      {isConvexConfigured ? (
+        <GamesBody />
+      ) : (
+        <Card>
+          <div className="p-4">
+            <Text>
+              This build has no account service configured, so shared games are unavailable and
+              everything is saved on this device.
+            </Text>
+          </div>
+        </Card>
+      )}
+    </main>
+  )
+}

--- a/apps/itun/src/components/games/__tests__/GamesScreen.test.tsx
+++ b/apps/itun/src/components/games/__tests__/GamesScreen.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+
+import { ConnectionProvider } from '../../../lib/connection/ConnectionProvider'
+import { isConvexConfigured } from '../../../lib/connection/convexClient'
+import { GamesScreen } from '../GamesScreen'
+
+/**
+ * Same structural guard as the account screen: every Convex hook in here
+ * (`useQuery`, `useMutation`) throws without a provider above it, and a Solo
+ * build deliberately has none.
+ *
+ * This is the failure mode that hides best — it works perfectly for whoever
+ * is developing with a configured `.env.local`, and crashes for every user who
+ * never signs in.
+ */
+
+describe('GamesScreen in a Solo build', () => {
+  test('the test build really is Solo', () => {
+    expect(isConvexConfigured).toBe(false)
+  })
+
+  test('renders without a Convex provider present', () => {
+    render(
+      <ConnectionProvider>
+        <GamesScreen />
+      </ConnectionProvider>
+    )
+    expect(screen.getByText('Games')).toBeTruthy()
+  })
+
+  test('explains why shared games are unavailable rather than showing a broken form', () => {
+    render(
+      <ConnectionProvider>
+        <GamesScreen />
+      </ConnectionProvider>
+    )
+    expect(screen.getByText(/saved on this device/i)).toBeTruthy()
+    // No create/join affordance should be offered when it cannot possibly work.
+    expect(screen.queryByLabelText('New game name')).toBeNull()
+    expect(screen.queryByLabelText('Invite code')).toBeNull()
+  })
+})

--- a/apps/itun/src/lib/__tests__/container.test.ts
+++ b/apps/itun/src/lib/__tests__/container.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test'
+
+import { DEFAULT_WORKSPACE_ID } from '../defaultWorkspace'
+import { containerOf, gameIdOf, isOnShelf, moveTo } from '../container'
+
+/**
+ * The container resolver (ADR-030 §2).
+ *
+ * The case worth the most attention is the difference between `gameId: null`
+ * and `gameId: undefined`. They look alike in JavaScript and mean opposite
+ * things here — "deliberately shelved" versus "not yet decided" — and getting
+ * them backwards would send every shelved entity back through the legacy
+ * fallback on every read.
+ */
+
+describe('null is a decision; undefined is not', () => {
+  test('gameId: null means the shelf, and does NOT consult workspaceId', () => {
+    // Even with a workspace still attached, an explicit null wins. Otherwise a
+    // deliberate "move to shelf" would silently bounce back to the old game.
+    const c = containerOf({ gameId: null, workspaceId: 'some-old-workspace' })
+    expect(c.kind).toBe('shelf')
+  })
+
+  test('gameId: undefined falls back to workspaceId', () => {
+    const c = containerOf({ workspaceId: 'campaign-a' })
+    expect(c).toEqual({ kind: 'game', gameId: 'campaign-a' })
+  })
+
+  test('a set gameId wins over a stale workspaceId', () => {
+    const c = containerOf({ gameId: 'campaign-b', workspaceId: 'campaign-a' })
+    expect(c).toEqual({ kind: 'game', gameId: 'campaign-b' })
+  })
+})
+
+describe('the Default workspace is the shelf, not a game', () => {
+  test('DEFAULT_WORKSPACE_ID resolves to the shelf', () => {
+    // It was never a campaign — it was where builds went when they belonged to
+    // no campaign, which is what a shelf is.
+    expect(containerOf({ workspaceId: DEFAULT_WORKSPACE_ID }).kind).toBe('shelf')
+  })
+
+  test('an entity with no container at all is on the shelf', () => {
+    expect(containerOf({}).kind).toBe('shelf')
+  })
+})
+
+describe('helpers', () => {
+  test('isOnShelf agrees with containerOf', () => {
+    expect(isOnShelf({ gameId: null })).toBe(true)
+    expect(isOnShelf({ gameId: 'g1' })).toBe(false)
+    expect(isOnShelf({ workspaceId: DEFAULT_WORKSPACE_ID })).toBe(true)
+  })
+
+  test('gameIdOf returns null for a shelved entity rather than undefined', () => {
+    // Callers write this straight into a nullable column, so the distinction
+    // between null and undefined has to survive the helper.
+    expect(gameIdOf({ gameId: null })).toBeNull()
+    expect(gameIdOf({})).toBeNull()
+    expect(gameIdOf({ gameId: 'g1' })).toBe('g1')
+  })
+
+  test('moveTo produces a patch that round-trips', () => {
+    expect(moveTo({ kind: 'shelf' })).toEqual({ gameId: null })
+    expect(moveTo({ kind: 'game', gameId: 'g1' })).toEqual({ gameId: 'g1' })
+    // The round trip is the property that matters: applying the patch and
+    // re-resolving must land in the same container.
+    expect(containerOf(moveTo({ kind: 'shelf' })).kind).toBe('shelf')
+    expect(containerOf(moveTo({ kind: 'game', gameId: 'g1' }))).toEqual({
+      kind: 'game',
+      gameId: 'g1',
+    })
+  })
+})

--- a/apps/itun/src/lib/connection/ConnectionProvider.tsx
+++ b/apps/itun/src/lib/connection/ConnectionProvider.tsx
@@ -6,6 +6,7 @@ import { ConnectionContext } from './connectionContext'
 import type { ConnectionState } from './connectionContext'
 import { resolveConnectionMode, shouldWarnDisconnected, writesAllowed } from './connectionMode'
 import { convexClient, isConvexConfigured } from './convexClient'
+import { setEntityBackendAuthState } from '../../stores/entityBackend'
 
 /**
  * Supplies the current storage mode (ADR-030 §1) to the tree.
@@ -50,6 +51,14 @@ function useOnline(): boolean {
 
 function useConnectionState(signedIn: boolean): ConnectionState {
   const online = useOnline()
+
+  // The stores are not components and cannot call hooks, so the mode is PUSHED
+  // to them from here rather than pulled. One writer, one direction — and it
+  // happens in an effect so a render never has a side effect.
+  useEffect(() => {
+    setEntityBackendAuthState({ signedIn, online })
+  }, [signedIn, online])
+
   return useMemo(() => {
     const mode = resolveConnectionMode({
       convexConfigured: isConvexConfigured,

--- a/apps/itun/src/lib/container.ts
+++ b/apps/itun/src/lib/container.ts
@@ -1,0 +1,70 @@
+import { DEFAULT_WORKSPACE_ID } from './defaultWorkspace'
+
+/**
+ * Which container an entity lives in (ADR-030 §2).
+ *
+ * There are exactly two: a shared **Game**, or the owner's personal **Shelf**.
+ * They are encoded in one nullable column rather than two fields, because an
+ * entity is always in exactly one and a second field could contradict the
+ * first.
+ *
+ * The subtle part is that **`null` is a value, not an absence**. `null` means
+ * "on the shelf" — a real place — while `undefined` means "this record predates
+ * the split and we have not decided yet". Conflating them is the bug this
+ * module exists to prevent: treating a shelved entity as unmigrated would send
+ * it back through the fallback on every read.
+ */
+
+/** A shared Game, by id. */
+export type GameContainer = { kind: 'game'; gameId: string }
+/** The owner's personal shelf. Not a Game: no crew, no Mediator, no invites. */
+export type ShelfContainer = { kind: 'shelf' }
+
+export type Container = GameContainer | ShelfContainer
+
+export const SHELF: ShelfContainer = { kind: 'shelf' }
+
+/** The minimum an entity needs to expose for its container to be resolved. */
+export type ContainerFields = {
+  gameId?: string | null | undefined
+  /** @deprecated Read only as a fallback for records written before ADR-030. */
+  workspaceId?: string | undefined
+}
+
+/**
+ * Resolve where an entity lives.
+ *
+ * The fallback chain matters and is ordered deliberately:
+ *
+ *  1. `gameId` set to a string — it is in that Game.
+ *  2. `gameId` explicitly `null` — it is on the shelf. Decided; stop.
+ *  3. `gameId` absent — pre-split record, so fall back to `workspaceId`, with
+ *     the built-in Default workspace mapping to the shelf rather than to a
+ *     Game. The Default workspace was never a campaign; it was the place
+ *     builds went when they belonged to no campaign, which is precisely a
+ *     shelf.
+ */
+export function containerOf(entity: ContainerFields): Container {
+  if (typeof entity.gameId === 'string') return { kind: 'game', gameId: entity.gameId }
+  if (entity.gameId === null) return SHELF
+  if (entity.workspaceId !== undefined && entity.workspaceId !== DEFAULT_WORKSPACE_ID) {
+    return { kind: 'game', gameId: entity.workspaceId }
+  }
+  return SHELF
+}
+
+/** True when the entity is on the owner's shelf rather than in a Game. */
+export function isOnShelf(entity: ContainerFields): boolean {
+  return containerOf(entity).kind === 'shelf'
+}
+
+/** The Game id, or null when the entity is shelved. */
+export function gameIdOf(entity: ContainerFields): string | null {
+  const container = containerOf(entity)
+  return container.kind === 'game' ? container.gameId : null
+}
+
+/** The patch that moves an entity into a container. */
+export function moveTo(container: Container): { gameId: string | null } {
+  return { gameId: container.kind === 'game' ? container.gameId : null }
+}

--- a/apps/itun/src/lib/db/__tests__/workspace-to-game-or-shelf.test.ts
+++ b/apps/itun/src/lib/db/__tests__/workspace-to-game-or-shelf.test.ts
@@ -1,0 +1,146 @@
+/**
+ * v12 → v13 fixture test: workspaceId → gameId (ADR-030 §2).
+ *
+ * A migration is the one edit a user cannot undo, so this seeds a real v12
+ * database and re-opens it through the live upgrade path rather than calling
+ * `migrate()` directly — the thing worth proving is that the ladder produces
+ * the right containers end to end, not that one function does.
+ *
+ * The claim under test is that the built-in Default workspace becomes the
+ * **shelf** rather than a Game. Getting that backwards would invent a campaign
+ * nobody ran and put every unassigned build into it.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { DEFAULT_WORKSPACE_ID } from '../../defaultWorkspace'
+import { containerOf } from '../../container'
+import { openItunDatabase } from '../index'
+
+const TEST_DB_NAME = 'itun-test-v12-to-v13'
+
+async function destroy(): Promise<void> {
+  const { deleteDB } = await import('idb')
+  await deleteDB(TEST_DB_NAME)
+}
+
+beforeEach(destroy)
+afterEach(destroy)
+
+/** Seed a v12-shaped database with pilots in three different container states. */
+async function seedV12(): Promise<void> {
+  const { openDB } = await import('idb')
+  const db = await openDB(TEST_DB_NAME, 12, {
+    upgrade(db) {
+      for (const name of [
+        'pilots',
+        'mechs',
+        'crawlers',
+        'workspaces',
+        'softLinks',
+        'mechPatterns',
+        'encounterNpcs',
+      ]) {
+        if (!db.objectStoreNames.contains(name)) db.createObjectStore(name, { keyPath: 'id' })
+      }
+      if (!db.objectStoreNames.contains('changeLog')) {
+        db.createObjectStore('changeLog', { keyPath: 'seq', autoIncrement: true })
+      }
+    },
+  })
+
+  const base = { schemaVersion: 1, createdAt: '2026-01-01T00:00:00.000Z' }
+  await db.put('pilots', {
+    ...base,
+    id: 'p-default',
+    name: 'Shelved',
+    workspaceId: DEFAULT_WORKSPACE_ID,
+  })
+  await db.put('pilots', {
+    ...base,
+    id: 'p-campaign',
+    name: 'In a game',
+    workspaceId: 'campaign-a',
+  })
+  await db.put('pilots', { ...base, id: 'p-none', name: 'No workspace' })
+  await db.put('mechs', { ...base, id: 'm-campaign', name: 'Mule', workspaceId: 'campaign-a' })
+  await db.put('crawlers', {
+    ...base,
+    id: 'c-default',
+    name: '#430',
+    workspaceId: DEFAULT_WORKSPACE_ID,
+  })
+  db.close()
+}
+
+/**
+ * Re-open through the app's own opener and read a row back.
+ *
+ * Deliberately `openItunDatabase` rather than a hand-rolled `openDB` upgrade
+ * callback: the first draft of this test wrote its own callback and every case
+ * failed with `AbortError`, because the migrations were fired without being
+ * awaited and the versionchange transaction auto-committed underneath them.
+ * Using the real opener tests the real ladder and cannot drift from it.
+ */
+async function readAfterUpgrade(store: string, id: string): Promise<Record<string, unknown>> {
+  const db = await openItunDatabase(TEST_DB_NAME)
+  const row = (await db.get(store, id)) as Record<string, unknown>
+  db.close()
+  return row
+}
+
+describe('v12 → v13 container split', () => {
+  test('the Default workspace becomes the shelf, not a game', async () => {
+    await seedV12()
+    const row = await readAfterUpgrade('pilots', 'p-default')
+
+    expect(row.gameId).toBeNull()
+    expect(containerOf(row).kind).toBe('shelf')
+  })
+
+  test('a real workspace becomes a game of the same id', async () => {
+    await seedV12()
+    const row = await readAfterUpgrade('pilots', 'p-campaign')
+
+    expect(row.gameId).toBe('campaign-a')
+    expect(containerOf(row)).toEqual({ kind: 'game', gameId: 'campaign-a' })
+  })
+
+  test('an entity with no workspace at all lands on the shelf', async () => {
+    await seedV12()
+    const row = await readAfterUpgrade('pilots', 'p-none')
+
+    // null, not undefined — the record now carries a decision.
+    expect(row.gameId).toBeNull()
+  })
+
+  test('mechs and crawlers migrate too, not just pilots', async () => {
+    await seedV12()
+    expect((await readAfterUpgrade('mechs', 'm-campaign')).gameId).toBe('campaign-a')
+    expect((await readAfterUpgrade('crawlers', 'c-default')).gameId).toBeNull()
+  })
+
+  test('workspaceId is retained, not stripped', async () => {
+    await seedV12()
+    const row = await readAfterUpgrade('pilots', 'p-campaign')
+
+    // The schemas are `.strict()`, so a row written here still has to parse on
+    // a build that predates the migration. Dropping the key is a separate,
+    // irreversible follow-up.
+    expect(row.workspaceId).toBe('campaign-a')
+  })
+
+  test('re-running is idempotent and never moves a placed entity', async () => {
+    await seedV12()
+    await readAfterUpgrade('pilots', 'p-campaign')
+
+    // Deliberately shelve it, then re-open: the migration must not drag it back
+    // to the old workspace on a second pass.
+    const db = await openItunDatabase(TEST_DB_NAME)
+    const existing = (await db.get('pilots', 'p-campaign')) as Record<string, unknown>
+    await db.put('pilots', { ...existing, gameId: null })
+    db.close()
+
+    const row = await readAfterUpgrade('pilots', 'p-campaign')
+    expect(row.gameId).toBeNull()
+  })
+})

--- a/apps/itun/src/lib/db/index.ts
+++ b/apps/itun/src/lib/db/index.ts
@@ -53,7 +53,7 @@ import { STORE_NAMES } from './stores'
  * model replaces the old cross-workspace "All Builds" view; see
  * lib/defaultWorkspace.ts.)
  */
-export const DB_VERSION = 12
+export const DB_VERSION = 13
 
 const DB_NAME = 'itun-v1'
 

--- a/apps/itun/src/lib/db/migrations/13-workspace-to-game-or-shelf.ts
+++ b/apps/itun/src/lib/db/migrations/13-workspace-to-game-or-shelf.ts
@@ -1,0 +1,54 @@
+import type { UpgradeTransaction } from './index'
+
+/**
+ * v12 → v13: give every entity an explicit container (ADR-030 §2).
+ *
+ * Before this, an entity's home was `workspaceId`, and the built-in Default
+ * workspace was a real row every unassigned build was backfilled into (v10).
+ * ADR-030 splits that into two containers — a shared **Game** or the owner's
+ * personal **Shelf** — encoded as one nullable `gameId`.
+ *
+ * The mapping:
+ *
+ *   workspaceId === DEFAULT_WORKSPACE_ID  →  gameId: null   (the shelf)
+ *   workspaceId === <anything else>       →  gameId: <that> (a game)
+ *   workspaceId absent                    →  gameId: null   (the shelf)
+ *
+ * The Default workspace becoming the shelf is the substantive claim here, and
+ * it is a restoration rather than a reinterpretation: the Default workspace was
+ * never a campaign. It existed because the app required *some* container and
+ * these builds belonged to no particular one — which is exactly what a shelf
+ * is. Mapping it to a Game would invent a campaign nobody ran.
+ *
+ * `workspaceId` is **not** stripped. The entity schemas are `.strict()`, so a
+ * record written by this migration still has to parse on a build that predates
+ * it; removing the key is a separate, irreversible follow-up. The constant is
+ * inlined rather than imported because migrations may only await IndexedDB
+ * operations — a module import could let the versionchange transaction commit
+ * mid-run (see this directory's README).
+ */
+
+/** Inlined from lib/defaultWorkspace.ts — see the note above on imports. */
+const DEFAULT_WORKSPACE_ID = 'default-workspace'
+
+const STORES = ['pilots', 'mechs', 'crawlers'] as const
+
+export async function migrate(tx: UpgradeTransaction): Promise<void> {
+  for (const store of STORES) {
+    let cursor = await tx.objectStore(store).openCursor()
+    while (cursor) {
+      const row = cursor.value as { workspaceId?: unknown; gameId?: unknown }
+
+      // Idempotent: a row that already has a decision keeps it. Re-running must
+      // never move an entity that has since been placed deliberately.
+      if (row.gameId === undefined) {
+        const workspaceId = typeof row.workspaceId === 'string' ? row.workspaceId : undefined
+        const gameId =
+          workspaceId === undefined || workspaceId === DEFAULT_WORKSPACE_ID ? null : workspaceId
+        await cursor.update({ ...row, gameId })
+      }
+
+      cursor = await cursor.continue()
+    }
+  }
+}

--- a/apps/itun/src/lib/db/migrations/index.ts
+++ b/apps/itun/src/lib/db/migrations/index.ts
@@ -26,6 +26,7 @@ import { migrate as migrate8CrawlerBattleSpToDerived } from './8-crawler-battle-
 import { migrate as migrate10WorkspaceDefaultBackfill } from './10-workspace-default-backfill'
 import { migrate as migrate11EquipmentLoadoutsToPartners } from './11-equipment-loadouts-to-partners'
 import { migrate as migrate12CompanionMechsToPartners } from './12-companion-mechs-to-partners'
+import { migrate as migrate13WorkspaceToGameOrShelf } from './13-workspace-to-game-or-shelf'
 
 /** The untyped versionchange transaction handed to the idb upgrade callback. */
 export type UpgradeTransaction = IDBPTransaction<
@@ -85,6 +86,11 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
     toVersion: 12,
     description: 'companion-mechs-to-partners',
     migrate: (tx) => migrate12CompanionMechsToPartners(tx),
+  },
+  {
+    toVersion: 13,
+    description: 'workspace-to-game-or-shelf',
+    migrate: (tx) => migrate13WorkspaceToGameOrShelf(tx),
   },
   // NOTE: the built-in Starter Set is NOT seeded by a migration. It is spawned
   // on-demand into each browser the first time the user opens the Starter Set

--- a/apps/itun/src/lib/ownership/__tests__/ownerChip.test.ts
+++ b/apps/itun/src/lib/ownership/__tests__/ownerChip.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test'
+
+import { UNCLAIMED_LABEL, ownerChipFor, viewerMayEdit } from '../ownerChip'
+
+/**
+ * Owner chips (D32).
+ *
+ * The case that carries the most weight is the difference between *unclaimed*
+ * and *owned but unresolved*. Both have no name to show, and collapsing them
+ * would tell a Mediator that a pilot is free to hand out when it already
+ * belongs to somebody — a data-integrity error dressed as a label.
+ */
+
+const lookup = (viewerId: string | null, names: Array<[string, string]> = []) => ({
+  viewerId,
+  namesById: new Map(names),
+})
+
+describe('unclaimed is a rendered state, not a blank', () => {
+  test('null owner reads as Unclaimed', () => {
+    const chip = ownerChipFor(null, lookup('u1'))
+    expect(chip.label).toBe(UNCLAIMED_LABEL)
+    expect(chip.unclaimed).toBe(true)
+  })
+
+  test('undefined owner reads the same way', () => {
+    // A row written before ownership existed must not render an empty chip.
+    expect(ownerChipFor(undefined, lookup('u1')).label).toBe(UNCLAIMED_LABEL)
+  })
+
+  test('the label is never empty', () => {
+    for (const owner of [null, undefined, 'u2', 'unknown-id']) {
+      expect(ownerChipFor(owner, lookup('u1', [['u2', 'Beefcake']])).label.length).toBeGreaterThan(
+        0
+      )
+    }
+  })
+})
+
+describe('owned-but-unresolved is not unclaimed', () => {
+  test('an owner with no known name still reads as owned', () => {
+    const chip = ownerChipFor('u-nobody-knows', lookup('u1'))
+    // The important assertion: NOT unclaimed. Offering this to a Mediator as
+    // assignable would hand out a pilot that already belongs to someone.
+    expect(chip.unclaimed).toBe(false)
+    expect(chip.label).toBe('Crewmate')
+  })
+
+  test('a resolvable owner shows their display name', () => {
+    const chip = ownerChipFor('u2', lookup('u1', [['u2', 'Beefcake']]))
+    expect(chip.label).toBe('Beefcake')
+    expect(chip.unclaimed).toBe(false)
+    expect(chip.mine).toBe(false)
+  })
+})
+
+describe('your own entities', () => {
+  test('read as You', () => {
+    const chip = ownerChipFor('u1', lookup('u1', [['u1', 'Alex']]))
+    expect(chip.label).toBe('You')
+    expect(chip.mine).toBe(true)
+  })
+
+  test('a signed-out viewer owns nothing', () => {
+    const chip = ownerChipFor('u1', lookup(null))
+    expect(chip.mine).toBe(false)
+  })
+})
+
+describe('viewerMayEdit mirrors the server rule', () => {
+  test('the owner may edit', () => {
+    expect(viewerMayEdit('u1', 'u1')).toBe(true)
+  })
+
+  test('a crewmate may not — a Mediator proposes instead', () => {
+    expect(viewerMayEdit('u2', 'u1')).toBe(false)
+  })
+
+  test('an unclaimed entity is not editable until assigned', () => {
+    // Otherwise a pre-gen could be quietly taken by editing it, bypassing the
+    // assignment act the Change Log records.
+    expect(viewerMayEdit(null, 'u1')).toBe(false)
+    expect(viewerMayEdit(undefined, 'u1')).toBe(false)
+  })
+
+  test('a signed-out viewer may not edit anything in a game', () => {
+    expect(viewerMayEdit('u1', null)).toBe(false)
+  })
+})

--- a/apps/itun/src/lib/ownership/ownerChip.ts
+++ b/apps/itun/src/lib/ownership/ownerChip.ts
@@ -1,0 +1,88 @@
+/**
+ * The owner chip (ADR-030, D32).
+ *
+ * Every entity row in a Game shows who holds it. This module produces the chip
+ * *content* as data; the rendering goes through the entity card's existing
+ * `controls` API as a `badge`, which is why there is no component here.
+ *
+ * That choice is deliberate and worth stating: `component-lib` is shared with
+ * `apps/srd`, which has no accounts and never will. Teaching the card about
+ * users would push an ITUN-only concept into a package whose contract is to
+ * stay backend-agnostic. Passing a `badge` in from the app keeps the knowledge
+ * where it belongs, and `badge` renders at every card extent — full, head, and
+ * catalog — so a dense listing row and an expanded card show the same chip.
+ */
+
+/** How an entity's ownership should read on a card. */
+export type OwnerChip = {
+  /** The text on the chip. Never empty — see `UNCLAIMED_LABEL`. */
+  label: string
+  /** True when nobody owns this entity. Callers may style it differently. */
+  unclaimed: boolean
+  /** True when the viewer owns it, for a subtler "yours" treatment. */
+  mine: boolean
+}
+
+/**
+ * What an ownerless entity reads as.
+ *
+ * **Unclaimed is a rendered state, not a blank.** An ownerless pilot is a
+ * normal, useful thing — a pre-gen waiting to be handed out — and rendering it
+ * as an empty chip would make it look broken rather than available. This is the
+ * single most likely place for the nullable `ownerId` to leak as a visual bug.
+ */
+export const UNCLAIMED_LABEL = 'Unclaimed'
+
+export type OwnerLookup = {
+  /** The viewer, so their own entities can read as "You". */
+  viewerId: string | null
+  /** userId → display name, from the Game roster. */
+  namesById: ReadonlyMap<string, string>
+}
+
+/**
+ * Resolve the chip for an entity.
+ *
+ * The fallback order matters: a name we cannot resolve is still an owned
+ * entity, so it must not silently collapse into "Unclaimed" — that would tell
+ * a Mediator a pilot is free to assign when it is not. An unknown owner reads
+ * as a crewmate whose name has not loaded, which is honest.
+ */
+export function ownerChipFor(ownerId: string | null | undefined, lookup: OwnerLookup): OwnerChip {
+  if (ownerId === null || ownerId === undefined) {
+    return { label: UNCLAIMED_LABEL, unclaimed: true, mine: false }
+  }
+
+  if (lookup.viewerId !== null && ownerId === lookup.viewerId) {
+    return { label: 'You', unclaimed: false, mine: true }
+  }
+
+  const name = lookup.namesById.get(ownerId)
+  return {
+    // Owned but unresolved — NOT unclaimed. Conflating the two would offer a
+    // Mediator an entity that already belongs to somebody.
+    label: name ?? 'Crewmate',
+    unclaimed: false,
+    mine: false,
+  }
+}
+
+/**
+ * Whether the viewer may edit this entity.
+ *
+ * Mirrors the server rule exactly (`assertMayWrite`): the owner may write, and
+ * nobody else — not even a Mediator, who proposes instead. Unclaimed entities
+ * are not editable until assigned, so a pre-gen cannot be quietly taken by
+ * editing it.
+ *
+ * This is a *courtesy* for the UI, never the boundary. The server check is the
+ * boundary, and it is tested separately.
+ */
+export function viewerMayEdit(
+  ownerId: string | null | undefined,
+  viewerId: string | null
+): boolean {
+  if (viewerId === null) return false
+  if (ownerId === null || ownerId === undefined) return false
+  return ownerId === viewerId
+}

--- a/apps/itun/src/lib/schemas/crawler.ts
+++ b/apps/itun/src/lib/schemas/crawler.ts
@@ -123,7 +123,22 @@ export const CrawlerSchema = z
      * needed (same tactic as Pilot.equipmentChoices / crawlerBays).
      */
     bayChoices: z.record(z.string(), ChoiceSelectionsSchema).optional(),
-    /** Optional: links this crawler to a workspace */
+    /**
+     * Which container holds this entity (ADR-030 §2).
+     *
+     * `undefined` means the record predates the container split and should be
+     * read through `containerOf()`, which falls back to `workspaceId`.
+     * `null` means the owner's **Shelf** — not "unset". The distinction is the
+     * whole point: a shelf is a real place an entity lives, not the absence of
+     * one.
+     */
+    gameId: z.string().nullable().optional(),
+    /**
+     * @deprecated Superseded by `gameId` (ADR-030 §2). Retained because these
+     * schemas are `.strict()`: dropping the key would fail the parse of every
+     * already-migrated record. Removing it needs a follow-up migration that
+     * strips it from stored rows first — a separate, irreversible change.
+     */
     workspaceId: z.string().optional(),
     // ---------------------------------------------------------------------------
     // Live-play current stat tracking (#245).

--- a/apps/itun/src/lib/schemas/mech.ts
+++ b/apps/itun/src/lib/schemas/mech.ts
@@ -213,7 +213,22 @@ export const MechSchema = z
     /** Absolute pinned Cargo Capacity. */
     maxCargoOverride: z.number().int().nonnegative().optional(),
 
-    /** Optional: links this mech to a workspace */
+    /**
+     * Which container holds this entity (ADR-030 §2).
+     *
+     * `undefined` means the record predates the container split and should be
+     * read through `containerOf()`, which falls back to `workspaceId`.
+     * `null` means the owner's **Shelf** — not "unset". The distinction is the
+     * whole point: a shelf is a real place an entity lives, not the absence of
+     * one.
+     */
+    gameId: z.string().nullable().optional(),
+    /**
+     * @deprecated Superseded by `gameId` (ADR-030 §2). Retained because these
+     * schemas are `.strict()`: dropping the key would fail the parse of every
+     * already-migrated record. Removing it needs a follow-up migration that
+     * strips it from stored rows first — a separate, irreversible change.
+     */
     workspaceId: z.string().optional(),
 
     // ---------------------------------------------------------------------------

--- a/apps/itun/src/lib/schemas/pilot.ts
+++ b/apps/itun/src/lib/schemas/pilot.ts
@@ -140,7 +140,22 @@ export const PilotSchema = z
     /** Active condition slugs */
     conditions: z.array(z.string()),
 
-    /** Optional: links this pilot to a workspace */
+    /**
+     * Which container holds this entity (ADR-030 §2).
+     *
+     * `undefined` means the record predates the container split and should be
+     * read through `containerOf()`, which falls back to `workspaceId`.
+     * `null` means the owner's **Shelf** — not "unset". The distinction is the
+     * whole point: a shelf is a real place an entity lives, not the absence of
+     * one.
+     */
+    gameId: z.string().nullable().optional(),
+    /**
+     * @deprecated Superseded by `gameId` (ADR-030 §2). Retained because these
+     * schemas are `.strict()`: dropping the key would fail the parse of every
+     * already-migrated record. Removing it needs a follow-up migration that
+     * strips it from stored rows first — a separate, irreversible change.
+     */
     workspaceId: z.string().optional(),
 
     // ---------------------------------------------------------------------------

--- a/apps/itun/src/routeTree.gen.ts
+++ b/apps/itun/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as AboutRouteImport } from './routes/about'
 import { Route as AccountRouteImport } from './routes/account'
 import { Route as ChangelogRouteImport } from './routes/changelog'
 import { Route as EncounterRouteImport } from './routes/encounter'
+import { Route as GamesRouteImport } from './routes/games'
 import { Route as CrawlersIdRouteImport } from './routes/crawlers/$id'
 import { Route as CrawlersNewRouteImport } from './routes/crawlers/new'
 import { Route as DashboardIdRouteImport } from './routes/dashboard/$id'
@@ -49,6 +50,11 @@ const ChangelogRoute = ChangelogRouteImport.update({
 const EncounterRoute = EncounterRouteImport.update({
   id: '/encounter',
   path: '/encounter',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const GamesRoute = GamesRouteImport.update({
+  id: '/games',
+  path: '/games',
   getParentRoute: () => rootRouteImport,
 } as any)
 const CrawlersIdRoute = CrawlersIdRouteImport.update({
@@ -113,6 +119,7 @@ export interface FileRoutesByFullPath {
   '/account': typeof AccountRoute
   '/changelog': typeof ChangelogRoute
   '/encounter': typeof EncounterRoute
+  '/games': typeof GamesRoute
   '/crawlers/$id': typeof CrawlersIdRoute
   '/crawlers/new': typeof CrawlersNewRoute
   '/dashboard/$id': typeof DashboardIdRoute
@@ -131,6 +138,7 @@ export interface FileRoutesByTo {
   '/account': typeof AccountRoute
   '/changelog': typeof ChangelogRoute
   '/encounter': typeof EncounterRoute
+  '/games': typeof GamesRoute
   '/crawlers/$id': typeof CrawlersIdRoute
   '/crawlers/new': typeof CrawlersNewRoute
   '/dashboard/$id': typeof DashboardIdRoute
@@ -150,6 +158,7 @@ export interface FileRoutesById {
   '/account': typeof AccountRoute
   '/changelog': typeof ChangelogRoute
   '/encounter': typeof EncounterRoute
+  '/games': typeof GamesRoute
   '/crawlers/$id': typeof CrawlersIdRoute
   '/crawlers/new': typeof CrawlersNewRoute
   '/dashboard/$id': typeof DashboardIdRoute
@@ -170,6 +179,7 @@ export interface FileRouteTypes {
     | '/account'
     | '/changelog'
     | '/encounter'
+    | '/games'
     | '/crawlers/$id'
     | '/crawlers/new'
     | '/dashboard/$id'
@@ -188,6 +198,7 @@ export interface FileRouteTypes {
     | '/account'
     | '/changelog'
     | '/encounter'
+    | '/games'
     | '/crawlers/$id'
     | '/crawlers/new'
     | '/dashboard/$id'
@@ -206,6 +217,7 @@ export interface FileRouteTypes {
     | '/account'
     | '/changelog'
     | '/encounter'
+    | '/games'
     | '/crawlers/$id'
     | '/crawlers/new'
     | '/dashboard/$id'
@@ -225,6 +237,7 @@ export interface RootRouteChildren {
   AccountRoute: typeof AccountRoute
   ChangelogRoute: typeof ChangelogRoute
   EncounterRoute: typeof EncounterRoute
+  GamesRoute: typeof GamesRoute
   CrawlersIdRoute: typeof CrawlersIdRoute
   CrawlersNewRoute: typeof CrawlersNewRoute
   DashboardIdRoute: typeof DashboardIdRoute
@@ -273,6 +286,13 @@ declare module '@tanstack/react-router' {
       path: '/encounter'
       fullPath: '/encounter'
       preLoaderRoute: typeof EncounterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/games': {
+      id: '/games'
+      path: '/games'
+      fullPath: '/games'
+      preLoaderRoute: typeof GamesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/crawlers/$id': {
@@ -361,6 +381,7 @@ const rootRouteChildren: RootRouteChildren = {
   AccountRoute: AccountRoute,
   ChangelogRoute: ChangelogRoute,
   EncounterRoute: EncounterRoute,
+  GamesRoute: GamesRoute,
   CrawlersIdRoute: CrawlersIdRoute,
   CrawlersNewRoute: CrawlersNewRoute,
   DashboardIdRoute: DashboardIdRoute,

--- a/apps/itun/src/routeTree.gen.ts
+++ b/apps/itun/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AboutRouteImport } from './routes/about'
+import { Route as AccountRouteImport } from './routes/account'
 import { Route as ChangelogRouteImport } from './routes/changelog'
 import { Route as EncounterRouteImport } from './routes/encounter'
 import { Route as CrawlersIdRouteImport } from './routes/crawlers/$id'
@@ -33,6 +34,11 @@ const IndexRoute = IndexRouteImport.update({
 const AboutRoute = AboutRouteImport.update({
   id: '/about',
   path: '/about',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AccountRoute = AccountRouteImport.update({
+  id: '/account',
+  path: '/account',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ChangelogRoute = ChangelogRouteImport.update({
@@ -104,6 +110,7 @@ const SheetKindIdShareRoute = SheetKindIdShareRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/account': typeof AccountRoute
   '/changelog': typeof ChangelogRoute
   '/encounter': typeof EncounterRoute
   '/crawlers/$id': typeof CrawlersIdRoute
@@ -121,6 +128,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/account': typeof AccountRoute
   '/changelog': typeof ChangelogRoute
   '/encounter': typeof EncounterRoute
   '/crawlers/$id': typeof CrawlersIdRoute
@@ -139,6 +147,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/account': typeof AccountRoute
   '/changelog': typeof ChangelogRoute
   '/encounter': typeof EncounterRoute
   '/crawlers/$id': typeof CrawlersIdRoute
@@ -158,6 +167,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/about'
+    | '/account'
     | '/changelog'
     | '/encounter'
     | '/crawlers/$id'
@@ -175,6 +185,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/about'
+    | '/account'
     | '/changelog'
     | '/encounter'
     | '/crawlers/$id'
@@ -192,6 +203,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/about'
+    | '/account'
     | '/changelog'
     | '/encounter'
     | '/crawlers/$id'
@@ -210,6 +222,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
+  AccountRoute: typeof AccountRoute
   ChangelogRoute: typeof ChangelogRoute
   EncounterRoute: typeof EncounterRoute
   CrawlersIdRoute: typeof CrawlersIdRoute
@@ -239,6 +252,13 @@ declare module '@tanstack/react-router' {
       path: '/about'
       fullPath: '/about'
       preLoaderRoute: typeof AboutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/account': {
+      id: '/account'
+      path: '/account'
+      fullPath: '/account'
+      preLoaderRoute: typeof AccountRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/changelog': {
@@ -338,6 +358,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
+  AccountRoute: AccountRoute,
   ChangelogRoute: ChangelogRoute,
   EncounterRoute: EncounterRoute,
   CrawlersIdRoute: CrawlersIdRoute,

--- a/apps/itun/src/routes/__root.tsx
+++ b/apps/itun/src/routes/__root.tsx
@@ -10,6 +10,7 @@ import { AppLink } from '../components/shared/AppLink'
 import { BlockedUpgradeError } from '../lib/db/index'
 import { GameDataReady } from '../components/shared/GameDataReady'
 import { NotConnectedBanner } from '../components/shared/NotConnectedBanner'
+import { AccountStrip } from '../components/account/AccountStrip'
 import { AppConvexProvider } from '../components/shared/AppConvexProvider'
 import { GlobalSearch } from '../components/shared/GlobalSearch'
 import { BackupNudgeToast } from '../components/shared/BackupNudgeToast'
@@ -83,6 +84,7 @@ function RootComponent() {
             data, so it paints immediately instead of sitting behind the full
             preload. */}
           <NotConnectedBanner />
+          <AccountStrip />
           <AppHeader onSearchClick={() => setSearchOpen(true)} LinkComponent={AppLink} />
           <GameDataReady>
             <Outlet />

--- a/apps/itun/src/routes/account.tsx
+++ b/apps/itun/src/routes/account.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { AccountScreen } from '../components/account/AccountScreen'
+
+export const Route = createFileRoute('/account')({
+  component: AccountScreen,
+})

--- a/apps/itun/src/routes/games.tsx
+++ b/apps/itun/src/routes/games.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { GamesScreen } from '../components/games/GamesScreen'
+
+export const Route = createFileRoute('/games')({
+  component: GamesScreen,
+})

--- a/apps/itun/src/stores/__tests__/entityBackend.test.ts
+++ b/apps/itun/src/stores/__tests__/entityBackend.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import {
+  WritesBlockedOffline,
+  requireWritableBackend,
+  selectBackend,
+  setEntityBackendAuthState,
+} from '../entityBackend'
+
+/**
+ * Backend selection (ADR-030 §1).
+ *
+ * The asymmetry in these tests is intentional. Choosing `remote` when the
+ * answer should be `local` costs a Solo user their writes — silently, because
+ * there is no server listening for them. Choosing `local` when the answer is
+ * `remote` merely delays a sync. So the cases below lean hardest on proving
+ * that **local is the default and every uncertain state resolves to it**.
+ *
+ * The test build has no `VITE_CONVEX_URL`, so `convexClient` is null and every
+ * outcome here is `local` regardless of auth state — which is itself the
+ * property worth pinning, because that is the configuration CI and every
+ * unmigrated contributor runs in.
+ */
+
+afterEach(() => {
+  setEntityBackendAuthState({ signedIn: false, online: true })
+})
+
+describe('a build with no Convex URL is always local', () => {
+  test('signed out', () => {
+    setEntityBackendAuthState({ signedIn: false, online: true })
+    expect(selectBackend()).toBe('local')
+  })
+
+  test('even when the auth state claims signed in', () => {
+    // There is no client to talk to, so "signed in" cannot be true in any
+    // meaningful sense. Resolving to remote here would strand every write.
+    setEntityBackendAuthState({ signedIn: true, online: true })
+    expect(selectBackend()).toBe('local')
+  })
+
+  test('even when offline', () => {
+    setEntityBackendAuthState({ signedIn: true, online: false })
+    expect(selectBackend()).toBe('local')
+  })
+})
+
+describe('writes are never blocked in a Solo build', () => {
+  test('requireWritableBackend returns local rather than throwing', () => {
+    setEntityBackendAuthState({ signedIn: false, online: false })
+    // Offline + signed out is Solo, not Disconnected. A person who never
+    // signed in has nothing to be disconnected FROM, and refusing their write
+    // would break the app for the majority of users.
+    expect(requireWritableBackend()).toBe('local')
+  })
+})
+
+describe('WritesBlockedOffline', () => {
+  test('carries the same wording as the banner', () => {
+    // The user reads one of these in a toast and the other in the banner; if
+    // they disagree it looks like two different faults.
+    expect(new WritesBlockedOffline().message).toMatch(/read-only until the connection returns/i)
+  })
+
+  test('is identifiable by name across a structured-clone boundary', () => {
+    // instanceof does not survive being re-thrown through some boundaries, so
+    // callers match on name — that has to keep working.
+    expect(new WritesBlockedOffline().name).toBe('WritesBlockedOffline')
+  })
+})

--- a/apps/itun/src/stores/entityBackend.ts
+++ b/apps/itun/src/stores/entityBackend.ts
@@ -1,0 +1,103 @@
+import { convexClient } from '../lib/connection/convexClient'
+import { resolveConnectionMode, usesServerOfRecord } from '../lib/connection/connectionMode'
+
+/**
+ * Where entity writes actually go (ADR-030 §1).
+ *
+ * `entityStore` reaches its persistence through one indirection —
+ * `dbStoreFor(type)` — so swapping the backend is a matter of changing what
+ * that returns rather than rewriting the store. The store's public API, its
+ * in-memory cache, its lazy hydration and its broadcast behaviour are all
+ * untouched by this file.
+ *
+ * ## Solo remains the default, structurally
+ *
+ * `selectBackend` returns the **local** backend unless the app is genuinely
+ * Connected. Not signed in, no Convex URL compiled in, offline — all resolve to
+ * local. That ordering is deliberate: the failure mode of getting it wrong in
+ * the other direction is a Solo user's writes silently going nowhere, which is
+ * the single worst outcome in this whole migration.
+ *
+ * ## Disconnected does not fall back to local
+ *
+ * A signed-in user who loses connectivity is **read-only** (D14), not
+ * quietly-writing-to-IndexedDB. Falling back would fork their data against the
+ * server of record and reintroduce, by accident, the conflict resolution the
+ * server-of-record decision exists to avoid. Callers check `canWrite` before
+ * offering the affordance; this module refuses if they do not.
+ */
+
+/** Signed-in state as far as this module is concerned. */
+type AuthState = { signedIn: boolean; online: boolean }
+
+/** Read once per write rather than subscribed — the store is not a component. */
+let authState: AuthState = { signedIn: false, online: true }
+
+/**
+ * Publish the current auth/connectivity state to the store layer.
+ *
+ * The store cannot call React hooks, so `ConnectionProvider` pushes the mode in
+ * rather than the store pulling it out. One writer, one direction.
+ */
+export function setEntityBackendAuthState(next: AuthState): void {
+  authState = next
+}
+
+export type BackendKind = 'local' | 'remote' | 'blocked'
+
+/**
+ * Which backend a write should use right now.
+ *
+ * Exported for tests and for surfaces that want to explain themselves — a
+ * button that would be `blocked` should say why rather than fail on click.
+ */
+export function selectBackend(): BackendKind {
+  const mode = resolveConnectionMode({
+    convexConfigured: convexClient !== null,
+    signedIn: authState.signedIn,
+    online: authState.online,
+  })
+  if (mode === 'solo') return 'local'
+  if (usesServerOfRecord(mode)) return 'remote'
+  return 'blocked'
+}
+
+/** Thrown when a write is attempted while the server of record is unreachable. */
+export class WritesBlockedOffline extends Error {
+  constructor() {
+    super('Not connected — your games are read-only until the connection returns')
+    this.name = 'WritesBlockedOffline'
+  }
+}
+
+/**
+ * ## Why there is no write-mirroring here yet
+ *
+ * The obvious next step — write locally, then mirror the same change to Convex
+ * — does not work, and it is worth writing down so nobody rediscovers it the
+ * hard way. Local records are keyed by an app-level `id` (a UUID minted by
+ * `crud.ts`); Convex rows are keyed by its own `_id`. A create can be mirrored
+ * because it needs no prior key, but an **update or delete has nothing to
+ * address**: there is no id map between the two, so the mirror would either
+ * silently no-op or need a lookup-by-body on every write.
+ *
+ * A mirror that works for creates and quietly fails for edits is worse than no
+ * mirror, because it looks synced. The real cutover is the one ADR-030
+ * describes — when Connected, Convex IS the source of truth and the store
+ * reads from a reactive subscription rather than from IndexedDB — and that
+ * needs the id mapping (or app-id-as-primary-key on the Convex side) decided
+ * first. This module deliberately ships only the part that is sound.
+ */
+
+/**
+ * Guard a write against the current mode.
+ *
+ * Called by the store before it touches persistence. Returns the backend to
+ * use; throws rather than silently degrading when the answer is "you cannot
+ * write right now".
+ */
+export function requireWritableBackend(): Exclude<BackendKind, 'blocked'> {
+  const backend = selectBackend()
+  if (backend === 'blocked') throw new WritesBlockedOffline()
+  return backend
+}

--- a/apps/itun/src/stores/entityBackend.ts
+++ b/apps/itun/src/stores/entityBackend.ts
@@ -1,3 +1,5 @@
+import { api } from '../../convex/_generated/api'
+import type { Id } from '../../convex/_generated/dataModel'
 import { convexClient } from '../lib/connection/convexClient'
 import { resolveConnectionMode, usesServerOfRecord } from '../lib/connection/connectionMode'
 
@@ -71,23 +73,51 @@ export class WritesBlockedOffline extends Error {
 }
 
 /**
- * ## Why there is no write-mirroring here yet
+ * Mirror a local write to the server of record, addressed by **app id**.
  *
- * The obvious next step — write locally, then mirror the same change to Convex
- * — does not work, and it is worth writing down so nobody rediscovers it the
- * hard way. Local records are keyed by an app-level `id` (a UUID minted by
- * `crud.ts`); Convex rows are keyed by its own `_id`. A create can be mirrored
- * because it needs no prior key, but an **update or delete has nothing to
- * address**: there is no id map between the two, so the mirror would either
- * silently no-op or need a lookup-by-body on every write.
+ * An earlier attempt at this could not work: Convex mints its own `_id`, so a
+ * client holding only its local UUID had nothing to address a row by. Creates
+ * mirrored fine and edits silently no-opped — a mirror that looks synced and
+ * is not. The fix is the indexed `appId` column, which lets one cheap lookup
+ * stand in for a mapping table.
  *
- * A mirror that works for creates and quietly fails for edits is worse than no
- * mirror, because it looks synced. The real cutover is the one ADR-030
- * describes — when Connected, Convex IS the source of truth and the store
- * reads from a reactive subscription rather than from IndexedDB — and that
- * needs the id mapping (or app-id-as-primary-key on the Convex side) decided
- * first. This module deliberately ships only the part that is sound.
+ * Three properties that matter:
+ *
+ *  - **Upsert, not update.** An entity built while Solo has no server row until
+ *    the account is claimed, so a missing row means "create it" rather than
+ *    "fail". That is what makes the mirror converge instead of dropping the
+ *    first edit after a claim.
+ *  - **Fire-and-forget.** The local write already succeeded and is what the UI
+ *    reads. A mirror failure must not roll it back or block the caller, so this
+ *    returns void and swallows into a console warning.
+ *  - **Only in `remote`.** In Solo there is no server to mirror to, and in
+ *    Disconnected the write never got this far (`requireWritableBackend`).
  */
+export async function mirrorWrite(
+  type: 'pilot' | 'mech',
+  op:
+    | { kind: 'upsert'; appId: string; gameId: string | null; body: unknown }
+    | { kind: 'delete'; appId: string }
+): Promise<void> {
+  if (selectBackend() !== 'remote' || convexClient === null) return
+
+  const table = type === 'pilot' ? 'pilots' : 'mechs'
+  try {
+    if (op.kind === 'upsert') {
+      await convexClient.mutation(api.entities.upsertByAppId, {
+        table,
+        appId: op.appId,
+        gameId: op.gameId === null ? null : (op.gameId as Id<'games'>),
+        body: op.body,
+      })
+    } else {
+      await convexClient.mutation(api.entities.removeByAppId, { table, appId: op.appId })
+    }
+  } catch (err) {
+    // Never surfaced as a failed user action: the local write stands.
+    console.warn('[itun] failed to mirror write to the server of record', err)
+  }
+}
 
 /**
  * Guard a write against the current mode.

--- a/apps/itun/src/stores/entityStore.ts
+++ b/apps/itun/src/stores/entityStore.ts
@@ -39,6 +39,7 @@ import type { Mech } from '../lib/schemas/mech'
 import type { Pilot } from '../lib/schemas/pilot'
 import type { SoftLink } from '../lib/schemas/softLink'
 import type { CreateInput, EntityForType, EntityType } from './types'
+import { requireWritableBackend } from './entityBackend'
 
 // Re-exported so consumers can import the type alongside the store itself.
 export type { EntityType }
@@ -337,6 +338,10 @@ export const useEntityStore = create<EntityState>((set, get) => ({
 
   async create<T extends EntityType>(type: T, input: CreateInput<T>): Promise<EntityForType<T>> {
     const key = storeKeyFor(type)
+    // Refuses rather than degrading when the server of record is unreachable
+    // (ADR-030 §1): a signed-in user offline is read-only, not silently
+    // writing to a local copy that would fork against the server.
+    requireWritableBackend()
     const record = await dbStoreFor(type).create(withActiveWorkspace(type, input))
     set((state) => ({
       [key]: [record, ...(state[key] as EntityForType<T>[])],
@@ -354,6 +359,7 @@ export const useEntityStore = create<EntityState>((set, get) => ({
     const key = storeKeyFor(type)
     // Capture the before-image BEFORE the write so the Change Log can diff it.
     const before = get().get(type, id)
+    requireWritableBackend()
     const updated = await dbStoreFor(type).update(id, patch)
     set((state) => ({
       [key]: (state[key] as EntityForType<T>[]).map((e) => (e.id === id ? updated : e)),
@@ -481,6 +487,7 @@ export const useEntityStore = create<EntityState>((set, get) => ({
 
   async delete(type, id) {
     const key = storeKeyFor(type)
+    requireWritableBackend()
 
     // Cascade: deleting an entity prunes its SoftLinks (plan 2.7, gap 9).
     // The entity delete and its link pruning run in a single IDB transaction

--- a/apps/itun/src/stores/entityStore.ts
+++ b/apps/itun/src/stores/entityStore.ts
@@ -39,7 +39,7 @@ import type { Mech } from '../lib/schemas/mech'
 import type { Pilot } from '../lib/schemas/pilot'
 import type { SoftLink } from '../lib/schemas/softLink'
 import type { CreateInput, EntityForType, EntityType } from './types'
-import { requireWritableBackend } from './entityBackend'
+import { mirrorWrite, requireWritableBackend } from './entityBackend'
 
 // Re-exported so consumers can import the type alongside the store itself.
 export type { EntityType }
@@ -249,6 +249,23 @@ const DB_STORES: { [K in EntityType]: DbStoreApi<K> } = {
   softLink: db.softLinks,
 }
 
+/**
+ * Mirror a just-persisted record to the server of record.
+ *
+ * Only pilots and mechs: the crawler is communal and merges per field
+ * server-side, and softLinks are derived. Fire-and-forget by design — the
+ * local write is what the UI reads, so a mirror failure must not undo it.
+ */
+function mirrorEntityWrite(type: EntityType, record: { id: string; gameId?: string | null }): void {
+  if (type !== 'pilot' && type !== 'mech') return
+  void mirrorWrite(type, {
+    kind: 'upsert',
+    appId: record.id,
+    gameId: record.gameId ?? null,
+    body: record,
+  })
+}
+
 function dbStoreFor<T extends EntityType>(type: T): DbStoreApi<T> {
   // Single correlated-union assertion: TS cannot carry the runtime
   // discriminant↔record-type invariant through the map lookup for a
@@ -343,6 +360,7 @@ export const useEntityStore = create<EntityState>((set, get) => ({
     // writing to a local copy that would fork against the server.
     requireWritableBackend()
     const record = await dbStoreFor(type).create(withActiveWorkspace(type, input))
+    mirrorEntityWrite(type, record)
     set((state) => ({
       [key]: [record, ...(state[key] as EntityForType<T>[])],
     }))
@@ -361,6 +379,7 @@ export const useEntityStore = create<EntityState>((set, get) => ({
     const before = get().get(type, id)
     requireWritableBackend()
     const updated = await dbStoreFor(type).update(id, patch)
+    mirrorEntityWrite(type, updated)
     set((state) => ({
       [key]: (state[key] as EntityForType<T>[]).map((e) => (e.id === id ? updated : e)),
     }))
@@ -488,6 +507,7 @@ export const useEntityStore = create<EntityState>((set, get) => ({
   async delete(type, id) {
     const key = storeKeyFor(type)
     requireWritableBackend()
+    if (type === 'pilot' || type === 'mech') void mirrorWrite(type, { kind: 'delete', appId: id })
 
     // Cascade: deleting an entity prunes its SoftLinks (plan 2.7, gap 9).
     // The entity delete and its link pruning run in a single IDB transaction


### PR DESCRIPTION
Tenth in the stack. **Phase 3 server layer** of [ADR-030](https://github.com/SalvageUnion-io/SU-SRD/blob/main/docs/adrs/ADR-030-accounts-games-server-of-record.md).

## The NPC tray is the one genuinely secret thing

These gate on `requireMediator`, not `requireMember` — the only place in the app that does. Everything else is readable by every member, which is what makes a crew a crew. **A player who can read prepared opposition can read the encounter before it happens**: the one leak that changes how the game is *played*, rather than merely who can edit what.

A test covers the case easiest to get wrong: **an Organizer who does not mediate cannot read the tray either.** The Organizer flag is administrative and confers no content authority, and prepared opposition is very much content.

## Presence is a heartbeat, not a stream

It upserts one row per `(game, member)` so a long session cannot grow it without bound, and **`present` is computed at read time from `lastSeen` rather than stored.** A stored boolean needs something to clear it — a timer, a disconnect hook — and every such mechanism can fail in a way that leaves somebody permanently "present" long after they closed the tab.

Presence itself is not privileged: any member may heartbeat and read it. A Mediator needs to see players arrive exactly as much as players need to see each other.

`amMediator` returns `false` rather than throwing for a non-member — "can I mediate this" is a reasonable question for anyone to ask, and a surface gating itself on the answer shouldn't have to catch.

## Scope, stated plainly

**This is the server layer only.** The Mediator *screen* is net-new product design — crew roster, live vitals, NPC tray, absorbing `/encounter` — and the plan specifies its behaviour but not its form.

This repo treats UI as a design problem: the `design-token` gate has already caught me twice, `ttrpg-ux-designer` exists for exactly this, and the locked v52 Dashboard went through ~60 iterations. Inventing that surface unreviewed would be presenting guesswork as specification. **The data it needs is here and tested; the screen wants a design pass.**

## Tests

10 new, weighted toward what must stay hidden: player-cannot-read, player-cannot-write, non-mediating-Organizer-cannot-read, plus presence upsert-not-append and the computed-not-stored window.

## Verification

typecheck 4/4 · knip clean · `format:check` clean · design-token gate clean · full suite green · lint at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014m6W8yMd1FM3Roumj9x4Zj
