### PR TITLE
fix(discord-bot): only rebuild the bot when the bot's own inputs change

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,10 @@
     "netlify": {
       "command": "npx",
       "args": ["-y", "@netlify/mcp"]
+    },
+    "sentry": {
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp"
     }
   }
 }

--- a/apps/discord-bot/src/observability.ts
+++ b/apps/discord-bot/src/observability.ts
@@ -34,7 +34,13 @@ export function initObservability(): void {
     release: config.releaseSha,
   })
   enabled = true
-  console.log('[observability] Sentry error tracking enabled')
+  // Deliberately avoids the word "error": Render classifies log level from
+  // message *content*, not the stream it arrived on. This is a console.log on
+  // stdout, exactly like the "Starting Salvage Union Discord Bot..." line that
+  // Render files as `info` — but while it read "Sentry error tracking enabled"
+  // Render filed it as `level=error`, so the bot's one success message showed
+  // up in every error-level log filter. Keep this string error-free.
+  console.log('[observability] Sentry tracking enabled')
 }
 
 /**

--- a/render.yaml
+++ b/render.yaml
@@ -9,6 +9,27 @@ services:
     # when the command shape changes — see apps/discord-bot/README.md.
     buildCommand: 'bun install --ignore-scripts && bun run build:bot'
     startCommand: 'node apps/discord-bot/dist/index.js'
+    # Without this, every commit to main rebuilds and redeploys the bot —
+    # including srd/itun/component-lib work and release-please chores that it
+    # cannot possibly depend on. Measured over the 71 commits between
+    # 2026-07-14 and 2026-07-28: only 32 touched anything the bot bundles, and
+    # only 4 touched the bot itself, so ~55% of builds were pure waste. Each
+    # one re-downloads a 614MB build cache and bounces the worker off Discord,
+    # and together they exhausted the workspace's build-pipeline minutes on
+    # 2026-07-28 (13 consecutive builds cancelled, bot stuck on a stale
+    # deploy).
+    #
+    # The bot bundles its own source plus salvageunion-reference and nothing
+    # else — it deliberately does not depend on component-lib (see
+    # apps/discord-bot/CLAUDE.md). `package.json` is the root one, which is
+    # where the `build:bot` script this service runs is defined.
+    buildFilter:
+      paths:
+        - apps/discord-bot/**
+        - packages/salvageunion-reference/**
+        - bun.lock
+        - package.json
+        - render.yaml
     envVars:
       - key: DISCORD_TOKEN
         sync: false


### PR DESCRIPTION
## The problem

`render.yaml` declared no `buildFilter`, so Render's `autoDeploy` rebuilt and redeployed the Discord bot on **every single commit to `main`** — including `srd`, `itun`, `component-lib` and release-please work that the bot cannot possibly depend on.

Measured over the 71 commits between 2026-07-14 and 2026-07-28:

| | count |
|---|---|
| commits to `main` (= bot rebuilds) | 71 |
| …touching anything the bot bundles | 32 |
| …touching `apps/discord-bot/` | 4 |

So roughly **55% of the bot's builds were pure waste**. Each one re-downloads a 614MB build cache, reinstalls Node 22 and Bun, rebuilds, and bounces the worker off Discord.

Together they exhausted the workspace's build-pipeline minutes on 2026-07-28 — **13 consecutive builds cancelled** with `Build canceled: your workspace has run out of build pipeline minutes`, leaving the bot stuck on a stale deploy. That quota is workspace-wide, so `hermuz` and `randsum-discord-bot` were blocked too.

## The fix

A `buildFilter` listing what the bot actually consumes: its own source plus `salvageunion-reference`, the lockfile, the root `package.json` that defines `build:bot`, and `render.yaml` itself.

The bot deliberately does **not** depend on `component-lib` (per `apps/discord-bot/CLAUDE.md`) — verified, the only `component-lib` mentions in its source are doc comments, not imports.

## Also in this PR

- **Project-scoped Sentry MCP** (`.mcp.json`) — the official hosted server at `https://mcp.sentry.dev/mcp`. OAuth-authenticated, so it stays secret-free like the rest of the file; each contributor approves it per-project on first use.

- **Reworded the bot's Sentry startup log.** Render derives log level from message *content*, not the stream it arrived on. `"Sentry error tracking enabled"` was a `console.log` on stdout — identical to the `"Starting Salvage Union Discord Bot..."` line Render files as `info` — but the word "error" made Render file it as `level=error`, putting the bot's one success message into every error-level filter.

## Verification

- `bun run typecheck` — 0 errors, all workspaces
- `bun --filter discord-bot test` — 69 pass, 0 fail
- `bun run lint` — exit 0 (4 pre-existing warnings, none in changed files)
- `bun run knip` — clean
- `render.yaml` parsed with a YAML loader; `buildFilter` well-formed and `envVars` intact

## Note

`buildFilter` only governs **auto-deploys triggered by commits** — manual deploys and `render.yaml` blueprint syncs are unaffected. Worth confirming the first post-merge `srd`-only commit does *not* trigger a bot build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NvX6jnVcFSRcLyQorYuUEm