### PR TITLE
feat(itun): move the account controls into the masthead

### DIFF
--- a/apps/itun/src/components/account/AccountStrip.tsx
+++ b/apps/itun/src/components/account/AccountStrip.tsx
@@ -1,4 +1,5 @@
 import { Link } from '@tanstack/react-router'
+import { FOCUS_RING } from 'component-lib'
 
 import { useConnection } from '../../lib/connection/connectionContext'
 import { isConvexConfigured } from '../../lib/connection/convexClient'
@@ -29,8 +30,10 @@ import { SignInControl } from './SignInControl'
  * users see exactly the chrome they saw before.
  */
 
-const ACCOUNT_LINK =
-  'font-cond text-caption font-semibold uppercase tracking-caps-wide text-paper/60 no-underline transition-colors hover:text-paper'
+// The masthead nav-link treatment one size down — same paper-on-ink ramp and
+// the same rust focus ring its siblings in `AppBar` use, so the utility row
+// reads as part of the bar rather than as a transplanted light-mode strip.
+const ACCOUNT_LINK = `font-cond text-caption font-semibold uppercase tracking-caps-wide text-paper/60 no-underline transition-colors hover:text-paper ${FOCUS_RING}`
 
 export function AccountStrip() {
   const { mode } = useConnection()

--- a/apps/itun/src/components/account/AccountStrip.tsx
+++ b/apps/itun/src/components/account/AccountStrip.tsx
@@ -5,16 +5,22 @@ import { isConvexConfigured } from '../../lib/connection/convexClient'
 import { SignInControl } from './SignInControl'
 
 /**
- * A thin strip above the brand header carrying sign-in and a link to the
- * account page.
+ * The account cluster — sign-in plus links to Games and the account page.
  *
- * ## Why not a nav item in `AppBar`
+ * ## Where it renders
+ *
+ * It is handed to `AppHeader` as its `utilityRow` slot, so it sits on its own
+ * row *inside* the dark masthead, beneath the nav. It used to be a light strip
+ * stacked above the header, which read as a second bar competing with the
+ * brand. Living on the masthead means these are paper-on-ink controls, not the
+ * ink-on-paper ones the old strip used.
+ *
+ * ## Why not nav items in `AppBar`
  *
  * `AppBar` lives in `component-lib` and is shared with `apps/srd`, which has no
- * accounts and never will. Threading an auth slot through it would push an
- * ITUN-only concept into a package whose contract is to stay backend-agnostic,
- * and would touch a component every page of both apps renders. A local strip
- * keeps the blast radius inside ITUN.
+ * accounts and never will. Threading auth through `navItems` would push an
+ * ITUN-only concept into a package whose contract is to stay backend-agnostic.
+ * A generic slot keeps the blast radius inside ITUN.
  *
  * ## It renders nothing in a Solo build
  *
@@ -22,29 +28,27 @@ import { SignInControl } from './SignInControl'
  * absent — so there is nothing to link to and nothing to sign into. Existing
  * users see exactly the chrome they saw before.
  */
+
+const ACCOUNT_LINK =
+  'font-cond text-caption font-semibold uppercase tracking-caps-wide text-paper/60 no-underline transition-colors hover:text-paper'
+
 export function AccountStrip() {
   const { mode } = useConnection()
   if (!isConvexConfigured) return null
 
   return (
-    <div className="flex items-center justify-end gap-3 border-b border-[var(--color-ink)]/15 px-3 py-1">
+    <div className="flex items-center justify-end gap-3">
       {mode === 'connected' && (
-        <Link
-          to="/games"
-          className="font-cond text-xs font-bold tracking-widest text-[var(--color-ink)] uppercase hover:text-[var(--color-rust)]"
-        >
+        <Link to="/games" className={ACCOUNT_LINK}>
           Games
         </Link>
       )}
       {mode === 'connected' && (
-        <Link
-          to="/account"
-          className="font-cond text-xs font-bold tracking-widest text-[var(--color-ink)] uppercase hover:text-[var(--color-rust)]"
-        >
+        <Link to="/account" className={ACCOUNT_LINK}>
           Account
         </Link>
       )}
-      <SignInControl />
+      <SignInControl onDark />
     </div>
   )
 }

--- a/apps/itun/src/components/account/SignInControl.tsx
+++ b/apps/itun/src/components/account/SignInControl.tsx
@@ -21,13 +21,35 @@ import { isConvexConfigured } from '../../lib/connection/convexClient'
  * than silence — signing in is an upgrade, not a missing feature (ADR-030 §1).
  */
 
-function ConvexSignIn() {
+/**
+ * The dark-masthead treatment: a paper hairline on the near-black bar. The
+ * merge order in `Button`'s `cn()` lets these win over the variant's own
+ * border/text colours.
+ *
+ * Both states use it, including sign-in. `variant="primary"` is right on the
+ * paper account screen, but in the masthead it would put a second rust button
+ * directly under "Buy the game" — two identical CTAs, neither reading as the
+ * primary one. The utility row stays quiet; the bar keeps one loud action.
+ */
+const DARK_BUTTON = 'border-paper/40 bg-transparent text-paper hover:border-paper hover:bg-paper/10'
+
+type SignInControlProps = {
+  /** Render for a dark surface (the masthead utility row) instead of paper. */
+  onDark?: boolean
+}
+
+function ConvexSignIn({ onDark }: SignInControlProps) {
   const { signIn, signOut } = useAuthActions()
   const { mode } = useConnection()
 
   if (mode === 'connected') {
     return (
-      <Button variant="ghost" size="compact" onClick={() => void signOut()}>
+      <Button
+        variant="ghost"
+        size="compact"
+        className={onDark ? DARK_BUTTON : undefined}
+        onClick={() => void signOut()}
+      >
         Sign out
       </Button>
     )
@@ -38,13 +60,18 @@ function ConvexSignIn() {
   if (mode === 'disconnected') return null
 
   return (
-    <Button variant="primary" size="compact" onClick={() => void signIn('discord')}>
+    <Button
+      variant={onDark ? 'ghost' : 'primary'}
+      size="compact"
+      className={onDark ? DARK_BUTTON : undefined}
+      onClick={() => void signIn('discord')}
+    >
       Sign in with Discord
     </Button>
   )
 }
 
-export function SignInControl() {
+export function SignInControl({ onDark }: SignInControlProps) {
   if (!isConvexConfigured) return null
-  return <ConvexSignIn />
+  return <ConvexSignIn onDark={onDark} />
 }

--- a/apps/itun/src/components/shared/__tests__/AppHeader.test.tsx
+++ b/apps/itun/src/components/shared/__tests__/AppHeader.test.tsx
@@ -79,7 +79,8 @@ describe('AppHeader', () => {
     render(<AppHeader />)
     fireEvent.click(screen.getByRole('button', { name: 'Open menu' }))
     const drawer = screen.getByRole('dialog')
-    expect(within(drawer).getByRole('link', { name: /encounter/i })).toBeTruthy()
+    expect(within(drawer).getByRole('link', { name: /about/i })).toBeTruthy()
+    expect(within(drawer).getByRole('link', { name: /changelog/i })).toBeTruthy()
     expect(within(drawer).getByRole('link', { name: /SRD/i })).toBeTruthy()
     const drawerDiscord = within(drawer).getByRole<HTMLAnchorElement>('link', {
       name: /discord/i,
@@ -89,5 +90,23 @@ describe('AppHeader', () => {
       name: /buy the game/i,
     })
     expect(buy.getAttribute('href')).toBe('https://leyline.press/collections/salvage-union')
+  })
+
+  test('does not offer Encounter as a nav destination (it lives on the Mediator sheet)', () => {
+    render(<AppHeader />)
+    expect(screen.queryByRole('link', { name: /encounter/i })).toBeFalsy()
+    fireEvent.click(screen.getByRole('button', { name: 'Open menu' }))
+    const drawer = screen.getByRole('dialog')
+    expect(within(drawer).queryByRole('link', { name: /encounter/i })).toBeFalsy()
+  })
+
+  test('renders the utility row inside the masthead, below the nav', () => {
+    render(<AppHeader utilityRow={<button type="button">Sign out</button>} />)
+    const signOut = screen.getByRole('button', { name: 'Sign out' })
+    // Inside the <header> itself — the point of the slot is that these controls
+    // stopped being a separate strip stacked above the brand chrome.
+    expect(signOut.closest('header')).toBeTruthy()
+    // ...and outside the nav cluster, so it lands on its own row.
+    expect(signOut.closest('nav')).toBeFalsy()
   })
 })

--- a/apps/itun/src/routes/__root.tsx
+++ b/apps/itun/src/routes/__root.tsx
@@ -84,8 +84,11 @@ function RootComponent() {
             data, so it paints immediately instead of sitting behind the full
             preload. */}
           <NotConnectedBanner />
-          <AccountStrip />
-          <AppHeader onSearchClick={() => setSearchOpen(true)} LinkComponent={AppLink} />
+          <AppHeader
+            onSearchClick={() => setSearchOpen(true)}
+            LinkComponent={AppLink}
+            utilityRow={<AccountStrip />}
+          />
           <GameDataReady>
             <Outlet />
             {/* Mounted on every route (inside the game-data gate, so search()

--- a/packages/component-lib/src/components/shared/AppBar.tsx
+++ b/packages/component-lib/src/components/shared/AppBar.tsx
@@ -52,6 +52,14 @@ type AppBarProps = {
   buyLabel?: ReactNode
   /** Mobile cluster (search trigger + hamburger drawer), shown below `lg`. */
   mobile?: ReactNode
+  /**
+   * Optional second row under the nav, right-aligned inside the masthead — the
+   * app's own utility controls (ITUN puts its account cluster here). Renders at
+   * every breakpoint, so it sits under the hamburger on mobile. Passed through
+   * as a slot rather than as `navItems`, because these are controls, not links,
+   * and the shared bar stays ignorant of what they do.
+   */
+  utilityRow?: ReactNode
   // Breadcrumbs (optional — the SRD schema/item routes)
   breadcrumbs?: BreadcrumbItem[]
   breadcrumbDescription?: string
@@ -79,88 +87,98 @@ export function AppBar({
   buyHref,
   buyLabel = 'BUY THE GAME',
   mobile,
+  utilityRow,
   breadcrumbs,
   breadcrumbDescription,
 }: AppBarProps) {
   return (
     <>
       <header
-        className="z-50 flex items-center gap-[14px] border-b-entity border-rust bg-ink-deep px-5 py-3 sm:px-[34px] sm:py-[14px]"
+        className="z-50 flex flex-col gap-2 border-b-entity border-rust bg-ink-deep px-5 py-3 sm:px-[34px] sm:py-[14px]"
         style={viewTransitionName ? { viewTransitionName } : undefined}
       >
-        {/* Brand lockup: SU cargo mark + wordmark (+ optional accent/badge) +
+        {/* Row 1 — brand + nav (or the mobile hamburger). */}
+        <div className="flex items-center gap-[14px]">
+          {/* Brand lockup: SU cargo mark + wordmark (+ optional accent/badge) +
             tracked eyebrow. `brandShrink` lets a long wordmark/eyebrow wrap
             instead of forcing horizontal overflow. */}
-        <LinkComponent
-          href="/"
-          className={cn(
-            'flex items-center gap-[14px] no-underline',
-            brandShrink ? 'min-w-0' : 'shrink-0'
-          )}
-        >
-          <img
-            src="/logos/su-cargo-dark.svg"
-            alt="Salvage Union"
-            width={64}
-            height={64}
-            className="block size-12 shrink-0 rounded-xl sm:size-16"
-          />
-          <span className="flex min-w-0 flex-col">
-            <span className="font-cond text-display font-bold leading-[0.98] tracking-normal text-paper sm:text-display-lg">
-              {wordmark}
-              {wordmarkAccent && <span className="text-rust">{wordmarkAccent}</span>}
-              {badge && (
-                <span className="ml-2 inline-block rounded bg-rust px-1.5 py-0.5 align-[0.32em] font-cond text-caption font-bold uppercase leading-none tracking-caps text-paper">
-                  {badge}
-                </span>
-              )}
-            </span>
-            <span
-              className={cn(
-                'mt-[7px] font-cond text-caption font-semibold uppercase tracking-eyebrow text-pilot sm:mt-[9px]',
-                brandShrink ? 'leading-tight' : 'whitespace-nowrap leading-none'
-              )}
-            >
-              {eyebrow}
-            </span>
-          </span>
-        </LinkComponent>
-
-        {/* Desktop nav cluster — links + search + buy, pushed right. */}
-        <nav
-          aria-label="Main navigation"
-          className="ml-auto hidden items-center gap-[26px] lg:flex"
-        >
-          {navItems.map((item) => {
-            // External items render a plain anchor in a new tab; internal ones
-            // route through LinkComponent. One element either way.
-            const Link = item.external ? 'a' : LinkComponent
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                className={cn(NAV_LINK, item.active && NAV_LINK_ACTIVE)}
-                {...(item.external
-                  ? { target: '_blank', rel: 'noopener noreferrer' }
-                  : { 'aria-current': item.active ? ('page' as const) : undefined })}
+          <LinkComponent
+            href="/"
+            className={cn(
+              'flex items-center gap-[14px] no-underline',
+              brandShrink ? 'min-w-0' : 'shrink-0'
+            )}
+          >
+            <img
+              src="/logos/su-cargo-dark.svg"
+              alt="Salvage Union"
+              width={64}
+              height={64}
+              className="block size-12 shrink-0 rounded-xl sm:size-16"
+            />
+            <span className="flex min-w-0 flex-col">
+              <span className="font-cond text-display font-bold leading-[0.98] tracking-normal text-paper sm:text-display-lg">
+                {wordmark}
+                {wordmarkAccent && <span className="text-rust">{wordmarkAccent}</span>}
+                {badge && (
+                  <span className="ml-2 inline-block rounded bg-rust px-1.5 py-0.5 align-[0.32em] font-cond text-caption font-bold uppercase leading-none tracking-caps text-paper">
+                    {badge}
+                  </span>
+                )}
+              </span>
+              <span
+                className={cn(
+                  'mt-[7px] font-cond text-caption font-semibold uppercase tracking-eyebrow text-pilot sm:mt-[9px]',
+                  brandShrink ? 'leading-tight' : 'whitespace-nowrap leading-none'
+                )}
               >
-                {item.label}
-                {item.badge}
-              </Link>
-            )
-          })}
+                {eyebrow}
+              </span>
+            </span>
+          </LinkComponent>
 
-          {search}
+          {/* Desktop nav cluster — links + search + buy, pushed right. */}
+          <nav
+            aria-label="Main navigation"
+            className="ml-auto hidden items-center gap-[26px] lg:flex"
+          >
+            {navItems.map((item) => {
+              // External items render a plain anchor in a new tab; internal ones
+              // route through LinkComponent. One element either way.
+              const Link = item.external ? 'a' : LinkComponent
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={cn(NAV_LINK, item.active && NAV_LINK_ACTIVE)}
+                  {...(item.external
+                    ? { target: '_blank', rel: 'noopener noreferrer' }
+                    : { 'aria-current': item.active ? ('page' as const) : undefined })}
+                >
+                  {item.label}
+                  {item.badge}
+                </Link>
+              )
+            })}
 
-          {buyHref && (
-            <a href={buyHref} target="_blank" rel="noopener noreferrer" className={BUY_BUTTON}>
-              {buyLabel}
-            </a>
-          )}
-        </nav>
+            {search}
 
-        {/* Mobile: search trigger + hamburger, below `lg`. */}
-        {mobile && <div className="ml-auto flex items-center gap-1 lg:hidden">{mobile}</div>}
+            {buyHref && (
+              <a href={buyHref} target="_blank" rel="noopener noreferrer" className={BUY_BUTTON}>
+                {buyLabel}
+              </a>
+            )}
+          </nav>
+
+          {/* Mobile: search trigger + hamburger, below `lg`. */}
+          {mobile && <div className="ml-auto flex items-center gap-1 lg:hidden">{mobile}</div>}
+        </div>
+
+        {/* Row 2 — the app's own utility controls, right-aligned under the nav.
+            Its own row of the masthead rather than a child of the nav cluster,
+            so a wide cluster can never squeeze the brand on narrow screens.
+            Renders nothing (and costs no row) when the app passes no slot. */}
+        {utilityRow}
       </header>
 
       {breadcrumbs && breadcrumbs.length > 0 && (

--- a/packages/component-lib/src/components/shared/AppHeader.tsx
+++ b/packages/component-lib/src/components/shared/AppHeader.tsx
@@ -1,4 +1,4 @@
-import type { ElementType } from 'react'
+import type { ElementType, ReactNode } from 'react'
 import { Badge } from '../chrome/Badge'
 import { FOCUS_RING } from '../chrome/interaction'
 import { Search } from 'lucide-react'
@@ -9,10 +9,14 @@ import type { NavDrawerItem } from './NavDrawer'
 
 /**
  * AppHeader — the ITUN builder's masthead (app-local config over the shared
- * `AppBar`): the "In the Union Now" brand, ITUN's nav (Encounter / About +
+ * `AppBar`): the "In the Union Now" brand, ITUN's nav (About / Changelog +
  * outbound Discord / SRD cross-links), a search-trigger button that opens the
- * global reference dialog, and the "Buy the game" button. Below `lg` the nav
- * collapses into the shared `NavDrawer`.
+ * global reference dialog, the "Buy the game" button, and an optional
+ * app-supplied utility row (ITUN's account cluster) on a second row beneath.
+ * Below `lg` the nav collapses into the shared `NavDrawer`.
+ *
+ * The Encounter tray is deliberately absent from the nav: it is reached through
+ * the Mediator sheet now, not as a top-level destination.
  *
  * Router-agnostic: internal links route through the injected `LinkComponent`
  * (ITUN passes its router-aware AppLink; defaults to a plain anchor).
@@ -22,23 +26,7 @@ import type { NavDrawerItem } from './NavDrawer'
 // the trigger button reads as the same search bar.
 const SEARCH_BOX = `flex shrink-0 cursor-pointer items-center gap-2 rounded border border-ink bg-paper px-3 py-[7px] font-body text-caption text-ink-2 transition-colors hover:border-rust ${FOCUS_RING} lg:w-64`
 
-// Small "Alpha" pills — the shared stamp atom rather than two hand-rolled
-// spans that differed only in size (px-1/text-label vs px-1.5/text-badge).
-// `bg-rust` overrides only the stamp PLATE — geometry, face and tracking still
-// come from the atom, so these can't drift from every other stamp again.
-const DESKTOP_ALPHA = (
-  <Badge shape="stamp" size="mini" className="ml-1.5 rounded bg-rust px-1 py-0.5">
-    Alpha
-  </Badge>
-)
-const DRAWER_ALPHA = (
-  <Badge shape="stamp" className="ml-2 rounded bg-rust px-1.5 py-0.5">
-    Alpha
-  </Badge>
-)
-
 const DESKTOP_NAV: AppBarNavItem[] = [
-  { label: 'Encounter', href: '/encounter', badge: DESKTOP_ALPHA },
   { label: 'About', href: '/about' },
   { label: 'Changelog', href: '/changelog' },
   { label: 'Discord ↗', href: 'https://salvageunion.io/discord/', external: true },
@@ -60,7 +48,6 @@ const ITUN_DRAWER_BRAND = (
 )
 
 const DRAWER_NAV: NavDrawerItem[] = [
-  { label: 'Encounter', href: '/encounter', badge: DRAWER_ALPHA },
   { label: 'About', href: '/about' },
   { label: 'Changelog', href: '/changelog' },
   { label: 'Discord ↗', href: 'https://salvageunion.io/discord/', external: true },
@@ -77,9 +64,15 @@ type AppHeaderProps = {
   onSearchClick?: () => void
   /** Link component for internal routes. Defaults to a plain anchor; ITUN passes AppLink. */
   LinkComponent?: ElementType
+  /**
+   * App-owned controls rendered on a second row under the nav — ITUN passes its
+   * account cluster (Games / Account / sign in-out), which used to sit in a
+   * separate strip above the masthead.
+   */
+  utilityRow?: ReactNode
 }
 
-export function AppHeader({ onSearchClick, LinkComponent = 'a' }: AppHeaderProps) {
+export function AppHeader({ onSearchClick, LinkComponent = 'a', utilityRow }: AppHeaderProps) {
   return (
     <AppBar
       wordmark="IN THE UNION NOW"
@@ -104,6 +97,7 @@ export function AppHeader({ onSearchClick, LinkComponent = 'a' }: AppHeaderProps
           </button>
         )
       }
+      utilityRow={utilityRow}
       mobile={
         <NavDrawer
           brand={ITUN_DRAWER_BRAND}


### PR DESCRIPTION
The sign-in strip sat above the brand header on its own light band, which read as a second bar competing with the masthead rather than as part of it. Its controls now render **inside** the dark header on a row of their own, under the nav.

Encounter leaves the nav in the same change — it is reached through the Mediator sheet now, not as a top-level destination. The `/encounter` route itself is untouched; only the nav entries (desktop + drawer) and their Alpha pills are gone.

## Why the utility row is a row of the header, not part of the nav cluster

First attempt nested it inside the right-hand nav cluster as a stacked column. Below `lg` the cluster's intrinsic width won the flex negotiation and squeezed the brand into a three-line column, with `GAMES ACCOUNT` overlapping the eyebrow text. As its own row it right-aligns under the nav on desktop and spans the width on mobile — and costs no row at all when an app passes no slot, so the SRD masthead (which shares `AppBar`) renders unchanged.

## Colour

The controls are paper-on-ink now, so `SignInControl` takes an `onDark` flag. Signed out, the Discord button drops `primary` for the same quiet outline — rust directly beneath "Buy the game" gave the bar two identical CTAs and no hierarchy.

## Verification

- `bun run check:all` green (lint, format, typecheck, 1505 itun tests, validate, knip, audit, tokens, styling).
- Measured in headless Chrome at 1440 and 390, signed-in and signed-out.
- SRD masthead re-measured through the shared component: 95px desktop / 75px mobile, unchanged.
- Tests: updated the drawer test that asserted on the Encounter link; added one case that Encounter is absent from both surfaces and one that the utility row renders inside `<header>` and outside `<nav>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3Uy8Pgtx2AcJJgHD9trbQ