### PR TITLE
coverage: fix workspace attribution, and take three workspaces past 95%

### DIFF
--- a/.claude/rules/testing-patterns.md
+++ b/.claude/rules/testing-patterns.md
@@ -42,6 +42,46 @@ Testing patterns using Bun's test runner and Testing Library for component tests
 - Use `mock()` from `bun:test` for module/function mocking
 - Mock external dependencies appropriately
 
+### `mock.module` is process-global — restore what you replace
+
+`mock.module` rewrites the entry in the module registry for the whole test
+process, **not** for the file that called it. Every test file that runs after
+yours gets your replacement. This is not theoretical: mocking the entity store
+in one component test broke 219 tests across the suite, and the failures
+surfaced in files that had never heard of the mocked module.
+
+Capture the real exports first, and put them back in `afterAll`:
+
+```typescript
+// The spread is load-bearing. A module namespace is a LIVE view, and mocking
+// rewrites it in place — hold the namespace itself and by `afterAll` it
+// already reads as the mock, so you restore the mock over the mock.
+const realStore = { ...(await import('../../stores/entityStore')) }
+
+mock.module('../../stores/entityStore', () => ({ useEntityStore: fake }))
+
+afterAll(() => {
+  mock.module('../../stores/entityStore', () => realStore)
+})
+```
+
+Two corollaries:
+
+- **Partial mocks break importers you did not think about.** Replacing
+  `convex/react` with only the hooks under test made `@convex-dev/auth/react`
+  fail at import on a missing `ConvexProviderWithAuth`. Mock every export the
+  transitive importers reach, not just the ones your component calls.
+- **Beware module-scope environment reads.** `config.ts` reads `process.env`
+  once at import, so setting an env var to drive a test hands that value to
+  every later file too. Mock the config module instead of setting the variable.
+
+### Call `cleanup()` explicitly in component tests
+
+Testing Library's auto-cleanup has proven order-dependent here — a file passed
+alone and failed in the full suite. When several tests in a file render the
+same accessible name, one leaked render turns every later query into "found
+multiple elements". Add `afterEach(cleanup)` rather than depending on it.
+
 ## Examples
 
 **Package test:**

--- a/apps/discord-bot/src/__tests__/observability.test.ts
+++ b/apps/discord-bot/src/__tests__/observability.test.ts
@@ -1,0 +1,151 @@
+import { afterAll, beforeAll, describe, expect, mock, test } from 'bun:test'
+
+/**
+ * observability — the bot's only channel for finding out that production
+ * broke. It is entirely env-gated, and the gate is the interesting part: with
+ * no DSN every function must be a silent no-op (local dev and CI run that way),
+ * and with one it must actually report. A regression in either direction is
+ * invisible until the day you need it — a bot that has stopped reporting looks
+ * exactly like a bot with no errors.
+ *
+ * `config` is mocked rather than driven through `process.env`, deliberately.
+ * `config.ts` reads the environment once at module scope, so setting
+ * `SENTRY_DSN` here would hand a live DSN to every test file that runs after
+ * this one — `mock.module` is process-global in Bun, not file-scoped, and the
+ * env is worse still. Both the mocks below are captured and restored.
+ */
+
+const sentryCalls: Array<{ fn: string; args: unknown[] }> = []
+let flushShouldThrow = false
+let dsn: string | undefined
+
+// `config.ts` throws at module scope on a missing token, and it is evaluated by
+// the capture below. Same `??=` as the sibling tests, and deliberately no
+// SENTRY_DSN: the DSN is supplied through the mock, never the environment.
+process.env.DISCORD_TOKEN ??= 'test-token'
+process.env.DISCORD_CLIENT_ID ??= 'test-client-id'
+
+const realSentry = { ...(await import('@sentry/node')) }
+const realConfig = { ...(await import('../config.js')) }
+
+mock.module('@sentry/node', () => ({
+  init: (...args: unknown[]) => sentryCalls.push({ fn: 'init', args }),
+  flush: async (...args: unknown[]) => {
+    sentryCalls.push({ fn: 'flush', args })
+    if (flushShouldThrow) throw new Error('transport down')
+    return true
+  },
+  captureException: (...args: unknown[]) => sentryCalls.push({ fn: 'captureException', args }),
+  captureMessage: (...args: unknown[]) => sentryCalls.push({ fn: 'captureMessage', args }),
+}))
+
+mock.module('../config.js', () => ({
+  config: {
+    get sentryDsn() {
+      return dsn
+    },
+    nodeEnv: undefined,
+    releaseSha: 'abc123',
+  },
+}))
+
+let obs: typeof import('../observability.js')
+
+beforeAll(async () => {
+  obs = await import('../observability.js')
+})
+
+afterAll(() => {
+  mock.module('@sentry/node', () => realSentry)
+  mock.module('../config.js', () => realConfig)
+})
+
+function calls(fn: string): Array<{ fn: string; args: unknown[] }> {
+  return sentryCalls.filter((c) => c.fn === fn)
+}
+
+/**
+ * These run in order against one module instance, because `enabled` is
+ * module-level state and the transition from off to on is exactly what is
+ * being tested.
+ */
+describe('with no DSN configured', () => {
+  test('init reports nothing and does not enable Sentry', () => {
+    dsn = undefined
+    obs.initObservability()
+    expect(calls('init')).toHaveLength(0)
+  })
+
+  test('captureException is a no-op rather than an unconfigured send', () => {
+    obs.captureException(new Error('boom'))
+    expect(calls('captureException')).toHaveLength(0)
+  })
+
+  test('captureMessage is a no-op too', () => {
+    obs.captureMessage('ready')
+    expect(calls('captureMessage')).toHaveLength(0)
+  })
+
+  test('flush resolves immediately instead of waiting on a transport', async () => {
+    // A 2s flush timeout on every exit of a bot that never had a DSN would be
+    // two wasted seconds on every restart.
+    await obs.flushObservability()
+    expect(calls('flush')).toHaveLength(0)
+  })
+})
+
+describe('once a DSN is configured', () => {
+  test('init passes the DSN, environment and release through', () => {
+    dsn = 'https://key@example.ingest.sentry.io/1'
+    obs.initObservability()
+
+    const init = calls('init')[0]
+    expect(init).toBeDefined()
+    expect(init?.args[0]).toMatchObject({
+      dsn: 'https://key@example.ingest.sentry.io/1',
+      // Unset NODE_ENV must not leave the environment blank — an untagged event
+      // is indistinguishable from one raised in dev.
+      environment: 'production',
+      release: 'abc123',
+    })
+  })
+
+  test('a second call is a no-op, so startup can call it freely', () => {
+    obs.initObservability()
+    expect(calls('init')).toHaveLength(1)
+  })
+
+  test('exceptions are reported, with context as extra when given', () => {
+    const error = new Error('boom')
+    obs.captureException(error, { guildId: 'g1' })
+
+    const c = calls('captureException')[0]
+    expect(c?.args[0]).toBe(error)
+    expect(c?.args[1]).toEqual({ extra: { guildId: 'g1' } })
+  })
+
+  test('no context sends undefined rather than an empty extra bag', () => {
+    obs.captureException(new Error('bare'))
+    expect(calls('captureException')[1]?.args[1]).toBeUndefined()
+  })
+
+  test('messages are reported — the worker has no port to health-probe', () => {
+    obs.captureMessage('logged in', { shard: 0 })
+    const c = calls('captureMessage')[0]
+    expect(c?.args[0]).toBe('logged in')
+    expect(c?.args[1]).toEqual({ extra: { shard: 0 } })
+  })
+
+  test('flush is awaited before exit, with the timeout passed through', async () => {
+    // The transport is async; a synchronous exit right after captureException
+    // drops the one event the restart happened for.
+    await obs.flushObservability(500)
+    expect(calls('flush')[0]?.args[0]).toBe(500)
+  })
+
+  test('a failing flush never rejects — the process is exiting anyway', async () => {
+    flushShouldThrow = true
+    expect(await obs.flushObservability(10).then(() => 'resolved')).toBe('resolved')
+    flushShouldThrow = false
+  })
+})

--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -1,7 +1,7 @@
 {
-  "packages/salvageunion-reference": 89,
-  "packages/component-lib": 86,
+  "packages/salvageunion-reference": 95,
+  "packages/component-lib": 87,
   "apps/srd": 95,
   "apps/itun": 89,
-  "apps/discord-bot": 92
+  "apps/discord-bot": 95
 }

--- a/coverage-baseline.json
+++ b/coverage-baseline.json
@@ -1,6 +1,6 @@
 {
   "packages/salvageunion-reference": 89,
-  "packages/component-lib": 75,
+  "packages/component-lib": 86,
   "apps/srd": 95,
   "apps/itun": 89,
   "apps/discord-bot": 92

--- a/packages/component-lib/src/components/chrome/__tests__/InlineEditField.test.tsx
+++ b/packages/component-lib/src/components/chrome/__tests__/InlineEditField.test.tsx
@@ -1,0 +1,320 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+import { InlineEditField } from '../InlineEditField'
+
+/**
+ * The edit-in-place atom every sheet value goes through. It owns the whole
+ * commit path — open, validate, save or refuse — so the things worth pinning
+ * are the ones that quietly lose a player's typing: a commit that fires on
+ * blur as well as Enter, an Escape that must NOT save, and a rejected number
+ * that must keep the editor open with the draft intact rather than reverting.
+ *
+ * `readOnly` gets its own attention because it is a correctness boundary, not
+ * a style: the read-only sheet must not offer an affordance that would write.
+ */
+
+// Explicit rather than relying on Testing Library's auto-cleanup: every test
+// here renders the same `Callsign` label, so a single leaked render turns every
+// later `getByLabelText` into "found multiple elements". Auto-cleanup covered
+// this when the file ran alone and did not when the whole suite ran together.
+afterEach(cleanup)
+
+/** Render with a recording `onSave`; returns the calls array. */
+function setup(props: Partial<Parameters<typeof InlineEditField>[0]> = {}) {
+  const saved: Array<string | number> = []
+  render(
+    <InlineEditField
+      value={props.value ?? 'Roach-Boy'}
+      onSave={(next) => {
+        saved.push(next)
+      }}
+      ariaLabel="Callsign"
+      {...props}
+    />
+  )
+  return saved
+}
+
+/** Open the editor by activating the display readout. */
+function openEditor(label = 'Callsign'): void {
+  fireEvent.click(screen.getByLabelText(label))
+}
+
+describe('the readout, before anything is edited', () => {
+  test('shows the value', () => {
+    setup()
+    expect(screen.getByLabelText('Callsign').textContent).toBe('Roach-Boy')
+  })
+
+  test('an empty value shows the placeholder', () => {
+    setup({ value: '', placeholder: 'Unnamed' })
+    expect(screen.getByLabelText('Callsign').textContent).toBe('Unnamed')
+  })
+
+  test('an empty value with no placeholder shows a dash, never nothing', () => {
+    // A blank cell on a sheet reads as a rendering bug rather than as an
+    // empty field waiting to be filled.
+    setup({ value: '   ' })
+    expect(screen.getByLabelText('Callsign').textContent).toBe('—')
+  })
+
+  test('a zero is a value, not an empty', () => {
+    setup({ value: 0, type: 'number', placeholder: 'none' })
+    expect(screen.getByLabelText('Callsign').textContent).toBe('0')
+  })
+})
+
+describe('opening the editor', () => {
+  test('clicking the readout opens an input carrying the current value', () => {
+    setup()
+    openEditor()
+    expect((screen.getByLabelText('Callsign') as HTMLInputElement).value).toBe('Roach-Boy')
+  })
+
+  test('Enter and Space open it from the keyboard', () => {
+    setup()
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+    expect(screen.getByLabelText('Callsign').tagName).toBe('INPUT')
+  })
+
+  test('Space opens it too', () => {
+    setup()
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: ' ' })
+    expect(screen.getByLabelText('Callsign').tagName).toBe('INPUT')
+  })
+
+  test('another key does not', () => {
+    setup()
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'a' })
+    expect(screen.getByLabelText('Callsign').tagName).not.toBe('INPUT')
+  })
+})
+
+describe('read-only', () => {
+  test('offers no way in — not a disabled one, none at all', () => {
+    setup({ readOnly: true })
+    const node = screen.getByLabelText('Callsign')
+
+    // No button role and no tab stop: a read-only sheet must not put a
+    // write affordance in the keyboard order at all.
+    expect(node.getAttribute('role')).toBeNull()
+    expect(node.getAttribute('tabindex')).toBeNull()
+
+    fireEvent.click(node)
+    fireEvent.keyDown(node, { key: 'Enter' })
+    expect(screen.getByLabelText('Callsign').tagName).not.toBe('INPUT')
+  })
+})
+
+describe('committing', () => {
+  test('Enter saves the typed value', async () => {
+    const saved = setup()
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: 'Ash' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(saved).toEqual(['Ash']))
+  })
+
+  test('blur saves too — clicking away must not discard typing', async () => {
+    const saved = setup()
+    openEditor()
+    fireEvent.blur(screen.getByLabelText('Callsign'), { target: { value: 'Ash' } })
+
+    await waitFor(() => expect(saved).toEqual(['Ash']))
+  })
+
+  test('the editor closes and the new value is read back', async () => {
+    setup()
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: 'Ash' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(screen.getByLabelText('Callsign').tagName).not.toBe('INPUT'))
+  })
+
+  test('Escape closes without saving', async () => {
+    const saved = setup()
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: 'discard me' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Escape' })
+
+    await waitFor(() => expect(screen.getByLabelText('Callsign').tagName).not.toBe('INPUT'))
+    expect(saved).toEqual([])
+  })
+
+  test('reopening after Escape shows the stored value, not the abandoned draft', () => {
+    setup()
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: 'discard me' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Escape' })
+
+    openEditor()
+    expect((screen.getByLabelText('Callsign') as HTMLInputElement).value).toBe('Roach-Boy')
+  })
+})
+
+describe('number validation', () => {
+  test('a valid number is saved as a number, not a string', async () => {
+    // Stats are arithmetic downstream; a string here corrupts every sum.
+    const saved = setup({ value: 5, type: 'number', min: 0, max: 10 })
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: '7' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(saved).toEqual([7]))
+  })
+
+  test('a non-number is refused, and the editor stays open', async () => {
+    const saved = setup({ value: 5, type: 'number' })
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: 'abc' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(screen.getByText('Must be a number.')).toBeTruthy())
+    expect(saved).toEqual([])
+    // Still editing — closing here would silently drop what they typed.
+    expect(screen.getByLabelText('Callsign').tagName).toBe('INPUT')
+  })
+
+  test('an empty number is refused rather than saved as zero', async () => {
+    const saved = setup({ value: 5, type: 'number' })
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: '  ' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(screen.getByText('Must be a number.')).toBeTruthy())
+    expect(saved).toEqual([])
+  })
+
+  test('below min is refused, and the bound is named', async () => {
+    const saved = setup({ value: 5, type: 'number', min: 1 })
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: '0' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(screen.getByText('min 1')).toBeTruthy())
+    expect(saved).toEqual([])
+  })
+
+  test('above max is refused, and the bound is named', async () => {
+    const saved = setup({ value: 5, type: 'number', max: 10 })
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: '11' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(screen.getByText('max 10')).toBeTruthy())
+    expect(saved).toEqual([])
+  })
+
+  test('the error clears as soon as they start fixing it', async () => {
+    const saved = setup({ value: 5, type: 'number', max: 10 })
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: '11' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+    await waitFor(() => expect(screen.getByText('max 10')).toBeTruthy())
+
+    // Nagging while somebody is mid-correction is the wrong moment for it.
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: '9' } })
+    expect(screen.queryByText('max 10')).toBeNull()
+
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+    await waitFor(() => expect(saved).toEqual([9]))
+  })
+
+  test('a text field does not validate as a number', async () => {
+    const saved = setup({ value: 'a' })
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: 'not a number' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(saved).toEqual(['not a number']))
+  })
+})
+
+describe('multiline', () => {
+  test('edits in a textarea', () => {
+    setup({ multiline: true })
+    openEditor()
+    expect(screen.getByLabelText('Callsign').tagName).toBe('TEXTAREA')
+  })
+
+  test('Enter commits', async () => {
+    const saved = setup({ multiline: true })
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: 'a motto' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(saved).toEqual(['a motto']))
+  })
+
+  test('Shift+Enter inserts a newline instead of committing', () => {
+    // The whole point of a textarea: prose fields need paragraph breaks.
+    const saved = setup({ multiline: true })
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: 'line one' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter', shiftKey: true })
+
+    expect(saved).toEqual([])
+    expect(screen.getByLabelText('Callsign').tagName).toBe('TEXTAREA')
+  })
+
+  test('Escape cancels', async () => {
+    const saved = setup({ multiline: true })
+    openEditor()
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Escape' })
+
+    await waitFor(() => expect(screen.getByLabelText('Callsign').tagName).not.toBe('TEXTAREA'))
+    expect(saved).toEqual([])
+  })
+
+  test('blur commits', async () => {
+    const saved = setup({ multiline: true })
+    openEditor()
+    fireEvent.blur(screen.getByLabelText('Callsign'), { target: { value: 'via blur' } })
+
+    await waitFor(() => expect(saved).toEqual(['via blur']))
+  })
+})
+
+describe('bordered value box', () => {
+  test('at rest the box draws the frame around the readout', () => {
+    const { container } = render(
+      <InlineEditField value="Roach-Boy" onSave={() => {}} ariaLabel="Callsign" bordered />
+    )
+    const box = container.firstElementChild as HTMLElement
+    expect(box.className).toContain('border-ink')
+  })
+
+  test('while editing the box does not draw a second border around the input', () => {
+    // The input supplies its own frame; a box-in-box is the bug this guards.
+    const { container } = render(
+      <InlineEditField value="Roach-Boy" onSave={() => {}} ariaLabel="Callsign" bordered />
+    )
+    openEditor()
+    const box = container.firstElementChild as HTMLElement
+    expect(box.className).not.toContain('border-ink')
+  })
+
+  test('an awaited async save still returns to the readout', async () => {
+    const saved: Array<string | number> = []
+    render(
+      <InlineEditField
+        value="Roach-Boy"
+        ariaLabel="Callsign"
+        bordered
+        onSave={async (next) => {
+          await Promise.resolve()
+          saved.push(next)
+        }}
+      />
+    )
+    openEditor()
+    fireEvent.change(screen.getByLabelText('Callsign'), { target: { value: 'Ash' } })
+    fireEvent.keyDown(screen.getByLabelText('Callsign'), { key: 'Enter' })
+
+    await waitFor(() => expect(saved).toEqual(['Ash']))
+    expect(screen.getByLabelText('Callsign').tagName).not.toBe('INPUT')
+  })
+})

--- a/packages/salvageunion-reference/lib/helpers-display.test.ts
+++ b/packages/salvageunion-reference/lib/helpers-display.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, test } from 'bun:test'
+
+import { SalvageUnionReference } from './index.js'
+import {
+  extractStaticEntitySummary,
+  getDisplayName,
+  getEntitySchemas,
+  getHybridClasses,
+  getModel,
+  getReferenceEntityData,
+  getUniqueSources,
+  getUniqueTechLevels,
+  getUniqueTrees,
+  normalizeSchemaName,
+  resolveActivationCurrency,
+  resolveGrantedEntities,
+} from './helpers.js'
+import type { SURefEntity } from './index.js'
+
+/**
+ * The read layer both apps go through: schema lookup, grant resolution, facet
+ * extraction, and the static summary the SRD's no-JS and crawler rendering is
+ * built from. `helpers.test.ts` next door covers the crawler-mutation helpers.
+ *
+ * Most of this runs against the real dataset on purpose. These functions are
+ * shape-tolerance over data that changes, so a test built entirely from
+ * hand-made objects would keep passing while the shipped data broke them.
+ */
+
+describe('schema names', () => {
+  test('a known schema gets its display name', () => {
+    expect(getDisplayName('chassis')).toBe('Chassis')
+  })
+
+  test('an unknown schema falls back to the name rather than to blank', () => {
+    // Better a raw slug on screen than an empty heading.
+    expect(getDisplayName('not-a-schema' as never)).toBe('not-a-schema')
+  })
+
+  test('every class alias normalises onto the one unified schema', () => {
+    // Six spellings reach this from data, routes and older links; all six are
+    // the same schema, and a miss yields no model at all.
+    for (const alias of [
+      'classes-core',
+      'classes.core',
+      'classes-advanced',
+      'classes.advanced',
+      'classes-hybrid',
+      'classes.hybrid',
+    ]) {
+      expect(normalizeSchemaName(alias)).toBe('classes')
+    }
+  })
+
+  test('a name that is already canonical is left alone', () => {
+    expect(normalizeSchemaName('chassis')).toBe('chassis')
+  })
+
+  test('getModel resolves through the alias', () => {
+    expect(getModel('classes-core')).toBe(getModel('classes'))
+    expect(getModel('chassis')?.all().length).toBeGreaterThan(0)
+  })
+
+  test('an unknown schema yields undefined rather than throwing', () => {
+    expect(getModel('not-a-schema')).toBeUndefined()
+  })
+
+  test('the entity schema list excludes meta schemas', () => {
+    const schemas = getEntitySchemas()
+    expect(schemas.length).toBeGreaterThan(0)
+    expect(schemas.every((s) => !s.meta)).toBe(true)
+  })
+})
+
+describe('grants', () => {
+  test('an entity with no grants resolves to nothing', () => {
+    const [chassis] = SalvageUnionReference.Chassis.all()
+    expect(resolveGrantedEntities(chassis as SURefEntity)).toEqual([])
+  })
+
+  test('granted entities resolve to real records, and `choice` grants are skipped', () => {
+    // A `choice` grant names no single entity — it is a prompt resolved
+    // elsewhere — so walking it here would invent a null.
+    const granters = SalvageUnionReference.Abilities.all().filter(
+      (a) => 'grants' in a && Array.isArray(a.grants) && a.grants.length > 0
+    )
+    expect(granters.length).toBeGreaterThan(0)
+
+    for (const granter of granters) {
+      const resolved = resolveGrantedEntities(granter as SURefEntity)
+      // Never a hole: unresolvable grants are dropped, not returned as null.
+      expect(resolved.every((e) => e != null && typeof e.id === 'string')).toBe(true)
+      const nonChoice = (granter.grants ?? []).filter((g) => g.schema !== 'choice')
+      expect(resolved.length).toBeLessThanOrEqual(nonChoice.length)
+    }
+  })
+})
+
+describe('classes', () => {
+  test('hybrid classes are exactly those flagged hybrid', () => {
+    const hybrids = getHybridClasses()
+    expect(hybrids.length).toBeGreaterThan(0)
+    expect(hybrids.every((c) => c.hybrid === true)).toBe(true)
+  })
+})
+
+describe('activation currency', () => {
+  test('mech-level sources cost EP', () => {
+    for (const schema of ['chassis', 'systems', 'modules'] as const) {
+      expect(resolveActivationCurrency(schema)).toBe('EP')
+    }
+  })
+
+  test('everything else costs AP', () => {
+    expect(resolveActivationCurrency('abilities')).toBe('AP')
+    expect(resolveActivationCurrency('actions')).toBe('AP')
+    expect(resolveActivationCurrency(undefined)).toBe('AP')
+  })
+
+  test('a variable cost is XP, and beats the schema', () => {
+    // Variable-cost abilities are paid in XP wherever they sit — including on
+    // a mech-level source, which would otherwise read as EP.
+    expect(resolveActivationCurrency('abilities', true)).toBe('XP')
+    expect(resolveActivationCurrency('chassis', true)).toBe('XP')
+  })
+})
+
+describe('facets', () => {
+  test('tech levels come back unique and in game order: numbers, then B, then N', () => {
+    const entities = [
+      { id: 'a', techLevel: 3 },
+      { id: 'b', techLevel: 1 },
+      { id: 'c', techLevel: 'N' },
+      { id: 'd', techLevel: 'B' },
+      { id: 'e', techLevel: 1 },
+      { id: 'f' },
+    ] as unknown as SURefEntity[]
+    expect(getUniqueTechLevels(entities)).toEqual([1, 3, 'B', 'N'])
+  })
+
+  test('no tech levels at all yields an empty list', () => {
+    expect(getUniqueTechLevels([{ id: 'a' } as unknown as SURefEntity])).toEqual([])
+  })
+
+  test('the Workshop Manual sorts first, the rest alphabetically', () => {
+    // The core book is what every other source is read against, so it leads
+    // the facet regardless of alphabet.
+    const entities = [
+      { id: 'a', source: 'Zephyr Expansion' },
+      { id: 'b', source: 'Salvage Union Workshop Manual' },
+      { id: 'c', source: 'Alpha Expansion' },
+    ] as unknown as SURefEntity[]
+    expect(getUniqueSources(entities)).toEqual([
+      'Salvage Union Workshop Manual',
+      'Alpha Expansion',
+      'Zephyr Expansion',
+    ])
+  })
+
+  test('without the core book the rest are simply alphabetical', () => {
+    const entities = [
+      { id: 'a', source: 'Zephyr' },
+      { id: 'b', source: 'Alpha' },
+    ] as unknown as SURefEntity[]
+    expect(getUniqueSources(entities)).toEqual(['Alpha', 'Zephyr'])
+  })
+
+  test('trees are unique, sorted, and entities without one are skipped', () => {
+    const entities = [
+      { id: 'a', tree: 'Gunner' },
+      { id: 'b', tree: 'Ace' },
+      { id: 'c', tree: 'Gunner' },
+      { id: 'd' },
+    ] as unknown as SURefEntity[]
+    expect(getUniqueTrees(entities)).toEqual(['Ace', 'Gunner'])
+  })
+
+  test('the real ability set produces real, sorted trees', () => {
+    const trees = getUniqueTrees(SalvageUnionReference.Abilities.all() as SURefEntity[])
+    expect(trees.length).toBeGreaterThan(0)
+    expect(trees).toEqual([...trees].sort())
+  })
+})
+
+describe('display data', () => {
+  test('every shipped chassis yields an id, a name and a slug', () => {
+    // The three fields every consumer indexes and links on. A blank name here
+    // is an unclickable card.
+    for (const chassis of SalvageUnionReference.Chassis.all()) {
+      const data = getReferenceEntityData(chassis as SURefEntity)
+      expect(data.id).toBe(chassis.id)
+      expect(data.name.length).toBeGreaterThan(0)
+      expect(data.slug.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('a nameless entity falls back to its id rather than to blank', () => {
+    const data = getReferenceEntityData({ id: 'orphan' } as unknown as SURefEntity)
+    expect(data.name).toBe('orphan')
+    expect(data.description).toBeUndefined()
+    expect(data.techLevel).toBeUndefined()
+  })
+})
+
+describe('the static summary the SRD indexes on', () => {
+  test('a chassis contributes its numeric stats, labelled', () => {
+    const chassis = SalvageUnionReference.Chassis.all()[0] as SURefEntity
+    const summary = extractStaticEntitySummary(chassis)
+
+    expect(summary.name.length).toBeGreaterThan(0)
+    const labels = summary.stats.map((s) => s.label)
+    expect(labels).toContain('Structure Points')
+    expect(labels).toContain('Energy Points')
+    expect(labels).toContain('Tech Level')
+  })
+
+  test('paragraph blocks are collected and non-paragraph blocks are not', () => {
+    const summary = extractStaticEntitySummary({
+      id: 'x',
+      name: 'X',
+      content: [
+        { type: 'paragraph', value: 'first' },
+        { value: 'untyped counts as prose' },
+        { type: 'table', value: 'not prose' },
+        { type: 'paragraph', value: 42 },
+        null,
+      ],
+    } as unknown as SURefEntity)
+
+    expect(summary.contentParagraphs).toEqual(['first', 'untyped counts as prose'])
+  })
+
+  test('range and damage are flattened into readable values', () => {
+    const summary = extractStaticEntitySummary({
+      id: 'w',
+      name: 'W',
+      range: ['Close', 'Medium'],
+      damage: { amount: 3, damageType: 'Kinetic' },
+    } as unknown as SURefEntity)
+
+    const byLabel = Object.fromEntries(summary.stats.map((s) => [s.label, s.value]))
+    expect(byLabel.Range).toBe('Close, Medium')
+    expect(byLabel.Damage).toBe('3 Kinetic')
+  })
+
+  test('trait names are collected, and malformed traits are skipped', () => {
+    const summary = extractStaticEntitySummary({
+      id: 't',
+      name: 'T',
+      traits: [{ type: 'reliable' }, { value: 'no type' }, null, 'bare string'],
+    } as unknown as SURefEntity)
+    expect(summary.traits).toEqual(['reliable'])
+  })
+
+  test("a guide's steps become named sections carrying their prose", () => {
+    // Without this a guide indexes as its title and one intro paragraph — the
+    // pages holding the game's procedures were the ones with almost no text.
+    const guides = SalvageUnionReference.Guides.all()
+    const withSteps = guides.filter((g) => Array.isArray(g.steps) && g.steps.length > 0)
+    expect(withSteps.length).toBeGreaterThan(0)
+
+    for (const guide of withSteps) {
+      const summary = extractStaticEntitySummary(guide as SURefEntity)
+      expect(summary.sections.length).toBe(guide.steps?.length ?? 0)
+      expect(summary.sections.every((s) => s.name.length > 0)).toBe(true)
+    }
+
+    const totalProse = withSteps
+      .map((g) => extractStaticEntitySummary(g as SURefEntity))
+      .flatMap((s) => s.sections.flatMap((sec) => sec.paragraphs))
+      .join('').length
+    expect(totalProse).toBeGreaterThan(1000)
+  })
+
+  test('a malformed step is skipped rather than producing a nameless section', () => {
+    const summary = extractStaticEntitySummary({
+      id: 'g',
+      name: 'G',
+      steps: [
+        { name: 'One', content: [{ type: 'paragraph', value: 'do this' }] },
+        { content: [{ type: 'paragraph', value: 'nameless' }] },
+        null,
+        { name: 'Three' },
+      ],
+    } as unknown as SURefEntity)
+
+    expect(summary.sections).toEqual([
+      { name: 'One', paragraphs: ['do this'] },
+      { name: 'Three', paragraphs: [] },
+    ])
+  })
+
+  test('an entity with nothing to say yields empty collections, never undefined', () => {
+    // Consumers map over all four without guarding.
+    const summary = extractStaticEntitySummary({ id: 'bare' } as unknown as SURefEntity)
+    expect(summary.name).toBe('bare')
+    expect(summary.contentParagraphs).toEqual([])
+    expect(summary.stats).toEqual([])
+    expect(summary.traits).toEqual([])
+    expect(summary.sections).toEqual([])
+  })
+})

--- a/tools/coverage-report.ts
+++ b/tools/coverage-report.ts
@@ -29,8 +29,10 @@ import {
   copyFileSync,
   appendFileSync,
 } from 'node:fs'
-import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
+import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+
+import { parseLcov } from './lib/parse-lcov'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 
@@ -56,38 +58,6 @@ const WORKSPACES = [
   'apps/itun',
   'apps/discord-bot',
 ]
-
-/**
- * Sum a workspace's line coverage from its lcov, counting ONLY files that belong
- * to that workspace.
- *
- * A test run pulls in source from other workspaces (e.g. srd's `preload-reference`
- * loads `salvageunion-reference`), and Bun reports coverage for every file it
- * loaded. Summing all records therefore charged one workspace for another's
- * uncovered lines — srd read 44.8% because it was being measured mostly on
- * reference-package files its own tests never exercise. Each `SF:` record is
- * resolved against the lcov's directory and skipped unless it sits inside the
- * workspace being measured, so the ratchet tracks each workspace's own code.
- */
-function parseLcov(path: string, workspaceRoot: string): { linesFound: number; linesHit: number } {
-  const contents = readFileSync(path, 'utf-8')
-  const lcovDir = dirname(path)
-  let linesFound = 0
-  let linesHit = 0
-  let include = false
-  for (const line of contents.split('\n')) {
-    if (line.startsWith('SF:')) {
-      const file = line.slice(3).trim()
-      const abs = isAbsolute(file) ? file : resolve(lcovDir, file)
-      include = !relative(workspaceRoot, abs).startsWith('..')
-      continue
-    }
-    if (!include) continue
-    if (line.startsWith('LF:')) linesFound += Number(line.slice(3))
-    if (line.startsWith('LH:')) linesHit += Number(line.slice(3))
-  }
-  return { linesFound, linesHit }
-}
 
 const results: WorkspaceCoverage[] = []
 const missing: string[] = []

--- a/tools/lib/parse-lcov.test.ts
+++ b/tools/lib/parse-lcov.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { parseLcov } from './parse-lcov'
+
+/**
+ * The ratchet is only worth having if the number it gates on is the
+ * workspace's own coverage. These cover the attribution rule — which `SF:`
+ * records count — because getting it wrong is silent: the gate still passes,
+ * still prints a number, and the number is simply of something else.
+ */
+
+/** Write an lcov holding one record per `[path, found, hit]`. */
+function lcovWith(records: Array<[string, number, number]>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'lcov-'))
+  mkdirSync(join(dir, 'coverage'), { recursive: true })
+  const body = records
+    .map(([file, found, hit]) => `SF:${file}\nLF:${found}\nLH:${hit}\nend_of_record`)
+    .join('\n')
+  const path = join(dir, 'coverage', 'lcov.info')
+  writeFileSync(path, `${body}\n`)
+  return path
+}
+
+describe('which files a workspace is measured on', () => {
+  test('its own source counts', () => {
+    const path = lcovWith([['src/a.ts', 100, 80]])
+    const root = join(path, '..', '..')
+    expect(parseLcov(path, root)).toEqual({ linesFound: 100, linesHit: 80 })
+  })
+
+  test('a sibling workspace reached by a single `..` does NOT count', () => {
+    // The regression this file exists for. `SF:` is written relative to the
+    // workspace root — the cwd of the test run — not to `coverage/`. Resolving
+    // against the lcov directory instead left this path at
+    // `<workspace>/salvageunion-reference/…`, which looks local, so
+    // component-lib was charged for 4,600 lines of the reference package and
+    // read 76% against a real 86%. Deeper `../../` paths escaped either way,
+    // which is why only the one shallow workspace was ever wrong.
+    const path = lcovWith([
+      ['src/a.ts', 100, 80],
+      ['../salvageunion-reference/lib/utilities.ts', 500, 100],
+    ])
+    const root = join(path, '..', '..')
+    expect(parseLcov(path, root)).toEqual({ linesFound: 100, linesHit: 80 })
+  })
+
+  test('a workspace two levels away does not count either', () => {
+    const path = lcovWith([
+      ['src/a.ts', 100, 80],
+      ['../../packages/component-lib/src/b.tsx', 400, 40],
+    ])
+    const root = join(path, '..', '..')
+    expect(parseLcov(path, root)).toEqual({ linesFound: 100, linesHit: 80 })
+  })
+
+  test('an absolute path outside the workspace does not count', () => {
+    const path = lcovWith([
+      ['src/a.ts', 10, 10],
+      ['/somewhere/else/c.ts', 999, 0],
+    ])
+    const root = join(path, '..', '..')
+    expect(parseLcov(path, root)).toEqual({ linesFound: 10, linesHit: 10 })
+  })
+
+  test('a path that merely starts with the workspace name is not counted as inside it', () => {
+    // `<root>-extra` shares a prefix with `<root>` but is a different directory;
+    // a string-prefix test would wrongly claim it.
+    const path = lcovWith([['../x-extra/src/a.ts', 50, 0]])
+    const root = join(path, '..', '..')
+    expect(parseLcov(path, root)).toEqual({ linesFound: 0, linesHit: 0 })
+  })
+
+  test('records are summed across files, not just read from the first', () => {
+    const path = lcovWith([
+      ['src/a.ts', 100, 80],
+      ['src/b.ts', 100, 40],
+    ])
+    const root = join(path, '..', '..')
+    expect(parseLcov(path, root)).toEqual({ linesFound: 200, linesHit: 120 })
+  })
+
+  test('an lcov with nothing of ours yields zero rather than throwing', () => {
+    // The caller turns 0/0 into 0% — it must not divide by zero or crash the
+    // gate on a workspace whose output is entirely foreign.
+    const path = lcovWith([['../other/src/a.ts', 100, 100]])
+    const root = join(path, '..', '..')
+    expect(parseLcov(path, root)).toEqual({ linesFound: 0, linesHit: 0 })
+  })
+})

--- a/tools/lib/parse-lcov.ts
+++ b/tools/lib/parse-lcov.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs'
+import { isAbsolute, relative, resolve } from 'node:path'
+
+/**
+ * Sum a workspace's line coverage from its lcov, counting ONLY files that belong
+ * to that workspace.
+ *
+ * A test run pulls in source from other workspaces (e.g. srd's `preload-reference`
+ * loads `salvageunion-reference`), and Bun reports coverage for every file it
+ * loaded. Summing all records therefore charged one workspace for another's
+ * uncovered lines — srd read 44.8% because it was being measured mostly on
+ * reference-package files its own tests never exercise. Each `SF:` record is
+ * resolved and skipped unless it sits inside the workspace being measured, so
+ * the ratchet tracks each workspace's own code.
+ *
+ * Resolve against the WORKSPACE ROOT, not the lcov directory. Bun writes `SF:`
+ * relative to the cwd it ran in, which is the workspace root, not
+ * `<workspace>/coverage` — so resolving against the lcov dir left every path one
+ * level too deep, and whether that mattered depended on how far the import
+ * reached. `apps/srd`'s `../../packages/…` landed outside `apps/srd` either way
+ * and read correctly; `packages/component-lib`'s `../salvageunion-reference/…`
+ * resolved to `packages/component-lib/salvageunion-reference/…`, which looks
+ * local. component-lib alone was therefore charged for 4,600 lines of the
+ * reference package and read 76% against a real 86%.
+ */
+export function parseLcov(
+  path: string,
+  workspaceRoot: string
+): { linesFound: number; linesHit: number } {
+  const contents = readFileSync(path, 'utf-8')
+  let linesFound = 0
+  let linesHit = 0
+  let include = false
+  for (const line of contents.split('\n')) {
+    if (line.startsWith('SF:')) {
+      const file = line.slice(3).trim()
+      const abs = isAbsolute(file) ? file : resolve(workspaceRoot, file)
+      include = !relative(workspaceRoot, abs).startsWith('..')
+      continue
+    }
+    if (!include) continue
+    if (line.startsWith('LF:')) linesFound += Number(line.slice(3))
+    if (line.startsWith('LH:')) linesHit += Number(line.slice(3))
+  }
+  return { linesFound, linesHit }
+}


### PR DESCRIPTION
Two commits: an accuracy fix, then the coverage it made worth chasing.

## 1. The ratchet was measuring the wrong files

`SF:` records were resolved against the lcov's own directory, but Bun writes
those paths relative to the cwd the run happened in — the workspace root, not
`<workspace>/coverage`. Every path was one level too deep, and whether that
mattered depended on how far the import reached.

`apps/srd` and `apps/itun` reach a sibling as `../../packages/…`, which lands
outside the workspace either way, so they read correctly and the bug stayed
invisible. `packages/component-lib` sits one level shallower: its
`../salvageunion-reference/…` resolved to
`packages/component-lib/salvageunion-reference/…`, which looks local — so
component-lib alone was charged for **4,600 lines of the reference package**,
already measured at 92% in its own run.

The failure mode worth naming: the gate still passed, still printed a number,
and the number was of something else.

`parseLcov` moves to `tools/lib/` so the attribution rule is testable directly
instead of only through a full report run. **Three of the seven new cases fail
against the old resolution.**

## 2. Coverage

| Workspace | Before | After | |
| --- | --- | --- | --- |
| packages/salvageunion-reference | 92.13% | **96.08%** | ✅ |
| apps/discord-bot | 92.40% | **95.47%** | ✅ |
| apps/srd | 95.57% | 95.57% | ✅ |
| packages/component-lib | 76.18% → 86.15% (fix) | **87.32%** | |
| apps/itun | 89.50% | 89.50% | |

- **`observability.ts`** (31%) — the bot's only channel for learning that
  production broke, untested in both directions. A bot that has silently
  stopped reporting looks exactly like a bot with no errors.
- **`helpers.ts`** (13.7%) — schema/alias resolution, grant walking, facet
  extraction, and `extractStaticEntitySummary`, which the SRD's no-JS and
  crawler rendering is built from.
- **`InlineEditField`** (3%) — the edit-in-place atom every sheet value goes
  through, untested on the paths that quietly lose a player's typing.

### What is still short of 95%, and why

`component-lib` needs 658 more covered lines and `itun` 920, concentrated in
`RollTable` (859 lines, nondeterministic rolls), `ReferenceEntityCard`, and the
itun sheet surfaces. Those are worth doing but are their own piece of work, not
a rider on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014m6W8yMd1FM3Roumj9x4Zj