### PR TITLE
feat(itun): accounts, Games, and a live Mediator surface (ADR-030)

### DIFF
--- a/.claude/rules/testing-patterns.md
+++ b/.claude/rules/testing-patterns.md
@@ -42,6 +42,46 @@ Testing patterns using Bun's test runner and Testing Library for component tests
 - Use `mock()` from `bun:test` for module/function mocking
 - Mock external dependencies appropriately
 
+### `mock.module` is process-global — restore what you replace
+
+`mock.module` rewrites the entry in the module registry for the whole test
+process, **not** for the file that called it. Every test file that runs after
+yours gets your replacement. This is not theoretical: mocking the entity store
+in one component test broke 219 tests across the suite, and the failures
+surfaced in files that had never heard of the mocked module.
+
+Capture the real exports first, and put them back in `afterAll`:
+
+```typescript
+// The spread is load-bearing. A module namespace is a LIVE view, and mocking
+// rewrites it in place — hold the namespace itself and by `afterAll` it
+// already reads as the mock, so you restore the mock over the mock.
+const realStore = { ...(await import('../../stores/entityStore')) }
+
+mock.module('../../stores/entityStore', () => ({ useEntityStore: fake }))
+
+afterAll(() => {
+  mock.module('../../stores/entityStore', () => realStore)
+})
+```
+
+Two corollaries:
+
+- **Partial mocks break importers you did not think about.** Replacing
+  `convex/react` with only the hooks under test made `@convex-dev/auth/react`
+  fail at import on a missing `ConvexProviderWithAuth`. Mock every export the
+  transitive importers reach, not just the ones your component calls.
+- **Beware module-scope environment reads.** `config.ts` reads `process.env`
+  once at import, so setting an env var to drive a test hands that value to
+  every later file too. Mock the config module instead of setting the variable.
+
+### Call `cleanup()` explicitly in component tests
+
+Testing Library's auto-cleanup has proven order-dependent here — a file passed
+alone and failed in the full suite. When several tests in a file render the
+same accessible name, one leaked render turns every later query into "found
+multiple elements". Add `afterEach(cleanup)` rather than depending on it.
+
 ## Examples
 
 **Package test:**

--- a/apps/discord-bot/src/__tests__/observability.test.ts
+++ b/apps/discord-bot/src/__tests__/observability.test.ts
@@ -1,0 +1,151 @@
+import { afterAll, beforeAll, describe, expect, mock, test } from 'bun:test'
+
+/**
+ * observability — the bot's only channel for finding out that production
+ * broke. It is entirely env-gated, and the gate is the interesting part: with
+ * no DSN every function must be a silent no-op (local dev and CI run that way),
+ * and with one it must actually report. A regression in either direction is
+ * invisible until the day you need it — a bot that has stopped reporting looks
+ * exactly like a bot with no errors.
+ *
+ * `config` is mocked rather than driven through `process.env`, deliberately.
+ * `config.ts` reads the environment once at module scope, so setting
+ * `SENTRY_DSN` here would hand a live DSN to every test file that runs after
+ * this one — `mock.module` is process-global in Bun, not file-scoped, and the
+ * env is worse still. Both the mocks below are captured and restored.
+ */
+
+const sentryCalls: Array<{ fn: string; args: unknown[] }> = []
+let flushShouldThrow = false
+let dsn: string | undefined
+
+// `config.ts` throws at module scope on a missing token, and it is evaluated by
+// the capture below. Same `??=` as the sibling tests, and deliberately no
+// SENTRY_DSN: the DSN is supplied through the mock, never the environment.
+process.env.DISCORD_TOKEN ??= 'test-token'
+process.env.DISCORD_CLIENT_ID ??= 'test-client-id'
+
+const realSentry = { ...(await import('@sentry/node')) }
+const realConfig = { ...(await import('../config.js')) }
+
+mock.module('@sentry/node', () => ({
+  init: (...args: unknown[]) => sentryCalls.push({ fn: 'init', args }),
+  flush: async (...args: unknown[]) => {
+    sentryCalls.push({ fn: 'flush', args })
+    if (flushShouldThrow) throw new Error('transport down')
+    return true
+  },
+  captureException: (...args: unknown[]) => sentryCalls.push({ fn: 'captureException', args }),
+  captureMessage: (...args: unknown[]) => sentryCalls.push({ fn: 'captureMessage', args }),
+}))
+
+mock.module('../config.js', () => ({
+  config: {
+    get sentryDsn() {
+      return dsn
+    },
+    nodeEnv: undefined,
+    releaseSha: 'abc123',
+  },
+}))
+
+let obs: typeof import('../observability.js')
+
+beforeAll(async () => {
+  obs = await import('../observability.js')
+})
+
+afterAll(() => {
+  mock.module('@sentry/node', () => realSentry)
+  mock.module('../config.js', () => realConfig)
+})
+
+function calls(fn: string): Array<{ fn: string; args: unknown[] }> {
+  return sentryCalls.filter((c) => c.fn === fn)
+}
+
+/**
+ * These run in order against one module instance, because `enabled` is
+ * module-level state and the transition from off to on is exactly what is
+ * being tested.
+ */
+describe('with no DSN configured', () => {
+  test('init reports nothing and does not enable Sentry', () => {
+    dsn = undefined
+    obs.initObservability()
+    expect(calls('init')).toHaveLength(0)
+  })
+
+  test('captureException is a no-op rather than an unconfigured send', () => {
+    obs.captureException(new Error('boom'))
+    expect(calls('captureException')).toHaveLength(0)
+  })
+
+  test('captureMessage is a no-op too', () => {
+    obs.captureMessage('ready')
+    expect(calls('captureMessage')).toHaveLength(0)
+  })
+
+  test('flush resolves immediately instead of waiting on a transport', async () => {
+    // A 2s flush timeout on every exit of a bot that never had a DSN would be
+    // two wasted seconds on every restart.
+    await obs.flushObservability()
+    expect(calls('flush')).toHaveLength(0)
+  })
+})
+
+describe('once a DSN is configured', () => {
+  test('init passes the DSN, environment and release through', () => {
+    dsn = 'https://key@example.ingest.sentry.io/1'
+    obs.initObservability()
+
+    const init = calls('init')[0]
+    expect(init).toBeDefined()
+    expect(init?.args[0]).toMatchObject({
+      dsn: 'https://key@example.ingest.sentry.io/1',
+      // Unset NODE_ENV must not leave the environment blank — an untagged event
+      // is indistinguishable from one raised in dev.
+      environment: 'production',
+      release: 'abc123',
+    })
+  })
+
+  test('a second call is a no-op, so startup can call it freely', () => {
+    obs.initObservability()
+    expect(calls('init')).toHaveLength(1)
+  })
+
+  test('exceptions are reported, with context as extra when given', () => {
+    const error = new Error('boom')
+    obs.captureException(error, { guildId: 'g1' })
+
+    const c = calls('captureException')[0]
+    expect(c?.args[0]).toBe(error)
+    expect(c?.args[1]).toEqual({ extra: { guildId: 'g1' } })
+  })
+
+  test('no context sends undefined rather than an empty extra bag', () => {
+    obs.captureException(new Error('bare'))
+    expect(calls('captureException')[1]?.args[1]).toBeUndefined()
+  })
+
+  test('messages are reported — the worker has no port to health-probe', () => {
+    obs.captureMessage('logged in', { shard: 0 })
+    const c = calls('captureMessage')[0]
+    expect(c?.args[0]).toBe('logged in')
+    expect(c?.args[1]).toEqual({ extra: { shard: 0 } })
+  })
+
+  test('flush is awaited before exit, with the timeout passed through', async () => {
+    // The transport is async; a synchronous exit right after captureException
+    // drops the one event the restart happened for.
+    await obs.flushObservability(500)
+    expect(calls('flush')[0]?.args[0]).toBe(500)
+  })
+
+  test('a failing flush never rejects — the process is exiting anyway', async () => {
+    flushShouldThrow = true
+    expect(await obs.flushObservability(10).then(() => 'resolved')).toBe('resolved')
+    flushShouldThrow = false
+  })
+})

--- a/apps/itun/CHANGELOG.md
+++ b/apps/itun/CHANGELOG.md
@@ -28,82 +28,71 @@ Maintained by release-please (see ADR-024).
 
 ## [0.7.0](https://github.com/SalvageUnion-io/SU-SRD/compare/itun-v0.6.0...itun-v0.7.0) (2026-07-28)
 
-
 ### Features
 
-* **component-lib:** make the roll-table title its own table picker ([#592](https://github.com/SalvageUnion-io/SU-SRD/issues/592)) ([18f315a](https://github.com/SalvageUnion-io/SU-SRD/commit/18f315ac0501f00f52db63181dbf383d66909245))
-* **itun:** render partners in place, delete the partner sheet ([#590](https://github.com/SalvageUnion-io/SU-SRD/issues/590)) ([33ddccd](https://github.com/SalvageUnion-io/SU-SRD/commit/33ddccd79c6b9db417dff0384f27188d3fe0b67f))
-* **itun:** render the SRD home page in the Dashboard SRD Explorer ([#593](https://github.com/SalvageUnion-io/SU-SRD/issues/593)) ([05906b6](https://github.com/SalvageUnion-io/SU-SRD/commit/05906b629fe97708f5c9faf8e638e29033e363e9))
+- **component-lib:** make the roll-table title its own table picker ([#592](https://github.com/SalvageUnion-io/SU-SRD/issues/592)) ([18f315a](https://github.com/SalvageUnion-io/SU-SRD/commit/18f315ac0501f00f52db63181dbf383d66909245))
+- **itun:** render partners in place, delete the partner sheet ([#590](https://github.com/SalvageUnion-io/SU-SRD/issues/590)) ([33ddccd](https://github.com/SalvageUnion-io/SU-SRD/commit/33ddccd79c6b9db417dff0384f27188d3fe0b67f))
+- **itun:** render the SRD home page in the Dashboard SRD Explorer ([#593](https://github.com/SalvageUnion-io/SU-SRD/issues/593)) ([05906b6](https://github.com/SalvageUnion-io/SU-SRD/commit/05906b629fe97708f5c9faf8e638e29033e363e9))
 
 ## [0.6.0](https://github.com/SalvageUnion-io/SU-SRD/compare/itun-v0.5.0...itun-v0.6.0) (2026-07-28)
 
-
 ### Features
 
-* **itun:** show the Actions deck as one catalog-tile grid, mech + pilot ([#591](https://github.com/SalvageUnion-io/SU-SRD/issues/591)) ([f8979b0](https://github.com/SalvageUnion-io/SU-SRD/commit/f8979b04b8d804c4c464bd596c0b31074d8f4769))
-
+- **itun:** show the Actions deck as one catalog-tile grid, mech + pilot ([#591](https://github.com/SalvageUnion-io/SU-SRD/issues/591)) ([f8979b0](https://github.com/SalvageUnion-io/SU-SRD/commit/f8979b04b8d804c4c464bd596c0b31074d8f4769))
 
 ### Bug Fixes
 
-* **itun:** start Heat at zero, never at capacity ([#588](https://github.com/SalvageUnion-io/SU-SRD/issues/588)) ([67cebf2](https://github.com/SalvageUnion-io/SU-SRD/commit/67cebf2901aff7bfda198e55f49c10a3f7442f3f))
+- **itun:** start Heat at zero, never at capacity ([#588](https://github.com/SalvageUnion-io/SU-SRD/issues/588)) ([67cebf2](https://github.com/SalvageUnion-io/SU-SRD/commit/67cebf2901aff7bfda198e55f49c10a3f7442f3f))
 
 ## [0.5.0](https://github.com/SalvageUnion-io/SU-SRD/compare/itun-v0.4.1...itun-v0.5.0) (2026-07-25)
 
-
 ### Features
 
-* **itun:** live-sheet redesign — card/slab containers, folding, and a crew-shaped crawler ([#561](https://github.com/SalvageUnion-io/SU-SRD/issues/561)) ([b180c24](https://github.com/SalvageUnion-io/SU-SRD/commit/b180c244ab7b8d8df39512ed3805b80661efc22a))
-* Partner Sheets — statted drones/companions owned by a pilot or a mech ([#578](https://github.com/SalvageUnion-io/SU-SRD/issues/578)) ([7ee4d1b](https://github.com/SalvageUnion-io/SU-SRD/commit/7ee4d1b45e11d44f90da0c90dad82e08a1edca30))
+- **itun:** live-sheet redesign — card/slab containers, folding, and a crew-shaped crawler ([#561](https://github.com/SalvageUnion-io/SU-SRD/issues/561)) ([b180c24](https://github.com/SalvageUnion-io/SU-SRD/commit/b180c244ab7b8d8df39512ed3805b80661efc22a))
+- Partner Sheets — statted drones/companions owned by a pilot or a mech ([#578](https://github.com/SalvageUnion-io/SU-SRD/issues/578)) ([7ee4d1b](https://github.com/SalvageUnion-io/SU-SRD/commit/7ee4d1b45e11d44f90da0c90dad82e08a1edca30))
 
 ## [0.4.1](https://github.com/SalvageUnion-io/SU-SRD/compare/itun-v0.4.0...itun-v0.4.1) (2026-07-24)
 
-
 ### Bug Fixes
 
-* **reference:** resolve data-inspection findings — dead flags, enum, null-marker, redundant fields ([#555](https://github.com/SalvageUnion-io/SU-SRD/issues/555)) ([2658095](https://github.com/SalvageUnion-io/SU-SRD/commit/2658095793f18341538cd977d328aca98a7861cb))
+- **reference:** resolve data-inspection findings — dead flags, enum, null-marker, redundant fields ([#555](https://github.com/SalvageUnion-io/SU-SRD/issues/555)) ([2658095](https://github.com/SalvageUnion-io/SU-SRD/commit/2658095793f18341538cd977d328aca98a7861cb))
 
 ## [0.4.0](https://github.com/SalvageUnion-io/SU-SRD/compare/itun-v0.3.1...itun-v0.4.0) (2026-07-24)
 
-
 ### Features
 
-* **dashboard:** lay the Actions deck out as a masonry grid ([#549](https://github.com/SalvageUnion-io/SU-SRD/issues/549)) ([49fc203](https://github.com/SalvageUnion-io/SU-SRD/commit/49fc203e54bf35c0e90423544d4184981bd06a68))
-
+- **dashboard:** lay the Actions deck out as a masonry grid ([#549](https://github.com/SalvageUnion-io/SU-SRD/issues/549)) ([49fc203](https://github.com/SalvageUnion-io/SU-SRD/commit/49fc203e54bf35c0e90423544d4184981bd06a68))
 
 ### Bug Fixes
 
-* **ci:** unbreak the nightly e2e suite, its alerting, and the routeTree drift ([#548](https://github.com/SalvageUnion-io/SU-SRD/issues/548)) ([5fd242a](https://github.com/SalvageUnion-io/SU-SRD/commit/5fd242a0aafd427ab80000f4235b6e1ee62c7712))
-* **live-sheets:** black-on-black titles + Workshop Manual redesign (mockup for sign-off) ([#554](https://github.com/SalvageUnion-io/SU-SRD/issues/554)) ([cf5f3ed](https://github.com/SalvageUnion-io/SU-SRD/commit/cf5f3ed45a0127ac6b5f82966dfd6eed539e203f))
+- **ci:** unbreak the nightly e2e suite, its alerting, and the routeTree drift ([#548](https://github.com/SalvageUnion-io/SU-SRD/issues/548)) ([5fd242a](https://github.com/SalvageUnion-io/SU-SRD/commit/5fd242a0aafd427ab80000f4235b6e1ee62c7712))
+- **live-sheets:** black-on-black titles + Workshop Manual redesign (mockup for sign-off) ([#554](https://github.com/SalvageUnion-io/SU-SRD/issues/554)) ([cf5f3ed](https://github.com/SalvageUnion-io/SU-SRD/commit/cf5f3ed45a0127ac6b5f82966dfd6eed539e203f))
 
 ## [0.3.1](https://github.com/SalvageUnion-io/SU-SRD/compare/itun-v0.3.0...itun-v0.3.1) (2026-07-23)
 
-
 ### Performance Improvements
 
-* **itun:** route-level code splitting + a PR-blocking bundle budget ([#543](https://github.com/SalvageUnion-io/SU-SRD/issues/543)) ([e75b1e9](https://github.com/SalvageUnion-io/SU-SRD/commit/e75b1e9ec427bc8c714cb3cad0efb8b9961a9fdb))
+- **itun:** route-level code splitting + a PR-blocking bundle budget ([#543](https://github.com/SalvageUnion-io/SU-SRD/issues/543)) ([e75b1e9](https://github.com/SalvageUnion-io/SU-SRD/commit/e75b1e9ec427bc8c714cb3cad0efb8b9961a9fdb))
 
 ## [0.3.0](https://github.com/SalvageUnion-io/SU-SRD/compare/itun-v0.2.0...itun-v0.3.0) (2026-07-23)
 
-
 ### Features
 
-* **itun:** make the mech hold and crawler Storage Bay independently usable ([#536](https://github.com/SalvageUnion-io/SU-SRD/issues/536)) ([ba911f3](https://github.com/SalvageUnion-io/SU-SRD/commit/ba911f3ad084ea411d42c46cc0f85d5a0c7f6043))
+- **itun:** make the mech hold and crawler Storage Bay independently usable ([#536](https://github.com/SalvageUnion-io/SU-SRD/issues/536)) ([ba911f3](https://github.com/SalvageUnion-io/SU-SRD/commit/ba911f3ad084ea411d42c46cc0f85d5a0c7f6043))
 
 ## [0.2.0](https://github.com/SalvageUnion-io/SU-SRD/compare/itun-v0.1.0...itun-v0.2.0) (2026-07-23)
 
-
 ### Features
 
-* shared about-page colophon + slab section heads on the back pages ([#524](https://github.com/SalvageUnion-io/SU-SRD/issues/524)) ([652e5fc](https://github.com/SalvageUnion-io/SU-SRD/commit/652e5fcdbd107d7eb3fa422d21441924114d2b97))
-
+- shared about-page colophon + slab section heads on the back pages ([#524](https://github.com/SalvageUnion-io/SU-SRD/issues/524)) ([652e5fc](https://github.com/SalvageUnion-io/SU-SRD/commit/652e5fcdbd107d7eb3fa422d21441924114d2b97))
 
 ### Bug Fixes
 
-* **reference:** correct three pattern names and add two missing book patterns ([#523](https://github.com/SalvageUnion-io/SU-SRD/issues/523)) ([736b1b8](https://github.com/SalvageUnion-io/SU-SRD/commit/736b1b8a04736215f63e0eca7831214f290d91ca))
-* **reference:** give every mech pattern its own verified source + page ([#529](https://github.com/SalvageUnion-io/SU-SRD/issues/529)) ([578a12f](https://github.com/SalvageUnion-io/SU-SRD/commit/578a12f8a7267bd49559b7dd67448463e7c20d77))
+- **reference:** correct three pattern names and add two missing book patterns ([#523](https://github.com/SalvageUnion-io/SU-SRD/issues/523)) ([736b1b8](https://github.com/SalvageUnion-io/SU-SRD/commit/736b1b8a04736215f63e0eca7831214f290d91ca))
+- **reference:** give every mech pattern its own verified source + page ([#529](https://github.com/SalvageUnion-io/SU-SRD/issues/529)) ([578a12f](https://github.com/SalvageUnion-io/SU-SRD/commit/578a12f8a7267bd49559b7dd67448463e7c20d77))
 
 ## 0.1.0 (2026-07-18)
 
 ### Features
 
-* Initial in-app changelog.
+- Initial in-app changelog.

--- a/apps/itun/convex/__tests__/account.test.ts
+++ b/apps/itun/convex/__tests__/account.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, test } from 'bun:test'
+
+import { api } from '../_generated/api'
+import type { Id } from '../_generated/dataModel'
+import { testConvex } from './harness'
+
+/**
+ * Account management, and in particular the promise D27 makes:
+ * **a campaign never dies because one person quit.**
+ *
+ * Deletion is the operation with no undo, so the cases below are less about
+ * "does it delete" and more about "does it delete *only* the right things" —
+ * the crew's Game, the communal crawler, and other people's characters all
+ * have to survive somebody exercising their right to be forgotten.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+async function seedPilot(t: Ctx, gameId: Id<'games'> | null, ownerId: Id<'users'> | null) {
+  return await t.run(
+    async (ctx) =>
+      await ctx.db.insert('pilots', { gameId, ownerId, body: { callsign: 'X' }, updatedAt: 1 })
+  )
+}
+
+describe('profile', () => {
+  test('displayName falls back to the Discord name when unset', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Roach-Boy')
+    await u.as.mutation(api.account.updateProfile, { displayName: null })
+
+    const me = await u.as.query(api.account.me, {})
+    // Cleared means "fall back", not "blank" — a nameless owner chip is worse
+    // than a stale one.
+    expect(me?.displayName).toBe('Roach-Boy')
+  })
+
+  test('a set displayName overrides the Discord name', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Roach-Boy')
+    await u.as.mutation(api.account.updateProfile, { displayName: '  Beefcake  ' })
+
+    const me = await u.as.query(api.account.me, {})
+    expect(me?.displayName).toBe('Beefcake')
+  })
+
+  test('an anonymous caller has no profile to read', async () => {
+    const t = testConvex()
+    await expect(t.query(api.account.me, {})).rejects.toThrow(/not signed in/i)
+  })
+})
+
+describe('export is scoped to what you own', () => {
+  test('excludes a crewmate pilot you can merely see', async () => {
+    const t = testConvex()
+    const owner = await makeUser(t, 'Owner')
+    const other = await makeUser(t, 'Other')
+    const gameId = await owner.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await owner.as.mutation(api.invites.create, { gameId })
+    await other.as.mutation(api.invites.redeem, { code })
+
+    await seedPilot(t, gameId, owner.userId)
+    await seedPilot(t, gameId, other.userId)
+
+    const mine = await owner.as.query(api.account.exportMine, {})
+    // Readable inside a Game is not the same as yours to take away.
+    expect(mine.pilots).toHaveLength(1)
+  })
+})
+
+describe('deleteAccount — the campaign survives', () => {
+  test('Organizer passes to the longest-standing remaining member', async () => {
+    const t = testConvex()
+    const organizer = await makeUser(t, 'Organizer')
+    const early = await makeUser(t, 'Early')
+    const late = await makeUser(t, 'Late')
+
+    const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await early.as.mutation(api.invites.redeem, { code })
+    await late.as.mutation(api.invites.redeem, { code })
+
+    // Make the ordering unambiguous rather than relying on clock resolution.
+    await t.run(async (ctx) => {
+      for (const m of await ctx.db.query('memberships').collect()) {
+        if (m.userId === early.userId) await ctx.db.patch(m._id, { joinedAt: 100 })
+        if (m.userId === late.userId) await ctx.db.patch(m._id, { joinedAt: 200 })
+      }
+    })
+
+    await organizer.as.mutation(api.account.deleteAccount, {})
+
+    const roster = await early.as.query(api.games.members, { gameId })
+    const organizers = roster.filter((m) => m.organizer)
+    expect(organizers).toHaveLength(1)
+    expect(organizers[0]?.userId).toBe(early.userId)
+  })
+
+  test('the Game and the communal crawler survive', async () => {
+    const t = testConvex()
+    const organizer = await makeUser(t, 'Organizer')
+    const player = await makeUser(t, 'Player')
+    const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await player.as.mutation(api.invites.redeem, { code })
+
+    const crawlerId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('crawlers', { gameId, body: { name: '#430' }, updatedAt: 1 })
+    )
+
+    await organizer.as.mutation(api.account.deleteAccount, {})
+
+    const game = await t.run(async (ctx) => await ctx.db.get(gameId))
+    const crawler = await t.run(async (ctx) => await ctx.db.get(crawlerId))
+    expect(game).not.toBeNull()
+    // The crawler belongs to the table, not to whoever set the Game up.
+    expect(crawler).not.toBeNull()
+  })
+
+  test("another member's pilot is untouched", async () => {
+    const t = testConvex()
+    const organizer = await makeUser(t, 'Organizer')
+    const player = await makeUser(t, 'Player')
+    const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await player.as.mutation(api.invites.redeem, { code })
+
+    const theirs = await seedPilot(t, gameId, player.userId)
+    await organizer.as.mutation(api.account.deleteAccount, {})
+
+    const pilot = await t.run(async (ctx) => await ctx.db.get(theirs))
+    expect(pilot).not.toBeNull()
+    expect(pilot?.ownerId).toBe(player.userId)
+  })
+
+  test('the departing account’s own entities go, in a Game and on the shelf alike', async () => {
+    const t = testConvex()
+    const organizer = await makeUser(t, 'Organizer')
+    const player = await makeUser(t, 'Player')
+    const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await player.as.mutation(api.invites.redeem, { code })
+
+    const inGame = await seedPilot(t, gameId, organizer.userId)
+    const onShelf = await seedPilot(t, null, organizer.userId)
+
+    await organizer.as.mutation(api.account.deleteAccount, {})
+
+    expect(await t.run(async (ctx) => await ctx.db.get(inGame))).toBeNull()
+    expect(await t.run(async (ctx) => await ctx.db.get(onShelf))).toBeNull()
+  })
+
+  test('the last member out takes the Game with them', async () => {
+    const t = testConvex()
+    const solo = await makeUser(t, 'Solo')
+    const gameId = await solo.as.mutation(api.games.create, { name: 'Alone' })
+    const crawlerId = await t.run(
+      async (ctx) => await ctx.db.insert('crawlers', { gameId, body: {}, updatedAt: 1 })
+    )
+    const unclaimed = await seedPilot(t, gameId, null)
+
+    await solo.as.mutation(api.account.deleteAccount, {})
+
+    // An empty Game is not a campaign anybody can come back to, and its
+    // unclaimed entities have no shelf to fall back to.
+    expect(await t.run(async (ctx) => await ctx.db.get(gameId))).toBeNull()
+    expect(await t.run(async (ctx) => await ctx.db.get(crawlerId))).toBeNull()
+    expect(await t.run(async (ctx) => await ctx.db.get(unclaimed))).toBeNull()
+  })
+
+  test('the user row and its auth rows are gone', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Gone')
+
+    // A session with a refresh token hanging off it — the ordering hazard.
+    await t.run(async (ctx) => {
+      const sessionId = await ctx.db.insert('authSessions', {
+        userId: u.userId,
+        expirationTime: Date.now() + 1000,
+      })
+      await ctx.db.insert('authRefreshTokens', {
+        sessionId,
+        expirationTime: Date.now() + 1000,
+      })
+      await ctx.db.insert('authAccounts', {
+        userId: u.userId,
+        provider: 'discord',
+        providerAccountId: 'abc123',
+      })
+    })
+
+    await u.as.mutation(api.account.deleteAccount, {})
+
+    const left = await t.run(async (ctx) => ({
+      user: await ctx.db.get(u.userId),
+      sessions: (await ctx.db.query('authSessions').collect()).length,
+      tokens: (await ctx.db.query('authRefreshTokens').collect()).length,
+      accounts: (await ctx.db.query('authAccounts').collect()).length,
+    }))
+
+    expect(left.user).toBeNull()
+    expect(left.sessions).toBe(0)
+    // Refresh tokens are keyed by session, not user — they are the rows most
+    // likely to be left behind pointing at something deleted.
+    expect(left.tokens).toBe(0)
+    expect(left.accounts).toBe(0)
+  })
+})

--- a/apps/itun/convex/__tests__/appId.test.ts
+++ b/apps/itun/convex/__tests__/appId.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from 'bun:test'
+
+import { api } from '../_generated/api'
+import { testConvex } from './harness'
+
+/**
+ * Addressing server rows by the client's own app id.
+ *
+ * This exists because the first write-mirroring attempt could not work at all:
+ * Convex mints its own `_id`, so a client holding only its local UUID had
+ * nothing to address a row by. Creates mirrored and edits silently no-opped —
+ * a mirror that looked synced and was not.
+ *
+ * The cases below pin the two properties that fix it: **an edit finds its row**,
+ * and **a missing row is created rather than dropped**, which is what makes the
+ * mirror converge for entities built while Solo and claimed afterwards.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+function pilotBody(over: Record<string, unknown> = {}) {
+  return {
+    id: 'local-uuid-1',
+    schemaVersion: 1,
+    name: 'Roach-Boy',
+    callsign: 'Roach-Boy',
+    classRef: 'salvager',
+    abilities: [],
+    equipment: [],
+    motto: '',
+    keepsake: '',
+    appearance: '',
+    conditions: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...over,
+  }
+}
+
+describe('upsertByAppId', () => {
+  test('creates when no row carries that app id', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    // The Solo-then-claim path: the entity exists locally long before the
+    // server has ever heard of it.
+    await u.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'local-uuid-1',
+      gameId: null,
+      body: pilotBody(),
+    })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.appId).toBe('local-uuid-1')
+  })
+
+  test('a second write updates rather than duplicating', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    await u.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'local-uuid-1',
+      gameId: null,
+      body: pilotBody(),
+    })
+    await u.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'local-uuid-1',
+      gameId: null,
+      body: pilotBody({ name: 'Renamed' }),
+    })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    // The bug this replaces: an edit that could not find its row. One row, new
+    // name — not two rows, and not a silent no-op.
+    expect(rows).toHaveLength(1)
+    expect((rows[0]?.body as { name: string } | undefined)?.name).toBe('Renamed')
+  })
+
+  test("cannot overwrite another player's row that happens to share an app id", async () => {
+    const t = testConvex()
+    const owner = await makeUser(t, 'Owner')
+    const other = await makeUser(t, 'Other')
+
+    await owner.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'local-uuid-1',
+      gameId: null,
+      body: pilotBody(),
+    })
+
+    // Addressing by a client-supplied id must not become a way to write
+    // somebody else's data by guessing theirs.
+    await expect(
+      other.as.mutation(api.entities.upsertByAppId, {
+        table: 'pilots',
+        appId: 'local-uuid-1',
+        gameId: null,
+        body: pilotBody({ name: 'Hijacked' }),
+      })
+    ).rejects.toThrow(/another player/i)
+  })
+
+  test('a malformed body is still rejected', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    await expect(
+      u.as.mutation(api.entities.upsertByAppId, {
+        table: 'pilots',
+        appId: 'local-uuid-1',
+        gameId: null,
+        body: { nonsense: true },
+      })
+    ).rejects.toThrow(/invalid pilots payload/i)
+  })
+})
+
+describe('removeByAppId', () => {
+  test('deletes the addressed row', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    await u.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'local-uuid-1',
+      gameId: null,
+      body: pilotBody(),
+    })
+
+    await u.as.mutation(api.entities.removeByAppId, { table: 'pilots', appId: 'local-uuid-1' })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(0)
+  })
+
+  test('a row that is already gone is not an error', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    // The mirror is fire-and-forget and may retry or arrive out of order; a
+    // delete of something already deleted must be a no-op, not a throw.
+    await u.as.mutation(api.entities.removeByAppId, { table: 'pilots', appId: 'never-existed' })
+  })
+
+  test("cannot delete another player's row", async () => {
+    const t = testConvex()
+    const owner = await makeUser(t, 'Owner')
+    const other = await makeUser(t, 'Other')
+    await owner.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'local-uuid-1',
+      gameId: null,
+      body: pilotBody(),
+    })
+
+    await expect(
+      other.as.mutation(api.entities.removeByAppId, { table: 'pilots', appId: 'local-uuid-1' })
+    ).rejects.toThrow(/another player/i)
+  })
+})

--- a/apps/itun/convex/__tests__/bot.test.ts
+++ b/apps/itun/convex/__tests__/bot.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from 'bun:test'
+
+import { api } from '../_generated/api'
+import { testConvex } from './harness'
+
+/**
+ * The Discord bot as a Game participant (Phase 6).
+ *
+ * The old #165 called for a service-role key and RLS policies — a bot that can
+ * act as anybody. These tests exist to prove this one cannot: every path
+ * resolves the actor from a *linked* Discord identity that is a *member* of the
+ * *bound* Game, and every failure of that chain is silent rather than
+ * informative, because a public channel is the wrong place to announce who has
+ * an account.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+async function seedBoundGame(t: Ctx) {
+  const organizer = await makeUser(t, 'Organizer')
+  const player = await makeUser(t, 'Player')
+  const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+  const code = await organizer.as.mutation(api.invites.create, { gameId })
+  await player.as.mutation(api.invites.redeem, { code })
+  await organizer.as.mutation(api.bot.bindChannel, { gameId, channelId: 'chan-1' })
+  await player.as.mutation(api.bot.linkDiscordId, { discordId: 'discord-player' })
+  return { organizer, player, gameId }
+}
+
+describe('channel binding', () => {
+  test('one game per channel', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedBoundGame(t)
+    const other = await organizer.as.mutation(api.games.create, { name: 'Other' })
+
+    // A channel meaning two games makes every roll in it ambiguous, and the
+    // bot has no way to ask which was meant.
+    await expect(
+      organizer.as.mutation(api.bot.bindChannel, { gameId: other, channelId: 'chan-1' })
+    ).rejects.toThrow(/already bound/i)
+
+    // Re-binding the same pair is a no-op, not an error.
+    await organizer.as.mutation(api.bot.bindChannel, { gameId, channelId: 'chan-1' })
+  })
+
+  test('only the Organizer may bind or unbind', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedBoundGame(t)
+
+    await expect(
+      player.as.mutation(api.bot.bindChannel, { gameId, channelId: 'chan-2' })
+    ).rejects.toThrow(/organizer/i)
+    await expect(
+      player.as.mutation(api.bot.unbindChannel, { channelId: 'chan-1' })
+    ).rejects.toThrow(/organizer/i)
+  })
+
+  test('resolves the game a channel speaks for', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedBoundGame(t)
+    const found = await player.as.query(api.bot.gameForChannel, { channelId: 'chan-1' })
+    expect(found?.gameId).toBe(gameId)
+  })
+})
+
+describe('the bot cannot act as anybody', () => {
+  test('a linked member roll is recorded, attributed to them', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedBoundGame(t)
+
+    const ok = await player.as.mutation(api.bot.recordRoll, {
+      channelId: 'chan-1',
+      discordId: 'discord-player',
+      description: 'Heat Check',
+      result: { total: 14 },
+    })
+    expect(ok).toBe(true)
+
+    const rolls = await player.as.query(api.bot.rolls, { gameId })
+    expect(rolls).toHaveLength(1)
+    expect(rolls[0]?.actorId).toBe(player.userId)
+  })
+
+  test('an unlinked Discord id records nothing', async () => {
+    const t = testConvex()
+    const { player } = await seedBoundGame(t)
+
+    const ok = await player.as.mutation(api.bot.recordRoll, {
+      channelId: 'chan-1',
+      discordId: 'some-stranger',
+      description: 'Heat Check',
+      result: {},
+    })
+    // Silent, not an error: distinguishing "no account" from "not a member" in
+    // a public channel would leak who has one.
+    expect(ok).toBe(false)
+  })
+
+  test('a linked NON-member records nothing', async () => {
+    const t = testConvex()
+    const { player } = await seedBoundGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+    await outsider.as.mutation(api.bot.linkDiscordId, { discordId: 'discord-outsider' })
+
+    const ok = await player.as.mutation(api.bot.recordRoll, {
+      channelId: 'chan-1',
+      discordId: 'discord-outsider',
+      description: 'Heat Check',
+      result: {},
+    })
+    // Being in the Discord channel is not membership of the Game.
+    expect(ok).toBe(false)
+  })
+
+  test('an unbound channel records nothing', async () => {
+    const t = testConvex()
+    const { player } = await seedBoundGame(t)
+
+    const ok = await player.as.mutation(api.bot.recordRoll, {
+      channelId: 'chan-nowhere',
+      discordId: 'discord-player',
+      description: 'Heat Check',
+      result: {},
+    })
+    expect(ok).toBe(false)
+  })
+})
+
+describe('linking a Discord identity', () => {
+  test('two accounts cannot claim the same Discord id', async () => {
+    const t = testConvex()
+    await seedBoundGame(t)
+    const impostor = await makeUser(t, 'Impostor')
+
+    // Otherwise the bot would resolve rolls to whichever it found first.
+    await expect(
+      impostor.as.mutation(api.bot.linkDiscordId, { discordId: 'discord-player' })
+    ).rejects.toThrow(/already linked/i)
+  })
+
+  test('re-linking your own id is idempotent', async () => {
+    const t = testConvex()
+    const { player } = await seedBoundGame(t)
+    await player.as.mutation(api.bot.linkDiscordId, { discordId: 'discord-player' })
+  })
+})
+
+describe('rolls are Game history, not a separate store', () => {
+  test('a non-member cannot read them', async () => {
+    const t = testConvex()
+    const { gameId } = await seedBoundGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+
+    await expect(outsider.as.query(api.bot.rolls, { gameId })).rejects.toThrow(/not a member/i)
+  })
+
+  test('they live in the Change Log alongside everything else', async () => {
+    const t = testConvex()
+    const { player } = await seedBoundGame(t)
+    await player.as.mutation(api.bot.recordRoll, {
+      channelId: 'chan-1',
+      discordId: 'discord-player',
+      description: 'Heat Check',
+      result: { total: 9 },
+    })
+
+    // A roll at the table and a roll in the channel are the same kind of fact,
+    // so there was no separate "bot events" store to invent.
+    const entries = await t.run(async (ctx) => await ctx.db.query('changeLog').collect())
+    expect(entries.some((e) => e.source === 'discord-bot' && e.field === 'roll')).toBe(true)
+  })
+})

--- a/apps/itun/convex/__tests__/crew.test.ts
+++ b/apps/itun/convex/__tests__/crew.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from 'bun:test'
+
+import { api } from '../_generated/api'
+import { testConvex } from './harness'
+
+/**
+ * Crew visibility (D12).
+ *
+ * The privacy boundary is what these tests are for. "Every member sees every
+ * crewmate" is easy to get right; the cases that matter are the two things that
+ * must stay *out* — a non-member seeing anything at all, and a shelved entity
+ * (which belongs to one person and to no crew) being reachable through a
+ * Game-scoped read.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+async function seedGame(t: Ctx) {
+  const organizer = await makeUser(t, 'Organizer')
+  const player = await makeUser(t, 'Beefcake')
+  const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+  const code = await organizer.as.mutation(api.invites.create, { gameId })
+  await player.as.mutation(api.invites.redeem, { code })
+  return { organizer, player, gameId }
+}
+
+describe('vitals', () => {
+  test('shows every crewmate, with owner names resolved', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    await t.run(async (ctx) => {
+      await ctx.db.insert('pilots', {
+        gameId,
+        ownerId: player.userId,
+        body: { callsign: 'Roach-Boy', currentHp: 7, currentAp: 3 },
+        updatedAt: 1,
+      })
+    })
+
+    const crew = await organizer.as.query(api.crew.vitals, { gameId })
+    expect(crew.pilots).toHaveLength(1)
+    expect(crew.pilots[0]?.name).toBe('Roach-Boy')
+    expect(crew.pilots[0]?.currentHp).toBe(7)
+    // The chip needs a name, not just an id.
+    expect(crew.pilots[0]?.ownerName).toBe('Beefcake')
+  })
+
+  test('an unclaimed pilot has a null owner name rather than a missing row', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    await t.run(async (ctx) => {
+      await ctx.db.insert('pilots', {
+        gameId,
+        ownerId: null,
+        body: { callsign: 'Pre-gen' },
+        updatedAt: 1,
+      })
+    })
+
+    const crew = await organizer.as.query(api.crew.vitals, { gameId })
+    // Unclaimed pre-gens must still appear — they are what the Mediator hands
+    // out, so hiding them would hide the onboarding path.
+    expect(crew.pilots).toHaveLength(1)
+    expect(crew.pilots[0]?.ownerId).toBeNull()
+    expect(crew.pilots[0]?.ownerName).toBeNull()
+  })
+
+  test('a missing numeric field reads as null, not NaN or zero', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    await t.run(async (ctx) => {
+      await ctx.db.insert('pilots', { gameId, ownerId: null, body: {}, updatedAt: 1 })
+    })
+
+    const crew = await organizer.as.query(api.crew.vitals, { gameId })
+    // Bodies are opaque, so the projection must not trust their shape. Zero
+    // would render as "dead" on a vitals strip, which is worse than blank.
+    expect(crew.pilots[0]?.currentHp).toBeNull()
+  })
+
+  test('a non-member gets nothing', async () => {
+    const t = testConvex()
+    const { gameId } = await seedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+
+    await expect(outsider.as.query(api.crew.vitals, { gameId })).rejects.toThrow(/not a member/i)
+  })
+})
+
+describe('readEntity', () => {
+  test("a member can read a crewmate's sheet", async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    const pilotId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('pilots', {
+          gameId,
+          ownerId: player.userId,
+          body: { callsign: 'Roach-Boy' },
+          updatedAt: 1,
+        })
+    )
+
+    // "Lean over and look at their sheet", which is what a table does.
+    const seen = await organizer.as.query(api.crew.readEntity, {
+      table: 'pilots',
+      entityId: pilotId,
+    })
+    expect(seen).not.toBeNull()
+    expect((seen?.body as { callsign: string } | undefined)?.callsign).toBe('Roach-Boy')
+  })
+
+  test('a non-member cannot', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+    const pilotId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('pilots', {
+          gameId,
+          ownerId: player.userId,
+          body: {},
+          updatedAt: 1,
+        })
+    )
+
+    await expect(
+      outsider.as.query(api.crew.readEntity, { table: 'pilots', entityId: pilotId })
+    ).rejects.toThrow(/not a member/i)
+  })
+
+  test('a shelved entity is not reachable through this query at all', async () => {
+    const t = testConvex()
+    const { organizer, player } = await seedGame(t)
+    const shelved = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('pilots', {
+          gameId: null,
+          ownerId: player.userId,
+          body: { callsign: 'Private draft' },
+          updatedAt: 1,
+        })
+    )
+
+    // A shelf belongs to one person and to no crew. There is no membership that
+    // could grant access, so the answer is "nothing here" rather than a check
+    // that might one day be loosened.
+    const seen = await organizer.as.query(api.crew.readEntity, {
+      table: 'pilots',
+      entityId: shelved,
+    })
+    expect(seen).toBeNull()
+  })
+})

--- a/apps/itun/convex/__tests__/downtime.test.ts
+++ b/apps/itun/convex/__tests__/downtime.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from 'bun:test'
+
+import { api } from '../_generated/api'
+import { testConvex } from './harness'
+
+/**
+ * Crew-wide Downtime (Phase 5).
+ *
+ * The two properties worth the most here are the ones that made per-player
+ * Downtime unworkable in the first place: **upkeep charged once rather than
+ * once per member**, and **step completion that means "done with THIS step"
+ * rather than "done at some point".**
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+async function seedTable(t: Ctx) {
+  const gm = await makeUser(t, 'Mediator')
+  const a = await makeUser(t, 'Ash')
+  const b = await makeUser(t, 'Bex')
+  const gameId = await gm.as.mutation(api.games.create, { name: 'Tenacity' })
+  const code = await gm.as.mutation(api.invites.create, { gameId })
+  await a.as.mutation(api.invites.redeem, { code })
+  await b.as.mutation(api.invites.redeem, { code })
+  await gm.as.mutation(api.games.setMediator, { gameId, userId: gm.userId, mediator: true })
+  return { gm, a, b, gameId }
+}
+
+describe('the phase is table-wide and Mediator-driven', () => {
+  test('not-running is a reported state, not a null', async () => {
+    const t = testConvex()
+    const { a, gameId } = await seedTable(t)
+
+    // Reporting it saves every caller inventing the same default.
+    const s = await a.as.query(api.downtime.state, { gameId })
+    expect(s.running).toBe(false)
+    expect(s.stepIndex).toBeNull()
+  })
+
+  test('the Mediator begins and advances; everybody sees it', async () => {
+    const t = testConvex()
+    const { gm, a, gameId } = await seedTable(t)
+
+    await gm.as.mutation(api.downtime.begin, { gameId })
+    expect((await a.as.query(api.downtime.state, { gameId })).stepIndex).toBe(0)
+
+    await gm.as.mutation(api.downtime.advance, { gameId })
+    expect((await a.as.query(api.downtime.state, { gameId })).stepIndex).toBe(1)
+  })
+
+  test('a player cannot begin, advance or end it', async () => {
+    const t = testConvex()
+    const { gm, a, gameId } = await seedTable(t)
+
+    await expect(a.as.mutation(api.downtime.begin, { gameId })).rejects.toThrow(/mediator/i)
+    await gm.as.mutation(api.downtime.begin, { gameId })
+    await expect(a.as.mutation(api.downtime.advance, { gameId })).rejects.toThrow(/mediator/i)
+    await expect(a.as.mutation(api.downtime.end, { gameId })).rejects.toThrow(/mediator/i)
+  })
+
+  test('advancing before it starts is refused', async () => {
+    const t = testConvex()
+    const { gm, gameId } = await seedTable(t)
+    await expect(gm.as.mutation(api.downtime.advance, { gameId })).rejects.toThrow(/not running/i)
+  })
+})
+
+describe('completion is per step, not cumulative', () => {
+  test('marking done shows up for the whole table', async () => {
+    const t = testConvex()
+    const { gm, a, b, gameId } = await seedTable(t)
+    await gm.as.mutation(api.downtime.begin, { gameId })
+
+    await a.as.mutation(api.downtime.markStepDone, { gameId, done: true })
+
+    // The point of a shared phase: Bex can see Ash is finished.
+    const seen = await b.as.query(api.downtime.state, { gameId })
+    expect(seen.completedBy.map((c) => c.displayName)).toContain('Ash')
+  })
+
+  test('advancing clears it', async () => {
+    const t = testConvex()
+    const { gm, a, gameId } = await seedTable(t)
+    await gm.as.mutation(api.downtime.begin, { gameId })
+    await a.as.mutation(api.downtime.markStepDone, { gameId, done: true })
+
+    await gm.as.mutation(api.downtime.advance, { gameId })
+
+    // Otherwise a player who finished step 1 looks finished for the whole
+    // Downtime — the opposite of what the Mediator needs to know.
+    expect((await a.as.query(api.downtime.state, { gameId })).completedBy).toHaveLength(0)
+  })
+
+  test('marking done twice does not duplicate', async () => {
+    const t = testConvex()
+    const { gm, a, gameId } = await seedTable(t)
+    await gm.as.mutation(api.downtime.begin, { gameId })
+
+    await a.as.mutation(api.downtime.markStepDone, { gameId, done: true })
+    await a.as.mutation(api.downtime.markStepDone, { gameId, done: true })
+
+    expect((await a.as.query(api.downtime.state, { gameId })).completedBy).toHaveLength(1)
+  })
+
+  test('a player can un-mark themselves', async () => {
+    const t = testConvex()
+    const { gm, a, gameId } = await seedTable(t)
+    await gm.as.mutation(api.downtime.begin, { gameId })
+    await a.as.mutation(api.downtime.markStepDone, { gameId, done: true })
+    await a.as.mutation(api.downtime.markStepDone, { gameId, done: false })
+
+    expect((await a.as.query(api.downtime.state, { gameId })).completedBy).toHaveLength(0)
+  })
+})
+
+describe('crawler upkeep is spent once, not per member', () => {
+  test('the second attempt reports already-spent rather than charging again', async () => {
+    const t = testConvex()
+    const { gm, a, b, gameId } = await seedTable(t)
+    await gm.as.mutation(api.downtime.begin, { gameId })
+
+    expect(await a.as.mutation(api.downtime.spendUpkeep, { gameId })).toBe(true)
+    // Six members each paying is the exact double-charging that made
+    // per-player Downtime unworkable.
+    expect(await b.as.mutation(api.downtime.spendUpkeep, { gameId })).toBe(false)
+  })
+
+  test('two players racing is not an error anybody sees', async () => {
+    const t = testConvex()
+    const { gm, a, b, gameId } = await seedTable(t)
+    await gm.as.mutation(api.downtime.begin, { gameId })
+
+    // An ordinary race at a table, not a fault to surface.
+    const results = [
+      await a.as.mutation(api.downtime.spendUpkeep, { gameId }),
+      await b.as.mutation(api.downtime.spendUpkeep, { gameId }),
+    ]
+    expect(results.filter(Boolean)).toHaveLength(1)
+  })
+
+  test('advancing a step does NOT reset it', async () => {
+    const t = testConvex()
+    const { gm, a, gameId } = await seedTable(t)
+    await gm.as.mutation(api.downtime.begin, { gameId })
+    await a.as.mutation(api.downtime.spendUpkeep, { gameId })
+
+    await gm.as.mutation(api.downtime.advance, { gameId })
+
+    // Resetting here would charge the crew again mid-procedure.
+    expect((await a.as.query(api.downtime.state, { gameId })).upkeepSpent).toBe(true)
+    expect(await a.as.mutation(api.downtime.spendUpkeep, { gameId })).toBe(false)
+  })
+
+  test('a NEW downtime does reset it', async () => {
+    const t = testConvex()
+    const { gm, a, gameId } = await seedTable(t)
+    await gm.as.mutation(api.downtime.begin, { gameId })
+    await a.as.mutation(api.downtime.spendUpkeep, { gameId })
+    await gm.as.mutation(api.downtime.end, { gameId })
+
+    await gm.as.mutation(api.downtime.begin, { gameId })
+    // Upkeep is per Downtime, so the next one is payable again.
+    expect(await a.as.mutation(api.downtime.spendUpkeep, { gameId })).toBe(true)
+  })
+})
+
+describe('non-members', () => {
+  test('cannot read or touch a table they are not at', async () => {
+    const t = testConvex()
+    const { gm, gameId } = await seedTable(t)
+    const outsider = await makeUser(t, 'Outsider')
+    await gm.as.mutation(api.downtime.begin, { gameId })
+
+    await expect(outsider.as.query(api.downtime.state, { gameId })).rejects.toThrow(/not a member/i)
+    await expect(
+      outsider.as.mutation(api.downtime.markStepDone, { gameId, done: true })
+    ).rejects.toThrow(/not a member/i)
+  })
+})

--- a/apps/itun/convex/__tests__/entities.test.ts
+++ b/apps/itun/convex/__tests__/entities.test.ts
@@ -269,3 +269,94 @@ describe('claiming local data on first sign-in', () => {
     )
   })
 })
+
+describe('claiming a legacy roster carries the whole thing', () => {
+  test('crawler, soft links and patterns come across, not just pilots and mechs', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Returning player')
+
+    const result = await u.as.mutation(api.entities.claimLocal, {
+      pilots: [pilotBody()],
+      mechs: [],
+      crawlers: [
+        {
+          id: 'c1',
+          schemaVersion: 1,
+          name: '#430',
+          techLevel: '1',
+          systems: [],
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      softLinks: [
+        {
+          from: { type: 'pilot', id: 'p1' },
+          to: { type: 'crawler', id: 'c1' },
+          type: 'pilot-to-crawler',
+        },
+      ],
+      mechPatterns: [{ id: 'pat1', name: 'Mule loadout' }],
+    })
+
+    // The first version of this mutation took only pilots and mechs, so a
+    // returning player would have watched their crawler and every link between
+    // their entities disappear with no error.
+    expect(result.byKind.pilots).toBe(1)
+    expect(result.byKind.crawlers).toBe(1)
+    expect(result.byKind.softLinks).toBe(1)
+    expect(result.byKind.mechPatterns).toBe(1)
+    expect(result.skipped).toBe(0)
+  })
+
+  test('a claimed crawler gets a game, because a shelf cannot hold one', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    await u.as.mutation(api.entities.claimLocal, {
+      pilots: [],
+      mechs: [],
+      crawlers: [
+        {
+          id: 'c1',
+          schemaVersion: 1,
+          name: '#430',
+          techLevel: '1',
+          systems: [],
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    })
+
+    // Crawlers are communal and game-scoped by design, so there is no shelf
+    // shaped to hold one — a placeholder game of one is the honest home.
+    const crawlers = await t.run(async (ctx) => await ctx.db.query('crawlers').collect())
+    expect(crawlers).toHaveLength(1)
+    expect(crawlers[0]?.gameId).not.toBeNull()
+
+    const memberships = await t.run(async (ctx) => await ctx.db.query('memberships').collect())
+    expect(memberships[0]?.organizer).toBe(true)
+  })
+
+  test('the local id is preserved as appId so later edits find the row', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    await u.as.mutation(api.entities.claimLocal, { pilots: [pilotBody()], mechs: [] })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    // Without this, the very first edit after a claim could not address its row.
+    expect(rows[0]?.appId).toBe('p1')
+  })
+
+  test('a malformed crawler is skipped without costing the rest of the roster', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    const result = await u.as.mutation(api.entities.claimLocal, {
+      pilots: [pilotBody()],
+      mechs: [],
+      crawlers: [{ nonsense: true }],
+    })
+    expect(result.byKind.pilots).toBe(1)
+    expect(result.skipped).toBe(1)
+  })
+})

--- a/apps/itun/convex/__tests__/entities.test.ts
+++ b/apps/itun/convex/__tests__/entities.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, test } from 'bun:test'
+
+import { api } from '../_generated/api'
+import type { Id } from '../_generated/dataModel'
+import { testConvex } from './harness'
+
+/**
+ * Entity reads and writes against the server of record.
+ *
+ * Two properties carry the weight here:
+ *
+ *  1. **Every write Zod-parses first.** The schema stores bodies as `v.any()`
+ *     so the Zod schemas stay the single source of truth, which means Convex
+ *     itself cannot reject a malformed body — the mutation must. If that check
+ *     is ever dropped, nothing else in the system will notice until a corrupt
+ *     row reaches a sheet and blanks it.
+ *  2. **Reading is per-Game, writing is per-entity.** Any member sees the whole
+ *     crew (which is what makes vitals and drill-in possible), but nobody
+ *     writes a crewmate's sheet — a Mediator wanting to change one goes through
+ *     a proposal, not a privileged write path.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+/**
+ * A minimal body that satisfies PilotSchema.
+ *
+ * Derived by probing the real schema rather than guessed — the first draft of
+ * this fixture invented fields (`currentHp`, `trainingPoints`, `abilityRefs`)
+ * that do not exist on it and omitted required ones (`classRef`, `motto`,
+ * `keepsake`, `appearance`), so every case failed at the parse step.
+ */
+function pilotBody(over: Record<string, unknown> = {}) {
+  return {
+    id: 'p1',
+    schemaVersion: 1,
+    name: 'Roach-Boy',
+    callsign: 'Roach-Boy',
+    classRef: 'salvager',
+    abilities: [],
+    equipment: [],
+    motto: '',
+    keepsake: '',
+    appearance: '',
+    conditions: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...over,
+  }
+}
+
+async function seedGame(t: Ctx) {
+  const organizer = await makeUser(t, 'Organizer')
+  const player = await makeUser(t, 'Player')
+  const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+  const code = await organizer.as.mutation(api.invites.create, { gameId })
+  await player.as.mutation(api.invites.redeem, { code })
+  return { organizer, player, gameId }
+}
+
+describe('every write Zod-parses first', () => {
+  test('a malformed pilot body is rejected, not stored', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    await expect(
+      u.as.mutation(api.entities.create, {
+        table: 'pilots',
+        gameId: null,
+        body: { nonsense: true },
+      })
+    ).rejects.toThrow(/invalid pilots payload/i)
+
+    // Nothing partial left behind.
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(0)
+  })
+
+  test('a well-formed pilot body is stored', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    await u.as.mutation(api.entities.create, { table: 'pilots', gameId: null, body: pilotBody() })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.gameId).toBeNull()
+    expect(rows[0]?.ownerId).toBe(u.userId)
+  })
+})
+
+describe('reading is per-game, writing is per-entity', () => {
+  test('a member sees the whole crew, including entities they do not own', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    await player.as.mutation(api.entities.create, { table: 'pilots', gameId, body: pilotBody() })
+
+    const seen = await organizer.as.query(api.entities.listForGame, { gameId })
+    // This is what makes crew vitals and read-only drill-in possible.
+    expect(seen.pilots).toHaveLength(1)
+  })
+
+  test('a non-member sees nothing', async () => {
+    const t = testConvex()
+    const { gameId } = await seedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+
+    await expect(outsider.as.query(api.entities.listForGame, { gameId })).rejects.toThrow(
+      /not a member/i
+    )
+  })
+
+  test("a crewmate cannot write another player's pilot", async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    const pilotId = await player.as.mutation(api.entities.create, {
+      table: 'pilots',
+      gameId,
+      body: pilotBody(),
+    })
+
+    await expect(
+      organizer.as.mutation(api.entities.update, {
+        table: 'pilots',
+        entityId: pilotId,
+        body: pilotBody({ name: 'Hijacked' }),
+      })
+    ).rejects.toThrow(/another player/i)
+  })
+
+  test('an unclaimed entity cannot be edited until it is assigned', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const pilotId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('pilots', {
+          gameId,
+          ownerId: null,
+          body: pilotBody(),
+          updatedAt: 1,
+        })
+    )
+
+    // Editing an unclaimed pre-gen would let anyone quietly take it without
+    // going through assignment, which is the act the Change Log records.
+    await expect(
+      organizer.as.mutation(api.entities.update, {
+        table: 'pilots',
+        entityId: pilotId,
+        body: pilotBody({ name: 'Mine now' }),
+      })
+    ).rejects.toThrow(/unclaimed/i)
+  })
+
+  test('the owner can write their own', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedGame(t)
+    const pilotId = await player.as.mutation(api.entities.create, {
+      table: 'pilots',
+      gameId,
+      body: pilotBody(),
+    })
+
+    await player.as.mutation(api.entities.update, {
+      table: 'pilots',
+      entityId: pilotId,
+      body: pilotBody({ name: 'Renamed' }),
+    })
+
+    const row = await t.run(async (ctx) => await ctx.db.get(pilotId as Id<'pilots'>))
+    expect(row).not.toBeNull()
+    expect((row?.body as { name: string } | undefined)?.name).toBe('Renamed')
+  })
+})
+
+describe('the crawler is communal and merges per field', () => {
+  test('two members editing different fields do not clobber each other', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    const crawlerId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('crawlers', {
+          gameId,
+          // Shape probed against CrawlerSchema, not guessed: techLevel is a
+          // STRING here, there is no `modules` key, and `systems` is required.
+          body: {
+            id: 'c1',
+            schemaVersion: 1,
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            name: '#430',
+            techLevel: '1',
+            systems: [],
+          },
+          updatedAt: 1,
+        })
+    )
+
+    await organizer.as.mutation(api.entities.patchCrawler, {
+      crawlerId,
+      patch: { name: 'Tenacity' },
+    })
+    await player.as.mutation(api.entities.patchCrawler, { crawlerId, patch: { techLevel: '2' } })
+
+    const row = await t.run(async (ctx) => await ctx.db.get(crawlerId))
+    const body = row?.body as { name: string; techLevel: string; id: string }
+
+    // Both survive. A full-body write would have discarded whichever member
+    // lost the race — on exactly the night it matters, during Downtime.
+    expect(body.name).toBe('Tenacity')
+    expect(body.techLevel).toBe('2')
+    expect(body.id).toBe('c1')
+  })
+
+  test('a non-member cannot touch the crawler', async () => {
+    const t = testConvex()
+    const { gameId } = await seedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+    const crawlerId = await t.run(
+      async (ctx) => await ctx.db.insert('crawlers', { gameId, body: {}, updatedAt: 1 })
+    )
+
+    await expect(
+      outsider.as.mutation(api.entities.patchCrawler, { crawlerId, patch: { scrap: 999 } })
+    ).rejects.toThrow(/not a member/i)
+  })
+})
+
+describe('claiming local data on first sign-in', () => {
+  test('everything lands on the shelf, never in a game', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    const result = await u.as.mutation(api.entities.claimLocal, {
+      pilots: [pilotBody(), pilotBody({ id: 'p2' })],
+      mechs: [],
+    })
+
+    expect(result.claimed).toBe(2)
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    // Guessing a Game for a build that has no relationship to any crew would be
+    // worse than making the person place it deliberately.
+    expect(rows.every((r) => r.gameId === null)).toBe(true)
+  })
+
+  test('one corrupt record is skipped rather than costing the whole roster', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    const result = await u.as.mutation(api.entities.claimLocal, {
+      pilots: [pilotBody(), { totally: 'broken' }, pilotBody({ id: 'p3' })],
+      mechs: [],
+    })
+
+    expect(result.claimed).toBe(2)
+    expect(result.skipped).toBe(1)
+  })
+
+  test('an anonymous caller cannot claim', async () => {
+    const t = testConvex()
+    await expect(t.mutation(api.entities.claimLocal, { pilots: [], mechs: [] })).rejects.toThrow(
+      /not signed in/i
+    )
+  })
+})

--- a/apps/itun/convex/__tests__/harness.ts
+++ b/apps/itun/convex/__tests__/harness.ts
@@ -22,6 +22,7 @@ const modules = {
   // map, so these two are required even though no test imports them directly.
   './_generated/api.js': () => import('../_generated/api'),
   './_generated/server.js': () => import('../_generated/server'),
+  './account.ts': () => import('../account'),
   './games.ts': () => import('../games'),
   './invites.ts': () => import('../invites'),
   './ownership.ts': () => import('../ownership'),

--- a/apps/itun/convex/__tests__/harness.ts
+++ b/apps/itun/convex/__tests__/harness.ts
@@ -26,6 +26,7 @@ const modules = {
   './crew.ts': () => import('../crew'),
   './entities.ts': () => import('../entities'),
   './games.ts': () => import('../games'),
+  './mediator.ts': () => import('../mediator'),
   './invites.ts': () => import('../invites'),
   './ownership.ts': () => import('../ownership'),
   './templates.ts': () => import('../templates'),

--- a/apps/itun/convex/__tests__/harness.ts
+++ b/apps/itun/convex/__tests__/harness.ts
@@ -23,6 +23,7 @@ const modules = {
   './_generated/api.js': () => import('../_generated/api'),
   './_generated/server.js': () => import('../_generated/server'),
   './account.ts': () => import('../account'),
+  './bot.ts': () => import('../bot'),
   './crew.ts': () => import('../crew'),
   './downtime.ts': () => import('../downtime'),
   './entities.ts': () => import('../entities'),

--- a/apps/itun/convex/__tests__/harness.ts
+++ b/apps/itun/convex/__tests__/harness.ts
@@ -24,6 +24,7 @@ const modules = {
   './_generated/server.js': () => import('../_generated/server'),
   './account.ts': () => import('../account'),
   './crew.ts': () => import('../crew'),
+  './downtime.ts': () => import('../downtime'),
   './entities.ts': () => import('../entities'),
   './games.ts': () => import('../games'),
   './mediator.ts': () => import('../mediator'),

--- a/apps/itun/convex/__tests__/harness.ts
+++ b/apps/itun/convex/__tests__/harness.ts
@@ -26,6 +26,7 @@ const modules = {
   './games.ts': () => import('../games'),
   './invites.ts': () => import('../invites'),
   './ownership.ts': () => import('../ownership'),
+  './templates.ts': () => import('../templates'),
   './model/permissions.ts': () => import('../model/permissions'),
 }
 

--- a/apps/itun/convex/__tests__/harness.ts
+++ b/apps/itun/convex/__tests__/harness.ts
@@ -23,6 +23,7 @@ const modules = {
   './_generated/api.js': () => import('../_generated/api'),
   './_generated/server.js': () => import('../_generated/server'),
   './account.ts': () => import('../account'),
+  './entities.ts': () => import('../entities'),
   './games.ts': () => import('../games'),
   './invites.ts': () => import('../invites'),
   './ownership.ts': () => import('../ownership'),

--- a/apps/itun/convex/__tests__/harness.ts
+++ b/apps/itun/convex/__tests__/harness.ts
@@ -23,6 +23,7 @@ const modules = {
   './_generated/api.js': () => import('../_generated/api'),
   './_generated/server.js': () => import('../_generated/server'),
   './account.ts': () => import('../account'),
+  './crew.ts': () => import('../crew'),
   './entities.ts': () => import('../entities'),
   './games.ts': () => import('../games'),
   './invites.ts': () => import('../invites'),

--- a/apps/itun/convex/__tests__/harness.ts
+++ b/apps/itun/convex/__tests__/harness.ts
@@ -29,6 +29,7 @@ const modules = {
   './mediator.ts': () => import('../mediator'),
   './invites.ts': () => import('../invites'),
   './ownership.ts': () => import('../ownership'),
+  './proposals.ts': () => import('../proposals'),
   './templates.ts': () => import('../templates'),
   './model/permissions.ts': () => import('../model/permissions'),
 }

--- a/apps/itun/convex/__tests__/mediator.test.ts
+++ b/apps/itun/convex/__tests__/mediator.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from 'bun:test'
+
+import { api } from '../_generated/api'
+import { PRESENCE_WINDOW_MS } from '../mediator'
+import { testConvex } from './harness'
+
+/**
+ * The Mediator surface's server layer.
+ *
+ * The NPC tray is the only genuinely secret thing in a Game, so most of these
+ * tests are about it staying that way. A player who can read prepared
+ * opposition can read the encounter before it happens — the one leak that
+ * changes how the game is *played*, rather than merely who can edit what.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+/** A Game where `organizer` also mediates, plus a plain player. */
+async function seedMediatedGame(t: Ctx) {
+  const organizer = await makeUser(t, 'Mediator')
+  const player = await makeUser(t, 'Player')
+  const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+  const code = await organizer.as.mutation(api.invites.create, { gameId })
+  await player.as.mutation(api.invites.redeem, { code })
+  await organizer.as.mutation(api.games.setMediator, {
+    gameId,
+    userId: organizer.userId,
+    mediator: true,
+  })
+  return { mediator: organizer, player, gameId }
+}
+
+describe('the NPC tray is Mediator-only', () => {
+  test('the Mediator can read it', async () => {
+    const t = testConvex()
+    const { mediator, gameId } = await seedMediatedGame(t)
+    await mediator.as.mutation(api.mediator.addNpc, { gameId, body: { name: 'Wretch' } })
+
+    const rows = await mediator.as.query(api.mediator.npcs, { gameId })
+    expect(rows).toHaveLength(1)
+  })
+
+  test('a player in the same game cannot', async () => {
+    const t = testConvex()
+    const { mediator, player, gameId } = await seedMediatedGame(t)
+    await mediator.as.mutation(api.mediator.addNpc, { gameId, body: { name: 'Wretch' } })
+
+    // Membership is not enough here, unlike everywhere else in the app.
+    await expect(player.as.query(api.mediator.npcs, { gameId })).rejects.toThrow(/mediator/i)
+  })
+
+  test('a player cannot add, edit or remove one', async () => {
+    const t = testConvex()
+    const { mediator, player, gameId } = await seedMediatedGame(t)
+    const npcId = await mediator.as.mutation(api.mediator.addNpc, { gameId, body: { name: 'A' } })
+
+    await expect(
+      player.as.mutation(api.mediator.addNpc, { gameId, body: { name: 'B' } })
+    ).rejects.toThrow(/mediator/i)
+    await expect(
+      player.as.mutation(api.mediator.updateNpc, { npcId, body: { name: 'C' } })
+    ).rejects.toThrow(/mediator/i)
+    await expect(player.as.mutation(api.mediator.removeNpc, { npcId })).rejects.toThrow(/mediator/i)
+  })
+
+  test('an Organizer who does not mediate cannot read it either', async () => {
+    const t = testConvex()
+    const organizer = await makeUser(t, 'Organizer')
+    const gm = await makeUser(t, 'GM')
+    const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await gm.as.mutation(api.invites.redeem, { code })
+    await organizer.as.mutation(api.games.setMediator, {
+      gameId,
+      userId: gm.userId,
+      mediator: true,
+    })
+
+    // The Organizer flag is administrative and confers no content authority —
+    // reading prepared opposition is very much content.
+    await expect(organizer.as.query(api.mediator.npcs, { gameId })).rejects.toThrow(/mediator/i)
+  })
+})
+
+describe('presence', () => {
+  test('a heartbeat upserts rather than appending', async () => {
+    const t = testConvex()
+    const { mediator, gameId } = await seedMediatedGame(t)
+
+    await mediator.as.mutation(api.mediator.heartbeat, { gameId })
+    await mediator.as.mutation(api.mediator.heartbeat, { gameId })
+    await mediator.as.mutation(api.mediator.heartbeat, { gameId })
+
+    // Otherwise a long session grows presence without bound.
+    const rows = await t.run(async (ctx) => await ctx.db.query('presence').collect())
+    expect(rows).toHaveLength(1)
+  })
+
+  test('present is computed from lastSeen, not stored', async () => {
+    const t = testConvex()
+    const { mediator, gameId } = await seedMediatedGame(t)
+    await mediator.as.mutation(api.mediator.heartbeat, { gameId })
+
+    // Backdate past the window: nothing had to turn a flag off.
+    await t.run(async (ctx) => {
+      for (const row of await ctx.db.query('presence').collect()) {
+        await ctx.db.patch(row._id, { lastSeen: Date.now() - PRESENCE_WINDOW_MS - 1000 })
+      }
+    })
+
+    const rows = await mediator.as.query(api.mediator.presence, { gameId })
+    // A stored boolean needs something to clear it, and every such mechanism
+    // can fail in a way that leaves somebody present forever.
+    expect(rows[0]?.present).toBe(false)
+  })
+
+  test('any member may heartbeat and read presence', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedMediatedGame(t)
+    await player.as.mutation(api.mediator.heartbeat, { gameId })
+
+    // Presence is not privileged: a Mediator needs to see players arrive
+    // exactly as much as players need to see each other.
+    const rows = await player.as.query(api.mediator.presence, { gameId })
+    expect(rows.some((r) => r.userId === player.userId && r.present)).toBe(true)
+  })
+
+  test('a non-member cannot heartbeat into a game they are not in', async () => {
+    const t = testConvex()
+    const { gameId } = await seedMediatedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+
+    await expect(outsider.as.mutation(api.mediator.heartbeat, { gameId })).rejects.toThrow(
+      /not a member/i
+    )
+  })
+})
+
+describe('amMediator', () => {
+  test('true for the Mediator, false for a player', async () => {
+    const t = testConvex()
+    const { mediator, player, gameId } = await seedMediatedGame(t)
+    expect(await mediator.as.query(api.mediator.amMediator, { gameId })).toBe(true)
+    expect(await player.as.query(api.mediator.amMediator, { gameId })).toBe(false)
+  })
+
+  test('false rather than a throw for a non-member', async () => {
+    const t = testConvex()
+    const { gameId } = await seedMediatedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+
+    // "Can I mediate this" is a reasonable question for anyone to ask, and a
+    // surface gating itself on the answer should not have to catch.
+    expect(await outsider.as.query(api.mediator.amMediator, { gameId })).toBe(false)
+  })
+})

--- a/apps/itun/convex/__tests__/proposals.test.ts
+++ b/apps/itun/convex/__tests__/proposals.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, test } from 'bun:test'
+
+import { api } from '../_generated/api'
+import type { Id } from '../_generated/dataModel'
+import { testConvex } from './harness'
+
+/**
+ * Propose-and-confirm (D7, D25).
+ *
+ * The thing being protected is that **a Mediator never writes a player's
+ * sheet**. So the tests are less about the happy path and more about the ways
+ * that promise could quietly erode: a force-apply path appearing, a proposal
+ * expiring and dropping damage, or two contradictory pendings against one field.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+async function seedTable(t: Ctx) {
+  const gm = await makeUser(t, 'Mediator')
+  const player = await makeUser(t, 'Player')
+  const gameId = await gm.as.mutation(api.games.create, { name: 'Tenacity' })
+  const code = await gm.as.mutation(api.invites.create, { gameId })
+  await player.as.mutation(api.invites.redeem, { code })
+  await gm.as.mutation(api.games.setMediator, { gameId, userId: gm.userId, mediator: true })
+
+  const mechId = await t.run(
+    async (ctx) =>
+      await ctx.db.insert('mechs', {
+        gameId,
+        ownerId: player.userId,
+        body: { name: 'Mule', currentSp: 10 },
+        updatedAt: 1,
+      })
+  )
+  return { gm, player, gameId, mechId }
+}
+
+describe('the Mediator proposes; the player writes', () => {
+  test('a proposal does not change the entity', async () => {
+    const t = testConvex()
+    const { gm, mechId } = await seedTable(t)
+
+    await gm.as.mutation(api.proposals.propose, {
+      entityId: mechId,
+      entityType: 'mech',
+      field: 'currentSp',
+      before: 10,
+      after: 6,
+    })
+
+    const mech = await t.run(async (ctx) => await ctx.db.get(mechId as Id<'mechs'>))
+    // Still 10. Proposing is not writing.
+    expect((mech?.body as { currentSp: number } | undefined)?.currentSp).toBe(10)
+  })
+
+  test('applying it does, and only the owner may', async () => {
+    const t = testConvex()
+    const { gm, player, gameId, mechId } = await seedTable(t)
+    await gm.as.mutation(api.proposals.propose, {
+      entityId: mechId,
+      entityType: 'mech',
+      field: 'currentSp',
+      before: 10,
+      after: 6,
+    })
+
+    const [pending] = await player.as.query(api.proposals.pending, { gameId })
+    expect(pending).toBeDefined()
+
+    // The Mediator cannot apply on the player's behalf — that would be the
+    // direct write this whole mechanism exists to avoid.
+    await expect(
+      gm.as.mutation(api.proposals.apply, { proposalId: pending?._id as Id<'changeLog'> })
+    ).rejects.toThrow(/only the owner/i)
+
+    await player.as.mutation(api.proposals.apply, {
+      proposalId: pending?._id as Id<'changeLog'>,
+    })
+    const mech = await t.run(async (ctx) => await ctx.db.get(mechId as Id<'mechs'>))
+    expect((mech?.body as { currentSp: number } | undefined)?.currentSp).toBe(6)
+  })
+
+  test("a player cannot propose to their own or a crewmate's entity", async () => {
+    const t = testConvex()
+    const { player, mechId } = await seedTable(t)
+    await expect(
+      player.as.mutation(api.proposals.propose, {
+        entityId: mechId,
+        entityType: 'mech',
+        field: 'currentSp',
+        before: 10,
+        after: 999,
+      })
+    ).rejects.toThrow(/mediator/i)
+  })
+
+  test('an unclaimed entity cannot be proposed to', async () => {
+    const t = testConvex()
+    const { gm, gameId } = await seedTable(t)
+    const orphan = await t.run(
+      async (ctx) => await ctx.db.insert('mechs', { gameId, ownerId: null, body: {}, updatedAt: 1 })
+    )
+
+    // Nobody would ever see it, so it would sit pending forever.
+    await expect(
+      gm.as.mutation(api.proposals.propose, {
+        entityId: orphan,
+        entityType: 'mech',
+        field: 'currentSp',
+        before: 0,
+        after: 1,
+      })
+    ).rejects.toThrow(/unclaimed/i)
+  })
+})
+
+describe('supersession, not expiry', () => {
+  test('a newer proposal on the same field retires the older one', async () => {
+    const t = testConvex()
+    const { gm, player, gameId, mechId } = await seedTable(t)
+
+    const first = await gm.as.mutation(api.proposals.propose, {
+      entityId: mechId,
+      entityType: 'mech',
+      field: 'currentSp',
+      before: 10,
+      after: 6,
+    })
+    await gm.as.mutation(api.proposals.propose, {
+      entityId: mechId,
+      entityType: 'mech',
+      field: 'currentSp',
+      before: 10,
+      after: 4,
+    })
+
+    const pending = await player.as.query(api.proposals.pending, { gameId })
+    // One pending, not two: a player is never asked to choose between
+    // contradictory values for the same field.
+    expect(pending).toHaveLength(1)
+    expect(pending[0]?.after).toBe(4)
+
+    const old = await t.run(async (ctx) => await ctx.db.get(first))
+    expect(old?.state).toBe('superseded')
+    expect(old?.supersededBy).toBeDefined()
+  })
+
+  test('a proposal on a DIFFERENT field is left alone', async () => {
+    const t = testConvex()
+    const { gm, player, gameId, mechId } = await seedTable(t)
+
+    await gm.as.mutation(api.proposals.propose, {
+      entityId: mechId,
+      entityType: 'mech',
+      field: 'currentSp',
+      before: 10,
+      after: 6,
+    })
+    await gm.as.mutation(api.proposals.propose, {
+      entityId: mechId,
+      entityType: 'mech',
+      field: 'currentHeat',
+      before: 0,
+      after: 3,
+    })
+
+    // Supersession is per FIELD. Damage and heat are separate facts.
+    expect(await player.as.query(api.proposals.pending, { gameId })).toHaveLength(2)
+  })
+
+  test('nothing expires — an unanswered proposal stays pending', async () => {
+    const t = testConvex()
+    const { gm, player, gameId, mechId } = await seedTable(t)
+    const id = await gm.as.mutation(api.proposals.propose, {
+      entityId: mechId,
+      entityType: 'mech',
+      field: 'currentSp',
+      before: 10,
+      after: 6,
+    })
+
+    // Backdate it well past any plausible timeout. A timer here would silently
+    // drop damage the player was meant to take.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(id, { ts: Date.now() - 1000 * 60 * 60 * 24 * 30 })
+    })
+
+    expect(await player.as.query(api.proposals.pending, { gameId })).toHaveLength(1)
+  })
+})
+
+describe('declining', () => {
+  test('records rather than deletes, and leaves the entity alone', async () => {
+    const t = testConvex()
+    const { gm, player, gameId, mechId } = await seedTable(t)
+    const id = await gm.as.mutation(api.proposals.propose, {
+      entityId: mechId,
+      entityType: 'mech',
+      field: 'currentSp',
+      before: 10,
+      after: 6,
+    })
+
+    await player.as.mutation(api.proposals.decline, { proposalId: id })
+
+    const row = await t.run(async (ctx) => await ctx.db.get(id))
+    // The log is append-only; a declined proposal is history, not a gap.
+    expect(row?.state).toBe('declined')
+    const mech = await t.run(async (ctx) => await ctx.db.get(mechId as Id<'mechs'>))
+    expect((mech?.body as { currentSp: number } | undefined)?.currentSp).toBe(10)
+    expect(await player.as.query(api.proposals.pending, { gameId })).toHaveLength(0)
+  })
+})
+
+describe('pending is scoped to the asker', () => {
+  test("a player is not shown proposals against a crewmate's entity", async () => {
+    const t = testConvex()
+    const { gm, gameId, mechId } = await seedTable(t)
+    const bystander = await makeUser(t, 'Bystander')
+    const code = await gm.as.mutation(api.invites.create, { gameId })
+    await bystander.as.mutation(api.invites.redeem, { code })
+
+    await gm.as.mutation(api.proposals.propose, {
+      entityId: mechId,
+      entityType: 'mech',
+      field: 'currentSp',
+      before: 10,
+      after: 6,
+    })
+
+    // Showing it would leak an edit in flight against a crewmate.
+    expect(await bystander.as.query(api.proposals.pending, { gameId })).toHaveLength(0)
+  })
+})
+
+describe('alerts share the proposal bus', () => {
+  test('the Mediator broadcasts and every member reads', async () => {
+    const t = testConvex()
+    const { gm, player, gameId } = await seedTable(t)
+    await gm.as.mutation(api.proposals.broadcast, { gameId, message: 'Sandstorm inbound' })
+
+    const seen = await player.as.query(api.proposals.alerts, { gameId })
+    expect(seen[0]?.message).toBe('Sandstorm inbound')
+  })
+
+  test('a player cannot broadcast', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedTable(t)
+    await expect(
+      player.as.mutation(api.proposals.broadcast, { gameId, message: 'free scrap' })
+    ).rejects.toThrow(/mediator/i)
+  })
+
+  test('an alert does not appear as a pending proposal', async () => {
+    const t = testConvex()
+    const { gm, player, gameId } = await seedTable(t)
+    await gm.as.mutation(api.proposals.broadcast, { gameId, message: 'Sandstorm' })
+
+    // Same table, different shape — an alert has no entity to answer for.
+    expect(await player.as.query(api.proposals.pending, { gameId })).toHaveLength(0)
+  })
+})

--- a/apps/itun/convex/__tests__/templates.test.ts
+++ b/apps/itun/convex/__tests__/templates.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test'
+
+import { api } from '../_generated/api'
+import { testConvex } from './harness'
+
+/**
+ * Game templates (D34).
+ *
+ * The property under test is the one that makes a template useful rather than
+ * decorative: **its entities arrive unclaimed**, so the person running the
+ * table hands them out. A template that pre-assigned everything to its creator
+ * would just be a private roster with extra steps.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+describe('starter-set template', () => {
+  test('is listed', async () => {
+    const t = testConvex()
+    const templates = await t.query(api.templates.list, {})
+    expect(templates.map((x) => x.id)).toContain('starter-set')
+  })
+
+  test('every pilot and mech arrives unclaimed', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const { pilots, mechs } = await t.run(async (ctx) => ({
+      pilots: await ctx.db.query('pilots').collect(),
+      mechs: await ctx.db.query('mechs').collect(),
+    }))
+
+    expect(pilots.length).toBeGreaterThan(0)
+    expect(mechs.length).toBeGreaterThan(0)
+    // Not owned by the creator — that is the difference between a template and
+    // a private roster.
+    expect(pilots.every((p) => p.ownerId === null)).toBe(true)
+    expect(mechs.every((m) => m.ownerId === null)).toBe(true)
+  })
+
+  test('the creator is Organizer and a seated Player, as with any game', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    const gameId = await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const roster = await u.as.query(api.games.members, { gameId })
+    expect(roster).toHaveLength(1)
+    expect(roster[0]?.organizer).toBe(true)
+    // A template changes what is IN the game, never who runs it.
+    expect(roster[0]?.mediator).toBe(false)
+  })
+
+  test('the crawler is created communally, with no owner column at all', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const crawlers = await t.run(async (ctx) => await ctx.db.query('crawlers').collect())
+    expect(crawlers.length).toBeGreaterThan(0)
+    expect(crawlers[0]).not.toHaveProperty('ownerId')
+  })
+
+  test('soft links come across, so the crew is wired together on arrival', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const links = await t.run(async (ctx) => await ctx.db.query('softLinks').collect())
+    // Without these the pilots and mechs would arrive as unrelated strangers.
+    expect(links.length).toBeGreaterThan(0)
+    expect(links.some((l) => l.type === 'mech-to-pilot')).toBe(true)
+  })
+
+  test('the game records which template it came from', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    const gameId = await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const game = await t.run(async (ctx) => await ctx.db.get(gameId))
+    expect(game?.templateOrigin).toBe('starter-set')
+  })
+
+  test('a custom name overrides the template name', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    const gameId = await u.as.mutation(api.templates.createGame, {
+      templateId: 'starter-set',
+      name: '  Our Tuesday Game  ',
+    })
+
+    const game = await t.run(async (ctx) => await ctx.db.get(gameId))
+    expect(game?.name).toBe('Our Tuesday Game')
+  })
+
+  test('an anonymous caller cannot create one', async () => {
+    const t = testConvex()
+    await expect(
+      t.mutation(api.templates.createGame, { templateId: 'starter-set' })
+    ).rejects.toThrow(/not signed in/i)
+  })
+})

--- a/apps/itun/convex/_generated/api.d.ts
+++ b/apps/itun/convex/_generated/api.d.ts
@@ -16,6 +16,7 @@ import type * as http from "../http.js";
 import type * as invites from "../invites.js";
 import type * as model_permissions from "../model/permissions.js";
 import type * as ownership from "../ownership.js";
+import type * as templates from "../templates.js";
 
 import type {
   ApiFromModules,
@@ -32,6 +33,7 @@ declare const fullApi: ApiFromModules<{
   invites: typeof invites;
   "model/permissions": typeof model_permissions;
   ownership: typeof ownership;
+  templates: typeof templates;
 }>;
 
 /**

--- a/apps/itun/convex/_generated/api.d.ts
+++ b/apps/itun/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as __tests___harness from "../__tests__/harness.js";
 import type * as account from "../account.js";
 import type * as auth from "../auth.js";
+import type * as crew from "../crew.js";
 import type * as entities from "../entities.js";
 import type * as games from "../games.js";
 import type * as http from "../http.js";
@@ -29,6 +30,7 @@ declare const fullApi: ApiFromModules<{
   "__tests__/harness": typeof __tests___harness;
   account: typeof account;
   auth: typeof auth;
+  crew: typeof crew;
   entities: typeof entities;
   games: typeof games;
   http: typeof http;

--- a/apps/itun/convex/_generated/api.d.ts
+++ b/apps/itun/convex/_generated/api.d.ts
@@ -12,6 +12,7 @@ import type * as __tests___harness from "../__tests__/harness.js";
 import type * as account from "../account.js";
 import type * as auth from "../auth.js";
 import type * as crew from "../crew.js";
+import type * as downtime from "../downtime.js";
 import type * as entities from "../entities.js";
 import type * as games from "../games.js";
 import type * as http from "../http.js";
@@ -33,6 +34,7 @@ declare const fullApi: ApiFromModules<{
   account: typeof account;
   auth: typeof auth;
   crew: typeof crew;
+  downtime: typeof downtime;
   entities: typeof entities;
   games: typeof games;
   http: typeof http;

--- a/apps/itun/convex/_generated/api.d.ts
+++ b/apps/itun/convex/_generated/api.d.ts
@@ -16,6 +16,7 @@ import type * as entities from "../entities.js";
 import type * as games from "../games.js";
 import type * as http from "../http.js";
 import type * as invites from "../invites.js";
+import type * as mediator from "../mediator.js";
 import type * as model_permissions from "../model/permissions.js";
 import type * as ownership from "../ownership.js";
 import type * as templates from "../templates.js";
@@ -35,6 +36,7 @@ declare const fullApi: ApiFromModules<{
   games: typeof games;
   http: typeof http;
   invites: typeof invites;
+  mediator: typeof mediator;
   "model/permissions": typeof model_permissions;
   ownership: typeof ownership;
   templates: typeof templates;

--- a/apps/itun/convex/_generated/api.d.ts
+++ b/apps/itun/convex/_generated/api.d.ts
@@ -19,6 +19,7 @@ import type * as invites from "../invites.js";
 import type * as mediator from "../mediator.js";
 import type * as model_permissions from "../model/permissions.js";
 import type * as ownership from "../ownership.js";
+import type * as proposals from "../proposals.js";
 import type * as templates from "../templates.js";
 
 import type {
@@ -39,6 +40,7 @@ declare const fullApi: ApiFromModules<{
   mediator: typeof mediator;
   "model/permissions": typeof model_permissions;
   ownership: typeof ownership;
+  proposals: typeof proposals;
   templates: typeof templates;
 }>;
 

--- a/apps/itun/convex/_generated/api.d.ts
+++ b/apps/itun/convex/_generated/api.d.ts
@@ -8,6 +8,8 @@
  * @module
  */
 
+import type * as __tests___harness from "../__tests__/harness.js";
+import type * as account from "../account.js";
 import type * as auth from "../auth.js";
 import type * as games from "../games.js";
 import type * as http from "../http.js";
@@ -22,6 +24,8 @@ import type {
 } from "convex/server";
 
 declare const fullApi: ApiFromModules<{
+  "__tests__/harness": typeof __tests___harness;
+  account: typeof account;
   auth: typeof auth;
   games: typeof games;
   http: typeof http;

--- a/apps/itun/convex/_generated/api.d.ts
+++ b/apps/itun/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as __tests___harness from "../__tests__/harness.js";
 import type * as account from "../account.js";
 import type * as auth from "../auth.js";
+import type * as entities from "../entities.js";
 import type * as games from "../games.js";
 import type * as http from "../http.js";
 import type * as invites from "../invites.js";
@@ -28,6 +29,7 @@ declare const fullApi: ApiFromModules<{
   "__tests__/harness": typeof __tests___harness;
   account: typeof account;
   auth: typeof auth;
+  entities: typeof entities;
   games: typeof games;
   http: typeof http;
   invites: typeof invites;

--- a/apps/itun/convex/_generated/api.d.ts
+++ b/apps/itun/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as __tests___harness from "../__tests__/harness.js";
 import type * as account from "../account.js";
 import type * as auth from "../auth.js";
+import type * as bot from "../bot.js";
 import type * as crew from "../crew.js";
 import type * as downtime from "../downtime.js";
 import type * as entities from "../entities.js";
@@ -33,6 +34,7 @@ declare const fullApi: ApiFromModules<{
   "__tests__/harness": typeof __tests___harness;
   account: typeof account;
   auth: typeof auth;
+  bot: typeof bot;
   crew: typeof crew;
   downtime: typeof downtime;
   entities: typeof entities;

--- a/apps/itun/convex/account.ts
+++ b/apps/itun/convex/account.ts
@@ -1,0 +1,230 @@
+import { v } from 'convex/values'
+
+import type { Doc, Id } from './_generated/dataModel'
+import { mutation, query } from './_generated/server'
+import type { MutationCtx } from './_generated/server'
+import { requireUser } from './model/permissions'
+
+/**
+ * Account management (ADR-030 §6, D33).
+ *
+ * Holding somebody's Discord identity is an obligation the project did not have
+ * before, so the three things that discharge it — read your profile, edit it,
+ * delete the account entirely — are part of the same module rather than a
+ * follow-up. Export is served here too, so "give me my data" and "delete my
+ * data" cannot drift apart.
+ */
+
+/** The signed-in user's own profile. Never exposes another user's row. */
+export const me = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await requireUser(ctx)
+    const user = await ctx.db.get(userId)
+    if (user === null) return null
+    return {
+      _id: user._id,
+      displayName: user.displayName ?? user.name ?? null,
+      avatarUrl: user.avatarUrl ?? user.image ?? null,
+      email: user.email ?? null,
+    }
+  },
+})
+
+/**
+ * Edit the display name and avatar shown on every owner chip.
+ *
+ * These are overrides layered on the Discord profile rather than replacements:
+ * clearing one falls back to the Discord value rather than to blank, because a
+ * nameless owner chip is worse than a stale one.
+ */
+export const updateProfile = mutation({
+  args: {
+    displayName: v.optional(v.union(v.string(), v.null())),
+    avatarUrl: v.optional(v.union(v.string(), v.null())),
+  },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    const patch: { displayName?: string | undefined; avatarUrl?: string | undefined } = {}
+
+    if (args.displayName !== undefined) {
+      const trimmed = args.displayName?.trim() ?? ''
+      patch.displayName = trimmed.length > 0 ? trimmed : undefined
+    }
+    if (args.avatarUrl !== undefined) {
+      const trimmed = args.avatarUrl?.trim() ?? ''
+      patch.avatarUrl = trimmed.length > 0 ? trimmed : undefined
+    }
+
+    await ctx.db.patch(userId, patch)
+  },
+})
+
+/**
+ * Everything this account owns, as a plain object suitable for download.
+ *
+ * Deliberately scoped to what the user *owns*, not everything they can see: a
+ * crewmate's pilot is readable inside a Game but is not this person's data to
+ * take away. The communal crawler is likewise excluded — it belongs to the
+ * table, not to any one member.
+ */
+export const exportMine = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await requireUser(ctx)
+
+    const pilots = await ctx.db
+      .query('pilots')
+      .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+      .collect()
+    const mechs = await ctx.db
+      .query('mechs')
+      .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+      .collect()
+    const mechPatterns = await ctx.db
+      .query('mechPatterns')
+      .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+      .collect()
+    const memberships = await ctx.db
+      .query('memberships')
+      .withIndex('by_user', (q) => q.eq('userId', userId))
+      .collect()
+
+    return {
+      exportedAt: new Date().toISOString(),
+      pilots: pilots.map((p) => p.body),
+      mechs: mechs.map((m) => m.body),
+      mechPatterns: mechPatterns.map((p) => p.body),
+      games: memberships.map((m) => ({
+        gameId: m.gameId,
+        mediator: m.mediator,
+        organizer: m.organizer,
+        joinedAt: m.joinedAt,
+      })),
+    }
+  },
+})
+
+/**
+ * Pass the Organizer flag to the longest-standing remaining member.
+ *
+ * "Longest-standing" is `joinedAt`, and the tie-break is deterministic rather
+ * than arbitrary — two members can share a timestamp if a Game was seeded in
+ * one mutation, and an unstable choice there would make the outcome depend on
+ * document scan order.
+ */
+async function reassignOrganizer(
+  ctx: MutationCtx,
+  gameId: Id<'games'>,
+  leavingUserId: Id<'users'>
+): Promise<boolean> {
+  const remaining = (
+    await ctx.db
+      .query('memberships')
+      .withIndex('by_game', (q) => q.eq('gameId', gameId))
+      .collect()
+  ).filter((m) => m.userId !== leavingUserId)
+
+  if (remaining.length === 0) return false
+
+  remaining.sort((a: Doc<'memberships'>, b: Doc<'memberships'>) =>
+    a.joinedAt === b.joinedAt ? a._id.localeCompare(b._id) : a.joinedAt - b.joinedAt
+  )
+  const heir = remaining[0]
+  if (heir === undefined) return false
+
+  await ctx.db.patch(heir._id, { organizer: true })
+  return true
+}
+
+/**
+ * Delete this account and everything personal to it (D27).
+ *
+ * The rule that matters: **a campaign never dies because one person quit.**
+ * Games survive, the communal crawler survives, and the Organizer flag passes
+ * to the longest-standing remaining member. Only when the departing user was
+ * the *last* member is the Game itself removed, because an empty Game is not a
+ * campaign anybody can return to.
+ *
+ * Their own pilots and mechs go with them — that is the point of a deletion
+ * request. Anyone who wants to keep a character exports first, which is why
+ * `exportMine` lives in this same module.
+ */
+export const deleteAccount = mutation({
+  args: {},
+  handler: async (ctx): Promise<void> => {
+    const userId = await requireUser(ctx)
+
+    const memberships = await ctx.db
+      .query('memberships')
+      .withIndex('by_user', (q) => q.eq('userId', userId))
+      .collect()
+
+    for (const membership of memberships) {
+      if (membership.organizer) {
+        const passedOn = await reassignOrganizer(ctx, membership.gameId, userId)
+        if (!passedOn) {
+          // Last member out: the Game has nobody left to run or play it.
+          for (const table of [
+            'crawlers',
+            'encounterNpcs',
+            'softLinks',
+            'invites',
+            'presence',
+          ] as const) {
+            const rows = await ctx.db
+              .query(table)
+              .withIndex('by_game', (q) => q.eq('gameId', membership.gameId))
+              .collect()
+            for (const row of rows) await ctx.db.delete(row._id)
+          }
+          // Unclaimed entities in a Game with no members have nowhere to go.
+          for (const table of ['pilots', 'mechs'] as const) {
+            const rows = await ctx.db
+              .query(table)
+              .withIndex('by_game', (q) => q.eq('gameId', membership.gameId))
+              .collect()
+            for (const row of rows) await ctx.db.delete(row._id)
+          }
+          await ctx.db.delete(membership.gameId)
+        }
+      }
+      await ctx.db.delete(membership._id)
+    }
+
+    // Personal entities, wherever they live — in a Game or on the shelf.
+    for (const table of ['pilots', 'mechs', 'mechPatterns'] as const) {
+      const rows = await ctx.db
+        .query(table)
+        .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+        .collect()
+      for (const row of rows) await ctx.db.delete(row._id)
+    }
+
+    // Auth rows, so the identity cannot be resurrected by signing in again.
+    //
+    // Order matters: refresh tokens are keyed by SESSION, not by user, so they
+    // have to go before the sessions they point at. Deleting sessions first
+    // would strand them as orphans referencing rows that no longer exist.
+    const sessions = await ctx.db
+      .query('authSessions')
+      .withIndex('userId', (q) => q.eq('userId', userId))
+      .collect()
+    for (const session of sessions) {
+      const tokens = await ctx.db
+        .query('authRefreshTokens')
+        .withIndex('sessionId', (q) => q.eq('sessionId', session._id))
+        .collect()
+      for (const token of tokens) await ctx.db.delete(token._id)
+      await ctx.db.delete(session._id)
+    }
+
+    const accounts = await ctx.db
+      .query('authAccounts')
+      .withIndex('userIdAndProvider', (q) => q.eq('userId', userId))
+      .collect()
+    for (const account of accounts) await ctx.db.delete(account._id)
+
+    await ctx.db.delete(userId)
+  },
+})

--- a/apps/itun/convex/bot.ts
+++ b/apps/itun/convex/bot.ts
@@ -1,0 +1,204 @@
+import { v } from 'convex/values'
+
+import type { Id } from './_generated/dataModel'
+import { mutation, query } from './_generated/server'
+import type { MutationCtx } from './_generated/server'
+import { NotAuthorized, requireOrganizer, requireUser } from './model/permissions'
+
+/**
+ * The Discord bot as a Game participant (ADR-030, Phase 6).
+ *
+ * This closes the intent of the old issue #165 — "connect the bot to live
+ * campaign state" — **without** the mechanism that issue assumed. It called for
+ * a service-role key and RLS policies, which is a bot that can act as anybody.
+ * Here the bot acts as a *participant*:
+ *
+ *  - A **channel binding** says "rolls in this channel belong to this Game".
+ *  - The actor is resolved from the Discord user id against `users.discordId`,
+ *    so the bot can only ever act as somebody who has linked their own account
+ *    and joined the Game. A stranger in the channel is not a member and gets
+ *    nothing.
+ *
+ * That is why Discord was chosen as the sole identity provider: the id the bot
+ * already has in hand *is* the account key, so no separate credential, no
+ * impersonation surface, and no privileged token to leak.
+ */
+
+/** Bind this channel to a Game. Administrative, so Organizer only. */
+export const bindChannel = mutation({
+  args: { gameId: v.id('games'), channelId: v.string() },
+  handler: async (ctx, args): Promise<void> => {
+    const membership = await requireOrganizer(ctx, args.gameId)
+    const channelId = args.channelId.trim()
+    if (channelId.length === 0) throw new Error('A binding needs a channel')
+
+    const existing = await ctx.db
+      .query('channelBindings')
+      .withIndex('by_channel', (q) => q.eq('channelId', channelId))
+      .unique()
+
+    // One Game per channel: a channel meaning two Games would make every roll
+    // in it ambiguous, and the bot has no way to ask which was meant.
+    if (existing !== null) {
+      if (existing.gameId === args.gameId) return
+      throw new NotAuthorized('That channel is already bound to another game')
+    }
+
+    await ctx.db.insert('channelBindings', {
+      gameId: args.gameId,
+      channelId,
+      boundBy: membership.userId,
+      boundAt: Date.now(),
+    })
+  },
+})
+
+export const unbindChannel = mutation({
+  args: { channelId: v.string() },
+  handler: async (ctx, args): Promise<void> => {
+    const existing = await ctx.db
+      .query('channelBindings')
+      .withIndex('by_channel', (q) => q.eq('channelId', args.channelId.trim()))
+      .unique()
+    if (existing === null) return
+
+    await requireOrganizer(ctx, existing.gameId)
+    await ctx.db.delete(existing._id)
+  },
+})
+
+/** Which Game, if any, a channel speaks for. */
+export const gameForChannel = query({
+  args: { channelId: v.string() },
+  handler: async (ctx, args): Promise<{ gameId: Id<'games'>; name: string } | null> => {
+    await requireUser(ctx)
+    const binding = await ctx.db
+      .query('channelBindings')
+      .withIndex('by_channel', (q) => q.eq('channelId', args.channelId.trim()))
+      .unique()
+    if (binding === null) return null
+
+    const game = await ctx.db.get(binding.gameId)
+    if (game === null) return null
+    return { gameId: game._id, name: game.name }
+  },
+})
+
+/**
+ * Resolve a Discord user to a member of the bound Game.
+ *
+ * Returns null rather than throwing for every failure mode — no binding, no
+ * linked account, not a member — because the bot's correct response to all
+ * three is the same: say nothing happened. Distinguishing them in a public
+ * channel would leak who has an account and who is in which Game.
+ */
+async function resolveActor(
+  ctx: MutationCtx,
+  channelId: string,
+  discordId: string
+): Promise<{ gameId: Id<'games'>; userId: Id<'users'> } | null> {
+  const binding = await ctx.db
+    .query('channelBindings')
+    .withIndex('by_channel', (q) => q.eq('channelId', channelId.trim()))
+    .unique()
+  if (binding === null) return null
+
+  const user = await ctx.db
+    .query('users')
+    .withIndex('by_discord', (q) => q.eq('discordId', discordId))
+    .unique()
+  if (user === null) return null
+
+  const membership = await ctx.db
+    .query('memberships')
+    .withIndex('by_game_user', (q) => q.eq('gameId', binding.gameId).eq('userId', user._id))
+    .unique()
+  if (membership === null) return null
+
+  return { gameId: binding.gameId, userId: user._id }
+}
+
+/**
+ * Record a roll made in Discord against the bound Game.
+ *
+ * It lands as a Change Log entry, so a roll made at the table and a roll made
+ * in the channel are the same kind of fact and appear in the same history.
+ * There was no separate "bot events" store to invent, for the same reason
+ * alerts needed no separate bus.
+ *
+ * Returns false when the actor could not be resolved. The bot treats that as
+ * "not for us" rather than an error — see `resolveActor`.
+ */
+export const recordRoll = mutation({
+  args: {
+    channelId: v.string(),
+    discordId: v.string(),
+    description: v.string(),
+    result: v.any(),
+  },
+  handler: async (ctx, args): Promise<boolean> => {
+    const actor = await resolveActor(ctx, args.channelId, args.discordId)
+    if (actor === null) return false
+
+    await ctx.db.insert('changeLog', {
+      gameId: actor.gameId,
+      entityType: 'game',
+      entityId: actor.gameId,
+      ts: Date.now(),
+      kind: 'transaction',
+      field: 'roll',
+      before: null,
+      after: { description: args.description, result: args.result },
+      source: 'discord-bot',
+      actorId: actor.userId,
+      state: 'applied',
+    })
+    return true
+  },
+})
+
+/** Rolls recorded from Discord, newest first. Any member may read them. */
+export const rolls = query({
+  args: { gameId: v.id('games'), limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const userId = await requireUser(ctx)
+    const membership = await ctx.db
+      .query('memberships')
+      .withIndex('by_game_user', (q) => q.eq('gameId', args.gameId).eq('userId', userId))
+      .unique()
+    if (membership === null) throw new NotAuthorized('Not a member of this game')
+
+    const rows = await ctx.db
+      .query('changeLog')
+      .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+      .collect()
+
+    return rows
+      .filter((r) => r.field === 'roll')
+      .sort((a, b) => b.ts - a.ts)
+      .slice(0, args.limit ?? 20)
+      .map((r) => ({ _id: r._id, ts: r.ts, actorId: r.actorId, payload: r.after }))
+  },
+})
+
+/** Link a Discord identity to the signed-in account, so the bot can find them. */
+export const linkDiscordId = mutation({
+  args: { discordId: v.string() },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    const discordId = args.discordId.trim()
+    if (discordId.length === 0) throw new Error('A Discord id is required')
+
+    const taken = await ctx.db
+      .query('users')
+      .withIndex('by_discord', (q) => q.eq('discordId', discordId))
+      .unique()
+    // Otherwise two accounts could claim one Discord identity and the bot
+    // would resolve rolls to whichever it happened to find first.
+    if (taken !== null && taken._id !== userId) {
+      throw new NotAuthorized('That Discord account is already linked to another user')
+    }
+
+    await ctx.db.patch(userId, { discordId })
+  },
+})

--- a/apps/itun/convex/crew.ts
+++ b/apps/itun/convex/crew.ts
@@ -1,0 +1,107 @@
+import { v } from 'convex/values'
+
+import { query } from './_generated/server'
+import { requireMember, requireUser } from './model/permissions'
+
+/**
+ * Crew visibility inside a Game (ADR-030 §5, D12).
+ *
+ * Every member sees every crewmate's **vitals** live, and can drill into a
+ * crewmate's full sheet **read-only**. What stays hidden is the Mediator's
+ * prepared opposition — that is the one thing a player must not be able to
+ * read, and it is simply not queried here.
+ *
+ * ## Why vitals are a separate, narrow query
+ *
+ * The crew strip re-renders on every point of damage anyone takes. Serving it
+ * from `entities.listForGame` would push every crewmate's full sheet — loadouts,
+ * abilities, cargo — down the wire on each change, for a row that shows four
+ * numbers. A narrow projection keeps the hot path small and, just as usefully,
+ * makes the privacy boundary legible: this query returns what a crewmate is
+ * *entitled* to see at a glance, and nothing more.
+ */
+
+/** The four numbers a crew strip shows, plus who the row belongs to. */
+export const vitals = query({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args) => {
+    await requireMember(ctx, args.gameId)
+    const viewerId = await requireUser(ctx)
+
+    const [pilots, mechs, members] = await Promise.all([
+      ctx.db
+        .query('pilots')
+        .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+        .collect(),
+      ctx.db
+        .query('mechs')
+        .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+        .collect(),
+      ctx.db
+        .query('memberships')
+        .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+        .collect(),
+    ])
+
+    const names = new Map<string, string>()
+    for (const m of members) {
+      const user = await ctx.db.get(m.userId)
+      names.set(m.userId, user?.displayName ?? user?.name ?? 'Crewmate')
+    }
+
+    /** Read a numeric field off an opaque body without trusting its shape. */
+    const num = (body: unknown, key: string): number | null => {
+      const value = (body as Record<string, unknown> | null)?.[key]
+      return typeof value === 'number' ? value : null
+    }
+
+    return {
+      viewerId,
+      pilots: pilots.map((p) => ({
+        _id: p._id,
+        appId: p.appId ?? null,
+        ownerId: p.ownerId,
+        ownerName: p.ownerId === null ? null : (names.get(p.ownerId) ?? null),
+        name: ((p.body as Record<string, unknown> | null)?.callsign as string) ?? 'Pilot',
+        currentHp: num(p.body, 'currentHp'),
+        currentAp: num(p.body, 'currentAp'),
+      })),
+      mechs: mechs.map((m) => ({
+        _id: m._id,
+        appId: m.appId ?? null,
+        ownerId: m.ownerId,
+        ownerName: m.ownerId === null ? null : (names.get(m.ownerId) ?? null),
+        name: ((m.body as Record<string, unknown> | null)?.name as string) ?? 'Mech',
+        currentSp: num(m.body, 'currentSp'),
+        currentHeat: num(m.body, 'currentHeat'),
+      })),
+    }
+  },
+})
+
+/**
+ * A crewmate's full sheet, read-only.
+ *
+ * Membership is the whole check — inside a Game you may read any crewmate's
+ * pilot or mech, which is what "lean over and look at their sheet" means at a
+ * physical table. There is no write counterpart to this query anywhere; a
+ * Mediator who wants to change what they are reading proposes instead (D7).
+ */
+export const readEntity = query({
+  args: {
+    table: v.union(v.literal('pilots'), v.literal('mechs')),
+    entityId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const doc = await ctx.db.get(args.entityId as never)
+    if (doc === null) return null
+
+    const row = doc as unknown as { gameId: string | null; ownerId: string | null; body: unknown }
+    // A shelved entity has no Game to be a member of; it is private to its
+    // owner, and this query is deliberately not the way to reach one.
+    if (row.gameId === null) return null
+
+    await requireMember(ctx, row.gameId as never)
+    return { ownerId: row.ownerId, body: row.body }
+  },
+})

--- a/apps/itun/convex/downtime.ts
+++ b/apps/itun/convex/downtime.ts
@@ -1,0 +1,178 @@
+import { v } from 'convex/values'
+
+import type { Doc, Id } from './_generated/dataModel'
+import { mutation, query } from './_generated/server'
+import type { MutationCtx, QueryCtx } from './_generated/server'
+import { NotAuthorized, requireMediator, requireMember } from './model/permissions'
+
+/**
+ * Crew-wide Downtime (ADR-030, Phase 5).
+ *
+ * Downtime is the one procedure in Salvage Union the whole crew performs **in
+ * step**, which is why the phase is Game state advanced by the Mediator rather
+ * than something each player tracks alone. Before this, six players ran six
+ * private Downtimes and reconciled verbally.
+ *
+ * ## Upkeep is spent once, not six times
+ *
+ * `upkeepSpent` is a flag on the *Game's* Downtime, not on each member. The
+ * crawler is communal, so its upkeep is one cost the crew pays together — six
+ * members each spending it is the exact double-charging that made per-player
+ * Downtime unworkable. The flag resets when a new Downtime starts, never when a
+ * step advances.
+ *
+ * ## Completion is per step, not cumulative
+ *
+ * `completedBy` clears on every advance. Keeping it would leave a player who
+ * finished step 1 looking finished for the whole Downtime, which tells the
+ * Mediator the opposite of what they need to know.
+ */
+
+/** The Game's Downtime row, created lazily on first use. */
+async function readState(
+  ctx: QueryCtx | MutationCtx,
+  gameId: Id<'games'>
+): Promise<Doc<'downtime'> | null> {
+  return await ctx.db
+    .query('downtime')
+    .withIndex('by_game', (q) => q.eq('gameId', gameId))
+    .unique()
+}
+
+async function ensureState(ctx: MutationCtx, gameId: Id<'games'>): Promise<Doc<'downtime'>> {
+  const existing = await readState(ctx, gameId)
+  if (existing !== null) return existing
+
+  const id = await ctx.db.insert('downtime', {
+    gameId,
+    stepIndex: null,
+    startedAt: null,
+    completedBy: [],
+    upkeepSpent: false,
+  })
+  const created = await ctx.db.get(id)
+  if (created === null) throw new Error('Failed to create downtime state')
+  return created
+}
+
+/** The table's current Downtime, plus who has finished the current step. */
+export const state = query({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args) => {
+    await requireMember(ctx, args.gameId)
+    const row = await readState(ctx, args.gameId)
+
+    // Not-running is a state, so report it rather than returning null and
+    // making every caller invent the same default.
+    if (row === null) {
+      return { running: false, stepIndex: null, completedBy: [], upkeepSpent: false }
+    }
+
+    const names: Array<{ userId: Id<'users'>; displayName: string }> = []
+    for (const userId of row.completedBy) {
+      const user = await ctx.db.get(userId)
+      names.push({ userId, displayName: user?.displayName ?? user?.name ?? 'Crewmate' })
+    }
+
+    return {
+      running: row.stepIndex !== null,
+      stepIndex: row.stepIndex,
+      startedAt: row.startedAt,
+      completedBy: names,
+      upkeepSpent: row.upkeepSpent,
+    }
+  },
+})
+
+/** Begin a Downtime. Mediator only — this is a table-wide phase change. */
+export const begin = mutation({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args): Promise<void> => {
+    await requireMediator(ctx, args.gameId)
+    const row = await ensureState(ctx, args.gameId)
+
+    // A fresh Downtime is the only thing that clears upkeep. Advancing a step
+    // must not, or the crew would be charged again mid-procedure.
+    await ctx.db.patch(row._id, {
+      stepIndex: 0,
+      startedAt: Date.now(),
+      completedBy: [],
+      upkeepSpent: false,
+    })
+  },
+})
+
+/** Move the whole table to the next step. */
+export const advance = mutation({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args): Promise<void> => {
+    await requireMediator(ctx, args.gameId)
+    const row = await readState(ctx, args.gameId)
+    if (row === null || row.stepIndex === null) {
+      throw new NotAuthorized('Downtime is not running')
+    }
+
+    await ctx.db.patch(row._id, {
+      stepIndex: row.stepIndex + 1,
+      // Per step, not cumulative — see the module header.
+      completedBy: [],
+    })
+  },
+})
+
+/** End the Downtime. */
+export const end = mutation({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args): Promise<void> => {
+    await requireMediator(ctx, args.gameId)
+    const row = await readState(ctx, args.gameId)
+    if (row === null) return
+    await ctx.db.patch(row._id, { stepIndex: null, startedAt: null, completedBy: [] })
+  },
+})
+
+/**
+ * Mark yourself done with the current step.
+ *
+ * Any member, for themselves only — a Mediator cannot tick a player off, which
+ * would be the same overreach as writing their sheet. Idempotent, so a
+ * double-tap does not add a duplicate.
+ */
+export const markStepDone = mutation({
+  args: { gameId: v.id('games'), done: v.boolean() },
+  handler: async (ctx, args): Promise<void> => {
+    const membership = await requireMember(ctx, args.gameId)
+    const row = await readState(ctx, args.gameId)
+    if (row === null || row.stepIndex === null) {
+      throw new NotAuthorized('Downtime is not running')
+    }
+
+    const without = row.completedBy.filter((id) => id !== membership.userId)
+    await ctx.db.patch(row._id, {
+      completedBy: args.done ? [...without, membership.userId] : without,
+    })
+  },
+})
+
+/**
+ * Record that the crew has paid crawler upkeep this Downtime.
+ *
+ * Returns false when it was already spent rather than throwing: two players
+ * pressing the button at the same moment is an ordinary race at a table, not an
+ * error to show anybody. The caller uses the result to decide whether to also
+ * deduct the scrap.
+ */
+export const spendUpkeep = mutation({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args): Promise<boolean> => {
+    await requireMember(ctx, args.gameId)
+    const row = await readState(ctx, args.gameId)
+    if (row === null || row.stepIndex === null) {
+      throw new NotAuthorized('Downtime is not running')
+    }
+    if (row.upkeepSpent) return false
+
+    await ctx.db.patch(row._id, { upkeepSpent: true })
+    return true
+  },
+})

--- a/apps/itun/convex/entities.ts
+++ b/apps/itun/convex/entities.ts
@@ -145,6 +145,8 @@ export const create = mutation({
   args: {
     table: OWNABLE,
     gameId: v.union(v.id('games'), v.null()),
+    /** The local UUID this row mirrors, so later edits can address it. */
+    appId: v.optional(v.string()),
     body: v.any(),
   },
   handler: async (ctx, args): Promise<Id<'pilots'> | Id<'mechs'>> => {
@@ -155,6 +157,7 @@ export const create = mutation({
     return await ctx.db.insert(args.table, {
       gameId: args.gameId,
       ownerId: userId,
+      appId: args.appId,
       body,
       updatedAt: Date.now(),
     })
@@ -268,5 +271,73 @@ export const claimLocal = mutation({
     }
 
     return { claimed, skipped }
+  },
+})
+
+/**
+ * Look a row up by the app-level UUID the client holds.
+ *
+ * This is the whole point of the `appId` column: a client that only knows its
+ * local UUID can still address the server row, so updates and deletes work
+ * without a mapping table. One indexed lookup, not a scan.
+ */
+async function byAppId(
+  ctx: MutationCtx,
+  table: OwnableTable,
+  appId: string
+): Promise<Doc<'pilots'> | Doc<'mechs'> | null> {
+  return (await ctx.db
+    .query(table)
+    .withIndex('by_app_id', (q) => q.eq('appId', appId))
+    .unique()) as Doc<'pilots'> | Doc<'mechs'> | null
+}
+
+/**
+ * Mirror a local write to the server of record, addressed by app id.
+ *
+ * Upsert rather than update: the row may not exist yet if the entity was
+ * created while Solo and the account was claimed afterwards. Treating a missing
+ * row as "create it" is what makes the mirror converge instead of silently
+ * dropping the first edit after a claim.
+ */
+export const upsertByAppId = mutation({
+  args: {
+    table: OWNABLE,
+    appId: v.string(),
+    gameId: v.union(v.id('games'), v.null()),
+    body: v.any(),
+  },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    await assertGameMemberOrShelfOwner(ctx, args.gameId, userId)
+    const body = parseBody(args.table, args.body)
+
+    const existing = await byAppId(ctx, args.table, args.appId)
+    if (existing === null) {
+      await ctx.db.insert(args.table, {
+        gameId: args.gameId,
+        ownerId: userId,
+        appId: args.appId,
+        body,
+        updatedAt: Date.now(),
+      })
+      return
+    }
+
+    assertMayWrite(existing, userId)
+    await ctx.db.patch(existing._id, { body, updatedAt: Date.now() })
+  },
+})
+
+/** Delete by app id. A row that is already gone is not an error. */
+export const removeByAppId = mutation({
+  args: { table: OWNABLE, appId: v.string() },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    const existing = await byAppId(ctx, args.table, args.appId)
+    if (existing === null) return
+
+    assertMayWrite(existing, userId)
+    await ctx.db.delete(existing._id)
   },
 })

--- a/apps/itun/convex/entities.ts
+++ b/apps/itun/convex/entities.ts
@@ -243,12 +243,24 @@ export const claimLocal = mutation({
   args: {
     pilots: v.array(v.any()),
     mechs: v.array(v.any()),
+    crawlers: v.optional(v.array(v.any())),
+    softLinks: v.optional(v.array(v.any())),
+    mechPatterns: v.optional(v.array(v.any())),
   },
-  handler: async (ctx, args): Promise<{ claimed: number; skipped: number }> => {
+  handler: async (
+    ctx,
+    args
+  ): Promise<{ claimed: number; skipped: number; byKind: Record<string, number> }> => {
     const userId = await requireUser(ctx)
     const now = Date.now()
     let claimed = 0
     let skipped = 0
+    const byKind: Record<string, number> = {}
+
+    const bump = (kind: string) => {
+      byKind[kind] = (byKind[kind] ?? 0) + 1
+      claimed += 1
+    }
 
     for (const [table, rows] of [
       ['pilots', args.pilots],
@@ -260,17 +272,98 @@ export const claimLocal = mutation({
           skipped += 1
           continue
         }
+        const appId =
+          typeof (body as { id?: unknown }).id === 'string'
+            ? (body as { id: string }).id
+            : undefined
         await ctx.db.insert(table, {
           gameId: null,
           ownerId: userId,
+          appId,
           body: parsed.data,
           updatedAt: now,
         })
-        claimed += 1
+        bump(table)
       }
     }
 
-    return { claimed, skipped }
+    /**
+     * Crawlers, soft links and patterns are claimed too.
+     *
+     * The first version of this mutation took only pilots and mechs, which
+     * silently dropped the crawler — the crew's HOME — along with every
+     * pilot-to-crawler and mech-to-pilot link that makes a roster a roster, and
+     * every saved pattern. Somebody claiming a long-running solo campaign would
+     * have watched half of it vanish with no error.
+     *
+     * A crawler has no owner column (it is communal, D8) and no Game yet, so a
+     * claimed one is parked on a **placeholder Game of one** rather than
+     * discarded: the shelf cannot hold it, and inventing a crawler-shaped shelf
+     * would be a third container the model does not have.
+     */
+    const crawlers = args.crawlers ?? []
+    let shelfGameId: Id<'games'> | null = null
+    if (crawlers.length > 0) {
+      shelfGameId = await ctx.db.insert('games', { name: 'Claimed crawler' })
+      await ctx.db.insert('memberships', {
+        gameId: shelfGameId,
+        userId,
+        mediator: false,
+        organizer: true,
+        joinedAt: now,
+      })
+    }
+    for (const body of crawlers) {
+      const parsed = CrawlerSchema.safeParse(body)
+      if (!parsed.success || shelfGameId === null) {
+        skipped += 1
+        continue
+      }
+      const appId =
+        typeof (body as { id?: unknown }).id === 'string' ? (body as { id: string }).id : undefined
+      await ctx.db.insert('crawlers', {
+        gameId: shelfGameId,
+        appId,
+        body: parsed.data,
+        updatedAt: now,
+      })
+      bump('crawlers')
+    }
+
+    for (const link of args.softLinks ?? []) {
+      const l = link as {
+        from?: { type?: string; id?: string }
+        to?: { type?: string; id?: string }
+        type?: string
+      }
+      if (
+        typeof l.from?.id !== 'string' ||
+        typeof l.to?.id !== 'string' ||
+        typeof l.type !== 'string'
+      ) {
+        skipped += 1
+        continue
+      }
+      await ctx.db.insert('softLinks', {
+        gameId: shelfGameId,
+        from: { type: String(l.from.type ?? ''), id: l.from.id },
+        to: { type: String(l.to.type ?? ''), id: l.to.id },
+        type: l.type,
+      })
+      bump('softLinks')
+    }
+
+    for (const body of args.mechPatterns ?? []) {
+      await ctx.db.insert('mechPatterns', {
+        ownerId: userId,
+        gameId: null,
+        sharedToGame: false,
+        body,
+      })
+      bump('mechPatterns')
+    }
+
+    return { claimed, skipped, byKind }
   },
 })
 

--- a/apps/itun/convex/entities.ts
+++ b/apps/itun/convex/entities.ts
@@ -1,0 +1,272 @@
+import { v } from 'convex/values'
+
+import { CrawlerSchema } from '../src/lib/schemas/crawler'
+import { MechSchema } from '../src/lib/schemas/mech'
+import { PilotSchema } from '../src/lib/schemas/pilot'
+import type { Doc, Id } from './_generated/dataModel'
+import { mutation, query } from './_generated/server'
+import type { MutationCtx, QueryCtx } from './_generated/server'
+import { NotAuthorized, getMembership, requireMember, requireUser } from './model/permissions'
+
+/**
+ * Entity reads and writes against the server of record (ADR-030 §1).
+ *
+ * ## Every write Zod-parses before it persists
+ *
+ * The schema stores entity bodies as `v.any()` so the Zod schemas in
+ * `src/lib/schemas/` stay the single source of truth rather than being forked
+ * into a second, hand-maintained set of Convex validators. The price of that is
+ * stated plainly in the schema header: **Convex cannot reject a malformed body,
+ * so the mutation has to.** These functions are where that obligation is paid.
+ *
+ * ## What you may read, and what you may write
+ *
+ * Reading is per-Game: any member sees every pilot and mech in it, which is
+ * what makes crew vitals and read-only drill-in possible (D12).
+ *
+ * Writing is per-*entity*: only the owner writes their own pilot, and nobody
+ * writes a crewmate's. A Mediator wanting to change someone else's sheet goes
+ * through a proposal (D7), not through here — there is deliberately no
+ * privileged write path in this module.
+ *
+ * The crawler is the exception on both axes, because it is communal (D8): any
+ * member may write it, resolved by field-level merge rather than
+ * last-write-wins, since the scrap pool and cargo lots are genuinely contended
+ * during Downtime.
+ */
+
+const OWNABLE = v.union(v.literal('pilots'), v.literal('mechs'))
+type OwnableTable = 'pilots' | 'mechs'
+
+const PARSERS = {
+  pilots: PilotSchema,
+  mechs: MechSchema,
+} as const
+
+/** Parse a body against its Zod schema, or throw with a legible reason. */
+function parseBody(table: OwnableTable, body: unknown): unknown {
+  const result = PARSERS[table].safeParse(body)
+  if (!result.success) {
+    throw new Error(`Invalid ${table} payload: ${result.error.issues[0]?.message ?? 'unknown'}`)
+  }
+  return result.data
+}
+
+/**
+ * Who may write an entity.
+ *
+ * Synchronous and ctx-free on purpose: the answer depends only on the row's
+ * own `ownerId`. There is deliberately no lookup that could grant a Mediator a
+ * privileged write here — changing someone else's sheet goes through a
+ * proposal (D7), and giving this function a ctx would invite exactly that.
+ */
+function assertMayWrite(doc: Doc<'pilots'> | Doc<'mechs'>, userId: Id<'users'>): void {
+  if (doc.ownerId === userId) return
+  if (doc.ownerId === null) {
+    throw new NotAuthorized(
+      'That entity is unclaimed — it must be assigned before it can be edited'
+    )
+  }
+  throw new NotAuthorized("You cannot edit another player's entity")
+}
+
+async function assertGameMemberOrShelfOwner(
+  ctx: QueryCtx | MutationCtx,
+  gameId: Id<'games'> | null,
+  userId: Id<'users'>
+): Promise<void> {
+  if (gameId === null) return
+  const membership = await getMembership(ctx, gameId, userId)
+  if (membership === null) throw new NotAuthorized('Not a member of this game')
+}
+
+/** Everything in a Game the caller can see: all pilots and mechs, plus the crawler. */
+export const listForGame = query({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args) => {
+    await requireMember(ctx, args.gameId)
+
+    const [pilots, mechs, crawlers, softLinks] = await Promise.all([
+      ctx.db
+        .query('pilots')
+        .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+        .collect(),
+      ctx.db
+        .query('mechs')
+        .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+        .collect(),
+      ctx.db
+        .query('crawlers')
+        .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+        .collect(),
+      ctx.db
+        .query('softLinks')
+        .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+        .collect(),
+    ])
+
+    return {
+      pilots: pilots.map((p) => ({ _id: p._id, ownerId: p.ownerId, body: p.body })),
+      mechs: mechs.map((m) => ({ _id: m._id, ownerId: m.ownerId, body: m.body })),
+      crawlers: crawlers.map((c) => ({ _id: c._id, body: c.body })),
+      softLinks: softLinks.map((l) => ({ _id: l._id, from: l.from, to: l.to, type: l.type })),
+    }
+  },
+})
+
+/** The caller's own shelf — entities that belong to them and to no Game. */
+export const listShelf = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await requireUser(ctx)
+
+    const pilots = (
+      await ctx.db
+        .query('pilots')
+        .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+        .collect()
+    ).filter((p) => p.gameId === null)
+    const mechs = (
+      await ctx.db
+        .query('mechs')
+        .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+        .collect()
+    ).filter((m) => m.gameId === null)
+
+    return {
+      pilots: pilots.map((p) => ({ _id: p._id, body: p.body })),
+      mechs: mechs.map((m) => ({ _id: m._id, body: m.body })),
+    }
+  },
+})
+
+/** Create an entity, on the caller's shelf or in a Game they belong to. */
+export const create = mutation({
+  args: {
+    table: OWNABLE,
+    gameId: v.union(v.id('games'), v.null()),
+    body: v.any(),
+  },
+  handler: async (ctx, args): Promise<Id<'pilots'> | Id<'mechs'>> => {
+    const userId = await requireUser(ctx)
+    await assertGameMemberOrShelfOwner(ctx, args.gameId, userId)
+    const body = parseBody(args.table, args.body)
+
+    return await ctx.db.insert(args.table, {
+      gameId: args.gameId,
+      ownerId: userId,
+      body,
+      updatedAt: Date.now(),
+    })
+  },
+})
+
+/** Replace an entity's body. Owner only — see the module header. */
+export const update = mutation({
+  args: {
+    table: OWNABLE,
+    entityId: v.string(),
+    body: v.any(),
+  },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    const doc = await ctx.db.get(args.entityId as Id<'pilots'> | Id<'mechs'>)
+    if (doc === null) throw new Error('That entity no longer exists')
+
+    assertMayWrite(doc as Doc<'pilots'> | Doc<'mechs'>, userId)
+    const body = parseBody(args.table, args.body)
+
+    await ctx.db.patch(doc._id, { body, updatedAt: Date.now() })
+  },
+})
+
+export const remove = mutation({
+  args: { table: OWNABLE, entityId: v.string() },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    const doc = await ctx.db.get(args.entityId as Id<'pilots'> | Id<'mechs'>)
+    if (doc === null) return
+
+    assertMayWrite(doc as Doc<'pilots'> | Doc<'mechs'>, userId)
+    await ctx.db.delete(doc._id)
+  },
+})
+
+/**
+ * Write the communal crawler with a **field-level merge** (D19).
+ *
+ * Last-write-wins would be wrong here in a way that shows up on exactly the
+ * night it matters: during Downtime the whole crew touches the crawler within
+ * the same few minutes, and a full-body write would silently discard whichever
+ * member happened to lose the race. Merging per top-level field means two
+ * people editing different things both succeed, and only a genuine same-field
+ * collision contends.
+ */
+export const patchCrawler = mutation({
+  args: {
+    crawlerId: v.id('crawlers'),
+    patch: v.any(),
+  },
+  handler: async (ctx, args): Promise<void> => {
+    const doc = await ctx.db.get(args.crawlerId)
+    if (doc === null) throw new Error('That crawler no longer exists')
+
+    // Communal: membership is the whole check. No ownerId to consult.
+    await requireMember(ctx, doc.gameId)
+
+    const merged = { ...(doc.body as Record<string, unknown>), ...(args.patch as object) }
+    const result = CrawlerSchema.safeParse(merged)
+    if (!result.success) {
+      throw new Error(`Invalid crawler payload: ${result.error.issues[0]?.message ?? 'unknown'}`)
+    }
+
+    await ctx.db.patch(args.crawlerId, { body: result.data, updatedAt: Date.now() })
+  },
+})
+
+/**
+ * Upload local entities into this account on first sign-in (D11).
+ *
+ * Everything lands on the **shelf**, never straight into a Game. A person
+ * signing in for the first time has local builds with no relationship to any
+ * crew, and guessing one would be worse than making them place it deliberately.
+ *
+ * Bodies are Zod-parsed like any other write, and a row that fails is **skipped
+ * rather than aborting the claim**. A single corrupt local record should not
+ * cost somebody their whole roster — the count of skipped rows comes back so
+ * the UI can say what did not make it.
+ */
+export const claimLocal = mutation({
+  args: {
+    pilots: v.array(v.any()),
+    mechs: v.array(v.any()),
+  },
+  handler: async (ctx, args): Promise<{ claimed: number; skipped: number }> => {
+    const userId = await requireUser(ctx)
+    const now = Date.now()
+    let claimed = 0
+    let skipped = 0
+
+    for (const [table, rows] of [
+      ['pilots', args.pilots],
+      ['mechs', args.mechs],
+    ] as const) {
+      for (const body of rows) {
+        const parsed = PARSERS[table].safeParse(body)
+        if (!parsed.success) {
+          skipped += 1
+          continue
+        }
+        await ctx.db.insert(table, {
+          gameId: null,
+          ownerId: userId,
+          body: parsed.data,
+          updatedAt: now,
+        })
+        claimed += 1
+      }
+    }
+
+    return { claimed, skipped }
+  },
+})

--- a/apps/itun/convex/mediator.ts
+++ b/apps/itun/convex/mediator.ts
@@ -1,0 +1,151 @@
+import { v } from 'convex/values'
+
+import { mutation, query } from './_generated/server'
+import type { Id } from './_generated/dataModel'
+import { requireMediator, requireMember, requireUser } from './model/permissions'
+
+/**
+ * The Mediator surface's server layer (ADR-030 §6, Phase 3).
+ *
+ * ## The NPC tray is the one genuinely secret thing
+ *
+ * Everything else in a Game is readable by every member — that is what makes a
+ * crew a crew. Prepared opposition is the exception, and it is the *only*
+ * exception, so these queries gate on `requireMediator` rather than
+ * `requireMember`. A player who can read the NPC tray can read the encounter
+ * before it happens, which is the one leak that changes how the game is played
+ * rather than merely who can edit what.
+ *
+ * ## Presence is deliberately not a subscription to everything
+ *
+ * "Who is at the table right now" is a heartbeat, not a stream of activity.
+ * Storing a `lastSeen` and letting readers decide what counts as present keeps
+ * it cheap and avoids inventing an online/offline state the app would then have
+ * to keep truthful.
+ */
+
+/** How long since a heartbeat before somebody stops counting as at the table. */
+export const PRESENCE_WINDOW_MS = 90_000
+
+/** The Mediator's prepared opposition. Mediator-only, by design. */
+export const npcs = query({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args) => {
+    await requireMediator(ctx, args.gameId)
+    const rows = await ctx.db
+      .query('encounterNpcs')
+      .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+      .collect()
+    return rows.map((r) => ({ _id: r._id, body: r.body }))
+  },
+})
+
+export const addNpc = mutation({
+  args: { gameId: v.id('games'), body: v.any() },
+  handler: async (ctx, args): Promise<Id<'encounterNpcs'>> => {
+    await requireMediator(ctx, args.gameId)
+    return await ctx.db.insert('encounterNpcs', { gameId: args.gameId, body: args.body })
+  },
+})
+
+export const updateNpc = mutation({
+  args: { npcId: v.id('encounterNpcs'), body: v.any() },
+  handler: async (ctx, args): Promise<void> => {
+    const doc = await ctx.db.get(args.npcId)
+    if (doc === null) return
+    await requireMediator(ctx, doc.gameId)
+    await ctx.db.patch(args.npcId, { body: args.body })
+  },
+})
+
+export const removeNpc = mutation({
+  args: { npcId: v.id('encounterNpcs') },
+  handler: async (ctx, args): Promise<void> => {
+    const doc = await ctx.db.get(args.npcId)
+    if (doc === null) return
+    await requireMediator(ctx, doc.gameId)
+    await ctx.db.delete(args.npcId)
+  },
+})
+
+/**
+ * Record that the caller is at the table.
+ *
+ * Upserts one row per (game, member) rather than appending, so presence cannot
+ * grow without bound during a long session. Any member may heartbeat — presence
+ * is not privileged information, and a Mediator needs to see players arrive
+ * exactly as much as players need to see each other.
+ */
+export const heartbeat = mutation({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args): Promise<void> => {
+    const membership = await requireMember(ctx, args.gameId)
+    const existing = await ctx.db
+      .query('presence')
+      .withIndex('by_game_user', (q) => q.eq('gameId', args.gameId).eq('userId', membership.userId))
+      .unique()
+
+    if (existing === null) {
+      await ctx.db.insert('presence', {
+        gameId: args.gameId,
+        userId: membership.userId,
+        lastSeen: Date.now(),
+      })
+      return
+    }
+    await ctx.db.patch(existing._id, { lastSeen: Date.now() })
+  },
+})
+
+/**
+ * Who is at the table.
+ *
+ * `present` is computed at read time from `lastSeen` rather than stored. A
+ * stored boolean would need something to turn it off — a timer, a disconnect
+ * hook — and every one of those can fail in a way that leaves somebody
+ * permanently "present" long after they closed the tab.
+ */
+export const presence = query({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args) => {
+    await requireMember(ctx, args.gameId)
+    const now = Date.now()
+
+    const rows = await ctx.db
+      .query('presence')
+      .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+      .collect()
+
+    return await Promise.all(
+      rows.map(async (r) => {
+        const user = await ctx.db.get(r.userId)
+        return {
+          userId: r.userId,
+          displayName: user?.displayName ?? user?.name ?? 'Crewmate',
+          lastSeen: r.lastSeen,
+          present: now - r.lastSeen < PRESENCE_WINDOW_MS,
+        }
+      })
+    )
+  },
+})
+
+/**
+ * Whether the caller mediates this Game.
+ *
+ * A plain query rather than something derived client-side from the roster, so
+ * a surface can gate itself on one authoritative answer instead of
+ * reconstructing the rule. Returns false rather than throwing for a
+ * non-member — "can I mediate this" is a reasonable question for anyone to ask.
+ */
+export const amMediator = query({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args): Promise<boolean> => {
+    const userId = await requireUser(ctx)
+    const membership = await ctx.db
+      .query('memberships')
+      .withIndex('by_game_user', (q) => q.eq('gameId', args.gameId).eq('userId', userId))
+      .unique()
+    return membership?.mediator ?? false
+  },
+})

--- a/apps/itun/convex/proposals.ts
+++ b/apps/itun/convex/proposals.ts
@@ -1,0 +1,227 @@
+import { v } from 'convex/values'
+
+import type { Doc, Id } from './_generated/dataModel'
+import { mutation, query } from './_generated/server'
+import type { MutationCtx } from './_generated/server'
+import { NotAuthorized, requireMediator, requireMember, requireUser } from './model/permissions'
+
+/**
+ * Proposals and alerts (ADR-030 §4, Phase 4).
+ *
+ * This is the mechanism that lets a Mediator reach a player's sheet without
+ * ever writing it. They push a **proposal**; the player applies or declines it.
+ *
+ * ## Alerts and cross-player writes are one system, not two
+ *
+ * Both are rows in the Change Log. A proposal is an entry in `proposed` state
+ * carrying `before`/`after` for one field; an alert is the same row with no
+ * entity target. That is the payoff for ADR-022 having built the log
+ * append-only, ordered and replay-shaped before any of this existed — there was
+ * no second bus to design.
+ *
+ * ## Three rules the tests pin
+ *
+ *  - **Nothing expires.** An unanswered proposal stays `proposed` forever. A
+ *    timer would silently drop damage a player was meant to take, which is the
+ *    exact bookkeeping error the feature exists to prevent.
+ *  - **Nothing is force-applied.** There is no mutation here that writes an
+ *    entity on the player's behalf. Adding one would collapse
+ *    propose-and-confirm back into the direct write ADR-030 rejects.
+ *  - **Newer supersedes older, per field.** A second proposal against the same
+ *    `(entityId, field)` retires the first, so a player never faces two
+ *    contradictory pending changes to one value.
+ */
+
+/** Only the Mediator proposes; only the target's owner answers. */
+async function requireProposalTarget(
+  ctx: MutationCtx,
+  entityId: string
+): Promise<{ doc: Doc<'pilots'> | Doc<'mechs'>; gameId: Id<'games'> }> {
+  const doc = (await ctx.db.get(entityId as Id<'pilots'> | Id<'mechs'>)) as
+    | Doc<'pilots'>
+    | Doc<'mechs'>
+    | null
+  if (doc === null) throw new Error('That entity no longer exists')
+  if (doc.gameId === null) {
+    throw new NotAuthorized('An entity on a shelf is not part of a game and cannot be proposed to')
+  }
+  return { doc, gameId: doc.gameId }
+}
+
+/**
+ * Propose a change to one field of a player's entity.
+ *
+ * `before` is captured from the Mediator's view at propose time and is shown to
+ * the player alongside `after`, so they can see what the Mediator believed the
+ * value was. It is deliberately not re-read at apply time: a mismatch is
+ * information the player should see, not something to paper over.
+ */
+export const propose = mutation({
+  args: {
+    entityId: v.string(),
+    entityType: v.union(v.literal('pilot'), v.literal('mech')),
+    field: v.string(),
+    before: v.any(),
+    after: v.any(),
+  },
+  handler: async (ctx, args): Promise<Id<'changeLog'>> => {
+    const { doc, gameId } = await requireProposalTarget(ctx, args.entityId)
+    const membership = await requireMediator(ctx, gameId)
+
+    if (doc.ownerId === null) {
+      throw new NotAuthorized('That entity is unclaimed — assign it before proposing changes')
+    }
+
+    // Supersede any live proposal against the same field, so the player is
+    // never asked to choose between two contradictory pending values.
+    const live = await ctx.db
+      .query('changeLog')
+      .withIndex('by_entity', (q) => q.eq('entityId', args.entityId))
+      .collect()
+
+    const proposalId = await ctx.db.insert('changeLog', {
+      gameId,
+      entityType: args.entityType,
+      entityId: args.entityId,
+      ts: Date.now(),
+      kind: 'transaction',
+      field: args.field,
+      before: args.before,
+      after: args.after,
+      source: 'mediator-proposal',
+      actorId: membership.userId,
+      state: 'proposed',
+    })
+
+    for (const row of live) {
+      if (row.state === 'proposed' && row.field === args.field && row._id !== proposalId) {
+        await ctx.db.patch(row._id, { state: 'superseded', supersededBy: proposalId })
+      }
+    }
+
+    return proposalId
+  },
+})
+
+/** Proposals awaiting this player's answer, newest first. */
+export const pending = query({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args) => {
+    await requireMember(ctx, args.gameId)
+    const userId = await requireUser(ctx)
+
+    const rows = await ctx.db
+      .query('changeLog')
+      .withIndex('by_game_state', (q) => q.eq('gameId', args.gameId).eq('state', 'proposed'))
+      .collect()
+
+    const mine = []
+    for (const row of rows) {
+      const target = (await ctx.db.get(row.entityId as Id<'pilots'> | Id<'mechs'>)) as
+        | Doc<'pilots'>
+        | Doc<'mechs'>
+        | null
+      // Only the owner is asked. A proposal against somebody else's entity is
+      // not this player's to answer, and showing it would leak an edit in
+      // flight.
+      if (target === null || target.ownerId !== userId) continue
+      mine.push({
+        _id: row._id,
+        entityId: row.entityId,
+        entityType: row.entityType,
+        field: row.field,
+        before: row.before,
+        after: row.after,
+        ts: row.ts,
+      })
+    }
+    return mine.sort((a, b) => b.ts - a.ts)
+  },
+})
+
+/**
+ * Apply a proposal to your own entity.
+ *
+ * The **player** performs the write — that is the whole point. The mutation
+ * refuses if the caller is not the owner, so "apply" can never become a path
+ * by which somebody else's confirmation moves your numbers.
+ */
+export const apply = mutation({
+  args: { proposalId: v.id('changeLog') },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    const proposal = await ctx.db.get(args.proposalId)
+    if (proposal === null) throw new Error('That proposal no longer exists')
+    if (proposal.state !== 'proposed') throw new Error('That proposal has already been answered')
+
+    const { doc } = await requireProposalTarget(ctx, proposal.entityId)
+    if (doc.ownerId !== userId) throw new NotAuthorized('Only the owner can apply this')
+
+    const body = { ...(doc.body as Record<string, unknown>), [proposal.field]: proposal.after }
+    await ctx.db.patch(doc._id, { body, updatedAt: Date.now() })
+    await ctx.db.patch(args.proposalId, { state: 'applied' })
+  },
+})
+
+/** Decline a proposal. Recorded, not deleted — the log is append-only. */
+export const decline = mutation({
+  args: { proposalId: v.id('changeLog') },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    const proposal = await ctx.db.get(args.proposalId)
+    if (proposal === null) return
+    if (proposal.state !== 'proposed') return
+
+    const { doc } = await requireProposalTarget(ctx, proposal.entityId)
+    if (doc.ownerId !== userId) throw new NotAuthorized('Only the owner can decline this')
+
+    await ctx.db.patch(args.proposalId, { state: 'declined' })
+  },
+})
+
+/**
+ * Broadcast a table-wide alert.
+ *
+ * The same log row with no entity target — which is why alerts needed no
+ * separate bus. Any member reads them; only the Mediator sends.
+ */
+export const broadcast = mutation({
+  args: { gameId: v.id('games'), message: v.string() },
+  handler: async (ctx, args): Promise<void> => {
+    const membership = await requireMediator(ctx, args.gameId)
+    const message = args.message.trim()
+    if (message.length === 0) throw new Error('An alert needs a message')
+
+    await ctx.db.insert('changeLog', {
+      gameId: args.gameId,
+      entityType: 'game',
+      entityId: args.gameId,
+      ts: Date.now(),
+      kind: 'transaction',
+      field: 'alert',
+      before: null,
+      after: message,
+      source: 'mediator-alert',
+      actorId: membership.userId,
+      state: 'applied',
+    })
+  },
+})
+
+/** Table-wide alerts, newest first. */
+export const alerts = query({
+  args: { gameId: v.id('games'), limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    await requireMember(ctx, args.gameId)
+    const rows = await ctx.db
+      .query('changeLog')
+      .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+      .collect()
+
+    return rows
+      .filter((r) => r.field === 'alert')
+      .sort((a, b) => b.ts - a.ts)
+      .slice(0, args.limit ?? 20)
+      .map((r) => ({ _id: r._id, message: String(r.after), ts: r.ts, actorId: r.actorId }))
+  },
+})

--- a/apps/itun/convex/schema.ts
+++ b/apps/itun/convex/schema.ts
@@ -229,6 +229,32 @@ export default defineSchema({
     .index('by_game', ['gameId'])
     .index('by_game_state', ['gameId', 'state']),
 
+  /**
+   * Crew-wide Downtime state (ADR-030, Phase 5).
+   *
+   * Downtime is the one procedure the whole crew performs in step, so the phase
+   * is **Game state advanced by the Mediator** rather than something each
+   * player tracks alone. Per-player step completion lives here too, so the
+   * table can see who is still working.
+   *
+   * One row per Game. `stepIndex: null` means Downtime is not running — which
+   * is a state, not an absence, and is why this is not simply the row's absence.
+   */
+  downtime: defineTable({
+    gameId: v.id('games'),
+    /** Null when Downtime is not running. */
+    stepIndex: v.union(v.number(), v.null()),
+    startedAt: v.union(v.number(), v.null()),
+    /**
+     * Which members have marked the current step done. Cleared whenever the
+     * phase advances — completion is per step, not cumulative, or a player who
+     * finished step 1 would look finished forever.
+     */
+    completedBy: v.array(v.id('users')),
+    /** Set once per Downtime so crawler upkeep is spent once, not per member. */
+    upkeepSpent: v.boolean(),
+  }).index('by_game', ['gameId']),
+
   /** Who is at the table right now. Ephemeral — never folded into an entity. */
   presence: defineTable({
     gameId: v.id('games'),

--- a/apps/itun/convex/schema.ts
+++ b/apps/itun/convex/schema.ts
@@ -42,6 +42,12 @@ export default defineSchema({
     image: v.optional(v.string()),
     emailVerificationTime: v.optional(v.number()),
     isAnonymous: v.optional(v.boolean()),
+    // Carried over from `authTables.users` even though Discord is the only
+    // provider: overriding that table means anything the library expects to
+    // find has to be redeclared here, and a missing field would surface as a
+    // write failure inside the auth flow rather than as a type error.
+    phone: v.optional(v.string()),
+    phoneVerificationTime: v.optional(v.number()),
 
     /** Discord snowflake, once linked. The only third-party identifier stored. */
     discordId: v.optional(v.string()),
@@ -55,6 +61,7 @@ export default defineSchema({
     avatarUrl: v.optional(v.string()),
   })
     .index('email', ['email'])
+    .index('phone', ['phone'])
     .index('by_discord', ['discordId']),
 
   /**

--- a/apps/itun/convex/schema.ts
+++ b/apps/itun/convex/schema.ts
@@ -230,6 +230,27 @@ export default defineSchema({
     .index('by_game_state', ['gameId', 'state']),
 
   /**
+   * Which Discord channel a Game is bound to (ADR-030, Phase 6).
+   *
+   * The bot authenticates as a **participant**, not an admin — the whole point
+   * of closing the old #165 differently. A binding says "rolls in this channel
+   * belong to this Game", and the actor is resolved from the Discord user id
+   * against `users.discordId`, so the bot can never act as somebody who has not
+   * linked their account.
+   *
+   * One Game per channel: a channel that meant two Games would make every roll
+   * ambiguous.
+   */
+  channelBindings: defineTable({
+    gameId: v.id('games'),
+    channelId: v.string(),
+    boundBy: v.id('users'),
+    boundAt: v.number(),
+  })
+    .index('by_channel', ['channelId'])
+    .index('by_game', ['gameId']),
+
+  /**
    * Crew-wide Downtime state (ADR-030, Phase 5).
    *
    * Downtime is the one procedure the whole crew performs in step, so the phase

--- a/apps/itun/convex/schema.ts
+++ b/apps/itun/convex/schema.ts
@@ -110,20 +110,48 @@ export default defineSchema({
   pilots: defineTable({
     gameId: v.union(v.id('games'), v.null()),
     ownerId: v.union(v.id('users'), v.null()),
+    /**
+     * The app-level UUID this row mirrors (ADR-030 §1).
+     *
+     * Convex mints its own `_id`, so a client holding only the local UUID has
+     * nothing to address a row by — which is what made an earlier
+     * write-mirroring attempt unworkable for updates and deletes. Carrying the
+     * app id as an indexed column gives one cheap lookup per write instead of
+     * a mapping table, and keeps `_id` idiomatic for everything server-side.
+     *
+     * Optional because rows created server-side (Game templates) have no local
+     * counterpart until somebody claims them.
+     */
+    appId: v.optional(v.string()),
     body: v.any(),
     updatedAt: v.number(),
   })
     .index('by_game', ['gameId'])
-    .index('by_owner', ['ownerId']),
+    .index('by_owner', ['ownerId'])
+    .index('by_app_id', ['appId']),
 
   mechs: defineTable({
     gameId: v.union(v.id('games'), v.null()),
     ownerId: v.union(v.id('users'), v.null()),
+    /**
+     * The app-level UUID this row mirrors (ADR-030 §1).
+     *
+     * Convex mints its own `_id`, so a client holding only the local UUID has
+     * nothing to address a row by — which is what made an earlier
+     * write-mirroring attempt unworkable for updates and deletes. Carrying the
+     * app id as an indexed column gives one cheap lookup per write instead of
+     * a mapping table, and keeps `_id` idiomatic for everything server-side.
+     *
+     * Optional because rows created server-side (Game templates) have no local
+     * counterpart until somebody claims them.
+     */
+    appId: v.optional(v.string()),
     body: v.any(),
     updatedAt: v.number(),
   })
     .index('by_game', ['gameId'])
-    .index('by_owner', ['ownerId']),
+    .index('by_owner', ['ownerId'])
+    .index('by_app_id', ['appId']),
 
   /**
    * The crawler is communal (D8) — no `ownerId` at all, and any member of the
@@ -133,9 +161,13 @@ export default defineSchema({
    */
   crawlers: defineTable({
     gameId: v.id('games'),
+    /** See `pilots.appId` — same reason, same lookup path. */
+    appId: v.optional(v.string()),
     body: v.any(),
     updatedAt: v.number(),
-  }).index('by_game', ['gameId']),
+  })
+    .index('by_game', ['gameId'])
+    .index('by_app_id', ['appId']),
 
   /** 'mech-to-pilot' | 'pilot-to-crawler'. EntityRef is NOT widened (ADR-027). */
   softLinks: defineTable({

--- a/apps/itun/convex/schema.ts
+++ b/apps/itun/convex/schema.ts
@@ -221,7 +221,7 @@ export default defineSchema({
     source: v.string(),
     /** Who performed or proposed it. */
     actorId: v.union(v.id('users'), v.null()),
-    /** 'applied' | 'proposed' | 'rejected' | 'superseded'. */
+    /** 'applied' | 'proposed' | 'declined' | 'superseded'. */
     state: v.string(),
     supersededBy: v.optional(v.id('changeLog')),
   })

--- a/apps/itun/convex/templates.ts
+++ b/apps/itun/convex/templates.ts
@@ -1,0 +1,104 @@
+import { v } from 'convex/values'
+
+import {
+  STARTER_CRAWLERS,
+  STARTER_MECHS,
+  STARTER_PILOTS,
+  STARTER_SOFT_LINKS,
+} from '../src/lib/starterSet/starterSet'
+import type { Id } from './_generated/dataModel'
+import { mutation, query } from './_generated/server'
+import { requireUser } from './model/permissions'
+
+/**
+ * Game templates (ADR-030, D34).
+ *
+ * A template is a pre-built crew you can start a Game from. The rule that makes
+ * it more than seeded data: **its entities arrive unclaimed** (`ownerId: null`).
+ * The Mediator — or the Organizer, while a Game has no Mediator — hands them
+ * out as players join, which turns pre-generated characters from a curiosity
+ * into the onboarding path.
+ *
+ * The Starter Set data is imported straight from `src/lib/starterSet/`. That
+ * module is deliberately static plain data with no runtime reference-data
+ * resolution (see its header), so it bundles into a Convex function safely and
+ * there is exactly one copy of the roster rather than a server-side duplicate
+ * that would drift from the local one.
+ */
+
+const TEMPLATES = {
+  'starter-set': {
+    name: "Reclamation of the Wastes — Union Crawler #430 'Tenacity'",
+    description:
+      'The six pilots of the Salvage Union Starter Set, their mechs, and their crawler. Everyone arrives unclaimed for you to hand out.',
+  },
+} as const
+
+export type TemplateId = keyof typeof TEMPLATES
+
+/** The templates a Game can be started from. */
+export const list = query({
+  args: {},
+  handler: async () => {
+    return Object.entries(TEMPLATES).map(([id, t]) => ({
+      id,
+      name: t.name,
+      description: t.description,
+    }))
+  },
+})
+
+/**
+ * Create a Game pre-populated from a template.
+ *
+ * The creator becomes its Organizer and is seated as a Player, exactly as
+ * `games.create` does — a template changes what is *in* the Game, never who
+ * runs it. `mediator` starts false, so the Organizer fallback covers handing
+ * out the pre-gens until somebody is appointed.
+ */
+export const createGame = mutation({
+  args: {
+    templateId: v.literal('starter-set'),
+    name: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<Id<'games'>> => {
+    const userId = await requireUser(ctx)
+    const template = TEMPLATES[args.templateId]
+
+    const gameId = await ctx.db.insert('games', {
+      name: args.name?.trim() || template.name,
+      templateOrigin: args.templateId,
+    })
+    await ctx.db.insert('memberships', {
+      gameId,
+      userId,
+      mediator: false,
+      organizer: true,
+      joinedAt: Date.now(),
+    })
+
+    const now = Date.now()
+
+    // ownerId: null is the whole point — see the module header.
+    for (const pilot of STARTER_PILOTS) {
+      await ctx.db.insert('pilots', { gameId, ownerId: null, body: pilot, updatedAt: now })
+    }
+    for (const mech of STARTER_MECHS) {
+      await ctx.db.insert('mechs', { gameId, ownerId: null, body: mech, updatedAt: now })
+    }
+    // The crawler has no ownerId column at all: it is communal by design (D8).
+    for (const crawler of STARTER_CRAWLERS) {
+      await ctx.db.insert('crawlers', { gameId, body: crawler, updatedAt: now })
+    }
+    for (const link of STARTER_SOFT_LINKS) {
+      await ctx.db.insert('softLinks', {
+        gameId,
+        from: { type: link.from.type, id: link.from.id },
+        to: { type: link.to.type, id: link.to.id },
+        type: link.type,
+      })
+    }
+
+    return gameId
+  },
+})

--- a/apps/itun/netlify.toml
+++ b/apps/itun/netlify.toml
@@ -13,7 +13,19 @@
   # src/lib/observability.ts and src/vite-env.d.ts). SENTRY_AUTH_TOKEN /
   # SENTRY_ORG / SENTRY_PROJECT (set as Netlify site env vars, not here) turn
   # on sourcemap upload for that same release in vite.config.ts.
-  command = "bun install --frozen-lockfile && VITE_COMMIT_REF=\"$COMMIT_REF\" bun --filter itun build"
+  #
+  # When CONVEX_DEPLOY_KEY is present the Convex backend (schema + functions in
+  # apps/itun/convex) is pushed FIRST, and `--cmd` then runs the site build with
+  # VITE_CONVEX_URL set to the deployment that was just pushed to. Doing it in
+  # that order is what keeps the shipped client and the backend it talks to in
+  # agreement: a build that compiled against a URL whose schema had not been
+  # deployed yet would fail at runtime, not at build time.
+  #
+  # Without the key the build is byte-for-byte what it was before accounts —
+  # a plain Solo build (ADR-030 §1). That is the supported state for deploy
+  # previews and branch deploys, which have no Convex deployment of their own,
+  # and it means adding this step cannot break them.
+  command = 'bun install --frozen-lockfile && if [ -n "$CONVEX_DEPLOY_KEY" ]; then cd apps/itun && VITE_COMMIT_REF="$COMMIT_REF" bunx convex deploy --cmd-url-env-var-name VITE_CONVEX_URL --cmd "bun run build"; else VITE_COMMIT_REF="$COMMIT_REF" bun --filter itun build; fi'
   publish = "apps/itun/dist"
   functions = "apps/itun/netlify/functions"
   # Skip the build when nothing affecting ITUN changed since the last published
@@ -108,7 +120,22 @@
     # one region under a CSP written for the other is blocked in the browser and
     # the project reports nothing — identical, from the outside, to "no errors".
     # The nightly live probe now compares this against the DSN actually shipped.
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://storage.ko-fi.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://ingesteer.services-prod.nsvcs.net https://*.ingest.de.sentry.io;"
+    #
+    # The Convex entries are load-bearing for the same reason, and fail the same
+    # silent way. The accounts client (ADR-030) opens a WebSocket to the
+    # deployment for its reactive queries and POSTs mutations over HTTPS, and
+    # `@convex-dev/auth` exchanges tokens against the deployment's `.site`
+    # origin. Omit these and every one of those is blocked by the browser before
+    # it leaves the page: `VITE_CONVEX_URL` is set, the client constructs
+    # happily, the app reports itself Connected — and nothing ever reaches the
+    # server. Sign-in just never completes, with no error surface.
+    #
+    # Wildcarded per deployment name, like the Sentry host above, because the
+    # deployment differs by context: production is `exuberant-porpoise-183`,
+    # while a branch deploy or a local `convex dev` points somewhere else. A
+    # hardcoded host would work in production and silently break everywhere
+    # else. Both schemes are required — `wss:` does NOT inherit from `https:`.
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://storage.ko-fi.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://ingesteer.services-prod.nsvcs.net https://*.ingest.de.sentry.io https://*.convex.cloud wss://*.convex.cloud https://*.convex.site;"
     X-DNS-Prefetch-Control = "on"
 
 [[headers]]

--- a/apps/itun/src/components/account/AccountScreen.tsx
+++ b/apps/itun/src/components/account/AccountScreen.tsx
@@ -5,6 +5,7 @@ import { useMutation, useQuery } from 'convex/react'
 import { api } from '../../../convex/_generated/api'
 import { useConnection } from '../../lib/connection/connectionContext'
 import { isConvexConfigured } from '../../lib/connection/convexClient'
+import { ClaimLocalData } from './ClaimLocalData'
 import { SignInControl } from './SignInControl'
 
 /**
@@ -47,6 +48,9 @@ function SignedInAccount() {
 
   return (
     <div className="flex flex-col gap-6">
+      {/* First thing on the account page: an existing player's local roster is
+          the most urgent thing to resolve after signing in. */}
+      <ClaimLocalData />
       <Card>
         <div className="flex flex-col gap-3 p-4">
           <Text as="label" className="font-cond text-xs font-bold tracking-widest uppercase">

--- a/apps/itun/src/components/account/AccountScreen.tsx
+++ b/apps/itun/src/components/account/AccountScreen.tsx
@@ -1,0 +1,213 @@
+import { useState } from 'react'
+import { Button, Card, Text } from 'component-lib'
+import { useMutation, useQuery } from 'convex/react'
+
+import { api } from '../../../convex/_generated/api'
+import { useConnection } from '../../lib/connection/connectionContext'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+import { SignInControl } from './SignInControl'
+
+/**
+ * The account screen (D33): profile, your Games, export, delete.
+ *
+ * All four live on one page deliberately. Holding somebody's Discord identity
+ * creates obligations — let me see it, let me correct it, let me take it away,
+ * let me erase it — and splitting those across surfaces is how one of them
+ * quietly never ships.
+ *
+ * As everywhere in this app, the Convex hooks are isolated behind a
+ * build-time branch so a Solo build (no `VITE_CONVEX_URL`) renders without a
+ * provider present.
+ */
+
+function download(filename: string, data: unknown): void {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function SignedInAccount() {
+  const me = useQuery(api.account.me, {})
+  const games = useQuery(api.games.listMine, {})
+  const exported = useQuery(api.account.exportMine, {})
+  const updateProfile = useMutation(api.account.updateProfile)
+  const deleteAccount = useMutation(api.account.deleteAccount)
+
+  const [name, setName] = useState<string | null>(null)
+  const [confirming, setConfirming] = useState(false)
+
+  if (me === undefined) return <Text>Loading your account…</Text>
+  if (me === null) return <Text>No account found.</Text>
+
+  const value = name ?? me.displayName ?? ''
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <div className="flex flex-col gap-3 p-4">
+          <Text as="label" className="font-cond text-xs font-bold tracking-widest uppercase">
+            Display name
+          </Text>
+          <Text variant="hint" className="text-left">
+            Shown on every entity you own. Defaults to your Discord name; clearing this falls back
+            to it rather than to blank.
+          </Text>
+          <input
+            aria-label="Display name"
+            className="border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-1"
+            value={value}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <div>
+            <Button
+              variant="primary"
+              size="compact"
+              onClick={() => void updateProfile({ displayName: value })}
+            >
+              Save
+            </Button>
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <div className="flex flex-col gap-2 p-4">
+          <Text as="label" className="font-cond text-xs font-bold tracking-widest uppercase">
+            Your games
+          </Text>
+          {games === undefined && (
+            <Text variant="hint" className="text-left">
+              Loading…
+            </Text>
+          )}
+          {games?.length === 0 && (
+            <Text variant="hint" className="text-left">
+              You are not in any games yet.
+            </Text>
+          )}
+          {games?.map((g) => (
+            <div key={g._id} className="flex items-baseline justify-between gap-3">
+              <Text>{g.name}</Text>
+              <Text variant="hint" className="text-left">
+                {g.organizer ? 'Organizer · ' : ''}
+                {g.mediator ? 'Mediator' : 'Player'} · {g.memberCount} member
+                {g.memberCount === 1 ? '' : 's'}
+              </Text>
+            </div>
+          ))}
+        </div>
+      </Card>
+
+      <Card>
+        <div className="flex flex-col gap-3 p-4">
+          <Text as="label" className="font-cond text-xs font-bold tracking-widest uppercase">
+            Your data
+          </Text>
+          <Text variant="hint" className="text-left">
+            Downloads everything you own. Crewmates' characters and the shared crawler are not
+            included — you can see them, but they are not yours to take.
+          </Text>
+          <div>
+            <Button
+              variant="ghost"
+              size="compact"
+              disabled={exported === undefined}
+              onClick={() => exported && download('itun-account-export.json', exported)}
+            >
+              Download my data
+            </Button>
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <div className="flex flex-col gap-3 p-4">
+          <Text as="label" className="font-cond text-xs font-bold tracking-widest uppercase">
+            Delete account
+          </Text>
+          <Text variant="hint" className="text-left">
+            Your pilots and mechs are deleted. Games you are in survive — the shared crawler stays,
+            and if you organise a game the role passes to the longest-standing member. Download your
+            data first; this cannot be undone.
+          </Text>
+          <div>
+            {confirming ? (
+              <div className="flex gap-2">
+                <Button variant="danger" size="compact" onClick={() => void deleteAccount({})}>
+                  Permanently delete
+                </Button>
+                <Button variant="ghost" size="compact" onClick={() => setConfirming(false)}>
+                  Cancel
+                </Button>
+              </div>
+            ) : (
+              <Button variant="danger" size="compact" onClick={() => setConfirming(true)}>
+                Delete my account
+              </Button>
+            )}
+          </div>
+        </div>
+      </Card>
+    </div>
+  )
+}
+
+function AccountBody() {
+  const { mode } = useConnection()
+
+  if (mode === 'connected') return <SignedInAccount />
+
+  if (mode === 'disconnected') {
+    return (
+      <Card>
+        <div className="p-4">
+          <Text>
+            Your account is unreachable right now. Reconnect to change your profile or manage your
+            games.
+          </Text>
+        </div>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <Text>
+          You are playing solo. Everything you build is saved on this device and needs no account.
+        </Text>
+        <Text variant="hint" className="text-left">
+          Signing in lets you join a game with other people and carry your builds between devices.
+        </Text>
+        <div>
+          <SignInControl />
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+export function AccountScreen() {
+  return (
+    <main className="mx-auto flex max-w-2xl flex-col gap-6 p-4">
+      <Text as="h1" className="font-cond text-2xl font-bold tracking-wide uppercase">
+        Account
+      </Text>
+      {isConvexConfigured ? (
+        <AccountBody />
+      ) : (
+        <Card>
+          <div className="p-4">
+            <Text>
+              This build has no account service configured, so everything is saved on this device.
+            </Text>
+          </div>
+        </Card>
+      )}
+    </main>
+  )
+}

--- a/apps/itun/src/components/account/AccountStrip.tsx
+++ b/apps/itun/src/components/account/AccountStrip.tsx
@@ -30,6 +30,14 @@ export function AccountStrip() {
     <div className="flex items-center justify-end gap-3 border-b border-[var(--color-ink)]/15 px-3 py-1">
       {mode === 'connected' && (
         <Link
+          to="/games"
+          className="font-cond text-xs font-bold tracking-widest text-[var(--color-ink)] uppercase hover:text-[var(--color-rust)]"
+        >
+          Games
+        </Link>
+      )}
+      {mode === 'connected' && (
+        <Link
           to="/account"
           className="font-cond text-xs font-bold tracking-widest text-[var(--color-ink)] uppercase hover:text-[var(--color-rust)]"
         >

--- a/apps/itun/src/components/account/AccountStrip.tsx
+++ b/apps/itun/src/components/account/AccountStrip.tsx
@@ -1,0 +1,42 @@
+import { Link } from '@tanstack/react-router'
+
+import { useConnection } from '../../lib/connection/connectionContext'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+import { SignInControl } from './SignInControl'
+
+/**
+ * A thin strip above the brand header carrying sign-in and a link to the
+ * account page.
+ *
+ * ## Why not a nav item in `AppBar`
+ *
+ * `AppBar` lives in `component-lib` and is shared with `apps/srd`, which has no
+ * accounts and never will. Threading an auth slot through it would push an
+ * ITUN-only concept into a package whose contract is to stay backend-agnostic,
+ * and would touch a component every page of both apps renders. A local strip
+ * keeps the blast radius inside ITUN.
+ *
+ * ## It renders nothing in a Solo build
+ *
+ * No `VITE_CONVEX_URL` means accounts are not merely signed-out, they are
+ * absent — so there is nothing to link to and nothing to sign into. Existing
+ * users see exactly the chrome they saw before.
+ */
+export function AccountStrip() {
+  const { mode } = useConnection()
+  if (!isConvexConfigured) return null
+
+  return (
+    <div className="flex items-center justify-end gap-3 border-b border-[var(--color-ink)]/15 px-3 py-1">
+      {mode === 'connected' && (
+        <Link
+          to="/account"
+          className="font-cond text-xs font-bold tracking-widest text-[var(--color-ink)] uppercase hover:text-[var(--color-rust)]"
+        >
+          Account
+        </Link>
+      )}
+      <SignInControl />
+    </div>
+  )
+}

--- a/apps/itun/src/components/account/ClaimLocalData.tsx
+++ b/apps/itun/src/components/account/ClaimLocalData.tsx
@@ -73,7 +73,10 @@ function ConnectedClaim() {
   // two different local rosters are two different claims worth offering.
   const userKey = `${pilots.length}-${mechs.length}-${crawlers.length}`
 
-  if (total === 0 || dismissed || hasClaimed(userKey)) return null
+  // `summary !== null` means this session just did the claim, and the marker it
+  // wrote is what would otherwise hide the confirmation the instant it arrived
+  // — the card would vanish on click with nothing said about what happened.
+  if (total === 0 || dismissed || (summary === null && hasClaimed(userKey))) return null
 
   return (
     <Card>

--- a/apps/itun/src/components/account/ClaimLocalData.tsx
+++ b/apps/itun/src/components/account/ClaimLocalData.tsx
@@ -1,0 +1,151 @@
+import { useState } from 'react'
+import { Button, Card, Text } from 'component-lib'
+import { useMutation } from 'convex/react'
+
+import { api } from '../../../convex/_generated/api'
+import { useConnection } from '../../lib/connection/connectionContext'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+import { useEntityStore } from '../../stores/entityStore'
+import { usePatternStore } from '../../stores/patternStore'
+
+/**
+ * The one-time "bring your local data into your account" step (D11).
+ *
+ * An existing player has a roster in IndexedDB built before accounts existed.
+ * Migration v13 gives it containers automatically, but that is all it does —
+ * the data stays on that device. This is the only path from local storage into
+ * an account, and without it signing in produces an empty account beside a full
+ * local one, which reads as data loss even though nothing was lost.
+ *
+ * ## Why it is offered, not automatic
+ *
+ * Uploading somebody's whole roster the instant they sign in is a decision made
+ * on their behalf with their data. Somebody signing in to look at a friend's
+ * game should not thereby publish their own builds. So it is a prompt with a
+ * count, and it says exactly what will happen.
+ *
+ * ## Why it is one-time
+ *
+ * Claiming twice would duplicate the roster: `claimLocal` inserts, and the
+ * local records keep their ids, so a second run creates a second copy of
+ * everything. The completion marker is per **account**, not per device — the
+ * same person on a second device should still be offered their local data
+ * there, but should never be asked twice for the same upload on the same one.
+ */
+
+const CLAIMED_KEY_PREFIX = 'itun.claimedLocalData.'
+
+function hasClaimed(userKey: string): boolean {
+  try {
+    return localStorage.getItem(CLAIMED_KEY_PREFIX + userKey) !== null
+  } catch {
+    // Private mode: fall back to offering it. A duplicate prompt is a smaller
+    // harm than never offering the only path off a device.
+    return false
+  }
+}
+
+function markClaimed(userKey: string): void {
+  try {
+    localStorage.setItem(CLAIMED_KEY_PREFIX + userKey, new Date().toISOString())
+  } catch {
+    // Nothing to do — the claim itself already succeeded.
+  }
+}
+
+type Summary = { claimed: number; skipped: number; byKind: Record<string, number> }
+
+function ConnectedClaim() {
+  const claimLocal = useMutation(api.entities.claimLocal)
+
+  const pilots = useEntityStore((s) => s.list('pilot'))
+  const mechs = useEntityStore((s) => s.list('mech'))
+  const crawlers = useEntityStore((s) => s.list('crawler'))
+  const softLinks = useEntityStore((s) => s.list('softLink'))
+  const patterns = usePatternStore((s) => s.mechPatterns)
+
+  const [summary, setSummary] = useState<Summary | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [dismissed, setDismissed] = useState(false)
+
+  const total = pilots.length + mechs.length + crawlers.length + patterns.length
+  // Keyed on the roster itself rather than a user id the client does not hold:
+  // two different local rosters are two different claims worth offering.
+  const userKey = `${pilots.length}-${mechs.length}-${crawlers.length}`
+
+  if (total === 0 || dismissed || hasClaimed(userKey)) return null
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <Text as="span" className="font-cond text-xs font-bold tracking-caps-wide uppercase">
+          Bring your builds with you
+        </Text>
+
+        {summary === null ? (
+          <>
+            <Text>
+              This device has {pilots.length} pilot{pilots.length === 1 ? '' : 's'}, {mechs.length}{' '}
+              mech{mechs.length === 1 ? '' : 's'}, {crawlers.length} crawler
+              {crawlers.length === 1 ? '' : 's'} and {patterns.length} saved pattern
+              {patterns.length === 1 ? '' : 's'} that are not in your account yet.
+            </Text>
+            <Text variant="hint" className="text-left">
+              They will be copied to your account and land on your shelf — not in any game — so you
+              can place them yourself. Nothing on this device is changed or removed.
+            </Text>
+            <div className="flex gap-2">
+              <Button
+                variant="primary"
+                size="compact"
+                disabled={busy}
+                onClick={() => {
+                  setBusy(true)
+                  void claimLocal({
+                    pilots: pilots as unknown[],
+                    mechs: mechs as unknown[],
+                    crawlers: crawlers as unknown[],
+                    softLinks: softLinks as unknown[],
+                    mechPatterns: patterns as unknown[],
+                  })
+                    .then((result) => {
+                      markClaimed(userKey)
+                      setSummary(result as Summary)
+                    })
+                    .finally(() => setBusy(false))
+                }}
+              >
+                {busy ? 'Copying…' : 'Copy to my account'}
+              </Button>
+              <Button variant="ghost" size="compact" onClick={() => setDismissed(true)}>
+                Not now
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <Text>
+              Copied {summary.claimed} item{summary.claimed === 1 ? '' : 's'} to your account.
+            </Text>
+            {summary.skipped > 0 && (
+              <Text variant="hint" className="text-left">
+                {summary.skipped} could not be read and {summary.skipped === 1 ? 'was' : 'were'}{' '}
+                left on this device — they are still here, and still exportable.
+              </Text>
+            )}
+          </>
+        )}
+      </div>
+    </Card>
+  )
+}
+
+/**
+ * Offered only while Connected. Solo has no account to claim into, and
+ * Disconnected cannot write — offering it there would fail on click.
+ */
+export function ClaimLocalData() {
+  const { mode } = useConnection()
+  if (!isConvexConfigured || mode !== 'connected') return null
+  return <ConnectedClaim />
+}

--- a/apps/itun/src/components/account/SignInControl.tsx
+++ b/apps/itun/src/components/account/SignInControl.tsx
@@ -1,0 +1,50 @@
+import { Button } from 'component-lib'
+import { useAuthActions } from '@convex-dev/auth/react'
+
+import { useConnection } from '../../lib/connection/connectionContext'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+
+/**
+ * Sign in / sign out with Discord.
+ *
+ * ## The Solo-build branch, again
+ *
+ * `useAuthActions` needs a `ConvexAuthProvider` above it, and a build with no
+ * `VITE_CONVEX_URL` deliberately has none. So this file uses the same
+ * component-level branch as `ConnectionProvider`: the hook lives in
+ * `ConvexSignIn`, which is only ever rendered when the build is configured.
+ * The branch is a build-time constant, so React sees a stable component
+ * identity across renders.
+ *
+ * In a Solo build this renders **nothing at all** rather than a disabled
+ * button. Offering an account to somebody whose app cannot have one is worse
+ * than silence — signing in is an upgrade, not a missing feature (ADR-030 §1).
+ */
+
+function ConvexSignIn() {
+  const { signIn, signOut } = useAuthActions()
+  const { mode } = useConnection()
+
+  if (mode === 'connected') {
+    return (
+      <Button variant="ghost" size="compact" onClick={() => void signOut()}>
+        Sign out
+      </Button>
+    )
+  }
+
+  // Disconnected means signed in but unreachable — offering "sign in" there
+  // would be nonsense, and the NOT CONNECTED banner already explains the state.
+  if (mode === 'disconnected') return null
+
+  return (
+    <Button variant="primary" size="compact" onClick={() => void signIn('discord')}>
+      Sign in with Discord
+    </Button>
+  )
+}
+
+export function SignInControl() {
+  if (!isConvexConfigured) return null
+  return <ConvexSignIn />
+}

--- a/apps/itun/src/components/account/__tests__/AccountScreen.connected.test.tsx
+++ b/apps/itun/src/components/account/__tests__/AccountScreen.connected.test.tsx
@@ -1,0 +1,202 @@
+import { afterAll, afterEach, describe, expect, mock, test } from 'bun:test'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+/**
+ * `AccountScreen` for somebody who has an account.
+ *
+ * Holding a person's Discord identity creates obligations — show it, let them
+ * correct it, let them take their data, let them erase it — and this is where
+ * all four are honoured. The tests below are about those obligations, not about
+ * layout: that deletion cannot happen on one click, that the export button is
+ * not offered before there is anything to export, and that a blank display name
+ * falls back to the Discord one rather than to nothing.
+ *
+ * Queries are answered in **call order** (`me`, `games`, `exportMine`); the
+ * generated `api` object is a Proxy that throws when inspected, so position is
+ * the only stable key.
+ */
+
+let queryQueue: unknown[] = []
+let queryIndex = 0
+let authed = true
+
+/**
+ * `mock.module` replaces the entry in the process-wide module registry, so these
+ * mocks outlive this file and would otherwise poison every test that runs after
+ * it — the exports below are captured first and put back in `afterAll`.
+ *
+ * The spread is load-bearing. A module namespace is a *live* view, and mocking
+ * rewrites it in place, so holding the namespace itself captures nothing: by
+ * `afterAll` it already reads as the mock.
+ */
+const realConvexClient = { ...(await import('../../../lib/connection/convexClient')) }
+const realConvexReact = { ...(await import('convex/react')) }
+const realAuthReact = { ...(await import('@convex-dev/auth/react')) }
+
+mock.module('../../../lib/connection/convexClient', () => ({
+  isConvexConfigured: true,
+  convexClient: {},
+}))
+
+mock.module('convex/react', () => ({
+  useQuery: () => {
+    // Wraps rather than running off the end: a state change re-renders the
+    // component, which replays the same fixed run of hooks. Without the wrap
+    // every post-interaction render would read `undefined` and the screen would
+    // collapse back to its loading state.
+    const value = queryQueue[queryIndex % Math.max(queryQueue.length, 1)]
+    queryIndex += 1
+    return value
+  },
+  useMutation: () => async () => undefined,
+  useConvexAuth: () => ({ isAuthenticated: authed, isLoading: false }),
+  ConvexReactClient: class {},
+  ConvexProvider: ({ children }: { children: unknown }) => children,
+  ConvexProviderWithAuth: ({ children }: { children: unknown }) => children,
+  useConvex: () => ({}),
+  useAction: () => async () => undefined,
+}))
+
+mock.module('@convex-dev/auth/react', () => ({
+  useAuthActions: () => ({ signIn: async () => undefined, signOut: async () => undefined }),
+  ConvexAuthProvider: ({ children }: { children: unknown }) => children,
+}))
+
+const { AccountScreen } = await import('../AccountScreen')
+const { ConnectionProvider } = await import('../../../lib/connection/ConnectionProvider')
+
+function withQueries(values: unknown[]): void {
+  queryQueue = values
+  queryIndex = 0
+}
+
+/** Force the browser's online flag, which is what picks Connected vs Disconnected. */
+function setOnline(value: boolean): void {
+  Object.defineProperty(navigator, 'onLine', { value, configurable: true })
+}
+
+afterEach(() => {
+  authed = true
+  setOnline(true)
+})
+
+const wrap = () =>
+  render(
+    <ConnectionProvider>
+      <AccountScreen />
+    </ConnectionProvider>
+  )
+
+const ME = { displayName: 'Beefcake', avatarUrl: null, discordId: 'd1' }
+const GAMES = [
+  { _id: 'g1', name: 'Union Crawler #430', mediator: true, organizer: true, memberCount: 4 },
+  { _id: 'g2', name: 'The Long Haul', mediator: false, organizer: false, memberCount: 1 },
+]
+
+describe('what the account page is when there is no account', () => {
+  test('solo says the data is safe here and offers the way in', () => {
+    authed = false
+    withQueries([])
+    wrap()
+
+    // Solo is a supported way to use the app, not a degraded one — the copy
+    // has to say so rather than nagging.
+    expect(screen.getByText(/You are playing solo/i)).toBeTruthy()
+    expect(screen.getByText(/needs no account/i)).toBeTruthy()
+  })
+
+  test('disconnected explains it rather than showing a broken profile form', () => {
+    setOnline(false)
+    withQueries([])
+    wrap()
+
+    expect(screen.getByText(/unreachable right now/i)).toBeTruthy()
+    // Offering an editable name that cannot be saved would be a lie.
+    expect(screen.queryByLabelText('Display name')).toBeNull()
+  })
+})
+
+describe('the profile', () => {
+  test('while it loads it says so', () => {
+    withQueries([undefined])
+    wrap()
+    expect(screen.getByText(/Loading your account/i)).toBeTruthy()
+  })
+
+  test('a signed-in session with no row says so plainly', () => {
+    withQueries([null])
+    wrap()
+    expect(screen.getByText('No account found.')).toBeTruthy()
+  })
+
+  test('the display name is pre-filled from Discord', () => {
+    withQueries([ME, GAMES, { pilots: [] }])
+    wrap()
+
+    const input = screen.getByLabelText('Display name') as HTMLInputElement
+    expect(input.value).toBe('Beefcake')
+  })
+
+  test('a null display name renders as empty, not as the string null', () => {
+    withQueries([{ ...ME, displayName: null }, GAMES, { pilots: [] }])
+    wrap()
+    expect((screen.getByLabelText('Display name') as HTMLInputElement).value).toBe('')
+  })
+})
+
+describe('your games, seen from the account page', () => {
+  test('each game names your role in it', () => {
+    withQueries([ME, GAMES, { pilots: [] }])
+    wrap()
+
+    expect(screen.getByText('Union Crawler #430')).toBeTruthy()
+    // Organizer is orthogonal to Mediator, so both can be true at once.
+    expect(screen.getByText(/Organizer · Mediator · 4 members/)).toBeTruthy()
+    expect(screen.getByText(/^Player · 1 member$/)).toBeTruthy()
+  })
+
+  test('no games says so rather than rendering an empty card', () => {
+    withQueries([ME, [], { pilots: [] }])
+    wrap()
+    expect(screen.getByText(/not in any games yet/i)).toBeTruthy()
+  })
+})
+
+describe('taking your data, and taking it away', () => {
+  test('download is refused until the export has actually arrived', () => {
+    // Clicking it early would hand somebody an empty file and call it their data.
+    withQueries([ME, GAMES, undefined])
+    wrap()
+    expect(screen.getByText('Download my data').closest('button')?.disabled).toBe(true)
+  })
+
+  test('once the export is ready the button is live', () => {
+    withQueries([ME, GAMES, { pilots: [] }])
+    wrap()
+    expect(screen.getByText('Download my data').closest('button')?.disabled).toBe(false)
+  })
+
+  test('deletion takes two deliberate clicks, and says what survives', () => {
+    withQueries([ME, GAMES, { pilots: [] }])
+    wrap()
+
+    // The first click only arms it; nothing irreversible is one click away.
+    expect(screen.queryByText('Permanently delete')).toBeNull()
+    fireEvent.click(screen.getByText('Delete my account'))
+    expect(screen.getByText('Permanently delete')).toBeTruthy()
+    expect(screen.getByText('Cancel')).toBeTruthy()
+  })
+
+  test('it warns that the shared game outlives the account', () => {
+    withQueries([ME, GAMES, { pilots: [] }])
+    wrap()
+    // A crawler is communal; deleting yourself must not delete the table's game.
+    expect(screen.getByText(/Games you are in survive/i)).toBeTruthy()
+  })
+})
+
+afterAll(() => {
+  mock.module('../../../lib/connection/convexClient', () => realConvexClient)
+  mock.module('convex/react', () => realConvexReact)
+  mock.module('@convex-dev/auth/react', () => realAuthReact)
+})

--- a/apps/itun/src/components/account/__tests__/AccountScreen.test.tsx
+++ b/apps/itun/src/components/account/__tests__/AccountScreen.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+
+import { ConnectionProvider } from '../../../lib/connection/ConnectionProvider'
+import { isConvexConfigured } from '../../../lib/connection/convexClient'
+import { AccountScreen } from '../AccountScreen'
+import { SignInControl } from '../SignInControl'
+
+/**
+ * The failure this guards against is structural rather than cosmetic.
+ *
+ * `AccountScreen` and `SignInControl` both reach for Convex hooks
+ * (`useQuery`, `useMutation`, `useAuthActions`), and every one of those throws
+ * without a provider above it. A Solo build deliberately has no provider, so if
+ * the build-time branch is ever removed or inverted, this page crashes for the
+ * majority of users — the ones who never sign in — while working perfectly for
+ * whoever is testing it with a configured `.env.local`.
+ *
+ * The test environment has no `VITE_CONVEX_URL`, so rendering here without a
+ * throw is the assertion.
+ */
+
+describe('AccountScreen in a Solo build', () => {
+  test('the test build really is Solo', () => {
+    // Asserted, not assumed: if this flips, the tests below would start
+    // passing for an entirely different reason.
+    expect(isConvexConfigured).toBe(false)
+  })
+
+  test('renders without a Convex provider present', () => {
+    render(
+      <ConnectionProvider>
+        <AccountScreen />
+      </ConnectionProvider>
+    )
+    expect(screen.getByText('Account')).toBeTruthy()
+  })
+
+  test('explains that data is local rather than offering an account', () => {
+    render(
+      <ConnectionProvider>
+        <AccountScreen />
+      </ConnectionProvider>
+    )
+    expect(screen.getByText(/saved on this device/i)).toBeTruthy()
+  })
+
+  test('SignInControl renders nothing at all', () => {
+    // Not a disabled button: offering an account to somebody whose build
+    // cannot have one is worse than silence.
+    const { container } = render(
+      <ConnectionProvider>
+        <SignInControl />
+      </ConnectionProvider>
+    )
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/apps/itun/src/components/account/__tests__/ClaimLocalData.connected.test.tsx
+++ b/apps/itun/src/components/account/__tests__/ClaimLocalData.connected.test.tsx
@@ -1,0 +1,214 @@
+import { afterAll, afterEach, describe, expect, mock, test } from 'bun:test'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+
+/**
+ * The one-time "bring your local data into your account" prompt (D11), for
+ * somebody who has an account. The Solo case lives next door and asserts
+ * silence.
+ *
+ * This is the only path from a pre-accounts IndexedDB roster into an account,
+ * so the failure modes are the expensive kind: never offering it strands
+ * somebody's builds on one device, and offering it twice duplicates their whole
+ * roster. Both are covered here, along with the promises the copy makes — that
+ * nothing local is removed, and that the copy lands on the shelf rather than in
+ * somebody's game.
+ */
+
+let authed = true
+let claimResult: unknown = { claimed: 0, skipped: 0, byKind: {} }
+let pilots: unknown[] = []
+let mechs: unknown[] = []
+let crawlers: unknown[] = []
+let patterns: unknown[] = []
+
+/**
+ * `mock.module` replaces the entry in the process-wide module registry, so these
+ * mocks outlive this file and would otherwise poison every test that runs after
+ * it — the exports below are captured first and put back in `afterAll`.
+ *
+ * The spread is load-bearing. A module namespace is a *live* view, and mocking
+ * rewrites it in place, so holding the namespace itself captures nothing: by
+ * `afterAll` it already reads as the mock.
+ */
+const realConvexClient = { ...(await import('../../../lib/connection/convexClient')) }
+const realConvexReact = { ...(await import('convex/react')) }
+const realEntityStore = { ...(await import('../../../stores/entityStore')) }
+const realPatternStore = { ...(await import('../../../stores/patternStore')) }
+
+mock.module('../../../lib/connection/convexClient', () => ({
+  isConvexConfigured: true,
+  convexClient: {},
+}))
+
+mock.module('convex/react', () => ({
+  useQuery: () => undefined,
+  useMutation: () => async () => claimResult,
+  useConvexAuth: () => ({ isAuthenticated: authed, isLoading: false }),
+  ConvexReactClient: class {},
+  ConvexProvider: ({ children }: { children: unknown }) => children,
+  ConvexProviderWithAuth: ({ children }: { children: unknown }) => children,
+  useConvex: () => ({}),
+  useAction: () => async () => undefined,
+}))
+
+/**
+ * The stores are stubbed rather than seeded through IndexedDB: what is under
+ * test is the prompt's arithmetic and its one-time marker, not hydration.
+ */
+mock.module('../../../stores/entityStore', () => ({
+  useEntityStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      list: (kind: string) => {
+        if (kind === 'pilot') return pilots
+        if (kind === 'mech') return mechs
+        if (kind === 'crawler') return crawlers
+        return []
+      },
+    }),
+}))
+
+mock.module('../../../stores/patternStore', () => ({
+  usePatternStore: (selector: (s: unknown) => unknown) => selector({ mechPatterns: patterns }),
+}))
+
+const { ClaimLocalData } = await import('../ClaimLocalData')
+const { ConnectionProvider } = await import('../../../lib/connection/ConnectionProvider')
+
+const wrap = () =>
+  render(
+    <ConnectionProvider>
+      <ClaimLocalData />
+    </ConnectionProvider>
+  )
+
+/** A roster of the given sizes, shaped only as far as the prompt reads it. */
+function localRoster(p = 2, m = 1, c = 1, pat = 3): void {
+  pilots = Array.from({ length: p }, (_, i) => ({ id: `p${i}` }))
+  mechs = Array.from({ length: m }, (_, i) => ({ id: `m${i}` }))
+  crawlers = Array.from({ length: c }, (_, i) => ({ id: `c${i}` }))
+  patterns = Array.from({ length: pat }, (_, i) => ({ id: `pat${i}` }))
+}
+
+function setOnline(value: boolean): void {
+  Object.defineProperty(navigator, 'onLine', { value, configurable: true })
+}
+
+afterEach(() => {
+  authed = true
+  pilots = []
+  mechs = []
+  crawlers = []
+  patterns = []
+  claimResult = { claimed: 0, skipped: 0, byKind: {} }
+  setOnline(true)
+  localStorage.clear()
+})
+
+describe('when the prompt is offered at all', () => {
+  test('an empty device is never asked', () => {
+    // Nothing to carry, so the prompt would be pure noise on a new account.
+    wrap()
+    expect(screen.queryByText(/Bring your builds with you/i)).toBeNull()
+  })
+
+  test('a device with a roster is asked', () => {
+    localRoster()
+    wrap()
+    expect(screen.getByText(/Bring your builds with you/i)).toBeTruthy()
+  })
+
+  test('solo is never asked — there is no account to claim into', () => {
+    authed = false
+    localRoster()
+    wrap()
+    expect(screen.queryByText(/Bring your builds with you/i)).toBeNull()
+  })
+
+  test('disconnected is never asked — the button would fail on click', () => {
+    setOnline(false)
+    localRoster()
+    wrap()
+    expect(screen.queryByText(/Bring your builds with you/i)).toBeNull()
+  })
+})
+
+describe('what the prompt says it will do', () => {
+  test('it counts what is here, pluralised', () => {
+    localRoster(2, 1, 1, 3)
+    wrap()
+    expect(screen.getByText(/2 pilots, 1 mech, 1 crawler and 3 saved patterns/)).toBeTruthy()
+  })
+
+  test('a single item of each reads as singular', () => {
+    localRoster(1, 1, 1, 1)
+    wrap()
+    expect(screen.getByText(/1 pilot, 1 mech, 1 crawler and 1 saved pattern/)).toBeTruthy()
+  })
+
+  test('it promises the shelf, not a game, and that nothing local is removed', () => {
+    // Both promises are load-bearing: uploading a roster straight into somebody
+    // else's game, or moving it off the device, would be a decision made with
+    // their data rather than by them.
+    localRoster()
+    wrap()
+    expect(screen.getByText(/land on your shelf — not in any game/i)).toBeTruthy()
+    expect(screen.getByText(/Nothing on this device is changed or removed/i)).toBeTruthy()
+  })
+
+  test('Not now dismisses it without claiming', () => {
+    localRoster()
+    wrap()
+    fireEvent.click(screen.getByText('Not now'))
+    expect(screen.queryByText(/Bring your builds with you/i)).toBeNull()
+  })
+})
+
+describe('after copying', () => {
+  test('it reports how much arrived', async () => {
+    localRoster(2, 1, 1, 3)
+    claimResult = { claimed: 7, skipped: 0, byKind: {} }
+    wrap()
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Copy to my account'))
+    })
+
+    expect(screen.getByText(/Copied 7 items to your account/)).toBeTruthy()
+  })
+
+  test('anything unreadable is named, and said to still be here', async () => {
+    // Silence would read as data loss; the point is that the local copy is
+    // still intact and still exportable.
+    localRoster()
+    claimResult = { claimed: 5, skipped: 2, byKind: {} }
+    wrap()
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Copy to my account'))
+    })
+
+    expect(screen.getByText(/2 could not be read and were left on this device/)).toBeTruthy()
+  })
+
+  test('it is not offered a second time', async () => {
+    localRoster()
+    claimResult = { claimed: 4, skipped: 0, byKind: {} }
+    wrap()
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Copy to my account'))
+    })
+
+    // Claiming twice would insert a second copy of the whole roster, because
+    // the mutation inserts and the local records keep their ids.
+    const second = wrap()
+    expect(second.container.innerHTML).toBe('')
+  })
+})
+
+afterAll(() => {
+  mock.module('../../../lib/connection/convexClient', () => realConvexClient)
+  mock.module('convex/react', () => realConvexReact)
+  mock.module('../../../stores/entityStore', () => realEntityStore)
+  mock.module('../../../stores/patternStore', () => realPatternStore)
+})

--- a/apps/itun/src/components/account/__tests__/ClaimLocalData.test.tsx
+++ b/apps/itun/src/components/account/__tests__/ClaimLocalData.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+
+import { ConnectionProvider } from '../../../lib/connection/ConnectionProvider'
+import { isConvexConfigured } from '../../../lib/connection/convexClient'
+import { ClaimLocalData } from '../ClaimLocalData'
+
+/**
+ * The claim prompt must not appear where it cannot work.
+ *
+ * Solo has no account to claim into and Disconnected cannot write, so offering
+ * the button there would fail on click — and this component reads four stores
+ * plus a Convex mutation, so a leak past the build-time branch would crash the
+ * account page for every user who never signs in.
+ */
+
+describe('ClaimLocalData in a Solo build', () => {
+  test('the test build really is Solo', () => {
+    expect(isConvexConfigured).toBe(false)
+  })
+
+  test('renders nothing at all', () => {
+    const { container } = render(
+      <ConnectionProvider>
+        <ClaimLocalData />
+      </ConnectionProvider>
+    )
+    // Not a disabled prompt — silence. There is nothing to claim into.
+    expect(container.innerHTML).toBe('')
+    expect(screen.queryByText(/copy to my account/i)).toBeNull()
+  })
+})

--- a/apps/itun/src/components/games/CrewVitals.tsx
+++ b/apps/itun/src/components/games/CrewVitals.tsx
@@ -1,0 +1,75 @@
+import { Text } from 'component-lib'
+import { useQuery } from 'convex/react'
+
+import { api } from '../../../convex/_generated/api'
+import type { Id } from '../../../convex/_generated/dataModel'
+import { UNCLAIMED_LABEL } from '../../lib/ownership/ownerChip'
+import { NUM, ROW, SECTION } from './gameChrome'
+
+/**
+ * The crew strip: everybody's vitals, live.
+ *
+ * Reads `crew.vitals` rather than the full entity listing — that query exists
+ * precisely so this component can re-render on every point of damage without
+ * dragging loadouts and cargo down the wire with it.
+ *
+ * **Unclaimed reads as a state, not a blank.** A pre-gen waiting to be handed
+ * out is a useful, normal thing; an empty owner cell would make it look broken
+ * instead of available.
+ *
+ * A null vital renders as `—`, never `0`. The bodies are opaque on the server,
+ * so a missing field means "we do not know", and showing zero would read as
+ * *dead* on a vitals strip.
+ */
+export function CrewVitals({ gameId }: { gameId: Id<'games'> }) {
+  const crew = useQuery(api.crew.vitals, { gameId })
+
+  if (crew === undefined) return <Text variant="hint">Loading the crew…</Text>
+
+  const owner = (name: string | null, ownerId: string | null) =>
+    ownerId === null ? UNCLAIMED_LABEL : (name ?? 'Crewmate')
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <Text as="span" className={SECTION}>
+          Pilots
+        </Text>
+        {crew.pilots.length === 0 && <Text variant="hint">No pilots in this game yet.</Text>}
+        {crew.pilots.map((p) => (
+          <div key={p._id} className={ROW}>
+            <Text as="span">{p.name}</Text>
+            <span className="flex items-baseline gap-3">
+              <Text as="span" variant="hint">
+                {owner(p.ownerName, p.ownerId)}
+              </Text>
+              <Text as="span" className={NUM}>
+                HP {p.currentHp ?? '—'} · AP {p.currentAp ?? '—'}
+              </Text>
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div>
+        <Text as="span" className={SECTION}>
+          Mechs
+        </Text>
+        {crew.mechs.length === 0 && <Text variant="hint">No mechs in this game yet.</Text>}
+        {crew.mechs.map((m) => (
+          <div key={m._id} className={ROW}>
+            <Text as="span">{m.name}</Text>
+            <span className="flex items-baseline gap-3">
+              <Text as="span" variant="hint">
+                {owner(m.ownerName, m.ownerId)}
+              </Text>
+              <Text as="span" className={NUM}>
+                SP {m.currentSp ?? '—'} · Heat {m.currentHeat ?? '—'}
+              </Text>
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/itun/src/components/games/DowntimePanel.tsx
+++ b/apps/itun/src/components/games/DowntimePanel.tsx
@@ -1,0 +1,120 @@
+import { Button, Card, Text } from 'component-lib'
+import { useMutation, useQuery } from 'convex/react'
+
+import { api } from '../../../convex/_generated/api'
+import type { Id } from '../../../convex/_generated/dataModel'
+import { ROW, STAMP } from './gameChrome'
+
+/**
+ * Crew-wide Downtime (Phase 5).
+ *
+ * The panel every member sees; the phase controls only appear for the Mediator.
+ *
+ * What it is really for is the **who is still working** list. Before this, six
+ * players ran six private Downtimes and reconciled verbally, and the Mediator's
+ * only way to know whether the table could move on was to ask. Showing
+ * completion per step turns that into a glance.
+ *
+ * Completion is per step, so this list emptying on every advance is correct
+ * rather than a bug — a name persisting would mean "finished at some point",
+ * which is the opposite of what the Mediator needs.
+ *
+ * Upkeep is shown as a single crew-level fact. It is spent once by whoever gets
+ * there first, and the button disables for everybody after — the double-charge
+ * being the thing that made per-player Downtime unworkable.
+ */
+export function DowntimePanel({ gameId }: { gameId: Id<'games'> }) {
+  const state = useQuery(api.downtime.state, { gameId })
+  const amMediator = useQuery(api.mediator.amMediator, { gameId })
+  const begin = useMutation(api.downtime.begin)
+  const advance = useMutation(api.downtime.advance)
+  const end = useMutation(api.downtime.end)
+  const markStepDone = useMutation(api.downtime.markStepDone)
+  const spendUpkeep = useMutation(api.downtime.spendUpkeep)
+
+  if (state === undefined) return null
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <Text as="span" className={STAMP}>
+          Downtime
+        </Text>
+
+        {!state.running && (
+          <>
+            <Text variant="hint">
+              Not running. The Mediator starts a Downtime when the crew is ready.
+            </Text>
+            {amMediator === true && (
+              <div>
+                <Button variant="primary" size="compact" onClick={() => void begin({ gameId })}>
+                  Begin Downtime
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+
+        {state.running && (
+          <>
+            <div className={ROW}>
+              <Text as="span">Step {(state.stepIndex ?? 0) + 1}</Text>
+              <Text as="span" variant="hint">
+                {state.upkeepSpent ? 'Upkeep paid' : 'Upkeep outstanding'}
+              </Text>
+            </div>
+
+            <div>
+              <Text as="span" className={STAMP}>
+                Finished this step
+              </Text>
+              {state.completedBy.length === 0 && <Text variant="hint">Nobody yet.</Text>}
+              {state.completedBy.map((c) => (
+                <div key={c.userId} className={ROW}>
+                  <Text as="span">{c.displayName}</Text>
+                </div>
+              ))}
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <Button
+                variant="primary"
+                size="compact"
+                onClick={() => void markStepDone({ gameId, done: true })}
+              >
+                I'm done with this step
+              </Button>
+              <Button
+                variant="ghost"
+                size="compact"
+                onClick={() => void markStepDone({ gameId, done: false })}
+              >
+                Not yet
+              </Button>
+              <Button
+                variant="ghost"
+                size="compact"
+                disabled={state.upkeepSpent}
+                onClick={() => void spendUpkeep({ gameId })}
+              >
+                Pay crawler upkeep
+              </Button>
+            </div>
+
+            {amMediator === true && (
+              <div className="flex gap-2">
+                <Button variant="primary" size="compact" onClick={() => void advance({ gameId })}>
+                  Next step
+                </Button>
+                <Button variant="danger" size="compact" onClick={() => void end({ gameId })}>
+                  End Downtime
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </Card>
+  )
+}

--- a/apps/itun/src/components/games/GamesScreen.tsx
+++ b/apps/itun/src/components/games/GamesScreen.tsx
@@ -154,7 +154,9 @@ function GameRow({
 
 function ConnectedGames() {
   const games = useQuery(api.games.listMine, {})
+  const templates = useQuery(api.templates.list, {})
   const create = useMutation(api.games.create)
+  const createFromTemplate = useMutation(api.templates.createGame)
   const redeem = useMutation(api.invites.redeem)
 
   const [newName, setNewName] = useState('')
@@ -183,6 +185,34 @@ function ConnectedGames() {
           >
             Create
           </Button>
+        </div>
+      </Card>
+
+      <Card>
+        <div className="flex flex-col gap-3 p-4">
+          <span className={label}>Or start from a template</span>
+          {templates?.map((t) => (
+            <div key={t.id} className="flex flex-col gap-2">
+              <Text as="span">{t.name}</Text>
+              <Text variant="hint" className="text-left">
+                {t.description}
+              </Text>
+              <div>
+                <Button
+                  variant="ghost"
+                  size="compact"
+                  onClick={() =>
+                    void createFromTemplate({
+                      templateId: 'starter-set',
+                      name: newName || undefined,
+                    })
+                  }
+                >
+                  Start this game
+                </Button>
+              </div>
+            </div>
+          ))}
         </div>
       </Card>
 

--- a/apps/itun/src/components/games/GamesScreen.tsx
+++ b/apps/itun/src/components/games/GamesScreen.tsx
@@ -7,6 +7,9 @@ import type { Id } from '../../../convex/_generated/dataModel'
 import { useConnection } from '../../lib/connection/connectionContext'
 import { isConvexConfigured } from '../../lib/connection/convexClient'
 import { SignInControl } from '../account/SignInControl'
+import { DowntimePanel } from './DowntimePanel'
+import { ProposalInbox } from './ProposalInbox'
+import { Link } from '@tanstack/react-router'
 
 /**
  * Games: create one, invite people, join by code, hand over the Organizer role.
@@ -147,6 +150,21 @@ function GameRow({
         </div>
 
         {game.organizer && <InvitePanel gameId={game._id} />}
+
+        {/* A player's answer queue and the table's Downtime live with the game
+            they belong to, so a member never has to go looking for either. */}
+        <ProposalInbox gameId={game._id} />
+        <DowntimePanel gameId={game._id} />
+
+        {game.mediator && (
+          <Link
+            to="/mediator/$gameId"
+            params={{ gameId: game._id }}
+            className={`${label} text-[var(--color-rust)] hover:text-[var(--color-rust-hi)]`}
+          >
+            Open the Mediator surface →
+          </Link>
+        )}
       </div>
     </Card>
   )

--- a/apps/itun/src/components/games/GamesScreen.tsx
+++ b/apps/itun/src/components/games/GamesScreen.tsx
@@ -1,0 +1,292 @@
+import { useState } from 'react'
+import { Button, Card, Text } from 'component-lib'
+import { useMutation, useQuery } from 'convex/react'
+
+import { api } from '../../../convex/_generated/api'
+import type { Id } from '../../../convex/_generated/dataModel'
+import { useConnection } from '../../lib/connection/connectionContext'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+import { SignInControl } from '../account/SignInControl'
+
+/**
+ * Games: create one, invite people, join by code, hand over the Organizer role.
+ *
+ * The whole screen is gated on `mode === 'connected'`. That is not defensive
+ * coding — a Game is inherently shared state, so there is nothing meaningful to
+ * show a Solo user and nothing safe to show a Disconnected one, whose view
+ * would be a stale snapshot of a roster that may have changed.
+ */
+
+const label = 'font-cond text-xs font-bold tracking-caps-wide uppercase'
+
+function InvitePanel({ gameId }: { gameId: Id<'games'> }) {
+  const createInvite = useMutation(api.invites.create)
+  const [code, setCode] = useState<string | null>(null)
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Button
+        variant="ghost"
+        size="compact"
+        onClick={() => void createInvite({ gameId }).then(setCode)}
+      >
+        Create invite code
+      </Button>
+      {code !== null && (
+        <div className="flex flex-col gap-1">
+          {/* Crockford base32 with no I/L/O/U, so a code read aloud across a
+              table cannot be mistyped into a different valid one. Rendered
+              large and spaced because reading it aloud is the primary use. */}
+          <Text as="span" className="font-cond text-2xl font-bold tracking-caps-wide">
+            {code}
+          </Text>
+          <Text variant="hint" className="text-left">
+            Valid for 14 days. Anyone with this code can join as a player.
+          </Text>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function GameRow({
+  game,
+}: {
+  game: {
+    _id: Id<'games'>
+    name: string
+    mediator: boolean
+    organizer: boolean
+    memberCount: number
+  }
+}) {
+  const members = useQuery(api.games.members, { gameId: game._id })
+  const rename = useMutation(api.games.rename)
+  const setMediator = useMutation(api.games.setMediator)
+  const transferOrganizer = useMutation(api.games.transferOrganizer)
+  const [name, setName] = useState<string | null>(null)
+
+  const value = name ?? game.name
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <div className="flex items-baseline justify-between gap-3">
+          <Text as="span" className="font-cond text-lg font-bold">
+            {game.name}
+          </Text>
+          <Text variant="hint" className="text-left">
+            {game.organizer ? 'Organizer · ' : ''}
+            {game.mediator ? 'Mediator' : 'Player'}
+          </Text>
+        </div>
+
+        {game.organizer && (
+          <div className="flex flex-wrap items-end gap-2">
+            <label className="flex flex-col gap-1">
+              <span className={label}>Name</span>
+              <input
+                aria-label={`Rename ${game.name}`}
+                className="border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-1"
+                value={value}
+                onChange={(e) => setName(e.target.value)}
+              />
+            </label>
+            <Button
+              variant="primary"
+              size="compact"
+              onClick={() => void rename({ gameId: game._id, name: value })}
+            >
+              Save
+            </Button>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-1">
+          <span className={label}>Crew</span>
+          {members === undefined && <Text variant="hint">Loading…</Text>}
+          {members?.map((m) => (
+            <div key={m.userId} className="flex items-baseline justify-between gap-3">
+              <Text as="span">{m.displayName}</Text>
+              <span className="flex items-center gap-2">
+                <Text variant="hint" className="text-left">
+                  {m.organizer ? 'Organizer · ' : ''}
+                  {m.mediator ? 'Mediator' : 'Player'}
+                </Text>
+                {game.organizer && (
+                  <>
+                    <Button
+                      variant="ghost"
+                      size="mini"
+                      onClick={() =>
+                        void setMediator({
+                          gameId: game._id,
+                          userId: m.userId,
+                          mediator: !m.mediator,
+                        })
+                      }
+                    >
+                      {m.mediator ? 'Stand down' : 'Make Mediator'}
+                    </Button>
+                    {!m.organizer && (
+                      <Button
+                        variant="ghost"
+                        size="mini"
+                        onClick={() =>
+                          void transferOrganizer({ gameId: game._id, userId: m.userId })
+                        }
+                      >
+                        Hand over
+                      </Button>
+                    )}
+                  </>
+                )}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {game.organizer && <InvitePanel gameId={game._id} />}
+      </div>
+    </Card>
+  )
+}
+
+function ConnectedGames() {
+  const games = useQuery(api.games.listMine, {})
+  const create = useMutation(api.games.create)
+  const redeem = useMutation(api.invites.redeem)
+
+  const [newName, setNewName] = useState('')
+  const [code, setCode] = useState('')
+  const [joinError, setJoinError] = useState<string | null>(null)
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <div className="flex flex-wrap items-end gap-2 p-4">
+          <label className="flex flex-col gap-1">
+            <span className={label}>Start a game</span>
+            <input
+              aria-label="New game name"
+              placeholder="Union Crawler #430"
+              className="border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-1"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+            />
+          </label>
+          <Button
+            variant="primary"
+            size="compact"
+            disabled={newName.trim().length === 0}
+            onClick={() => void create({ name: newName }).then(() => setNewName(''))}
+          >
+            Create
+          </Button>
+        </div>
+      </Card>
+
+      <Card>
+        <div className="flex flex-col gap-2 p-4">
+          <div className="flex flex-wrap items-end gap-2">
+            <label className="flex flex-col gap-1">
+              <span className={label}>Join with a code</span>
+              <input
+                aria-label="Invite code"
+                placeholder="A1B2C3D4"
+                className="border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-1 tracking-caps-wide uppercase"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+              />
+            </label>
+            <Button
+              variant="primary"
+              size="compact"
+              disabled={code.trim().length === 0}
+              onClick={() => {
+                setJoinError(null)
+                void redeem({ code })
+                  .then(() => setCode(''))
+                  // The server distinguishes not-valid / expired / used-up, so
+                  // surface its wording rather than a generic failure.
+                  .catch((err: Error) => setJoinError(err.message))
+              }}
+            >
+              Join
+            </Button>
+          </div>
+          {joinError !== null && (
+            <Text variant="hint" className="text-left text-[var(--color-roll-cascade)]">
+              {joinError}
+            </Text>
+          )}
+        </div>
+      </Card>
+
+      {games === undefined && <Text>Loading your games…</Text>}
+      {games?.length === 0 && (
+        <Text variant="hint" className="text-left">
+          You are not in any games yet. Create one, or join with a code from whoever set yours up.
+        </Text>
+      )}
+      {games?.map((g) => (
+        <GameRow key={g._id} game={g} />
+      ))}
+    </div>
+  )
+}
+
+function GamesBody() {
+  const { mode } = useConnection()
+
+  if (mode === 'connected') return <ConnectedGames />
+
+  if (mode === 'disconnected') {
+    return (
+      <Card>
+        <div className="p-4">
+          <Text>
+            Your games are unreachable right now. Reconnect to see your crew or manage invites.
+          </Text>
+        </div>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <Text>Games let several people share one crawler, with a Mediator running the table.</Text>
+        <Text variant="hint" className="text-left">
+          You are playing solo. Everything you build stays on this device and needs no account —
+          sign in only if you want to play with other people.
+        </Text>
+        <div>
+          <SignInControl />
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+export function GamesScreen() {
+  return (
+    <main className="mx-auto flex max-w-2xl flex-col gap-6 p-4">
+      <Text as="h1" className="font-cond text-2xl font-bold tracking-caps uppercase">
+        Games
+      </Text>
+      {isConvexConfigured ? (
+        <GamesBody />
+      ) : (
+        <Card>
+          <div className="p-4">
+            <Text>
+              This build has no account service configured, so shared games are unavailable and
+              everything is saved on this device.
+            </Text>
+          </div>
+        </Card>
+      )}
+    </main>
+  )
+}

--- a/apps/itun/src/components/games/MediatorScreen.tsx
+++ b/apps/itun/src/components/games/MediatorScreen.tsx
@@ -1,0 +1,301 @@
+import { useState } from 'react'
+import { Button, Card, Text } from 'component-lib'
+import { useMutation, useQuery } from 'convex/react'
+
+import { api } from '../../../convex/_generated/api'
+import type { Id } from '../../../convex/_generated/dataModel'
+import { useConnection } from '../../lib/connection/connectionContext'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+import { CrewVitals } from './CrewVitals'
+import { DowntimePanel } from './DowntimePanel'
+import { INPUT, ROW, SECTION, STAMP, TITLE } from './gameChrome'
+
+/**
+ * The Mediator surface — the layer ADR-021 deferred and ADR-030 §6 specifies.
+ *
+ * It is one screen because the Mediator's problem is holding four things at
+ * once: what the crew's numbers are, what the opposition is, what they want to
+ * change, and where the table is in a Downtime. Splitting those across routes
+ * would recreate the tab-flipping this is meant to replace.
+ *
+ * ## Deliberately not the player Dashboard
+ *
+ * The player Dashboard is a locked 1280×800 canvas built around one
+ * pilot + mech + crawler (ADR-020). An N-player table view does not fit it, and
+ * stretching it to would reopen a layout that took ~60 iterations to settle.
+ * This is a plain scrolling surface instead — the *right* shape for a list that
+ * grows with the crew.
+ *
+ * ## Scope note
+ *
+ * The composition here is functional and uses the app's existing chrome
+ * vocabulary (hard ink borders, stamped condensed caps, the shipped tracking
+ * ladder). It has not had a design pass, and the visual arrangement is the part
+ * most likely to change.
+ */
+
+const PROPOSABLE_FIELDS = ['currentHp', 'currentAp', 'currentSp', 'currentHeat'] as const
+
+function NpcTray({ gameId }: { gameId: Id<'games'> }) {
+  const npcs = useQuery(api.mediator.npcs, { gameId })
+  const addNpc = useMutation(api.mediator.addNpc)
+  const removeNpc = useMutation(api.mediator.removeNpc)
+  const [name, setName] = useState('')
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <Text as="span" className={SECTION}>
+          Opposition
+        </Text>
+        <Text variant="hint">Only you can see this. Players never read the tray.</Text>
+
+        {npcs?.map((n) => (
+          <div key={n._id} className={ROW}>
+            <Text as="span">{String((n.body as { name?: string })?.name ?? 'Unnamed')}</Text>
+            <Button variant="ghost" size="mini" onClick={() => void removeNpc({ npcId: n._id })}>
+              Remove
+            </Button>
+          </div>
+        ))}
+
+        <div className="flex flex-wrap items-end gap-2">
+          <label className="flex flex-col gap-1">
+            <span className={STAMP}>Add</span>
+            <input
+              aria-label="NPC name"
+              className={INPUT}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </label>
+          <Button
+            variant="primary"
+            size="compact"
+            disabled={name.trim().length === 0}
+            onClick={() => void addNpc({ gameId, body: { name } }).then(() => setName(''))}
+          >
+            Add
+          </Button>
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+function ProposeForm({ gameId }: { gameId: Id<'games'> }) {
+  const crew = useQuery(api.crew.vitals, { gameId })
+  const propose = useMutation(api.proposals.propose)
+
+  const [target, setTarget] = useState('')
+  const [field, setField] = useState<string>(PROPOSABLE_FIELDS[0])
+  const [value, setValue] = useState('')
+
+  // Only claimed entities can be proposed to — an unclaimed pre-gen has nobody
+  // to answer, so offering it here would build a dead end into the UI.
+  const targets = [
+    ...(crew?.pilots ?? [])
+      .filter((p) => p.ownerId !== null)
+      .map((p) => ({ id: p._id, label: `${p.name} (pilot)`, type: 'pilot' as const })),
+    ...(crew?.mechs ?? [])
+      .filter((m) => m.ownerId !== null)
+      .map((m) => ({ id: m._id, label: `${m.name} (mech)`, type: 'mech' as const })),
+  ]
+  const chosen = targets.find((t) => t.id === target)
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <Text as="span" className={SECTION}>
+          Propose a change
+        </Text>
+        <Text variant="hint">
+          You are asking, not setting. The player sees the before and after, and applies or declines
+          it.
+        </Text>
+
+        <div className="flex flex-wrap items-end gap-2">
+          <label className="flex flex-col gap-1">
+            <span className={STAMP}>To</span>
+            <select
+              aria-label="Proposal target"
+              className={INPUT}
+              value={target}
+              onChange={(e) => setTarget(e.target.value)}
+            >
+              <option value="">Choose…</option>
+              {targets.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span className={STAMP}>Field</span>
+            <select
+              aria-label="Proposal field"
+              className={INPUT}
+              value={field}
+              onChange={(e) => setField(e.target.value)}
+            >
+              {PROPOSABLE_FIELDS.map((f) => (
+                <option key={f} value={f}>
+                  {f}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span className={STAMP}>New value</span>
+            <input
+              aria-label="Proposed value"
+              className={INPUT}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+            />
+          </label>
+
+          <Button
+            variant="primary"
+            size="compact"
+            disabled={chosen === undefined || value.trim().length === 0}
+            onClick={() => {
+              if (chosen === undefined) return
+              void propose({
+                entityId: chosen.id,
+                entityType: chosen.type,
+                field,
+                before: null,
+                after: Number(value),
+              }).then(() => setValue(''))
+            }}
+          >
+            Propose
+          </Button>
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+function AlertBar({ gameId }: { gameId: Id<'games'> }) {
+  const broadcast = useMutation(api.proposals.broadcast)
+  const alerts = useQuery(api.proposals.alerts, { gameId, limit: 5 })
+  const [message, setMessage] = useState('')
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <Text as="span" className={SECTION}>
+          Tell the table
+        </Text>
+        <div className="flex flex-wrap items-end gap-2">
+          <label className="flex flex-1 flex-col gap-1">
+            <span className={STAMP}>Alert</span>
+            <input
+              aria-label="Alert message"
+              className={INPUT}
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+            />
+          </label>
+          <Button
+            variant="primary"
+            size="compact"
+            disabled={message.trim().length === 0}
+            onClick={() => void broadcast({ gameId, message }).then(() => setMessage(''))}
+          >
+            Send
+          </Button>
+        </div>
+        {alerts?.map((a) => (
+          <div key={a._id} className={ROW}>
+            <Text as="span" variant="hint">
+              {a.message}
+            </Text>
+          </div>
+        ))}
+      </div>
+    </Card>
+  )
+}
+
+function PresenceList({ gameId }: { gameId: Id<'games'> }) {
+  const rows = useQuery(api.mediator.presence, { gameId })
+  if (rows === undefined || rows.length === 0) return null
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-1 p-4">
+        <Text as="span" className={SECTION}>
+          At the table
+        </Text>
+        {rows.map((r) => (
+          <div key={r.userId} className={ROW}>
+            <Text as="span">{r.displayName}</Text>
+            <Text as="span" variant="hint">
+              {r.present ? 'here' : 'away'}
+            </Text>
+          </div>
+        ))}
+      </div>
+    </Card>
+  )
+}
+
+function MediatorBody({ gameId }: { gameId: Id<'games'> }) {
+  const amMediator = useQuery(api.mediator.amMediator, { gameId })
+
+  if (amMediator === undefined) return <Text>Loading…</Text>
+  if (!amMediator) {
+    return (
+      <Card>
+        <div className="p-4">
+          <Text>You do not mediate this game. Ask whoever organises it to hand you the role.</Text>
+        </div>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <div className="p-4">
+          <CrewVitals gameId={gameId} />
+        </div>
+      </Card>
+      <PresenceList gameId={gameId} />
+      <ProposeForm gameId={gameId} />
+      <AlertBar gameId={gameId} />
+      <DowntimePanel gameId={gameId} />
+      <NpcTray gameId={gameId} />
+    </div>
+  )
+}
+
+export function MediatorScreen({ gameId }: { gameId: string }) {
+  const { mode } = useConnection()
+
+  return (
+    <main className="mx-auto flex max-w-3xl flex-col gap-6 p-4">
+      <Text as="h1" className={TITLE}>
+        Mediator
+      </Text>
+      {!isConvexConfigured || mode !== 'connected' ? (
+        <Card>
+          <div className="p-4">
+            <Text>
+              Running a table needs a connected account. This build is playing solo, so there is no
+              game to mediate.
+            </Text>
+          </div>
+        </Card>
+      ) : (
+        <MediatorBody gameId={gameId as Id<'games'>} />
+      )}
+    </main>
+  )
+}

--- a/apps/itun/src/components/games/ProposalInbox.tsx
+++ b/apps/itun/src/components/games/ProposalInbox.tsx
@@ -1,0 +1,75 @@
+import { Button, Card, Text } from 'component-lib'
+import { useMutation, useQuery } from 'convex/react'
+
+import { api } from '../../../convex/_generated/api'
+import type { Id } from '../../../convex/_generated/dataModel'
+import { NUM, ROW, STAMP } from './gameChrome'
+
+/**
+ * The player's side of propose-and-confirm (D7).
+ *
+ * The Mediator has said what they think should change; this is where the player
+ * decides. Two things about the presentation are load-bearing rather than
+ * cosmetic:
+ *
+ *  - **Before and after are both shown.** The Mediator captured `before` from
+ *    their own view at propose time, and it is deliberately not re-read on
+ *    apply. If it disagrees with what the player is looking at, that mismatch
+ *    is information they should see — the table can then work out who is out of
+ *    step — rather than something the UI silently reconciles.
+ *  - **Decline is a peer of Apply, not a dismissal.** Declining is a recorded
+ *    answer, so it gets equal weight; hiding it behind an X would imply the
+ *    only real option is to accept.
+ *
+ * Nothing here can be auto-applied. There is no server mutation that would let
+ * it be, and no timer that would make waiting cost the player anything.
+ */
+export function ProposalInbox({ gameId }: { gameId: Id<'games'> }) {
+  const pending = useQuery(api.proposals.pending, { gameId })
+  const apply = useMutation(api.proposals.apply)
+  const decline = useMutation(api.proposals.decline)
+
+  if (pending === undefined) return null
+  if (pending.length === 0) return null
+
+  const show = (value: unknown): string =>
+    value === null || value === undefined ? '—' : String(value)
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <Text as="span" className={STAMP}>
+          Awaiting your answer
+        </Text>
+        {pending.map((p) => (
+          <div key={p._id} className="flex flex-col gap-2">
+            <div className={ROW}>
+              <Text as="span">
+                {p.entityType} · {p.field}
+              </Text>
+              <Text as="span" className={NUM}>
+                {show(p.before)} → {show(p.after)}
+              </Text>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="primary"
+                size="compact"
+                onClick={() => void apply({ proposalId: p._id as Id<'changeLog'> })}
+              >
+                Apply
+              </Button>
+              <Button
+                variant="ghost"
+                size="compact"
+                onClick={() => void decline({ proposalId: p._id as Id<'changeLog'> })}
+              >
+                Decline
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  )
+}

--- a/apps/itun/src/components/games/__tests__/GamesScreen.connected.test.tsx
+++ b/apps/itun/src/components/games/__tests__/GamesScreen.connected.test.tsx
@@ -1,0 +1,198 @@
+import { afterAll, describe, expect, mock, test } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+
+/**
+ * `GamesScreen` in its connected state.
+ *
+ * The Solo test proves it does not crash without a provider. This covers what
+ * the screen actually does for a signed-in player: which controls a plain
+ * member gets versus an Organizer, and whether the Mediator link appears only
+ * for somebody who mediates.
+ *
+ * Queries are answered in **call order** — the generated `api` object is a
+ * Proxy that throws the moment a test inspects it, so position is the only
+ * stable key. The order is the render order of the hooks.
+ */
+
+let queryQueue: unknown[] = []
+let queryIndex = 0
+
+/**
+ * `mock.module` replaces the entry in the process-wide module registry, so these
+ * mocks outlive this file and would otherwise poison every test that runs after
+ * it — the exports below are captured first and put back in `afterAll`.
+ *
+ * The spread is load-bearing. A module namespace is a *live* view, and mocking
+ * rewrites it in place, so holding the namespace itself captures nothing: by
+ * `afterAll` it already reads as the mock.
+ */
+const realConvexClient = { ...(await import('../../../lib/connection/convexClient')) }
+const realConvexReact = { ...(await import('convex/react')) }
+const realAuthReact = { ...(await import('@convex-dev/auth/react')) }
+const realRouter = { ...(await import('@tanstack/react-router')) }
+
+mock.module('../../../lib/connection/convexClient', () => ({
+  isConvexConfigured: true,
+  convexClient: {},
+}))
+
+mock.module('convex/react', () => ({
+  useQuery: () => {
+    const v = queryQueue[queryIndex]
+    queryIndex += 1
+    return v
+  },
+  useMutation: () => async () => undefined,
+  useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
+  ConvexReactClient: class {},
+  // `@convex-dev/auth/react` (reached via SignInControl) imports these from
+  // convex/react, so a partial mock of the module breaks its import rather
+  // than the component under test.
+  ConvexProviderWithAuth: ({ children }: { children: unknown }) => children,
+  ConvexProvider: ({ children }: { children: unknown }) => children,
+  useConvex: () => ({}),
+  useAction: () => async () => undefined,
+}))
+
+mock.module('@convex-dev/auth/react', () => ({
+  useAuthActions: () => ({ signIn: async () => undefined, signOut: async () => undefined }),
+  ConvexAuthProvider: ({ children }: { children: unknown }) => children,
+}))
+
+// The Mediator link is a router `Link`, which needs a RouterProvider it has no
+// business needing here — the assertion is whether the link is offered at all.
+mock.module('@tanstack/react-router', () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}))
+
+const { GamesScreen } = await import('../GamesScreen')
+const { ConnectionProvider } = await import('../../../lib/connection/ConnectionProvider')
+
+function withQueries(values: unknown[]): void {
+  queryQueue = values
+  queryIndex = 0
+}
+
+const wrap = () =>
+  render(
+    <ConnectionProvider>
+      <GamesScreen />
+    </ConnectionProvider>
+  )
+
+const GAME = {
+  _id: 'g1',
+  name: 'Union Crawler #430',
+  templateOrigin: undefined,
+  mediator: false,
+  organizer: false,
+  memberCount: 3,
+}
+
+const MEMBERS = [
+  {
+    userId: 'u1',
+    displayName: 'Ash',
+    avatarUrl: undefined,
+    mediator: false,
+    organizer: true,
+    joinedAt: 1,
+  },
+  {
+    userId: 'u2',
+    displayName: 'Beefcake',
+    avatarUrl: undefined,
+    mediator: true,
+    organizer: false,
+    joinedAt: 2,
+  },
+]
+
+const TEMPLATES = [
+  { id: 'starter-set', name: 'Reclamation of the Wastes', description: 'Six pre-gens.' },
+]
+
+/** listMine, templates, members, pending, downtime state, amMediator. */
+function queriesFor(game: Record<string, unknown>): unknown[] {
+  return [
+    [game],
+    TEMPLATES,
+    MEMBERS,
+    [],
+    { running: false, stepIndex: null, completedBy: [], upkeepSpent: false },
+    false,
+  ]
+}
+
+describe('GamesScreen for a signed-in player', () => {
+  test('lists the games you are in, with the crew', () => {
+    withQueries(queriesFor(GAME))
+    wrap()
+
+    expect(screen.getByText('Union Crawler #430')).toBeTruthy()
+    expect(screen.getByText('Ash')).toBeTruthy()
+    expect(screen.getByText('Beefcake')).toBeTruthy()
+  })
+
+  test('offers create and join to everybody', () => {
+    withQueries(queriesFor(GAME))
+    wrap()
+
+    expect(screen.getByLabelText('New game name')).toBeTruthy()
+    expect(screen.getByLabelText('Invite code')).toBeTruthy()
+  })
+
+  test('a plain member gets no administrative controls', () => {
+    withQueries(queriesFor(GAME))
+    wrap()
+
+    // Renaming, inviting and role changes are the Organizer's, and hiding them
+    // is the courtesy half of a rule the server enforces regardless.
+    expect(screen.queryByLabelText('Rename Union Crawler #430')).toBeNull()
+    expect(screen.queryByText('Create invite code')).toBeNull()
+    expect(screen.queryByText('Make Mediator')).toBeNull()
+  })
+
+  test('an Organizer gets rename, invites and role controls', () => {
+    withQueries(queriesFor({ ...GAME, organizer: true }))
+    wrap()
+
+    expect(screen.getByLabelText('Rename Union Crawler #430')).toBeTruthy()
+    expect(screen.getByText('Create invite code')).toBeTruthy()
+    expect(screen.getAllByText(/Make Mediator|Stand down/).length).toBeGreaterThan(0)
+  })
+
+  test('the Mediator link appears only for somebody who mediates', () => {
+    withQueries(queriesFor(GAME))
+    wrap()
+    expect(screen.queryByText(/Open the Mediator surface/)).toBeNull()
+
+    withQueries(queriesFor({ ...GAME, mediator: true }))
+    wrap()
+    expect(screen.getAllByText(/Open the Mediator surface/).length).toBeGreaterThan(0)
+  })
+
+  test('offers a template to start from', () => {
+    withQueries(queriesFor(GAME))
+    wrap()
+    expect(screen.getByText('Reclamation of the Wastes')).toBeTruthy()
+    expect(screen.getByText('Start this game')).toBeTruthy()
+  })
+
+  test('no games yet says so, and still offers the way in', () => {
+    withQueries([[], TEMPLATES])
+    wrap()
+
+    expect(screen.getByText(/not in any games yet/i)).toBeTruthy()
+    expect(screen.getByLabelText('Invite code')).toBeTruthy()
+  })
+})
+
+afterAll(() => {
+  mock.module('../../../lib/connection/convexClient', () => realConvexClient)
+  mock.module('convex/react', () => realConvexReact)
+  mock.module('@convex-dev/auth/react', () => realAuthReact)
+  mock.module('@tanstack/react-router', () => realRouter)
+})

--- a/apps/itun/src/components/games/__tests__/GamesScreen.test.tsx
+++ b/apps/itun/src/components/games/__tests__/GamesScreen.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+
+import { ConnectionProvider } from '../../../lib/connection/ConnectionProvider'
+import { isConvexConfigured } from '../../../lib/connection/convexClient'
+import { GamesScreen } from '../GamesScreen'
+
+/**
+ * Same structural guard as the account screen: every Convex hook in here
+ * (`useQuery`, `useMutation`) throws without a provider above it, and a Solo
+ * build deliberately has none.
+ *
+ * This is the failure mode that hides best — it works perfectly for whoever
+ * is developing with a configured `.env.local`, and crashes for every user who
+ * never signs in.
+ */
+
+describe('GamesScreen in a Solo build', () => {
+  test('the test build really is Solo', () => {
+    expect(isConvexConfigured).toBe(false)
+  })
+
+  test('renders without a Convex provider present', () => {
+    render(
+      <ConnectionProvider>
+        <GamesScreen />
+      </ConnectionProvider>
+    )
+    expect(screen.getByText('Games')).toBeTruthy()
+  })
+
+  test('explains why shared games are unavailable rather than showing a broken form', () => {
+    render(
+      <ConnectionProvider>
+        <GamesScreen />
+      </ConnectionProvider>
+    )
+    expect(screen.getByText(/saved on this device/i)).toBeTruthy()
+    // No create/join affordance should be offered when it cannot possibly work.
+    expect(screen.queryByLabelText('New game name')).toBeNull()
+    expect(screen.queryByLabelText('Invite code')).toBeNull()
+  })
+})

--- a/apps/itun/src/components/games/__tests__/MediatorScreen.connected.test.tsx
+++ b/apps/itun/src/components/games/__tests__/MediatorScreen.connected.test.tsx
@@ -1,0 +1,248 @@
+import { afterAll, describe, expect, mock, test } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+
+/**
+ * `MediatorScreen` in its connected state.
+ *
+ * The Solo test proves the screen refuses gracefully with no account. This
+ * covers the surface itself: that it is gated on actually mediating, and that
+ * the propose form obeys the one rule that is easy to lose — you may only
+ * propose to an entity that has somebody to answer.
+ *
+ * Queries are answered in **call order**; the generated `api` object is a Proxy
+ * that throws when inspected, so position is the only stable key. Render order
+ * is: amMediator, crew (vitals), presence, crew (propose form), alerts,
+ * downtime state, downtime amMediator, npcs.
+ */
+
+let queryQueue: unknown[] = []
+let queryIndex = 0
+
+/**
+ * `mock.module` replaces the entry in the process-wide module registry, so these
+ * mocks outlive this file and would otherwise poison every test that runs after
+ * it — the exports below are captured first and put back in `afterAll`.
+ *
+ * The spread is load-bearing. A module namespace is a *live* view, and mocking
+ * rewrites it in place, so holding the namespace itself captures nothing: by
+ * `afterAll` it already reads as the mock.
+ */
+const realConvexClient = { ...(await import('../../../lib/connection/convexClient')) }
+const realConvexReact = { ...(await import('convex/react')) }
+
+mock.module('../../../lib/connection/convexClient', () => ({
+  isConvexConfigured: true,
+  convexClient: {},
+}))
+
+mock.module('convex/react', () => ({
+  useQuery: () => {
+    const value = queryQueue[queryIndex]
+    queryIndex += 1
+    return value
+  },
+  useMutation: () => async () => undefined,
+  useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
+  ConvexReactClient: class {},
+  ConvexProvider: ({ children }: { children: unknown }) => children,
+  ConvexProviderWithAuth: ({ children }: { children: unknown }) => children,
+  useConvex: () => ({}),
+  useAction: () => async () => undefined,
+}))
+
+const { MediatorScreen } = await import('../MediatorScreen')
+const { ConnectionProvider } = await import('../../../lib/connection/ConnectionProvider')
+
+function withQueries(values: unknown[]): void {
+  queryQueue = values
+  queryIndex = 0
+}
+
+const wrap = () =>
+  render(
+    <ConnectionProvider>
+      <MediatorScreen gameId="g1" />
+    </ConnectionProvider>
+  )
+
+const CLAIMED_PILOT = {
+  _id: 'p1',
+  appId: null,
+  ownerId: 'u2',
+  ownerName: 'Beefcake',
+  name: 'Roach-Boy',
+  currentHp: 8,
+  currentAp: 4,
+}
+
+const UNCLAIMED_PILOT = {
+  _id: 'p2',
+  appId: null,
+  ownerId: null,
+  ownerName: null,
+  name: 'Pre-gen',
+  currentHp: 10,
+  currentAp: 5,
+}
+
+const DOWNTIME = { running: false, stepIndex: null, completedBy: [], upkeepSpent: false }
+
+/** The full mediating render, with whatever crew and tray the case needs. */
+function mediatingQueries(
+  crew: Record<string, unknown>,
+  extra: { presence?: unknown; alerts?: unknown; npcs?: unknown } = {}
+): unknown[] {
+  return [
+    true,
+    crew,
+    extra.presence ?? [],
+    crew,
+    extra.alerts ?? [],
+    DOWNTIME,
+    true,
+    extra.npcs ?? [],
+  ]
+}
+
+describe('who the Mediator surface is for', () => {
+  test('somebody who does not mediate is told so, and gets none of the tools', () => {
+    withQueries([false])
+    wrap()
+
+    expect(screen.getByText(/You do not mediate this game/i)).toBeTruthy()
+    // The refusal has to be total: a visible propose form that the server would
+    // reject is worse than no form.
+    expect(screen.queryByLabelText('Proposal target')).toBeNull()
+    expect(screen.queryByLabelText('Alert message')).toBeNull()
+    expect(screen.queryByLabelText('NPC name')).toBeNull()
+  })
+
+  test('while the role is still unknown it says so rather than guessing', () => {
+    // Rendering the tools optimistically would flash the whole Mediator surface
+    // at a player who is about to be refused it.
+    withQueries([undefined])
+    wrap()
+    expect(screen.getByText('Loading…')).toBeTruthy()
+  })
+
+  test('the Mediator gets every panel', () => {
+    withQueries(mediatingQueries({ viewerId: 'u1', pilots: [CLAIMED_PILOT], mechs: [] }))
+    wrap()
+
+    expect(screen.getByText('Propose a change')).toBeTruthy()
+    expect(screen.getByText('Tell the table')).toBeTruthy()
+    expect(screen.getByText('Opposition')).toBeTruthy()
+  })
+})
+
+describe('proposing a change', () => {
+  test('only claimed entities are offered as targets', () => {
+    withQueries(
+      mediatingQueries({
+        viewerId: 'u1',
+        pilots: [CLAIMED_PILOT, UNCLAIMED_PILOT],
+        mechs: [],
+      })
+    )
+    wrap()
+
+    // An unclaimed pre-gen has nobody to answer the proposal, so offering it
+    // would build a dead end into the form.
+    expect(screen.getByRole('option', { name: 'Roach-Boy (pilot)' })).toBeTruthy()
+    expect(screen.queryByRole('option', { name: 'Pre-gen (pilot)' })).toBeNull()
+  })
+
+  test('mechs are offered alongside pilots, labelled by kind', () => {
+    withQueries(
+      mediatingQueries({
+        viewerId: 'u1',
+        pilots: [],
+        mechs: [{ ...CLAIMED_PILOT, _id: 'm1', name: 'Iron Mongrel' }],
+      })
+    )
+    wrap()
+    expect(screen.getByRole('option', { name: 'Iron Mongrel (mech)' })).toBeTruthy()
+  })
+
+  test('it says out loud that it is asking, not setting', () => {
+    // The propose/confirm rule is the whole point of the surface; if the
+    // wording ever drifts to sounding authoritative, this should fail.
+    withQueries(mediatingQueries({ viewerId: 'u1', pilots: [], mechs: [] }))
+    wrap()
+    expect(screen.getByText(/You are asking, not setting/i)).toBeTruthy()
+  })
+
+  test('Propose stays disabled until there is a target and a value', () => {
+    withQueries(mediatingQueries({ viewerId: 'u1', pilots: [CLAIMED_PILOT], mechs: [] }))
+    wrap()
+
+    const button = screen.getByText('Propose').closest('button')
+    expect(button?.disabled).toBe(true)
+  })
+})
+
+describe('the rest of the table', () => {
+  test('presence reads as here or away, per person', () => {
+    withQueries(
+      mediatingQueries(
+        { viewerId: 'u1', pilots: [], mechs: [] },
+        {
+          presence: [
+            { userId: 'u2', displayName: 'Beefcake', present: true },
+            { userId: 'u3', displayName: 'Ash', present: false },
+          ],
+        }
+      )
+    )
+    wrap()
+
+    expect(screen.getByText('At the table')).toBeTruthy()
+    expect(screen.getByText('here')).toBeTruthy()
+    expect(screen.getByText('away')).toBeTruthy()
+  })
+
+  test('nobody at the table renders no panel at all', () => {
+    withQueries(mediatingQueries({ viewerId: 'u1', pilots: [], mechs: [] }, { presence: [] }))
+    wrap()
+    // An empty roster of who is present is noise, not information.
+    expect(screen.queryByText('At the table')).toBeNull()
+  })
+
+  test('recent alerts are shown back, and Send needs a message', () => {
+    withQueries(
+      mediatingQueries(
+        { viewerId: 'u1', pilots: [], mechs: [] },
+        { alerts: [{ _id: 'a1', message: 'The crawler is taking fire.' }] }
+      )
+    )
+    wrap()
+
+    expect(screen.getByText('The crawler is taking fire.')).toBeTruthy()
+    expect(screen.getByText('Send').closest('button')?.disabled).toBe(true)
+  })
+
+  test('the tray is named as private, and an unnamed NPC still reads as something', () => {
+    withQueries(
+      mediatingQueries(
+        { viewerId: 'u1', pilots: [], mechs: [] },
+        {
+          npcs: [
+            { _id: 'n1', body: {} },
+            { _id: 'n2', body: { name: 'Scrap Hound' } },
+          ],
+        }
+      )
+    )
+    wrap()
+
+    expect(screen.getByText(/Only you can see this/i)).toBeTruthy()
+    // A blank row would look like a rendering bug in the middle of a session.
+    expect(screen.getByText('Unnamed')).toBeTruthy()
+    expect(screen.getByText('Scrap Hound')).toBeTruthy()
+  })
+})
+
+afterAll(() => {
+  mock.module('../../../lib/connection/convexClient', () => realConvexClient)
+  mock.module('convex/react', () => realConvexReact)
+})

--- a/apps/itun/src/components/games/__tests__/MediatorScreen.test.tsx
+++ b/apps/itun/src/components/games/__tests__/MediatorScreen.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+
+import { ConnectionProvider } from '../../../lib/connection/ConnectionProvider'
+import { isConvexConfigured } from '../../../lib/connection/convexClient'
+import { MediatorScreen } from '../MediatorScreen'
+
+/**
+ * The Mediator surface in a Solo build.
+ *
+ * Same structural guard as every other Convex-touching screen: `useQuery` and
+ * `useMutation` throw without a provider above them, and a Solo build
+ * deliberately has none. This screen has more hooks than any other in the app,
+ * so it is the one most likely to leak one past the build-time branch.
+ *
+ * The assertion is that it renders at all — and that it says something true
+ * rather than showing an empty mediator console nobody can use.
+ */
+
+describe('MediatorScreen in a Solo build', () => {
+  test('the test build really is Solo', () => {
+    expect(isConvexConfigured).toBe(false)
+  })
+
+  test('renders without a Convex provider present', () => {
+    render(
+      <ConnectionProvider>
+        <MediatorScreen gameId="whatever" />
+      </ConnectionProvider>
+    )
+    expect(screen.getByText('Mediator')).toBeTruthy()
+  })
+
+  test('explains that there is no table to run rather than showing empty controls', () => {
+    render(
+      <ConnectionProvider>
+        <MediatorScreen gameId="whatever" />
+      </ConnectionProvider>
+    )
+    expect(screen.getByText(/playing solo/i)).toBeTruthy()
+    // None of the mediator affordances should be reachable — an inert console
+    // is worse than an honest explanation.
+    expect(screen.queryByLabelText('NPC name')).toBeNull()
+    expect(screen.queryByLabelText('Alert message')).toBeNull()
+    expect(screen.queryByLabelText('Proposal target')).toBeNull()
+  })
+})

--- a/apps/itun/src/components/games/__tests__/connectedSurfaces.test.tsx
+++ b/apps/itun/src/components/games/__tests__/connectedSurfaces.test.tsx
@@ -1,0 +1,229 @@
+import { afterAll, describe, expect, mock, test } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+
+/**
+ * The Game surfaces in their **connected** state.
+ *
+ * Every other test of these components exercises the Solo path, because the
+ * test build has no `VITE_CONVEX_URL`. That proves they do not crash without a
+ * provider — but it leaves the branch people actually use untested, which is
+ * where the interesting behaviour lives: how an unclaimed pilot reads, what a
+ * missing vital renders as, whether a non-Mediator can see the opposition.
+ *
+ * Both the Convex hooks and the build-time `isConvexConfigured` flag are mocked
+ * so the connected branch renders. `mock.module` is file-scoped in Bun, so
+ * these live together rather than being spread across the component files.
+ */
+
+/**
+ * Queries answered in CALL ORDER rather than by looking up the function
+ * reference. The generated `api` object is a Proxy that throws ("No default
+ * value") the moment a test touches a property on it, so introspecting the
+ * reference is not available — but each component's hook order is fixed, which
+ * makes position a stable key.
+ */
+let queryQueue: unknown[] = []
+let queryIndex = 0
+
+/**
+ * `mock.module` replaces the entry in the process-wide module registry, so these
+ * mocks outlive this file and would otherwise poison every test that runs after
+ * it — the exports below are captured first and put back in `afterAll`.
+ *
+ * The spread is load-bearing. A module namespace is a *live* view, and mocking
+ * rewrites it in place, so holding the namespace itself captures nothing: by
+ * `afterAll` it already reads as the mock.
+ */
+const realConvexClient = { ...(await import('../../../lib/connection/convexClient')) }
+const realConvexReact = { ...(await import('convex/react')) }
+
+mock.module('../../../lib/connection/convexClient', () => ({
+  isConvexConfigured: true,
+  convexClient: {},
+}))
+
+mock.module('convex/react', () => ({
+  useQuery: () => {
+    const value = queryQueue[queryIndex]
+    queryIndex += 1
+    return value
+  },
+  useMutation: () => async () => undefined,
+  useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
+  ConvexReactClient: class {},
+  ConvexProvider: ({ children }: { children: unknown }) => children,
+}))
+
+const { CrewVitals } = await import('../CrewVitals')
+const { DowntimePanel } = await import('../DowntimePanel')
+const { ProposalInbox } = await import('../ProposalInbox')
+const { ConnectionProvider } = await import('../../../lib/connection/ConnectionProvider')
+
+/** Answer this component's useQuery calls, in the order it makes them. */
+function withQueries(values: unknown[]): void {
+  queryQueue = values
+  queryIndex = 0
+}
+
+const wrap = (ui: React.ReactNode) => render(<ConnectionProvider>{ui}</ConnectionProvider>)
+
+describe('CrewVitals', () => {
+  test('an unclaimed pilot reads as Unclaimed, not as a blank', () => {
+    withQueries([
+      {
+        viewerId: 'u1',
+        pilots: [
+          {
+            _id: 'p1',
+            appId: null,
+            ownerId: null,
+            ownerName: null,
+            name: 'Pre-gen',
+            currentHp: 10,
+            currentAp: 5,
+          },
+        ],
+        mechs: [],
+      },
+    ])
+    wrap(<CrewVitals gameId={'g1' as never} />)
+
+    // A pre-gen waiting to be handed out is available, not broken.
+    expect(screen.getByText('Unclaimed')).toBeTruthy()
+  })
+
+  test('a missing vital renders as a dash, never as zero', () => {
+    withQueries([
+      {
+        viewerId: 'u1',
+        pilots: [
+          {
+            _id: 'p1',
+            appId: null,
+            ownerId: 'u2',
+            ownerName: 'Beefcake',
+            name: 'Roach-Boy',
+            currentHp: null,
+            currentAp: null,
+          },
+        ],
+        mechs: [],
+      },
+    ])
+    wrap(<CrewVitals gameId={'g1' as never} />)
+
+    // Zero would read as DEAD on a vitals strip, which is worse than blank.
+    expect(screen.getByText(/HP — · AP —/)).toBeTruthy()
+    expect(screen.getByText('Beefcake')).toBeTruthy()
+  })
+
+  test('an empty game says so rather than rendering nothing', () => {
+    withQueries([{ viewerId: 'u1', pilots: [], mechs: [] }])
+    wrap(<CrewVitals gameId={'g1' as never} />)
+    expect(screen.getByText(/No pilots in this game yet/i)).toBeTruthy()
+  })
+
+  test('while loading it says so', () => {
+    withQueries([undefined])
+    wrap(<CrewVitals gameId={'g1' as never} />)
+    expect(screen.getByText(/Loading the crew/i)).toBeTruthy()
+  })
+})
+
+describe('DowntimePanel', () => {
+  test('not running, and a non-Mediator is offered no phase controls', () => {
+    withQueries([{ running: false, stepIndex: null, completedBy: [], upkeepSpent: false }, false])
+    wrap(<DowntimePanel gameId={'g1' as never} />)
+
+    expect(screen.getByText(/Not running/i)).toBeTruthy()
+    expect(screen.queryByText('Begin Downtime')).toBeNull()
+  })
+
+  test('the Mediator can begin it', () => {
+    withQueries([{ running: false, stepIndex: null, completedBy: [], upkeepSpent: false }, true])
+    wrap(<DowntimePanel gameId={'g1' as never} />)
+    expect(screen.getByText('Begin Downtime')).toBeTruthy()
+  })
+
+  test('running: shows the step, who has finished, and upkeep state', () => {
+    withQueries([
+      {
+        running: true,
+        stepIndex: 2,
+        completedBy: [{ userId: 'u2', displayName: 'Beefcake' }],
+        upkeepSpent: true,
+      },
+      true,
+    ])
+    wrap(<DowntimePanel gameId={'g1' as never} />)
+
+    // stepIndex is zero-based on the wire and one-based on screen.
+    expect(screen.getByText('Step 3')).toBeTruthy()
+    expect(screen.getByText('Beefcake')).toBeTruthy()
+    expect(screen.getByText('Upkeep paid')).toBeTruthy()
+  })
+
+  test('nobody finished yet says so rather than showing an empty list', () => {
+    withQueries([{ running: true, stepIndex: 0, completedBy: [], upkeepSpent: false }, false])
+    wrap(<DowntimePanel gameId={'g1' as never} />)
+
+    expect(screen.getByText(/Nobody yet/i)).toBeTruthy()
+    expect(screen.getByText('Upkeep outstanding')).toBeTruthy()
+  })
+})
+
+describe('ProposalInbox', () => {
+  test('renders nothing when there is nothing to answer', () => {
+    withQueries([[]])
+    const { container } = wrap(<ProposalInbox gameId={'g1' as never} />)
+    // An empty inbox should not occupy space on a play surface.
+    expect(container.innerHTML).toBe('')
+  })
+
+  test('shows before and after so a mismatch is visible', () => {
+    withQueries([
+      [
+        {
+          _id: 'c1',
+          entityId: 'm1',
+          entityType: 'mech',
+          field: 'currentSp',
+          before: 10,
+          after: 6,
+          ts: 1,
+        },
+      ],
+    ])
+    wrap(<ProposalInbox gameId={'g1' as never} />)
+
+    // The Mediator's `before` is what THEY believed; showing it lets the table
+    // spot a disagreement rather than having the UI paper over it.
+    expect(screen.getByText('10 → 6')).toBeTruthy()
+    expect(screen.getByText('Apply')).toBeTruthy()
+    // Decline is a peer, not a dismissal.
+    expect(screen.getByText('Decline')).toBeTruthy()
+  })
+
+  test('a null before renders as a dash rather than "null"', () => {
+    withQueries([
+      [
+        {
+          _id: 'c1',
+          entityId: 'm1',
+          entityType: 'mech',
+          field: 'currentSp',
+          before: null,
+          after: 6,
+          ts: 1,
+        },
+      ],
+    ])
+    wrap(<ProposalInbox gameId={'g1' as never} />)
+    expect(screen.getByText('— → 6')).toBeTruthy()
+  })
+})
+
+afterAll(() => {
+  mock.module('../../../lib/connection/convexClient', () => realConvexClient)
+  mock.module('convex/react', () => realConvexReact)
+})

--- a/apps/itun/src/components/games/gameChrome.ts
+++ b/apps/itun/src/components/games/gameChrome.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared class strings for the Game surfaces (Mediator screen, proposal inbox,
+ * Downtime panel).
+ *
+ * These are the app's existing vocabulary, not a new one: hard 2px ink borders
+ * and stamped condensed caps are how every other ITUN surface frames a section,
+ * and the tracking values come from the shipped ladder rather than arbitrary
+ * bracketed literals, which the design-token gate rejects outright. (Spelling
+ * that pattern out here would itself trip the gate, which scans file text
+ * rather than only class attributes.)
+ *
+ * Collected here so the three new surfaces stay consistent with each other
+ * without inventing a component layer that a real design pass would have to
+ * unpick.
+ */
+
+/** Small stamped label above a group. */
+export const STAMP = 'font-cond text-xs font-bold tracking-caps-wide uppercase'
+
+/** Screen title. */
+export const TITLE = 'font-cond text-2xl font-bold tracking-caps uppercase'
+
+/** Section heading inside a card. */
+export const SECTION = 'font-cond text-lg font-bold tracking-caps-snug uppercase'
+
+/** Text input, matching the sheet's inline-edit fields. */
+export const INPUT = 'border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-1'
+
+/** A single row in a list of people or entities. */
+export const ROW =
+  'flex flex-wrap items-baseline justify-between gap-2 border-b border-[var(--color-ink)]/15 py-1 last:border-b-0'
+
+/** Numeric readout — tabular so columns of vitals line up. */
+export const NUM = 'font-cond tabular-nums'

--- a/apps/itun/src/lib/__tests__/container.test.ts
+++ b/apps/itun/src/lib/__tests__/container.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test'
+
+import { DEFAULT_WORKSPACE_ID } from '../defaultWorkspace'
+import { containerOf, gameIdOf, isOnShelf, moveTo } from '../container'
+
+/**
+ * The container resolver (ADR-030 §2).
+ *
+ * The case worth the most attention is the difference between `gameId: null`
+ * and `gameId: undefined`. They look alike in JavaScript and mean opposite
+ * things here — "deliberately shelved" versus "not yet decided" — and getting
+ * them backwards would send every shelved entity back through the legacy
+ * fallback on every read.
+ */
+
+describe('null is a decision; undefined is not', () => {
+  test('gameId: null means the shelf, and does NOT consult workspaceId', () => {
+    // Even with a workspace still attached, an explicit null wins. Otherwise a
+    // deliberate "move to shelf" would silently bounce back to the old game.
+    const c = containerOf({ gameId: null, workspaceId: 'some-old-workspace' })
+    expect(c.kind).toBe('shelf')
+  })
+
+  test('gameId: undefined falls back to workspaceId', () => {
+    const c = containerOf({ workspaceId: 'campaign-a' })
+    expect(c).toEqual({ kind: 'game', gameId: 'campaign-a' })
+  })
+
+  test('a set gameId wins over a stale workspaceId', () => {
+    const c = containerOf({ gameId: 'campaign-b', workspaceId: 'campaign-a' })
+    expect(c).toEqual({ kind: 'game', gameId: 'campaign-b' })
+  })
+})
+
+describe('the Default workspace is the shelf, not a game', () => {
+  test('DEFAULT_WORKSPACE_ID resolves to the shelf', () => {
+    // It was never a campaign — it was where builds went when they belonged to
+    // no campaign, which is what a shelf is.
+    expect(containerOf({ workspaceId: DEFAULT_WORKSPACE_ID }).kind).toBe('shelf')
+  })
+
+  test('an entity with no container at all is on the shelf', () => {
+    expect(containerOf({}).kind).toBe('shelf')
+  })
+})
+
+describe('helpers', () => {
+  test('isOnShelf agrees with containerOf', () => {
+    expect(isOnShelf({ gameId: null })).toBe(true)
+    expect(isOnShelf({ gameId: 'g1' })).toBe(false)
+    expect(isOnShelf({ workspaceId: DEFAULT_WORKSPACE_ID })).toBe(true)
+  })
+
+  test('gameIdOf returns null for a shelved entity rather than undefined', () => {
+    // Callers write this straight into a nullable column, so the distinction
+    // between null and undefined has to survive the helper.
+    expect(gameIdOf({ gameId: null })).toBeNull()
+    expect(gameIdOf({})).toBeNull()
+    expect(gameIdOf({ gameId: 'g1' })).toBe('g1')
+  })
+
+  test('moveTo produces a patch that round-trips', () => {
+    expect(moveTo({ kind: 'shelf' })).toEqual({ gameId: null })
+    expect(moveTo({ kind: 'game', gameId: 'g1' })).toEqual({ gameId: 'g1' })
+    // The round trip is the property that matters: applying the patch and
+    // re-resolving must land in the same container.
+    expect(containerOf(moveTo({ kind: 'shelf' })).kind).toBe('shelf')
+    expect(containerOf(moveTo({ kind: 'game', gameId: 'g1' }))).toEqual({
+      kind: 'game',
+      gameId: 'g1',
+    })
+  })
+})

--- a/apps/itun/src/lib/connection/ConnectionProvider.tsx
+++ b/apps/itun/src/lib/connection/ConnectionProvider.tsx
@@ -6,6 +6,7 @@ import { ConnectionContext } from './connectionContext'
 import type { ConnectionState } from './connectionContext'
 import { resolveConnectionMode, shouldWarnDisconnected, writesAllowed } from './connectionMode'
 import { convexClient, isConvexConfigured } from './convexClient'
+import { setEntityBackendAuthState } from '../../stores/entityBackend'
 
 /**
  * Supplies the current storage mode (ADR-030 §1) to the tree.
@@ -50,6 +51,14 @@ function useOnline(): boolean {
 
 function useConnectionState(signedIn: boolean): ConnectionState {
   const online = useOnline()
+
+  // The stores are not components and cannot call hooks, so the mode is PUSHED
+  // to them from here rather than pulled. One writer, one direction — and it
+  // happens in an effect so a render never has a side effect.
+  useEffect(() => {
+    setEntityBackendAuthState({ signedIn, online })
+  }, [signedIn, online])
+
   return useMemo(() => {
     const mode = resolveConnectionMode({
       convexConfigured: isConvexConfigured,

--- a/apps/itun/src/lib/container.ts
+++ b/apps/itun/src/lib/container.ts
@@ -1,0 +1,70 @@
+import { DEFAULT_WORKSPACE_ID } from './defaultWorkspace'
+
+/**
+ * Which container an entity lives in (ADR-030 §2).
+ *
+ * There are exactly two: a shared **Game**, or the owner's personal **Shelf**.
+ * They are encoded in one nullable column rather than two fields, because an
+ * entity is always in exactly one and a second field could contradict the
+ * first.
+ *
+ * The subtle part is that **`null` is a value, not an absence**. `null` means
+ * "on the shelf" — a real place — while `undefined` means "this record predates
+ * the split and we have not decided yet". Conflating them is the bug this
+ * module exists to prevent: treating a shelved entity as unmigrated would send
+ * it back through the fallback on every read.
+ */
+
+/** A shared Game, by id. */
+export type GameContainer = { kind: 'game'; gameId: string }
+/** The owner's personal shelf. Not a Game: no crew, no Mediator, no invites. */
+export type ShelfContainer = { kind: 'shelf' }
+
+export type Container = GameContainer | ShelfContainer
+
+export const SHELF: ShelfContainer = { kind: 'shelf' }
+
+/** The minimum an entity needs to expose for its container to be resolved. */
+export type ContainerFields = {
+  gameId?: string | null | undefined
+  /** @deprecated Read only as a fallback for records written before ADR-030. */
+  workspaceId?: string | undefined
+}
+
+/**
+ * Resolve where an entity lives.
+ *
+ * The fallback chain matters and is ordered deliberately:
+ *
+ *  1. `gameId` set to a string — it is in that Game.
+ *  2. `gameId` explicitly `null` — it is on the shelf. Decided; stop.
+ *  3. `gameId` absent — pre-split record, so fall back to `workspaceId`, with
+ *     the built-in Default workspace mapping to the shelf rather than to a
+ *     Game. The Default workspace was never a campaign; it was the place
+ *     builds went when they belonged to no campaign, which is precisely a
+ *     shelf.
+ */
+export function containerOf(entity: ContainerFields): Container {
+  if (typeof entity.gameId === 'string') return { kind: 'game', gameId: entity.gameId }
+  if (entity.gameId === null) return SHELF
+  if (entity.workspaceId !== undefined && entity.workspaceId !== DEFAULT_WORKSPACE_ID) {
+    return { kind: 'game', gameId: entity.workspaceId }
+  }
+  return SHELF
+}
+
+/** True when the entity is on the owner's shelf rather than in a Game. */
+export function isOnShelf(entity: ContainerFields): boolean {
+  return containerOf(entity).kind === 'shelf'
+}
+
+/** The Game id, or null when the entity is shelved. */
+export function gameIdOf(entity: ContainerFields): string | null {
+  const container = containerOf(entity)
+  return container.kind === 'game' ? container.gameId : null
+}
+
+/** The patch that moves an entity into a container. */
+export function moveTo(container: Container): { gameId: string | null } {
+  return { gameId: container.kind === 'game' ? container.gameId : null }
+}

--- a/apps/itun/src/lib/db/__tests__/workspace-to-game-or-shelf.test.ts
+++ b/apps/itun/src/lib/db/__tests__/workspace-to-game-or-shelf.test.ts
@@ -1,0 +1,146 @@
+/**
+ * v12 → v13 fixture test: workspaceId → gameId (ADR-030 §2).
+ *
+ * A migration is the one edit a user cannot undo, so this seeds a real v12
+ * database and re-opens it through the live upgrade path rather than calling
+ * `migrate()` directly — the thing worth proving is that the ladder produces
+ * the right containers end to end, not that one function does.
+ *
+ * The claim under test is that the built-in Default workspace becomes the
+ * **shelf** rather than a Game. Getting that backwards would invent a campaign
+ * nobody ran and put every unassigned build into it.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+
+import { DEFAULT_WORKSPACE_ID } from '../../defaultWorkspace'
+import { containerOf } from '../../container'
+import { openItunDatabase } from '../index'
+
+const TEST_DB_NAME = 'itun-test-v12-to-v13'
+
+async function destroy(): Promise<void> {
+  const { deleteDB } = await import('idb')
+  await deleteDB(TEST_DB_NAME)
+}
+
+beforeEach(destroy)
+afterEach(destroy)
+
+/** Seed a v12-shaped database with pilots in three different container states. */
+async function seedV12(): Promise<void> {
+  const { openDB } = await import('idb')
+  const db = await openDB(TEST_DB_NAME, 12, {
+    upgrade(db) {
+      for (const name of [
+        'pilots',
+        'mechs',
+        'crawlers',
+        'workspaces',
+        'softLinks',
+        'mechPatterns',
+        'encounterNpcs',
+      ]) {
+        if (!db.objectStoreNames.contains(name)) db.createObjectStore(name, { keyPath: 'id' })
+      }
+      if (!db.objectStoreNames.contains('changeLog')) {
+        db.createObjectStore('changeLog', { keyPath: 'seq', autoIncrement: true })
+      }
+    },
+  })
+
+  const base = { schemaVersion: 1, createdAt: '2026-01-01T00:00:00.000Z' }
+  await db.put('pilots', {
+    ...base,
+    id: 'p-default',
+    name: 'Shelved',
+    workspaceId: DEFAULT_WORKSPACE_ID,
+  })
+  await db.put('pilots', {
+    ...base,
+    id: 'p-campaign',
+    name: 'In a game',
+    workspaceId: 'campaign-a',
+  })
+  await db.put('pilots', { ...base, id: 'p-none', name: 'No workspace' })
+  await db.put('mechs', { ...base, id: 'm-campaign', name: 'Mule', workspaceId: 'campaign-a' })
+  await db.put('crawlers', {
+    ...base,
+    id: 'c-default',
+    name: '#430',
+    workspaceId: DEFAULT_WORKSPACE_ID,
+  })
+  db.close()
+}
+
+/**
+ * Re-open through the app's own opener and read a row back.
+ *
+ * Deliberately `openItunDatabase` rather than a hand-rolled `openDB` upgrade
+ * callback: the first draft of this test wrote its own callback and every case
+ * failed with `AbortError`, because the migrations were fired without being
+ * awaited and the versionchange transaction auto-committed underneath them.
+ * Using the real opener tests the real ladder and cannot drift from it.
+ */
+async function readAfterUpgrade(store: string, id: string): Promise<Record<string, unknown>> {
+  const db = await openItunDatabase(TEST_DB_NAME)
+  const row = (await db.get(store, id)) as Record<string, unknown>
+  db.close()
+  return row
+}
+
+describe('v12 → v13 container split', () => {
+  test('the Default workspace becomes the shelf, not a game', async () => {
+    await seedV12()
+    const row = await readAfterUpgrade('pilots', 'p-default')
+
+    expect(row.gameId).toBeNull()
+    expect(containerOf(row).kind).toBe('shelf')
+  })
+
+  test('a real workspace becomes a game of the same id', async () => {
+    await seedV12()
+    const row = await readAfterUpgrade('pilots', 'p-campaign')
+
+    expect(row.gameId).toBe('campaign-a')
+    expect(containerOf(row)).toEqual({ kind: 'game', gameId: 'campaign-a' })
+  })
+
+  test('an entity with no workspace at all lands on the shelf', async () => {
+    await seedV12()
+    const row = await readAfterUpgrade('pilots', 'p-none')
+
+    // null, not undefined — the record now carries a decision.
+    expect(row.gameId).toBeNull()
+  })
+
+  test('mechs and crawlers migrate too, not just pilots', async () => {
+    await seedV12()
+    expect((await readAfterUpgrade('mechs', 'm-campaign')).gameId).toBe('campaign-a')
+    expect((await readAfterUpgrade('crawlers', 'c-default')).gameId).toBeNull()
+  })
+
+  test('workspaceId is retained, not stripped', async () => {
+    await seedV12()
+    const row = await readAfterUpgrade('pilots', 'p-campaign')
+
+    // The schemas are `.strict()`, so a row written here still has to parse on
+    // a build that predates the migration. Dropping the key is a separate,
+    // irreversible follow-up.
+    expect(row.workspaceId).toBe('campaign-a')
+  })
+
+  test('re-running is idempotent and never moves a placed entity', async () => {
+    await seedV12()
+    await readAfterUpgrade('pilots', 'p-campaign')
+
+    // Deliberately shelve it, then re-open: the migration must not drag it back
+    // to the old workspace on a second pass.
+    const db = await openItunDatabase(TEST_DB_NAME)
+    const existing = (await db.get('pilots', 'p-campaign')) as Record<string, unknown>
+    await db.put('pilots', { ...existing, gameId: null })
+    db.close()
+
+    const row = await readAfterUpgrade('pilots', 'p-campaign')
+    expect(row.gameId).toBeNull()
+  })
+})

--- a/apps/itun/src/lib/db/index.ts
+++ b/apps/itun/src/lib/db/index.ts
@@ -53,7 +53,7 @@ import { STORE_NAMES } from './stores'
  * model replaces the old cross-workspace "All Builds" view; see
  * lib/defaultWorkspace.ts.)
  */
-export const DB_VERSION = 12
+export const DB_VERSION = 13
 
 const DB_NAME = 'itun-v1'
 

--- a/apps/itun/src/lib/db/migrations/13-workspace-to-game-or-shelf.ts
+++ b/apps/itun/src/lib/db/migrations/13-workspace-to-game-or-shelf.ts
@@ -1,0 +1,54 @@
+import type { UpgradeTransaction } from './index'
+
+/**
+ * v12 → v13: give every entity an explicit container (ADR-030 §2).
+ *
+ * Before this, an entity's home was `workspaceId`, and the built-in Default
+ * workspace was a real row every unassigned build was backfilled into (v10).
+ * ADR-030 splits that into two containers — a shared **Game** or the owner's
+ * personal **Shelf** — encoded as one nullable `gameId`.
+ *
+ * The mapping:
+ *
+ *   workspaceId === DEFAULT_WORKSPACE_ID  →  gameId: null   (the shelf)
+ *   workspaceId === <anything else>       →  gameId: <that> (a game)
+ *   workspaceId absent                    →  gameId: null   (the shelf)
+ *
+ * The Default workspace becoming the shelf is the substantive claim here, and
+ * it is a restoration rather than a reinterpretation: the Default workspace was
+ * never a campaign. It existed because the app required *some* container and
+ * these builds belonged to no particular one — which is exactly what a shelf
+ * is. Mapping it to a Game would invent a campaign nobody ran.
+ *
+ * `workspaceId` is **not** stripped. The entity schemas are `.strict()`, so a
+ * record written by this migration still has to parse on a build that predates
+ * it; removing the key is a separate, irreversible follow-up. The constant is
+ * inlined rather than imported because migrations may only await IndexedDB
+ * operations — a module import could let the versionchange transaction commit
+ * mid-run (see this directory's README).
+ */
+
+/** Inlined from lib/defaultWorkspace.ts — see the note above on imports. */
+const DEFAULT_WORKSPACE_ID = 'default-workspace'
+
+const STORES = ['pilots', 'mechs', 'crawlers'] as const
+
+export async function migrate(tx: UpgradeTransaction): Promise<void> {
+  for (const store of STORES) {
+    let cursor = await tx.objectStore(store).openCursor()
+    while (cursor) {
+      const row = cursor.value as { workspaceId?: unknown; gameId?: unknown }
+
+      // Idempotent: a row that already has a decision keeps it. Re-running must
+      // never move an entity that has since been placed deliberately.
+      if (row.gameId === undefined) {
+        const workspaceId = typeof row.workspaceId === 'string' ? row.workspaceId : undefined
+        const gameId =
+          workspaceId === undefined || workspaceId === DEFAULT_WORKSPACE_ID ? null : workspaceId
+        await cursor.update({ ...row, gameId })
+      }
+
+      cursor = await cursor.continue()
+    }
+  }
+}

--- a/apps/itun/src/lib/db/migrations/index.ts
+++ b/apps/itun/src/lib/db/migrations/index.ts
@@ -26,6 +26,7 @@ import { migrate as migrate8CrawlerBattleSpToDerived } from './8-crawler-battle-
 import { migrate as migrate10WorkspaceDefaultBackfill } from './10-workspace-default-backfill'
 import { migrate as migrate11EquipmentLoadoutsToPartners } from './11-equipment-loadouts-to-partners'
 import { migrate as migrate12CompanionMechsToPartners } from './12-companion-mechs-to-partners'
+import { migrate as migrate13WorkspaceToGameOrShelf } from './13-workspace-to-game-or-shelf'
 
 /** The untyped versionchange transaction handed to the idb upgrade callback. */
 export type UpgradeTransaction = IDBPTransaction<
@@ -85,6 +86,11 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
     toVersion: 12,
     description: 'companion-mechs-to-partners',
     migrate: (tx) => migrate12CompanionMechsToPartners(tx),
+  },
+  {
+    toVersion: 13,
+    description: 'workspace-to-game-or-shelf',
+    migrate: (tx) => migrate13WorkspaceToGameOrShelf(tx),
   },
   // NOTE: the built-in Starter Set is NOT seeded by a migration. It is spawned
   // on-demand into each browser the first time the user opens the Starter Set

--- a/apps/itun/src/lib/export/__tests__/export.test.ts
+++ b/apps/itun/src/lib/export/__tests__/export.test.ts
@@ -104,7 +104,9 @@ describe('parseImportBundle', () => {
       encounterNpcs: [],
     }
     const result = parseImportBundle(JSON.stringify(bundle))
-    expect(result.schemaVersion).toBe(1)
+    // A v1 payload is normalised to the current version on the way in, so the
+    // rest of the pipeline sees one format (ADR-030 containers).
+    expect(result.schemaVersion).toBe(2)
     expect(result.entities.pilots).toEqual([])
   })
 
@@ -145,7 +147,7 @@ describe('buildExportBundle', () => {
 
     const bundle = await buildExportBundle(entityStore, workspaceStore)
 
-    expect(bundle.schemaVersion).toBe(1)
+    expect(bundle.schemaVersion).toBe(2)
     expect(bundle.entities.pilots).toHaveLength(1)
     expect(bundle.entities.pilots[0]?.name).toBe('Test Pilot')
     expect(bundle.entities.mechs).toHaveLength(0)

--- a/apps/itun/src/lib/export/__tests__/legacyContainers.test.ts
+++ b/apps/itun/src/lib/export/__tests__/legacyContainers.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'bun:test'
+
+import { DEFAULT_WORKSPACE_ID } from '../../defaultWorkspace'
+import { parseImportBundle } from '../parseImportBundle'
+import { assignContainers, withContainer } from '../legacyContainers'
+
+/**
+ * Legacy data carried forward (ADR-030 §2).
+ *
+ * The requirement being protected: a backup taken **before accounts existed**
+ * must still import, and must land in the same container the v13 migration
+ * would have put it in on the device it came from. A roster that reads
+ * differently depending on whether it arrived by migration or by import is the
+ * bug this exists to prevent.
+ */
+
+describe('withContainer', () => {
+  test('the Default workspace becomes the shelf', () => {
+    // Same claim as migration 13: it was never a campaign, only where builds
+    // went when they belonged to none.
+    expect(withContainer({ workspaceId: DEFAULT_WORKSPACE_ID }).gameId).toBeNull()
+  })
+
+  test('a real workspace becomes a game of the same id', () => {
+    expect(withContainer({ workspaceId: 'campaign-a' }).gameId).toBe('campaign-a')
+  })
+
+  test('no workspace at all lands on the shelf', () => {
+    expect(withContainer({}).gameId).toBeNull()
+  })
+
+  test('an existing gameId is preserved rather than recomputed', () => {
+    // A v2 bundle already carries a decision; re-deriving it from a stale
+    // workspaceId would move entities somebody had deliberately placed.
+    expect(withContainer({ gameId: 'g1', workspaceId: 'old' }).gameId).toBe('g1')
+    expect(withContainer({ gameId: null, workspaceId: 'old' }).gameId).toBeNull()
+  })
+
+  test('assignContainers maps a whole array', () => {
+    const out = assignContainers([{ workspaceId: 'a' }, { workspaceId: DEFAULT_WORKSPACE_ID }, {}])
+    expect(out.map((e) => e.gameId)).toEqual(['a', null, null])
+  })
+})
+
+/** A minimal v1 bundle, shaped as the pre-accounts app wrote them. */
+function v1Bundle(over: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    schemaVersion: 1,
+    exportedAt: '2026-01-01T00:00:00.000Z',
+    entities: {
+      pilots: [
+        {
+          id: 'p1',
+          schemaVersion: 1,
+          name: 'Roach-Boy',
+          callsign: 'Roach-Boy',
+          classRef: 'salvager',
+          abilities: [],
+          equipment: [],
+          motto: '',
+          keepsake: '',
+          appearance: '',
+          conditions: [],
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          workspaceId: 'campaign-a',
+        },
+      ],
+      mechs: [],
+      crawlers: [],
+    },
+    workspaces: [],
+    softLinks: [],
+    ...over,
+  })
+}
+
+describe('importing a pre-accounts backup', () => {
+  test('a v1 bundle still parses', () => {
+    // The file somebody reaches for after a year away. Refusing it would
+    // strand exactly the data this migration exists to carry forward.
+    const bundle = parseImportBundle(v1Bundle())
+    expect(bundle.entities.pilots).toHaveLength(1)
+  })
+
+  test('its entities arrive with a container', () => {
+    const bundle = parseImportBundle(v1Bundle())
+    const pilot = bundle.entities.pilots[0] as unknown as { gameId: string | null }
+    // Not left undecided: an entity with no container is invisible to anything
+    // that filters by one.
+    expect(pilot.gameId).toBe('campaign-a')
+  })
+
+  test('it is normalised to the current version', () => {
+    // So the rest of the pipeline sees one format instead of branching on
+    // version at every step.
+    expect(parseImportBundle(v1Bundle()).schemaVersion).toBe(2)
+  })
+
+  test('a Default-workspace entity lands on the shelf', () => {
+    const raw = JSON.parse(v1Bundle()) as {
+      entities: { pilots: Array<Record<string, unknown>> }
+    }
+    const first = raw.entities.pilots[0]
+    if (first !== undefined) first.workspaceId = DEFAULT_WORKSPACE_ID
+
+    const bundle = parseImportBundle(JSON.stringify(raw))
+    const pilot = bundle.entities.pilots[0] as unknown as { gameId: string | null }
+    expect(pilot.gameId).toBeNull()
+  })
+
+  test('an unknown future version is still refused, with both supported ones named', () => {
+    const raw = JSON.parse(v1Bundle()) as Record<string, unknown>
+    raw.schemaVersion = 99
+    expect(() => parseImportBundle(JSON.stringify(raw))).toThrow(/1, 2/)
+  })
+})

--- a/apps/itun/src/lib/export/buildExportBundle.ts
+++ b/apps/itun/src/lib/export/buildExportBundle.ts
@@ -62,7 +62,7 @@ export async function buildExportBundle(
   ])
 
   const bundle: ExportBundle = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     exportedAt: new Date().toISOString(),
     entities: {
       pilots: entityStore.list('pilot'),
@@ -108,7 +108,7 @@ export async function buildEntityExport(
     case 'pilot': {
       const pilot = entityStore.list('pilot').find((p) => p.id === id)
       return {
-        schemaVersion: 1,
+        schemaVersion: 2,
         exportedAt: new Date().toISOString(),
         entities: { ...emptyEntities, pilots: pilot ? [pilot] : [] },
         workspaces: [],
@@ -120,7 +120,7 @@ export async function buildEntityExport(
     case 'mech': {
       const mech = entityStore.list('mech').find((m) => m.id === id)
       return {
-        schemaVersion: 1,
+        schemaVersion: 2,
         exportedAt: new Date().toISOString(),
         entities: { ...emptyEntities, mechs: mech ? [mech] : [] },
         workspaces: [],
@@ -132,7 +132,7 @@ export async function buildEntityExport(
     case 'crawler': {
       const crawler = entityStore.list('crawler').find((c) => c.id === id)
       return {
-        schemaVersion: 1,
+        schemaVersion: 2,
         exportedAt: new Date().toISOString(),
         entities: { ...emptyEntities, crawlers: crawler ? [crawler] : [] },
         workspaces: [],

--- a/apps/itun/src/lib/export/legacyContainers.ts
+++ b/apps/itun/src/lib/export/legacyContainers.ts
@@ -1,0 +1,34 @@
+import { containerOf } from '../container'
+import type { ContainerFields } from '../container'
+
+/**
+ * Give imported entities a container (ADR-030 §2).
+ *
+ * A bundle exported before the Game/Shelf split carries `workspaceId` and no
+ * `gameId`, so importing one straight into the new model would leave every
+ * entity in the "not yet decided" state — legible to `containerOf`, but
+ * indefinitely undecided, and invisible to anything that filters by container.
+ *
+ * The mapping is deliberately the **same rule migration 13 applies**, reused
+ * rather than restated: a bundle restored on a new device has to land in the
+ * same place the migration would have put it on the old one, or the same
+ * roster reads differently depending on how it arrived.
+ *
+ * The Default workspace becomes the shelf for the reason recorded in that
+ * migration: it was never a campaign, only where builds went when they
+ * belonged to none.
+ */
+export function withContainer<T extends ContainerFields>(entity: T): T & { gameId: string | null } {
+  const container = containerOf(entity)
+  return {
+    ...entity,
+    gameId: container.kind === 'game' ? container.gameId : null,
+  }
+}
+
+/** Apply the container rule across a bundle's entity arrays. */
+export function assignContainers<T extends ContainerFields>(
+  entities: readonly T[]
+): Array<T & { gameId: string | null }> {
+  return entities.map(withContainer)
+}

--- a/apps/itun/src/lib/export/parseImportBundle.ts
+++ b/apps/itun/src/lib/export/parseImportBundle.ts
@@ -3,6 +3,8 @@ import { normalizeLegacyCargoRecord } from '../schemas/cargoLot'
 import { ExportBundleSchema } from '../schemas/exportBundle'
 import type { ExportBundle } from '../schemas/exportBundle'
 import { normalizeLegacyPilotRecord } from '../schemas/pilot'
+import type { ContainerFields } from '../container'
+import { assignContainers } from './legacyContainers'
 
 /**
  * Bundles written before the cargo→cargoLots rename carry mechs (and
@@ -57,6 +59,11 @@ function normalizeLegacyBundle(raw: unknown): unknown {
  *
  * On success returns the validated ExportBundle.
  */
+/** Bundle versions this build can read. v1 predates the Game/Shelf split. */
+const SUPPORTED_VERSIONS: readonly number[] = [1, 2]
+/** What a bundle written today declares. */
+const CURRENT_VERSION = 2
+
 export function parseImportBundle(jsonText: string): ExportBundle {
   let raw: unknown
   try {
@@ -67,10 +74,35 @@ export function parseImportBundle(jsonText: string): ExportBundle {
   raw = normalizeLegacyBundle(raw)
 
   // Check schemaVersion early to give a clearer error before full Zod parse.
-  if (isRecord(raw) && 'schemaVersion' in raw && raw.schemaVersion !== 1) {
+  //
+  // v2 is the post-ADR-030 shape: entities carry `gameId` (a Game, or null for
+  // the owner's shelf) instead of `workspaceId`. v1 is still accepted and
+  // always will be — a backup taken before accounts existed is exactly the file
+  // somebody reaches for when they come back after a year, and refusing it
+  // would strand the data this whole migration is supposed to carry forward.
+  if (
+    isRecord(raw) &&
+    'schemaVersion' in raw &&
+    !SUPPORTED_VERSIONS.includes(Number(raw.schemaVersion))
+  ) {
     throw new Error(
-      `Import failed: unsupported schemaVersion "${String(raw.schemaVersion)}". Only version 1 is supported.`
+      `Import failed: unsupported schemaVersion "${String(raw.schemaVersion)}". Supported: ${SUPPORTED_VERSIONS.join(', ')}.`
     )
+  }
+
+  // A v1 bundle predates containers, so give every entity one on the way in,
+  // using the SAME rule migration 13 applies on an existing device. A roster
+  // must not land somewhere different depending on how it arrived.
+  if (isRecord(raw) && Number(raw.schemaVersion) === 1 && isRecord(raw.entities)) {
+    const e = raw.entities as Record<string, unknown>
+    for (const kind of ['pilots', 'mechs', 'crawlers'] as const) {
+      if (Array.isArray(e[kind])) {
+        e[kind] = assignContainers(e[kind] as ContainerFields[])
+      }
+    }
+    // Normalised to the current shape so the rest of the pipeline sees one
+    // format rather than branching on version at every step.
+    ;(raw as Record<string, unknown>).schemaVersion = CURRENT_VERSION
   }
 
   const result = ExportBundleSchema.safeParse(raw)

--- a/apps/itun/src/lib/ownership/__tests__/ownerChip.test.ts
+++ b/apps/itun/src/lib/ownership/__tests__/ownerChip.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test'
+
+import { UNCLAIMED_LABEL, ownerChipFor, viewerMayEdit } from '../ownerChip'
+
+/**
+ * Owner chips (D32).
+ *
+ * The case that carries the most weight is the difference between *unclaimed*
+ * and *owned but unresolved*. Both have no name to show, and collapsing them
+ * would tell a Mediator that a pilot is free to hand out when it already
+ * belongs to somebody — a data-integrity error dressed as a label.
+ */
+
+const lookup = (viewerId: string | null, names: Array<[string, string]> = []) => ({
+  viewerId,
+  namesById: new Map(names),
+})
+
+describe('unclaimed is a rendered state, not a blank', () => {
+  test('null owner reads as Unclaimed', () => {
+    const chip = ownerChipFor(null, lookup('u1'))
+    expect(chip.label).toBe(UNCLAIMED_LABEL)
+    expect(chip.unclaimed).toBe(true)
+  })
+
+  test('undefined owner reads the same way', () => {
+    // A row written before ownership existed must not render an empty chip.
+    expect(ownerChipFor(undefined, lookup('u1')).label).toBe(UNCLAIMED_LABEL)
+  })
+
+  test('the label is never empty', () => {
+    for (const owner of [null, undefined, 'u2', 'unknown-id']) {
+      expect(ownerChipFor(owner, lookup('u1', [['u2', 'Beefcake']])).label.length).toBeGreaterThan(
+        0
+      )
+    }
+  })
+})
+
+describe('owned-but-unresolved is not unclaimed', () => {
+  test('an owner with no known name still reads as owned', () => {
+    const chip = ownerChipFor('u-nobody-knows', lookup('u1'))
+    // The important assertion: NOT unclaimed. Offering this to a Mediator as
+    // assignable would hand out a pilot that already belongs to someone.
+    expect(chip.unclaimed).toBe(false)
+    expect(chip.label).toBe('Crewmate')
+  })
+
+  test('a resolvable owner shows their display name', () => {
+    const chip = ownerChipFor('u2', lookup('u1', [['u2', 'Beefcake']]))
+    expect(chip.label).toBe('Beefcake')
+    expect(chip.unclaimed).toBe(false)
+    expect(chip.mine).toBe(false)
+  })
+})
+
+describe('your own entities', () => {
+  test('read as You', () => {
+    const chip = ownerChipFor('u1', lookup('u1', [['u1', 'Alex']]))
+    expect(chip.label).toBe('You')
+    expect(chip.mine).toBe(true)
+  })
+
+  test('a signed-out viewer owns nothing', () => {
+    const chip = ownerChipFor('u1', lookup(null))
+    expect(chip.mine).toBe(false)
+  })
+})
+
+describe('viewerMayEdit mirrors the server rule', () => {
+  test('the owner may edit', () => {
+    expect(viewerMayEdit('u1', 'u1')).toBe(true)
+  })
+
+  test('a crewmate may not — a Mediator proposes instead', () => {
+    expect(viewerMayEdit('u2', 'u1')).toBe(false)
+  })
+
+  test('an unclaimed entity is not editable until assigned', () => {
+    // Otherwise a pre-gen could be quietly taken by editing it, bypassing the
+    // assignment act the Change Log records.
+    expect(viewerMayEdit(null, 'u1')).toBe(false)
+    expect(viewerMayEdit(undefined, 'u1')).toBe(false)
+  })
+
+  test('a signed-out viewer may not edit anything in a game', () => {
+    expect(viewerMayEdit('u1', null)).toBe(false)
+  })
+})

--- a/apps/itun/src/lib/ownership/ownerChip.ts
+++ b/apps/itun/src/lib/ownership/ownerChip.ts
@@ -1,0 +1,88 @@
+/**
+ * The owner chip (ADR-030, D32).
+ *
+ * Every entity row in a Game shows who holds it. This module produces the chip
+ * *content* as data; the rendering goes through the entity card's existing
+ * `controls` API as a `badge`, which is why there is no component here.
+ *
+ * That choice is deliberate and worth stating: `component-lib` is shared with
+ * `apps/srd`, which has no accounts and never will. Teaching the card about
+ * users would push an ITUN-only concept into a package whose contract is to
+ * stay backend-agnostic. Passing a `badge` in from the app keeps the knowledge
+ * where it belongs, and `badge` renders at every card extent — full, head, and
+ * catalog — so a dense listing row and an expanded card show the same chip.
+ */
+
+/** How an entity's ownership should read on a card. */
+export type OwnerChip = {
+  /** The text on the chip. Never empty — see `UNCLAIMED_LABEL`. */
+  label: string
+  /** True when nobody owns this entity. Callers may style it differently. */
+  unclaimed: boolean
+  /** True when the viewer owns it, for a subtler "yours" treatment. */
+  mine: boolean
+}
+
+/**
+ * What an ownerless entity reads as.
+ *
+ * **Unclaimed is a rendered state, not a blank.** An ownerless pilot is a
+ * normal, useful thing — a pre-gen waiting to be handed out — and rendering it
+ * as an empty chip would make it look broken rather than available. This is the
+ * single most likely place for the nullable `ownerId` to leak as a visual bug.
+ */
+export const UNCLAIMED_LABEL = 'Unclaimed'
+
+export type OwnerLookup = {
+  /** The viewer, so their own entities can read as "You". */
+  viewerId: string | null
+  /** userId → display name, from the Game roster. */
+  namesById: ReadonlyMap<string, string>
+}
+
+/**
+ * Resolve the chip for an entity.
+ *
+ * The fallback order matters: a name we cannot resolve is still an owned
+ * entity, so it must not silently collapse into "Unclaimed" — that would tell
+ * a Mediator a pilot is free to assign when it is not. An unknown owner reads
+ * as a crewmate whose name has not loaded, which is honest.
+ */
+export function ownerChipFor(ownerId: string | null | undefined, lookup: OwnerLookup): OwnerChip {
+  if (ownerId === null || ownerId === undefined) {
+    return { label: UNCLAIMED_LABEL, unclaimed: true, mine: false }
+  }
+
+  if (lookup.viewerId !== null && ownerId === lookup.viewerId) {
+    return { label: 'You', unclaimed: false, mine: true }
+  }
+
+  const name = lookup.namesById.get(ownerId)
+  return {
+    // Owned but unresolved — NOT unclaimed. Conflating the two would offer a
+    // Mediator an entity that already belongs to somebody.
+    label: name ?? 'Crewmate',
+    unclaimed: false,
+    mine: false,
+  }
+}
+
+/**
+ * Whether the viewer may edit this entity.
+ *
+ * Mirrors the server rule exactly (`assertMayWrite`): the owner may write, and
+ * nobody else — not even a Mediator, who proposes instead. Unclaimed entities
+ * are not editable until assigned, so a pre-gen cannot be quietly taken by
+ * editing it.
+ *
+ * This is a *courtesy* for the UI, never the boundary. The server check is the
+ * boundary, and it is tested separately.
+ */
+export function viewerMayEdit(
+  ownerId: string | null | undefined,
+  viewerId: string | null
+): boolean {
+  if (viewerId === null) return false
+  if (ownerId === null || ownerId === undefined) return false
+  return ownerId === viewerId
+}

--- a/apps/itun/src/lib/schemas/crawler.ts
+++ b/apps/itun/src/lib/schemas/crawler.ts
@@ -123,7 +123,22 @@ export const CrawlerSchema = z
      * needed (same tactic as Pilot.equipmentChoices / crawlerBays).
      */
     bayChoices: z.record(z.string(), ChoiceSelectionsSchema).optional(),
-    /** Optional: links this crawler to a workspace */
+    /**
+     * Which container holds this entity (ADR-030 §2).
+     *
+     * `undefined` means the record predates the container split and should be
+     * read through `containerOf()`, which falls back to `workspaceId`.
+     * `null` means the owner's **Shelf** — not "unset". The distinction is the
+     * whole point: a shelf is a real place an entity lives, not the absence of
+     * one.
+     */
+    gameId: z.string().nullable().optional(),
+    /**
+     * @deprecated Superseded by `gameId` (ADR-030 §2). Retained because these
+     * schemas are `.strict()`: dropping the key would fail the parse of every
+     * already-migrated record. Removing it needs a follow-up migration that
+     * strips it from stored rows first — a separate, irreversible change.
+     */
     workspaceId: z.string().optional(),
     // ---------------------------------------------------------------------------
     // Live-play current stat tracking (#245).

--- a/apps/itun/src/lib/schemas/exportBundle.ts
+++ b/apps/itun/src/lib/schemas/exportBundle.ts
@@ -33,7 +33,14 @@ import { WorkspaceSchema } from './workspace'
  * the raw shape before validation.
  */
 export const ExportBundleSchema = z.object({
-  schemaVersion: z.literal(1),
+  /**
+   * 1 = pre-ADR-030 (entities carry `workspaceId`); 2 = containers
+   * (`gameId`, null meaning the owner's shelf). `parseImportBundle` upgrades a
+   * v1 payload to v2 before validation, so anything reaching this schema is
+   * already normalised — but both are accepted so a hand-edited or
+   * partially-processed bundle still parses rather than failing opaquely.
+   */
+  schemaVersion: z.union([z.literal(1), z.literal(2)]),
   exportedAt: z.string(),
   entities: z.object({
     pilots: z.array(PilotSchema),

--- a/apps/itun/src/lib/schemas/mech.ts
+++ b/apps/itun/src/lib/schemas/mech.ts
@@ -213,7 +213,22 @@ export const MechSchema = z
     /** Absolute pinned Cargo Capacity. */
     maxCargoOverride: z.number().int().nonnegative().optional(),
 
-    /** Optional: links this mech to a workspace */
+    /**
+     * Which container holds this entity (ADR-030 §2).
+     *
+     * `undefined` means the record predates the container split and should be
+     * read through `containerOf()`, which falls back to `workspaceId`.
+     * `null` means the owner's **Shelf** — not "unset". The distinction is the
+     * whole point: a shelf is a real place an entity lives, not the absence of
+     * one.
+     */
+    gameId: z.string().nullable().optional(),
+    /**
+     * @deprecated Superseded by `gameId` (ADR-030 §2). Retained because these
+     * schemas are `.strict()`: dropping the key would fail the parse of every
+     * already-migrated record. Removing it needs a follow-up migration that
+     * strips it from stored rows first — a separate, irreversible change.
+     */
     workspaceId: z.string().optional(),
 
     // ---------------------------------------------------------------------------

--- a/apps/itun/src/lib/schemas/pilot.ts
+++ b/apps/itun/src/lib/schemas/pilot.ts
@@ -140,7 +140,22 @@ export const PilotSchema = z
     /** Active condition slugs */
     conditions: z.array(z.string()),
 
-    /** Optional: links this pilot to a workspace */
+    /**
+     * Which container holds this entity (ADR-030 §2).
+     *
+     * `undefined` means the record predates the container split and should be
+     * read through `containerOf()`, which falls back to `workspaceId`.
+     * `null` means the owner's **Shelf** — not "unset". The distinction is the
+     * whole point: a shelf is a real place an entity lives, not the absence of
+     * one.
+     */
+    gameId: z.string().nullable().optional(),
+    /**
+     * @deprecated Superseded by `gameId` (ADR-030 §2). Retained because these
+     * schemas are `.strict()`: dropping the key would fail the parse of every
+     * already-migrated record. Removing it needs a follow-up migration that
+     * strips it from stored rows first — a separate, irreversible change.
+     */
     workspaceId: z.string().optional(),
 
     // ---------------------------------------------------------------------------

--- a/apps/itun/src/routeTree.gen.ts
+++ b/apps/itun/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as AboutRouteImport } from './routes/about'
 import { Route as AccountRouteImport } from './routes/account'
 import { Route as ChangelogRouteImport } from './routes/changelog'
 import { Route as EncounterRouteImport } from './routes/encounter'
+import { Route as GamesRouteImport } from './routes/games'
 import { Route as CrawlersIdRouteImport } from './routes/crawlers/$id'
 import { Route as CrawlersNewRouteImport } from './routes/crawlers/new'
 import { Route as DashboardIdRouteImport } from './routes/dashboard/$id'
@@ -49,6 +50,11 @@ const ChangelogRoute = ChangelogRouteImport.update({
 const EncounterRoute = EncounterRouteImport.update({
   id: '/encounter',
   path: '/encounter',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const GamesRoute = GamesRouteImport.update({
+  id: '/games',
+  path: '/games',
   getParentRoute: () => rootRouteImport,
 } as any)
 const CrawlersIdRoute = CrawlersIdRouteImport.update({
@@ -113,6 +119,7 @@ export interface FileRoutesByFullPath {
   '/account': typeof AccountRoute
   '/changelog': typeof ChangelogRoute
   '/encounter': typeof EncounterRoute
+  '/games': typeof GamesRoute
   '/crawlers/$id': typeof CrawlersIdRoute
   '/crawlers/new': typeof CrawlersNewRoute
   '/dashboard/$id': typeof DashboardIdRoute
@@ -131,6 +138,7 @@ export interface FileRoutesByTo {
   '/account': typeof AccountRoute
   '/changelog': typeof ChangelogRoute
   '/encounter': typeof EncounterRoute
+  '/games': typeof GamesRoute
   '/crawlers/$id': typeof CrawlersIdRoute
   '/crawlers/new': typeof CrawlersNewRoute
   '/dashboard/$id': typeof DashboardIdRoute
@@ -150,6 +158,7 @@ export interface FileRoutesById {
   '/account': typeof AccountRoute
   '/changelog': typeof ChangelogRoute
   '/encounter': typeof EncounterRoute
+  '/games': typeof GamesRoute
   '/crawlers/$id': typeof CrawlersIdRoute
   '/crawlers/new': typeof CrawlersNewRoute
   '/dashboard/$id': typeof DashboardIdRoute
@@ -170,6 +179,7 @@ export interface FileRouteTypes {
     | '/account'
     | '/changelog'
     | '/encounter'
+    | '/games'
     | '/crawlers/$id'
     | '/crawlers/new'
     | '/dashboard/$id'
@@ -188,6 +198,7 @@ export interface FileRouteTypes {
     | '/account'
     | '/changelog'
     | '/encounter'
+    | '/games'
     | '/crawlers/$id'
     | '/crawlers/new'
     | '/dashboard/$id'
@@ -206,6 +217,7 @@ export interface FileRouteTypes {
     | '/account'
     | '/changelog'
     | '/encounter'
+    | '/games'
     | '/crawlers/$id'
     | '/crawlers/new'
     | '/dashboard/$id'
@@ -225,6 +237,7 @@ export interface RootRouteChildren {
   AccountRoute: typeof AccountRoute
   ChangelogRoute: typeof ChangelogRoute
   EncounterRoute: typeof EncounterRoute
+  GamesRoute: typeof GamesRoute
   CrawlersIdRoute: typeof CrawlersIdRoute
   CrawlersNewRoute: typeof CrawlersNewRoute
   DashboardIdRoute: typeof DashboardIdRoute
@@ -273,6 +286,13 @@ declare module '@tanstack/react-router' {
       path: '/encounter'
       fullPath: '/encounter'
       preLoaderRoute: typeof EncounterRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/games': {
+      id: '/games'
+      path: '/games'
+      fullPath: '/games'
+      preLoaderRoute: typeof GamesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/crawlers/$id': {
@@ -361,6 +381,7 @@ const rootRouteChildren: RootRouteChildren = {
   AccountRoute: AccountRoute,
   ChangelogRoute: ChangelogRoute,
   EncounterRoute: EncounterRoute,
+  GamesRoute: GamesRoute,
   CrawlersIdRoute: CrawlersIdRoute,
   CrawlersNewRoute: CrawlersNewRoute,
   DashboardIdRoute: DashboardIdRoute,

--- a/apps/itun/src/routeTree.gen.ts
+++ b/apps/itun/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AboutRouteImport } from './routes/about'
+import { Route as AccountRouteImport } from './routes/account'
 import { Route as ChangelogRouteImport } from './routes/changelog'
 import { Route as EncounterRouteImport } from './routes/encounter'
 import { Route as CrawlersIdRouteImport } from './routes/crawlers/$id'
@@ -33,6 +34,11 @@ const IndexRoute = IndexRouteImport.update({
 const AboutRoute = AboutRouteImport.update({
   id: '/about',
   path: '/about',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AccountRoute = AccountRouteImport.update({
+  id: '/account',
+  path: '/account',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ChangelogRoute = ChangelogRouteImport.update({
@@ -104,6 +110,7 @@ const SheetKindIdShareRoute = SheetKindIdShareRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/account': typeof AccountRoute
   '/changelog': typeof ChangelogRoute
   '/encounter': typeof EncounterRoute
   '/crawlers/$id': typeof CrawlersIdRoute
@@ -121,6 +128,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/account': typeof AccountRoute
   '/changelog': typeof ChangelogRoute
   '/encounter': typeof EncounterRoute
   '/crawlers/$id': typeof CrawlersIdRoute
@@ -139,6 +147,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/account': typeof AccountRoute
   '/changelog': typeof ChangelogRoute
   '/encounter': typeof EncounterRoute
   '/crawlers/$id': typeof CrawlersIdRoute
@@ -158,6 +167,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/about'
+    | '/account'
     | '/changelog'
     | '/encounter'
     | '/crawlers/$id'
@@ -175,6 +185,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/about'
+    | '/account'
     | '/changelog'
     | '/encounter'
     | '/crawlers/$id'
@@ -192,6 +203,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/about'
+    | '/account'
     | '/changelog'
     | '/encounter'
     | '/crawlers/$id'
@@ -210,6 +222,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
+  AccountRoute: typeof AccountRoute
   ChangelogRoute: typeof ChangelogRoute
   EncounterRoute: typeof EncounterRoute
   CrawlersIdRoute: typeof CrawlersIdRoute
@@ -239,6 +252,13 @@ declare module '@tanstack/react-router' {
       path: '/about'
       fullPath: '/about'
       preLoaderRoute: typeof AboutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/account': {
+      id: '/account'
+      path: '/account'
+      fullPath: '/account'
+      preLoaderRoute: typeof AccountRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/changelog': {
@@ -338,6 +358,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
+  AccountRoute: AccountRoute,
   ChangelogRoute: ChangelogRoute,
   EncounterRoute: EncounterRoute,
   CrawlersIdRoute: CrawlersIdRoute,

--- a/apps/itun/src/routeTree.gen.ts
+++ b/apps/itun/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as CrawlersNewRouteImport } from './routes/crawlers/new'
 import { Route as DashboardIdRouteImport } from './routes/dashboard/$id'
 import { Route as MechsIdRouteImport } from './routes/mechs/$id'
 import { Route as MechsNewRouteImport } from './routes/mechs/new'
+import { Route as MediatorGameIdRouteImport } from './routes/mediator/$gameId'
 import { Route as PilotsIdRouteImport } from './routes/pilots/$id'
 import { Route as PilotsNewRouteImport } from './routes/pilots/new'
 import { Route as SIdRouteImport } from './routes/s/$id'
@@ -82,6 +83,11 @@ const MechsNewRoute = MechsNewRouteImport.update({
   path: '/mechs/new',
   getParentRoute: () => rootRouteImport,
 } as any)
+const MediatorGameIdRoute = MediatorGameIdRouteImport.update({
+  id: '/mediator/$gameId',
+  path: '/mediator/$gameId',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const PilotsIdRoute = PilotsIdRouteImport.update({
   id: '/pilots/$id',
   path: '/pilots/$id',
@@ -125,6 +131,7 @@ export interface FileRoutesByFullPath {
   '/dashboard/$id': typeof DashboardIdRoute
   '/mechs/$id': typeof MechsIdRoute
   '/mechs/new': typeof MechsNewRoute
+  '/mediator/$gameId': typeof MediatorGameIdRoute
   '/pilots/$id': typeof PilotsIdRoute
   '/pilots/new': typeof PilotsNewRoute
   '/s/$id': typeof SIdRoute
@@ -144,6 +151,7 @@ export interface FileRoutesByTo {
   '/dashboard/$id': typeof DashboardIdRoute
   '/mechs/$id': typeof MechsIdRoute
   '/mechs/new': typeof MechsNewRoute
+  '/mediator/$gameId': typeof MediatorGameIdRoute
   '/pilots/$id': typeof PilotsIdRoute
   '/pilots/new': typeof PilotsNewRoute
   '/s/$id': typeof SIdRoute
@@ -164,6 +172,7 @@ export interface FileRoutesById {
   '/dashboard/$id': typeof DashboardIdRoute
   '/mechs/$id': typeof MechsIdRoute
   '/mechs/new': typeof MechsNewRoute
+  '/mediator/$gameId': typeof MediatorGameIdRoute
   '/pilots/$id': typeof PilotsIdRoute
   '/pilots/new': typeof PilotsNewRoute
   '/s/$id': typeof SIdRoute
@@ -185,6 +194,7 @@ export interface FileRouteTypes {
     | '/dashboard/$id'
     | '/mechs/$id'
     | '/mechs/new'
+    | '/mediator/$gameId'
     | '/pilots/$id'
     | '/pilots/new'
     | '/s/$id'
@@ -204,6 +214,7 @@ export interface FileRouteTypes {
     | '/dashboard/$id'
     | '/mechs/$id'
     | '/mechs/new'
+    | '/mediator/$gameId'
     | '/pilots/$id'
     | '/pilots/new'
     | '/s/$id'
@@ -223,6 +234,7 @@ export interface FileRouteTypes {
     | '/dashboard/$id'
     | '/mechs/$id'
     | '/mechs/new'
+    | '/mediator/$gameId'
     | '/pilots/$id'
     | '/pilots/new'
     | '/s/$id'
@@ -243,6 +255,7 @@ export interface RootRouteChildren {
   DashboardIdRoute: typeof DashboardIdRoute
   MechsIdRoute: typeof MechsIdRoute
   MechsNewRoute: typeof MechsNewRoute
+  MediatorGameIdRoute: typeof MediatorGameIdRoute
   PilotsIdRoute: typeof PilotsIdRoute
   PilotsNewRoute: typeof PilotsNewRoute
   SIdRoute: typeof SIdRoute
@@ -330,6 +343,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MechsNewRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/mediator/$gameId': {
+      id: '/mediator/$gameId'
+      path: '/mediator/$gameId'
+      fullPath: '/mediator/$gameId'
+      preLoaderRoute: typeof MediatorGameIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/pilots/$id': {
       id: '/pilots/$id'
       path: '/pilots/$id'
@@ -387,6 +407,7 @@ const rootRouteChildren: RootRouteChildren = {
   DashboardIdRoute: DashboardIdRoute,
   MechsIdRoute: MechsIdRoute,
   MechsNewRoute: MechsNewRoute,
+  MediatorGameIdRoute: MediatorGameIdRoute,
   PilotsIdRoute: PilotsIdRoute,
   PilotsNewRoute: PilotsNewRoute,
   SIdRoute: SIdRoute,

--- a/apps/itun/src/routes/__root.tsx
+++ b/apps/itun/src/routes/__root.tsx
@@ -10,6 +10,7 @@ import { AppLink } from '../components/shared/AppLink'
 import { BlockedUpgradeError } from '../lib/db/index'
 import { GameDataReady } from '../components/shared/GameDataReady'
 import { NotConnectedBanner } from '../components/shared/NotConnectedBanner'
+import { AccountStrip } from '../components/account/AccountStrip'
 import { AppConvexProvider } from '../components/shared/AppConvexProvider'
 import { GlobalSearch } from '../components/shared/GlobalSearch'
 import { BackupNudgeToast } from '../components/shared/BackupNudgeToast'
@@ -83,6 +84,7 @@ function RootComponent() {
             data, so it paints immediately instead of sitting behind the full
             preload. */}
           <NotConnectedBanner />
+          <AccountStrip />
           <AppHeader onSearchClick={() => setSearchOpen(true)} LinkComponent={AppLink} />
           <GameDataReady>
             <Outlet />

--- a/apps/itun/src/routes/account.tsx
+++ b/apps/itun/src/routes/account.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { AccountScreen } from '../components/account/AccountScreen'
+
+export const Route = createFileRoute('/account')({
+  component: AccountScreen,
+})

--- a/apps/itun/src/routes/games.tsx
+++ b/apps/itun/src/routes/games.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { GamesScreen } from '../components/games/GamesScreen'
+
+export const Route = createFileRoute('/games')({
+  component: GamesScreen,
+})

--- a/apps/itun/src/routes/mediator/$gameId.tsx
+++ b/apps/itun/src/routes/mediator/$gameId.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute, useParams } from '@tanstack/react-router'
+
+import { MediatorScreen } from '../../components/games/MediatorScreen'
+
+export const Route = createFileRoute('/mediator/$gameId')({
+  component: MediatorRoute,
+})
+
+function MediatorRoute() {
+  const { gameId } = useParams({ from: '/mediator/$gameId' })
+  return <MediatorScreen gameId={gameId} />
+}

--- a/apps/itun/src/stores/__tests__/entityBackend.test.ts
+++ b/apps/itun/src/stores/__tests__/entityBackend.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+
+import {
+  WritesBlockedOffline,
+  requireWritableBackend,
+  selectBackend,
+  setEntityBackendAuthState,
+} from '../entityBackend'
+
+/**
+ * Backend selection (ADR-030 §1).
+ *
+ * The asymmetry in these tests is intentional. Choosing `remote` when the
+ * answer should be `local` costs a Solo user their writes — silently, because
+ * there is no server listening for them. Choosing `local` when the answer is
+ * `remote` merely delays a sync. So the cases below lean hardest on proving
+ * that **local is the default and every uncertain state resolves to it**.
+ *
+ * The test build has no `VITE_CONVEX_URL`, so `convexClient` is null and every
+ * outcome here is `local` regardless of auth state — which is itself the
+ * property worth pinning, because that is the configuration CI and every
+ * unmigrated contributor runs in.
+ */
+
+afterEach(() => {
+  setEntityBackendAuthState({ signedIn: false, online: true })
+})
+
+describe('a build with no Convex URL is always local', () => {
+  test('signed out', () => {
+    setEntityBackendAuthState({ signedIn: false, online: true })
+    expect(selectBackend()).toBe('local')
+  })
+
+  test('even when the auth state claims signed in', () => {
+    // There is no client to talk to, so "signed in" cannot be true in any
+    // meaningful sense. Resolving to remote here would strand every write.
+    setEntityBackendAuthState({ signedIn: true, online: true })
+    expect(selectBackend()).toBe('local')
+  })
+
+  test('even when offline', () => {
+    setEntityBackendAuthState({ signedIn: true, online: false })
+    expect(selectBackend()).toBe('local')
+  })
+})
+
+describe('writes are never blocked in a Solo build', () => {
+  test('requireWritableBackend returns local rather than throwing', () => {
+    setEntityBackendAuthState({ signedIn: false, online: false })
+    // Offline + signed out is Solo, not Disconnected. A person who never
+    // signed in has nothing to be disconnected FROM, and refusing their write
+    // would break the app for the majority of users.
+    expect(requireWritableBackend()).toBe('local')
+  })
+})
+
+describe('WritesBlockedOffline', () => {
+  test('carries the same wording as the banner', () => {
+    // The user reads one of these in a toast and the other in the banner; if
+    // they disagree it looks like two different faults.
+    expect(new WritesBlockedOffline().message).toMatch(/read-only until the connection returns/i)
+  })
+
+  test('is identifiable by name across a structured-clone boundary', () => {
+    // instanceof does not survive being re-thrown through some boundaries, so
+    // callers match on name — that has to keep working.
+    expect(new WritesBlockedOffline().name).toBe('WritesBlockedOffline')
+  })
+})

--- a/apps/itun/src/stores/entityBackend.ts
+++ b/apps/itun/src/stores/entityBackend.ts
@@ -1,0 +1,103 @@
+import { convexClient } from '../lib/connection/convexClient'
+import { resolveConnectionMode, usesServerOfRecord } from '../lib/connection/connectionMode'
+
+/**
+ * Where entity writes actually go (ADR-030 §1).
+ *
+ * `entityStore` reaches its persistence through one indirection —
+ * `dbStoreFor(type)` — so swapping the backend is a matter of changing what
+ * that returns rather than rewriting the store. The store's public API, its
+ * in-memory cache, its lazy hydration and its broadcast behaviour are all
+ * untouched by this file.
+ *
+ * ## Solo remains the default, structurally
+ *
+ * `selectBackend` returns the **local** backend unless the app is genuinely
+ * Connected. Not signed in, no Convex URL compiled in, offline — all resolve to
+ * local. That ordering is deliberate: the failure mode of getting it wrong in
+ * the other direction is a Solo user's writes silently going nowhere, which is
+ * the single worst outcome in this whole migration.
+ *
+ * ## Disconnected does not fall back to local
+ *
+ * A signed-in user who loses connectivity is **read-only** (D14), not
+ * quietly-writing-to-IndexedDB. Falling back would fork their data against the
+ * server of record and reintroduce, by accident, the conflict resolution the
+ * server-of-record decision exists to avoid. Callers check `canWrite` before
+ * offering the affordance; this module refuses if they do not.
+ */
+
+/** Signed-in state as far as this module is concerned. */
+type AuthState = { signedIn: boolean; online: boolean }
+
+/** Read once per write rather than subscribed — the store is not a component. */
+let authState: AuthState = { signedIn: false, online: true }
+
+/**
+ * Publish the current auth/connectivity state to the store layer.
+ *
+ * The store cannot call React hooks, so `ConnectionProvider` pushes the mode in
+ * rather than the store pulling it out. One writer, one direction.
+ */
+export function setEntityBackendAuthState(next: AuthState): void {
+  authState = next
+}
+
+export type BackendKind = 'local' | 'remote' | 'blocked'
+
+/**
+ * Which backend a write should use right now.
+ *
+ * Exported for tests and for surfaces that want to explain themselves — a
+ * button that would be `blocked` should say why rather than fail on click.
+ */
+export function selectBackend(): BackendKind {
+  const mode = resolveConnectionMode({
+    convexConfigured: convexClient !== null,
+    signedIn: authState.signedIn,
+    online: authState.online,
+  })
+  if (mode === 'solo') return 'local'
+  if (usesServerOfRecord(mode)) return 'remote'
+  return 'blocked'
+}
+
+/** Thrown when a write is attempted while the server of record is unreachable. */
+export class WritesBlockedOffline extends Error {
+  constructor() {
+    super('Not connected — your games are read-only until the connection returns')
+    this.name = 'WritesBlockedOffline'
+  }
+}
+
+/**
+ * ## Why there is no write-mirroring here yet
+ *
+ * The obvious next step — write locally, then mirror the same change to Convex
+ * — does not work, and it is worth writing down so nobody rediscovers it the
+ * hard way. Local records are keyed by an app-level `id` (a UUID minted by
+ * `crud.ts`); Convex rows are keyed by its own `_id`. A create can be mirrored
+ * because it needs no prior key, but an **update or delete has nothing to
+ * address**: there is no id map between the two, so the mirror would either
+ * silently no-op or need a lookup-by-body on every write.
+ *
+ * A mirror that works for creates and quietly fails for edits is worse than no
+ * mirror, because it looks synced. The real cutover is the one ADR-030
+ * describes — when Connected, Convex IS the source of truth and the store
+ * reads from a reactive subscription rather than from IndexedDB — and that
+ * needs the id mapping (or app-id-as-primary-key on the Convex side) decided
+ * first. This module deliberately ships only the part that is sound.
+ */
+
+/**
+ * Guard a write against the current mode.
+ *
+ * Called by the store before it touches persistence. Returns the backend to
+ * use; throws rather than silently degrading when the answer is "you cannot
+ * write right now".
+ */
+export function requireWritableBackend(): Exclude<BackendKind, 'blocked'> {
+  const backend = selectBackend()
+  if (backend === 'blocked') throw new WritesBlockedOffline()
+  return backend
+}

--- a/apps/itun/src/stores/entityBackend.ts
+++ b/apps/itun/src/stores/entityBackend.ts
@@ -1,3 +1,5 @@
+import { api } from '../../convex/_generated/api'
+import type { Id } from '../../convex/_generated/dataModel'
 import { convexClient } from '../lib/connection/convexClient'
 import { resolveConnectionMode, usesServerOfRecord } from '../lib/connection/connectionMode'
 
@@ -71,23 +73,51 @@ export class WritesBlockedOffline extends Error {
 }
 
 /**
- * ## Why there is no write-mirroring here yet
+ * Mirror a local write to the server of record, addressed by **app id**.
  *
- * The obvious next step — write locally, then mirror the same change to Convex
- * — does not work, and it is worth writing down so nobody rediscovers it the
- * hard way. Local records are keyed by an app-level `id` (a UUID minted by
- * `crud.ts`); Convex rows are keyed by its own `_id`. A create can be mirrored
- * because it needs no prior key, but an **update or delete has nothing to
- * address**: there is no id map between the two, so the mirror would either
- * silently no-op or need a lookup-by-body on every write.
+ * An earlier attempt at this could not work: Convex mints its own `_id`, so a
+ * client holding only its local UUID had nothing to address a row by. Creates
+ * mirrored fine and edits silently no-opped — a mirror that looks synced and
+ * is not. The fix is the indexed `appId` column, which lets one cheap lookup
+ * stand in for a mapping table.
  *
- * A mirror that works for creates and quietly fails for edits is worse than no
- * mirror, because it looks synced. The real cutover is the one ADR-030
- * describes — when Connected, Convex IS the source of truth and the store
- * reads from a reactive subscription rather than from IndexedDB — and that
- * needs the id mapping (or app-id-as-primary-key on the Convex side) decided
- * first. This module deliberately ships only the part that is sound.
+ * Three properties that matter:
+ *
+ *  - **Upsert, not update.** An entity built while Solo has no server row until
+ *    the account is claimed, so a missing row means "create it" rather than
+ *    "fail". That is what makes the mirror converge instead of dropping the
+ *    first edit after a claim.
+ *  - **Fire-and-forget.** The local write already succeeded and is what the UI
+ *    reads. A mirror failure must not roll it back or block the caller, so this
+ *    returns void and swallows into a console warning.
+ *  - **Only in `remote`.** In Solo there is no server to mirror to, and in
+ *    Disconnected the write never got this far (`requireWritableBackend`).
  */
+export async function mirrorWrite(
+  type: 'pilot' | 'mech',
+  op:
+    | { kind: 'upsert'; appId: string; gameId: string | null; body: unknown }
+    | { kind: 'delete'; appId: string }
+): Promise<void> {
+  if (selectBackend() !== 'remote' || convexClient === null) return
+
+  const table = type === 'pilot' ? 'pilots' : 'mechs'
+  try {
+    if (op.kind === 'upsert') {
+      await convexClient.mutation(api.entities.upsertByAppId, {
+        table,
+        appId: op.appId,
+        gameId: op.gameId === null ? null : (op.gameId as Id<'games'>),
+        body: op.body,
+      })
+    } else {
+      await convexClient.mutation(api.entities.removeByAppId, { table, appId: op.appId })
+    }
+  } catch (err) {
+    // Never surfaced as a failed user action: the local write stands.
+    console.warn('[itun] failed to mirror write to the server of record', err)
+  }
+}
 
 /**
  * Guard a write against the current mode.

--- a/apps/itun/src/stores/entityStore.ts
+++ b/apps/itun/src/stores/entityStore.ts
@@ -39,6 +39,7 @@ import type { Mech } from '../lib/schemas/mech'
 import type { Pilot } from '../lib/schemas/pilot'
 import type { SoftLink } from '../lib/schemas/softLink'
 import type { CreateInput, EntityForType, EntityType } from './types'
+import { requireWritableBackend } from './entityBackend'
 
 // Re-exported so consumers can import the type alongside the store itself.
 export type { EntityType }
@@ -337,6 +338,10 @@ export const useEntityStore = create<EntityState>((set, get) => ({
 
   async create<T extends EntityType>(type: T, input: CreateInput<T>): Promise<EntityForType<T>> {
     const key = storeKeyFor(type)
+    // Refuses rather than degrading when the server of record is unreachable
+    // (ADR-030 §1): a signed-in user offline is read-only, not silently
+    // writing to a local copy that would fork against the server.
+    requireWritableBackend()
     const record = await dbStoreFor(type).create(withActiveWorkspace(type, input))
     set((state) => ({
       [key]: [record, ...(state[key] as EntityForType<T>[])],
@@ -354,6 +359,7 @@ export const useEntityStore = create<EntityState>((set, get) => ({
     const key = storeKeyFor(type)
     // Capture the before-image BEFORE the write so the Change Log can diff it.
     const before = get().get(type, id)
+    requireWritableBackend()
     const updated = await dbStoreFor(type).update(id, patch)
     set((state) => ({
       [key]: (state[key] as EntityForType<T>[]).map((e) => (e.id === id ? updated : e)),
@@ -481,6 +487,7 @@ export const useEntityStore = create<EntityState>((set, get) => ({
 
   async delete(type, id) {
     const key = storeKeyFor(type)
+    requireWritableBackend()
 
     // Cascade: deleting an entity prunes its SoftLinks (plan 2.7, gap 9).
     // The entity delete and its link pruning run in a single IDB transaction

--- a/apps/itun/src/stores/entityStore.ts
+++ b/apps/itun/src/stores/entityStore.ts
@@ -39,7 +39,7 @@ import type { Mech } from '../lib/schemas/mech'
 import type { Pilot } from '../lib/schemas/pilot'
 import type { SoftLink } from '../lib/schemas/softLink'
 import type { CreateInput, EntityForType, EntityType } from './types'
-import { requireWritableBackend } from './entityBackend'
+import { mirrorWrite, requireWritableBackend } from './entityBackend'
 
 // Re-exported so consumers can import the type alongside the store itself.
 export type { EntityType }
@@ -249,6 +249,23 @@ const DB_STORES: { [K in EntityType]: DbStoreApi<K> } = {
   softLink: db.softLinks,
 }
 
+/**
+ * Mirror a just-persisted record to the server of record.
+ *
+ * Only pilots and mechs: the crawler is communal and merges per field
+ * server-side, and softLinks are derived. Fire-and-forget by design — the
+ * local write is what the UI reads, so a mirror failure must not undo it.
+ */
+function mirrorEntityWrite(type: EntityType, record: { id: string; gameId?: string | null }): void {
+  if (type !== 'pilot' && type !== 'mech') return
+  void mirrorWrite(type, {
+    kind: 'upsert',
+    appId: record.id,
+    gameId: record.gameId ?? null,
+    body: record,
+  })
+}
+
 function dbStoreFor<T extends EntityType>(type: T): DbStoreApi<T> {
   // Single correlated-union assertion: TS cannot carry the runtime
   // discriminant↔record-type invariant through the map lookup for a
@@ -343,6 +360,7 @@ export const useEntityStore = create<EntityState>((set, get) => ({
     // writing to a local copy that would fork against the server.
     requireWritableBackend()
     const record = await dbStoreFor(type).create(withActiveWorkspace(type, input))
+    mirrorEntityWrite(type, record)
     set((state) => ({
       [key]: [record, ...(state[key] as EntityForType<T>[])],
     }))
@@ -361,6 +379,7 @@ export const useEntityStore = create<EntityState>((set, get) => ({
     const before = get().get(type, id)
     requireWritableBackend()
     const updated = await dbStoreFor(type).update(id, patch)
+    mirrorEntityWrite(type, updated)
     set((state) => ({
       [key]: (state[key] as EntityForType<T>[]).map((e) => (e.id === id ? updated : e)),
     }))
@@ -488,6 +507,7 @@ export const useEntityStore = create<EntityState>((set, get) => ({
   async delete(type, id) {
     const key = storeKeyFor(type)
     requireWritableBackend()
+    if (type === 'pilot' || type === 'mech') void mirrorWrite(type, { kind: 'delete', appId: id })
 
     // Cascade: deleting an entity prunes its SoftLinks (plan 2.7, gap 9).
     // The entity delete and its link pruning run in a single IDB transaction

--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -1,7 +1,7 @@
 {
-  "packages/salvageunion-reference": 89,
-  "packages/component-lib": 86,
+  "packages/salvageunion-reference": 95,
+  "packages/component-lib": 87,
   "apps/srd": 95,
   "apps/itun": 89,
-  "apps/discord-bot": 92
+  "apps/discord-bot": 95
 }

--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -1,6 +1,6 @@
 {
   "packages/salvageunion-reference": 89,
-  "packages/component-lib": 75,
+  "packages/component-lib": 86,
   "apps/srd": 95,
   "apps/itun": 89,
   "apps/discord-bot": 92

--- a/docs/architecture/accounts-and-games.md
+++ b/docs/architecture/accounts-and-games.md
@@ -148,16 +148,118 @@ Discord land as Change Log entries.
 
 ---
 
-## 6. External services
+## 6. External services — operational reference
 
-| Resource       | Value                                                       |
-| -------------- | ----------------------------------------------------------- |
-| Convex project | `alex-jarvis:suref-itun`                                    |
-| Dev deployment | `dev/alex-jarvis`                                           |
-| Discord app    | the bot's existing application (one app covers bot + login) |
-| Redirect URI   | `<VITE_CONVEX_SITE_URL>/api/auth/callback/discord`          |
+Everything needed to stand this up, or to work out why sign-in is failing.
+Values here are **not secret**: deployment URLs and a Discord client id are
+public by design. The client _secret_ lives only on the Convex deployments.
 
-Required deployment variables — all three, or sign-in fails:
-`AUTH_DISCORD_ID`, `AUTH_DISCORD_SECRET`, and `SITE_URL` (the **frontend**
-origin, which is _not_ `VITE_CONVEX_SITE_URL`; omitting it fails with an opaque
-`Missing environment variable` 500). See `apps/itun/.env.example`.
+### Convex
+
+|                                       | Dev                                      | Production                                    |
+| ------------------------------------- | ---------------------------------------- | --------------------------------------------- |
+| Deployment                            | `dev/alex-jarvis` (`perfect-donkey-72`)  | `exuberant-porpoise-183`                      |
+| Client URL (`VITE_CONVEX_URL`)        | `https://perfect-donkey-72.convex.cloud` | `https://exuberant-porpoise-183.convex.cloud` |
+| HTTP actions (`VITE_CONVEX_SITE_URL`) | `https://perfect-donkey-72.convex.site`  | `https://exuberant-porpoise-183.convex.site`  |
+| `SITE_URL` (the **frontend** origin)  | `http://localhost:5173`                  | `https://intheunionnow.com`                   |
+
+Project: `alex-jarvis:suref-itun` ·
+[dashboard](https://dashboard.convex.dev/t/alex-jarvis/suref-itun)
+
+### Netlify
+
+| Site               | Serves                           | Notes                                                                                                                                        |
+| ------------------ | -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `in-the-union-now` | `https://intheunionnow.com`      | ITUN. **The production origin is the custom domain, not the `.netlify.app` subdomain** — `SITE_URL` and the OAuth redirect must both use it. |
+| `suindex`          | `https://salvageunion.io`        | `apps/srd`. No accounts, ever.                                                                                                               |
+| `su-assets`        | `https://assets.salvageunion.io` | Entity artwork. Unrelated to accounts.                                                                                                       |
+
+### Discord
+
+One application covers both the bot and web sign-in, so players meet a consent
+screen they already recognise and there is one credential to rotate. Resetting
+the OAuth2 client secret does **not** disturb the bot token — they are separate
+credentials on the same app.
+
+Each deployment needs its **own** redirect URI, and Discord permits several, so
+adding one is additive rather than a swap:
+
+```
+https://perfect-donkey-72.convex.site/api/auth/callback/discord      (dev)
+https://exuberant-porpoise-183.convex.site/api/auth/callback/discord (prod)
+```
+
+The path is not arbitrary: `@convex-dev/auth` mounts callbacks under
+`/api/auth/callback/` and appends the provider id, which `@auth/core` declares
+as `discord`.
+
+### Required deployment variables
+
+**All three, or sign-in fails**, per deployment:
+
+```bash
+bunx convex env set AUTH_DISCORD_ID     <client-id>
+bunx convex env set AUTH_DISCORD_SECRET <client-secret>
+bunx convex env set SITE_URL            <frontend origin>
+# add --prod to target production
+```
+
+`SITE_URL` is the one that bites. It is the **frontend** origin, _not_
+`VITE_CONVEX_SITE_URL`, nothing prompts for it, and omitting it fails with an
+opaque `Missing environment variable SITE_URL` 500 from the OAuth callback
+rather than anything pointing at configuration.
+
+### Verifying a deployment without signing in
+
+Curl the callback. The status distinguishes all three failure modes:
+
+| Result                                 | Means                                                      |
+| -------------------------------------- | ---------------------------------------------------------- |
+| **302** → your `SITE_URL`              | Correctly configured.                                      |
+| **500** `Missing environment variable` | `SITE_URL` unset.                                          |
+| **404**                                | Auth routes not mounted — check `convex/http.ts` deployed. |
+
+Always check a bogus provider too (`/api/auth/callback/bogusprovider` → **500**).
+Without that control, a router answering everything looks identical to one
+correctly configured for Discord.
+
+```bash
+curl -s -D - -o /dev/null https://<deployment>.convex.site/api/auth/callback/discord | grep -i location
+```
+
+### Switching production on
+
+Production builds in **Solo mode** until `VITE_CONVEX_URL` is set on the Netlify
+site — which is safe and deliberate, not an outage: a build with no Convex URL
+is the pre-accounts app, fully working. To switch accounts on:
+
+1. Add the prod redirect URI to the Discord application (above). **Done.**
+2. Set `VITE_CONVEX_URL=https://exuberant-porpoise-183.convex.cloud` on the
+   `in-the-union-now` Netlify site (production context, `builds` scope) and
+   redeploy. **Done** — it is a build-time variable, so it only takes effect on
+   the next deploy, not immediately.
+
+> **Note the two different origins.** That site also carries a pre-existing
+> `VITE_SITE_URL` of `https://in-the-union-now.netlify.app`, while the primary
+> domain — and Convex's `SITE_URL` — is `https://intheunionnow.com`. Sign-in
+> therefore returns a visitor to the canonical domain even if they started on
+> the `.netlify.app` subdomain. That is defensible, but it is a difference
+> somebody will eventually trip over, so it is written down rather than left to
+> be rediscovered.
+
+Reversing it is equally simple: unset the variable and production returns to
+Solo, with every local build intact.
+
+### Secrets
+
+Never commit the client secret. `.env.local` is gitignored and holds only the
+non-secret deployment URLs. When reading a value back, pipe it — do not echo it
+into a terminal or a transcript. `bunx convex env get` prints in the clear, so
+prefer testing presence by length:
+
+```bash
+bunx convex env get AUTH_DISCORD_SECRET | tr -d '[:space:]' | wc -c
+```
+
+Exit code is **not** a presence check: `convex env get` exits 0 for a variable
+that does not exist.

--- a/docs/architecture/accounts-and-games.md
+++ b/docs/architecture/accounts-and-games.md
@@ -2,8 +2,10 @@
 
 > **Status:** Delivery plan for [ADR-030](../adrs/ADR-030-accounts-games-server-of-record.md).
 > The ADR records _why_ and _what_; this document records _in what order_ and
-> _what breaks_. Phase 0 and part of Phase 1 have landed; everything from Phase 2
-> on is planned, not built.
+> _what breaks_. **Phases 0-6 have landed as a stack of draft PRs** (#609 through
+> #645). The server layer, data model and permission rules are complete and
+> tested; the surfaces for Phases 3-5 are wired to that data but want a design
+> pass before they are called finished.
 >
 > Read alongside [ADR-021](../adrs/ADR-021-itun-surface-taxonomy.md) (the
 > enforcement modes this adds an ownership axis to),
@@ -79,7 +81,7 @@ Each phase's exit criterion is the next one's precondition.
   Pushing, Crafting, Salvage) are single-player gameplay mis-filed under
   "Multiplayer", and closing them would destroy live backlog.
 
-### Phase 1 — Accounts, Games & sync
+### Phase 1 — Accounts, Games & sync ✅
 
 Everything structural, nothing live. The Dashboard stays single-player, which is
 what de-risks the rest.
@@ -97,7 +99,7 @@ what de-risks the rest.
 each sees their own entities scoped to it — on two machines. An account can be
 fully deleted.
 
-### Phase 2 — Roles & visibility
+### Phase 2 — Roles & visibility ✅
 
 Capabilities on membership, Organizer transfer, Mediator assignment,
 **server-side** authorization on every mutation, read-only crewmate drill-in,
@@ -107,22 +109,22 @@ ownership assign/release/reassign, owner chips.
 Player cannot write a crewmate's pilot and that an Organizer gains nothing over
 content by holding the flag.
 
-### Phase 3 — The Mediator surface
+### Phase 3 — The Mediator surface ✅ (server; screen wants a design pass)
 
 Crew roster with live vitals, the communal crawler, the NPC tray; `/encounter`
 absorbed and retired; presence.
 
-### Phase 4 — Alerts & propose/confirm
+### Phase 4 — Alerts & propose/confirm ✅
 
 Proposal states on the Change Log, same-field supersession, player Apply/Decline,
 broadcast alerts, and the **Crew** dial item.
 
-### Phase 5 — Synchronized Downtime
+### Phase 5 — Synchronized Downtime ✅
 
 Downtime phase as Game state advanced by the Mediator; per-player step completion
 visible to the table; crawler upkeep resolved once rather than six times.
 
-### Phase 6 — Discord bot as a Game client
+### Phase 6 — Discord bot as a Game client ✅
 
 The bot authenticates as a participant rather than an admin; rolls made in
 Discord land as Change Log entries.

--- a/packages/component-lib/src/components/chrome/__tests__/InlineEditField.test.tsx
+++ b/packages/component-lib/src/components/chrome/__tests__/InlineEditField.test.tsx
@@ -1,0 +1,320 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { InlineEditField } from '../InlineEditField'
+
+/**
+ * The edit-in-place atom every sheet value goes through. It owns the whole
+ * commit path — open, validate, save or refuse — so the things worth pinning
+ * are the ones that quietly lose a player's typing: a commit that fires on
+ * blur as well as Enter, an Escape that must NOT save, and a rejected number
+ * that must keep the editor open with the draft intact rather than reverting.
+ *
+ * `readOnly` gets its own attention because it is a correctness boundary, not
+ * a style: the read-only sheet must not offer an affordance that would write.
+ */
+
+// Explicit rather than relying on Testing Library's auto-cleanup: every test
+// here renders the same `Callsign` label, so a single leaked render turns every
+// later `getByLabelText` into "found multiple elements". Auto-cleanup covered
+// this when the file ran alone and did not when the whole suite ran together.
+afterEach(cleanup)
+
+/** Render with a recording `onSave`; returns the calls array. */
+function setup(props: Partial<Parameters<typeof InlineEditField>[0]> = {}) {
+  const saved: Array<string | number> = []
+  render(
+    <InlineEditField
+      value={props.value ?? 'Roach-Boy'}
+      onSave={(next) => {
+        saved.push(next)
+      }}
+      ariaLabel="Callsign"
+      {...props}
+    />
+  )
+  return saved
+}
+
+/** Open the editor by activating the display readout. */
+function openEditor(label = 'Callsign'): void {
+  fireEvent.click(screen.getByLabelText(label))
+}
+
+describe('the readout, before anything is edited', () => {
+  test('shows the value', () => {
+    setup()
+    expect(screen.getByLabelText('Callsign').textContent).toBe('Roach-Boy')
+  })
+
+  test('an empty value shows the placeholder', () => {
+    setup({ value: '', placeholder: 'Unnamed' })
+    expect(screen.getByLabelText('Callsign').textContent).toBe('Unnamed')
+  })
+
+  test('an empty value with no placeholder shows a dash, never nothing', () => {
+    // A blank cell on a sheet reads as a rendering bug rather than as an
+    // empty field waiting to be filled.
+    setup({ value: '   ' })
+    expect(screen.getByLabelText('Callsign').textContent).toBe('—')
+  })
+
+  test('a zero is a value, not an empty', () => {
+    setup({ value: 0, type: 'number', placeholder: 'none' })
+    expect(screen.getByLabelText('Callsign').textContent).toBe('0')
+  })
+})
+
+describe('opening the editor', () => {
+  test('clicking the readout opens an input carrying the current value', () => {
+    setup()
+    openEditor()
+    expect((screen.getByLabelText('Callsign') as HTMLInputElement).value).toBe('Roach-Boy')
+  })
+
+  test('Enter and Space open it from the keyboard', () => {
+    setup()
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+    expect(screen.getByLabelText('Callsign').tagName).toBe('INPUT')
+  })
+
+  test('Space opens it too', () => {
+    setup()
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: ' ' })
+    expect(screen.getByLabelText('Callsign').tagName).toBe('INPUT')
+  })
+
+  test('another key does not', () => {
+    setup()
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'a' })
+    expect(screen.getByLabelText('Callsign').tagName).not.toBe('INPUT')
+  })
+})
+
+describe('read-only', () => {
+  test('offers no way in — not a disabled one, none at all', () => {
+    setup({ readOnly: true })
+    const node = screen.getByLabelText('Callsign')
+
+    // No button role and no tab stop: a read-only sheet must not put a
+    // write affordance in the keyboard order at all.
+    expect(node.getAttribute('role')).toBeNull()
+    expect(node.getAttribute('tabindex')).toBeNull()
+
+    fireEvent.click(node)
+    fireEvent.keyDown(node, { key: 'Enter' })
+    expect(screen.getByLabelText('Callsign').tagName).not.toBe('INPUT')
+  })
+})
+
+describe('committing', () => {
+  test('Enter saves the typed value', async () => {
+    const saved = setup()
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: 'Ash' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(saved).toEqual(['Ash']))
+  })
+
+  test('blur saves too — clicking away must not discard typing', async () => {
+    const saved = setup()
+    openEditor()
+    fireEvent.blur(screen.getByLabelText('Callsign'), { target: { value: 'Ash' } })
+
+    await waitFor(() => expect(saved).toEqual(['Ash']))
+  })
+
+  test('the editor closes and the new value is read back', async () => {
+    setup()
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: 'Ash' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(screen.getByLabelText('Callsign').tagName).not.toBe('INPUT'))
+  })
+
+  test('Escape closes without saving', async () => {
+    const saved = setup()
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: 'discard me' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Escape' })
+
+    await waitFor(() => expect(screen.getByLabelText('Callsign').tagName).not.toBe('INPUT'))
+    expect(saved).toEqual([])
+  })
+
+  test('reopening after Escape shows the stored value, not the abandoned draft', () => {
+    setup()
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: 'discard me' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Escape' })
+
+    openEditor()
+    expect((screen.getByLabelText('Callsign') as HTMLInputElement).value).toBe('Roach-Boy')
+  })
+})
+
+describe('number validation', () => {
+  test('a valid number is saved as a number, not a string', async () => {
+    // Stats are arithmetic downstream; a string here corrupts every sum.
+    const saved = setup({ value: 5, type: 'number', min: 0, max: 10 })
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: '7' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(saved).toEqual([7]))
+  })
+
+  test('a non-number is refused, and the editor stays open', async () => {
+    const saved = setup({ value: 5, type: 'number' })
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: 'abc' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(screen.getByText('Must be a number.')).toBeTruthy())
+    expect(saved).toEqual([])
+    // Still editing — closing here would silently drop what they typed.
+    expect(screen.getByLabelText('Callsign').tagName).toBe('INPUT')
+  })
+
+  test('an empty number is refused rather than saved as zero', async () => {
+    const saved = setup({ value: 5, type: 'number' })
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: '  ' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(screen.getByText('Must be a number.')).toBeTruthy())
+    expect(saved).toEqual([])
+  })
+
+  test('below min is refused, and the bound is named', async () => {
+    const saved = setup({ value: 5, type: 'number', min: 1 })
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: '0' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(screen.getByText('min 1')).toBeTruthy())
+    expect(saved).toEqual([])
+  })
+
+  test('above max is refused, and the bound is named', async () => {
+    const saved = setup({ value: 5, type: 'number', max: 10 })
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: '11' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(screen.getByText('max 10')).toBeTruthy())
+    expect(saved).toEqual([])
+  })
+
+  test('the error clears as soon as they start fixing it', async () => {
+    const saved = setup({ value: 5, type: 'number', max: 10 })
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: '11' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+    await waitFor(() => expect(screen.getByText('max 10')).toBeTruthy())
+
+    // Nagging while somebody is mid-correction is the wrong moment for it.
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: '9' } })
+    expect(screen.queryByText('max 10')).toBeNull()
+
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+    await waitFor(() => expect(saved).toEqual([9]))
+  })
+
+  test('a text field does not validate as a number', async () => {
+    const saved = setup({ value: 'a' })
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: 'not a number' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(saved).toEqual(['not a number']))
+  })
+})
+
+describe('multiline', () => {
+  test('edits in a textarea', () => {
+    setup({ multiline: true })
+    openEditor()
+    expect(screen.getByLabelText('Callsign').tagName).toBe('TEXTAREA')
+  })
+
+  test('Enter commits', async () => {
+    const saved = setup({ multiline: true })
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: 'a motto' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(saved).toEqual(['a motto']))
+  })
+
+  test('Shift+Enter inserts a newline instead of committing', () => {
+    // The whole point of a textarea: prose fields need paragraph breaks.
+    const saved = setup({ multiline: true })
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: 'line one' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter', shiftKey: true })
+
+    expect(saved).toEqual([])
+    expect(screen.getByLabelText('Callsign').tagName).toBe('TEXTAREA')
+  })
+
+  test('Escape cancels', async () => {
+    const saved = setup({ multiline: true })
+    openEditor()
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Escape' })
+
+    await waitFor(() => expect(screen.getByLabelText('Callsign').tagName).not.toBe('TEXTAREA'))
+    expect(saved).toEqual([])
+  })
+
+  test('blur commits', async () => {
+    const saved = setup({ multiline: true })
+    openEditor()
+    fireEvent.blur(screen.getByLabelText('Callsign'), { target: { value: 'via blur' } })
+
+    await waitFor(() => expect(saved).toEqual(['via blur']))
+  })
+})
+
+describe('bordered value box', () => {
+  test('at rest the box draws the frame around the readout', () => {
+    const { container } = render(
+      <InlineEditField value="Roach-Boy" onSave={() => {}} ariaLabel="Callsign" bordered />
+    )
+    const box = container.firstElementChild as HTMLElement
+    expect(box.className).toContain('border-ink')
+  })
+
+  test('while editing the box does not draw a second border around the input', () => {
+    // The input supplies its own frame; a box-in-box is the bug this guards.
+    const { container } = render(
+      <InlineEditField value="Roach-Boy" onSave={() => {}} ariaLabel="Callsign" bordered />
+    )
+    openEditor()
+    const box = container.firstElementChild as HTMLElement
+    expect(box.className).not.toContain('border-ink')
+  })
+
+  test('an awaited async save still returns to the readout', async () => {
+    const saved: Array<string | number> = []
+    render(
+      <InlineEditField
+        value="Roach-Boy"
+        ariaLabel="Callsign"
+        bordered
+        onSave={async (next) => {
+          await Promise.resolve()
+          saved.push(next)
+        }}
+      />
+    )
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: 'Ash' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(saved).toEqual(['Ash']))
+    expect(screen.getByLabelText('Callsign').tagName).not.toBe('INPUT')
+  })
+})

--- a/packages/salvageunion-reference/lib/helpers-display.test.ts
+++ b/packages/salvageunion-reference/lib/helpers-display.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, test } from 'bun:test'
+
+import { SalvageUnionReference } from './index.js'
+import {
+  extractStaticEntitySummary,
+  getDisplayName,
+  getEntitySchemas,
+  getHybridClasses,
+  getModel,
+  getReferenceEntityData,
+  getUniqueSources,
+  getUniqueTechLevels,
+  getUniqueTrees,
+  normalizeSchemaName,
+  resolveActivationCurrency,
+  resolveGrantedEntities,
+} from './helpers.js'
+import type { SURefEntity } from './index.js'
+
+/**
+ * The read layer both apps go through: schema lookup, grant resolution, facet
+ * extraction, and the static summary the SRD's no-JS and crawler rendering is
+ * built from. `helpers.test.ts` next door covers the crawler-mutation helpers.
+ *
+ * Most of this runs against the real dataset on purpose. These functions are
+ * shape-tolerance over data that changes, so a test built entirely from
+ * hand-made objects would keep passing while the shipped data broke them.
+ */
+
+describe('schema names', () => {
+  test('a known schema gets its display name', () => {
+    expect(getDisplayName('chassis')).toBe('Chassis')
+  })
+
+  test('an unknown schema falls back to the name rather than to blank', () => {
+    // Better a raw slug on screen than an empty heading.
+    expect(getDisplayName('not-a-schema' as never)).toBe('not-a-schema')
+  })
+
+  test('every class alias normalises onto the one unified schema', () => {
+    // Six spellings reach this from data, routes and older links; all six are
+    // the same schema, and a miss yields no model at all.
+    for (const alias of [
+      'classes-core',
+      'classes.core',
+      'classes-advanced',
+      'classes.advanced',
+      'classes-hybrid',
+      'classes.hybrid',
+    ]) {
+      expect(normalizeSchemaName(alias)).toBe('classes')
+    }
+  })
+
+  test('a name that is already canonical is left alone', () => {
+    expect(normalizeSchemaName('chassis')).toBe('chassis')
+  })
+
+  test('getModel resolves through the alias', () => {
+    expect(getModel('classes-core')).toBe(getModel('classes'))
+    expect(getModel('chassis')?.all().length).toBeGreaterThan(0)
+  })
+
+  test('an unknown schema yields undefined rather than throwing', () => {
+    expect(getModel('not-a-schema')).toBeUndefined()
+  })
+
+  test('the entity schema list excludes meta schemas', () => {
+    const schemas = getEntitySchemas()
+    expect(schemas.length).toBeGreaterThan(0)
+    expect(schemas.every((s) => !s.meta)).toBe(true)
+  })
+})
+
+describe('grants', () => {
+  test('an entity with no grants resolves to nothing', () => {
+    const [chassis] = SalvageUnionReference.Chassis.all()
+    expect(resolveGrantedEntities(chassis as SURefEntity)).toEqual([])
+  })
+
+  test('granted entities resolve to real records, and `choice` grants are skipped', () => {
+    // A `choice` grant names no single entity — it is a prompt resolved
+    // elsewhere — so walking it here would invent a null.
+    const granters = SalvageUnionReference.Abilities.all().filter(
+      (a) => 'grants' in a && Array.isArray(a.grants) && a.grants.length > 0
+    )
+    expect(granters.length).toBeGreaterThan(0)
+
+    for (const granter of granters) {
+      const resolved = resolveGrantedEntities(granter as SURefEntity)
+      // Never a hole: unresolvable grants are dropped, not returned as null.
+      expect(resolved.every((e) => e != null && typeof e.id === 'string')).toBe(true)
+      const nonChoice = (granter.grants ?? []).filter((g) => g.schema !== 'choice')
+      expect(resolved.length).toBeLessThanOrEqual(nonChoice.length)
+    }
+  })
+})
+
+describe('classes', () => {
+  test('hybrid classes are exactly those flagged hybrid', () => {
+    const hybrids = getHybridClasses()
+    expect(hybrids.length).toBeGreaterThan(0)
+    expect(hybrids.every((c) => c.hybrid === true)).toBe(true)
+  })
+})
+
+describe('activation currency', () => {
+  test('mech-level sources cost EP', () => {
+    for (const schema of ['chassis', 'systems', 'modules'] as const) {
+      expect(resolveActivationCurrency(schema)).toBe('EP')
+    }
+  })
+
+  test('everything else costs AP', () => {
+    expect(resolveActivationCurrency('abilities')).toBe('AP')
+    expect(resolveActivationCurrency('actions')).toBe('AP')
+    expect(resolveActivationCurrency(undefined)).toBe('AP')
+  })
+
+  test('a variable cost is XP, and beats the schema', () => {
+    // Variable-cost abilities are paid in XP wherever they sit — including on
+    // a mech-level source, which would otherwise read as EP.
+    expect(resolveActivationCurrency('abilities', true)).toBe('XP')
+    expect(resolveActivationCurrency('chassis', true)).toBe('XP')
+  })
+})
+
+describe('facets', () => {
+  test('tech levels come back unique and in game order: numbers, then B, then N', () => {
+    const entities = [
+      { id: 'a', techLevel: 3 },
+      { id: 'b', techLevel: 1 },
+      { id: 'c', techLevel: 'N' },
+      { id: 'd', techLevel: 'B' },
+      { id: 'e', techLevel: 1 },
+      { id: 'f' },
+    ] as unknown as SURefEntity[]
+    expect(getUniqueTechLevels(entities)).toEqual([1, 3, 'B', 'N'])
+  })
+
+  test('no tech levels at all yields an empty list', () => {
+    expect(getUniqueTechLevels([{ id: 'a' } as unknown as SURefEntity])).toEqual([])
+  })
+
+  test('the Workshop Manual sorts first, the rest alphabetically', () => {
+    // The core book is what every other source is read against, so it leads
+    // the facet regardless of alphabet.
+    const entities = [
+      { id: 'a', source: 'Zephyr Expansion' },
+      { id: 'b', source: 'Salvage Union Workshop Manual' },
+      { id: 'c', source: 'Alpha Expansion' },
+    ] as unknown as SURefEntity[]
+    expect(getUniqueSources(entities)).toEqual([
+      'Salvage Union Workshop Manual',
+      'Alpha Expansion',
+      'Zephyr Expansion',
+    ])
+  })
+
+  test('without the core book the rest are simply alphabetical', () => {
+    const entities = [
+      { id: 'a', source: 'Zephyr' },
+      { id: 'b', source: 'Alpha' },
+    ] as unknown as SURefEntity[]
+    expect(getUniqueSources(entities)).toEqual(['Alpha', 'Zephyr'])
+  })
+
+  test('trees are unique, sorted, and entities without one are skipped', () => {
+    const entities = [
+      { id: 'a', tree: 'Gunner' },
+      { id: 'b', tree: 'Ace' },
+      { id: 'c', tree: 'Gunner' },
+      { id: 'd' },
+    ] as unknown as SURefEntity[]
+    expect(getUniqueTrees(entities)).toEqual(['Ace', 'Gunner'])
+  })
+
+  test('the real ability set produces real, sorted trees', () => {
+    const trees = getUniqueTrees(SalvageUnionReference.Abilities.all() as SURefEntity[])
+    expect(trees.length).toBeGreaterThan(0)
+    expect(trees).toEqual([...trees].sort())
+  })
+})
+
+describe('display data', () => {
+  test('every shipped chassis yields an id, a name and a slug', () => {
+    // The three fields every consumer indexes and links on. A blank name here
+    // is an unclickable card.
+    for (const chassis of SalvageUnionReference.Chassis.all()) {
+      const data = getReferenceEntityData(chassis as SURefEntity)
+      expect(data.id).toBe(chassis.id)
+      expect(data.name.length).toBeGreaterThan(0)
+      expect(data.slug.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('a nameless entity falls back to its id rather than to blank', () => {
+    const data = getReferenceEntityData({ id: 'orphan' } as unknown as SURefEntity)
+    expect(data.name).toBe('orphan')
+    expect(data.description).toBeUndefined()
+    expect(data.techLevel).toBeUndefined()
+  })
+})
+
+describe('the static summary the SRD indexes on', () => {
+  test('a chassis contributes its numeric stats, labelled', () => {
+    const chassis = SalvageUnionReference.Chassis.all()[0] as SURefEntity
+    const summary = extractStaticEntitySummary(chassis)
+
+    expect(summary.name.length).toBeGreaterThan(0)
+    const labels = summary.stats.map((s) => s.label)
+    expect(labels).toContain('Structure Points')
+    expect(labels).toContain('Energy Points')
+    expect(labels).toContain('Tech Level')
+  })
+
+  test('paragraph blocks are collected and non-paragraph blocks are not', () => {
+    const summary = extractStaticEntitySummary({
+      id: 'x',
+      name: 'X',
+      content: [
+        { type: 'paragraph', value: 'first' },
+        { value: 'untyped counts as prose' },
+        { type: 'table', value: 'not prose' },
+        { type: 'paragraph', value: 42 },
+        null,
+      ],
+    } as unknown as SURefEntity)
+
+    expect(summary.contentParagraphs).toEqual(['first', 'untyped counts as prose'])
+  })
+
+  test('range and damage are flattened into readable values', () => {
+    const summary = extractStaticEntitySummary({
+      id: 'w',
+      name: 'W',
+      range: ['Close', 'Medium'],
+      damage: { amount: 3, damageType: 'Kinetic' },
+    } as unknown as SURefEntity)
+
+    const byLabel = Object.fromEntries(summary.stats.map((s) => [s.label, s.value]))
+    expect(byLabel.Range).toBe('Close, Medium')
+    expect(byLabel.Damage).toBe('3 Kinetic')
+  })
+
+  test('trait names are collected, and malformed traits are skipped', () => {
+    const summary = extractStaticEntitySummary({
+      id: 't',
+      name: 'T',
+      traits: [{ type: 'reliable' }, { value: 'no type' }, null, 'bare string'],
+    } as unknown as SURefEntity)
+    expect(summary.traits).toEqual(['reliable'])
+  })
+
+  test("a guide's steps become named sections carrying their prose", () => {
+    // Without this a guide indexes as its title and one intro paragraph — the
+    // pages holding the game's procedures were the ones with almost no text.
+    const guides = SalvageUnionReference.Guides.all()
+    const withSteps = guides.filter((g) => Array.isArray(g.steps) && g.steps.length > 0)
+    expect(withSteps.length).toBeGreaterThan(0)
+
+    for (const guide of withSteps) {
+      const summary = extractStaticEntitySummary(guide as SURefEntity)
+      expect(summary.sections.length).toBe(guide.steps?.length ?? 0)
+      expect(summary.sections.every((s) => s.name.length > 0)).toBe(true)
+    }
+
+    const totalProse = withSteps
+      .map((g) => extractStaticEntitySummary(g as SURefEntity))
+      .flatMap((s) => s.sections.flatMap((sec) => sec.paragraphs))
+      .join('').length
+    expect(totalProse).toBeGreaterThan(1000)
+  })
+
+  test('a malformed step is skipped rather than producing a nameless section', () => {
+    const summary = extractStaticEntitySummary({
+      id: 'g',
+      name: 'G',
+      steps: [
+        { name: 'One', content: [{ type: 'paragraph', value: 'do this' }] },
+        { content: [{ type: 'paragraph', value: 'nameless' }] },
+        null,
+        { name: 'Three' },
+      ],
+    } as unknown as SURefEntity)
+
+    expect(summary.sections).toEqual([
+      { name: 'One', paragraphs: ['do this'] },
+      { name: 'Three', paragraphs: [] },
+    ])
+  })
+
+  test('an entity with nothing to say yields empty collections, never undefined', () => {
+    // Consumers map over all four without guarding.
+    const summary = extractStaticEntitySummary({ id: 'bare' } as unknown as SURefEntity)
+    expect(summary.name).toBe('bare')
+    expect(summary.contentParagraphs).toEqual([])
+    expect(summary.stats).toEqual([])
+    expect(summary.traits).toEqual([])
+    expect(summary.sections).toEqual([])
+  })
+})

--- a/tools/coverage-report.ts
+++ b/tools/coverage-report.ts
@@ -29,8 +29,10 @@ import {
   copyFileSync,
   appendFileSync,
 } from 'node:fs'
-import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
+import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+
+import { parseLcov } from './lib/parse-lcov'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 
@@ -56,38 +58,6 @@ const WORKSPACES = [
   'apps/itun',
   'apps/discord-bot',
 ]
-
-/**
- * Sum a workspace's line coverage from its lcov, counting ONLY files that belong
- * to that workspace.
- *
- * A test run pulls in source from other workspaces (e.g. srd's `preload-reference`
- * loads `salvageunion-reference`), and Bun reports coverage for every file it
- * loaded. Summing all records therefore charged one workspace for another's
- * uncovered lines — srd read 44.8% because it was being measured mostly on
- * reference-package files its own tests never exercise. Each `SF:` record is
- * resolved against the lcov's directory and skipped unless it sits inside the
- * workspace being measured, so the ratchet tracks each workspace's own code.
- */
-function parseLcov(path: string, workspaceRoot: string): { linesFound: number; linesHit: number } {
-  const contents = readFileSync(path, 'utf-8')
-  const lcovDir = dirname(path)
-  let linesFound = 0
-  let linesHit = 0
-  let include = false
-  for (const line of contents.split('\n')) {
-    if (line.startsWith('SF:')) {
-      const file = line.slice(3).trim()
-      const abs = isAbsolute(file) ? file : resolve(lcovDir, file)
-      include = !relative(workspaceRoot, abs).startsWith('..')
-      continue
-    }
-    if (!include) continue
-    if (line.startsWith('LF:')) linesFound += Number(line.slice(3))
-    if (line.startsWith('LH:')) linesHit += Number(line.slice(3))
-  }
-  return { linesFound, linesHit }
-}
 
 const results: WorkspaceCoverage[] = []
 const missing: string[] = []

--- a/tools/lib/parse-lcov.test.ts
+++ b/tools/lib/parse-lcov.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { parseLcov } from './parse-lcov'
+
+/**
+ * The ratchet is only worth having if the number it gates on is the
+ * workspace's own coverage. These cover the attribution rule — which `SF:`
+ * records count — because getting it wrong is silent: the gate still passes,
+ * still prints a number, and the number is simply of something else.
+ */
+
+/** Write an lcov holding one record per `[path, found, hit]`. */
+function lcovWith(records: Array<[string, number, number]>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'lcov-'))
+  mkdirSync(join(dir, 'coverage'), { recursive: true })
+  const body = records
+    .map(([file, found, hit]) => `SF:${file}\nLF:${found}\nLH:${hit}\nend_of_record`)
+    .join('\n')
+  const path = join(dir, 'coverage', 'lcov.info')
+  writeFileSync(path, `${body}\n`)
+  return path
+}
+
+describe('which files a workspace is measured on', () => {
+  test('its own source counts', () => {
+    const path = lcovWith([['src/a.ts', 100, 80]])
+    const root = join(path, '..', '..')
+    expect(parseLcov(path, root)).toEqual({ linesFound: 100, linesHit: 80 })
+  })
+
+  test('a sibling workspace reached by a single `..` does NOT count', () => {
+    // The regression this file exists for. `SF:` is written relative to the
+    // workspace root — the cwd of the test run — not to `coverage/`. Resolving
+    // against the lcov directory instead left this path at
+    // `<workspace>/salvageunion-reference/…`, which looks local, so
+    // component-lib was charged for 4,600 lines of the reference package and
+    // read 76% against a real 86%. Deeper `../../` paths escaped either way,
+    // which is why only the one shallow workspace was ever wrong.
+    const path = lcovWith([
+      ['src/a.ts', 100, 80],
+      ['../salvageunion-reference/lib/utilities.ts', 500, 100],
+    ])
+    const root = join(path, '..', '..')
+    expect(parseLcov(path, root)).toEqual({ linesFound: 100, linesHit: 80 })
+  })
+
+  test('a workspace two levels away does not count either', () => {
+    const path = lcovWith([
+      ['src/a.ts', 100, 80],
+      ['../../packages/component-lib/src/b.tsx', 400, 40],
+    ])
+    const root = join(path, '..', '..')
+    expect(parseLcov(path, root)).toEqual({ linesFound: 100, linesHit: 80 })
+  })
+
+  test('an absolute path outside the workspace does not count', () => {
+    const path = lcovWith([
+      ['src/a.ts', 10, 10],
+      ['/somewhere/else/c.ts', 999, 0],
+    ])
+    const root = join(path, '..', '..')
+    expect(parseLcov(path, root)).toEqual({ linesFound: 10, linesHit: 10 })
+  })
+
+  test('a path that merely starts with the workspace name is not counted as inside it', () => {
+    // `<root>-extra` shares a prefix with `<root>` but is a different directory;
+    // a string-prefix test would wrongly claim it.
+    const path = lcovWith([['../x-extra/src/a.ts', 50, 0]])
+    const root = join(path, '..', '..')
+    expect(parseLcov(path, root)).toEqual({ linesFound: 0, linesHit: 0 })
+  })
+
+  test('records are summed across files, not just read from the first', () => {
+    const path = lcovWith([
+      ['src/a.ts', 100, 80],
+      ['src/b.ts', 100, 40],
+    ])
+    const root = join(path, '..', '..')
+    expect(parseLcov(path, root)).toEqual({ linesFound: 200, linesHit: 120 })
+  })
+
+  test('an lcov with nothing of ours yields zero rather than throwing', () => {
+    // The caller turns 0/0 into 0% — it must not divide by zero or crash the
+    // gate on a workspace whose output is entirely foreign.
+    const path = lcovWith([['../other/src/a.ts', 100, 100]])
+    const root = join(path, '..', '..')
+    expect(parseLcov(path, root)).toEqual({ linesFound: 0, linesHit: 0 })
+  })
+})

--- a/tools/lib/parse-lcov.ts
+++ b/tools/lib/parse-lcov.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs'
+import { isAbsolute, relative, resolve } from 'node:path'
+
+/**
+ * Sum a workspace's line coverage from its lcov, counting ONLY files that belong
+ * to that workspace.
+ *
+ * A test run pulls in source from other workspaces (e.g. srd's `preload-reference`
+ * loads `salvageunion-reference`), and Bun reports coverage for every file it
+ * loaded. Summing all records therefore charged one workspace for another's
+ * uncovered lines — srd read 44.8% because it was being measured mostly on
+ * reference-package files its own tests never exercise. Each `SF:` record is
+ * resolved and skipped unless it sits inside the workspace being measured, so
+ * the ratchet tracks each workspace's own code.
+ *
+ * Resolve against the WORKSPACE ROOT, not the lcov directory. Bun writes `SF:`
+ * relative to the cwd it ran in, which is the workspace root, not
+ * `<workspace>/coverage` — so resolving against the lcov dir left every path one
+ * level too deep, and whether that mattered depended on how far the import
+ * reached. `apps/srd`'s `../../packages/…` landed outside `apps/srd` either way
+ * and read correctly; `packages/component-lib`'s `../salvageunion-reference/…`
+ * resolved to `packages/component-lib/salvageunion-reference/…`, which looks
+ * local. component-lib alone was therefore charged for 4,600 lines of the
+ * reference package and read 76% against a real 86%.
+ */
+export function parseLcov(
+  path: string,
+  workspaceRoot: string
+): { linesFound: number; linesHit: number } {
+  const contents = readFileSync(path, 'utf-8')
+  let linesFound = 0
+  let linesHit = 0
+  let include = false
+  for (const line of contents.split('\n')) {
+    if (line.startsWith('SF:')) {
+      const file = line.slice(3).trim()
+      const abs = isAbsolute(file) ? file : resolve(workspaceRoot, file)
+      include = !relative(workspaceRoot, abs).startsWith('..')
+      continue
+    }
+    if (!include) continue
+    if (line.startsWith('LF:')) linesFound += Number(line.slice(3))
+    if (line.startsWith('LH:')) linesHit += Number(line.slice(3))
+  }
+  return { linesFound, linesHit }
+}


### PR DESCRIPTION
The whole accounts feature plus the coverage work, consolidated into one PR.
This branch contains every commit from the former #631–#646 stack (each of those
branches was a patch-identical ancestor) and from #649. **All 14 of those PRs are
closed as superseded by this one.**

Implements [ADR-030](docs/adrs/ADR-030-accounts-games-server-of-record.md),
which supersedes ADR-001, amends ADR-022 and extends ADR-021 with an ownership
axis.

## The feature

- **Three storage modes.** Solo (not signed in — IndexedDB is the source of
  truth, nothing gated, and this stays the default forever), Connected, and
  Disconnected (signed in but offline = **read-only**, not a write queue).
  Resolved in one place, `src/lib/connection/`.
- **Two containers, not one.** Workspaces split into a shared **Game** and a
  personal **Shelf**, encoded as a nullable `gameId` — `null` means deliberately
  shelved, `undefined` means not yet decided.
- **Roles.** Base role Player | Mediator, plus an orthogonal Organizer flag that
  is administrative only.
- **The Mediator never writes your sheet.** Changes are *proposed*: a Change Log
  row the player applies or declines, showing before and after so a mismatch is
  visible rather than papered over. Proposals never expire and are never
  force-applied.
- **Discord sign-in**, account management, export and deletion — with the shared
  crawler and the table's game surviving an account deletion.
- **Discord bot as a Game participant** (Phase 6).
- **Your existing local data comes with you**: a v13 migration gives every
  pre-accounts row a container, v1 export bundles still import, and a one-time
  prompt copies a device's roster into an account — offered, not automatic,
  because uploading somebody's whole roster on sign-in is a decision made with
  their data.

## Going live

Two fixes here are what make the deployed app work at all:

- `connect-src` now allows Convex (`https://*.convex.cloud`,
  `wss://*.convex.cloud`, `https://*.convex.site`). `VITE_CONVEX_URL` is
  *already* set on the production site, so without this the app would have
  shipped Connected, failed every request at the CSP layer, and reported
  nothing — sign-in silently never completing. `wss:` does not inherit from
  `https:`, and the hosts are wildcarded because the deployment differs by
  context.
- The Netlify build runs `convex deploy` before the site build when
  `CONVEX_DEPLOY_KEY` is present, so backend and bundle deploy together.

Without that key the build is byte-for-byte the old one, so previews keep
building Solo. **Setting `CONVEX_DEPLOY_KEY` on the Netlify site is the single
remaining switch that turns production accounts on** — it cannot live in a PR.

## Coverage (was #649)

The ratchet was **measuring the wrong files**. It resolved lcov `SF:` paths
against the lcov's directory, but Bun writes them relative to the workspace
root. `apps/srd` and `apps/itun` reach siblings as `../../packages/…` and landed
outside either way; `packages/component-lib` is one level shallower, so its
`../salvageunion-reference/…` resolved to something that looked local and it was
charged for 4,600 lines of another package. The gate passed, printed a number,
and the number was of something else. `parseLcov` moves to `tools/lib/` so the
rule is testable directly — three of the seven new cases fail against the old
resolution.

| Workspace | Before | Now |
| --- | --- | --- |
| packages/salvageunion-reference | 92.13% | **96.08%** ✅ |
| apps/srd | 95.57% | 95.57% ✅ |
| apps/discord-bot | 92.40% | **95.47%** ✅ |
| packages/component-lib | 76.18% (mis-measured) | **88.57%** |
| apps/itun | 89.20% | **90.09%** |

New tests cover the connected surfaces (GamesScreen, MediatorScreen,
AccountScreen, ClaimLocalData, CrewVitals, DowntimePanel, ProposalInbox) — the
branch people actually use, previously untested because the test build has no
`VITE_CONVEX_URL` — plus `observability.ts` (the bot's only channel for learning
production broke), `helpers.ts`, and `InlineEditField`.

Three real defects fell out of writing them, all fixed here: the claim prompt
hid its own confirmation, `mock.module` is process-global in Bun and was
poisoning 219 tests, and Testing Library's auto-cleanup proved order-dependent.
The mocking lesson is written into `.claude/rules/testing-patterns.md`.

`component-lib` and `itun` remain short of 95% — 658 and ~920 lines, concentrated
in `RollTable` (859 lines, nondeterministic rolls), `ReferenceEntityCard` and the
itun sheet surfaces. That is its own piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014m6W8yMd1FM3Roumj9x4Zj