### PR TITLE
feat(itun): a Game's crew as a roster, and the rules for setting a table up

### DIFF
--- a/apps/itun/convex/__tests__/crew.test.ts
+++ b/apps/itun/convex/__tests__/crew.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
+import { MechSchema } from '../../src/lib/schemas/mech'
+import { PilotSchema } from '../../src/lib/schemas/pilot'
 import { api } from '../_generated/api'
 import { testConvex } from './harness'
 
@@ -39,7 +41,7 @@ describe('vitals', () => {
       await ctx.db.insert('pilots', {
         gameId,
         ownerId: player.userId,
-        body: { callsign: 'Roach-Boy', currentHp: 7, currentAp: 3 },
+        body: { callsign: 'Roach-Boy', currentHP: 7, currentAP: 3 },
         updatedAt: 1,
       })
     })
@@ -47,9 +49,63 @@ describe('vitals', () => {
     const crew = await organizer.as.query(api.crew.vitals, { gameId })
     expect(crew.pilots).toHaveLength(1)
     expect(crew.pilots[0]?.name).toBe('Roach-Boy')
-    expect(crew.pilots[0]?.currentHp).toBe(7)
+    expect(crew.pilots[0]?.currentHP).toBe(7)
     // The chip needs a name, not just an id.
     expect(crew.pilots[0]?.ownerName).toBe('Beefcake')
+  })
+
+  test('reads the field names the Zod schema actually defines', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+
+    // The body is built by PARSING a real record rather than hand-written, so
+    // the key names come from the schema instead of from this test's memory of
+    // them. That is the whole point: this query used to read `currentHp` while
+    // the schema defines `currentHP`, every vital came back null, and the crew
+    // strip rendered em-dashes that were indistinguishable from an undamaged
+    // crew. A hand-written fixture agreed with the bug and kept it green.
+    const pilot = PilotSchema.parse({
+      id: 'p1',
+      schemaVersion: 1,
+      name: 'Roach-Boy',
+      callsign: 'Roach-Boy',
+      classRef: 'salvager',
+      abilities: [],
+      equipment: [],
+      motto: '',
+      keepsake: '',
+      appearance: '',
+      conditions: [],
+      currentHP: 9,
+      currentAP: 4,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    })
+    const mech = MechSchema.parse({
+      id: 'm1',
+      schemaVersion: 1,
+      name: 'Iron Mongrel',
+      chassisRef: 'iron-mongrel',
+      systems: [],
+      modules: [],
+      cargoLots: [],
+      conditions: [],
+      currentSP: 12,
+      currentHeat: 2,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    })
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('pilots', { gameId, ownerId: player.userId, body: pilot, updatedAt: 1 })
+      await ctx.db.insert('mechs', { gameId, ownerId: player.userId, body: mech, updatedAt: 1 })
+    })
+
+    const crew = await organizer.as.query(api.crew.vitals, { gameId })
+    expect(crew.pilots[0]?.currentHP).toBe(9)
+    expect(crew.pilots[0]?.currentAP).toBe(4)
+    expect(crew.mechs[0]?.currentSP).toBe(12)
+    expect(crew.mechs[0]?.currentHeat).toBe(2)
   })
 
   test('an unclaimed pilot has a null owner name rather than a missing row', async () => {
@@ -82,7 +138,7 @@ describe('vitals', () => {
     const crew = await organizer.as.query(api.crew.vitals, { gameId })
     // Bodies are opaque, so the projection must not trust their shape. Zero
     // would render as "dead" on a vitals strip, which is worse than blank.
-    expect(crew.pilots[0]?.currentHp).toBeNull()
+    expect(crew.pilots[0]?.currentHP).toBeNull()
   })
 
   test('a non-member gets nothing', async () => {

--- a/apps/itun/convex/__tests__/entities.test.ts
+++ b/apps/itun/convex/__tests__/entities.test.ts
@@ -56,12 +56,38 @@ function pilotBody(over: Record<string, unknown> = {}) {
   }
 }
 
+/** A minimal body that satisfies CrawlerSchema — techLevel is a STRING. */
+function crawlerBody(over: Record<string, unknown> = {}) {
+  return {
+    id: 'c1',
+    schemaVersion: 1,
+    name: '#430',
+    techLevel: '1',
+    systems: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...over,
+  }
+}
+
+/**
+ * A Game that is **set up**: crew invited and a crawler raised.
+ *
+ * The crawler is not decoration. A player may only add pilots and mechs to a
+ * Game that has one, so a fixture without it is a Game nobody can play in —
+ * every "the owner can write their own" case would fail at the create step, on
+ * a rule that has nothing to do with what it is testing. Raising it here keeps
+ * those tests about what they say they are about; the gate itself is proven
+ * directly in `tableSetup.test.ts`.
+ */
 async function seedGame(t: Ctx) {
   const organizer = await makeUser(t, 'Organizer')
   const player = await makeUser(t, 'Player')
   const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
   const code = await organizer.as.mutation(api.invites.create, { gameId })
   await player.as.mutation(api.invites.redeem, { code })
+  // The Organizer runs the table while the Game has no Mediator appointed.
+  await organizer.as.mutation(api.entities.createCrawler, { gameId, body: crawlerBody() })
   return { organizer, player, gameId }
 }
 

--- a/apps/itun/convex/__tests__/proposals.test.ts
+++ b/apps/itun/convex/__tests__/proposals.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
+import { MechSchema } from '../../src/lib/schemas/mech'
 import { api } from '../_generated/api'
 import type { Id } from '../_generated/dataModel'
 import { testConvex } from './harness'
@@ -30,12 +31,35 @@ async function seedTable(t: Ctx) {
   await player.as.mutation(api.invites.redeem, { code })
   await gm.as.mutation(api.games.setMediator, { gameId, userId: gm.userId, mediator: true })
 
+  /**
+   * A REAL mech body, parsed by the schema rather than hand-sketched.
+   *
+   * `apply` now Zod-parses the merged body before it persists, which means a
+   * fixture that is not a valid Mech cannot be applied to — correctly, since no
+   * production write path can produce one. The earlier two-field sketch also
+   * spelled the field `currentSp`, which the schema does not define, so the
+   * proposal it applied added a key nothing reads and every assertion passed
+   * anyway. Parsing here is what stops this file agreeing with that bug.
+   */
   const mechId = await t.run(
     async (ctx) =>
       await ctx.db.insert('mechs', {
         gameId,
         ownerId: player.userId,
-        body: { name: 'Mule', currentSp: 10 },
+        body: MechSchema.parse({
+          id: 'm1',
+          schemaVersion: 1,
+          name: 'Mule',
+          chassisRef: 'mule',
+          systems: [],
+          modules: [],
+          cargoLots: [],
+          conditions: [],
+          currentSP: 10,
+          currentHeat: 0,
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        }),
         updatedAt: 1,
       })
   )
@@ -50,14 +74,14 @@ describe('the Mediator proposes; the player writes', () => {
     await gm.as.mutation(api.proposals.propose, {
       entityId: mechId,
       entityType: 'mech',
-      field: 'currentSp',
+      field: 'currentSP',
       before: 10,
       after: 6,
     })
 
     const mech = await t.run(async (ctx) => await ctx.db.get(mechId as Id<'mechs'>))
     // Still 10. Proposing is not writing.
-    expect((mech?.body as { currentSp: number } | undefined)?.currentSp).toBe(10)
+    expect((mech?.body as { currentSP: number } | undefined)?.currentSP).toBe(10)
   })
 
   test('applying it does, and only the owner may', async () => {
@@ -66,7 +90,7 @@ describe('the Mediator proposes; the player writes', () => {
     await gm.as.mutation(api.proposals.propose, {
       entityId: mechId,
       entityType: 'mech',
-      field: 'currentSp',
+      field: 'currentSP',
       before: 10,
       after: 6,
     })
@@ -84,7 +108,30 @@ describe('the Mediator proposes; the player writes', () => {
       proposalId: pending?._id as Id<'changeLog'>,
     })
     const mech = await t.run(async (ctx) => await ctx.db.get(mechId as Id<'mechs'>))
-    expect((mech?.body as { currentSp: number } | undefined)?.currentSp).toBe(6)
+    expect((mech?.body as { currentSP: number } | undefined)?.currentSP).toBe(6)
+  })
+
+  test('applying a proposal against a field the sheet has no room for is refused', async () => {
+    const t = testConvex()
+    const { gm, player, gameId, mechId } = await seedTable(t)
+    await gm.as.mutation(api.proposals.propose, {
+      entityId: mechId,
+      entityType: 'mech',
+      // The casing the Mediator surface used to offer. It is not a Mech field.
+      field: 'currentSp',
+      before: 10,
+      after: 6,
+    })
+    const [pending] = await player.as.query(api.proposals.pending, { gameId })
+
+    // Before the body was parsed on apply, this wrote a key nothing reads: the
+    // player pressed Apply, the number did not move, and nothing said why.
+    await expect(
+      player.as.mutation(api.proposals.apply, { proposalId: pending?._id as Id<'changeLog'> })
+    ).rejects.toThrow(/does not fit this sheet/i)
+
+    const mech = await t.run(async (ctx) => await ctx.db.get(mechId as Id<'mechs'>))
+    expect((mech?.body as { currentSP: number } | undefined)?.currentSP).toBe(10)
   })
 
   test("a player cannot propose to their own or a crewmate's entity", async () => {
@@ -94,7 +141,7 @@ describe('the Mediator proposes; the player writes', () => {
       player.as.mutation(api.proposals.propose, {
         entityId: mechId,
         entityType: 'mech',
-        field: 'currentSp',
+        field: 'currentSP',
         before: 10,
         after: 999,
       })
@@ -113,7 +160,7 @@ describe('the Mediator proposes; the player writes', () => {
       gm.as.mutation(api.proposals.propose, {
         entityId: orphan,
         entityType: 'mech',
-        field: 'currentSp',
+        field: 'currentSP',
         before: 0,
         after: 1,
       })
@@ -129,14 +176,14 @@ describe('supersession, not expiry', () => {
     const first = await gm.as.mutation(api.proposals.propose, {
       entityId: mechId,
       entityType: 'mech',
-      field: 'currentSp',
+      field: 'currentSP',
       before: 10,
       after: 6,
     })
     await gm.as.mutation(api.proposals.propose, {
       entityId: mechId,
       entityType: 'mech',
-      field: 'currentSp',
+      field: 'currentSP',
       before: 10,
       after: 4,
     })
@@ -159,7 +206,7 @@ describe('supersession, not expiry', () => {
     await gm.as.mutation(api.proposals.propose, {
       entityId: mechId,
       entityType: 'mech',
-      field: 'currentSp',
+      field: 'currentSP',
       before: 10,
       after: 6,
     })
@@ -181,7 +228,7 @@ describe('supersession, not expiry', () => {
     const id = await gm.as.mutation(api.proposals.propose, {
       entityId: mechId,
       entityType: 'mech',
-      field: 'currentSp',
+      field: 'currentSP',
       before: 10,
       after: 6,
     })
@@ -203,7 +250,7 @@ describe('declining', () => {
     const id = await gm.as.mutation(api.proposals.propose, {
       entityId: mechId,
       entityType: 'mech',
-      field: 'currentSp',
+      field: 'currentSP',
       before: 10,
       after: 6,
     })
@@ -214,7 +261,7 @@ describe('declining', () => {
     // The log is append-only; a declined proposal is history, not a gap.
     expect(row?.state).toBe('declined')
     const mech = await t.run(async (ctx) => await ctx.db.get(mechId as Id<'mechs'>))
-    expect((mech?.body as { currentSp: number } | undefined)?.currentSp).toBe(10)
+    expect((mech?.body as { currentSP: number } | undefined)?.currentSP).toBe(10)
     expect(await player.as.query(api.proposals.pending, { gameId })).toHaveLength(0)
   })
 })
@@ -230,7 +277,7 @@ describe('pending is scoped to the asker', () => {
     await gm.as.mutation(api.proposals.propose, {
       entityId: mechId,
       entityType: 'mech',
-      field: 'currentSp',
+      field: 'currentSP',
       before: 10,
       after: 6,
     })

--- a/apps/itun/convex/__tests__/tableSetup.test.ts
+++ b/apps/itun/convex/__tests__/tableSetup.test.ts
@@ -1,0 +1,464 @@
+import { describe, expect, test } from 'bun:test'
+
+import { api } from '../_generated/api'
+import type { Id } from '../_generated/dataModel'
+import { testConvex } from './harness'
+
+/**
+ * Setting a table up: who raises the crawler, who may add to a Game, and how an
+ * offered character is picked up (ADR-030 §4–5 as amended).
+ *
+ * Three rules, and each one is only worth anything because it is enforced HERE
+ * rather than by hiding a button:
+ *
+ *  1. **The table runner raises the crawler.** Every member may then edit its
+ *     fields — that is what communal means — but creating and scrapping one is
+ *     the act of whoever runs the table.
+ *  2. **A Game takes players' pilots and mechs once it has a crawler.** A Game
+ *     with none is not set up yet, and the crew has nowhere to be anchored.
+ *  3. **A Mediator's pre-built character lands unclaimed, and a player takes
+ *     it.** Unclaimed is an offer; claiming is accepting it. Nobody can take
+ *     what a crewmate already holds.
+ *
+ * "Table runner" throughout means the Mediator, or the Organizer while the Game
+ * has no Mediator — the narrow fallback that stops a brand-new Game being a
+ * dead end.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+function pilotBody(over: Record<string, unknown> = {}) {
+  return {
+    id: 'p1',
+    schemaVersion: 1,
+    name: 'Roach-Boy',
+    callsign: 'Roach-Boy',
+    classRef: 'salvager',
+    abilities: [],
+    equipment: [],
+    motto: '',
+    keepsake: '',
+    appearance: '',
+    conditions: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...over,
+  }
+}
+
+function crawlerBody(over: Record<string, unknown> = {}) {
+  return {
+    id: 'c1',
+    schemaVersion: 1,
+    name: '#430',
+    techLevel: '1',
+    systems: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...over,
+  }
+}
+
+/** A Game with an Organizer, a Mediator and a Player — and NO crawler yet. */
+async function seedTable(t: Ctx) {
+  const organizer = await makeUser(t, 'Organizer')
+  const mediator = await makeUser(t, 'Mediator')
+  const player = await makeUser(t, 'Player')
+
+  const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+  const code = await organizer.as.mutation(api.invites.create, { gameId })
+  await mediator.as.mutation(api.invites.redeem, { code })
+  await player.as.mutation(api.invites.redeem, { code })
+  await organizer.as.mutation(api.games.setMediator, {
+    gameId,
+    userId: mediator.userId,
+    mediator: true,
+  })
+
+  return { organizer, mediator, player, gameId }
+}
+
+describe('the table runner raises the crawler', () => {
+  test('the Mediator can raise one', async () => {
+    const t = testConvex()
+    const { mediator, gameId } = await seedTable(t)
+
+    await mediator.as.mutation(api.entities.createCrawler, { gameId, body: crawlerBody() })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('crawlers').collect())
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.gameId).toBe(gameId)
+  })
+
+  test('a player cannot', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedTable(t)
+
+    await expect(
+      player.as.mutation(api.entities.createCrawler, { gameId, body: crawlerBody() })
+    ).rejects.toThrow(/only the mediator/i)
+  })
+
+  test('the Organizer can, but only while the game has no Mediator', async () => {
+    const t = testConvex()
+    const { organizer, mediator, gameId } = await seedTable(t)
+
+    // A Mediator is appointed, so the fallback is closed.
+    await expect(
+      organizer.as.mutation(api.entities.createCrawler, { gameId, body: crawlerBody() })
+    ).rejects.toThrow(/only the mediator/i)
+
+    await organizer.as.mutation(api.games.setMediator, {
+      gameId,
+      userId: mediator.userId,
+      mediator: false,
+    })
+    await organizer.as.mutation(api.entities.createCrawler, { gameId, body: crawlerBody() })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('crawlers').collect())
+    expect(rows).toHaveLength(1)
+  })
+
+  test('a game may hold several crawlers', async () => {
+    const t = testConvex()
+    const { mediator, gameId } = await seedTable(t)
+
+    await mediator.as.mutation(api.entities.createCrawler, { gameId, body: crawlerBody() })
+    await mediator.as.mutation(api.entities.createCrawler, {
+      gameId,
+      body: crawlerBody({ id: 'c2', name: '#12 Perseverance' }),
+    })
+
+    // A campaign that loses a crawler and rebuilds, or joins a second one, is
+    // ordinary play — not a state to be rejected.
+    const listed = await mediator.as.query(api.entities.listForGame, { gameId })
+    expect(listed.crawlers).toHaveLength(2)
+  })
+
+  test('a malformed crawler body is rejected, not stored', async () => {
+    const t = testConvex()
+    const { mediator, gameId } = await seedTable(t)
+
+    await expect(
+      mediator.as.mutation(api.entities.createCrawler, { gameId, body: { nonsense: true } })
+    ).rejects.toThrow(/invalid crawler payload/i)
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('crawlers').collect())
+    expect(rows).toHaveLength(0)
+  })
+
+  test('every member may still edit its fields', async () => {
+    const t = testConvex()
+    const { mediator, player, gameId } = await seedTable(t)
+    const crawlerId = await mediator.as.mutation(api.entities.createCrawler, {
+      gameId,
+      body: crawlerBody(),
+    })
+
+    // Communal editing is the whole point of the crawler; only authorship moved.
+    await player.as.mutation(api.entities.patchCrawler, { crawlerId, patch: { techLevel: '2' } })
+
+    const row = await t.run(async (ctx) => await ctx.db.get(crawlerId))
+    expect((row?.body as { techLevel: string } | undefined)?.techLevel).toBe('2')
+  })
+
+  test('a player cannot scrap it', async () => {
+    const t = testConvex()
+    const { mediator, player, gameId } = await seedTable(t)
+    const crawlerId = await mediator.as.mutation(api.entities.createCrawler, {
+      gameId,
+      body: crawlerBody(),
+    })
+
+    await expect(player.as.mutation(api.entities.removeCrawler, { crawlerId })).rejects.toThrow(
+      /only the mediator/i
+    )
+
+    await mediator.as.mutation(api.entities.removeCrawler, { crawlerId })
+    const rows = await t.run(async (ctx) => await ctx.db.query('crawlers').collect())
+    expect(rows).toHaveLength(0)
+  })
+})
+
+describe('a game takes the crew once it has a crawler', () => {
+  test('a player cannot add a pilot before one exists', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedTable(t)
+
+    await expect(
+      player.as.mutation(api.entities.create, { table: 'pilots', gameId, body: pilotBody() })
+    ).rejects.toThrow(/no union crawler yet/i)
+  })
+
+  test('and can as soon as one does', async () => {
+    const t = testConvex()
+    const { mediator, player, gameId } = await seedTable(t)
+    await mediator.as.mutation(api.entities.createCrawler, { gameId, body: crawlerBody() })
+
+    await player.as.mutation(api.entities.create, { table: 'pilots', gameId, body: pilotBody() })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.ownerId).toBe(player.userId)
+  })
+
+  test('the table runner is exempt — somebody has to go first', async () => {
+    const t = testConvex()
+    const { mediator, gameId } = await seedTable(t)
+
+    // If this were gated too, a new Game could never be populated at all.
+    await mediator.as.mutation(api.entities.create, { table: 'pilots', gameId, body: pilotBody() })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(1)
+  })
+
+  test('the shelf is never gated — it is your own', async () => {
+    const t = testConvex()
+    const { player } = await seedTable(t)
+
+    await player.as.mutation(api.entities.create, {
+      table: 'pilots',
+      gameId: null,
+      body: pilotBody(),
+    })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows[0]?.gameId).toBeNull()
+  })
+
+  test('the mirrored write path is gated too, or the rule would be cosmetic', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedTable(t)
+
+    // The client's ordinary write path is the appId mirror. Left open, a player
+    // would build the pilot locally and have the mirror place it in the Game.
+    await expect(
+      player.as.mutation(api.entities.upsertByAppId, {
+        table: 'pilots',
+        appId: 'p1',
+        gameId,
+        body: pilotBody(),
+      })
+    ).rejects.toThrow(/no union crawler yet/i)
+  })
+
+  test('a mirrored write re-homes a build the client moved', async () => {
+    const t = testConvex()
+    const { mediator, player, gameId } = await seedTable(t)
+    await mediator.as.mutation(api.entities.createCrawler, { gameId, body: crawlerBody() })
+
+    await player.as.mutation(api.entities.create, {
+      table: 'pilots',
+      gameId: null,
+      appId: 'p1',
+      body: pilotBody(),
+    })
+    await player.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'p1',
+      gameId,
+      body: pilotBody(),
+    })
+
+    // Without this the move looked like it worked locally and the server row
+    // never left the shelf.
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.gameId).toBe(gameId)
+  })
+
+  test('a crawler mirror merges fields but never creates a crawler', async () => {
+    const t = testConvex()
+    const { mediator, player, gameId } = await seedTable(t)
+
+    // Nothing to address yet: this must be a no-op, not a way in.
+    await player.as.mutation(api.entities.patchCrawlerByAppId, {
+      appId: 'c1',
+      patch: { techLevel: '3' },
+    })
+    expect(await t.run(async (ctx) => await ctx.db.query('crawlers').collect())).toHaveLength(0)
+
+    await mediator.as.mutation(api.entities.createCrawler, {
+      gameId,
+      appId: 'c1',
+      body: crawlerBody(),
+    })
+    await player.as.mutation(api.entities.patchCrawlerByAppId, {
+      appId: 'c1',
+      patch: { techLevel: '3' },
+    })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('crawlers').collect())
+    expect(rows).toHaveLength(1)
+    expect((rows[0]?.body as { techLevel: string } | undefined)?.techLevel).toBe('3')
+    // The merge is per field: the name it did not mention survives.
+    expect((rows[0]?.body as { name: string } | undefined)?.name).toBe('#430')
+  })
+})
+
+describe('a mediator offers characters; players pick them up', () => {
+  test('a Mediator can create one unclaimed', async () => {
+    const t = testConvex()
+    const { mediator, gameId } = await seedTable(t)
+
+    await mediator.as.mutation(api.entities.create, {
+      table: 'pilots',
+      gameId,
+      unassigned: true,
+      body: pilotBody(),
+    })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows[0]?.ownerId).toBeNull()
+  })
+
+  test('a player cannot', async () => {
+    const t = testConvex()
+    const { mediator, player, gameId } = await seedTable(t)
+    await mediator.as.mutation(api.entities.createCrawler, { gameId, body: crawlerBody() })
+
+    await expect(
+      player.as.mutation(api.entities.create, {
+        table: 'pilots',
+        gameId,
+        unassigned: true,
+        body: pilotBody(),
+      })
+    ).rejects.toThrow(/only the mediator/i)
+  })
+
+  test('nothing on a shelf can be unclaimed — it would belong to nobody', async () => {
+    const t = testConvex()
+    const { mediator } = await seedTable(t)
+
+    // `gameId: null && ownerId: null` is the schema's one invalid combination.
+    await expect(
+      mediator.as.mutation(api.entities.create, {
+        table: 'pilots',
+        gameId: null,
+        unassigned: true,
+        body: pilotBody(),
+      })
+    ).rejects.toThrow(/shelf/i)
+  })
+
+  test('a player picks up what is offered, and it becomes theirs to edit', async () => {
+    const t = testConvex()
+    const { mediator, player, gameId } = await seedTable(t)
+    const pilotId = await mediator.as.mutation(api.entities.create, {
+      table: 'pilots',
+      gameId,
+      unassigned: true,
+      body: pilotBody(),
+    })
+
+    await player.as.mutation(api.ownership.claim, { table: 'pilots', entityId: pilotId })
+    await player.as.mutation(api.entities.update, {
+      table: 'pilots',
+      entityId: pilotId,
+      body: pilotBody({ name: 'Renamed' }),
+    })
+
+    const row = await t.run(async (ctx) => await ctx.db.get(pilotId as Id<'pilots'>))
+    expect(row?.ownerId).toBe(player.userId)
+    expect((row?.body as { name: string } | undefined)?.name).toBe('Renamed')
+  })
+
+  test('claiming is recorded in the Change Log like any other ownership move', async () => {
+    const t = testConvex()
+    const { mediator, player, gameId } = await seedTable(t)
+    const pilotId = await mediator.as.mutation(api.entities.create, {
+      table: 'pilots',
+      gameId,
+      unassigned: true,
+      body: pilotBody(),
+    })
+    await player.as.mutation(api.ownership.claim, { table: 'pilots', entityId: pilotId })
+
+    const log = await t.run(async (ctx) => await ctx.db.query('changeLog').collect())
+    expect(log).toHaveLength(1)
+    expect(log[0]?.field).toBe('ownerId')
+    expect(log[0]?.before).toBeNull()
+    expect(log[0]?.after).toBe(player.userId)
+    expect(log[0]?.actorId).toBe(player.userId)
+  })
+
+  test('what a crewmate already holds cannot be taken', async () => {
+    const t = testConvex()
+    const { organizer, mediator, player, gameId } = await seedTable(t)
+    await mediator.as.mutation(api.entities.createCrawler, { gameId, body: crawlerBody() })
+    const pilotId = await player.as.mutation(api.entities.create, {
+      table: 'pilots',
+      gameId,
+      body: pilotBody(),
+    })
+
+    const other = await makeUser(t, 'Latecomer')
+    // Inviting is administrative, so it is the Organizer's — not the Mediator's.
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await other.as.mutation(api.invites.redeem, { code })
+
+    await expect(
+      other.as.mutation(api.ownership.claim, { table: 'pilots', entityId: pilotId })
+    ).rejects.toThrow(/already holds/i)
+  })
+
+  test('released, it is offered again and somebody else may take it', async () => {
+    const t = testConvex()
+    const { mediator, player, gameId } = await seedTable(t)
+    await mediator.as.mutation(api.entities.createCrawler, { gameId, body: crawlerBody() })
+    const pilotId = await player.as.mutation(api.entities.create, {
+      table: 'pilots',
+      gameId,
+      body: pilotBody(),
+    })
+
+    // This is how a campaign survives somebody leaving mid-season.
+    await player.as.mutation(api.ownership.release, { table: 'pilots', entityId: pilotId })
+    await mediator.as.mutation(api.ownership.claim, { table: 'pilots', entityId: pilotId })
+
+    const row = await t.run(async (ctx) => await ctx.db.get(pilotId as Id<'pilots'>))
+    expect(row?.ownerId).toBe(mediator.userId)
+  })
+
+  test('a non-member cannot claim into a game they are not in', async () => {
+    const t = testConvex()
+    const { mediator, gameId } = await seedTable(t)
+    const pilotId = await mediator.as.mutation(api.entities.create, {
+      table: 'pilots',
+      gameId,
+      unassigned: true,
+      body: pilotBody(),
+    })
+    const outsider = await makeUser(t, 'Outsider')
+
+    await expect(
+      outsider.as.mutation(api.ownership.claim, { table: 'pilots', entityId: pilotId })
+    ).rejects.toThrow(/not a member/i)
+  })
+
+  test('claiming needs no crawler — an offer stands whatever order the table was set up in', async () => {
+    const t = testConvex()
+    const { mediator, player, gameId } = await seedTable(t)
+    const pilotId = await mediator.as.mutation(api.entities.create, {
+      table: 'pilots',
+      gameId,
+      unassigned: true,
+      body: pilotBody(),
+    })
+
+    // The crawler gate governs ADDING to a game; claiming adds nothing.
+    await player.as.mutation(api.ownership.claim, { table: 'pilots', entityId: pilotId })
+
+    const row = await t.run(async (ctx) => await ctx.db.get(pilotId as Id<'pilots'>))
+    expect(row?.ownerId).toBe(player.userId)
+  })
+})

--- a/apps/itun/convex/crew.ts
+++ b/apps/itun/convex/crew.ts
@@ -49,7 +49,18 @@ export const vitals = query({
       names.set(m.userId, user?.displayName ?? user?.name ?? 'Crewmate')
     }
 
-    /** Read a numeric field off an opaque body without trusting its shape. */
+    /**
+     * Read a numeric field off an opaque body without trusting its shape.
+     *
+     * **The key must match the Zod schema exactly, including case.** These
+     * originally read `currentHp` / `currentAp` / `currentSp` while
+     * `src/lib/schemas/` defines `currentHP` / `currentAP` / `currentSP`, so
+     * every pilot's HP and AP and every mech's SP came back null and the crew
+     * strip rendered a full row of em-dashes — indistinguishable from "nobody
+     * has taken damage yet", which is why it survived review. The body is
+     * `v.any()` on this side of the wire, so nothing but this comment and the
+     * test below will catch it next time.
+     */
     const num = (body: unknown, key: string): number | null => {
       const value = (body as Record<string, unknown> | null)?.[key]
       return typeof value === 'number' ? value : null
@@ -63,8 +74,8 @@ export const vitals = query({
         ownerId: p.ownerId,
         ownerName: p.ownerId === null ? null : (names.get(p.ownerId) ?? null),
         name: ((p.body as Record<string, unknown> | null)?.callsign as string) ?? 'Pilot',
-        currentHp: num(p.body, 'currentHp'),
-        currentAp: num(p.body, 'currentAp'),
+        currentHP: num(p.body, 'currentHP'),
+        currentAP: num(p.body, 'currentAP'),
       })),
       mechs: mechs.map((m) => ({
         _id: m._id,
@@ -72,7 +83,7 @@ export const vitals = query({
         ownerId: m.ownerId,
         ownerName: m.ownerId === null ? null : (names.get(m.ownerId) ?? null),
         name: ((m.body as Record<string, unknown> | null)?.name as string) ?? 'Mech',
-        currentSp: num(m.body, 'currentSp'),
+        currentSP: num(m.body, 'currentSP'),
         currentHeat: num(m.body, 'currentHeat'),
       })),
     }

--- a/apps/itun/convex/entities.ts
+++ b/apps/itun/convex/entities.ts
@@ -6,7 +6,15 @@ import { PilotSchema } from '../src/lib/schemas/pilot'
 import type { Doc, Id } from './_generated/dataModel'
 import { mutation, query } from './_generated/server'
 import type { MutationCtx, QueryCtx } from './_generated/server'
-import { NotAuthorized, getMembership, requireMember, requireUser } from './model/permissions'
+import {
+  NotAuthorized,
+  gameHasCrawler,
+  getMembership,
+  isTableRunner,
+  requireMember,
+  requireTableRunner,
+  requireUser,
+} from './model/permissions'
 
 /**
  * Entity reads and writes against the server of record (ADR-030 §1).
@@ -33,6 +41,20 @@ import { NotAuthorized, getMembership, requireMember, requireUser } from './mode
  * member may write it, resolved by field-level merge rather than
  * last-write-wins, since the scrap pool and cargo lots are genuinely contended
  * during Downtime.
+ *
+ * ## Who may put things *into* a Game
+ *
+ * Communal-to-edit is not the same as free-to-create, and the crawler is where
+ * the two come apart. **Raising and scrapping a crawler is the table runner's
+ * act; filling its fields is everyone's.** That split is what makes a Game a
+ * table rather than a shared folder: the Mediator sets out what the crew sails
+ * in, and the crew then keeps its scrap, cargo and bays between them.
+ *
+ * The mirror image is the gate on players: a Game with no crawler is not yet
+ * set up, so a player's pilots and mechs wait until there is one. The table
+ * runner is exempt for the obvious reason — somebody has to be able to raise
+ * the first crawler, and a rule that stopped them would make every new Game a
+ * dead end.
  */
 
 const OWNABLE = v.union(v.literal('pilots'), v.literal('mechs'))
@@ -70,14 +92,38 @@ function assertMayWrite(doc: Doc<'pilots'> | Doc<'mechs'>, userId: Id<'users'>):
   throw new NotAuthorized("You cannot edit another player's entity")
 }
 
-async function assertGameMemberOrShelfOwner(
+/**
+ * Whether this user may add a new entity to this Game, and as whom.
+ *
+ * The shelf is unconditional: it is your own, so there is nobody to be set up
+ * for and nothing to gate on. Inside a Game the answer depends on the crawler,
+ * for the reason in the module header — with one exception, the table runner,
+ * who is who *raises* the crawler.
+ *
+ * Returns whether the caller is the table runner rather than a bare boolean
+ * pass/fail, because the caller immediately needs that same answer to decide
+ * whether an `unassigned` create is allowed. Asking twice would mean two
+ * lookups and, worse, two places the rule could drift.
+ */
+async function assertMayAddToContainer(
   ctx: QueryCtx | MutationCtx,
   gameId: Id<'games'> | null,
   userId: Id<'users'>
-): Promise<void> {
-  if (gameId === null) return
+): Promise<{ tableRunner: boolean }> {
+  if (gameId === null) return { tableRunner: false }
+
   const membership = await getMembership(ctx, gameId, userId)
   if (membership === null) throw new NotAuthorized('Not a member of this game')
+
+  const tableRunner = await isTableRunner(ctx, gameId, membership)
+  if (tableRunner) return { tableRunner }
+
+  if (!(await gameHasCrawler(ctx, gameId))) {
+    throw new NotAuthorized(
+      'This game has no Union Crawler yet — the Mediator raises one before the crew joins it'
+    )
+  }
+  return { tableRunner }
 }
 
 /** Everything in a Game the caller can see: all pilots and mechs, plus the crawler. */
@@ -105,10 +151,27 @@ export const listForGame = query({
         .collect(),
     ])
 
+    /**
+     * `appId` travels with every row because the client's copy of an entity is
+     * addressed by it, not by `_id`. Without it a surface cannot answer "do I
+     * already hold this one locally?", and the honest answer to that question
+     * is what decides whether a row offers a sheet link or an offer to pick it
+     * up. It is not secret — it is a UUID the owner's own browser minted.
+     */
     return {
-      pilots: pilots.map((p) => ({ _id: p._id, ownerId: p.ownerId, body: p.body })),
-      mechs: mechs.map((m) => ({ _id: m._id, ownerId: m.ownerId, body: m.body })),
-      crawlers: crawlers.map((c) => ({ _id: c._id, body: c.body })),
+      pilots: pilots.map((p) => ({
+        _id: p._id,
+        appId: p.appId ?? null,
+        ownerId: p.ownerId,
+        body: p.body,
+      })),
+      mechs: mechs.map((m) => ({
+        _id: m._id,
+        appId: m.appId ?? null,
+        ownerId: m.ownerId,
+        body: m.body,
+      })),
+      crawlers: crawlers.map((c) => ({ _id: c._id, appId: c.appId ?? null, body: c.body })),
       softLinks: softLinks.map((l) => ({ _id: l._id, from: l.from, to: l.to, type: l.type })),
     }
   },
@@ -140,23 +203,44 @@ export const listShelf = query({
   },
 })
 
-/** Create an entity, on the caller's shelf or in a Game they belong to. */
+/**
+ * Create an entity, on the caller's shelf or in a Game they belong to.
+ *
+ * `unassigned` is how a Mediator pre-builds a character **for somebody else**:
+ * the row lands with `ownerId: null` and any player in the Game may pick it up
+ * (`ownership.claim`). It is the create-time twin of a template's pre-gens, and
+ * it is table-runner-only for the same reason assignment is — an ownerless
+ * entity is an offer to the crew, and a player making one would be dropping
+ * their own character into the pool rather than offering anything.
+ */
 export const create = mutation({
   args: {
     table: OWNABLE,
     gameId: v.union(v.id('games'), v.null()),
     /** The local UUID this row mirrors, so later edits can address it. */
     appId: v.optional(v.string()),
+    /** Table-runner only: land it unclaimed for a player to pick up. */
+    unassigned: v.optional(v.boolean()),
     body: v.any(),
   },
   handler: async (ctx, args): Promise<Id<'pilots'> | Id<'mechs'>> => {
     const userId = await requireUser(ctx)
-    await assertGameMemberOrShelfOwner(ctx, args.gameId, userId)
+    const { tableRunner } = await assertMayAddToContainer(ctx, args.gameId, userId)
     const body = parseBody(args.table, args.body)
+
+    // `gameId: null && ownerId: null` is the one invalid combination in the
+    // schema — a shelf is a *person's*, so an unclaimed shelf entity would be
+    // owned by nobody and reachable by nobody.
+    if (args.unassigned === true && args.gameId === null) {
+      throw new NotAuthorized('A shelf has no crew to pick anything up — shelved builds are yours')
+    }
+    if (args.unassigned === true && !tableRunner) {
+      throw new NotAuthorized('Only the Mediator can leave a new character unclaimed')
+    }
 
     return await ctx.db.insert(args.table, {
       gameId: args.gameId,
-      ownerId: userId,
+      ownerId: args.unassigned === true ? null : userId,
       appId: args.appId,
       body,
       updatedAt: Date.now(),
@@ -192,6 +276,61 @@ export const remove = mutation({
 
     assertMayWrite(doc as Doc<'pilots'> | Doc<'mechs'>, userId)
     await ctx.db.delete(doc._id)
+  },
+})
+
+/**
+ * Raise a Union Crawler in this Game. Table runner only.
+ *
+ * A Game may hold **several** crawlers, and that is not a leniency — a long
+ * campaign genuinely runs more than one: a crawler is lost or scrapped and the
+ * crew rebuilds, or a second one is met, escorted and eventually joined. The
+ * schema never said one, and forcing it here would make the ordinary course of
+ * a campaign look like a bug.
+ *
+ * There is deliberately no `unassigned` axis: a crawler has no `ownerId` at all
+ * (D8). It belongs to the crew from the moment it exists, which is exactly why
+ * players may fill in its fields without ever being handed it.
+ */
+export const createCrawler = mutation({
+  args: {
+    gameId: v.id('games'),
+    /** The local UUID this row mirrors — see `pilots.appId`. */
+    appId: v.optional(v.string()),
+    body: v.any(),
+  },
+  handler: async (ctx, args): Promise<Id<'crawlers'>> => {
+    await requireTableRunner(ctx, args.gameId)
+
+    const result = CrawlerSchema.safeParse(args.body)
+    if (!result.success) {
+      throw new Error(`Invalid crawler payload: ${result.error.issues[0]?.message ?? 'unknown'}`)
+    }
+
+    return await ctx.db.insert('crawlers', {
+      gameId: args.gameId,
+      appId: args.appId,
+      body: result.data,
+      updatedAt: Date.now(),
+    })
+  },
+})
+
+/**
+ * Scrap a crawler. Table runner only — the mirror of raising one.
+ *
+ * Communal editing does **not** extend to destruction: the crawler is the
+ * crew's home and every pilot in the Game is anchored to it, so one member
+ * deleting it would take the table's shared state with them. Whoever runs the
+ * table decides a crawler is gone.
+ */
+export const removeCrawler = mutation({
+  args: { crawlerId: v.id('crawlers') },
+  handler: async (ctx, args): Promise<void> => {
+    const doc = await ctx.db.get(args.crawlerId)
+    if (doc === null) return
+    await requireTableRunner(ctx, doc.gameId)
+    await ctx.db.delete(args.crawlerId)
   },
 })
 
@@ -392,6 +531,12 @@ async function byAppId(
  * created while Solo and the account was claimed afterwards. Treating a missing
  * row as "create it" is what makes the mirror converge instead of silently
  * dropping the first edit after a claim.
+ *
+ * The insert branch is a **create into a container**, so it answers to the same
+ * gate `create` does. Leaving it open would have made the whole rule cosmetic:
+ * the client's ordinary write path comes through here, so a player blocked from
+ * `create` would simply have built the pilot locally and had the mirror place
+ * it in the Game a moment later.
  */
 export const upsertByAppId = mutation({
   args: {
@@ -402,11 +547,11 @@ export const upsertByAppId = mutation({
   },
   handler: async (ctx, args): Promise<void> => {
     const userId = await requireUser(ctx)
-    await assertGameMemberOrShelfOwner(ctx, args.gameId, userId)
     const body = parseBody(args.table, args.body)
 
     const existing = await byAppId(ctx, args.table, args.appId)
     if (existing === null) {
+      await assertMayAddToContainer(ctx, args.gameId, userId)
       await ctx.db.insert(args.table, {
         gameId: args.gameId,
         ownerId: userId,
@@ -418,7 +563,75 @@ export const upsertByAppId = mutation({
     }
 
     assertMayWrite(existing, userId)
+
+    /**
+     * A mirrored write also re-homes the row when the client has moved it.
+     *
+     * Until this existed, `MoveToContainerControl` re-stamped the local record
+     * and the mirror patched only the body — so moving a build onto a Game
+     * looked like it worked, the roster filtered by the new container, and the
+     * server row never left the shelf. The move is a create *into* the target
+     * container as far as the rules are concerned, so it answers to the same
+     * gate; leaving the source is unconditional.
+     */
+    if (existing.gameId !== args.gameId) {
+      await assertMayAddToContainer(ctx, args.gameId, userId)
+      await ctx.db.patch(existing._id, { gameId: args.gameId })
+    }
+
     await ctx.db.patch(existing._id, { body, updatedAt: Date.now() })
+  },
+})
+
+/**
+ * Mirror a local crawler write, addressed by app id, as a field-level merge.
+ *
+ * The crawler needs its own mirror because it is the one entity whose local
+ * edits are legitimate from *any* member — "players can only edit fields" is
+ * only true end to end if those edits actually arrive. Routing them through the
+ * same merge `patchCrawler` uses is what keeps two people editing scrap and
+ * cargo in the same minute from overwriting each other.
+ *
+ * Unlike the ownable tables this **never inserts**. A missing row means the
+ * crawler is not in this Game — either it is a purely local build (Solo, or on
+ * the shelf, neither of which has a server row to reach) or it was scrapped by
+ * the table runner. Creating one here would route around the rule that raising
+ * a crawler is the table runner's act, which is precisely the hole the ownable
+ * upsert had to be closed against.
+ */
+export const patchCrawlerByAppId = mutation({
+  args: { appId: v.string(), patch: v.any() },
+  handler: async (ctx, args): Promise<void> => {
+    const existing = await ctx.db
+      .query('crawlers')
+      .withIndex('by_app_id', (q) => q.eq('appId', args.appId))
+      .unique()
+    if (existing === null) return
+
+    await requireMember(ctx, existing.gameId)
+
+    const merged = { ...(existing.body as Record<string, unknown>), ...(args.patch as object) }
+    const result = CrawlerSchema.safeParse(merged)
+    if (!result.success) {
+      throw new Error(`Invalid crawler payload: ${result.error.issues[0]?.message ?? 'unknown'}`)
+    }
+
+    await ctx.db.patch(existing._id, { body: result.data, updatedAt: Date.now() })
+  },
+})
+
+/** Scrap a crawler addressed by app id. Table runner only, like `removeCrawler`. */
+export const removeCrawlerByAppId = mutation({
+  args: { appId: v.string() },
+  handler: async (ctx, args): Promise<void> => {
+    const existing = await ctx.db
+      .query('crawlers')
+      .withIndex('by_app_id', (q) => q.eq('appId', args.appId))
+      .unique()
+    if (existing === null) return
+
+    await requireTableRunner(ctx, existing.gameId)
+    await ctx.db.delete(existing._id)
   },
 })
 

--- a/apps/itun/convex/model/permissions.ts
+++ b/apps/itun/convex/model/permissions.ts
@@ -91,25 +91,80 @@ export async function gameHasMediator(ctx: AnyCtx, gameId: Id<'games'>): Promise
 }
 
 /**
- * Whoever may assign or reassign entity ownership in this Game.
+ * Whoever runs the table: the Mediator, or the Organizer while a Game has none.
  *
  * This is the **one deliberate bend** in "Organizer confers no content
- * authority" (ADR-030 §3). Assignment belongs to the Mediator, but a Game with
- * no Mediator assigned would otherwise have nobody able to hand out a pilot —
- * a dead end reachable the moment a Game is created. So the Organizer picks it
- * up, and *only* when there is no Mediator.
+ * authority" (ADR-030 §3), and it exists because every one of these acts is a
+ * dead end otherwise. A Game is created with `mediator: false` on its only
+ * membership, so if table authority were Mediator-strict there would be an
+ * unreachable state the moment somebody makes a Game alone: no crawler can be
+ * raised, no pilot handed out, and nothing to appoint a Mediator *for*.
  *
- * It is defensible because who-owns-what is closer to membership than to
- * content: assigning a pilot never edits one.
+ * The fallback is narrow on purpose — it applies only while the Game has no
+ * Mediator at all, and it is re-evaluated per call rather than latched, so
+ * appointing one takes the authority back the same instant.
+ *
+ * Three acts share this rule, and they share it because they are the same
+ * kind of act — *setting the table up* rather than editing what is on it:
+ *
+ *   - raising or scrapping a **crawler** (ADR-030 §5 amendment)
+ *   - creating an entity **unclaimed**, for the crew to pick up
+ *   - **assigning** or reassigning ownership
+ *
+ * None of them edits a sheet. That is the line: a table runner arranges who
+ * holds what and what the crew sails in, and still cannot change a number on
+ * somebody else's pilot — for that there is a proposal (§4).
+ */
+export async function isTableRunner(
+  ctx: AnyCtx,
+  gameId: Id<'games'>,
+  membership: Doc<'memberships'>
+): Promise<boolean> {
+  if (membership.mediator) return true
+  return membership.organizer && !(await gameHasMediator(ctx, gameId))
+}
+
+export async function requireTableRunner(
+  ctx: AnyCtx,
+  gameId: Id<'games'>
+): Promise<Doc<'memberships'>> {
+  const membership = await requireMember(ctx, gameId)
+  if (await isTableRunner(ctx, gameId, membership)) return membership
+  throw new NotAuthorized(
+    'Only the Mediator can do that (or the Organizer, when the game has no Mediator)'
+  )
+}
+
+/**
+ * Whoever may assign or reassign entity ownership in this Game.
+ *
+ * Kept as its own name because the call sites read better for it and because
+ * ADR-030 §3 names assignment specifically; the rule itself is
+ * `requireTableRunner`, and there is deliberately only one implementation of
+ * it so the two can never drift into different answers.
  */
 export async function requireOwnershipAssigner(
   ctx: AnyCtx,
   gameId: Id<'games'>
 ): Promise<Doc<'memberships'>> {
-  const membership = await requireMember(ctx, gameId)
-  if (membership.mediator) return membership
-  if (membership.organizer && !(await gameHasMediator(ctx, gameId))) return membership
-  throw new NotAuthorized(
-    'Only the Mediator can assign ownership (or the Organizer, when the game has no Mediator)'
-  )
+  return await requireTableRunner(ctx, gameId)
+}
+
+/**
+ * True once a Game has somewhere for its crew to live.
+ *
+ * The crawler is the crew's home, and in Salvage Union a pilot without one is
+ * a character with no context — no Bay to repair in, no scrap pool, no place
+ * to return to. So a Game is *set up* by raising a crawler, and only then does
+ * it start taking pilots and mechs from its players.
+ *
+ * This is a gate on **players adding to a Game**, never on the table runner,
+ * who has to be able to build the crawler first for anyone else to have one.
+ */
+export async function gameHasCrawler(ctx: AnyCtx, gameId: Id<'games'>): Promise<boolean> {
+  const first = await ctx.db
+    .query('crawlers')
+    .withIndex('by_game', (q) => q.eq('gameId', gameId))
+    .first()
+  return first !== null
 }

--- a/apps/itun/convex/ownership.ts
+++ b/apps/itun/convex/ownership.ts
@@ -19,9 +19,25 @@ import {
  * pre-builds a character, or when a Game is seeded from a template. Every
  * surface that renders an owner must render "Unclaimed" rather than a blank.
  *
- * Players do **not** self-claim. Assignment is a deliberate act by whoever runs
- * the table (see `requireOwnershipAssigner`), so this module is the whole of
- * the write path for the `ownerId` column and each act lands in the Change Log.
+ * This module is the whole of the write path for the `ownerId` column, and
+ * every act in it lands in the Change Log.
+ *
+ * ## Players self-claim what is offered (amends ADR-030 §4)
+ *
+ * ADR-030 originally said assignment was the Mediator's alone and players never
+ * self-claimed. That has been amended, and the reason is what the unclaimed
+ * state is actually *for*: a Mediator pre-builds characters, or a template
+ * seeds six of them, precisely so people can arrive and take one. Making the
+ * Mediator hand each one over individually adds a round trip to the table's
+ * first ten minutes and buys nothing — an unclaimed entity is already an offer
+ * to the crew, and `claim` is a player accepting it.
+ *
+ * What did **not** change is the boundary the original rule protected: claiming
+ * touches only what is *free*. An entity somebody already holds cannot be taken
+ * — it must be released first, by its owner or the Mediator — so no player can
+ * ever pull a character out from under a crewmate. `assign` remains the
+ * table runner's power for placing an entity with a *particular* person, which
+ * self-claim cannot express.
  */
 
 /** The two entity tables that carry an owner. Crawlers are communal by design. */
@@ -112,6 +128,49 @@ export const assign = mutation({
       before: doc.ownerId,
       after: args.toUserId,
       actorId: actor.userId,
+    })
+  },
+})
+
+/**
+ * Pick up an unclaimed entity in a Game you belong to.
+ *
+ * Membership is the whole check *plus* the entity being free — see the module
+ * header for why that pair is the entire rule. Note what is deliberately absent:
+ * there is no crawler gate here. That gate governs a player *adding* to a Game;
+ * claiming adds nothing, it only puts a name to something the table already
+ * holds, and a pre-gen offered before the crawler was raised should not become
+ * unclaimable because of the order the Mediator worked in.
+ *
+ * Racing is resolved by the transaction: two players claiming the same pre-gen
+ * in the same instant serialize, and the second one finds it owned and is told
+ * so, rather than silently overwriting the first.
+ */
+export const claim = mutation({
+  args: { table: ownableTable, entityId: v.string() },
+  handler: async (ctx, args): Promise<void> => {
+    const doc = await loadOwnable(ctx, args.table, args.entityId)
+    if (doc.gameId === null) {
+      throw new NotAuthorized('That build is on somebody’s shelf, not in a game')
+    }
+
+    const membership = await requireMember(ctx, doc.gameId)
+
+    if (doc.ownerId === membership.userId) return
+    if (doc.ownerId !== null) {
+      throw new NotAuthorized(
+        'A crewmate already holds that — it has to be released before anyone else can take it'
+      )
+    }
+
+    await ctx.db.patch(doc._id, { ownerId: membership.userId, updatedAt: Date.now() })
+    await logOwnershipChange(ctx, {
+      table: args.table,
+      entityId: args.entityId,
+      gameId: doc.gameId,
+      before: null,
+      after: membership.userId,
+      actorId: membership.userId,
     })
   },
 })

--- a/apps/itun/convex/proposals.ts
+++ b/apps/itun/convex/proposals.ts
@@ -1,5 +1,7 @@
 import { v } from 'convex/values'
 
+import { MechSchema } from '../src/lib/schemas/mech'
+import { PilotSchema } from '../src/lib/schemas/pilot'
 import type { Doc, Id } from './_generated/dataModel'
 import { mutation, query } from './_generated/server'
 import type { MutationCtx } from './_generated/server'
@@ -157,8 +159,26 @@ export const apply = mutation({
     const { doc } = await requireProposalTarget(ctx, proposal.entityId)
     if (doc.ownerId !== userId) throw new NotAuthorized('Only the owner can apply this')
 
-    const body = { ...(doc.body as Record<string, unknown>), [proposal.field]: proposal.after }
-    await ctx.db.patch(doc._id, { body, updatedAt: Date.now() })
+    /**
+     * Parse before persisting, like every other write against an entity body.
+     *
+     * This mutation used to patch the merged object straight in, and it is the
+     * one place where skipping the parse does real damage rather than merely
+     * risking it: the field name comes from a proposal row, so a typo'd or
+     * stale key was written as a **new** key on the body instead of changing
+     * anything. The player applied a proposal, saw nothing move, and the sheet
+     * quietly carried a field nothing reads. Parsing rejects that at the source.
+     */
+    const parser = proposal.entityType === 'mech' ? MechSchema : PilotSchema
+    const merged = { ...(doc.body as Record<string, unknown>), [proposal.field]: proposal.after }
+    const result = parser.safeParse(merged)
+    if (!result.success) {
+      throw new Error(
+        `That proposal does not fit this sheet: ${result.error.issues[0]?.message ?? 'unknown'}`
+      )
+    }
+
+    await ctx.db.patch(doc._id, { body: result.data, updatedAt: Date.now() })
     await ctx.db.patch(args.proposalId, { state: 'applied' })
   },
 })

--- a/apps/itun/src/components/__tests__/mockEntityStore.ts
+++ b/apps/itun/src/components/__tests__/mockEntityStore.ts
@@ -42,6 +42,8 @@ export type EntityStoreMockOverrides = {
   list?: (type: EntityType) => AnyEntity[]
   get?: (type: EntityType, id: string) => AnyEntity | null
   create?: (type: EntityType, input: CreateInput<EntityType>) => Promise<AnyEntity | null>
+  adopt?: (type: EntityType, record: AnyEntity) => Promise<AnyEntity | null>
+  forget?: EntityState['forget']
   update?: (
     type: EntityType,
     id: string,
@@ -94,6 +96,12 @@ export function makeEntityStoreMock(
       : async () => {
           throw new Error('entityStore mock: create not stubbed')
         },
+    adopt: overrides.adopt
+      ? (overrides.adopt as EntityState['adopt'])
+      : async () => {
+          throw new Error('entityStore mock: adopt not stubbed')
+        },
+    forget: overrides.forget ?? (async () => {}),
     update: overrides.update
       ? (overrides.update as EntityState['update'])
       : async () => {

--- a/apps/itun/src/components/games/CrewVitals.tsx
+++ b/apps/itun/src/components/games/CrewVitals.tsx
@@ -44,7 +44,7 @@ export function CrewVitals({ gameId }: { gameId: Id<'games'> }) {
                 {owner(p.ownerName, p.ownerId)}
               </Text>
               <Text as="span" className={NUM}>
-                HP {p.currentHp ?? '—'} · AP {p.currentAp ?? '—'}
+                HP {p.currentHP ?? '—'} · AP {p.currentAP ?? '—'}
               </Text>
             </span>
           </div>
@@ -64,7 +64,7 @@ export function CrewVitals({ gameId }: { gameId: Id<'games'> }) {
                 {owner(m.ownerName, m.ownerId)}
               </Text>
               <Text as="span" className={NUM}>
-                SP {m.currentSp ?? '—'} · Heat {m.currentHeat ?? '—'}
+                SP {m.currentSP ?? '—'} · Heat {m.currentHeat ?? '—'}
               </Text>
             </span>
           </div>

--- a/apps/itun/src/components/games/GameRoster.tsx
+++ b/apps/itun/src/components/games/GameRoster.tsx
@@ -1,0 +1,573 @@
+/**
+ * GameRoster — a Game's crew, rendered as the Roster renders a shelf.
+ *
+ * ## Why this looks like the home page
+ *
+ * The Roster (`components/roster/Roster.tsx`) is the app's answer to "what have
+ * I got and what can I do with it": three ontology-toned columns of
+ * `EntityRow`s, a create CTA at the head of each, a Dashboard launch in the
+ * header. A Game asks the same question of a different container, and the first
+ * cut of the Game surfaces answered it in a different vocabulary entirely — a
+ * vertical stack of bordered cards listing names and numbers, with no way in to
+ * a sheet and no way to make anything. Two shapes for one question is how an
+ * app stops feeling like one app.
+ *
+ * So this is the same shape, with the parts a shared table adds: an owner chip
+ * on every row, a way to pick up what nobody holds, and creation gated by the
+ * rules in `lib/games/gameRoster.ts`.
+ *
+ * ## Creation goes through the wizards, not through a form here
+ *
+ * A create CTA points this browser's **current container** at the Game and then
+ * opens the ordinary wizard. Nothing about building a pilot changes because the
+ * pilot is destined for a crew, and a second, thinner creation path would drift
+ * from the real one immediately. The entity is stamped with the Game on write
+ * (`entityStore.create`) and mirrored up from there.
+ *
+ * ## What a row will and will not open
+ *
+ * Only what you own offers a sheet, and the reasoning is in
+ * `lib/games/gameRoster.ts` — ITUN's sheet is a live editing surface, so
+ * opening a crewmate's would hand you an editor the server then refuses. The
+ * crawler is the exception because it is genuinely communal.
+ *
+ * Rows you may open but have never held locally are **adopted on the way in**:
+ * the server body is cached into IndexedDB under its own id, which is what
+ * makes the sheet and the Dashboard work at all for a character built at
+ * somebody else's table.
+ */
+
+import { useState } from 'react'
+import { useRouter } from '@tanstack/react-router'
+import { Bot, UserRound, Warehouse } from 'lucide-react'
+import { useMutation, useQuery } from 'convex/react'
+import {
+  Badge,
+  Button,
+  buttonVariants,
+  EmptyState,
+  EntityRow,
+  ModalShell,
+  Text,
+} from 'component-lib'
+
+import { api } from '../../../convex/_generated/api'
+import type { Id } from '../../../convex/_generated/dataModel'
+import { useCrawlers, useHydrateEntities, useMechs, usePilots } from '../../hooks/queries'
+import { resolveClassName } from '../../lib/classRef'
+import {
+  crawlerRows,
+  ownableRows,
+  tableCapabilities,
+  type RosterRow,
+  type RosterKind,
+} from '../../lib/games/gameRoster'
+import type { Crawler } from '../../lib/schemas/crawler'
+import type { Mech } from '../../lib/schemas/mech'
+import type { Pilot } from '../../lib/schemas/pilot'
+import { setActiveContainer } from '../../stores/activeContainerStore'
+import { useEntityStore } from '../../stores/entityStore'
+import { cn } from '../../lib/utils'
+import { AppLink } from '../shared/AppLink'
+import { SECTION } from './gameChrome'
+
+type GameRosterProps = {
+  gameId: string
+  /** Shown above the columns; the Game's name, when the caller knows it. */
+  gameName?: string
+}
+
+/** The three columns, in the build order the app teaches everywhere else. */
+const COLUMNS: ReadonlyArray<{
+  kind: RosterKind
+  title: string
+  createHref: string
+  createLabel: string
+  empty: string
+}> = [
+  {
+    kind: 'pilot',
+    title: 'Pilots',
+    createHref: '/pilots/new',
+    createLabel: 'Create Pilot',
+    empty: 'No pilots in this game yet.',
+  },
+  {
+    kind: 'mech',
+    title: 'Mechs',
+    createHref: '/mechs/new',
+    createLabel: 'Create Mech',
+    empty: 'No mechs in this game yet.',
+  },
+  {
+    kind: 'crawler',
+    title: 'Crawlers',
+    createHref: '/crawlers/new',
+    createLabel: 'Raise a Crawler',
+    empty: 'No Union Crawler yet.',
+  },
+]
+
+const ICON: Record<RosterKind, typeof UserRound> = {
+  pilot: UserRound,
+  mech: Bot,
+  crawler: Warehouse,
+}
+
+const TONE_TEXT: Record<RosterKind, string> = {
+  pilot: 'text-sheet-pilot-deep',
+  mech: 'text-sheet-mech-deep',
+  crawler: 'text-sheet-crawler-deep',
+}
+
+/** Vitals for the row's stat strip. Absent numbers are omitted, never zeroed. */
+function statsFor(row: RosterRow): Array<{ label: string; value: string | number }> {
+  const num = (key: string): number | undefined => {
+    const value = row.body[key]
+    return typeof value === 'number' ? value : undefined
+  }
+  const out: Array<{ label: string; value: string | number }> = []
+
+  if (row.kind === 'pilot') {
+    if (num('currentHP') !== undefined) out.push({ label: 'HP', value: num('currentHP') as number })
+    if (num('currentAP') !== undefined) out.push({ label: 'AP', value: num('currentAP') as number })
+  }
+  if (row.kind === 'mech') {
+    if (num('currentSP') !== undefined) out.push({ label: 'SP', value: num('currentSP') as number })
+    if (num('currentHeat') !== undefined) {
+      out.push({ label: 'Heat', value: num('currentHeat') as number })
+    }
+  }
+  if (row.kind === 'crawler') {
+    const tl = String(row.body.techLevel ?? '').replace(/[^0-9]/g, '')
+    if (tl) out.push({ label: 'TL', value: tl })
+    const bays = Array.isArray(row.body.crawlerBays) ? row.body.crawlerBays.length : 0
+    out.push({ label: 'Bays', value: bays })
+  }
+  return out
+}
+
+/** The muted caption under the name: callsign / chassis, then the owner chip. */
+function metaLineFor(row: RosterRow) {
+  const parts: string[] = []
+  if (row.kind === 'pilot') {
+    const callsign = row.body.callsign
+    if (typeof callsign === 'string' && callsign.length > 0 && callsign !== row.name) {
+      parts.push(`"${callsign}"`)
+    }
+    const className = resolveClassName(String(row.body.classRef ?? ''))
+    if (className) parts.push(className)
+  }
+  if (row.kind === 'mech') {
+    const chassis = row.body.chassisRef
+    if (typeof chassis === 'string' && chassis.length > 0) parts.push(chassis)
+  }
+
+  return (
+    <span className="flex flex-wrap items-center gap-1.5">
+      {parts.length > 0 && <span>{parts.join(' · ')}</span>}
+      {/* Ownership is a STATE, not a blank (ADR-030 D32). An UNCLAIMED row
+          carries its state as a stamp seal in the row's trailing controls
+          instead of a chip here — see `UnclaimedSeal`. */}
+      {row.owner !== null && !row.owner.unclaimed && (
+        <Badge shape="chip" surface="tone" tone={row.kind} className="max-w-full truncate">
+          {row.owner.label}
+        </Badge>
+      )}
+    </span>
+  )
+}
+
+/**
+ * The UNCLAIMED seal: a stamped mark on the right of the row, and the way in
+ * to picking that character up.
+ *
+ * It is one control rather than a chip plus a button because it is one fact.
+ * An unclaimed pre-gen is an *offer*, so the thing that announces it should
+ * also be the thing you press — a row that read "Unclaimed" in muted grey next
+ * to a separate "Pick up" said the same thing twice and buried the invitation
+ * in the quieter half.
+ *
+ * Stamped rather than chipped for the same reason a document is stamped: it is
+ * a mark applied ON the record about its status, not a property of the
+ * character. It opens a confirm rather than claiming outright — taking a
+ * character is a commitment at the table, and the modal is where the surface
+ * says what happens next (it becomes yours, and it lands in this browser).
+ */
+function UnclaimedSeal({ onClick, disabled }: { onClick: () => void; disabled: boolean }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label="Unclaimed — pick this up"
+      className={cn(
+        'rotate-[-4deg] cursor-pointer border-0 bg-transparent p-0',
+        'transition-transform duration-200 hover:rotate-0 disabled:cursor-default disabled:opacity-50'
+      )}
+    >
+      <Badge shape="stamp" size="compact" surface="inverse" className="tracking-caps-wide">
+        Unclaimed
+      </Badge>
+    </button>
+  )
+}
+
+export function GameRoster({ gameId, gameName }: GameRosterProps) {
+  // Probed rather than required, the way `AppLink` and `DashboardChooser` do:
+  // component tests render these surfaces without a RouterProvider, and a hook
+  // that throws on a missing context would make the whole screen untestable.
+  const router = useRouter({ warn: false })
+  const [busy, setBusy] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  /** The row whose UNCLAIMED seal was pressed, awaiting confirmation. */
+  const [claimTarget, setClaimTarget] = useState<RosterRow | null>(null)
+
+  const me = useQuery(api.account.me, {})
+  const members = useQuery(api.games.members, { gameId: gameId as Id<'games'> })
+  const listing = useQuery(api.entities.listForGame, { gameId: gameId as Id<'games'> })
+
+  const claim = useMutation(api.ownership.claim)
+  const release = useMutation(api.ownership.release)
+  const scrapCrawler = useMutation(api.entities.removeCrawler)
+
+  // Local copies decide what opens without a round trip, so the columns need
+  // the local stores hydrated even though the listing itself is remote.
+  useHydrateEntities(['pilot', 'mech', 'crawler'])
+  const localPilots: Pilot[] = usePilots()
+  const localMechs: Mech[] = useMechs()
+  const localCrawlers: Crawler[] = useCrawlers()
+
+  const viewerId = me?._id ?? null
+  const roster = members ?? []
+  const caps = tableCapabilities({
+    viewerId,
+    members: roster,
+    crawlerCount: listing?.crawlers.length ?? 0,
+  })
+
+  const rows: Record<RosterKind, RosterRow[]> = {
+    pilot: ownableRows({
+      kind: 'pilot',
+      rows: listing?.pilots ?? [],
+      viewerId,
+      members: roster,
+      localIds: new Set(localPilots.map((p) => p.id)),
+    }),
+    mech: ownableRows({
+      kind: 'mech',
+      rows: listing?.mechs ?? [],
+      viewerId,
+      members: roster,
+      localIds: new Set(localMechs.map((m) => m.id)),
+    }),
+    crawler: crawlerRows({
+      rows: listing?.crawlers ?? [],
+      tableRunner: caps.tableRunner,
+      localIds: new Set(localCrawlers.map((c) => c.id)),
+    }),
+  }
+
+  /**
+   * Make sure this browser holds the row, then hand back the id a sheet route
+   * takes. Adoption keeps the entity's own id, so the copy IS the entity rather
+   * than a fork of it — see `entityStore.adopt`.
+   */
+  async function ensureLocal(row: RosterRow): Promise<string | null> {
+    const id = row.body.id
+    if (typeof id !== 'string' || id.length === 0) return row.localId
+    // Adopted even when a copy is already here: the server is the source of
+    // record, and the copy may be stale — most obviously for the crawler, which
+    // the whole crew edits. Overwriting is safe because every local write
+    // mirrors up immediately, so a local copy is never legitimately ahead.
+    await useEntityStore.getState().adopt(row.kind, row.body as never)
+    return id
+  }
+
+  async function run(key: string, work: () => Promise<void>) {
+    setBusy(key)
+    setError(null)
+    try {
+      await work()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'That did not work.')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  async function openSheet(row: RosterRow) {
+    const localId = await ensureLocal(row)
+    if (localId === null) {
+      throw new Error('That build has not been saved anywhere this browser can open yet.')
+    }
+    await router?.navigate({ to: '/sheet/$kind/$id', params: { kind: row.kind, id: localId } })
+  }
+
+  async function launchDashboard(row: RosterRow) {
+    const localId = await ensureLocal(row)
+    if (localId === null) throw new Error('That mech cannot be launched from this browser yet.')
+    await router?.navigate({ to: '/dashboard/$id', params: { id: localId } })
+  }
+
+  /**
+   * Point this browser at the Game on the way into the wizard.
+   *
+   * Rendered as a link with a side effect rather than a button that navigates:
+   * `entityStore.create` stamps whatever container is current, so the container
+   * has to change BEFORE the wizard's create call — and going through `AppLink`
+   * keeps the CTA a real anchor (middle-click, open-in-new-tab, and the
+   * router-less fallback the component tests rely on).
+   */
+  function enterGameContainer() {
+    setActiveContainer({ kind: 'game', gameId })
+  }
+
+  const loading = listing === undefined || members === undefined
+
+  return (
+    <section className="flex flex-col gap-5">
+      <div className="flex flex-wrap items-end justify-between gap-3 border-b-2 border-ink pb-4">
+        <div>
+          <Text as="div" className={SECTION}>
+            {gameName ?? 'The crew'}
+          </Text>
+          <Text variant="hint" className="text-left">
+            {caps.tableRunner
+              ? 'You run this table: raise its crawler, and build characters for the crew to pick up.'
+              : 'Everything the crew has brought to this game. Pick up anything nobody holds.'}
+          </Text>
+        </div>
+      </div>
+
+      {error !== null && (
+        <Text variant="hint" className="text-left text-[var(--color-roll-cascade)]">
+          {error}
+        </Text>
+      )}
+
+      {!caps.canAddCrew && caps.addCrewBlocked !== null && (
+        <Text variant="hint" className="text-left">
+          {caps.addCrewBlocked}
+        </Text>
+      )}
+
+      {loading ? (
+        <Text variant="hint">Loading the crew…</Text>
+      ) : (
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
+          {COLUMNS.map((column) => {
+            const Icon = ICON[column.kind]
+            const columnRows = rows[column.kind]
+            // The crawler column answers to the table runner; the other two to
+            // the crawler gate. Both mirror `assertMayAddToContainer`.
+            const mayCreate =
+              column.kind === 'crawler'
+                ? caps.canRaiseCrawler
+                : caps.canAddCrew && viewerId !== null
+
+            return (
+              <div key={column.kind}>
+                <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                  <h3 className="font-cond text-base font-bold uppercase tracking-widest text-rust">
+                    {column.title}
+                  </h3>
+                  {mayCreate && columnRows.length > 0 && (
+                    <AppLink
+                      href={column.createHref}
+                      onClick={enterGameContainer}
+                      className={cn(
+                        buttonVariants({ variant: 'default', size: 'compact' }),
+                        'no-underline'
+                      )}
+                    >
+                      + {column.createLabel}
+                    </AppLink>
+                  )}
+                </div>
+
+                {columnRows.length === 0 ? (
+                  <EmptyState
+                    variant="quiet"
+                    body={
+                      column.kind === 'crawler' && !caps.canRaiseCrawler
+                        ? 'No Union Crawler yet — the Mediator raises one.'
+                        : column.empty
+                    }
+                    icon={<Icon className={cn('size-7', TONE_TEXT[column.kind])} />}
+                    action={
+                      mayCreate ? (
+                        <AppLink
+                          href={column.createHref}
+                          onClick={enterGameContainer}
+                          className={cn(
+                            buttonVariants({ variant: 'primary', size: 'compact' }),
+                            'no-underline'
+                          )}
+                        >
+                          {column.createLabel}
+                        </AppLink>
+                      ) : undefined
+                    }
+                  />
+                ) : (
+                  <ul className="flex flex-col gap-2.5">
+                    {columnRows.map((row) => (
+                      <li key={row.serverId} className="list-none">
+                        <EntityRow
+                          entityType={row.kind}
+                          name={row.name}
+                          stats={statsFor(row)}
+                          metaLine={metaLineFor(row)}
+                          linkAs={AppLink}
+                          actions={
+                            <>
+                              {row.can.openSheet && (
+                                <Button
+                                  variant="default"
+                                  size="compact"
+                                  disabled={busy !== null}
+                                  onClick={() =>
+                                    void run(`open-${row.serverId}`, () => openSheet(row))
+                                  }
+                                >
+                                  Sheet
+                                </Button>
+                              )}
+                              {row.kind === 'mech' && row.can.openSheet && (
+                                <Button
+                                  variant="primary"
+                                  size="compact"
+                                  disabled={busy !== null}
+                                  onClick={() =>
+                                    void run(`dash-${row.serverId}`, () => launchDashboard(row))
+                                  }
+                                >
+                                  Dashboard
+                                </Button>
+                              )}
+                              {row.can.claim && (
+                                <UnclaimedSeal
+                                  disabled={busy !== null}
+                                  onClick={() => setClaimTarget(row)}
+                                />
+                              )}
+                              {row.can.release && caps.tableRunner && (
+                                <Button
+                                  variant="ghost"
+                                  size="compact"
+                                  disabled={busy !== null}
+                                  onClick={() =>
+                                    void run(`offer-${row.serverId}`, async () => {
+                                      await release({
+                                        table: row.kind === 'pilot' ? 'pilots' : 'mechs',
+                                        entityId: row.serverId,
+                                      })
+                                      // It belongs to the table now, not to this
+                                      // browser: keeping a local copy would leave
+                                      // an editor whose writes the server refuses.
+                                      if (row.localId !== null) {
+                                        await useEntityStore
+                                          .getState()
+                                          .forget(row.kind, row.localId)
+                                      }
+                                    })
+                                  }
+                                >
+                                  Offer to the crew
+                                </Button>
+                              )}
+                              {row.can.scrap && (
+                                <Button
+                                  variant="ghost"
+                                  size="compact"
+                                  disabled={busy !== null}
+                                  onClick={() =>
+                                    void run(`scrap-${row.serverId}`, async () => {
+                                      await scrapCrawler({
+                                        crawlerId: row.serverId as Id<'crawlers'>,
+                                      })
+                                      if (row.localId !== null) {
+                                        await useEntityStore
+                                          .getState()
+                                          .forget('crawler', row.localId)
+                                      }
+                                    })
+                                  }
+                                >
+                                  Scrap
+                                </Button>
+                              )}
+                            </>
+                          }
+                        />
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      <p className="font-body text-xs text-wk-muted">
+        Sheets you open from here are cached in this browser and saved back to the game.{' '}
+        <AppLink href="/" className={cn(buttonVariants({ variant: 'ghost', size: 'mini' }))}>
+          Back to your builds
+        </AppLink>
+      </p>
+
+      {/* Picking a character up is constructive, not destructive, so this is an
+          `action`-toned confirm rather than the danger one the delete flows use.
+          It exists to say what happens next — it becomes yours, and it lands in
+          this browser — which the seal alone cannot. */}
+      <ModalShell
+        open={claimTarget !== null}
+        onOpenChange={(next) => {
+          if (!next) setClaimTarget(null)
+        }}
+        title={`Pick up ${claimTarget?.name ?? ''}?`}
+        tone="action"
+        maxWidth="max-w-md"
+      >
+        <div className="flex flex-col gap-4 bg-paper p-5">
+          <div className="font-body text-sm text-wk-muted">
+            {claimTarget?.name ?? 'This character'} is unclaimed — the Mediator left them for
+            somebody to take. Picking them up makes you their owner: they become yours to edit, they
+            open in this browser, and every change saves back to the game.
+          </div>
+          <div className="font-body text-xs text-wk-muted">
+            Changed your mind later? Hand them back with “Offer to the crew”.
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" size="compact" onClick={() => setClaimTarget(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              size="compact"
+              disabled={busy !== null}
+              onClick={() => {
+                const row = claimTarget
+                if (row === null) return
+                void run(`claim-${row.serverId}`, async () => {
+                  await claim({
+                    table: row.kind === 'pilot' ? 'pilots' : 'mechs',
+                    entityId: row.serverId,
+                  })
+                  // Pull it down so it opens straight away — picking something
+                  // up and then having nowhere to open it would be half a verb.
+                  await ensureLocal(row)
+                  setClaimTarget(null)
+                })
+              }}
+            >
+              Pick up
+            </Button>
+          </div>
+        </div>
+      </ModalShell>
+    </section>
+  )
+}

--- a/apps/itun/src/components/games/GameRoster.tsx
+++ b/apps/itun/src/components/games/GameRoster.tsx
@@ -452,7 +452,11 @@ export function GameRoster({ gameId, gameName }: GameRosterProps) {
                                   onClick={() => setClaimTarget(row)}
                                 />
                               )}
-                              {row.can.release && caps.tableRunner && (
+                              {/* Any owner, not just the table runner: ADR-030
+                                  §4 says ownership is voluntary in the outward
+                                  direction, and the pick-up confirm promises
+                                  exactly this as the way back out. */}
+                              {row.can.release && (
                                 <Button
                                   variant="ghost"
                                   size="compact"

--- a/apps/itun/src/components/games/GameScreen.tsx
+++ b/apps/itun/src/components/games/GameScreen.tsx
@@ -1,0 +1,84 @@
+/**
+ * GameScreen — one Game, as a player sees it.
+ *
+ * The crew roster, the answer queue, and the table's Downtime: everything a
+ * member needs during a session that is not the Mediator's private apparatus.
+ * The Mediator opens `MediatorScreen`, which is this plus the instruments only
+ * they may see.
+ *
+ * ## Why the lobby no longer carries this
+ *
+ * `GamesScreen` used to render a proposal inbox and a Downtime panel inside
+ * every row of the games list, so a member of three campaigns met three
+ * Downtime panels stacked above each other with nothing saying which table each
+ * belonged to. A list of games is a list; the work happens inside one.
+ */
+
+import { useQuery } from 'convex/react'
+import { Card, Text } from 'component-lib'
+
+import { api } from '../../../convex/_generated/api'
+import type { Id } from '../../../convex/_generated/dataModel'
+import { useConnection } from '../../lib/connection/connectionContext'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+import { DowntimePanel } from './DowntimePanel'
+import { GameRoster } from './GameRoster'
+import { ProposalInbox } from './ProposalInbox'
+import { TITLE } from './gameChrome'
+import { AppLink } from '../shared/AppLink'
+
+function GameBody({ gameId }: { gameId: string }) {
+  const games = useQuery(api.games.listMine, {})
+  const game = games?.find((g) => g._id === gameId)
+
+  if (games === undefined) return <Text>Loading this game…</Text>
+  if (game === undefined) {
+    return (
+      <Card>
+        <div className="p-4">
+          <Text>
+            You are not in this game. Ask whoever organises it for an invite code, then join from
+            the Games screen.
+          </Text>
+        </div>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <GameRoster gameId={gameId} gameName={game.name} />
+      <ProposalInbox gameId={gameId as Id<'games'>} />
+      <DowntimePanel gameId={gameId as Id<'games'>} />
+      {game.mediator && (
+        <AppLink href={`/mediator/${gameId}`} className="font-cond text-sm font-bold uppercase">
+          Open the Mediator surface →
+        </AppLink>
+      )}
+    </div>
+  )
+}
+
+export function GameScreen({ gameId }: { gameId: string }) {
+  const { mode } = useConnection()
+
+  return (
+    <main className="mx-auto flex max-w-6xl flex-col gap-6 p-4 sm:p-8">
+      <Text as="h1" className={TITLE}>
+        Game
+      </Text>
+      {!isConvexConfigured || mode !== 'connected' ? (
+        <Card>
+          <div className="p-4">
+            <Text>
+              A Game is shared state, so it needs a connected account. You are playing solo — your
+              builds are on this device and need no account at all.
+            </Text>
+          </div>
+        </Card>
+      ) : (
+        <GameBody gameId={gameId} />
+      )}
+    </main>
+  )
+}

--- a/apps/itun/src/components/games/GamesScreen.tsx
+++ b/apps/itun/src/components/games/GamesScreen.tsx
@@ -7,8 +7,6 @@ import type { Id } from '../../../convex/_generated/dataModel'
 import { useConnection } from '../../lib/connection/connectionContext'
 import { isConvexConfigured } from '../../lib/connection/convexClient'
 import { SignInControl } from '../account/SignInControl'
-import { DowntimePanel } from './DowntimePanel'
-import { ProposalInbox } from './ProposalInbox'
 import { Link } from '@tanstack/react-router'
 
 /**
@@ -151,20 +149,28 @@ function GameRow({
 
         {game.organizer && <InvitePanel gameId={game._id} />}
 
-        {/* A player's answer queue and the table's Downtime live with the game
-            they belong to, so a member never has to go looking for either. */}
-        <ProposalInbox gameId={game._id} />
-        <DowntimePanel gameId={game._id} />
-
-        {game.mediator && (
+        {/* This screen is the lobby, so a row is a door rather than a
+            workspace. The answer queue and the table's Downtime used to render
+            inline here, which meant somebody in three campaigns met three
+            Downtime panels stacked up with nothing saying whose was whose. */}
+        <div className="flex flex-wrap items-center gap-3">
           <Link
-            to="/mediator/$gameId"
+            to="/games/$gameId"
             params={{ gameId: game._id }}
             className={`${label} text-[var(--color-rust)] hover:text-[var(--color-rust-hi)]`}
           >
-            Open the Mediator surface →
+            Open the crew →
           </Link>
-        )}
+          {game.mediator && (
+            <Link
+              to="/mediator/$gameId"
+              params={{ gameId: game._id }}
+              className={`${label} text-[var(--color-rust)] hover:text-[var(--color-rust-hi)]`}
+            >
+              Open the Mediator surface →
+            </Link>
+          )}
+        </div>
       </div>
     </Card>
   )

--- a/apps/itun/src/components/games/MediatorScreen.tsx
+++ b/apps/itun/src/components/games/MediatorScreen.tsx
@@ -8,6 +8,7 @@ import { useConnection } from '../../lib/connection/connectionContext'
 import { isConvexConfigured } from '../../lib/connection/convexClient'
 import { CrewVitals } from './CrewVitals'
 import { DowntimePanel } from './DowntimePanel'
+import { GameRoster } from './GameRoster'
 import { INPUT, ROW, SECTION, STAMP, TITLE } from './gameChrome'
 
 /**
@@ -26,15 +27,31 @@ import { INPUT, ROW, SECTION, STAMP, TITLE } from './gameChrome'
  * This is a plain scrolling surface instead — the *right* shape for a list that
  * grows with the crew.
  *
- * ## Scope note
+ * ## It opens with the crew, in the app's own vocabulary
  *
- * The composition here is functional and uses the app's existing chrome
- * vocabulary (hard ink borders, stamped condensed caps, the shipped tracking
- * ladder). It has not had a design pass, and the visual arrangement is the part
- * most likely to change.
+ * The first version of this screen opened with a bordered list of names and
+ * numbers and offered no way into a sheet, no way to launch anything, and no
+ * way to make anything — a status display for a surface whose whole job is
+ * running a table. It now opens with `GameRoster`, the same three ontology-toned
+ * columns of `EntityRow`s the home Roster uses, so the Mediator sees the crew
+ * the way they see their own builds and can act on them from the same place.
+ *
+ * The instruments below it are what a Mediator has that a player does not:
+ * presence, proposals, alerts, the Downtime phase, and the opposition tray.
+ * That ordering is the claim — the table first, the apparatus second.
  */
 
-const PROPOSABLE_FIELDS = ['currentHp', 'currentAp', 'currentSp', 'currentHeat'] as const
+/**
+ * The live-play fields a Mediator may propose a change to.
+ *
+ * **These are Zod field names and the casing is load-bearing.** They read
+ * `currentHp` / `currentAp` / `currentSp` before, none of which exist on
+ * `PilotSchema` or `MechSchema` — so a proposal applied cleanly, wrote a key
+ * nothing reads, and moved no number on the player's sheet. `proposals.apply`
+ * now parses the merged body and refuses a field the schema has no room for,
+ * which turns that class of typo into an error instead of a silent no-op.
+ */
+const PROPOSABLE_FIELDS = ['currentHP', 'currentAP', 'currentSP', 'currentHeat'] as const
 
 function NpcTray({ gameId }: { gameId: Id<'games'> }) {
   const npcs = useQuery(api.mediator.npcs, { gameId })
@@ -262,6 +279,11 @@ function MediatorBody({ gameId }: { gameId: Id<'games'> }) {
 
   return (
     <div className="flex flex-col gap-6">
+      {/* The table first: who is in this game, and everything you can do about
+          it — open, launch, hand out, raise a crawler. */}
+      <GameRoster gameId={gameId} />
+      {/* Then the numbers, live. The roster shows vitals per row; this is the
+          same crew read as one strip, which is how you scan a table mid-fight. */}
       <Card>
         <div className="p-4">
           <CrewVitals gameId={gameId} />
@@ -280,7 +302,9 @@ export function MediatorScreen({ gameId }: { gameId: string }) {
   const { mode } = useConnection()
 
   return (
-    <main className="mx-auto flex max-w-3xl flex-col gap-6 p-4">
+    // Wider than it was: the surface now leads with a three-column roster, and
+    // the old 3xl column squeezed it to one column on every screen size.
+    <main className="mx-auto flex max-w-6xl flex-col gap-6 p-4 sm:p-8">
       <Text as="h1" className={TITLE}>
         Mediator
       </Text>

--- a/apps/itun/src/components/games/__tests__/GameRoster.connected.test.tsx
+++ b/apps/itun/src/components/games/__tests__/GameRoster.connected.test.tsx
@@ -109,6 +109,18 @@ describe('what a row offers', () => {
     expect(screen.getByRole('button', { name: 'Dashboard' })).toBeTruthy()
   })
 
+  test('what you own can be handed back to the crew', () => {
+    renderAs(ME, listing({ pilots: [MY_PILOT] }))
+    // Ownership is voluntary outward (ADR-030 §4), and the pick-up confirm
+    // promises this as the way back out — so it cannot be Mediator-only.
+    expect(screen.getByRole('button', { name: 'Offer to the crew' })).toBeTruthy()
+  })
+
+  test("but a crewmate's cannot", () => {
+    renderAs(ME, listing({ pilots: [THEIR_PILOT] }))
+    expect(screen.queryByRole('button', { name: 'Offer to the crew' })).toBeNull()
+  })
+
   test("a crewmate's pilot shows who holds it and opens nothing", () => {
     renderAs(ME, listing({ pilots: [THEIR_PILOT] }))
 

--- a/apps/itun/src/components/games/__tests__/GameRoster.connected.test.tsx
+++ b/apps/itun/src/components/games/__tests__/GameRoster.connected.test.tsx
@@ -1,0 +1,198 @@
+import { afterAll, afterEach, describe, expect, mock, test } from 'bun:test'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+/**
+ * `GameRoster` — the crew roster, connected.
+ *
+ * What is worth testing here is not that three columns render; it is that the
+ * surface tells the truth about **what you may do**, because every control on
+ * it corresponds to a server rule that will refuse. The cases below are the
+ * ones where showing the wrong thing is actively harmful:
+ *
+ *  - offering a sheet for a crewmate's pilot (an editor whose saves are refused)
+ *  - offering to pick up something somebody already holds
+ *  - offering "create" in a Game with no crawler, which the server rejects
+ *  - hiding the crawler CTA from the only person who can raise one
+ *
+ * Queries are answered in **call order** — the generated `api` is a Proxy that
+ * throws when inspected, so position is the only stable key. This component
+ * asks for: account.me, games.members, entities.listForGame.
+ */
+
+let queryQueue: unknown[] = []
+let queryIndex = 0
+
+const realConvexClient = { ...(await import('../../../lib/connection/convexClient')) }
+const realConvexReact = { ...(await import('convex/react')) }
+
+mock.module('../../../lib/connection/convexClient', () => ({
+  isConvexConfigured: true,
+  convexClient: {},
+}))
+
+mock.module('convex/react', () => ({
+  useQuery: () => {
+    const value = queryQueue[queryIndex]
+    queryIndex += 1
+    return value
+  },
+  useMutation: () => async () => undefined,
+  useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
+  ConvexReactClient: class {},
+  ConvexProvider: ({ children }: { children: unknown }) => children,
+  ConvexProviderWithAuth: ({ children }: { children: unknown }) => children,
+  useConvex: () => ({}),
+  useAction: () => async () => undefined,
+}))
+
+const { GameRoster } = await import('../GameRoster')
+
+const ME = { _id: 'u-me', displayName: 'Me', avatarUrl: null, email: null }
+
+const MEMBERS = [
+  { userId: 'u-med', displayName: 'Mediator', mediator: true, organizer: true },
+  { userId: 'u-me', displayName: 'Me', mediator: false, organizer: false },
+]
+
+const MY_PILOT = {
+  _id: 's-mine',
+  appId: 'a-mine',
+  ownerId: 'u-me',
+  body: { id: 'a-mine', name: 'Roach-Boy', callsign: 'Roach-Boy', currentHP: 8 },
+}
+const THEIR_PILOT = {
+  _id: 's-theirs',
+  appId: 'a-theirs',
+  ownerId: 'u-med',
+  body: { id: 'a-theirs', name: 'Ash' },
+}
+const PRE_GEN = {
+  _id: 's-free',
+  appId: null,
+  ownerId: null,
+  body: { id: 'a-free', name: 'Pre-gen' },
+}
+const MY_MECH = {
+  _id: 's-mech',
+  appId: 'a-mech',
+  ownerId: 'u-me',
+  body: { id: 'a-mech', name: 'Iron Mongrel', chassisRef: 'iron-mongrel', currentSP: 12 },
+}
+const CRAWLER = {
+  _id: 's-crawler',
+  appId: 'a-crawler',
+  body: { id: 'a-crawler', name: '#430 Tenacity', techLevel: '1' },
+}
+
+function listing(over: Record<string, unknown> = {}) {
+  return { pilots: [], mechs: [], crawlers: [], softLinks: [], ...over }
+}
+
+/** Render as `viewer`, against one crew listing. */
+function renderAs(me: unknown, rows: ReturnType<typeof listing>, members: unknown = MEMBERS): void {
+  queryQueue = [me, members, rows]
+  queryIndex = 0
+  render(<GameRoster gameId="g1" gameName="Tenacity" />)
+}
+
+afterEach(cleanup)
+
+describe('what a row offers', () => {
+  test('your own pilot opens its sheet', () => {
+    renderAs(ME, listing({ pilots: [MY_PILOT] }))
+    expect(screen.getByText('Roach-Boy')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Sheet' })).toBeTruthy()
+  })
+
+  test('your own mech also offers the Dashboard', () => {
+    renderAs(ME, listing({ mechs: [MY_MECH] }))
+    expect(screen.getByRole('button', { name: 'Dashboard' })).toBeTruthy()
+  })
+
+  test("a crewmate's pilot shows who holds it and opens nothing", () => {
+    renderAs(ME, listing({ pilots: [THEIR_PILOT] }))
+
+    expect(screen.getByText('Ash')).toBeTruthy()
+    // Naming the owner is the point of the chip; opening their sheet would
+    // hand over an editor whose every save the server refuses.
+    expect(screen.getByText('Mediator')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Sheet' })).toBeNull()
+    expect(screen.queryByRole('button', { name: /Unclaimed/i })).toBeNull()
+  })
+})
+
+describe('picking up what nobody holds', () => {
+  test('an unclaimed pre-gen carries an UNCLAIMED seal', () => {
+    renderAs(ME, listing({ pilots: [PRE_GEN] }))
+
+    // Unclaimed is a STATE, not a blank — and the mark announcing it is the
+    // same control you press to take the character.
+    expect(screen.getByRole('button', { name: /Unclaimed/i })).toBeTruthy()
+  })
+
+  test('pressing the seal asks before it claims', () => {
+    renderAs(ME, listing({ pilots: [PRE_GEN] }))
+    fireEvent.click(screen.getByRole('button', { name: /Unclaimed/i }))
+
+    // Taking a character is a commitment at the table, so the seal opens a
+    // confirm that says what happens next rather than claiming on one click.
+    // The dialog carries its title twice — visible heading plus the sr-only
+    // accessible label — so this counts rather than demanding a single match.
+    expect(screen.getAllByText(/Pick up Pre-gen\?/i).length).toBeGreaterThan(0)
+    expect(screen.getByRole('button', { name: 'Pick up' })).toBeTruthy()
+  })
+})
+
+describe('what the game will accept', () => {
+  test('a player with no crawler is told why they cannot add crew', () => {
+    renderAs(ME, listing())
+
+    // Said twice on purpose: once as the reason creation is unavailable, once
+    // as the Crawlers column's own empty state.
+    expect(screen.getAllByText(/no Union Crawler yet/i).length).toBeGreaterThan(0)
+    // Refusing without explaining reads as a broken screen.
+    expect(screen.queryByText('Create Pilot')).toBeNull()
+  })
+
+  test('and can create once the crawler exists', () => {
+    renderAs(ME, listing({ crawlers: [CRAWLER] }))
+    expect(screen.getByText('Create Pilot')).toBeTruthy()
+  })
+
+  test('a player is never offered the crawler CTA', () => {
+    renderAs(ME, listing({ crawlers: [CRAWLER] }))
+    expect(screen.queryByText('Raise a Crawler')).toBeNull()
+  })
+
+  test('the table runner may raise one before anything else exists', () => {
+    const mediator = { ...ME, _id: 'u-med', displayName: 'Mediator' }
+    renderAs(mediator, listing())
+
+    expect(screen.getByText('Raise a Crawler')).toBeTruthy()
+    // Exempt from the crawler gate, or a new game could never be set up.
+    expect(screen.getByText('Create Pilot')).toBeTruthy()
+  })
+
+  test('only the table runner may scrap a crawler', () => {
+    renderAs(ME, listing({ crawlers: [CRAWLER] }))
+    expect(screen.queryByRole('button', { name: 'Scrap' })).toBeNull()
+
+    cleanup()
+    renderAs({ ...ME, _id: 'u-med' }, listing({ crawlers: [CRAWLER] }))
+    expect(screen.getByRole('button', { name: 'Scrap' })).toBeTruthy()
+  })
+
+  test('the crawler opens for every member — that is what communal means', () => {
+    renderAs(ME, listing({ crawlers: [CRAWLER] }))
+
+    expect(screen.getByText('#430 Tenacity')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Sheet' })).toBeTruthy()
+    // It has no owner at all, so nothing invites anyone to claim it.
+    expect(screen.queryByRole('button', { name: /Unclaimed/i })).toBeNull()
+  })
+})
+
+afterAll(() => {
+  mock.module('../../../lib/connection/convexClient', () => realConvexClient)
+  mock.module('convex/react', () => realConvexReact)
+})

--- a/apps/itun/src/components/games/__tests__/MediatorScreen.connected.test.tsx
+++ b/apps/itun/src/components/games/__tests__/MediatorScreen.connected.test.tsx
@@ -11,8 +11,13 @@ import { render, screen } from '@testing-library/react'
  *
  * Queries are answered in **call order**; the generated `api` object is a Proxy
  * that throws when inspected, so position is the only stable key. Render order
- * is: amMediator, crew (vitals), presence, crew (propose form), alerts,
- * downtime state, downtime amMediator, npcs.
+ * is: amMediator, then the crew roster's three (me, members, listForGame), then
+ * crew (vitals), presence, crew (propose form), alerts, downtime state,
+ * downtime amMediator, npcs.
+ *
+ * Positional answering is brittle by construction — inserting a panel shifts
+ * every later answer — so `mediatingQueries` is the single place that encodes
+ * the order, and each case names only what it cares about.
  */
 
 let queryQueue: unknown[] = []
@@ -71,8 +76,8 @@ const CLAIMED_PILOT = {
   ownerId: 'u2',
   ownerName: 'Beefcake',
   name: 'Roach-Boy',
-  currentHp: 8,
-  currentAp: 4,
+  currentHP: 8,
+  currentAP: 4,
 }
 
 const UNCLAIMED_PILOT = {
@@ -81,19 +86,42 @@ const UNCLAIMED_PILOT = {
   ownerId: null,
   ownerName: null,
   name: 'Pre-gen',
-  currentHp: 10,
-  currentAp: 5,
+  currentHP: 10,
+  currentAP: 5,
 }
 
 const DOWNTIME = { running: false, stepIndex: null, completedBy: [], upkeepSpent: false }
 
+/** The signed-in viewer, as `account.me` returns them. */
+const ME = { _id: 'u1', displayName: 'Mediator', avatarUrl: null, email: null }
+
+/** This game's roster, as `games.members` returns it. */
+const MEMBERS = [
+  { userId: 'u1', displayName: 'Mediator', mediator: true, organizer: true },
+  { userId: 'u2', displayName: 'Beefcake', mediator: false, organizer: false },
+]
+
+/** An empty crew listing, as `entities.listForGame` returns one. */
+const EMPTY_LISTING = { pilots: [], mechs: [], crawlers: [], softLinks: [] }
+
 /** The full mediating render, with whatever crew and tray the case needs. */
 function mediatingQueries(
   crew: Record<string, unknown>,
-  extra: { presence?: unknown; alerts?: unknown; npcs?: unknown } = {}
+  extra: {
+    presence?: unknown
+    alerts?: unknown
+    npcs?: unknown
+    members?: unknown
+    listing?: unknown
+  } = {}
 ): unknown[] {
   return [
     true,
+    // The crew roster leads the surface now: who I am, who is in this game,
+    // and what the game holds.
+    ME,
+    extra.members ?? MEMBERS,
+    extra.listing ?? EMPTY_LISTING,
     crew,
     extra.presence ?? [],
     crew,

--- a/apps/itun/src/components/roster/Roster.tsx
+++ b/apps/itun/src/components/roster/Roster.tsx
@@ -192,6 +192,25 @@ export function Roster() {
   const crawlers = inContainer(allCrawlers)
 
   /**
+   * Raising a crawler INSIDE a Game is the table runner's act (ADR-030 §5a), so
+   * while a Game is the current container this CTA hands off to that Game's
+   * crew surface, which knows who the viewer is and either offers the control
+   * or explains why it cannot.
+   *
+   * The alternative — keeping the wizard link and letting the write fail — is
+   * the worst of both: `entityStore.create` stamps the current container, the
+   * crawler is built locally, the mirror is refused, and the roster shows a
+   * crawler that the Game does not have. Deciding it here needs no permission
+   * lookup, because the container alone is enough to know this is the wrong
+   * door.
+   */
+  const inGame = mode === 'connected' && activeContainer.kind === 'game'
+  const crawlerCreateHref = inGame
+    ? `/games/${activeContainer.kind === 'game' ? activeContainer.gameId : ''}`
+    : '/crawlers/new'
+  const crawlerCreateLabel = inGame ? 'Raise one in this game' : 'Create Crawler'
+
+  /**
    * First-run welcome: a brand-new user with nothing at all. Deliberately keyed
    * to the UNFILTERED lists — an empty *container* belonging to someone who
    * already has builds elsewhere is not a first run, and the big welcome would
@@ -397,8 +416,8 @@ export function Roster() {
                 title="Crawlers"
                 headingId="crawlers-heading"
                 active={activeSegment === 'crawler'}
-                createHref="/crawlers/new"
-                createLabel="Create Crawler"
+                createHref={crawlerCreateHref}
+                createLabel={crawlerCreateLabel}
                 emptyMessage="No crawlers yet."
                 emptyIcon={<Warehouse className="size-7 text-sheet-crawler-deep" />}
               >

--- a/apps/itun/src/components/sheet/SnapshotSheet.tsx
+++ b/apps/itun/src/components/sheet/SnapshotSheet.tsx
@@ -138,6 +138,10 @@ function makeSnapshotStore(parsed: Extract<ParseResult, { ok: true }>): typeof u
     get: ((type: EntityType, id: string) =>
       byType(type).find((e) => e.id === id) ?? null) as EntityState['get'],
     create: readOnlyWrite,
+    // A snapshot is frozen and container-less (ADR-004), so there is no server
+    // row it could be a cache of — adoption is as unavailable as any other write.
+    adopt: readOnlyWrite,
+    forget: readOnlyWrite,
     update: readOnlyWrite,
     updateCrawlerBay: readOnlyWrite,
     delete: readOnlyWrite,

--- a/apps/itun/src/lib/db/crud.ts
+++ b/apps/itun/src/lib/db/crud.ts
@@ -30,6 +30,12 @@ type EntityStore<T extends EntityBase> = {
    * Throws if id not found.
    */
   update: (id: string, patch: Partial<Omit<T, 'id'>>) => Promise<T>
+  /**
+   * Writes a record the app did not mint, under the id it already carries.
+   * The cache-fill path for rows pulled from the server of record — see the
+   * implementation for why this is not `create` or `update`.
+   */
+  put: (record: T) => Promise<T>
   /** Deletes by id. Silent no-op if id not found. */
   delete: (id: string) => Promise<void>
 }
@@ -169,6 +175,36 @@ export function makeStore<T extends EntityBase>(
     return record
   }
 
+  /**
+   * Cache a record that arrived from somewhere else, keeping its id.
+   *
+   * Neither `create` nor `update` can do this, and the reasons are the whole
+   * point of having a third verb:
+   *
+   *  - `create` mints a fresh UUID. A server row cached under a new id is a
+   *    *copy*, so the next edit would mirror back addressed by an appId the
+   *    server has never seen and land as a second entity.
+   *  - `update` requires the row to exist locally, which by definition it does
+   *    not the first time a Game's crawler or a claimed pre-gen is pulled down.
+   *
+   * Reads are salvage-tolerant everywhere else in this module, and adoption is
+   * a read that happens to persist: a Game row written by a newer build than
+   * this one must still be openable, so a strict-parse failure falls back to
+   * the salvage shape rather than refusing the whole entity.
+   */
+  async function put(record: T): Promise<T> {
+    const db = await getDb()
+    const strict = schema.safeParse(record)
+    const parsed = strict.success ? strict.data : salvageRead(record, `id="${record.id}"`)
+    if (parsed === null) {
+      throw new Error(
+        `[itun-db] Cannot cache record id="${record.id}" in "${storeName}": it does not parse`
+      )
+    }
+    await db.put(storeName, parsed)
+    return parsed
+  }
+
   async function del(id: string): Promise<void> {
     const db = await getDb()
     const existing = await db.get(storeName, id)
@@ -176,5 +212,5 @@ export function makeStore<T extends EntityBase>(
     await db.delete(storeName, id)
   }
 
-  return { list, get, create, update, prepareUpdate, delete: del }
+  return { list, get, create, update, prepareUpdate, put, delete: del }
 }

--- a/apps/itun/src/lib/games/__tests__/gameRoster.test.ts
+++ b/apps/itun/src/lib/games/__tests__/gameRoster.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  crawlerRows,
+  isTableRunner,
+  ownableRows,
+  tableCapabilities,
+  type GameMember,
+} from '../gameRoster'
+
+/**
+ * The Game roster's rules, tested against the same cases as the server.
+ *
+ * These assertions intentionally read like `convex/__tests__/tableSetup.test.ts`
+ * — that is the point. This module exists so the surface can hide what the
+ * server would refuse, and the only way that stays true is for both to be
+ * pinned to the same table of cases. If one of these ever has to change without
+ * its server twin changing, the surface has started lying.
+ */
+
+const MEDIATOR: GameMember = {
+  userId: 'u-med',
+  displayName: 'Mediator',
+  mediator: true,
+  organizer: false,
+}
+const ORGANIZER: GameMember = {
+  userId: 'u-org',
+  displayName: 'Organizer',
+  mediator: false,
+  organizer: true,
+}
+const PLAYER: GameMember = {
+  userId: 'u-play',
+  displayName: 'Player',
+  mediator: false,
+  organizer: false,
+}
+
+const ALL = [MEDIATOR, ORGANIZER, PLAYER]
+
+describe('who runs the table', () => {
+  test('the Mediator does', () => {
+    expect(isTableRunner('u-med', ALL)).toBe(true)
+  })
+
+  test('a player does not', () => {
+    expect(isTableRunner('u-play', ALL)).toBe(false)
+  })
+
+  test('the Organizer does only while nobody mediates', () => {
+    expect(isTableRunner('u-org', ALL)).toBe(false)
+    // A brand-new Game is exactly this shape: one member, organizer, no
+    // Mediator. Without the fallback nobody could raise its first crawler.
+    expect(isTableRunner('u-org', [ORGANIZER, PLAYER])).toBe(true)
+  })
+
+  test('a signed-out viewer never does', () => {
+    expect(isTableRunner(null, ALL)).toBe(false)
+  })
+
+  test('somebody who is not in the game never does', () => {
+    expect(isTableRunner('u-stranger', ALL)).toBe(false)
+  })
+})
+
+describe('what the game will accept', () => {
+  test('a player waits for the crawler, and is told why', () => {
+    const caps = tableCapabilities({ viewerId: 'u-play', members: ALL, crawlerCount: 0 })
+    expect(caps.canAddCrew).toBe(false)
+    // A refusal with no reason reads as a broken button.
+    expect(caps.addCrewBlocked).toMatch(/crawler/i)
+    expect(caps.canRaiseCrawler).toBe(false)
+  })
+
+  test('and can add crew once one exists', () => {
+    const caps = tableCapabilities({ viewerId: 'u-play', members: ALL, crawlerCount: 1 })
+    expect(caps.canAddCrew).toBe(true)
+    expect(caps.addCrewBlocked).toBeNull()
+  })
+
+  test('the table runner is exempt, or a new game could never be set up', () => {
+    const caps = tableCapabilities({ viewerId: 'u-med', members: ALL, crawlerCount: 0 })
+    expect(caps.canAddCrew).toBe(true)
+    expect(caps.canRaiseCrawler).toBe(true)
+    expect(caps.canOfferUnclaimed).toBe(true)
+  })
+
+  test('only the table runner may leave a character unclaimed', () => {
+    const caps = tableCapabilities({ viewerId: 'u-play', members: ALL, crawlerCount: 1 })
+    expect(caps.canOfferUnclaimed).toBe(false)
+  })
+})
+
+describe('rows carry ownership as a state, never a blank', () => {
+  const rows = [
+    { _id: 's1', appId: 'a1', ownerId: 'u-play', body: { name: 'Roach-Boy' } },
+    { _id: 's2', appId: null, ownerId: null, body: { name: 'Pre-gen' } },
+    { _id: 's3', appId: 'a3', ownerId: 'u-med', body: { name: "Someone else's" } },
+  ]
+
+  const built = (viewerId: string | null, localIds: string[] = []) =>
+    ownableRows({
+      kind: 'pilot',
+      rows,
+      viewerId,
+      members: ALL,
+      localIds: new Set(localIds),
+    })
+
+  test('an unclaimed pilot reads as Unclaimed and offers a pick-up', () => {
+    const [, pregen] = built('u-play')
+    expect(pregen?.owner?.label).toBe('Unclaimed')
+    expect(pregen?.can.claim).toBe(true)
+  })
+
+  test("a crewmate's pilot is neither claimable nor openable", () => {
+    const [, , theirs] = built('u-play')
+    expect(theirs?.owner?.label).toBe('Mediator')
+    expect(theirs?.can.claim).toBe(false)
+    // The sheet is a live editing surface; opening one whose writes the server
+    // refuses would be worse than not linking it.
+    expect(theirs?.can.openSheet).toBe(false)
+  })
+
+  test('your own reads as You, opens, and can be handed back', () => {
+    const [mine] = built('u-play')
+    expect(mine?.owner?.label).toBe('You')
+    expect(mine?.can.openSheet).toBe(true)
+    expect(mine?.can.release).toBe(true)
+  })
+
+  test('localId is set only when this browser actually holds a copy', () => {
+    expect(built('u-play')[0]?.localId).toBeNull()
+    expect(built('u-play', ['a1'])[0]?.localId).toBe('a1')
+  })
+
+  test('a body with no name still renders something', () => {
+    const [row] = ownableRows({
+      kind: 'mech',
+      rows: [{ _id: 's9', appId: null, ownerId: null, body: {} }],
+      viewerId: 'u-play',
+      members: ALL,
+      localIds: new Set(),
+    })
+    expect(row?.name).toBe('Mech')
+  })
+})
+
+describe('crawler rows are communal', () => {
+  const rows = [{ _id: 'c1', appId: 'ca1', body: { name: '#430 Tenacity' } }]
+
+  test('every member may open one — that is what communal means', () => {
+    const [row] = crawlerRows({ rows, tableRunner: false, localIds: new Set() })
+    expect(row?.can.openSheet).toBe(true)
+    // No owner chip at all: "who owns the crawler" is not a question with an
+    // answer, and rendering "Unclaimed" would invite somebody to claim it.
+    expect(row?.owner).toBeNull()
+    expect(row?.can.claim).toBe(false)
+  })
+
+  test('only the table runner may scrap one', () => {
+    expect(crawlerRows({ rows, tableRunner: false, localIds: new Set() })[0]?.can.scrap).toBe(false)
+    expect(crawlerRows({ rows, tableRunner: true, localIds: new Set() })[0]?.can.scrap).toBe(true)
+  })
+})

--- a/apps/itun/src/lib/games/gameRoster.ts
+++ b/apps/itun/src/lib/games/gameRoster.ts
@@ -1,0 +1,223 @@
+/**
+ * What a Game's roster shows, and what each row lets you do (ADR-030 §3–5).
+ *
+ * This module is deliberately pure — no React, no Convex, no router. Everything
+ * on the Game surface that is a *rule* rather than a pixel lives here, for one
+ * reason: these answers already exist on the server, in
+ * `convex/model/permissions.ts` and `convex/entities.ts`, and a second copy
+ * written inline across a component's JSX would drift from them silently. Kept
+ * here they can be tested side by side with the mutations they mirror, which is
+ * exactly what `__tests__/gameRoster.test.ts` does.
+ *
+ * **None of this is a boundary.** The server refuses what it refuses whatever
+ * this file says; hiding a control the caller cannot use is a courtesy that
+ * saves them a failed click and a confusing error. Where the two ever disagree,
+ * the server is right and this file is the bug.
+ */
+
+import { ownerChipFor } from '../ownership/ownerChip'
+import type { OwnerChip } from '../ownership/ownerChip'
+
+export type RosterKind = 'pilot' | 'mech' | 'crawler'
+
+/** A pilot or mech as `entities.listForGame` returns it. */
+export type ServerOwnable = {
+  _id: string
+  appId: string | null
+  ownerId: string | null
+  body: unknown
+}
+
+/** A crawler as `entities.listForGame` returns it — communal, so no owner. */
+export type ServerCrawler = {
+  _id: string
+  appId: string | null
+  body: unknown
+}
+
+/** A member as `games.members` returns it. */
+export type GameMember = {
+  userId: string
+  displayName: string
+  mediator: boolean
+  organizer: boolean
+}
+
+/** What the viewer may do with one row. */
+export type RowCapabilities = {
+  /** There is a sheet to open — either already in this browser, or fetchable. */
+  openSheet: boolean
+  /** Free, and the viewer is in the Game: they can take it. */
+  claim: boolean
+  /** The viewer holds it and can hand it back to the crew. */
+  release: boolean
+  /** Crawler only: the table runner may scrap it. */
+  scrap: boolean
+}
+
+export type RosterRow = {
+  kind: RosterKind
+  /** The Convex row id — what every ownership mutation is addressed by. */
+  serverId: string
+  /** The id the owner's browser minted, when this row was ever in one. */
+  appId: string | null
+  name: string
+  ownerId: string | null
+  /** Null for a crawler: it is communal, so "who owns it" is not a question. */
+  owner: OwnerChip | null
+  /** Set when this browser already holds a copy — the id a sheet route takes. */
+  localId: string | null
+  body: Record<string, unknown>
+  can: RowCapabilities
+}
+
+/** What the viewer may do to the Game as a whole. */
+export type TableCapabilities = {
+  /** The Mediator, or the Organizer while the Game has no Mediator. */
+  tableRunner: boolean
+  hasCrawler: boolean
+  /** Raising and scrapping a crawler is the table runner's act. */
+  canRaiseCrawler: boolean
+  /** Whether the viewer may add pilots and mechs to this Game right now. */
+  canAddCrew: boolean
+  /** Why not, in the surface's own words. Null when they can. */
+  addCrewBlocked: string | null
+  /** Only the table runner may leave a new character unclaimed for the crew. */
+  canOfferUnclaimed: boolean
+}
+
+/**
+ * The viewer's standing in this Game.
+ *
+ * Mirrors `isTableRunner`: Mediator, or Organizer *only while nobody mediates*.
+ * The fallback is computed from the roster rather than assumed, so appointing a
+ * Mediator withdraws it here at the same moment it does on the server.
+ */
+export function isTableRunner(viewerId: string | null, members: readonly GameMember[]): boolean {
+  if (viewerId === null) return false
+  const me = members.find((m) => m.userId === viewerId)
+  if (me === undefined) return false
+  if (me.mediator) return true
+  return me.organizer && !members.some((m) => m.mediator)
+}
+
+/**
+ * What the viewer may do to this Game.
+ *
+ * The crawler gate is the interesting one, and the wording matters as much as
+ * the boolean: a player who cannot add a pilot yet is not being refused, they
+ * are waiting for the table to be set up, and a surface that says "you can't"
+ * without saying "yet, because —" reads as a broken button.
+ */
+export function tableCapabilities(args: {
+  viewerId: string | null
+  members: readonly GameMember[]
+  crawlerCount: number
+}): TableCapabilities {
+  const tableRunner = isTableRunner(args.viewerId, args.members)
+  const hasCrawler = args.crawlerCount > 0
+  const canAddCrew = tableRunner || hasCrawler
+
+  return {
+    tableRunner,
+    hasCrawler,
+    canRaiseCrawler: tableRunner,
+    canAddCrew,
+    addCrewBlocked: canAddCrew
+      ? null
+      : 'This game has no Union Crawler yet. The Mediator raises one first — the crew is anchored to it.',
+    canOfferUnclaimed: tableRunner,
+  }
+}
+
+/** Best-effort display name off an opaque server body. */
+function nameOf(body: unknown, fallback: string): string {
+  const value = (body as Record<string, unknown> | null)?.name
+  return typeof value === 'string' && value.length > 0 ? value : fallback
+}
+
+/** The body as a record, so callers can read known fields without casting. */
+function bodyOf(body: unknown): Record<string, unknown> {
+  return (body ?? {}) as Record<string, unknown>
+}
+
+/**
+ * Build the pilot/mech rows for a Game.
+ *
+ * `localIds` is the set of entity ids this browser already holds. It decides
+ * whether a row can open a sheet *without a round trip*, not whether it may —
+ * see `openSheet` below.
+ *
+ * The `openSheet` rule is the one place this file is stricter than it strictly
+ * has to be, and deliberately: only what the viewer **owns** offers a sheet.
+ * ADR-030 §5 does allow reading a crewmate's sheet, but ITUN's sheet is a
+ * *live, editing* surface backed by local storage — caching a crewmate's pilot
+ * into it would hand the viewer an editor whose writes the server then refuses,
+ * and a sheet that silently stops saving is worse than no link at all. A
+ * read-only drill-in is its own surface and is not built yet; the crew strip
+ * carries the vitals in the meantime.
+ */
+export function ownableRows(args: {
+  kind: 'pilot' | 'mech'
+  rows: readonly ServerOwnable[]
+  viewerId: string | null
+  members: readonly GameMember[]
+  localIds: ReadonlySet<string>
+}): RosterRow[] {
+  const namesById = new Map(args.members.map((m) => [m.userId, m.displayName]))
+  const lookup = { viewerId: args.viewerId, namesById }
+  const memberOfGame = args.viewerId !== null
+
+  return args.rows.map((row) => {
+    const owner = ownerChipFor(row.ownerId, lookup)
+    const mine = owner.mine
+    const localId = row.appId !== null && args.localIds.has(row.appId) ? row.appId : null
+
+    return {
+      kind: args.kind,
+      serverId: row._id,
+      appId: row.appId,
+      name: nameOf(row.body, args.kind === 'pilot' ? 'Pilot' : 'Mech'),
+      ownerId: row.ownerId,
+      owner,
+      localId,
+      body: bodyOf(row.body),
+      can: {
+        openSheet: mine,
+        claim: memberOfGame && owner.unclaimed,
+        release: mine,
+        scrap: false,
+      },
+    }
+  })
+}
+
+/**
+ * Build the crawler rows for a Game.
+ *
+ * Every row opens: the crawler is communal, so any member may read and edit its
+ * fields, which is precisely the split this feature turns on — the table runner
+ * decides a crawler *exists*, the crew keeps its scrap, cargo and bays.
+ */
+export function crawlerRows(args: {
+  rows: readonly ServerCrawler[]
+  tableRunner: boolean
+  localIds: ReadonlySet<string>
+}): RosterRow[] {
+  return args.rows.map((row) => ({
+    kind: 'crawler' as const,
+    serverId: row._id,
+    appId: row.appId,
+    name: nameOf(row.body, 'Union Crawler'),
+    ownerId: null,
+    owner: null,
+    localId: row.appId !== null && args.localIds.has(row.appId) ? row.appId : null,
+    body: bodyOf(row.body),
+    can: {
+      openSheet: true,
+      claim: false,
+      release: false,
+      scrap: args.tableRunner,
+    },
+  }))
+}

--- a/apps/itun/src/routeTree.gen.ts
+++ b/apps/itun/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as GamesRouteImport } from './routes/games'
 import { Route as CrawlersIdRouteImport } from './routes/crawlers/$id'
 import { Route as CrawlersNewRouteImport } from './routes/crawlers/new'
 import { Route as DashboardIdRouteImport } from './routes/dashboard/$id'
+import { Route as GamesGameIdRouteImport } from './routes/games_.$gameId'
 import { Route as MechsIdRouteImport } from './routes/mechs/$id'
 import { Route as MechsNewRouteImport } from './routes/mechs/new'
 import { Route as MediatorGameIdRouteImport } from './routes/mediator/$gameId'
@@ -71,6 +72,11 @@ const CrawlersNewRoute = CrawlersNewRouteImport.update({
 const DashboardIdRoute = DashboardIdRouteImport.update({
   id: '/dashboard/$id',
   path: '/dashboard/$id',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const GamesGameIdRoute = GamesGameIdRouteImport.update({
+  id: '/games_/$gameId',
+  path: '/games/$gameId',
   getParentRoute: () => rootRouteImport,
 } as any)
 const MechsIdRoute = MechsIdRouteImport.update({
@@ -129,6 +135,7 @@ export interface FileRoutesByFullPath {
   '/crawlers/$id': typeof CrawlersIdRoute
   '/crawlers/new': typeof CrawlersNewRoute
   '/dashboard/$id': typeof DashboardIdRoute
+  '/games/$gameId': typeof GamesGameIdRoute
   '/mechs/$id': typeof MechsIdRoute
   '/mechs/new': typeof MechsNewRoute
   '/mediator/$gameId': typeof MediatorGameIdRoute
@@ -149,6 +156,7 @@ export interface FileRoutesByTo {
   '/crawlers/$id': typeof CrawlersIdRoute
   '/crawlers/new': typeof CrawlersNewRoute
   '/dashboard/$id': typeof DashboardIdRoute
+  '/games/$gameId': typeof GamesGameIdRoute
   '/mechs/$id': typeof MechsIdRoute
   '/mechs/new': typeof MechsNewRoute
   '/mediator/$gameId': typeof MediatorGameIdRoute
@@ -170,6 +178,7 @@ export interface FileRoutesById {
   '/crawlers/$id': typeof CrawlersIdRoute
   '/crawlers/new': typeof CrawlersNewRoute
   '/dashboard/$id': typeof DashboardIdRoute
+  '/games_/$gameId': typeof GamesGameIdRoute
   '/mechs/$id': typeof MechsIdRoute
   '/mechs/new': typeof MechsNewRoute
   '/mediator/$gameId': typeof MediatorGameIdRoute
@@ -192,6 +201,7 @@ export interface FileRouteTypes {
     | '/crawlers/$id'
     | '/crawlers/new'
     | '/dashboard/$id'
+    | '/games/$gameId'
     | '/mechs/$id'
     | '/mechs/new'
     | '/mediator/$gameId'
@@ -212,6 +222,7 @@ export interface FileRouteTypes {
     | '/crawlers/$id'
     | '/crawlers/new'
     | '/dashboard/$id'
+    | '/games/$gameId'
     | '/mechs/$id'
     | '/mechs/new'
     | '/mediator/$gameId'
@@ -232,6 +243,7 @@ export interface FileRouteTypes {
     | '/crawlers/$id'
     | '/crawlers/new'
     | '/dashboard/$id'
+    | '/games_/$gameId'
     | '/mechs/$id'
     | '/mechs/new'
     | '/mediator/$gameId'
@@ -253,6 +265,7 @@ export interface RootRouteChildren {
   CrawlersIdRoute: typeof CrawlersIdRoute
   CrawlersNewRoute: typeof CrawlersNewRoute
   DashboardIdRoute: typeof DashboardIdRoute
+  GamesGameIdRoute: typeof GamesGameIdRoute
   MechsIdRoute: typeof MechsIdRoute
   MechsNewRoute: typeof MechsNewRoute
   MediatorGameIdRoute: typeof MediatorGameIdRoute
@@ -327,6 +340,13 @@ declare module '@tanstack/react-router' {
       path: '/dashboard/$id'
       fullPath: '/dashboard/$id'
       preLoaderRoute: typeof DashboardIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/games_/$gameId': {
+      id: '/games_/$gameId'
+      path: '/games/$gameId'
+      fullPath: '/games/$gameId'
+      preLoaderRoute: typeof GamesGameIdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/mechs/$id': {
@@ -405,6 +425,7 @@ const rootRouteChildren: RootRouteChildren = {
   CrawlersIdRoute: CrawlersIdRoute,
   CrawlersNewRoute: CrawlersNewRoute,
   DashboardIdRoute: DashboardIdRoute,
+  GamesGameIdRoute: GamesGameIdRoute,
   MechsIdRoute: MechsIdRoute,
   MechsNewRoute: MechsNewRoute,
   MediatorGameIdRoute: MediatorGameIdRoute,

--- a/apps/itun/src/routes/games_.$gameId.tsx
+++ b/apps/itun/src/routes/games_.$gameId.tsx
@@ -1,0 +1,25 @@
+import { createFileRoute, useParams } from '@tanstack/react-router'
+
+import { GameScreen } from '../components/games/GameScreen'
+
+/**
+ * One Game's crew — the shared-container twin of the Roster at `/`.
+ *
+ * Separate from `/games` (the lobby: start one, join one, list the ones you are
+ * in) because a crew roster is a place you work rather than a row in a list,
+ * and separate from `/mediator/$gameId` because the Mediator surface adds
+ * private instruments on top of this rather than replacing it.
+ *
+ * The trailing `_` on `games_` opts this route OUT of nesting under
+ * `routes/games.tsx`. Without it TanStack treats `/games` as a layout and
+ * expects an `<Outlet />` there — which `GamesScreen` does not render, so the
+ * crew roster would resolve, match, and display nothing at all.
+ */
+export const Route = createFileRoute('/games_/$gameId')({
+  component: GameRoute,
+})
+
+function GameRoute() {
+  const { gameId } = useParams({ from: '/games_/$gameId' })
+  return <GameScreen gameId={gameId} />
+}

--- a/apps/itun/src/stores/entityBackend.ts
+++ b/apps/itun/src/stores/entityBackend.ts
@@ -120,6 +120,55 @@ export async function mirrorWrite(
 }
 
 /**
+ * Mirror a local **crawler** write. Separate from `mirrorWrite` because the
+ * crawler's server contract is genuinely a different one, not a variant.
+ *
+ * Three differences, each of them a rule rather than an implementation detail:
+ *
+ *  - **Updates merge per field, they do not replace.** The crawler is communal
+ *    and contended during Downtime, so this sends the *patch* rather than the
+ *    whole body — two members editing scrap and cargo in the same minute both
+ *    land (ADR-030 §5).
+ *  - **There is no upsert.** Raising a crawler is the table runner's act, so a
+ *    create is a create (`createCrawler`, which the server refuses for a
+ *    player) and an edit can never quietly become one.
+ *  - **Only inside a Game.** A shelved or Solo crawler has no server row and
+ *    nothing to merge into.
+ *
+ * Fire-and-forget like the ownable mirror: the local write already succeeded
+ * and is what the UI reads. A refusal here means the local copy is ahead of a
+ * Game that did not accept it — see the known-gaps note in
+ * `docs/architecture/accounts-and-games.md`.
+ */
+export async function mirrorCrawlerWrite(
+  op:
+    | { kind: 'create'; appId: string; gameId: string; body: unknown }
+    | { kind: 'patch'; appId: string; patch: unknown }
+    | { kind: 'delete'; appId: string }
+): Promise<void> {
+  if (selectBackend() !== 'remote' || convexClient === null) return
+
+  try {
+    if (op.kind === 'create') {
+      await convexClient.mutation(api.entities.createCrawler, {
+        gameId: op.gameId as Id<'games'>,
+        appId: op.appId,
+        body: op.body,
+      })
+    } else if (op.kind === 'patch') {
+      await convexClient.mutation(api.entities.patchCrawlerByAppId, {
+        appId: op.appId,
+        patch: op.patch,
+      })
+    } else {
+      await convexClient.mutation(api.entities.removeCrawlerByAppId, { appId: op.appId })
+    }
+  } catch (err) {
+    console.warn('[itun] failed to mirror crawler write to the server of record', err)
+  }
+}
+
+/**
  * Guard a write against the current mode.
  *
  * Called by the store before it touches persistence. Returns the backend to

--- a/apps/itun/src/stores/entityStore.ts
+++ b/apps/itun/src/stores/entityStore.ts
@@ -40,7 +40,7 @@ import type { Mech } from '../lib/schemas/mech'
 import type { Pilot } from '../lib/schemas/pilot'
 import type { SoftLink } from '../lib/schemas/softLink'
 import type { CreateInput, EntityForType, EntityType } from './types'
-import { mirrorWrite, requireWritableBackend } from './entityBackend'
+import { mirrorCrawlerWrite, mirrorWrite, requireWritableBackend } from './entityBackend'
 
 // Re-exported so consumers can import the type alongside the store itself.
 export type { EntityType }
@@ -84,6 +84,32 @@ export type EntityState = {
 
   /** Persists to db then updates in-memory state. Zod errors propagate. */
   create: <T extends EntityType>(type: T, input: CreateInput<T>) => Promise<EntityForType<T>>
+
+  /**
+   * Cache a row from the server of record under the id it already has
+   * (ADR-030 §1 — IndexedDB is the warm cache once you are signed in).
+   *
+   * This is the *only* write path that does not mirror back, and that is the
+   * point rather than an optimisation: the record came from the server, so
+   * echoing it would be a write nobody asked for — and for a crawler, whose
+   * mirror is a field merge, a pointless round trip that could clobber an edit
+   * a crewmate made between the read and the echo.
+   *
+   * It is also not a Change Log event. Nothing changed; a copy arrived.
+   */
+  adopt: <T extends EntityType>(type: T, record: EntityForType<T>) => Promise<EntityForType<T>>
+
+  /**
+   * Drop this browser's copy of an entity **without deleting it anywhere else**
+   * — the exact inverse of `adopt`, and deliberately not `delete`.
+   *
+   * The case it exists for: you hand a character back to the crew. The entity
+   * is not gone, it is simply no longer yours, and `delete` would try to mirror
+   * a destruction the server rightly refuses. Keeping the copy instead is worse
+   * still — it leaves a live sheet whose every save is rejected, which is the
+   * most confusing failure this app can produce.
+   */
+  forget: (type: EntityType, id: string) => Promise<void>
 
   /**
    * Merges patch, persists to db, updates in-memory state, then appends a
@@ -240,6 +266,7 @@ type DbStoreApi<T extends EntityType> = {
   create: (input: CreateInput<T>) => Promise<EntityForType<T>>
   update: (id: string, patch: Partial<EntityForType<T>>) => Promise<EntityForType<T>>
   prepareUpdate: (id: string, patch: Partial<EntityForType<T>>) => Promise<EntityForType<T>>
+  put: (record: EntityForType<T>) => Promise<EntityForType<T>>
   delete: (id: string) => Promise<void>
 }
 
@@ -253,11 +280,32 @@ const DB_STORES: { [K in EntityType]: DbStoreApi<K> } = {
 /**
  * Mirror a just-persisted record to the server of record.
  *
- * Only pilots and mechs: the crawler is communal and merges per field
- * server-side, and softLinks are derived. Fire-and-forget by design — the
- * local write is what the UI reads, so a mirror failure must not undo it.
+ * SoftLinks are derived and never mirrored. Pilots and mechs upsert their whole
+ * body; the crawler takes the other path (`mirrorCrawlerWrite`) because it is
+ * communal — its edits merge per field and only its table runner may raise or
+ * scrap one. Fire-and-forget by design: the local write is what the UI reads,
+ * so a mirror failure must not undo it.
+ *
+ * `patch` is passed on an update so a crawler mirrors the *changed fields*
+ * rather than its whole body; sending everything would turn a merge back into
+ * last-write-wins and lose whatever a crewmate changed in the same minute.
  */
-function mirrorEntityWrite(type: EntityType, record: { id: string; gameId?: string | null }): void {
+function mirrorEntityWrite(
+  type: EntityType,
+  record: { id: string; gameId?: string | null },
+  patch?: object
+): void {
+  if (type === 'crawler') {
+    const gameId = record.gameId ?? null
+    // Shelf and Solo crawlers have no server row to merge into.
+    if (gameId === null) return
+    if (patch === undefined) {
+      void mirrorCrawlerWrite({ kind: 'create', appId: record.id, gameId, body: record })
+      return
+    }
+    void mirrorCrawlerWrite({ kind: 'patch', appId: record.id, patch })
+    return
+  }
   if (type !== 'pilot' && type !== 'mech') return
   void mirrorWrite(type, {
     kind: 'upsert',
@@ -373,6 +421,40 @@ export const useEntityStore = create<EntityState>((set, get) => ({
     return record
   },
 
+  async adopt<T extends EntityType>(type: T, record: EntityForType<T>): Promise<EntityForType<T>> {
+    const key = storeKeyFor(type)
+    // Deliberately no `requireWritableBackend()`: filling the cache is not a
+    // user write. A Disconnected reader must still be able to open what they
+    // already pulled down, and refusing here would make going offline lose
+    // access to a sheet rather than merely making it read-only.
+    const cached = await dbStoreFor(type).put(record)
+    set((state) => {
+      const list = state[key] as EntityForType<T>[]
+      const exists = list.some((e) => e.id === cached.id)
+      return {
+        [key]: exists ? list.map((e) => (e.id === cached.id ? cached : e)) : [cached, ...list],
+      }
+    })
+    publishStoreChange(broadcastNameFor(type))
+    return cached
+  },
+
+  async forget(type, id) {
+    const key = storeKeyFor(type)
+    // Local only, and cascading like `delete` does: a SoftLink pointing at an
+    // entity this browser no longer holds would render as a broken cross-link.
+    const prunedIds = await db.deleteEntityWithSoftLinks(broadcastNameFor(type), id)
+    if (prunedIds.length > 0) {
+      const pruned = new Set(prunedIds)
+      set((state) => ({ softLinks: state.softLinks.filter((l) => !pruned.has(l.id)) }))
+      publishStoreChange(STORE_NAMES.softLinks)
+    }
+    set((state) => ({
+      [key]: (state[key] as { id: string }[]).filter((e) => e.id !== id),
+    }))
+    publishStoreChange(broadcastNameFor(type))
+  },
+
   async update<T extends EntityType>(
     type: T,
     id: string,
@@ -384,7 +466,7 @@ export const useEntityStore = create<EntityState>((set, get) => ({
     const before = get().get(type, id)
     requireWritableBackend()
     const updated = await dbStoreFor(type).update(id, patch)
-    mirrorEntityWrite(type, updated)
+    mirrorEntityWrite(type, updated, patch)
     set((state) => ({
       [key]: (state[key] as EntityForType<T>[]).map((e) => (e.id === id ? updated : e)),
     }))
@@ -513,6 +595,11 @@ export const useEntityStore = create<EntityState>((set, get) => ({
     const key = storeKeyFor(type)
     requireWritableBackend()
     if (type === 'pilot' || type === 'mech') void mirrorWrite(type, { kind: 'delete', appId: id })
+    // Scrapping a crawler is the table runner's act; the server refuses anyone
+    // else, which is why this mirrors rather than deleting only locally.
+    if (type === 'crawler' && get().get('crawler', id)?.gameId != null) {
+      void mirrorCrawlerWrite({ kind: 'delete', appId: id })
+    }
 
     // Cascade: deleting an entity prunes its SoftLinks (plan 2.7, gap 9).
     // The entity delete and its link pruning run in a single IDB transaction

--- a/docs/adrs/ADR-030-accounts-games-server-of-record.md
+++ b/docs/adrs/ADR-030-accounts-games-server-of-record.md
@@ -133,10 +133,23 @@ to one value.
 This keeps ADR-001's honour-system ethos intact while giving the Mediator real
 reach, and it means **alerts and cross-player writes are one mechanism, not two**.
 
-Ownership itself is assigned rather than claimed: players do not self-claim
-unclaimed entities. Owners may always **release** what they hold, and the Mediator
-may **reassign**, so a mis-assignment is fixable. A player may own any number of
-entities in a Game — solo play and covering for an absent player both need it.
+Owners may always **release** what they hold, and the Mediator may **reassign**,
+so a mis-assignment is fixable. A player may own any number of entities in a
+Game — solo play and covering for an absent player both need it.
+
+> **Amended: players self-claim what is offered.** This section originally read
+> "ownership is assigned rather than claimed: players do not self-claim". That
+> is reversed. An unclaimed entity is an **offer to the crew** — that is the
+> whole reason the Mediator pre-builds characters and a template seeds six of
+> them — so a player taking one is accepting an offer, not seizing anything.
+> Requiring the Mediator to hand each one over individually added a round trip
+> to the first ten minutes of every table and bought no safety.
+>
+> The boundary the original rule protected is intact and is the important half:
+> **claiming touches only what is free.** An entity somebody already holds
+> cannot be taken; it must be released first, by its owner or by the Mediator.
+> `assign` remains the table runner's power to place an entity with a
+> _particular_ person, which self-claim cannot express.
 
 ### 5. Visibility
 
@@ -146,6 +159,35 @@ into a crewmate's full sheet **read-only**. The Mediator's prepared opposition
 any member may edit it — with conflicting writes resolved by field-level merge,
 because the scrap pool and cargo lots are genuinely contended during Downtime.
 
+### 5a. Setting the table up: who raises the crawler, and when a Game takes crew
+
+Communal-to-**edit** is not free-to-**create**, and the crawler is where the two
+come apart:
+
+- **Raising and scrapping a crawler is the table runner's act** — the Mediator,
+  or the Organizer while a Game has no Mediator (the same narrow fallback §3
+  already grants for assignment, and for the same reason: a Game is created with
+  `mediator: false` on its only membership, so a Mediator-strict rule would make
+  every new Game an unreachable state). Filling the crawler's fields stays
+  everyone's, exactly as §5 says.
+- **A Game takes a player's pilots and mechs once it has a crawler.** In Salvage
+  Union the crew is anchored to its crawler — it is where they repair, where the
+  scrap pool lives, where they return to — so a Game without one is not yet set
+  up. The table runner is exempt, because somebody has to be able to raise the
+  first one.
+- **A Game may hold several crawlers.** This was always true of the schema and is
+  now true of the surfaces. A campaign that loses a crawler and rebuilds, or
+  meets and eventually joins a second, is ordinary play rather than a state to
+  reject.
+
+The line all three sit on: a table runner arranges **what the crew sails in and
+who holds what**, and still cannot change a number on somebody else's sheet. For
+that there is a proposal (§4).
+
+Enforced in `convex/model/permissions.ts` (`requireTableRunner`, `gameHasCrawler`)
+and `convex/entities.ts`, and mirrored — never re-decided — for the UI in
+`apps/itun/src/lib/games/gameRoster.ts`.
+
 ### 6. Surfaces
 
 The **Mediator gets its own surface**, the layer ADR-021 deferred; the Encounter
@@ -153,6 +195,22 @@ tray is absorbed into it and `/encounter` retires. The player Dashboard's locked
 1280×800 canvas ([ADR-020](ADR-020-dashboard-fixed-canvas-scale-to-fit.md)) is
 **not** reopened: crew vitals arrive there as a **"Crew" dial item**, using the
 dial track's existing configurable show/hide and order.
+
+**A Game's crew is rendered as the Roster renders a shelf.** `/games/:id` (any
+member) and `/mediator/:id` (the Mediator, who gets the private instruments
+below it) both open with the same three ontology-toned columns of `EntityRow`s
+the home Roster uses, with a create CTA per column and a Dashboard launch on the
+rows that support one. A Game asks "what have we got and what can I do with it"
+of a different container, and answering it in a second visual vocabulary — which
+the first cut did, as a stack of bordered cards with no way into a sheet and no
+way to make anything — is how an app stops feeling like one app.
+
+What a shared roster adds on top of the personal one: an owner chip per row,
+an **UNCLAIMED** stamp seal that opens the pick-up confirm, and creation gated by
+§5a. Only entities the viewer **owns** offer a sheet link; ITUN's sheet is a live
+editing surface, so opening a crewmate's would hand over an editor whose writes
+the server refuses. The read-only drill-in §5 permits is a separate surface and
+is not built — the crew vitals strip carries that information for now.
 
 ## Amendment to ADR-022
 

--- a/docs/architecture/accounts-and-games.md
+++ b/docs/architecture/accounts-and-games.md
@@ -41,8 +41,9 @@ In brief, grouped:
 | Containers   | **Game** (shared) and **Shelf** (personal). One entity, one container. Moving is an explicit fork.     |
 | Roles        | Base role Player \| Mediator, plus an orthogonal **Organizer** flag. Organizer ⇒ no content authority. |
 | Cross-player | **Propose → player confirms.** Never a direct write, never force-applied.                              |
-| Ownership    | Nullable. Mediator assigns (Organizer falls back); owners release; Mediator reassigns.                 |
-| Crawler      | Communal, field-level merge.                                                                           |
+| Ownership    | Nullable. Mediator assigns; owners release; **players self-claim what nobody holds**.                  |
+| Crawler      | Communal to edit; **the table runner raises and scraps one**. A Game may hold several.                 |
+| Joining      | A Game takes a player's pilots and mechs **once it has a crawler**. The table runner is exempt.        |
 | Visibility   | Live vitals for all; read-only sheet drill-in; Mediator NPCs hidden.                                   |
 | Surfaces     | New Mediator surface absorbs `/encounter`; a **"Crew" dial item** on the player Dashboard.             |
 | Anonymous    | Solo stays first-class and needs no account, forever.                                                  |
@@ -133,6 +134,48 @@ visible to the table; crawler upkeep resolved once rather than six times.
 
 The bot authenticates as a participant rather than an admin; rolls made in
 Discord land as Change Log entries.
+
+### Phase 7 — The crew roster, and the rules for setting a table up ✅
+
+The design pass Phase 3 deferred, plus the ownership rules it exposed as missing.
+
+- **`GameRoster`** — a Game's crew in the home Roster's own shape: three
+  ontology-toned `EntityRow` columns, create CTAs, sheet and Dashboard launches,
+  an owner chip per row, and an **UNCLAIMED** stamp seal that opens a pick-up
+  confirm. `/games/:id` for any member; `/mediator/:id` opens with it and keeps
+  the private instruments below.
+- **The table-setup rules** (ADR-030 §5a): the table runner raises and scraps
+  crawlers, a Game may hold several, and it takes a player's pilots and mechs
+  once one exists.
+- **Self-claim** (`ownership.claim`), amending ADR-030 §4.
+- **Adoption** — `entityStore.adopt` / `forget` cache a Game row into IndexedDB
+  under its own id and drop it again, which is what makes a sheet or the
+  Dashboard openable for a character built at somebody else's table.
+- **The crawler mirror** — local crawler edits reach the Game as a field merge
+  (`patchCrawlerByAppId`), so "players may edit its fields" is true end to end.
+- Two live defects found on the way: `crew.vitals` read `currentHp`/`currentSp`
+  where the Zod schemas define `currentHP`/`currentSP`, so **every vital on the
+  Mediator's crew strip was null** and rendered as an em-dash indistinguishable
+  from an undamaged crew; and `proposals.apply` wrote the merged body **without
+  parsing it**, so a proposal against a misspelled field added a key nothing
+  reads and moved no number. Both fixed, both pinned by tests that build their
+  fixtures by parsing the real schema rather than hand-writing field names.
+
+**Known gaps, deliberately left:**
+
+- **A refused mirror is only a console warning.** If the server rejects a
+  mirrored write (a player creating into a Game with no crawler, an edit to
+  something they no longer own), the local copy stands and nothing tells them.
+  The surfaces avoid offering those actions, so this is reachable mainly by
+  going around them; surfacing it as a toast is the next step.
+- **No read-only drill-in.** ADR-030 §5 permits reading a crewmate's sheet;
+  `crew.readEntity` exists on the server with no consumer, because ITUN's sheet
+  is an editing surface. Rows for entities you do not own therefore offer
+  vitals and an owner, but no link.
+- **Adopted copies re-sync only on the way in.** Opening a row through the
+  roster overwrites this browser's copy from the server, so the crawler a
+  crewmate just edited is current when you open it — but a sheet already open
+  does not update underneath you.
 
 ---
 

--- a/packages/component-lib/src/components/shared/EntityRow.tsx
+++ b/packages/component-lib/src/components/shared/EntityRow.tsx
@@ -59,8 +59,16 @@ type FilledEntityRowProps = {
    * Badge would be illegible, which is why these are two props and not one.
    */
   metaLine?: ReactNode
-  /** Destination for the View link. */
-  sheetHref: string
+  /**
+   * Destination for the View link. **Omit when there is nothing to open.**
+   *
+   * A row is not always a door. A shared roster lists entities the viewer can
+   * see but has no sheet for — a crewmate's pilot, a pre-generated character
+   * nobody has picked up yet — and rendering a View link that leads somewhere
+   * empty (or worse, somewhere they cannot legitimately edit) would be the
+   * dead end the row exists to describe. Without it, no link renders.
+   */
+  sheetHref?: string
   /**
    * Element the View link renders as (default `'a'`). Pass an app's router Link
    * to get client-side navigation; it receives `href` and `className`.
@@ -69,6 +77,18 @@ type FilledEntityRowProps = {
   /** Fired when the ghost trash Delete button is pressed. Omit to hide the
    * Delete button entirely (e.g. read-only poster surfaces). */
   onDeleteClick?: () => void
+  /**
+   * Extra trailing controls, rendered before View/Delete.
+   *
+   * Deliberately a slot rather than a set of named props: what a row can do
+   * depends on the surface it is listed on, and the two known consumers already
+   * disagree — a personal roster row navigates and deletes, while a shared
+   * Game row may also be picked up, offered back to the crew, or launched into
+   * the Dashboard. Teaching this primitive those verbs would push ownership,
+   * accounts and routing into a package whose contract is to know about none of
+   * them (the same reasoning as the owner chip's, ADR-030 D32).
+   */
+  actions?: ReactNode
 }
 
 /**
@@ -166,6 +186,7 @@ export function EntityRow(props: EntityRowProps) {
     metaLine,
     sheetHref,
     onDeleteClick,
+    actions,
     linkAs: Link = 'a',
   } = props
   const frameStyle: CSSProperties = { background: tone.wash }
@@ -220,13 +241,19 @@ export function EntityRow(props: EntityRowProps) {
           )}
         </div>
 
-        <div className="flex shrink-0 items-center gap-1.5">
-          <Link
-            href={sheetHref}
-            className={cn(buttonVariants({ variant: 'default', size: 'compact' }), 'no-underline')}
-          >
-            View
-          </Link>
+        <div className="flex shrink-0 flex-wrap items-center justify-end gap-1.5">
+          {actions}
+          {sheetHref !== undefined && (
+            <Link
+              href={sheetHref}
+              className={cn(
+                buttonVariants({ variant: 'default', size: 'compact' }),
+                'no-underline'
+              )}
+            >
+              View
+            </Link>
+          )}
           {onDeleteClick && (
             <Button
               variant="ghost"


### PR DESCRIPTION
## Why

The Mediator surface shipped as a stack of bordered cards listing names and numbers: no way into a sheet, no way to launch anything, no way to make anything. A Game asks the same question the home Roster answers — *what have we got and what can I do with it* — so it now answers it in the same vocabulary.

Two shapes for one question is how an app stops feeling like one app.

## What

**`GameRoster`** — a Game's crew in the home Roster's shape: three ontology-toned `EntityRow` columns, a create CTA per column, sheet and Dashboard launches, an owner chip per row.

- `/games/:id` — the crew, for any member (new route)
- `/mediator/:id` — opens with the roster, keeps the private instruments below
- `/games` goes back to being a lobby. It used to render a proposal inbox and a Downtime panel *inside every row*, so a member of three campaigns met three stacked Downtime panels with nothing saying whose was whose.

**The table-setup rules** (ADR-030 §5a, new), enforced in Convex and mirrored — never re-decided — for the UI in `lib/games/gameRoster.ts`:

| Rule | Who |
| --- | --- |
| Raise / scrap a crawler | the table runner (Mediator, or Organizer while there is none) |
| Edit a crawler's fields | every member — that is what communal means |
| Add pilots & mechs to a Game | any player, **once the Game has a crawler**; the table runner is exempt |
| Create a character unclaimed | the table runner |
| Pick up an unclaimed character | any member, if nobody holds it |

A Game may hold **several** crawlers — losing one and rebuilding is ordinary play, not a state to reject.

**Self-claim amends ADR-030 §4**, which said players never self-claim. An unclaimed entity is an *offer to the crew* — that is why a Mediator pre-builds characters and a template seeds six. Requiring the Mediator to hand each one over added a round trip to every table's first ten minutes and bought no safety. The half that mattered is intact: claiming touches only what is **free**; what a crewmate holds must be released first.

Unclaimed reads as an **UNCLAIMED stamp seal** on the row, which opens a pick-up confirm. One control, because it is one fact — a muted "Unclaimed" chip beside a separate "Pick up" said the same thing twice and buried the invitation in the quieter half.

**Adoption** (`entityStore.adopt` / `forget`) caches a Game row into IndexedDB under its own id and drops it again. That is what makes a sheet or the Dashboard openable at all for a character built at somebody else's table. Local crawler edits now mirror up as a **field merge**, so "players may edit its fields" is true end to end rather than only locally.

## Two live defects found on the way

- **`crew.vitals` read `currentHp` / `currentSp`** where the Zod schemas define `currentHP` / `currentSP`. Every vital on the Mediator's crew strip came back null and rendered as an em-dash — indistinguishable from an undamaged crew, which is why it survived review. The existing test hand-wrote the same wrong key and agreed with the bug.
- **`proposals.apply` wrote the merged body without parsing it.** A proposal against a misspelled field added a key nothing reads: the player pressed Apply, no number moved, nothing said why. It now Zod-parses and refuses. (The Mediator surface was offering exactly those misspelled fields.)

Both are pinned by tests that build fixtures by **parsing the real schema** rather than hand-writing field names.

## Testing

- `convex/__tests__/tableSetup.test.ts` — 22 cases over the new rules, server-side
- `lib/games/__tests__/gameRoster.test.ts` — the UI's copy of those rules, pinned to the same table of cases
- `components/games/__tests__/GameRoster.connected.test.tsx` — the surface tells the truth about what you may do
- `bun run check:all` green (lint, format, typecheck, 1500+ tests, validate, knip, audit, tokens, styling)

## Known gaps, deliberately left

- **A refused mirror is only a console warning.** The surfaces avoid offering actions the server would refuse, so this is reachable mainly by going around them; a toast is the next step.
- **No read-only drill-in.** ADR-030 §5 permits reading a crewmate's sheet, but ITUN's sheet is a live *editing* surface — opening one would hand over an editor whose saves are refused. Rows you do not own show vitals and an owner, no link.
- **Adopted copies re-sync on the way in**, not while a sheet sits open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016osniJWrGgSrfq4VaCbHoq