### PR TITLE
feat(itun): a Game invite scheme that can be managed, carried, and gated

### DIFF
--- a/apps/itun/convex/__tests__/invites.test.ts
+++ b/apps/itun/convex/__tests__/invites.test.ts
@@ -1,0 +1,425 @@
+import { describe, expect, test } from 'bun:test'
+
+import { api } from '../_generated/api'
+import type { Id } from '../_generated/dataModel'
+import { testConvex } from './harness'
+
+/**
+ * The invite scheme past a bare code (ADR-030 §2–4).
+ *
+ * The three things worth defending here are the ones a UI cannot enforce:
+ * an invite grants exactly the seat it was minted for, a grant that has gone
+ * stale must not strand the joiner outside the Game, and a knock must not be
+ * a membership until someone says so.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+/**
+ * The first row, or a failure that says so.
+ *
+ * Destructuring and then asserting non-null hides the interesting case: when a
+ * query unexpectedly returns nothing, the test should fail on "expected a row"
+ * rather than on a property access against `undefined` several lines later.
+ */
+function firstRow<T>(rows: T[]): T {
+  const row = rows[0]
+  if (row === undefined) throw new Error('expected at least one row, got none')
+  return row
+}
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(async (ctx) => {
+    return await ctx.db.insert('users', { name, displayName: name })
+  })
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+async function seedGame(t: Ctx) {
+  const organizer = await makeUser(t, 'Organizer')
+  const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+  return { organizer, gameId }
+}
+
+async function seedPilot(t: Ctx, gameId: Id<'games'>, ownerId: Id<'users'> | null) {
+  return await t.run(async (ctx) =>
+    ctx.db.insert('pilots', {
+      gameId,
+      ownerId,
+      body: { callsign: 'Roach-Boy' },
+      updatedAt: Date.now(),
+    })
+  )
+}
+
+describe('invite management', () => {
+  test('list reports derived status and who redeemed', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const joiner = await makeUser(t, 'Sam')
+
+    const code = await organizer.as.mutation(api.invites.create, {
+      gameId,
+      label: 'for Sam',
+      usesRemaining: 1,
+    })
+    await joiner.as.mutation(api.invites.redeem, { code })
+
+    const invite = firstRow(await organizer.as.query(api.invites.list, { gameId }))
+    expect(invite.label).toBe('for Sam')
+    // One use, spent — so the code is exhausted rather than merely used.
+    expect(invite.status).toBe('exhausted')
+    expect(invite.redeemers).toEqual(['Sam'])
+  })
+
+  test('revoke is a soft delete that keeps the audit trail', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const joiner = await makeUser(t, 'Sam')
+
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await joiner.as.mutation(api.invites.redeem, { code })
+
+    const before = firstRow(await organizer.as.query(api.invites.list, { gameId }))
+    await organizer.as.mutation(api.invites.revoke, { inviteId: before._id })
+
+    const [after] = await organizer.as.query(api.invites.list, { gameId })
+    expect(after?.status).toBe('revoked')
+    // The row survived, so "who joined via which code" is still answerable.
+    expect(after?.redeemers).toEqual(['Sam'])
+  })
+
+  test('a revoked code is refused, but does not evict whoever already joined', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const early = await makeUser(t, 'Early')
+    const late = await makeUser(t, 'Late')
+
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await early.as.mutation(api.invites.redeem, { code })
+
+    const invite = firstRow(await organizer.as.query(api.invites.list, { gameId }))
+    await organizer.as.mutation(api.invites.revoke, { inviteId: invite._id })
+
+    await expect(late.as.mutation(api.invites.redeem, { code })).rejects.toThrow(/revoked/i)
+    // Early is still seated — revocation closes the door, it does not sweep the room.
+    const games = await early.as.query(api.games.listMine, {})
+    expect(games).toHaveLength(1)
+  })
+
+  test('a non-organizer can neither list nor revoke', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const player = await makeUser(t, 'Player')
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await player.as.mutation(api.invites.redeem, { code })
+
+    await expect(player.as.query(api.invites.list, { gameId })).rejects.toThrow()
+
+    const invite = firstRow(await organizer.as.query(api.invites.list, { gameId }))
+    await expect(player.as.mutation(api.invites.revoke, { inviteId: invite._id })).rejects.toThrow()
+  })
+})
+
+describe('invites carry a seat and a hand-out', () => {
+  test('a mediator invite seats the joiner as Mediator', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const gm = await makeUser(t, 'Vex')
+
+    const code = await organizer.as.mutation(api.invites.create, { gameId, role: 'mediator' })
+    await gm.as.mutation(api.invites.redeem, { code })
+
+    const [game] = await gm.as.query(api.games.listMine, {})
+    expect(game?.mediator).toBe(true)
+  })
+
+  test('a mediator invite defaults to single use', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const first = await makeUser(t, 'First')
+    const second = await makeUser(t, 'Second')
+
+    const code = await organizer.as.mutation(api.invites.create, { gameId, role: 'mediator' })
+    await first.as.mutation(api.invites.redeem, { code })
+
+    // The schema permits several Mediators; the UI is built for one, so an
+    // unlimited mediator code would quietly seat a second.
+    await expect(second.as.mutation(api.invites.redeem, { code })).rejects.toThrow(/used up/i)
+  })
+
+  test('a grant assigns the pilot and logs the ORGANIZER as the actor', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const joiner = await makeUser(t, 'Sam')
+    const pilotId = await seedPilot(t, gameId, null)
+
+    const code = await organizer.as.mutation(api.invites.create, {
+      gameId,
+      grants: [{ table: 'pilots', entityId: pilotId }],
+    })
+    const result = await joiner.as.mutation(api.invites.redeem, { code })
+
+    expect(result).toMatchObject({ kind: 'joined', granted: 1 })
+
+    const pilot = await t.run(async (ctx) => ctx.db.get(pilotId))
+    expect(pilot?.ownerId).toBe(joiner.userId)
+
+    // ADR-030 §4: ownership is ASSIGNED, never self-claimed. The Organizer made
+    // this call when they minted the invite, so the log must name them — not the
+    // person who happened to walk through the door.
+    const entry = await t.run(async (ctx) =>
+      (await ctx.db.query('changeLog').collect()).find(
+        (row) => row.entityId === pilotId && row.field === 'ownerId'
+      )
+    )
+    expect(entry?.actorId).toBe(organizer.userId)
+    expect(entry?.after).toBe(joiner.userId)
+  })
+
+  test('a stale grant is skipped and the joiner still gets in', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const claimer = await makeUser(t, 'Claimer')
+    const joiner = await makeUser(t, 'Sam')
+    const pilotId = await seedPilot(t, gameId, null)
+
+    const code = await organizer.as.mutation(api.invites.create, {
+      gameId,
+      grants: [{ table: 'pilots', entityId: pilotId }],
+      usesRemaining: 5,
+    })
+
+    // Somebody else takes the pilot between minting and redeeming.
+    await t.run(async (ctx) => ctx.db.patch(pilotId, { ownerId: claimer.userId }))
+
+    const result = await joiner.as.mutation(api.invites.redeem, { code })
+
+    // Arriving without the promised pilot is a notice. Failing the join over a
+    // stale pointer would strand someone outside a Game they were invited to.
+    expect(result).toMatchObject({ kind: 'joined', granted: 0 })
+    const games = await joiner.as.query(api.games.listMine, {})
+    expect(games).toHaveLength(1)
+    const pilot = await t.run(async (ctx) => ctx.db.get(pilotId))
+    expect(pilot?.ownerId).toBe(claimer.userId)
+  })
+
+  test('redeeming twice is idempotent and consumes no second use', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const joiner = await makeUser(t, 'Sam')
+    const code = await organizer.as.mutation(api.invites.create, { gameId, usesRemaining: 2 })
+
+    await joiner.as.mutation(api.invites.redeem, { code })
+    const second = await joiner.as.mutation(api.invites.redeem, { code })
+
+    expect(second).toMatchObject({ kind: 'already' })
+    const invite = firstRow(await organizer.as.query(api.invites.list, { gameId }))
+    expect(invite.usesRemaining).toBe(1)
+  })
+})
+
+describe('preview', () => {
+  test('describes the invite without spending it or leaking the crew', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const stranger = await makeUser(t, 'Stranger')
+    const code = await organizer.as.mutation(api.invites.create, { gameId, role: 'mediator' })
+
+    const preview = await stranger.as.query(api.invites.preview, { code })
+    expect(preview).toMatchObject({
+      gameName: 'Tenacity',
+      invitedBy: 'Organizer',
+      role: 'mediator',
+      status: 'active',
+    })
+    // Looking is not joining.
+    expect(await stranger.as.query(api.games.listMine, {})).toHaveLength(0)
+    // Nothing about who is already at the table.
+    expect(JSON.stringify(preview)).not.toContain('memberCount')
+  })
+
+  test('an unknown code is null rather than an error', async () => {
+    const t = testConvex()
+    const stranger = await makeUser(t, 'Stranger')
+    expect(await stranger.as.query(api.invites.preview, { code: 'ZZZZZZZZ' })).toBeNull()
+  })
+
+  test('a revoked code previews as revoked, so the landing page can say so', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const stranger = await makeUser(t, 'Stranger')
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    const invite = firstRow(await organizer.as.query(api.invites.list, { gameId }))
+    await organizer.as.mutation(api.invites.revoke, { inviteId: invite._id })
+
+    const preview = await stranger.as.query(api.invites.preview, { code })
+    expect(preview?.status).toBe('revoked')
+  })
+})
+
+describe('knock and approve', () => {
+  test('a knock creates no membership and burns no use', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const knocker = await makeUser(t, 'Knocker')
+
+    const code = await organizer.as.mutation(api.invites.create, {
+      gameId,
+      requiresApproval: true,
+      usesRemaining: 1,
+    })
+    const result = await knocker.as.mutation(api.invites.redeem, { code })
+
+    expect(result).toMatchObject({ kind: 'pending' })
+    expect(await knocker.as.query(api.games.listMine, {})).toHaveLength(0)
+
+    // A spam of knocks must not be able to burn a code before anyone joins.
+    await knocker.as.mutation(api.invites.redeem, { code })
+    const invite = firstRow(await organizer.as.query(api.invites.list, { gameId }))
+    expect(invite.usesRemaining).toBe(1)
+    expect(await organizer.as.query(api.invites.pendingRequests, { gameId })).toHaveLength(1)
+  })
+
+  test('approval seats them with the invite’s role and grants', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const knocker = await makeUser(t, 'Knocker')
+    const pilotId = await seedPilot(t, gameId, null)
+
+    const code = await organizer.as.mutation(api.invites.create, {
+      gameId,
+      requiresApproval: true,
+      role: 'mediator',
+      grants: [{ table: 'pilots', entityId: pilotId }],
+    })
+    await knocker.as.mutation(api.invites.redeem, { code })
+
+    const request = firstRow(await organizer.as.query(api.invites.pendingRequests, { gameId }))
+    await organizer.as.mutation(api.invites.decideRequest, {
+      requestId: request._id,
+      approve: true,
+    })
+
+    // Whichever door they came through, the seat is the same one.
+    const [game] = await knocker.as.query(api.games.listMine, {})
+    expect(game?.mediator).toBe(true)
+    const pilot = await t.run(async (ctx) => ctx.db.get(pilotId))
+    expect(pilot?.ownerId).toBe(knocker.userId)
+    expect(await organizer.as.query(api.invites.pendingRequests, { gameId })).toHaveLength(0)
+  })
+
+  test('a decline leaves them out, and they may knock again', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const knocker = await makeUser(t, 'Knocker')
+
+    const code = await organizer.as.mutation(api.invites.create, {
+      gameId,
+      requiresApproval: true,
+    })
+    await knocker.as.mutation(api.invites.redeem, { code })
+    const request = firstRow(await organizer.as.query(api.invites.pendingRequests, { gameId }))
+    await organizer.as.mutation(api.invites.decideRequest, {
+      requestId: request._id,
+      approve: false,
+    })
+
+    expect(await knocker.as.query(api.games.listMine, {})).toHaveLength(0)
+    expect(await organizer.as.query(api.invites.pendingRequests, { gameId })).toHaveLength(0)
+
+    // An Organizer who declined by mistake should not have to mint a fresh code.
+    await knocker.as.mutation(api.invites.redeem, { code })
+    expect(await organizer.as.query(api.invites.pendingRequests, { gameId })).toHaveLength(1)
+  })
+
+  test('only the organizer can see or answer knocks', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const player = await makeUser(t, 'Player')
+    const knocker = await makeUser(t, 'Knocker')
+
+    const open = await organizer.as.mutation(api.invites.create, { gameId })
+    await player.as.mutation(api.invites.redeem, { code: open })
+
+    const gated = await organizer.as.mutation(api.invites.create, {
+      gameId,
+      requiresApproval: true,
+    })
+    await knocker.as.mutation(api.invites.redeem, { code: gated })
+
+    await expect(player.as.query(api.invites.pendingRequests, { gameId })).rejects.toThrow()
+    const request = firstRow(await organizer.as.query(api.invites.pendingRequests, { gameId }))
+    await expect(
+      player.as.mutation(api.invites.decideRequest, { requestId: request._id, approve: true })
+    ).rejects.toThrow()
+  })
+
+  test('approving a code that expired while pending is refused', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const knocker = await makeUser(t, 'Knocker')
+
+    const code = await organizer.as.mutation(api.invites.create, {
+      gameId,
+      requiresApproval: true,
+    })
+    await knocker.as.mutation(api.invites.redeem, { code })
+
+    await t.run(async (ctx) => {
+      for (const row of await ctx.db.query('invites').collect()) {
+        if (row.code === code) await ctx.db.patch(row._id, { expiresAt: Date.now() - 1000 })
+      }
+    })
+
+    const request = firstRow(await organizer.as.query(api.invites.pendingRequests, { gameId }))
+    await expect(
+      organizer.as.mutation(api.invites.decideRequest, { requestId: request._id, approve: true })
+    ).rejects.toThrow(/expired/i)
+  })
+})
+
+describe('games.get and the row summary', () => {
+  test('summarize carries the crawler name and the entity counts', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    await seedPilot(t, gameId, null)
+    await seedPilot(t, gameId, null)
+    await t.run(async (ctx) => {
+      await ctx.db.insert('mechs', {
+        gameId,
+        ownerId: null,
+        body: { name: 'Mule' },
+        updatedAt: Date.now(),
+      })
+      await ctx.db.insert('crawlers', {
+        gameId,
+        body: { name: 'Hamlet' },
+        updatedAt: Date.now(),
+      })
+    })
+
+    const game = await organizer.as.query(api.games.get, { gameId })
+    expect(game).toMatchObject({
+      crawlerName: 'Hamlet',
+      pilotCount: 2,
+      mechCount: 1,
+    })
+  })
+
+  test('a game with no crawler and nothing built degrades rather than breaking', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const game = await organizer.as.query(api.games.get, { gameId })
+    // The badges need a null to render "No crawler", not an undefined to crash on.
+    expect(game).toMatchObject({ crawlerName: null, pilotCount: 0, mechCount: 0 })
+  })
+
+  test('games.get is null for a non-member rather than an error', async () => {
+    const t = testConvex()
+    const { gameId } = await seedGame(t)
+    const stranger = await makeUser(t, 'Stranger')
+    // A bookmarked URL for a game you left is an ordinary thing to visit.
+    expect(await stranger.as.query(api.games.get, { gameId })).toBeNull()
+  })
+})

--- a/apps/itun/convex/__tests__/permissions.test.ts
+++ b/apps/itun/convex/__tests__/permissions.test.ts
@@ -448,7 +448,10 @@ describe('invite lifecycle', () => {
     )
     await organizer.as.mutation(api.invites.revoke, { inviteId: invite?._id as never })
 
-    await expect(joiner.as.mutation(api.invites.redeem, { code })).rejects.toThrow(/not valid/i)
+    // "revoked", not "not valid": revocation is now a soft delete, so the row
+    // survives to keep its redemption history resolvable and the refusal can say
+    // what actually happened instead of pretending the code never existed.
+    await expect(joiner.as.mutation(api.invites.redeem, { code })).rejects.toThrow(/revoked/i)
   })
 
   test('a Player cannot revoke', async () => {

--- a/apps/itun/convex/games.ts
+++ b/apps/itun/convex/games.ts
@@ -28,17 +28,56 @@ type GameSummary = {
   mediator: boolean
   organizer: boolean
   memberCount: number
+  /** The communal crawler's name, or null before one exists. */
+  crawlerName: string | null
+  pilotCount: number
+  mechCount: number
 }
 
+/**
+ * Collapse a Game + the caller's membership into the row the Games list draws.
+ *
+ * The crawler name and the two counts exist because a Game lists as an
+ * `EntityRow` whose badges are "crawler · n pilots · n mechs" — the row has to
+ * say what the table *is*, not just what it is called.
+ *
+ * **Counting means collecting.** Convex has no count API, so each count is a
+ * `by_game` scan whose rows are then discarded, and `listMine` runs this once
+ * per Game you belong to. That is fine at a table's scale (a Game holds single
+ * digits of each) and is the honest cost of the badges; if it ever bites, the
+ * fix is a denormalised counter on `games`, not a cleverer query here.
+ */
 async function summarize(
   ctx: MutationCtx | Parameters<typeof requireMember>[0],
   game: Doc<'games'>,
   membership: Doc<'memberships'>
 ): Promise<GameSummary> {
-  const members = await ctx.db
-    .query('memberships')
-    .withIndex('by_game', (q) => q.eq('gameId', game._id))
-    .collect()
+  const [members, pilots, mechs, crawlers] = await Promise.all([
+    ctx.db
+      .query('memberships')
+      .withIndex('by_game', (q) => q.eq('gameId', game._id))
+      .collect(),
+    ctx.db
+      .query('pilots')
+      .withIndex('by_game', (q) => q.eq('gameId', game._id))
+      .collect(),
+    ctx.db
+      .query('mechs')
+      .withIndex('by_game', (q) => q.eq('gameId', game._id))
+      .collect(),
+    ctx.db
+      .query('crawlers')
+      .withIndex('by_game', (q) => q.eq('gameId', game._id))
+      .collect(),
+  ])
+
+  // The name lives in the opaque body Convex cannot validate (ADR-030), so read
+  // it defensively rather than trusting the shape — the same move `crew.vitals`
+  // makes for pilot and mech names.
+  const crawlerBody = crawlers[0]?.body as Record<string, unknown> | null | undefined
+  const rawName = crawlerBody?.name
+  const crawlerName = typeof rawName === 'string' && rawName.length > 0 ? rawName : null
+
   return {
     _id: game._id,
     name: game.name,
@@ -46,6 +85,9 @@ async function summarize(
     mediator: membership.mediator,
     organizer: membership.organizer,
     memberCount: members.length,
+    crawlerName,
+    pilotCount: pilots.length,
+    mechCount: mechs.length,
   }
 }
 
@@ -67,6 +109,26 @@ export const listMine = query({
       out.push(await summarize(ctx, game, membership))
     }
     return out
+  },
+})
+
+/**
+ * One Game, for its own route.
+ *
+ * Returns `null` rather than throwing when the caller is not a member, because
+ * a bookmarked `/games/<id>` for a Game you left is an ordinary thing to visit,
+ * not an error to surface. `null` also covers "no such Game", deliberately: a
+ * non-member must not be able to tell an existing Game from a deleted one.
+ */
+export const get = query({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args): Promise<GameSummary | null> => {
+    const userId = await requireUser(ctx)
+    const membership = await getMembership(ctx, args.gameId, userId)
+    if (membership === null) return null
+    const game = await ctx.db.get(args.gameId)
+    if (game === null) return null
+    return await summarize(ctx, game, membership)
   },
 })
 

--- a/apps/itun/convex/invites.ts
+++ b/apps/itun/convex/invites.ts
@@ -1,9 +1,11 @@
 import { v } from 'convex/values'
 
 import { generateUniqueId } from '../src/lib/snapshot/id'
-import type { Id } from './_generated/dataModel'
-import { mutation } from './_generated/server'
+import type { Doc, Id } from './_generated/dataModel'
+import { mutation, query } from './_generated/server'
+import type { MutationCtx } from './_generated/server'
 import { NotAuthorized, getMembership, requireOrganizer, requireUser } from './model/permissions'
+import { logOwnershipChange } from './ownership'
 
 /**
  * Invite codes (ADR-030 §2) — how a player joins a Game.
@@ -13,9 +15,38 @@ import { NotAuthorized, getMembership, requireOrganizer, requireUser } from './m
  * aloud across a table cannot be mistyped), already collision-checked against a
  * caller-supplied `exists`, and already backed by `crypto.getRandomValues`.
  * Those are exactly the properties an invite code wants.
+ *
+ * An invite carries three things beyond the code itself:
+ *
+ *   - **A seat** (`role`). A Mediator invite hands over the GM chair on join,
+ *     which is the Organizer pre-exercising the authority `games.setMediator`
+ *     already gives them.
+ *   - **Grants**. Unclaimed entities assigned on join. Ownership stays
+ *     *assigned, never self-claimed* (ADR-030 §4) — the Organizer made the
+ *     decision when minting, and the Change Log records them as the actor.
+ *   - **A door** (`requiresApproval`). A bearer code IS the authority; a knock
+ *     grants nothing until the Organizer approves it, which is what a code
+ *     posted somewhere public needs, since membership confers read access to
+ *     every crewmate's sheet (ADR-030 §5).
  */
 
 const DEFAULT_EXPIRY_MS = 1000 * 60 * 60 * 24 * 14 // 14 days
+
+/** What an invite is currently worth, derived rather than stored. */
+export type InviteStatus = 'active' | 'revoked' | 'expired' | 'exhausted'
+
+/**
+ * Derive status from the row and the clock.
+ *
+ * Deliberately not a stored column: an `expired` flag would need a cron to stay
+ * true, and a stale one would let a dead code through.
+ */
+function statusOf(invite: Doc<'invites'>, now: number): InviteStatus {
+  if (invite.revokedAt !== undefined) return 'revoked'
+  if (invite.expiresAt !== undefined && invite.expiresAt < now) return 'expired'
+  if (invite.usesRemaining !== undefined && invite.usesRemaining <= 0) return 'exhausted'
+  return 'active'
+}
 
 /** Mint an invite for a Game. Administrative, so Organizer only. */
 export const create = mutation({
@@ -23,6 +54,17 @@ export const create = mutation({
     gameId: v.id('games'),
     usesRemaining: v.optional(v.number()),
     expiresInMs: v.optional(v.number()),
+    label: v.optional(v.string()),
+    role: v.optional(v.union(v.literal('player'), v.literal('mediator'))),
+    grants: v.optional(
+      v.array(
+        v.object({
+          table: v.union(v.literal('pilots'), v.literal('mechs')),
+          entityId: v.string(),
+        })
+      )
+    ),
+    requiresApproval: v.optional(v.boolean()),
   },
   handler: async (ctx, args): Promise<string> => {
     const membership = await requireOrganizer(ctx, args.gameId)
@@ -35,32 +77,245 @@ export const create = mutation({
       return existing !== null
     })
 
+    const role = args.role ?? 'player'
+    const grants = args.grants ?? []
+
+    /*
+     * Two kinds of invite are single-use unless the Organizer says otherwise,
+     * because both are foot-guns when shared:
+     *
+     *   - A Mediator code. The schema permits several Mediators but the UI is
+     *     built for one, so an unlimited one quietly seats a second.
+     *   - A code carrying grants. Two people cannot both receive the same
+     *     pilot; the second would join and silently get nothing.
+     */
+    const defaultsToSingleUse = role === 'mediator' || grants.length > 0
+    const usesRemaining = args.usesRemaining ?? (defaultsToSingleUse ? 1 : undefined)
+
+    const now = Date.now()
     await ctx.db.insert('invites', {
       gameId: args.gameId,
       code,
       createdBy: membership.userId,
-      expiresAt: Date.now() + (args.expiresInMs ?? DEFAULT_EXPIRY_MS),
-      usesRemaining: args.usesRemaining,
+      createdAt: now,
+      expiresAt: now + (args.expiresInMs ?? DEFAULT_EXPIRY_MS),
+      usesRemaining,
+      label: args.label,
+      role,
+      grants: grants.length > 0 ? grants : undefined,
+      requiresApproval: args.requiresApproval ?? false,
     })
     return code
   },
 })
 
+/** Every invite for a Game, with its derived status and who has used it. */
+export const list = query({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args) => {
+    await requireOrganizer(ctx, args.gameId)
+    const now = Date.now()
+
+    const invites = await ctx.db
+      .query('invites')
+      .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+      .collect()
+
+    const out = []
+    for (const invite of invites) {
+      const redemptions = await ctx.db
+        .query('inviteRedemptions')
+        .withIndex('by_invite', (q) => q.eq('inviteId', invite._id))
+        .collect()
+
+      const redeemers: string[] = []
+      for (const redemption of redemptions) {
+        const user = await ctx.db.get(redemption.userId)
+        redeemers.push(user?.displayName ?? user?.name ?? 'Crewmate')
+      }
+
+      out.push({
+        _id: invite._id,
+        code: invite.code,
+        label: invite.label ?? null,
+        role: invite.role ?? 'player',
+        grantCount: invite.grants?.length ?? 0,
+        requiresApproval: invite.requiresApproval ?? false,
+        expiresAt: invite.expiresAt ?? null,
+        usesRemaining: invite.usesRemaining ?? null,
+        status: statusOf(invite, now),
+        redeemers,
+      })
+    }
+
+    // Newest first — the code an Organizer just minted is the one they want to
+    // read out. `_creationTime` is Convex's own field and always present.
+    return out.sort((a, b) => b._id.localeCompare(a._id))
+  },
+})
+
 /**
- * Redeem a code and join the Game as a Player.
+ * Revoke an invite early.
+ *
+ * A soft delete: the row stays so its redemption history keeps resolving. It
+ * also does **not** evict anyone already seated — removing a member is a
+ * different act, and a revoked code that silently kicked people out would be a
+ * nasty surprise.
+ */
+export const revoke = mutation({
+  args: { inviteId: v.id('invites') },
+  handler: async (ctx, args): Promise<void> => {
+    const invite = await ctx.db.get(args.inviteId)
+    if (invite === null) return
+    await requireOrganizer(ctx, invite.gameId)
+    if (invite.revokedAt !== undefined) return
+    await ctx.db.patch(invite._id, { revokedAt: Date.now() })
+  },
+})
+
+/**
+ * What a code is worth, without spending it — the landing page's oracle.
+ *
+ * Returns only what the invite already tells its bearer: never the member list,
+ * never the crew, never entity names. A valid code is not yet a seat, and
+ * ADR-030 §5 visibility begins at membership, so `grants` is reported as a
+ * count rather than as identity.
+ *
+ * Unauthenticated on purpose — someone following an invite link has not signed
+ * in yet, and refusing to say what the link is for until they do is how you get
+ * a person signing in to find out they were sent a dead code.
+ */
+export const preview = query({
+  args: { code: v.string() },
+  handler: async (ctx, args) => {
+    const code = args.code.trim().toUpperCase()
+    if (code.length === 0) return null
+
+    const invite = await ctx.db
+      .query('invites')
+      .withIndex('by_code', (q) => q.eq('code', code))
+      .unique()
+    if (invite === null) return null
+
+    const game = await ctx.db.get(invite.gameId)
+    if (game === null) return null
+
+    const inviter = await ctx.db.get(invite.createdBy)
+
+    return {
+      gameName: game.name,
+      invitedBy: inviter?.displayName ?? inviter?.name ?? 'the organizer',
+      role: invite.role ?? 'player',
+      requiresApproval: invite.requiresApproval ?? false,
+      grantCount: invite.grants?.length ?? 0,
+      status: statusOf(invite, Date.now()),
+    }
+  },
+})
+
+/**
+ * Seat someone in a Game with everything their invite promised.
+ *
+ * Shared by `redeem` (the bearer door) and `decideRequest` (the knock door) so
+ * role and grants behave identically whichever way someone came in — one
+ * implementation rather than two that drift.
+ *
+ * Returns how many grants actually landed.
+ */
+async function seat(
+  ctx: MutationCtx,
+  invite: Doc<'invites'>,
+  userId: Id<'users'>
+): Promise<number> {
+  const now = Date.now()
+
+  await ctx.db.insert('memberships', {
+    gameId: invite.gameId,
+    userId,
+    mediator: (invite.role ?? 'player') === 'mediator',
+    organizer: false,
+    joinedAt: now,
+  })
+
+  let granted = 0
+  for (const grant of invite.grants ?? []) {
+    const doc = await ctx.db.get(grant.entityId as Id<'pilots'> | Id<'mechs'>)
+    /*
+     * A grant is a promise made when the invite was minted, and the world may
+     * have moved since: the entity could have been claimed by someone else,
+     * moved to another Game, or deleted. Skip it and seat them anyway —
+     * arriving without the promised pilot is a notice, whereas failing the join
+     * over a stale pointer would strand someone outside a Game they were
+     * genuinely invited to.
+     */
+    if (doc === null) continue
+    if (!('ownerId' in doc)) continue
+    if (doc.gameId !== invite.gameId) continue
+    if (doc.ownerId !== null) continue
+
+    await ctx.db.patch(doc._id, { ownerId: userId, updatedAt: now })
+    await logOwnershipChange(ctx, {
+      table: grant.table,
+      entityId: grant.entityId,
+      gameId: invite.gameId,
+      before: null,
+      after: userId,
+      // The Organizer decided this when they minted the invite; the joiner
+      // merely turned up. Recording the joiner would make ownership look
+      // self-claimed, which ADR-030 §4 is explicit that it is not.
+      actorId: invite.createdBy,
+    })
+    granted += 1
+  }
+
+  await ctx.db.insert('inviteRedemptions', {
+    inviteId: invite._id,
+    gameId: invite.gameId,
+    userId,
+    redeemedAt: now,
+  })
+
+  if (invite.usesRemaining !== undefined) {
+    await ctx.db.patch(invite._id, { usesRemaining: invite.usesRemaining - 1 })
+  }
+
+  return granted
+}
+
+/** Reject a code that cannot currently be spent, with wording worth showing. */
+function assertSpendable(invite: Doc<'invites'>): void {
+  switch (statusOf(invite, Date.now())) {
+    case 'revoked':
+      throw new NotAuthorized('That invite code has been revoked')
+    case 'expired':
+      throw new NotAuthorized('That invite code has expired')
+    case 'exhausted':
+      throw new NotAuthorized('That invite code has already been used up')
+    default:
+      return
+  }
+}
+
+export type RedeemResult =
+  | { kind: 'joined'; gameId: Id<'games'>; granted: number }
+  | { kind: 'pending'; gameId: Id<'games'> }
+  | { kind: 'already'; gameId: Id<'games'> }
+
+/**
+ * Redeem a code and join the Game.
  *
  * Joining is deliberately the *only* self-serve membership act. Everything
- * downstream of it — what you own, whether you mediate — is assigned by someone
- * already in the Game (ADR-030 §3), so a valid code buys a seat at the table
- * and nothing else.
+ * downstream of it — what you own, whether you mediate — is decided by the
+ * Organizer, either when they minted the invite or afterwards (ADR-030 §3), so
+ * a valid code buys the seat it was minted for and nothing else.
  *
  * Redeeming twice is a no-op rather than an error: a player who taps a link
- * again should land in the Game, not read a failure. The use is not decremented
- * in that case, because they did not consume a new seat.
+ * again should land in the Game, not read a failure. No use is consumed in that
+ * case, because they did not take a new seat.
  */
 export const redeem = mutation({
   args: { code: v.string() },
-  handler: async (ctx, args): Promise<Id<'games'>> => {
+  handler: async (ctx, args): Promise<RedeemResult> => {
     const userId = await requireUser(ctx)
     const code = args.code.trim().toUpperCase()
 
@@ -70,37 +325,108 @@ export const redeem = mutation({
       .unique()
     if (invite === null) throw new NotAuthorized('That invite code is not valid')
 
-    if (invite.expiresAt !== undefined && invite.expiresAt < Date.now()) {
-      throw new NotAuthorized('That invite code has expired')
-    }
-    if (invite.usesRemaining !== undefined && invite.usesRemaining <= 0) {
-      throw new NotAuthorized('That invite code has already been used up')
-    }
-
+    // Membership is checked before spendability: someone already seated is home
+    // whether or not the code has since expired or been revoked.
     const existing = await getMembership(ctx, invite.gameId, userId)
-    if (existing !== null) return invite.gameId
+    if (existing !== null) return { kind: 'already', gameId: invite.gameId }
 
-    await ctx.db.insert('memberships', {
-      gameId: invite.gameId,
-      userId,
-      mediator: false,
-      organizer: false,
-      joinedAt: Date.now(),
-    })
-    if (invite.usesRemaining !== undefined) {
-      await ctx.db.patch(invite._id, { usesRemaining: invite.usesRemaining - 1 })
+    assertSpendable(invite)
+
+    if (invite.requiresApproval === true) {
+      const prior = await ctx.db
+        .query('joinRequests')
+        .withIndex('by_invite_user', (q) => q.eq('inviteId', invite._id).eq('userId', userId))
+        .unique()
+
+      if (prior === null) {
+        await ctx.db.insert('joinRequests', {
+          gameId: invite.gameId,
+          inviteId: invite._id,
+          userId,
+          requestedAt: Date.now(),
+          state: 'pending',
+        })
+      } else if (prior.state === 'declined') {
+        // Let a declined knocker ask again: an Organizer who declined by mistake
+        // should not have to mint a fresh code to undo it.
+        await ctx.db.patch(prior._id, {
+          state: 'pending',
+          requestedAt: Date.now(),
+          decidedBy: undefined,
+          decidedAt: undefined,
+        })
+      }
+      // Knocking twice is knocking once, and notably NO use is consumed here —
+      // otherwise a spam of knocks could burn a code before anyone joined.
+      return { kind: 'pending', gameId: invite.gameId }
     }
-    return invite.gameId
+
+    const granted = await seat(ctx, invite, userId)
+    return { kind: 'joined', gameId: invite.gameId, granted }
   },
 })
 
-/** Revoke an invite early. */
-export const revoke = mutation({
-  args: { inviteId: v.id('invites') },
+/** Pending knocks for a Game, for the Organizer to answer. */
+export const pendingRequests = query({
+  args: { gameId: v.id('games') },
+  handler: async (ctx, args) => {
+    await requireOrganizer(ctx, args.gameId)
+    const requests = await ctx.db
+      .query('joinRequests')
+      .withIndex('by_game_state', (q) => q.eq('gameId', args.gameId).eq('state', 'pending'))
+      .collect()
+
+    const out = []
+    for (const request of requests) {
+      const user = await ctx.db.get(request.userId)
+      const invite = await ctx.db.get(request.inviteId)
+      out.push({
+        _id: request._id,
+        displayName: user?.displayName ?? user?.name ?? 'Someone',
+        requestedAt: request.requestedAt,
+        inviteLabel: invite?.label ?? null,
+        role: invite?.role ?? 'player',
+      })
+    }
+    return out
+  },
+})
+
+/** Answer a knock. Approving seats them exactly as a direct redeem would. */
+export const decideRequest = mutation({
+  args: { requestId: v.id('joinRequests'), approve: v.boolean() },
   handler: async (ctx, args): Promise<void> => {
-    const invite = await ctx.db.get(args.inviteId)
-    if (invite === null) return
-    await requireOrganizer(ctx, invite.gameId)
-    await ctx.db.delete(args.inviteId)
+    const request = await ctx.db.get(args.requestId)
+    if (request === null) throw new NotAuthorized('That request no longer exists')
+    const membership = await requireOrganizer(ctx, request.gameId)
+    // Deciding twice is not an error, but the first decision stands.
+    if (request.state !== 'pending') return
+
+    const now = Date.now()
+
+    if (!args.approve) {
+      await ctx.db.patch(request._id, {
+        state: 'declined',
+        decidedBy: membership.userId,
+        decidedAt: now,
+      })
+      return
+    }
+
+    const invite = await ctx.db.get(request.inviteId)
+    if (invite === null) throw new NotAuthorized('That invite no longer exists')
+
+    // The code still has to be live at approval time — an Organizer who sat on a
+    // knock past the expiry has let the invitation lapse.
+    assertSpendable(invite)
+
+    const already = await getMembership(ctx, request.gameId, request.userId)
+    if (already === null) await seat(ctx, invite, request.userId)
+
+    await ctx.db.patch(request._id, {
+      state: 'approved',
+      decidedBy: membership.userId,
+      decidedAt: now,
+    })
   },
 })

--- a/apps/itun/convex/ownership.ts
+++ b/apps/itun/convex/ownership.ts
@@ -66,7 +66,8 @@ async function loadOwnable(
  * on *who holds* an entity rather than on its contents, which is the boundary
  * the propose-and-confirm rule actually protects.
  */
-async function logOwnershipChange(
+/* Exported so invite-driven grants log identically — see `invites.ts`. */
+export async function logOwnershipChange(
   ctx: MutationCtx,
   args: {
     table: OwnableTable

--- a/apps/itun/convex/schema.ts
+++ b/apps/itun/convex/schema.ts
@@ -96,16 +96,93 @@ export default defineSchema({
     .index('by_user', ['userId'])
     .index('by_game_user', ['gameId', 'userId']),
 
-  /** Invite codes (closes the intent of legacy issue #157). */
+  /**
+   * Invite codes (closes the intent of legacy issue #157).
+   *
+   * An invite is not just a key to the door — it carries what the Organizer
+   * already decided when they minted it: which seat the joiner takes, and which
+   * unclaimed entities are waiting for them. That turns "send code → they join →
+   * find them in the crew list → assign a pilot → assign its mech" into one act.
+   *
+   * Everything past `usesRemaining` is optional so pre-existing rows stay valid.
+   */
   invites: defineTable({
     gameId: v.id('games'),
     code: v.string(),
     createdBy: v.id('users'),
     expiresAt: v.optional(v.number()),
     usesRemaining: v.optional(v.number()),
+
+    createdAt: v.optional(v.number()),
+
+    /** Organizer's private note ("for Sam"). Never shown to the redeemer. */
+    label: v.optional(v.string()),
+
+    /** The seat granted on redeem. Absent means 'player'. */
+    role: v.optional(v.union(v.literal('player'), v.literal('mediator'))),
+
+    /**
+     * Entities handed over on join. A list, not a single id: the Starter Set
+     * case is a pilot AND its mech, and a one-entity field would need a second
+     * mechanism a week later.
+     */
+    grants: v.optional(
+      v.array(
+        v.object({
+          table: v.union(v.literal('pilots'), v.literal('mechs')),
+          entityId: v.string(),
+        })
+      )
+    ),
+
+    /**
+     * When true the code identifies the Game but grants nothing until the
+     * Organizer approves the knock. For a code posted somewhere public, where
+     * membership would otherwise hand a stranger read access to every
+     * crewmate's sheet (ADR-030 §5).
+     */
+    requiresApproval: v.optional(v.boolean()),
+
+    /**
+     * Soft revoke. The row survives so `inviteRedemptions` keeps referring to
+     * something and "who joined via which code" stays answerable after an
+     * Organizer tidies up.
+     */
+    revokedAt: v.optional(v.number()),
   })
     .index('by_code', ['code'])
     .index('by_game', ['gameId']),
+
+  /** Who actually used which invite — the audit trail revocation alone can't give. */
+  inviteRedemptions: defineTable({
+    inviteId: v.id('invites'),
+    gameId: v.id('games'),
+    userId: v.id('users'),
+    redeemedAt: v.number(),
+  })
+    .index('by_invite', ['inviteId'])
+    .index('by_game', ['gameId']),
+
+  /**
+   * A knock at the door, for invites minted with `requiresApproval`.
+   *
+   * A pending request is **not** a membership: no `memberships` row exists until
+   * approval, so a knocker sees nothing of the Game. Approval runs the same
+   * seat-granting path a direct redeem does, so role and grants behave
+   * identically whichever door was used.
+   */
+  joinRequests: defineTable({
+    gameId: v.id('games'),
+    inviteId: v.id('invites'),
+    userId: v.id('users'),
+    requestedAt: v.number(),
+    state: v.union(v.literal('pending'), v.literal('approved'), v.literal('declined')),
+    decidedBy: v.optional(v.id('users')),
+    decidedAt: v.optional(v.number()),
+  })
+    .index('by_game_state', ['gameId', 'state'])
+    .index('by_user', ['userId'])
+    .index('by_invite_user', ['inviteId', 'userId']),
 
   pilots: defineTable({
     gameId: v.union(v.id('games'), v.null()),

--- a/apps/itun/src/components/games/GameRow.tsx
+++ b/apps/itun/src/components/games/GameRow.tsx
@@ -1,0 +1,60 @@
+import { EntityRow } from 'component-lib'
+
+import type { Id } from '../../../convex/_generated/dataModel'
+import { AppLink } from '../shared/AppLink'
+
+/**
+ * A Game, listed the way a pilot, mech, or crawler is listed on the Roster.
+ *
+ * A Game is not game data, so it does not render through `ReferenceEntityDisplay`
+ * — but it *is* another thing you own and open, so it gets the same `EntityRow`
+ * the player entities use, with its own blue ontology tone (ADR-030).
+ *
+ * The three badges answer "what is this table" before you open it: which
+ * crawler the crew rides, and how much is built. A brand-new Game reads
+ * "No crawler · 0 Pilots · 0 Mechs" rather than dropping the badges, because a
+ * row with nothing under the name looks broken rather than empty.
+ *
+ * Deleting is deliberately absent. `games.destroy` ends a shared campaign for
+ * everyone in it, which needs a confirm that names what is being destroyed —
+ * that lives on the Game's own screen, not behind a trash icon in a list.
+ */
+export type GameRowGame = {
+  _id: Id<'games'>
+  name: string
+  templateOrigin: string | undefined
+  mediator: boolean
+  organizer: boolean
+  memberCount: number
+  crawlerName: string | null
+  pilotCount: number
+  mechCount: number
+}
+
+/** Join the row's caption segments with the Roster's separator, dropping blanks. */
+function captionOf(game: GameRowGame): string {
+  const role = game.mediator ? 'Mediator' : 'Player'
+  const segments = [
+    game.organizer ? `${role} · Organizer` : role,
+    `${game.memberCount} ${game.memberCount === 1 ? 'member' : 'members'}`,
+    game.templateOrigin === undefined ? null : `from the ${game.templateOrigin} template`,
+  ]
+  return segments.filter((segment) => segment !== null).join(' · ')
+}
+
+export function GameRow({ game }: { game: GameRowGame }) {
+  return (
+    <EntityRow
+      entityType="game"
+      name={game.name}
+      sheetHref={`/games/${game._id}`}
+      linkAs={AppLink}
+      meta={[
+        game.crawlerName ?? 'No crawler',
+        `${game.pilotCount} ${game.pilotCount === 1 ? 'Pilot' : 'Pilots'}`,
+        `${game.mechCount} ${game.mechCount === 1 ? 'Mech' : 'Mechs'}`,
+      ]}
+      metaLine={captionOf(game)}
+    />
+  )
+}

--- a/apps/itun/src/components/games/GameScreen.tsx
+++ b/apps/itun/src/components/games/GameScreen.tsx
@@ -23,16 +23,21 @@ import { useConnection } from '../../lib/connection/connectionContext'
 import { isConvexConfigured } from '../../lib/connection/convexClient'
 import { DowntimePanel } from './DowntimePanel'
 import { GameRoster } from './GameRoster'
+import { InvitePanel } from './InvitePanel'
 import { ProposalInbox } from './ProposalInbox'
 import { TITLE } from './gameChrome'
 import { AppLink } from '../shared/AppLink'
 
 function GameBody({ gameId }: { gameId: string }) {
-  const games = useQuery(api.games.listMine, {})
-  const game = games?.find((g) => g._id === gameId)
+  // `games.get` rather than listMine-and-find: this route wants one Game, and
+  // it distinguishes "still loading" from "not a member" without fetching every
+  // table the viewer belongs to.
+  const game = useQuery(api.games.get, { gameId: gameId as Id<'games'> })
 
-  if (games === undefined) return <Text>Loading this game…</Text>
-  if (game === undefined) {
+  if (game === undefined) return <Text>Loading this game…</Text>
+  // `null` covers both "you left" and "no such game", deliberately — a
+  // non-member must not be able to tell an existing Game from a deleted one.
+  if (game === null) {
     return (
       <Card>
         <div className="p-4">
@@ -48,6 +53,15 @@ function GameBody({ gameId }: { gameId: string }) {
   return (
     <div className="flex flex-col gap-6">
       <GameRoster gameId={gameId} gameName={game.name} />
+      {/* Invites are administrative, so they live with the Game rather than in
+          the lobby, and only the Organizer sees them (ADR-030 §3). */}
+      {game.organizer && (
+        <Card>
+          <div className="p-4">
+            <InvitePanel gameId={gameId as Id<'games'>} />
+          </div>
+        </Card>
+      )}
       <ProposalInbox gameId={gameId as Id<'games'>} />
       <DowntimePanel gameId={gameId as Id<'games'>} />
       {game.mediator && (

--- a/apps/itun/src/components/games/GamesScreen.tsx
+++ b/apps/itun/src/components/games/GamesScreen.tsx
@@ -1,180 +1,27 @@
 import { useState } from 'react'
-import { Button, Card, Text } from 'component-lib'
+import { Button, Card, EntityRow, Text } from 'component-lib'
 import { useMutation, useQuery } from 'convex/react'
+import { useNavigate } from '@tanstack/react-router'
 
 import { api } from '../../../convex/_generated/api'
-import type { Id } from '../../../convex/_generated/dataModel'
 import { useConnection } from '../../lib/connection/connectionContext'
 import { isConvexConfigured } from '../../lib/connection/convexClient'
 import { SignInControl } from '../account/SignInControl'
-import { Link } from '@tanstack/react-router'
+import { GameRow } from './GameRow'
+import { STAMP } from './gameChrome'
 
 /**
- * Games: create one, invite people, join by code, hand over the Organizer role.
+ * Games — the shelf of tables you belong to.
+ *
+ * This screen is about *choosing* a Game: start one, join one, open one. The
+ * crew, invites, proposals and Downtime all live on the Game's own screen,
+ * because stacking them under every list entry did not survive a second Game.
  *
  * The whole screen is gated on `mode === 'connected'`. That is not defensive
  * coding — a Game is inherently shared state, so there is nothing meaningful to
  * show a Solo user and nothing safe to show a Disconnected one, whose view
  * would be a stale snapshot of a roster that may have changed.
  */
-
-const label = 'font-cond text-xs font-bold tracking-caps-wide uppercase'
-
-function InvitePanel({ gameId }: { gameId: Id<'games'> }) {
-  const createInvite = useMutation(api.invites.create)
-  const [code, setCode] = useState<string | null>(null)
-
-  return (
-    <div className="flex flex-col gap-2">
-      <Button
-        variant="ghost"
-        size="compact"
-        onClick={() => void createInvite({ gameId }).then(setCode)}
-      >
-        Create invite code
-      </Button>
-      {code !== null && (
-        <div className="flex flex-col gap-1">
-          {/* Crockford base32 with no I/L/O/U, so a code read aloud across a
-              table cannot be mistyped into a different valid one. Rendered
-              large and spaced because reading it aloud is the primary use. */}
-          <Text as="span" className="font-cond text-2xl font-bold tracking-caps-wide">
-            {code}
-          </Text>
-          <Text variant="hint" className="text-left">
-            Valid for 14 days. Anyone with this code can join as a player.
-          </Text>
-        </div>
-      )}
-    </div>
-  )
-}
-
-function GameRow({
-  game,
-}: {
-  game: {
-    _id: Id<'games'>
-    name: string
-    mediator: boolean
-    organizer: boolean
-    memberCount: number
-  }
-}) {
-  const members = useQuery(api.games.members, { gameId: game._id })
-  const rename = useMutation(api.games.rename)
-  const setMediator = useMutation(api.games.setMediator)
-  const transferOrganizer = useMutation(api.games.transferOrganizer)
-  const [name, setName] = useState<string | null>(null)
-
-  const value = name ?? game.name
-
-  return (
-    <Card>
-      <div className="flex flex-col gap-3 p-4">
-        <div className="flex items-baseline justify-between gap-3">
-          <Text as="span" className="font-cond text-lg font-bold">
-            {game.name}
-          </Text>
-          <Text variant="hint" className="text-left">
-            {game.organizer ? 'Organizer · ' : ''}
-            {game.mediator ? 'Mediator' : 'Player'}
-          </Text>
-        </div>
-
-        {game.organizer && (
-          <div className="flex flex-wrap items-end gap-2">
-            <label className="flex flex-col gap-1">
-              <span className={label}>Name</span>
-              <input
-                aria-label={`Rename ${game.name}`}
-                className="border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-1"
-                value={value}
-                onChange={(e) => setName(e.target.value)}
-              />
-            </label>
-            <Button
-              variant="primary"
-              size="compact"
-              onClick={() => void rename({ gameId: game._id, name: value })}
-            >
-              Save
-            </Button>
-          </div>
-        )}
-
-        <div className="flex flex-col gap-1">
-          <span className={label}>Crew</span>
-          {members === undefined && <Text variant="hint">Loading…</Text>}
-          {members?.map((m) => (
-            <div key={m.userId} className="flex items-baseline justify-between gap-3">
-              <Text as="span">{m.displayName}</Text>
-              <span className="flex items-center gap-2">
-                <Text variant="hint" className="text-left">
-                  {m.organizer ? 'Organizer · ' : ''}
-                  {m.mediator ? 'Mediator' : 'Player'}
-                </Text>
-                {game.organizer && (
-                  <>
-                    <Button
-                      variant="ghost"
-                      size="mini"
-                      onClick={() =>
-                        void setMediator({
-                          gameId: game._id,
-                          userId: m.userId,
-                          mediator: !m.mediator,
-                        })
-                      }
-                    >
-                      {m.mediator ? 'Stand down' : 'Make Mediator'}
-                    </Button>
-                    {!m.organizer && (
-                      <Button
-                        variant="ghost"
-                        size="mini"
-                        onClick={() =>
-                          void transferOrganizer({ gameId: game._id, userId: m.userId })
-                        }
-                      >
-                        Hand over
-                      </Button>
-                    )}
-                  </>
-                )}
-              </span>
-            </div>
-          ))}
-        </div>
-
-        {game.organizer && <InvitePanel gameId={game._id} />}
-
-        {/* This screen is the lobby, so a row is a door rather than a
-            workspace. The answer queue and the table's Downtime used to render
-            inline here, which meant somebody in three campaigns met three
-            Downtime panels stacked up with nothing saying whose was whose. */}
-        <div className="flex flex-wrap items-center gap-3">
-          <Link
-            to="/games/$gameId"
-            params={{ gameId: game._id }}
-            className={`${label} text-[var(--color-rust)] hover:text-[var(--color-rust-hi)]`}
-          >
-            Open the crew →
-          </Link>
-          {game.mediator && (
-            <Link
-              to="/mediator/$gameId"
-              params={{ gameId: game._id }}
-              className={`${label} text-[var(--color-rust)] hover:text-[var(--color-rust-hi)]`}
-            >
-              Open the Mediator surface →
-            </Link>
-          )}
-        </div>
-      </div>
-    </Card>
-  )
-}
 
 function ConnectedGames() {
   const games = useQuery(api.games.listMine, {})
@@ -183,16 +30,36 @@ function ConnectedGames() {
   const createFromTemplate = useMutation(api.templates.createGame)
   const redeem = useMutation(api.invites.redeem)
 
+  const navigate = useNavigate()
+
   const [newName, setNewName] = useState('')
   const [code, setCode] = useState('')
   const [joinError, setJoinError] = useState<string | null>(null)
+  const [joinNotice, setJoinNotice] = useState<string | null>(null)
+
+  const join = () => {
+    setJoinError(null)
+    setJoinNotice(null)
+    void redeem({ code })
+      .then((result) => {
+        setCode('')
+        if (result.kind === 'pending') {
+          setJoinNotice('Asked to join. You will get in once the organizer approves.')
+          return
+        }
+        void navigate({ to: '/games/$gameId', params: { gameId: result.gameId } })
+      })
+      // The server distinguishes not-valid / expired / revoked / used-up, so
+      // surface its wording rather than a generic failure.
+      .catch((err: Error) => setJoinError(err.message))
+  }
 
   return (
     <div className="flex flex-col gap-6">
       <Card>
         <div className="flex flex-wrap items-end gap-2 p-4">
           <label className="flex flex-col gap-1">
-            <span className={label}>Start a game</span>
+            <span className={STAMP}>Start a game</span>
             <input
               aria-label="New game name"
               placeholder="Union Crawler #430"
@@ -214,7 +81,7 @@ function ConnectedGames() {
 
       <Card>
         <div className="flex flex-col gap-3 p-4">
-          <span className={label}>Or start from a template</span>
+          <span className={STAMP}>Or start from a template</span>
           {templates?.map((t) => (
             <div key={t.id} className="flex flex-col gap-2">
               <Text as="span">{t.name}</Text>
@@ -244,7 +111,7 @@ function ConnectedGames() {
         <div className="flex flex-col gap-2 p-4">
           <div className="flex flex-wrap items-end gap-2">
             <label className="flex flex-col gap-1">
-              <span className={label}>Join with a code</span>
+              <span className={STAMP}>Join with a code</span>
               <input
                 aria-label="Invite code"
                 placeholder="A1B2C3D4"
@@ -257,14 +124,7 @@ function ConnectedGames() {
               variant="primary"
               size="compact"
               disabled={code.trim().length === 0}
-              onClick={() => {
-                setJoinError(null)
-                void redeem({ code })
-                  .then(() => setCode(''))
-                  // The server distinguishes not-valid / expired / used-up, so
-                  // surface its wording rather than a generic failure.
-                  .catch((err: Error) => setJoinError(err.message))
-              }}
+              onClick={join}
             >
               Join
             </Button>
@@ -274,18 +134,32 @@ function ConnectedGames() {
               {joinError}
             </Text>
           )}
+          {joinNotice !== null && (
+            <Text variant="hint" className="text-left">
+              {joinNotice}
+            </Text>
+          )}
         </div>
       </Card>
 
       {games === undefined && <Text>Loading your games…</Text>}
       {games?.length === 0 && (
-        <Text variant="hint" className="text-left">
-          You are not in any games yet. Create one, or join with a code from whoever set yours up.
-        </Text>
+        <EntityRow
+          empty
+          entityType="game"
+          roleLabel="Game"
+          message="You are not in any games yet — start one above, or join with a code from whoever set yours up."
+        />
       )}
-      {games?.map((g) => (
-        <GameRow key={g._id} game={g} />
-      ))}
+      {games !== undefined && games.length > 0 && (
+        <ul className="flex list-none flex-col gap-2.5 p-0">
+          {games.map((game) => (
+            <li key={game._id}>
+              <GameRow game={game} />
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   )
 }

--- a/apps/itun/src/components/games/InvitePanel.tsx
+++ b/apps/itun/src/components/games/InvitePanel.tsx
@@ -1,0 +1,206 @@
+import { useState } from 'react'
+import { Badge, Button, Text } from 'component-lib'
+import { useMutation, useQuery } from 'convex/react'
+
+import { api } from '../../../convex/_generated/api'
+import type { Id } from '../../../convex/_generated/dataModel'
+import { INPUT, ROW, STAMP } from './gameChrome'
+
+/**
+ * Invite management — mint, read back, and revoke.
+ *
+ * The screen this replaces could only mint: it showed a code once and then
+ * forgot it, so an Organizer could not see what was outstanding, how many uses
+ * were left, or kill one that had leaked. `revoke` existed on the server the
+ * whole time with nothing calling it.
+ *
+ * Two doors are offered per invite, and which one to use is a judgement about
+ * where the code is going rather than a setting to leave alone:
+ *
+ *   - **Bearer** — the code IS the authority. Right for reading aloud at a
+ *     table or DMing someone you know.
+ *   - **Approval** — the code only identifies the Game. Right for anywhere
+ *     more people can read it than you intend, because joining hands over
+ *     read access to every crewmate's sheet (ADR-030 §5).
+ */
+
+function humanExpiry(expiresAt: number | null): string {
+  if (expiresAt === null) return 'no expiry'
+  const days = Math.ceil((expiresAt - Date.now()) / (1000 * 60 * 60 * 24))
+  if (days <= 0) return 'expired'
+  return `${days} ${days === 1 ? 'day' : 'days'} left`
+}
+
+function humanUses(usesRemaining: number | null): string {
+  if (usesRemaining === null) return 'unlimited uses'
+  return `${usesRemaining} ${usesRemaining === 1 ? 'use' : 'uses'} left`
+}
+
+/** Status → the badge tone that reads right: only `active` is good news. */
+const STATUS_TONE = {
+  active: 'ok',
+  revoked: 'bad',
+  expired: 'warn',
+  exhausted: 'warn',
+} as const
+
+export function InvitePanel({ gameId }: { gameId: Id<'games'> }) {
+  const invites = useQuery(api.invites.list, { gameId })
+  const requests = useQuery(api.invites.pendingRequests, { gameId })
+  const createInvite = useMutation(api.invites.create)
+  const revoke = useMutation(api.invites.revoke)
+  const decide = useMutation(api.invites.decideRequest)
+
+  const [label, setLabel] = useState('')
+  const [role, setRole] = useState<'player' | 'mediator'>('player')
+  const [requiresApproval, setRequiresApproval] = useState(false)
+
+  const mint = () => {
+    void createInvite({
+      gameId,
+      label: label.trim() === '' ? undefined : label.trim(),
+      role,
+      requiresApproval,
+    }).then(() => {
+      setLabel('')
+      setRole('player')
+      setRequiresApproval(false)
+    })
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <span className={STAMP}>Invite someone</span>
+        <div className="flex flex-wrap items-end gap-2">
+          <label className="flex flex-col gap-1">
+            <span className={STAMP}>Note (optional)</span>
+            <input
+              aria-label="Invite note"
+              placeholder="for Sam"
+              className={INPUT}
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className={STAMP}>Seat</span>
+            <select
+              aria-label="Invite seat"
+              className={INPUT}
+              value={role}
+              onChange={(e) => setRole(e.target.value === 'mediator' ? 'mediator' : 'player')}
+            >
+              <option value="player">Player</option>
+              <option value="mediator">Mediator</option>
+            </select>
+          </label>
+          <label className="flex items-center gap-2 py-1">
+            <input
+              type="checkbox"
+              aria-label="Require approval"
+              checked={requiresApproval}
+              onChange={(e) => setRequiresApproval(e.target.checked)}
+            />
+            <span className="font-body text-sm">Require my approval</span>
+          </label>
+          <Button variant="primary" size="compact" onClick={mint}>
+            Create invite code
+          </Button>
+        </div>
+        <Text variant="hint" className="text-left">
+          {requiresApproval
+            ? 'Anyone with this code asks to join, and waits for you. Use this for a code you post somewhere public.'
+            : 'Anyone with this code joins immediately. Members can read every crewmate’s sheet, so share it like a key.'}
+        </Text>
+      </div>
+
+      {requests !== undefined && requests.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <span className={STAMP}>Asking to join</span>
+          {requests.map((request) => (
+            <div key={request._id} className={ROW}>
+              <Text as="span">
+                {request.displayName}
+                {request.inviteLabel === null ? '' : ` · ${request.inviteLabel}`}
+              </Text>
+              <span className="flex items-center gap-2">
+                {request.role === 'mediator' && (
+                  <Badge surface="tone" tone="game">
+                    Mediator seat
+                  </Badge>
+                )}
+                <Button
+                  variant="primary"
+                  size="mini"
+                  onClick={() => void decide({ requestId: request._id, approve: true })}
+                >
+                  Approve
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="mini"
+                  onClick={() => void decide({ requestId: request._id, approve: false })}
+                >
+                  Decline
+                </Button>
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-1">
+        <span className={STAMP}>Codes</span>
+        {invites === undefined && <Text variant="hint">Loading…</Text>}
+        {invites?.length === 0 && (
+          <Text variant="hint" className="text-left">
+            No invite codes yet.
+          </Text>
+        )}
+        {invites?.map((invite) => (
+          <div key={invite._id} className={ROW}>
+            <span className="flex flex-col gap-0.5">
+              {/* Crockford base32 with no I/L/O/U, so a code read aloud across a
+                  table cannot be mistyped into a different valid one. Rendered
+                  large and spaced because reading it aloud is a primary use. */}
+              <Text as="span" className="font-cond text-xl font-bold tracking-caps-wide">
+                {invite.code}
+              </Text>
+              <Text variant="hint" className="text-left">
+                {[
+                  invite.label,
+                  invite.role === 'mediator' ? 'Mediator seat' : null,
+                  invite.requiresApproval ? 'needs approval' : null,
+                  invite.grantCount > 0 ? `${invite.grantCount} handed over` : null,
+                  humanUses(invite.usesRemaining),
+                  humanExpiry(invite.expiresAt),
+                  invite.redeemers.length > 0 ? `used by ${invite.redeemers.join(', ')}` : null,
+                ]
+                  .filter((segment) => segment !== null && segment !== '')
+                  .join(' · ')}
+              </Text>
+            </span>
+            <span className="flex items-center gap-2">
+              <Badge surface="tone" tone={STATUS_TONE[invite.status]}>
+                {invite.status}
+              </Badge>
+              {invite.status === 'active' && (
+                <Button
+                  variant="ghost"
+                  size="mini"
+                  onClick={() => void revoke({ inviteId: invite._id })}
+                >
+                  Revoke
+                </Button>
+              )}
+            </span>
+          </div>
+        ))}
+        <Text variant="hint" className="text-left">
+          Revoking closes a code. It never removes anyone who has already joined.
+        </Text>
+      </div>
+    </div>
+  )
+}

--- a/apps/itun/src/components/games/JoinScreen.tsx
+++ b/apps/itun/src/components/games/JoinScreen.tsx
@@ -1,0 +1,213 @@
+import { useState } from 'react'
+import { Button, Card, Text } from 'component-lib'
+import { useMutation, useQuery } from 'convex/react'
+import { useNavigate } from '@tanstack/react-router'
+
+import { api } from '../../../convex/_generated/api'
+import { useConnection } from '../../lib/connection/connectionContext'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+import { SignInControl } from '../account/SignInControl'
+import { AppLink } from '../shared/AppLink'
+import { STAMP, TITLE } from './gameChrome'
+
+/**
+ * `/join/$code` — the link half of an invite.
+ *
+ * Signed-out is the **expected** state here, not an edge case: the whole point
+ * of a link is that you can hand it to someone who has no account yet. So the
+ * page describes the invitation *before* asking for a sign-in, and a dead code
+ * says so without ever prompting one — being asked to authenticate only to find
+ * out the code expired is the worst version of this screen.
+ *
+ * The code lives in the URL rather than in `sessionStorage`, so it survives the
+ * OAuth round-trip and still works when pasted into a different browser.
+ */
+
+/** What the invite is worth, phrased for the person holding it. */
+const DEAD_CODE_COPY = {
+  revoked: 'That invite has been revoked.',
+  expired: 'That invite has expired.',
+  exhausted: 'That invite has already been used.',
+} as const
+
+function ConnectedJoin({ code }: { code: string }) {
+  const preview = useQuery(api.invites.preview, { code })
+  const redeem = useMutation(api.invites.redeem)
+  const navigate = useNavigate()
+
+  const [error, setError] = useState<string | null>(null)
+  const [pending, setPending] = useState(false)
+
+  if (preview === undefined) return <Text>Checking that invite…</Text>
+
+  if (preview === null) {
+    return (
+      <Card>
+        <div className="flex flex-col gap-3 p-4">
+          <Text>That invite code is not valid.</Text>
+          <Text variant="hint" className="text-left">
+            Check it for a typo, or ask whoever invited you for a fresh one.
+          </Text>
+          <div>
+            <AppLink href="/games">Go to your games</AppLink>
+          </div>
+        </div>
+      </Card>
+    )
+  }
+
+  if (preview.status !== 'active') {
+    return (
+      <Card>
+        <div className="flex flex-col gap-3 p-4">
+          <Text>{DEAD_CODE_COPY[preview.status]}</Text>
+          <Text variant="hint" className="text-left">
+            Ask {preview.invitedBy} for a fresh code.
+          </Text>
+          <div>
+            <AppLink href="/games">Go to your games</AppLink>
+          </div>
+        </div>
+      </Card>
+    )
+  }
+
+  if (pending) {
+    return (
+      <Card>
+        <div className="flex flex-col gap-3 p-4">
+          <Text>Asked to join {preview.gameName}.</Text>
+          <Text variant="hint" className="text-left">
+            {preview.invitedBy} has to approve you before you can see the table. You can close this
+            page — it will show up in your games once they do.
+          </Text>
+          <div>
+            <AppLink href="/games">Go to your games</AppLink>
+          </div>
+        </div>
+      </Card>
+    )
+  }
+
+  const accept = () => {
+    setError(null)
+    void redeem({ code })
+      .then((result) => {
+        if (result.kind === 'pending') {
+          setPending(true)
+          return
+        }
+        void navigate({ to: '/games/$gameId', params: { gameId: result.gameId } })
+      })
+      .catch((err: Error) => setError(err.message))
+  }
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        <span className={STAMP}>You have been invited</span>
+        <Text>
+          {preview.invitedBy} invited you to <strong>{preview.gameName}</strong>
+          {preview.role === 'mediator' ? ' as its Mediator' : ''}.
+        </Text>
+        {preview.grantCount > 0 && (
+          <Text variant="hint" className="text-left">
+            {preview.grantCount === 1
+              ? 'A character is waiting for you.'
+              : `${preview.grantCount} characters are waiting for you.`}
+          </Text>
+        )}
+        <Text variant="hint" className="text-left">
+          {preview.requiresApproval
+            ? 'Joining asks the organizer to let you in.'
+            : 'Everyone at a table can read each other’s sheets.'}
+        </Text>
+        <div>
+          <Button variant="primary" size="compact" onClick={accept}>
+            {preview.requiresApproval ? 'Ask to join' : 'Join this game'}
+          </Button>
+        </div>
+        {error !== null && (
+          <Text variant="hint" className="text-left text-[var(--color-roll-cascade)]">
+            {error}
+          </Text>
+        )}
+      </div>
+    </Card>
+  )
+}
+
+/**
+ * The signed-out view. It still previews the invite, because the point of a
+ * link is that it means something before you have an account — `preview` is
+ * unauthenticated for exactly this.
+ */
+function SignedOutJoin({ code }: { code: string }) {
+  const preview = useQuery(api.invites.preview, { code })
+
+  return (
+    <Card>
+      <div className="flex flex-col gap-3 p-4">
+        {preview === undefined && <Text>Checking that invite…</Text>}
+        {preview === null && <Text>That invite code is not valid.</Text>}
+        {preview != null && preview.status !== 'active' && (
+          <Text>{DEAD_CODE_COPY[preview.status]}</Text>
+        )}
+        {preview != null && preview.status === 'active' && (
+          <>
+            <span className={STAMP}>You have been invited</span>
+            <Text>
+              {preview.invitedBy} invited you to <strong>{preview.gameName}</strong>
+              {preview.role === 'mediator' ? ' as its Mediator' : ''}.
+            </Text>
+            <Text variant="hint" className="text-left">
+              Sign in to accept. Playing alone never needs an account — signing in is what lets you
+              share a table.
+            </Text>
+            <div>
+              <SignInControl />
+            </div>
+          </>
+        )}
+      </div>
+    </Card>
+  )
+}
+
+export function JoinScreen({ code }: { code: string }) {
+  const { mode } = useConnection()
+
+  const body = () => {
+    if (!isConvexConfigured) {
+      return (
+        <Card>
+          <div className="p-4">
+            <Text>
+              This build has no account service configured, so invite links cannot be accepted here.
+            </Text>
+          </div>
+        </Card>
+      )
+    }
+    if (mode === 'connected') return <ConnectedJoin code={code} />
+    if (mode === 'disconnected') {
+      return (
+        <Card>
+          <div className="p-4">
+            <Text>You are offline, so this invite cannot be checked right now.</Text>
+          </div>
+        </Card>
+      )
+    }
+    return <SignedOutJoin code={code} />
+  }
+
+  return (
+    <main className="mx-auto flex max-w-lg flex-col gap-6 p-4">
+      <Text as="h1" className={TITLE}>
+        Join a game
+      </Text>
+      {body()}
+    </main>
+  )
+}

--- a/apps/itun/src/components/games/__tests__/GameScreen.connected.test.tsx
+++ b/apps/itun/src/components/games/__tests__/GameScreen.connected.test.tsx
@@ -1,0 +1,140 @@
+import { afterAll, afterEach, describe, expect, mock, test } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+
+/**
+ * `GameScreen` — one Game, connected.
+ *
+ * Two things are worth defending here. Invite management belongs to the
+ * Organizer, and showing it to anyone else would be offering a control the
+ * server will refuse. And `games.get` returning `null` means "not a member",
+ * which must read as an explanation rather than a crash — a bookmarked URL for
+ * a Game you left is an ordinary thing to visit.
+ *
+ * Queries are answered in **call order** — the generated `api` is a Proxy that
+ * throws when inspected, so position is the only stable key.
+ */
+
+let queryQueue: unknown[] = []
+let queryIndex = 0
+
+const realConvexClient = { ...(await import('../../../lib/connection/convexClient')) }
+const realConvexReact = { ...(await import('convex/react')) }
+const realRouter = { ...(await import('@tanstack/react-router')) }
+
+mock.module('../../../lib/connection/convexClient', () => ({
+  isConvexConfigured: true,
+  convexClient: {},
+}))
+
+mock.module('convex/react', () => ({
+  useQuery: () => {
+    const value = queryQueue[queryIndex]
+    queryIndex += 1
+    return value
+  },
+  useMutation: () => async () => undefined,
+  useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
+  ConvexReactClient: class {},
+  ConvexProvider: ({ children }: { children: unknown }) => children,
+  ConvexProviderWithAuth: ({ children }: { children: unknown }) => children,
+  useConvex: () => ({}),
+  useAction: () => async () => undefined,
+}))
+
+mock.module('@tanstack/react-router', () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+  useNavigate: () => async () => undefined,
+  useRouter: () => undefined,
+}))
+
+const { GameScreen } = await import('../GameScreen')
+const { ConnectionProvider } = await import('../../../lib/connection/ConnectionProvider')
+
+function withQueries(values: unknown[]): void {
+  queryQueue = values
+  queryIndex = 0
+}
+
+const wrap = () =>
+  render(
+    <ConnectionProvider>
+      <GameScreen gameId="g1" />
+    </ConnectionProvider>
+  )
+
+const GAME = {
+  _id: 'g1',
+  name: 'Union Crawler #430',
+  templateOrigin: undefined,
+  mediator: false,
+  organizer: false,
+  memberCount: 3,
+  crawlerName: 'Hamlet',
+  pilotCount: 4,
+  mechCount: 3,
+}
+
+/**
+ * Everything downstream of `games.get`, in render order: GameRoster's
+ * account.me / games.members / entities.listForGame, then the invite panel's
+ * two queries, then the proposal inbox and Downtime panel. Only the first slot
+ * (games.get) varies between these tests.
+ */
+const REST = [
+  { _id: 'u1', displayName: 'Ash' },
+  [],
+  { pilots: [], mechs: [], crawlers: [], softLinks: [] },
+  [],
+  [],
+  [],
+  { running: false, stepIndex: null, completedBy: [], upkeepSpent: false },
+  false,
+]
+
+afterEach(cleanup)
+
+describe('GameScreen', () => {
+  test('a plain member gets no invite management', () => {
+    withQueries([GAME, ...REST])
+    wrap()
+
+    // The server refuses a non-Organizer's invites.list outright, so offering
+    // the panel here would be a control that only ever errors.
+    expect(screen.queryByText('Create invite code')).toBeNull()
+    expect(screen.queryByLabelText('Invite note')).toBeNull()
+  })
+
+  test('an Organizer gets invite management', () => {
+    withQueries([{ ...GAME, organizer: true }, ...REST])
+    wrap()
+
+    expect(screen.getByText('Create invite code')).toBeTruthy()
+    expect(screen.getByLabelText('Invite note')).toBeTruthy()
+    expect(screen.getByLabelText('Invite seat')).toBeTruthy()
+    expect(screen.getByLabelText('Require approval')).toBeTruthy()
+  })
+
+  test('a game you are not in explains itself instead of crashing', () => {
+    withQueries([null, ...REST])
+    wrap()
+
+    expect(screen.getByText(/not in this game/i)).toBeTruthy()
+    expect(screen.queryByText('Create invite code')).toBeNull()
+  })
+
+  test('still loading is not the same as not a member', () => {
+    withQueries([undefined, ...REST])
+    wrap()
+
+    expect(screen.getByText(/Loading this game/i)).toBeTruthy()
+    expect(screen.queryByText(/not in this game/i)).toBeNull()
+  })
+})
+
+afterAll(() => {
+  mock.module('../../../lib/connection/convexClient', () => realConvexClient)
+  mock.module('convex/react', () => realConvexReact)
+  mock.module('@tanstack/react-router', () => realRouter)
+})

--- a/apps/itun/src/components/games/__tests__/GamesScreen.connected.test.tsx
+++ b/apps/itun/src/components/games/__tests__/GamesScreen.connected.test.tsx
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, describe, expect, mock, test } from 'bun:test'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 /**
  * `GamesScreen` in its connected state — the Games *index*.
@@ -16,6 +16,9 @@ import { cleanup, render, screen } from '@testing-library/react'
 
 let queryQueue: unknown[] = []
 let queryIndex = 0
+let redeemResult: unknown = { kind: 'joined', gameId: 'g9', granted: 0 }
+let redeemError: Error | null = null
+const navigations: unknown[] = []
 
 /**
  * `mock.module` replaces the entry in the process-wide module registry, so these
@@ -42,7 +45,10 @@ mock.module('convex/react', () => ({
     queryIndex += 1
     return v
   },
-  useMutation: () => async () => undefined,
+  useMutation: () => async () => {
+    if (redeemError !== null) throw redeemError
+    return redeemResult
+  },
   useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
   ConvexReactClient: class {},
   // `@convex-dev/auth/react` (reached via SignInControl) imports these from
@@ -65,7 +71,9 @@ mock.module('@tanstack/react-router', () => ({
   Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
     <a href={to}>{children}</a>
   ),
-  useNavigate: () => async () => undefined,
+  useNavigate: () => async (opts: unknown) => {
+    navigations.push(opts)
+  },
   useRouter: () => undefined,
 }))
 
@@ -75,6 +83,8 @@ const { ConnectionProvider } = await import('../../../lib/connection/ConnectionP
 function withQueries(values: unknown[]): void {
   queryQueue = values
   queryIndex = 0
+  navigations.length = 0
+  redeemError = null
 }
 
 const wrap = () =>
@@ -173,6 +183,50 @@ describe('the Games index for a signed-in player', () => {
 
     expect(screen.getByText(/not in any games yet/i)).toBeTruthy()
     expect(screen.getByLabelText('Invite code')).toBeTruthy()
+  })
+})
+
+describe('joining by code from the lobby', () => {
+  test('a successful join routes into the game it joined', async () => {
+    withQueries(queriesFor(GAME))
+    wrap()
+
+    fireEvent.change(screen.getByLabelText('Invite code'), { target: { value: 'A1B2C3D4' } })
+    fireEvent.click(screen.getByText('Join'))
+
+    await waitFor(() => expect(navigations).toHaveLength(1))
+    expect(navigations[0]).toMatchObject({ params: { gameId: 'g9' } })
+  })
+
+  test('a gated code says it is waiting instead of routing nowhere', async () => {
+    withQueries(queriesFor(GAME))
+    redeemResult = { kind: 'pending', gameId: 'g9' }
+    wrap()
+
+    fireEvent.change(screen.getByLabelText('Invite code'), { target: { value: 'A1B2C3D4' } })
+    fireEvent.click(screen.getByText('Join'))
+
+    await waitFor(() => expect(screen.getByText(/once the organizer approves/i)).toBeTruthy())
+    // Routing into a Game you cannot yet see would be the wrong reassurance.
+    expect(navigations).toHaveLength(0)
+    redeemResult = { kind: 'joined', gameId: 'g9', granted: 0 }
+  })
+
+  test('a refusal is shown in the server’s own words', async () => {
+    withQueries(queriesFor(GAME))
+    wrap()
+    redeemError = new Error('That invite code has expired')
+
+    fireEvent.change(screen.getByLabelText('Invite code'), { target: { value: 'A1B2C3D4' } })
+    fireEvent.click(screen.getByText('Join'))
+
+    await waitFor(() => expect(screen.getByText(/has expired/)).toBeTruthy())
+  })
+
+  test('Join is disabled until a code is typed', () => {
+    withQueries(queriesFor(GAME))
+    wrap()
+    expect((screen.getByText('Join') as HTMLButtonElement).disabled).toBe(true)
   })
 })
 

--- a/apps/itun/src/components/games/__tests__/GamesScreen.connected.test.tsx
+++ b/apps/itun/src/components/games/__tests__/GamesScreen.connected.test.tsx
@@ -1,13 +1,13 @@
-import { afterAll, describe, expect, mock, test } from 'bun:test'
-import { render, screen } from '@testing-library/react'
+import { afterAll, afterEach, describe, expect, mock, test } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
 
 /**
- * `GamesScreen` in its connected state.
+ * `GamesScreen` in its connected state — the Games *index*.
  *
- * The Solo test proves it does not crash without a provider. This covers what
- * the screen actually does for a signed-in player: which controls a plain
- * member gets versus an Organizer, and whether the Mediator link appears only
- * for somebody who mediates.
+ * Since the route split this screen is only about choosing a Game: create,
+ * join, and one row per table. Everything per-Game (crew, invites, roles, the
+ * Mediator link) moved to `/games/$gameId`, and is covered by
+ * `GameDetailScreen.connected.test.tsx`.
  *
  * Queries are answered in **call order** — the generated `api` object is a
  * Proxy that throws the moment a test inspects it, so position is the only
@@ -59,12 +59,14 @@ mock.module('@convex-dev/auth/react', () => ({
   ConvexAuthProvider: ({ children }: { children: unknown }) => children,
 }))
 
-// The Mediator link is a router `Link`, which needs a RouterProvider it has no
-// business needing here — the assertion is whether the link is offered at all.
+// Rows link through the router, and joining navigates — neither needs a real
+// RouterProvider for these assertions.
 mock.module('@tanstack/react-router', () => ({
   Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
     <a href={to}>{children}</a>
   ),
+  useNavigate: () => async () => undefined,
+  useRouter: () => undefined,
 }))
 
 const { GamesScreen } = await import('../GamesScreen')
@@ -89,51 +91,53 @@ const GAME = {
   mediator: false,
   organizer: false,
   memberCount: 3,
+  crawlerName: 'Hamlet',
+  pilotCount: 4,
+  mechCount: 3,
 }
-
-const MEMBERS = [
-  {
-    userId: 'u1',
-    displayName: 'Ash',
-    avatarUrl: undefined,
-    mediator: false,
-    organizer: true,
-    joinedAt: 1,
-  },
-  {
-    userId: 'u2',
-    displayName: 'Beefcake',
-    avatarUrl: undefined,
-    mediator: true,
-    organizer: false,
-    joinedAt: 2,
-  },
-]
 
 const TEMPLATES = [
   { id: 'starter-set', name: 'Reclamation of the Wastes', description: 'Six pre-gens.' },
 ]
 
-/** listMine, templates, members, pending, downtime state, amMediator. */
+/** listMine, templates — the index's only two queries. */
 function queriesFor(game: Record<string, unknown>): unknown[] {
-  return [
-    [game],
-    TEMPLATES,
-    MEMBERS,
-    [],
-    { running: false, stepIndex: null, completedBy: [], upkeepSpent: false },
-    false,
-  ]
+  return [[game], TEMPLATES]
 }
 
-describe('GamesScreen for a signed-in player', () => {
-  test('lists the games you are in, with the crew', () => {
+afterEach(cleanup)
+
+describe('the Games index for a signed-in player', () => {
+  test('lists a row per game', () => {
+    withQueries(queriesFor(GAME))
+    wrap()
+    expect(screen.getByText('Union Crawler #430')).toBeTruthy()
+  })
+
+  test('the row badges say what the table is', () => {
     withQueries(queriesFor(GAME))
     wrap()
 
-    expect(screen.getByText('Union Crawler #430')).toBeTruthy()
-    expect(screen.getByText('Ash')).toBeTruthy()
-    expect(screen.getByText('Beefcake')).toBeTruthy()
+    // A Game row answers "what is this table" before you open it.
+    expect(screen.getByText('Hamlet')).toBeTruthy()
+    expect(screen.getByText('4 Pilots')).toBeTruthy()
+    expect(screen.getByText('3 Mechs')).toBeTruthy()
+  })
+
+  test('a game with nothing in it still renders all three badges', () => {
+    withQueries(queriesFor({ ...GAME, crawlerName: null, pilotCount: 0, mechCount: 0 }))
+    wrap()
+
+    // Dropping the badges would make a new Game's row look broken rather than empty.
+    expect(screen.getByText('No crawler')).toBeTruthy()
+    expect(screen.getByText('0 Pilots')).toBeTruthy()
+    expect(screen.getByText('0 Mechs')).toBeTruthy()
+  })
+
+  test('the row links to the game, not to a modal', () => {
+    withQueries(queriesFor(GAME))
+    wrap()
+    expect(screen.getByText('View').getAttribute('href')).toBe('/games/g1')
   })
 
   test('offers create and join to everybody', () => {
@@ -144,34 +148,16 @@ describe('GamesScreen for a signed-in player', () => {
     expect(screen.getByLabelText('Invite code')).toBeTruthy()
   })
 
-  test('a plain member gets no administrative controls', () => {
-    withQueries(queriesFor(GAME))
+  test('per-game administration is NOT on the index, for anyone', () => {
+    withQueries(queriesFor({ ...GAME, organizer: true, mediator: true }))
     wrap()
 
-    // Renaming, inviting and role changes are the Organizer's, and hiding them
-    // is the courtesy half of a rule the server enforces regardless.
+    // These moved to /games/$gameId. An Organizer seeing them here would mean
+    // the split half-happened.
     expect(screen.queryByLabelText('Rename Union Crawler #430')).toBeNull()
     expect(screen.queryByText('Create invite code')).toBeNull()
     expect(screen.queryByText('Make Mediator')).toBeNull()
-  })
-
-  test('an Organizer gets rename, invites and role controls', () => {
-    withQueries(queriesFor({ ...GAME, organizer: true }))
-    wrap()
-
-    expect(screen.getByLabelText('Rename Union Crawler #430')).toBeTruthy()
-    expect(screen.getByText('Create invite code')).toBeTruthy()
-    expect(screen.getAllByText(/Make Mediator|Stand down/).length).toBeGreaterThan(0)
-  })
-
-  test('the Mediator link appears only for somebody who mediates', () => {
-    withQueries(queriesFor(GAME))
-    wrap()
     expect(screen.queryByText(/Open the Mediator surface/)).toBeNull()
-
-    withQueries(queriesFor({ ...GAME, mediator: true }))
-    wrap()
-    expect(screen.getAllByText(/Open the Mediator surface/).length).toBeGreaterThan(0)
   })
 
   test('offers a template to start from', () => {

--- a/apps/itun/src/components/games/__tests__/InvitePanel.connected.test.tsx
+++ b/apps/itun/src/components/games/__tests__/InvitePanel.connected.test.tsx
@@ -1,0 +1,232 @@
+import { afterAll, afterEach, describe, expect, mock, test } from 'bun:test'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+/**
+ * `InvitePanel` — mint, read back, revoke.
+ *
+ * The panel exists because the previous screen could only mint: it showed a
+ * code once and forgot it, so a leaked code could not be found again, let alone
+ * killed. So what is worth testing is what an Organizer can *see and do about*
+ * a code that already exists — its state, who spent it, and whether the Revoke
+ * button is offered when it would actually do something.
+ *
+ * Queries are answered in call order: `invites.list`, then
+ * `invites.pendingRequests`.
+ */
+
+let queryQueue: unknown[] = []
+let queryIndex = 0
+const calls: { name: string; args: unknown }[] = []
+
+const realConvexClient = { ...(await import('../../../lib/connection/convexClient')) }
+const realConvexReact = { ...(await import('convex/react')) }
+
+mock.module('../../../lib/connection/convexClient', () => ({
+  isConvexConfigured: true,
+  convexClient: {},
+}))
+
+mock.module('convex/react', () => ({
+  useQuery: () => {
+    const value = queryQueue[queryIndex]
+    queryIndex += 1
+    return value
+  },
+  // Every mutation records its call so the tests can assert what the panel
+  // asked the server to do, which is the half a render assertion cannot cover.
+  useMutation: () => async (args: unknown) => {
+    calls.push({ name: 'mutation', args })
+    return undefined
+  },
+  useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
+  ConvexReactClient: class {},
+  ConvexProvider: ({ children }: { children: unknown }) => children,
+  ConvexProviderWithAuth: ({ children }: { children: unknown }) => children,
+  useConvex: () => ({}),
+  useAction: () => async () => undefined,
+}))
+
+const { InvitePanel } = await import('../InvitePanel')
+
+const DAY = 1000 * 60 * 60 * 24
+
+function invite(over: Record<string, unknown> = {}) {
+  return {
+    _id: 'i1',
+    code: 'A1B2C3D4',
+    label: null,
+    role: 'player',
+    grantCount: 0,
+    requiresApproval: false,
+    expiresAt: Date.now() + 14 * DAY,
+    usesRemaining: null,
+    status: 'active',
+    redeemers: [],
+    ...over,
+  }
+}
+
+function renderPanel(invites: unknown[], requests: unknown[] = []) {
+  queryQueue = [invites, requests]
+  queryIndex = 0
+  calls.length = 0
+  return render(<InvitePanel gameId={'g1' as never} />)
+}
+
+afterEach(cleanup)
+
+describe('reading a code back', () => {
+  test('shows the code, its life left, and who spent it', () => {
+    renderPanel([invite({ label: 'for Sam', usesRemaining: 2, redeemers: ['Sam'] })])
+
+    expect(screen.getByText('A1B2C3D4')).toBeTruthy()
+    expect(screen.getByText(/for Sam/)).toBeTruthy()
+    expect(screen.getByText(/2 uses left/)).toBeTruthy()
+    expect(screen.getByText(/14 days left/)).toBeTruthy()
+    // The whole point of the redemption trail: a name, not a number.
+    expect(screen.getByText(/used by Sam/)).toBeTruthy()
+  })
+
+  test('an unlimited, never-expiring code says so rather than showing blanks', () => {
+    renderPanel([invite({ usesRemaining: null, expiresAt: null })])
+    expect(screen.getByText(/unlimited uses/)).toBeTruthy()
+    expect(screen.getByText(/no expiry/)).toBeTruthy()
+  })
+
+  test('a mediator invite and a gated invite are both legible at a glance', () => {
+    renderPanel([invite({ role: 'mediator', requiresApproval: true, grantCount: 2 })])
+    expect(screen.getByText(/Mediator seat/)).toBeTruthy()
+    expect(screen.getByText(/needs approval/)).toBeTruthy()
+    expect(screen.getByText(/2 handed over/)).toBeTruthy()
+  })
+
+  test('no codes yet says so', () => {
+    renderPanel([])
+    expect(screen.getByText(/No invite codes yet/i)).toBeTruthy()
+  })
+})
+
+describe('revoking', () => {
+  test('is offered for a live code and calls through', () => {
+    renderPanel([invite()])
+    const button = screen.getByText('Revoke')
+    fireEvent.click(button)
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.args).toMatchObject({ inviteId: 'i1' })
+  })
+
+  test('is not offered for a code that is already dead', () => {
+    // Revoking an expired or spent code does nothing, so offering the button
+    // would be a control that silently no-ops.
+    for (const status of ['revoked', 'expired', 'exhausted']) {
+      renderPanel([invite({ status })])
+      expect(screen.queryByText('Revoke')).toBeNull()
+      expect(screen.getByText(status)).toBeTruthy()
+      cleanup()
+    }
+  })
+
+  test('says plainly that revoking does not remove anyone', () => {
+    renderPanel([invite()])
+    expect(screen.getByText(/never removes anyone who has already joined/i)).toBeTruthy()
+  })
+})
+
+describe('minting', () => {
+  test('passes the note, seat and door through', () => {
+    renderPanel([])
+
+    fireEvent.change(screen.getByLabelText('Invite note'), { target: { value: '  for Sam  ' } })
+    fireEvent.change(screen.getByLabelText('Invite seat'), { target: { value: 'mediator' } })
+    fireEvent.click(screen.getByLabelText('Require approval'))
+    fireEvent.click(screen.getByText('Create invite code'))
+
+    expect(calls[0]?.args).toMatchObject({
+      gameId: 'g1',
+      label: 'for Sam',
+      role: 'mediator',
+      requiresApproval: true,
+    })
+  })
+
+  test('an empty note is omitted rather than sent as a blank string', () => {
+    renderPanel([])
+    fireEvent.click(screen.getByText('Create invite code'))
+
+    const args = calls[0]?.args as { label?: string } | undefined
+    expect(args).toBeDefined()
+    expect(args?.label).toBeUndefined()
+  })
+
+  test('the warning changes with the door being opened', () => {
+    renderPanel([])
+    expect(screen.getByText(/share it like a key/i)).toBeTruthy()
+
+    fireEvent.click(screen.getByLabelText('Require approval'))
+    expect(screen.getByText(/asks to join, and waits for you/i)).toBeTruthy()
+  })
+})
+
+describe('answering knocks', () => {
+  test('lists who is asking, and approving calls through', () => {
+    renderPanel(
+      [invite({ requiresApproval: true })],
+      [
+        {
+          _id: 'r1',
+          displayName: 'Knocker',
+          requestedAt: Date.now(),
+          inviteLabel: 'from Discord',
+          role: 'player',
+        },
+      ]
+    )
+
+    expect(screen.getByText(/Knocker/)).toBeTruthy()
+    fireEvent.click(screen.getByText('Approve'))
+    expect(calls[0]?.args).toMatchObject({ requestId: 'r1', approve: true })
+  })
+
+  test('declining is a separate, explicit act', () => {
+    renderPanel(
+      [invite({ requiresApproval: true })],
+      [
+        {
+          _id: 'r1',
+          displayName: 'Knocker',
+          requestedAt: Date.now(),
+          inviteLabel: null,
+          role: 'player',
+        },
+      ]
+    )
+    fireEvent.click(screen.getByText('Decline'))
+    expect(calls[0]?.args).toMatchObject({ requestId: 'r1', approve: false })
+  })
+
+  test('a knock for the Mediator seat is flagged, because it is a bigger yes', () => {
+    renderPanel(
+      [invite({ requiresApproval: true, role: 'mediator' })],
+      [
+        {
+          _id: 'r1',
+          displayName: 'Knocker',
+          requestedAt: Date.now(),
+          inviteLabel: null,
+          role: 'mediator',
+        },
+      ]
+    )
+    expect(screen.getByText('Mediator seat')).toBeTruthy()
+  })
+
+  test('no knocks means no section at all', () => {
+    renderPanel([invite()], [])
+    expect(screen.queryByText(/Asking to join/i)).toBeNull()
+  })
+})
+
+afterAll(() => {
+  mock.module('../../../lib/connection/convexClient', () => realConvexClient)
+  mock.module('convex/react', () => realConvexReact)
+})

--- a/apps/itun/src/components/games/__tests__/JoinScreen.connected.test.tsx
+++ b/apps/itun/src/components/games/__tests__/JoinScreen.connected.test.tsx
@@ -1,0 +1,223 @@
+import { afterAll, afterEach, describe, expect, mock, test } from 'bun:test'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+/**
+ * `/join/$code` — the link half of an invite.
+ *
+ * This is the one URL in the app a stranger can be handed, so the failure modes
+ * worth defending are about people who are not signed in and codes that are no
+ * longer any good:
+ *
+ *  - a dead code must say which kind of dead, and must NOT prompt a sign-in
+ *    (authenticating only to learn the code expired is the worst version of it)
+ *  - a signed-out visitor must still see what they were invited to
+ *  - a gated invite must say it is asking, not claim it joined
+ *
+ * Queries answer in call order; this screen asks only `invites.preview`.
+ */
+
+let previewValue: unknown
+let redeemResult: unknown = { kind: 'joined', gameId: 'g1', granted: 0 }
+let redeemError: Error | null = null
+// Flipped per-test: the signed-out path is the one a stranger following a link
+// actually hits, so it needs exercising rather than assuming.
+let isAuthenticated = true
+const navigations: unknown[] = []
+
+const realConvexClient = { ...(await import('../../../lib/connection/convexClient')) }
+const realConvexReact = { ...(await import('convex/react')) }
+const realAuthReact = { ...(await import('@convex-dev/auth/react')) }
+const realRouter = { ...(await import('@tanstack/react-router')) }
+
+mock.module('../../../lib/connection/convexClient', () => ({
+  isConvexConfigured: true,
+  convexClient: {},
+}))
+
+mock.module('convex/react', () => ({
+  useQuery: () => previewValue,
+  useMutation: () => async () => {
+    if (redeemError !== null) throw redeemError
+    return redeemResult
+  },
+  useConvexAuth: () => ({ isAuthenticated, isLoading: false }),
+  ConvexReactClient: class {},
+  ConvexProvider: ({ children }: { children: unknown }) => children,
+  ConvexProviderWithAuth: ({ children }: { children: unknown }) => children,
+  useConvex: () => ({}),
+  useAction: () => async () => undefined,
+}))
+
+mock.module('@convex-dev/auth/react', () => ({
+  useAuthActions: () => ({ signIn: async () => undefined, signOut: async () => undefined }),
+  ConvexAuthProvider: ({ children }: { children: unknown }) => children,
+}))
+
+mock.module('@tanstack/react-router', () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+  useNavigate: () => async (opts: unknown) => {
+    navigations.push(opts)
+  },
+  useRouter: () => undefined,
+}))
+
+const { JoinScreen } = await import('../JoinScreen')
+const { ConnectionProvider } = await import('../../../lib/connection/ConnectionProvider')
+
+function preview(over: Record<string, unknown> = {}) {
+  return {
+    gameName: 'Union Crawler #430',
+    invitedBy: 'Vex',
+    role: 'player',
+    requiresApproval: false,
+    grantCount: 0,
+    status: 'active',
+    ...over,
+  }
+}
+
+function renderJoin(value: unknown) {
+  previewValue = value
+  navigations.length = 0
+  redeemError = null
+  isAuthenticated = true
+  return render(
+    <ConnectionProvider>
+      <JoinScreen code="A1B2C3D4" />
+    </ConnectionProvider>
+  )
+}
+
+afterEach(cleanup)
+
+describe('a live invite', () => {
+  test('names the game and who invited you before asking for anything', () => {
+    renderJoin(preview())
+    expect(screen.getByText(/Vex/)).toBeTruthy()
+    expect(screen.getByText('Union Crawler #430')).toBeTruthy()
+    expect(screen.getByText('Join this game')).toBeTruthy()
+  })
+
+  test('a Mediator invite says which chair is on offer', () => {
+    renderJoin(preview({ role: 'mediator' }))
+    expect(screen.getByText(/as its Mediator/)).toBeTruthy()
+  })
+
+  test('a waiting character is mentioned, singular and plural', () => {
+    renderJoin(preview({ grantCount: 1 }))
+    expect(screen.getByText(/A character is waiting for you/)).toBeTruthy()
+    cleanup()
+
+    renderJoin(preview({ grantCount: 3 }))
+    expect(screen.getByText(/3 characters are waiting for you/)).toBeTruthy()
+  })
+
+  test('warns that a table reads each other’s sheets', () => {
+    renderJoin(preview())
+    expect(screen.getByText(/read each other/i)).toBeTruthy()
+  })
+
+  test('accepting routes into the game', async () => {
+    renderJoin(preview())
+    fireEvent.click(screen.getByText('Join this game'))
+    await waitFor(() => expect(navigations).toHaveLength(1))
+    expect(navigations[0]).toMatchObject({ params: { gameId: 'g1' } })
+  })
+
+  test('a refusal is surfaced in the server’s own words', async () => {
+    renderJoin(preview())
+    redeemError = new Error('That invite code has been revoked')
+    fireEvent.click(screen.getByText('Join this game'))
+    await waitFor(() => expect(screen.getByText(/has been revoked/)).toBeTruthy())
+  })
+})
+
+describe('a gated invite', () => {
+  test('offers to ask rather than to join', () => {
+    renderJoin(preview({ requiresApproval: true }))
+    expect(screen.getByText('Ask to join')).toBeTruthy()
+    expect(screen.getByText(/asks the organizer to let you in/i)).toBeTruthy()
+  })
+
+  test('after knocking it says it is waiting, and does not pretend to have joined', async () => {
+    renderJoin(preview({ requiresApproval: true }))
+    redeemResult = { kind: 'pending', gameId: 'g1' }
+    fireEvent.click(screen.getByText('Ask to join'))
+    await waitFor(() => expect(screen.getByText(/Asked to join/)).toBeTruthy())
+
+    expect(navigations).toHaveLength(0)
+    redeemResult = { kind: 'joined', gameId: 'g1', granted: 0 }
+  })
+})
+
+describe('a code that is no good', () => {
+  test('an unknown code says so and offers no sign-in', () => {
+    renderJoin(null)
+    expect(screen.getByText(/not valid/i)).toBeTruthy()
+    expect(screen.queryByText('Join this game')).toBeNull()
+  })
+
+  test('each kind of dead code says which kind it is', () => {
+    for (const [status, copy] of [
+      ['revoked', /has been revoked/i],
+      ['expired', /has expired/i],
+      ['exhausted', /already been used/i],
+    ] as const) {
+      renderJoin(preview({ status }))
+      expect(screen.getByText(copy)).toBeTruthy()
+      // Never a join button for a code that cannot be spent.
+      expect(screen.queryByText('Join this game')).toBeNull()
+      cleanup()
+    }
+  })
+
+  test('still checking is not the same as invalid', () => {
+    renderJoin(undefined)
+    expect(screen.getByText(/Checking that invite/i)).toBeTruthy()
+    expect(screen.queryByText(/not valid/i)).toBeNull()
+  })
+})
+
+describe('a visitor who is not signed in', () => {
+  test('still sees what they were invited to, then a way in', () => {
+    // The whole point of a link is that it means something before you have an
+    // account. Demanding a sign-in first would tell a stranger nothing.
+    renderJoin(preview())
+    isAuthenticated = false
+    cleanup()
+    previewValue = preview()
+    render(
+      <ConnectionProvider>
+        <JoinScreen code="A1B2C3D4" />
+      </ConnectionProvider>
+    )
+
+    expect(screen.getByText('Union Crawler #430')).toBeTruthy()
+    expect(screen.getByText(/Sign in to accept/i)).toBeTruthy()
+    // Not offered the button, because pressing it could not work yet.
+    expect(screen.queryByText('Join this game')).toBeNull()
+  })
+
+  test('a dead code is refused without ever prompting a sign-in', () => {
+    isAuthenticated = false
+    previewValue = preview({ status: 'expired' })
+    render(
+      <ConnectionProvider>
+        <JoinScreen code="A1B2C3D4" />
+      </ConnectionProvider>
+    )
+
+    expect(screen.getByText(/has expired/i)).toBeTruthy()
+    expect(screen.queryByText(/Sign in to accept/i)).toBeNull()
+    isAuthenticated = true
+  })
+})
+
+afterAll(() => {
+  mock.module('../../../lib/connection/convexClient', () => realConvexClient)
+  mock.module('convex/react', () => realConvexReact)
+  mock.module('@convex-dev/auth/react', () => realAuthReact)
+  mock.module('@tanstack/react-router', () => realRouter)
+})

--- a/apps/itun/src/components/games/__tests__/JoinScreen.test.tsx
+++ b/apps/itun/src/components/games/__tests__/JoinScreen.test.tsx
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { ConnectionProvider } from '../../../lib/connection/ConnectionProvider'
+import { isConvexConfigured } from '../../../lib/connection/convexClient'
+import { JoinScreen } from '../JoinScreen'
+
+/**
+ * The same structural guard the other Game surfaces carry: every Convex hook
+ * throws without a provider above it, and a Solo build deliberately has none.
+ *
+ * It matters more here than anywhere else. `/join/$code` is the one URL a
+ * stranger can be handed, so it is the most likely page in the app to be opened
+ * by someone whose build has no account service at all — and a white screen
+ * would look like the inviter sent a broken link.
+ */
+
+afterEach(cleanup)
+
+describe('JoinScreen in a Solo build', () => {
+  test('the test build really is Solo', () => {
+    expect(isConvexConfigured).toBe(false)
+  })
+
+  test('renders without a Convex provider present', () => {
+    render(
+      <ConnectionProvider>
+        <JoinScreen code="A1B2C3D4" />
+      </ConnectionProvider>
+    )
+    expect(screen.getByText('Join a game')).toBeTruthy()
+  })
+
+  test('says the build cannot accept invites rather than showing a dead button', () => {
+    render(
+      <ConnectionProvider>
+        <JoinScreen code="A1B2C3D4" />
+      </ConnectionProvider>
+    )
+    expect(screen.getByText(/no account service configured/i)).toBeTruthy()
+    expect(screen.queryByText(/Join this game/i)).toBeNull()
+  })
+})

--- a/apps/itun/src/routeTree.gen.ts
+++ b/apps/itun/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as CrawlersIdRouteImport } from './routes/crawlers/$id'
 import { Route as CrawlersNewRouteImport } from './routes/crawlers/new'
 import { Route as DashboardIdRouteImport } from './routes/dashboard/$id'
 import { Route as GamesGameIdRouteImport } from './routes/games_.$gameId'
+import { Route as JoinCodeRouteImport } from './routes/join/$code'
 import { Route as MechsIdRouteImport } from './routes/mechs/$id'
 import { Route as MechsNewRouteImport } from './routes/mechs/new'
 import { Route as MediatorGameIdRouteImport } from './routes/mediator/$gameId'
@@ -79,6 +80,11 @@ const GamesGameIdRoute = GamesGameIdRouteImport.update({
   path: '/games/$gameId',
   getParentRoute: () => rootRouteImport,
 } as any)
+const JoinCodeRoute = JoinCodeRouteImport.update({
+  id: '/join/$code',
+  path: '/join/$code',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MechsIdRoute = MechsIdRouteImport.update({
   id: '/mechs/$id',
   path: '/mechs/$id',
@@ -136,6 +142,7 @@ export interface FileRoutesByFullPath {
   '/crawlers/new': typeof CrawlersNewRoute
   '/dashboard/$id': typeof DashboardIdRoute
   '/games/$gameId': typeof GamesGameIdRoute
+  '/join/$code': typeof JoinCodeRoute
   '/mechs/$id': typeof MechsIdRoute
   '/mechs/new': typeof MechsNewRoute
   '/mediator/$gameId': typeof MediatorGameIdRoute
@@ -157,6 +164,7 @@ export interface FileRoutesByTo {
   '/crawlers/new': typeof CrawlersNewRoute
   '/dashboard/$id': typeof DashboardIdRoute
   '/games/$gameId': typeof GamesGameIdRoute
+  '/join/$code': typeof JoinCodeRoute
   '/mechs/$id': typeof MechsIdRoute
   '/mechs/new': typeof MechsNewRoute
   '/mediator/$gameId': typeof MediatorGameIdRoute
@@ -179,6 +187,7 @@ export interface FileRoutesById {
   '/crawlers/new': typeof CrawlersNewRoute
   '/dashboard/$id': typeof DashboardIdRoute
   '/games_/$gameId': typeof GamesGameIdRoute
+  '/join/$code': typeof JoinCodeRoute
   '/mechs/$id': typeof MechsIdRoute
   '/mechs/new': typeof MechsNewRoute
   '/mediator/$gameId': typeof MediatorGameIdRoute
@@ -202,6 +211,7 @@ export interface FileRouteTypes {
     | '/crawlers/new'
     | '/dashboard/$id'
     | '/games/$gameId'
+    | '/join/$code'
     | '/mechs/$id'
     | '/mechs/new'
     | '/mediator/$gameId'
@@ -223,6 +233,7 @@ export interface FileRouteTypes {
     | '/crawlers/new'
     | '/dashboard/$id'
     | '/games/$gameId'
+    | '/join/$code'
     | '/mechs/$id'
     | '/mechs/new'
     | '/mediator/$gameId'
@@ -244,6 +255,7 @@ export interface FileRouteTypes {
     | '/crawlers/new'
     | '/dashboard/$id'
     | '/games_/$gameId'
+    | '/join/$code'
     | '/mechs/$id'
     | '/mechs/new'
     | '/mediator/$gameId'
@@ -266,6 +278,7 @@ export interface RootRouteChildren {
   CrawlersNewRoute: typeof CrawlersNewRoute
   DashboardIdRoute: typeof DashboardIdRoute
   GamesGameIdRoute: typeof GamesGameIdRoute
+  JoinCodeRoute: typeof JoinCodeRoute
   MechsIdRoute: typeof MechsIdRoute
   MechsNewRoute: typeof MechsNewRoute
   MediatorGameIdRoute: typeof MediatorGameIdRoute
@@ -349,6 +362,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof GamesGameIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/join/$code': {
+      id: '/join/$code'
+      path: '/join/$code'
+      fullPath: '/join/$code'
+      preLoaderRoute: typeof JoinCodeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/mechs/$id': {
       id: '/mechs/$id'
       path: '/mechs/$id'
@@ -426,6 +446,7 @@ const rootRouteChildren: RootRouteChildren = {
   CrawlersNewRoute: CrawlersNewRoute,
   DashboardIdRoute: DashboardIdRoute,
   GamesGameIdRoute: GamesGameIdRoute,
+  JoinCodeRoute: JoinCodeRoute,
   MechsIdRoute: MechsIdRoute,
   MechsNewRoute: MechsNewRoute,
   MediatorGameIdRoute: MediatorGameIdRoute,

--- a/apps/itun/src/routes/join/$code.tsx
+++ b/apps/itun/src/routes/join/$code.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute, useParams } from '@tanstack/react-router'
+
+import { JoinScreen } from '../../components/games/JoinScreen'
+
+export const Route = createFileRoute('/join/$code')({
+  component: JoinRoute,
+})
+
+function JoinRoute() {
+  const { code } = useParams({ from: '/join/$code' })
+  return <JoinScreen code={code} />
+}

--- a/docs/adrs/ADR-030-accounts-games-server-of-record.md
+++ b/docs/adrs/ADR-030-accounts-games-server-of-record.md
@@ -212,6 +212,45 @@ editing surface, so opening a crewmate's would hand over an editor whose writes
 the server refuses. The read-only drill-in §5 permits is a separate surface and
 is not built — the crew vitals strip carries that information for now.
 
+## Amendment — an invite carries what the Organizer decided
+
+§2 describes an invite code as sufficient to join, and §3 leaves the seat and
+the hand-out as separate acts performed after the fact. Both are amended in one
+direction: **an invite now expresses a decision the Organizer has already made.**
+
+**An invite may be minted as a request.** With approval required, the code
+identifies the Game and grants nothing until the Organizer lets the knocker in.
+This adds no role and no membership state — a pending request is _not_ a
+membership, and an approved one produces exactly the membership a direct redeem
+would, through the same code path. Bearer codes remain the default; this is a
+per-invite choice, not a mode.
+
+The reason is §5. Membership confers read access to every crewmate's sheet, so
+a code posted somewhere public is a broader disclosure than the Organizer
+intended. Approval is the Organizer exercising the membership authority §3
+already gives them, one step later.
+
+**An invite may also carry a seat and a hand-out** — a `role` of Player or
+Mediator, and a list of unclaimed entities handed over on join.
+
+This sits alongside the self-claim amendment above rather than against it. That
+amendment made an unclaimed entity an **offer to the crew**, which anyone may
+accept; `assign` survived it as the table runner's power to place an entity with
+a _particular_ person. An invite grant is exactly that power, scheduled: the
+Organizer names the recipient in advance, and the Change Log records **them** as
+`actorId` rather than whoever walked through the door. Both routes to ownership
+respect the same boundary — neither can touch an entity somebody already holds.
+A grant whose entity has since been claimed, moved, or deleted is **skipped, and
+the join still succeeds**: arriving without the promised pilot is a notice,
+whereas failing the join over a stale pointer would strand someone outside a
+Game they were genuinely invited to.
+
+Revocation becomes a **soft delete**, so an invite's redemption history stays
+resolvable, and it never evicts anyone already seated: closing a door is not the
+same act as removing someone from the room.
+
+Enforced in `convex/invites.ts` (`seat`, `assertSpendable`, `decideRequest`).
+
 ## Amendment to ADR-022
 
 ADR-022 states the Change Log is **local only** and never travels with a

--- a/docs/design/game-invites-and-membership-plan.md
+++ b/docs/design/game-invites-and-membership-plan.md
@@ -1,0 +1,551 @@
+# Game invites & membership — design plan
+
+**Status: BUILT.** This began as a proposal and is kept as the reasoning behind
+what shipped — the "what exists today" in §1 describes the state this replaced,
+not the current one. The §9 amendment has been **applied** to
+[ADR-030](../adrs/ADR-030-accounts-games-server-of-record.md); read the ADR, not
+§9, for the governing text.
+
+Governed by [ADR-030](../adrs/ADR-030-accounts-games-server-of-record.md)
+(accounts, Games, server of record) and
+[ADR-021](../adrs/ADR-021-itun-surface-taxonomy.md) (surface/mode taxonomy).
+
+| Shipped                                                              | Where                                                                            |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Game as a fourth `EntityRow` ontology, blue tone, multi-badge `meta` | `packages/component-lib/src/components/shared/EntityRow.tsx`, `styles/theme.css` |
+| `/games` index + `/games/$gameId` + `/join/$code`                    | `apps/itun/src/routes/games/`, `routes/join/`                                    |
+| Manageable invites — list, soft revoke, labels, redemption audit     | `apps/itun/convex/invites.ts`, `components/games/InvitePanel.tsx`                |
+| Invites carrying a seat and a hand-out                               | `invites.ts` (`seat`)                                                            |
+| Knock-and-approve                                                    | `invites.ts` (`joinRequests`), `InvitePanel.tsx`                                 |
+
+---
+
+## 1. What exists today
+
+The whole invite scheme is `apps/itun/convex/invites.ts`: three mutations,
+sixty lines, plus one panel in `GamesScreen.tsx`.
+
+| Piece            | Today                                                                                                                                                                 |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `invites.create` | Organizer-only. Mints an 8-char Crockford base32 code (~40 bits, `crypto.getRandomValues`), 14-day default expiry, `usesRemaining` optional and **unset by default**. |
+| `invites.redeem` | Any signed-in user. Validates expiry + uses, inserts a `memberships` row with `mediator: false, organizer: false`. Re-redeeming is an idempotent no-op.               |
+| `invites.revoke` | Organizer-only. **Hard-deletes** the row.                                                                                                                             |
+| `invites` table  | `gameId, code, createdBy, expiresAt?, usesRemaining?` + `by_code` / `by_game` indexes.                                                                                |
+| UI               | `InvitePanel` — one "Create invite code" button that renders the returned code and a fixed "Valid for 14 days" caption. `redeem` is a text input on the Games index.  |
+
+### The gaps, in order of how much they hurt
+
+1. **`revoke` has no caller.** It is implemented and covered by
+   `convex/__tests__/` but nothing in the app invokes it. There is no
+   `invites.list`, so the organizer cannot see a code again after navigating
+   away, cannot see uses remaining or time left, and cannot kill one. A minted
+   code is effectively immortal for 14 days.
+
+2. **A code is a bearer token to a read-everything seat.** ADR-030 §5 gives
+   every member live vitals for the whole crew and read-only drill-down into
+   any crewmate's full sheet. The default invite is unlimited-use for 14 days,
+   and nothing records who redeemed which code — so a code pasted into the
+   wrong Discord channel is both undetectable and unstoppable.
+
+3. **The code cannot travel as a link.** There is no `/join/$code` route, so
+   the code must be re-typed by hand after sign-in. Reading it aloud at a table
+   is a real and well-served use case; it is currently the _only_ one.
+
+4. **Every joiner lands as a bare Player owning nothing.** Seating a Mediator
+   is a second manual step on the crew list. `templates.ts` deliberately
+   creates the six Starter Set pilots and mechs **unclaimed** (`ownerId: null`)
+   for hand-out, so the common path is: send code → they join → find them in
+   the crew list → assign a pilot → assign its mech. Four steps for a thing the
+   organizer already decided when they minted the code.
+
+5. **Discord is wired up and unused for this.** `convex/bot.ts` already has
+   `bindChannel` / `gameForChannel` / `linkDiscordId`; a bound channel already
+   knows which Game it is. Nothing connects that to membership.
+
+**Not a gap:** the code itself. 40 bits against an online-only oracle is fine,
+the alphabet excludes I/L/O/U so a code read aloud cannot be mistyped into a
+different valid one, and `b % 32` over `Uint8Array` has no modulo bias (32
+divides 256). Keep the generator exactly as it is.
+
+---
+
+## 2. Constraints this design must respect
+
+- **ADR-030 §3** — roles are `Player | Mediator` with `Organizer` as an
+  orthogonal flag. Membership administration is the Organizer's; content
+  authority is not.
+- **ADR-030 §4** — ownership is **assigned, never self-claimed**. An invite
+  that hands over a pilot must be the _organizer's_ assignment executed later,
+  not the joiner claiming something.
+- **ADR-030 §4** — the `ownership.assign` path writes a Change Log entry
+  (`source: 'ownership'`, `field: 'ownerId'`). Invite-driven assignment must
+  produce the same entry, with `actorId` = the inviter, not the joiner.
+- **ADR-030 §1** — **Solo must keep working forever.** Every new surface needs
+  a defined signed-out and `isConvexConfigured === false` behaviour.
+- **ADR-030 §Consequences** — Convex stores entity bodies opaquely; anything
+  touching an entity body Zod-parses first. (Only §5's assignment path touches
+  entities at all, and it patches `ownerId`, not a body.)
+- **ADR-004 is untouched.** Snapshots remain the account-free way to hand
+  someone a build. Nothing here changes them.
+- **ADR-021** — the Games surfaces stay administrative. No play action, no
+  rules enforcement, moves here.
+
+---
+
+## 3. Data model
+
+### 3.1 `invites` — revised
+
+```ts
+invites: defineTable({
+  gameId: v.id('games'),
+  code: v.string(),
+  createdBy: v.id('users'),
+  createdAt: v.number(),
+
+  /** Free-text organizer note, e.g. "for Sam". Never shown to the redeemer. */
+  label: v.optional(v.string()),
+
+  /** The seat this invite grants. Defaults to 'player'. */
+  role: v.union(v.literal('player'), v.literal('mediator')),
+
+  /** Entities handed to the redeemer on join (Tier 2). */
+  grants: v.optional(v.array(v.object({ table: ownableTable, entityId: v.string() }))),
+
+  /** Tier 3: the code identifies the Game but grants nothing until approved. */
+  requiresApproval: v.boolean(),
+
+  expiresAt: v.optional(v.number()),
+  usesRemaining: v.optional(v.number()),
+
+  /** Soft revoke — the row survives so redemption history stays readable. */
+  revokedAt: v.optional(v.number()),
+})
+  .index('by_code', ['code'])
+  .index('by_game', ['gameId'])
+```
+
+Three notes on the shape:
+
+- **Soft revoke, not delete.** Today `revoke` hard-deletes, which would orphan
+  the redemption rows below and make "who joined via which code" unanswerable
+  the moment an organizer tidies up. Games are small; keep the row.
+- **`grants` is a list, not a single pilot.** The Starter Set case is a pilot
+  _and_ its mech; a one-entity field would need a second mechanism a week
+  later. `ownableTable` is the existing validator from `convex/ownership.ts`.
+- **`role` is stored, not derived.** A mediator invite is the organizer
+  pre-exercising the same authority `games.setMediator` already gives them.
+
+### 3.2 `inviteRedemptions` — new
+
+```ts
+inviteRedemptions: defineTable({
+  inviteId: v.id('invites'),
+  gameId: v.id('games'),
+  userId: v.id('users'),
+  redeemedAt: v.number(),
+})
+  .index('by_invite', ['inviteId'])
+  .index('by_game', ['gameId'])
+```
+
+The audit trail gap 2 is missing. Cheap, append-only, and it is what makes the
+management panel able to say "used by Sam, 3 days ago" instead of "2 uses left".
+
+### 3.3 `joinRequests` — new (Tier 3)
+
+```ts
+joinRequests: defineTable({
+  gameId: v.id('games'),
+  inviteId: v.id('invites'),
+  userId: v.id('users'),
+  requestedAt: v.number(),
+  state: v.union(v.literal('pending'), v.literal('approved'), v.literal('declined')),
+  decidedBy: v.optional(v.id('users')),
+  decidedAt: v.optional(v.number()),
+})
+  .index('by_game_state', ['gameId', 'state'])
+  .index('by_user', ['userId'])
+```
+
+A pending request is **not** a membership: no `memberships` row exists until
+approval, so a knocker sees nothing of the Game. Approving runs exactly the
+same seat-granting code path as a direct redeem (§4.3) — one implementation, so
+role and grants behave identically whichever door was used.
+
+---
+
+## 4. Server API
+
+### 4.1 Mutations & queries
+
+| Name                  | Who           | Notes                                                                                                                                                 |
+| --------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `invites.create`      | Organizer     | Args gain `label?`, `role?`, `grants?`, `requiresApproval?`. Existing args keep their meaning and defaults, so the current call site keeps compiling. |
+| `invites.list`        | Organizer     | Every invite for a Game with derived `status` and resolved redeemer display names.                                                                    |
+| `invites.revoke`      | Organizer     | Patches `revokedAt` instead of deleting.                                                                                                              |
+| `invites.preview`     | Any signed-in | Read-only look at a code — see §4.2.                                                                                                                  |
+| `invites.redeem`      | Any signed-in | Returns a discriminated result — see §4.3.                                                                                                            |
+| `joinRequests.list`   | Organizer     | Pending knocks for a Game.                                                                                                                            |
+| `joinRequests.decide` | Organizer     | `{ requestId, approve }`. Approval seats them via the shared path.                                                                                    |
+| `games.get`           | Member        | Missing today; `/games/$gameId` needs it (§5.1).                                                                                                      |
+| `games.listMine`      | Any signed-in | `summarize()` gains the crawler name and the pilot / mech counts the row badges show (§6.1).                                                          |
+
+`invites.list` returns a **derived** status rather than storing one, so there is
+no state to drift out of sync with the clock:
+
+```
+revoked        revokedAt is set
+expired        expiresAt < now
+exhausted      usesRemaining === 0
+active         otherwise
+```
+
+### 4.2 `invites.preview` — the landing-page oracle
+
+`/join/$code` must be able to say _"Vex invited you to Union Crawler #430 as
+Mediator"_ before the visitor commits, and must be able to say it to someone
+who has not signed in yet.
+
+It returns **only** what the invite itself already tells the bearer:
+
+```ts
+{
+  ;(gameName, invitedBy, role, requiresApproval, status)
+}
+```
+
+Never the member list, never the crew, never entity names — a valid code is not
+yet a seat, and §5 visibility begins at membership. `grants` is reported as a
+boolean ("a pilot is waiting for you"), not as entity identity.
+
+It requires a syntactically valid code and returns a uniform "not valid" for
+every failure mode, so it is not an enumeration oracle beyond what `redeem`
+already is.
+
+### 4.3 Redemption
+
+`redeem` becomes a discriminated union rather than a bare `Id<'games'>`:
+
+```ts
+| { kind: 'joined';   gameId: Id<'games'>; granted: number }
+| { kind: 'pending';  gameId: Id<'games'> }     // knocked, awaiting approval
+| { kind: 'already';  gameId: Id<'games'> }     // idempotent re-redeem
+```
+
+The seat-granting path, shared by `redeem` and `joinRequests.decide`:
+
+1. Validate: exists, not revoked, not expired, uses remaining.
+2. If already a member → `already`, no use consumed. (Today's behaviour, kept.)
+3. If `requiresApproval` and no membership → insert/return a `joinRequests` row
+   → `pending`. **No use is consumed at knock time**; a use is consumed on
+   approval, so a spam of knocks cannot burn a code.
+4. Insert `memberships` with `mediator: role === 'mediator'`, `organizer: false`.
+5. For each `grants` entry: re-check the entity is still in this Game and still
+   `ownerId === null`. If so, assign it — reusing `ownership.assign`'s logic
+   with `actorId` = `invite.createdBy`, so the Change Log records that the
+   **organizer** made the assignment. If it has since been claimed, **skip it
+   and still join** — a stale grant is a notice, never a failed join.
+6. Insert `inviteRedemptions`, decrement `usesRemaining`.
+
+### 4.4 Guards worth stating
+
+- **Mediator invites default to single-use.** ADR-030 §3 permits several
+  Mediators in the schema but the UI is built for one; an unlimited-use
+  mediator code is a foot-gun. `role: 'mediator'` without an explicit
+  `usesRemaining` gets `1`.
+- **Grants imply single-use.** Two people cannot both receive the same pilot;
+  the second would silently get nothing (step 5). If `grants` is non-empty and
+  `usesRemaining` is unset, it gets `1`.
+- **Revoking does not evict.** Someone already seated stays seated; removing a
+  member is `ownership.leaveGame` / a future kick, not invite revocation. The
+  panel should say so.
+
+---
+
+## 5. Routes
+
+### 5.1 `/games/$gameId` as a first-class route
+
+Today `routes/games.tsx` is a single leaf rendering everything: create,
+templates, join-by-code, and — per Game — the crew list, invite panel, proposal
+inbox, and Downtime panel, all stacked in one column. It does not scale past
+two Games and there is nothing to link to or bookmark.
+
+Split into a directory (deleting `routes/games.tsx`;
+`routeTree.gen.ts` regenerates and is never hand-edited):
+
+```
+routes/games/index.tsx     →  /games          the shelf of Games
+routes/games/$gameId.tsx   →  /games/$gameId  one Game
+routes/join/$code.tsx      →  /join/$code     invite landing (§5.2)
+```
+
+| Surface          | Holds                                                                                                                                                       |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/games`         | Start a game · start from template · join with a code · a list of **Game rows** (§6). Nothing per-Game beyond the row.                                      |
+| `/games/$gameId` | Crew list with role controls, invite management (list/mint/revoke), pending join requests, `ProposalInbox`, `DowntimePanel`, and the Mediator-surface link. |
+
+`/mediator/$gameId` stays where it is — it is a different surface with a
+different mode under ADR-021, not a tab of this one.
+
+**Mode behaviour**, in all three routes: `connected` renders; `disconnected`
+renders the existing "unreachable right now" card; Solo renders the sign-in
+explainer; `isConvexConfigured === false` renders the "no account service"
+card. `/games/$gameId` additionally needs a **not-a-member** state — a
+bookmarked URL for a Game you left must not 500, it must say you are not in
+that Game and offer `/games`.
+
+### 5.2 `/join/$code`
+
+The link half of gap 3. Signed-out is the **expected** state here, not an edge
+case:
+
+1. Land → `invites.preview(code)` → render the Game name, who invited you, the
+   seat offered, and whether it needs approval.
+2. If invalid/expired/revoked → say which, and offer `/games`. No sign-in
+   prompt for a dead code.
+3. Signed out → sign-in control. The code must survive the Discord OAuth
+   round-trip; carry it in the return URL rather than `sessionStorage`, so a
+   different-browser paste still works.
+4. Signed in → "Join" → `redeem` → route on the result: `joined` / `already` →
+   `/games/$gameId`; `pending` → a "waiting for the organizer" state on this
+   page.
+5. Solo build with no Convex → the honest "this build has no account service"
+   card. A `/join` link in a CI or self-hosted build must not look broken.
+
+Typing a code on `/games` keeps working unchanged. The link is an addition, not
+a replacement — a table reading a code aloud is still the primary case.
+
+---
+
+## 6. The Game row
+
+A Game renders as an **`EntityRow`** — the same compact listing primitive the
+Roster uses for pilots, mechs, and crawlers. `/games` becomes a list of Game
+rows, and a Game reads as a peer of the other things you own rather than as a
+bespoke panel.
+
+That means **Game becomes a fourth ontology in `component-lib`**, not an
+app-local composition. `EntityRow` is keyed off `entityType` throughout, so this
+is a four-point change in the package — three of which the compiler forces the
+moment the union grows, because they are **total `Record`s**:
+
+| Site                                    | Change                                                                                                                                                                                                                                           |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `EntityRowType`                         | `'pilot' \| 'mech' \| 'crawler'` → `+ 'game'`                                                                                                                                                                                                    |
+| `TONE: Record<EntityRowType, …>`        | A `game` entry — `rail` (6px deep accent) + `wash` (faint tint).                                                                                                                                                                                 |
+| `EMPTY_GLYPH: Record<EntityRowType, …>` | A `game` glyph. `Users` is the natural lucide pick beside `UserRound` / `Bot` / `Warehouse`.                                                                                                                                                     |
+| `BadgeTone` + `BADGE_TONES`             | Forced, because the row carries badges (below) — `meta` renders `<Badge surface="tone" tone={entityType}>`, and `BadgeTone` is its own union (`pilot \| mech \| crawler \| ok \| warn \| bad`) that does not currently accept a fourth ontology. |
+| `meta` **arity**                        | `ReactNode` → `ReactNode \| ReactNode[]`. See §6.1 — the Game row needs three badges and the prop renders exactly one.                                                                                                                           |
+
+The call shape on `/games`, mirroring `Roster.tsx`:
+
+| `EntityRow` prop | Game content                                                                                                                                                                                                                                                                                                                                     |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `entityType`     | `'game'`                                                                                                                                                                                                                                                                                                                                         |
+| `name`           | Game name — the black stamp name tab.                                                                                                                                                                                                                                                                                                            |
+| `sheetHref`      | `/games/${id}`                                                                                                                                                                                                                                                                                                                                   |
+| `linkAs`         | `AppLink` — the same router/anchor-degrading link the Roster passes.                                                                                                                                                                                                                                                                             |
+| `meta`           | **Three badges: the crawler's name, the pilot count, the mech count.** See §6.1.                                                                                                                                                                                                                                                                 |
+| `metaLine`       | Your role (`Mediator` / `Player`) · organizer name · template origin, joined with the Roster's `' · '` helper.                                                                                                                                                                                                                                   |
+| `stats`          | Omitted. The counts moved into the badges, and crew count is better said as "4 pilots" than as a second numeric readout.                                                                                                                                                                                                                         |
+| `onDeleteClick`  | **Omitted for non-organizers.** For an organizer it maps to `games.destroy`, which deletes a shared campaign for everyone — so it needs a heavier confirm than the Roster's, naming the Game and its crew count. Recommendation: omit it here entirely and keep destroy on `/games/$gameId`, where there is room to say what is being destroyed. |
+
+### 6.1 The badges, and what they cost
+
+The row carries **crawler name · _n_ pilots · _n_ mechs** as badges. Two
+consequences, one in the component and one on the server.
+
+**`meta` renders exactly one badge.** It is typed `ReactNode` and wrapped in a
+single `<Badge surface="tone">`, so passing three nodes would nest badges inside
+a badge. The minimal fix is to widen it to `ReactNode | ReactNode[]` and map an
+array to one toned Badge per entry — additive, and every existing call site
+passes a single node, so nothing else changes. (`Roster.tsx` passes no `meta` at
+all today; it uses `metaLine`.)
+
+**`games.listMine` does not return any of this.** Its `summarize()` returns
+`{ _id, name, templateOrigin, mediator, organizer, memberCount }`. All three new
+values need adding:
+
+- **Pilot / mech counts** — both tables have a `by_game` index, so this is a
+  scoped query per table. But **Convex has no count API**: counting means
+  `.collect()`ing the rows and taking `.length`, and `listMine` already loops
+  over every Game you belong to. Three extra collects per Game is fine at a
+  table's scale and worth stating rather than discovering — if it ever bites,
+  the fix is a denormalized counter on `games`, not a cleverer query.
+- **Crawler name** — `crawlers.gameId` is non-nullable (`v.id('games')`, unlike
+  pilots and mechs), so the communal crawler is always reachable by `by_game`.
+  Its name lives in the **opaque `body`**, which ADR-030 says Convex cannot
+  validate. Read it defensively, exactly as `crew.vitals` already does:
+  `((c.body as Record<string, unknown> | null)?.name as string) ?? 'Crawler'`.
+  That is an established pattern in this codebase, not a new liberty.
+
+**One flag, then I'll build it as asked.** `EntityRow`'s own docstring cites the
+"stats-render-through-`Stat` law (ruleset §3)" for `label | value` content, and
+a pilot count is exactly that shape. Rendering counts as badges is a deliberate
+departure from it. I think it is the right call here — "4 PILOTS" reads as a
+chip describing the Game, not as a stat readout of it, and three badges scan as
+one row of facts where a badge-plus-two-Stats would look like two different
+kinds of information. Worth a reviewer's eye, not a blocker.
+
+The **empty variant** gets a real use: `/games` currently renders a plain
+`Text` hint when you are in no Games. An empty `EntityRow` with a `GAME` role
+tab, the existing copy as its `message`, and create/join as its `actions` is
+both more consistent and less code.
+
+### 6.2 Tone — blue (decided)
+
+Games are **blue**. That settles Q1, and it separates Game cleanly from pilot
+orange, mech green, and crawler pink — which matters here because in
+`EntityRow` the rail tone **is** the ontology signal, not decoration. (An
+earlier draft of this plan proposed reusing the crawler tone; that was premised
+on a `Card` composition where tone is decorative, and it would have made a Game
+row and a crawler row indistinguishable.)
+
+The palette already carries the base, annotated for exactly this:
+
+```css
+--color-wk-accent: rgb(125, 206, 235); /* #7dceeb — game-state accent (was su-blue-game) */
+```
+
+Proposed pair, following the existing sheet-tone block's structure:
+
+```css
+--color-sheet-game: var(--color-wk-accent); /* #7dceeb */
+--color-sheet-game-deep: rgb(30, 83, 100); /* #1e5364 */
+```
+
+The deep is a **literal, not an alias**. The palette's blue ramp
+(`--color-tl-1` … `--color-tl-6`) has a perfect match at `--color-tl-5`
+(`#1e5364`), but that ramp means _tech level_ in this app — aliasing it would
+tie the Game ontology to tech-level semantics, the same category error as
+borrowing crawler pink. Take the value, not the token. (`--color-sheet-mech-deep`
+and `--color-sheet-crawler-deep` are both literals too; only pilot aliases, to
+`--color-rust`.)
+
+**#1e5364 is a checked value, not a guess.** `tone.rail` is not only the 6px
+accent bar — `EntityRow`'s empty variant also uses it as **text colour** on the
+wash, so it carries a real contrast obligation. Measured against the Game wash
+(`color-mix(#7dceeb 10–12%, paper)`):
+
+| Candidate                | Contrast on wash | Verdict                                  |
+| ------------------------ | ---------------- | ---------------------------------------- |
+| `--color-tl-4` (#306b80) | 5.4:1            | Passes AA, but the weakest of the four.  |
+| **#1e5364**              | **7.7:1**        | **Sits right between mech and crawler.** |
+| `--color-tl-6` (#063441) | 12.1:1           | Passes, but far darker than the family.  |
+
+For reference, the three existing pairs score 4.8:1 (pilot), 9.1:1 (mech), and
+7.5:1 (crawler) by the same measure — so #1e5364 lands mid-family and clears AA
+for normal text with room to spare.
+
+**Story + guard obligations.** `EntityRow` already has a co-located story, so
+this adds a variant to `EntityRow.stories.tsx` rather than a new file — the
+story-coverage guard wants one story file per public component, and a second
+one would collide on title. The story must render with real data per the
+package's rules.
+
+---
+
+## 7. Security model, stated plainly
+
+Two doors, and the organizer chooses per invite:
+
+| Door                                   | Who should use it                                                                                                                              |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Bearer** (`requiresApproval: false`) | A code read aloud at a table, or DM'd to a person you know. Fast, and the code _is_ the authority.                                             |
+| **Knock** (`requiresApproval: true`)   | Anything posted where more than the intended people can read it — a Discord channel, a forum. The link identifies the Game and grants nothing. |
+
+What this design does **not** do:
+
+- **No rate limiting on `redeem`/`preview`.** 40 bits against an online oracle
+  needs ~10¹² attempts; a limiter would be theatre against that and real
+  friction for a table mistyping a code. Revisit if Convex usage shows abuse.
+- **No shortening or prettifying the code.** The read-aloud property is worth
+  more than the aesthetics.
+- **No email invites.** ADR-030 §1: Discord is the only identity provider.
+
+---
+
+## 8. Build order
+
+Five PRs, each independently shippable and reviewable. Each ends green on
+`bun run check:all`.
+
+| #   | Slice                                                                                                                                                                                                                                                    | Depends on |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| 1   | **Route split + `games.get`.** `/games/index` + `/games/$gameId`, not-a-member state, panels moved to the detail route. Pure re-org, no invite change.                                                                                                   | —          |
+| 2   | **Game as an `EntityRow` ontology.** The `component-lib` union + tone + glyph + `BadgeTone`, `meta` widened to an array, the blue `--color-sheet-game` pair, the badge trio, the `summarize()` fields behind them, the `/games` list, the empty variant. | 1          |
+| 3   | **Tier 1 — manage invites.** Schema (`label`, `createdAt`, `revokedAt`, `inviteRedemptions`), `invites.list`, soft revoke, the management panel.                                                                                                         | 1          |
+| 4   | **Tier 2 + `/join/$code`.** `role`, `grants`, `preview`, the discriminated `redeem`, the landing route.                                                                                                                                                  | 3          |
+| 5   | **Tier 3 — knock & approve.** `joinRequests`, `requiresApproval`, the organizer's pending list, the ADR-030 amendment (§9).                                                                                                                              | 4          |
+
+**Test plan per slice** — the Convex modules already have a `__tests__/`
+harness (`convex/__tests__/harness.ts`), and `invites` is covered there today:
+
+- 1: route-level tests for each of the four modes + not-a-member.
+- 2: filled + empty `game` row render tests in `component-lib`; **a test that
+  `meta` still renders one badge when given a single node** (the array widening
+  must not regress existing callers); a `game` variant added to the existing
+  `EntityRow.stories.tsx` (not a new story file — the coverage guard is one
+  story per component); a `summarize()` test covering a Game with no crawler and
+  with zero pilots/mechs, so the badges degrade rather than render `undefined`;
+  an ITUN test that `/games` lists a row per Game and links to
+  `/games/$gameId`. Because PR 2 touches a shared package, re-check both
+  consuming apps per the cross-package rule.
+- 3: derived-status matrix (active/expired/exhausted/revoked); revoke keeps the
+  row; non-organizer is denied `list` and `revoke`.
+- 4: mediator role lands as `mediator: true`; grants assign and write a Change
+  Log entry with `actorId` = inviter; **a stale grant still joins**; re-redeem
+  stays idempotent and consumes no use; `preview` leaks nothing beyond §4.2.
+- 5: knock creates no membership; approval seats with the invite's role and
+  grants; knock consumes no use, approval does; decline is terminal.
+
+---
+
+## 9. Draft ADR-030 amendment (Tier 3 only)
+
+Tiers 1, 2, and the route work are all _within_ ADR-030 as written — they
+implement §3's Organizer authority and §4's assigned ownership rather than
+changing them. **Tier 3 changes a stated invariant** and needs the ADR amended
+before it is built. Proposed text, for review as part of PR 5:
+
+> **Amendment — joining may be gated.**
+>
+> §2 describes an invite code as sufficient to join. An invite may now instead
+> be minted as a **request**: the code identifies the Game and grants nothing
+> until the Organizer approves it. This does not add a role or a membership
+> state — a pending request is not a membership, and an approved one produces
+> exactly the membership a direct redeem would.
+>
+> The reason is §5: membership confers read access to every crewmate's sheet,
+> so a code posted in a public channel is a broader disclosure than the
+> Organizer intended. Approval is the Organizer exercising the membership
+> authority §3 already gives them, one step later.
+>
+> Bearer codes remain the default and are unchanged. This is a per-invite
+> choice, not a mode.
+
+---
+
+## 10. Open questions
+
+- ~~**Q1 — Game tone.**~~ **Resolved: blue.** `--color-sheet-game` =
+  `--color-wk-accent` (#7dceeb) with a #1e5364 deep — see §6.2.
+- ~~**Q1b — does the Game row carry `meta`?**~~ **Resolved: yes**, and it
+  carries three of them (crawler name, pilot count, mech count), so `BadgeTone`
+  widens and `meta` becomes `ReactNode | ReactNode[]` — see §6.1.
+- **Q1c — counts as badges vs. `Stat`s.** §6.1 renders the pilot/mech counts as
+  badges, which departs from the stats-render-through-`Stat` law that
+  `EntityRow`'s docstring cites. Called as asked; noted for a reviewer rather
+  than left silent.
+- **Q2 — Does `/games/$gameId` absorb the Mediator surface?** Recommendation:
+  no. Different mode under ADR-021. Stated here because the route split makes
+  it an obvious question.
+- **Q3 — Discord-native join (the "Tier 4" from the original discussion).**
+  Deliberately out of scope. `bot.ts` already binds channels to Games, so
+  `/join` in a bound channel is a small addition — but it should sit on Tier
+  3's approval primitive rather than beside it, and it wants its own plan.
+- **Q4 — Kicking a member.** Out of scope, but §4.4's "revoking does not evict"
+  makes its absence visible. Today the only exit is `ownership.leaveGame` by
+  the member themselves.

--- a/packages/component-lib/src/components/chrome/Badge.stories.tsx
+++ b/packages/component-lib/src/components/chrome/Badge.stories.tsx
@@ -37,6 +37,9 @@ const TONE_LABELS: Record<BadgeTone, string> = {
   pilot: pilotLabel,
   mech: chassisName,
   crawler: crawlerName,
+  // The Salvage Union term for the person running the table — the role a Game
+  // row's badge actually carries.
+  game: 'Mediator',
   ok: 'Intact',
   warn: 'Damaged',
   bad: 'Destroyed',
@@ -46,7 +49,7 @@ function Row({ children }: { children: ReactNode }) {
   return <div className="flex flex-wrap items-start gap-3">{children}</div>
 }
 
-const BADGE_TONES: BadgeTone[] = ['pilot', 'mech', 'crawler', 'ok', 'warn', 'bad']
+const BADGE_TONES: BadgeTone[] = ['pilot', 'mech', 'crawler', 'game', 'ok', 'warn', 'bad']
 
 /**
  * The unified `Badge` — Pill / Chip were named presets, now retired into this one

--- a/packages/component-lib/src/components/chrome/Badge.tsx
+++ b/packages/component-lib/src/components/chrome/Badge.tsx
@@ -5,7 +5,7 @@ import { FOCUS_RING } from './interaction'
 import { STAMP_SEAM } from './stampSeam'
 import { DEFAULT_RUNG, RUNG_INLINE_PADDING, RUNG_TYPE, type SizeRung } from '../../styles/sizing'
 
-export type BadgeTone = 'pilot' | 'mech' | 'crawler' | 'ok' | 'warn' | 'bad'
+export type BadgeTone = 'pilot' | 'mech' | 'crawler' | 'game' | 'ok' | 'warn' | 'bad'
 /** Chip surfaces (the rounded `shape="chip"` default). */
 export type BadgeSurface = 'solid' | 'ghost' | 'outline' | 'tone' | 'quiet'
 /**
@@ -23,6 +23,8 @@ const BADGE_TONES: Record<BadgeTone, string> = {
   pilot: 'border-ink bg-pilot text-ink',
   mech: 'border-ink bg-mech text-ink',
   crawler: 'border-ink bg-crawler text-paper',
+  // Light enough for dark ink, like pilot and mech — crawler is the dark one.
+  game: 'border-ink bg-sheet-game text-ink',
   ok: 'border-status-ok bg-status-ok text-paper',
   warn: 'border-status-warn bg-status-warn text-paper',
   bad: 'border-status-bad bg-status-bad text-paper',

--- a/packages/component-lib/src/components/shared/EntityRow.stories.tsx
+++ b/packages/component-lib/src/components/shared/EntityRow.stories.tsx
@@ -66,8 +66,47 @@ export const Default: Story = () => (
  * the ontology tone wash + a black role tab and the default per-ontology
  * missing-entity glyph, over a helper message and optional create action.
  */
+/**
+ * The `game` ontology (ADR-030) — a shared table, listed as a peer of the
+ * player builds. Blue rail, and three toned badges instead of one: the Game's
+ * communal crawler, its pilot count, its mech count. `meta` takes an array to
+ * carry them.
+ */
+export const Game: Story = () => (
+  <div className="max-w-md bg-paper p-5">
+    <ul className="flex list-none flex-col gap-2.5">
+      <li>
+        <EntityRow
+          entityType="game"
+          name="Union Crawler #430"
+          meta={[crawlerType?.name ?? 'Crawler', '4 Pilots', '3 Mechs']}
+          metaLine="Mediator · started from the Starter Set"
+          sheetHref="#/games/430"
+        />
+      </li>
+      <li>
+        {/* A brand-new Game: no crawler yet and nothing built, so the counts
+            read zero rather than the badges vanishing. */}
+        <EntityRow
+          entityType="game"
+          name="Thursday Night Salvage"
+          meta={['No crawler', '0 Pilots', '0 Mechs']}
+          metaLine="Player · organized by Vex"
+          sheetHref="#/games/thursday"
+        />
+      </li>
+    </ul>
+  </div>
+)
+
 export const Empty: Story = () => (
   <div className="flex max-w-md flex-col gap-2.5 bg-paper p-5">
+    <EntityRow
+      empty
+      entityType="game"
+      roleLabel="Game"
+      message="You are not in any games yet — start one, or join with a code."
+    />
     <EntityRow
       empty
       entityType="mech"

--- a/packages/component-lib/src/components/shared/EntityRow.tsx
+++ b/packages/component-lib/src/components/shared/EntityRow.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, ElementType, ReactNode } from 'react'
-import { Bot, type LucideIcon, Trash2, UserRound, Warehouse } from 'lucide-react'
+import { Bot, type LucideIcon, Trash2, UserRound, Users, Warehouse } from 'lucide-react'
 import { cn } from '../../utils/cn'
 import { Badge } from '../chrome/Badge'
 import { Button } from '../chrome/Button'
@@ -13,7 +13,7 @@ import { Stat } from './Stat'
  * Anatomy (grounded in ITUN's `EntityListItem`, re-composed on canon atoms):
  * a hover-lift frame (2px ink border, faint tone-wash background) fronted by a
  * 6px deep-tone LEFT accent rail keyed to entity ontology (pilot → orange,
- * mech → green, crawler → pink — the `--color-sheet-*` tokens), a black name
+ * mech → green, crawler → pink, game → blue — the `--color-sheet-*` tokens), a black name
  * tab (Barlow Semi Condensed, white-on-ink, caps at 0.04em tracking), an
  * optional muted meta caption beneath it, and trailing View (link) + Delete
  * (ghost trash) actions. Neither action is the rust action colour — a row
@@ -25,7 +25,12 @@ import { Stat } from './Stat'
  * a router dependency.
  */
 
-export type EntityRowType = 'pilot' | 'mech' | 'crawler'
+/**
+ * `game` is the shared table (ADR-030), not a game-data entity — it lists
+ * alongside the three player entities because it is another thing you own and
+ * open, and it carries its own tone so a Game row never reads as a crawler row.
+ */
+export type EntityRowType = 'pilot' | 'mech' | 'crawler' | 'game'
 
 /** A single `label | value` stat rendered in the subheader as a horizontal Stat. */
 export type EntityRowStat = {
@@ -47,9 +52,16 @@ type FilledEntityRowProps = {
    * (see the stats-render-through-Stat law, ruleset §3).
    */
   stats?: EntityRowStat[]
-  /** Optional class/role label beside the stats — rendered as an ontology-toned
-   * Badge (pilot → orange, mech → green, crawler → pink), never plain prose. */
-  meta?: ReactNode
+  /**
+   * Class/role label(s) beside the stats — rendered as ontology-toned Badges
+   * (pilot → orange, mech → green, crawler → pink, game → blue), never plain
+   * prose.
+   *
+   * Pass an ARRAY to render several badges; a Game row carries three (its
+   * crawler, its pilot count, its mech count). A single node stays a single
+   * badge, which is what every pre-existing caller passes.
+   */
+  meta?: ReactNode | ReactNode[]
   /**
    * Free-form caption under the name tab — muted, single-line, truncating.
    *
@@ -130,6 +142,10 @@ const TONE: Record<EntityRowType, { rail: string; wash: string }> = {
     rail: 'var(--color-sheet-crawler-deep)',
     wash: 'color-mix(in srgb, var(--color-sheet-crawler) 11%, var(--color-paper))',
   },
+  game: {
+    rail: 'var(--color-sheet-game-deep)',
+    wash: 'color-mix(in srgb, var(--color-sheet-game) 11%, var(--color-paper))',
+  },
 }
 
 /** Per-ontology "missing entity" glyph for the empty variant (decorative). */
@@ -137,6 +153,7 @@ const EMPTY_GLYPH: Record<EntityRowType, LucideIcon> = {
   pilot: UserRound,
   mech: Bot,
   crawler: Warehouse,
+  game: Users,
 }
 
 export function EntityRow(props: EntityRowProps) {
@@ -191,6 +208,13 @@ export function EntityRow(props: EntityRowProps) {
   } = props
   const frameStyle: CSSProperties = { background: tone.wash }
 
+  // `meta` accepts one node or several. Normalise to a list, dropping empties so
+  // a caller passing `undefined` (or a falsy conditional) renders no badge at
+  // all rather than an empty one.
+  const metaBadges = (Array.isArray(meta) ? meta : [meta]).filter(
+    (node) => node !== null && node !== undefined && node !== false && node !== ''
+  )
+
   return (
     <div
       className={cn(
@@ -218,16 +242,22 @@ export function EntityRow(props: EntityRowProps) {
           {metaLine && (
             <div className="mt-1.5 truncate font-body text-xs text-wk-muted">{metaLine}</div>
           )}
-          {(meta || (stats && stats.length > 0)) && (
+          {(metaBadges.length > 0 || (stats && stats.length > 0)) && (
             <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1">
               {/* Subheader info is only stats or toned badges — the class/role
                   line is a badge keyed to the entity's ontology tone (pilot →
-                  orange, mech → green, crawler → pink). */}
-              {meta && (
-                <Badge surface="tone" tone={entityType} className="max-w-full truncate">
-                  {meta}
+                  orange, mech → green, crawler → pink, game → blue). */}
+              {metaBadges.map((badge, i) => (
+                <Badge
+                  // biome-ignore lint/suspicious/noArrayIndexKey: static per-render list that never reorders; a count badge's text changes as the count does, so content is a worse key than position
+                  key={i}
+                  surface="tone"
+                  tone={entityType}
+                  className="max-w-full truncate"
+                >
+                  {badge}
                 </Badge>
-              )}
+              ))}
               {stats?.map((stat) => (
                 <Stat
                   key={String(stat.label)}

--- a/packages/component-lib/src/components/shared/__tests__/EntityRow.test.tsx
+++ b/packages/component-lib/src/components/shared/__tests__/EntityRow.test.tsx
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { EntityRow } from '../EntityRow'
+
+// Not automatic under bun:test — without it, rows accumulate in the document and
+// `screen` queries match the previous test's markup.
+afterEach(cleanup)
+
+/**
+ * EntityRow gained a fourth ontology (`game`, ADR-030) and `meta` gained array
+ * arity to carry a Game's three badges. Both are widenings of shared surfaces,
+ * so the load-bearing assertion here is the one about NOT regressing: a caller
+ * passing a single `meta` node must still get exactly one badge.
+ */
+describe('EntityRow — meta arity', () => {
+  test('a single meta node renders exactly one badge', () => {
+    render(<EntityRow entityType="pilot" name="Ace" meta="Salvager" sheetHref="#/pilot/ace" />)
+    expect(screen.getByText('Salvager')).toBeDefined()
+  })
+
+  test('an array renders one badge per entry, in order', () => {
+    const { container } = render(
+      <EntityRow
+        entityType="game"
+        name="Union Crawler #430"
+        meta={['Hamlet', '4 Pilots', '3 Mechs']}
+        sheetHref="#/games/430"
+      />
+    )
+    for (const label of ['Hamlet', '4 Pilots', '3 Mechs']) {
+      expect(screen.getByText(label)).toBeDefined()
+    }
+    // Order matters — the crawler names the table before the counts describe it.
+    const text = container.textContent ?? ''
+    expect(text.indexOf('Hamlet')).toBeLessThan(text.indexOf('4 Pilots'))
+    expect(text.indexOf('4 Pilots')).toBeLessThan(text.indexOf('3 Mechs'))
+  })
+
+  test('omitted meta renders no badge, and a nullish entry is dropped', () => {
+    // A caller building the array conditionally (no crawler yet) must not get an
+    // empty badge for the hole.
+    const { container } = render(
+      <EntityRow
+        entityType="game"
+        name="Thursday Night Salvage"
+        meta={[null, '0 Pilots', undefined]}
+        sheetHref="#/games/thursday"
+      />
+    )
+    expect(screen.getByText('0 Pilots')).toBeDefined()
+    expect(container.textContent).not.toContain('null')
+    expect(container.textContent).not.toContain('undefined')
+  })
+})
+
+describe('EntityRow — the game ontology', () => {
+  test('a game row paints the game rail, not the crawler rail', () => {
+    const { container } = render(
+      <EntityRow entityType="game" name="Union Crawler #430" sheetHref="#/games/430" />
+    )
+    const html = container.innerHTML
+    expect(html).toContain('--color-sheet-game-deep')
+    expect(html).not.toContain('--color-sheet-crawler')
+  })
+
+  test('the empty variant renders a game placeholder', () => {
+    render(
+      <EntityRow empty entityType="game" roleLabel="Game" message="You are not in any games yet." />
+    )
+    expect(screen.getByText('Game')).toBeDefined()
+    expect(screen.getByText('You are not in any games yet.')).toBeDefined()
+  })
+
+  test('the View link points at the game', () => {
+    render(<EntityRow entityType="game" name="Union Crawler #430" sheetHref="/games/430" />)
+    expect(screen.getByText('View').getAttribute('href')).toBe('/games/430')
+  })
+})

--- a/packages/component-lib/src/styles/theme.css
+++ b/packages/component-lib/src/styles/theme.css
@@ -225,6 +225,15 @@
   --color-sheet-mech-deep: rgb(47, 67, 56); /* #2f4338 */
   --color-sheet-crawler: var(--color-crawler); /* #ce5898 */
   --color-sheet-crawler-deep: rgb(126, 42, 91); /* #7e2a5b */
+  /* Game — the shared table (ADR-030), the fourth ontology. Blue, so a Game row
+     never reads as the crawler row sitting next to it. The base is the palette's
+     existing game-state accent; the deep is a LITERAL, not `var(--color-tl-5)`,
+     which holds the same value but means TECH LEVEL — aliasing it would tie the
+     Game ontology to tech-level semantics. Chosen for contrast, not by eye:
+     EntityRow's empty variant paints `tone.rail` as TEXT on the tone wash, and
+     #1e5364 measures 7.7:1 there, mid-family between mech (9.1) and crawler (7.5). */
+  --color-sheet-game: var(--color-wk-accent); /* #7dceeb */
+  --color-sheet-game-deep: rgb(30, 83, 100); /* #1e5364 */
 
   /* Heat-at-cap pulse (design review U-1): a subtle status-bad ring that
      breathes outward. Use as `motion-safe:animate-heat-pulse` so


### PR DESCRIPTION
## Why

The invite scheme was three mutations and one button: mint a code, redeem it as a bare Player, revoke it. Except **nothing in the app ever called revoke**, and with no `invites.list` a minted code could not be seen again, audited, or killed for its whole 14-day life. A code pasted into the wrong Discord channel was both undetectable and unstoppable — and joining hands over read access to every crewmate's sheet (ADR-030 §5).

## What landed

**Invites are manageable.** `invites.list` derives status from the row and the clock rather than a stored flag that would need a cron to stay true. `revoke` becomes a soft delete, so the new `inviteRedemptions` trail keeps resolving — "used by Sam" instead of "2 uses left". Revoking closes a code; it never evicts anyone already seated.

**Invites carry what the Organizer already decided** — a seat (`role: 'mediator'` hands over the GM chair) and grants (unclaimed entities handed over on join). This is `assign` *scheduled*, not self-claim: the Organizer names the recipient in advance, so the Change Log records **them** as `actorId`. A grant gone stale is skipped and the join still succeeds — arriving without the promised pilot is a notice, whereas failing over a stale pointer would strand someone outside a game they were genuinely invited to.

**Invites can be knocks.** `requiresApproval` means the code identifies the game and grants nothing until the Organizer approves. A knock is not a membership and **consumes no use**, so it cannot burn a code before anyone joins. Both doors seat people through one shared `seat()` path, so role and grants cannot drift apart.

**A Game is a place you can be sent.** `/join/$code` describes the invitation *before* asking anyone to sign in — signed-out is the expected state for a link you hand a stranger, and being asked to authenticate only to learn the code expired is the worst version of that page. The lobby lists each Game as an `EntityRow` like the pilots and mechs do — a fourth **blue** ontology whose badges say which crawler the crew rides and how much is built.

## Notes for review

- **Rebuilt on top of #656**, which landed while this was in flight. That PR had already made `/games/$gameId` the place per-game work happens, so the invite panel went *there* rather than into the duplicate detail screen this branch originally had — that screen and its route are gone. `GameScreen` now reads `games.get` instead of `listMine`-and-find (one game, not all, and it distinguishes loading from not-a-member).
- **The ADR amendment is reconciled with #656's self-claim amendment**, not written over it. Self-claim made an unclaimed entity an offer to the crew; `assign` survived as the power to place an entity with a *particular* person. An invite grant is that power, scheduled.
- `--color-sheet-game-deep` (#1e5364) is a **literal, not `var(--color-tl-5)`** — that token holds the same value but means *tech level*, and aliasing it would tie the Game ontology to tech-level semantics. It was picked for contrast, not by eye: `EntityRow`'s empty variant paints `tone.rail` as **text**, and #1e5364 measures 7.7:1 on the game wash, mid-family between mech (9.1) and crawler (7.5).
- `summarize()` now counts pilots and mechs, and **Convex has no count API** — counting means collecting. That is stated in the code: fine at a table's scale, and if it ever bites the fix is a denormalised counter, not a cleverer query.
- **Deliberately not done:** rate limiting on `redeem`/`preview` (40 bits needs ~10¹² online attempts; a limiter would be theatre and real friction for a table mistyping a code), and any change to the code generator.

## Verification

`bun run check:all` green on top of current main: **4335 tests** (itun 1587, reference 1003, srd 984, component-lib 681, discord-bot 80), plus lint, format, typecheck, knip, validate, audit, design-tokens, styling-ownership.

The design doc (`docs/design/game-invites-and-membership-plan.md`) is kept as the reasoning behind the shape; its §1 describes the state this replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxsNxRvv4nDHZuZ9SqyNYG