### PR TITLE
fix(itun): unstack the wizard step tab, and derive every step card from its page tone

### DIFF
--- a/packages/component-lib/src/components/shared/WizShell.tsx
+++ b/packages/component-lib/src/components/shared/WizShell.tsx
@@ -386,7 +386,16 @@ export function WizShell({
                flush ink number tab, white condensed step head. */
             <div className={cn('min-h-0 flex-1 sm:pl-5', contentPad)}>
               <article
-                className="relative rounded-xl px-5 pb-6 pt-5 shadow-[0_14px_26px_-14px_var(--color-ink-40),inset_0_0_46px_var(--color-ink-8)] sm:pl-8"
+                /* `sm:pl-12` (48px) is LOAD-BEARING, not a taste-level inset: it
+                   is the gutter the overhanging number tab below is measured
+                   against. The tab is `w-14` (56px) at `-left-5` (-20px), so its
+                   right edge lands 36px inside the card — under the old `sm:pl-8`
+                   (32px) the content box started 4px to the LEFT of that, and the
+                   black tab printed on top of both the step title's first glyph
+                   and the RuleBrief panel's left edge. 48px clears it by 12px.
+                   Same overhang-plus-clearance relationship as `ModeDoor`'s tab.
+                   Move one of the three numbers and you must move the others. */
+                className="relative rounded-xl px-5 pb-6 pt-5 shadow-[0_14px_26px_-14px_var(--color-ink-40),inset_0_0_46px_var(--color-ink-8)] sm:pl-12"
                 style={{
                   background: 'var(--tone-card, var(--tone))',
                   // Card ink: rust (mech) needs WHITE body ink for legible

--- a/packages/component-lib/src/components/shared/WizShell.tsx
+++ b/packages/component-lib/src/components/shared/WizShell.tsx
@@ -411,7 +411,16 @@ export function WizShell({
                   {active + 1}
                 </span>
                 <header>
-                  <h1 className="m-0 font-cond text-display font-bold uppercase leading-[1.05] text-paper [text-shadow:0_1px_0_var(--color-ink-40)]">
+                  {/* The title INHERITS `--tone-card-ink` from the article
+                      (`text-current`) instead of hardcoding `text-paper`. White
+                      was safe only while the step cards were dark book literals;
+                      now that every card is a light tint derived from its page
+                      tone, a white title lands at 1.47:1 on pilot — invisible.
+                      Inheriting keeps the title and the body copy on the same
+                      ink rule, so a future dark card flips both together. The
+                      dark `text-shadow` went with it: it existed to lift white
+                      type off a saturated fill and only muddies dark type. */}
+                  <h1 className="m-0 font-cond text-display font-bold uppercase leading-[1.05] text-current">
                     <span className="sr-only">
                       Step {active + 1} of {steps.length} ·{' '}
                     </span>

--- a/packages/component-lib/src/components/shared/WizShell.tsx
+++ b/packages/component-lib/src/components/shared/WizShell.tsx
@@ -383,7 +383,7 @@ export function WizShell({
         <main className="flex min-w-0 flex-1 flex-col px-5 py-5 lg:px-10 lg:py-[30px]">
           {tintedStepCard ? (
             /* Blown-up tinted step card (mockup `.stepcard`): tone-card fill,
-               flush ink number tab, white condensed step head. */
+               flush ink number tab, condensed step head in the card ink. */
             <div className={cn('min-h-0 flex-1 sm:pl-5', contentPad)}>
               <article
                 /* `sm:pl-12` (48px) is LOAD-BEARING, not a taste-level inset: it
@@ -398,9 +398,10 @@ export function WizShell({
                 className="relative rounded-xl px-5 pb-6 pt-5 shadow-[0_14px_26px_-14px_var(--color-ink-40),inset_0_0_46px_var(--color-ink-8)] sm:pl-12"
                 style={{
                   background: 'var(--tone-card, var(--tone))',
-                  // Card ink: rust (mech) needs WHITE body ink for legible
-                  // contrast; sky blue / peach keep dark ink. Content that
-                  // sits directly on the card inherits via `text-current`.
+                  // Card ink, ONE rule for all three sheets: every step card is
+                  // now a light tint derived from its page tone, so all of them
+                  // take dark ink (6.8–9.7:1). Content sitting directly on the
+                  // card — the step head included — inherits via `text-current`.
                   color: 'var(--tone-card-ink, var(--color-ink))',
                 }}
               >
@@ -415,7 +416,8 @@ export function WizShell({
                       (`text-current`) instead of hardcoding `text-paper`. White
                       was safe only while the step cards were dark book literals;
                       now that every card is a light tint derived from its page
-                      tone, a white title lands at 1.47:1 on pilot — invisible.
+                      tone, a white title measures 1.54:1 on the pilot fill and
+                      1.91 / 2.18 on mech and crawler — invisible.
                       Inheriting keeps the title and the body copy on the same
                       ink rule, so a future dark card flips both together. The
                       dark `text-shadow` went with it: it existed to lift white

--- a/packages/component-lib/src/styles/theme.css
+++ b/packages/component-lib/src/styles/theme.css
@@ -361,10 +361,12 @@
                          legibility ceiling on the other two.
        chroma   ×0.62  — backs off the saturation so the card reads as the
                          paper the step is printed on, not a second band.
-     Resolves to ≈ #FFC09D (pilot), #AABDB4 (mech), #E296BB (crawler).
+     Sampled from rendered pixels (NOT the raw formula output — pilot's ideal
+     value is outside sRGB, so the browser gamut-maps it): #F9BC99 (pilot),
+     #A6B9B0 (mech), #DD93B7 (crawler).
 
-     Every card therefore lands light (L 0.76–0.86) and takes DARK ink, at
-     8.1–10.1:1. That unifies a split that used to exist: mech alone carried
+     Every card therefore lands light and takes DARK ink, at 9.67 / 7.77 /
+     6.81:1. That unifies a split that used to exist: mech alone carried
      `--color-paper` ink because rust was too dark to read against. One fill
      rule, one ink rule. See WizShell's `tintedStepCard`, whose step title
      inherits this ink rather than hardcoding white. */

--- a/packages/component-lib/src/styles/theme.css
+++ b/packages/component-lib/src/styles/theme.css
@@ -371,10 +371,20 @@
   --tone-deep: var(--color-sheet-crawler-deep);
   --ground: oklch(from var(--tone) 0.955 0.03 h);
   --ground-2: oklch(from var(--tone) 0.985 0.012 h);
-  /* Union Crawler step-card peach, pp.212–213 (#EC9C67) — unused until the
-     crawler wizard's book-order phase opts in. Peach is light enough for
-     dark ink. */
-  --tone-card: rgb(236, 156, 103);
+  /* Crawler step-card pink — DERIVED from the page tone, not a book literal.
+     This used to be the printed spread's peach (#EC9C67, pp.212–213), which
+     shipped an orange card onto a wholly pink surface: the masthead band, the
+     `--ground` page fill and the guided door all resolve from `--tone`
+     (#CE5898), so the one blown-up element in the middle of the screen was the
+     only thing that did not belong to the page. Relative colour keeps it tied
+     to the tone — restyle the crawler and the step card follows.
+
+     L/C are chosen to land on the SAME ink contrast as its sibling step cards
+     (7.13:1, vs pilot sky-blue 7.21 and the retired peach 7.26), so
+     `--tone-card-ink: ink` stays as legible as it was and the card still reads
+     a clear step lighter than the `--tone` masthead band above it.
+     Resolves to ≈ #E197BB. */
+  --tone-card: oklch(from var(--tone) 0.76 0.1 h);
   --tone-card-ink: var(--color-ink);
 }
 

--- a/packages/component-lib/src/styles/theme.css
+++ b/packages/component-lib/src/styles/theme.css
@@ -339,6 +339,37 @@
 .sheet--mech,
 .sheet--crawler {
   --tone: var(--sheet-tone, var(--tone-default));
+
+  /* WIZARD STEP-CARD FILL — ONE rule for all three sheets, derived from the
+     page tone rather than three book literals.
+
+     It used to be three hardcoded spread colours: pilot sky-blue (#6BB8D6,
+     pp.18–19), mech rust (#B0553A, pp.94–95), crawler peach (#EC9C67,
+     pp.212–213). On the crawler that shipped an ORANGE card onto a wholly pink
+     page — the masthead band, the `--ground` fill and the guided door all
+     resolve from `--tone`, so the one blown-up element mid-screen was the only
+     thing that did not belong. Deriving it fixes that by construction and
+     survives a restyle: change `--tone` and the step card follows.
+
+     The formula is a fixed STEP off the tone, not a fixed colour, so each sheet
+     keeps its own hue:
+       lightness +0.13 — enough of a gap that the `var(--tone)` RuleBrief band
+                         sitting INSIDE the card still reads as a distinct band.
+                         A fixed target lightness could not do this: pilot's
+                         tone is already L=0.729, so any shared absolute value
+                         either collapsed against pilot's band or blew past the
+                         legibility ceiling on the other two.
+       chroma   ×0.62  — backs off the saturation so the card reads as the
+                         paper the step is printed on, not a second band.
+     Resolves to ≈ #FFC09D (pilot), #AABDB4 (mech), #E296BB (crawler).
+
+     Every card therefore lands light (L 0.76–0.86) and takes DARK ink, at
+     8.1–10.1:1. That unifies a split that used to exist: mech alone carried
+     `--color-paper` ink because rust was too dark to read against. One fill
+     rule, one ink rule. See WizShell's `tintedStepCard`, whose step title
+     inherits this ink rather than hardcoding white. */
+  --tone-card: oklch(from var(--tone) calc(l + 0.13) calc(c * 0.62) h);
+  --tone-card-ink: var(--color-ink);
 }
 
 .sheet--pilot {
@@ -346,12 +377,6 @@
   --tone-deep: var(--color-sheet-pilot-deep);
   --ground: oklch(from var(--tone) 0.955 0.03 h);
   --ground-2: oklch(from var(--tone) 0.985 0.012 h);
-  /* Wizard step-card fill (wizard-refresh mockup): the sky-blue step cards of
-     the printed Pilot Bay spread, pp.18–19 (#6BB8D6). Opt-in via WizShell's
-     tintedStepCard — only book-order wizards render it. Sky blue is light
-     enough for dark ink. */
-  --tone-card: rgb(107, 184, 214);
-  --tone-card-ink: var(--color-ink);
 }
 
 .sheet--mech {
@@ -359,11 +384,6 @@
   --tone-deep: var(--color-sheet-mech-deep);
   --ground: oklch(from var(--tone) 0.955 0.022 h);
   --ground-2: oklch(from var(--tone) 0.985 0.01 h);
-  /* Mech Workshop step-card rust, pp.94–95 (#B0553A). Rust is too dark for
-     ink text — the card ink is WHITE (matching the printed spread's white
-     body copy on the rust step cards). */
-  --tone-card: rgb(176, 85, 58);
-  --tone-card-ink: var(--color-paper);
 }
 
 .sheet--crawler {
@@ -371,21 +391,6 @@
   --tone-deep: var(--color-sheet-crawler-deep);
   --ground: oklch(from var(--tone) 0.955 0.03 h);
   --ground-2: oklch(from var(--tone) 0.985 0.012 h);
-  /* Crawler step-card pink — DERIVED from the page tone, not a book literal.
-     This used to be the printed spread's peach (#EC9C67, pp.212–213), which
-     shipped an orange card onto a wholly pink surface: the masthead band, the
-     `--ground` page fill and the guided door all resolve from `--tone`
-     (#CE5898), so the one blown-up element in the middle of the screen was the
-     only thing that did not belong to the page. Relative colour keeps it tied
-     to the tone — restyle the crawler and the step card follows.
-
-     L/C are chosen to land on the SAME ink contrast as its sibling step cards
-     (7.13:1, vs pilot sky-blue 7.21 and the retired peach 7.26), so
-     `--tone-card-ink: ink` stays as legible as it was and the card still reads
-     a clear step lighter than the `--tone` masthead band above it.
-     Resolves to ≈ #E197BB. */
-  --tone-card: oklch(from var(--tone) 0.76 0.1 h);
-  --tone-card-ink: var(--color-ink);
 }
 
 /* Mobile-first touch targets */


### PR DESCRIPTION
Two defects on the same surface, reported from the crawler wizard: "elements are stacked on top of each other, and the orange background should be relative to the color of the pages".

## 1. The number tab printed on top of its own card's content

The tab is `w-14` (56px) at `-left-5` (-20px), so its right edge lands **36px inside** the card — but the card's content box started at `sm:pl-8` (**32px**). Measured in headless Chrome:

| | before | after |
|---|---|---|
| `badge.right - h1.left` | **+4px (overlap)** | −12px |
| `badge.right - rule.left` | **+4px (overlap)** | −12px |

The tab's vertical span (230..294) also crossed the RuleBrief panel's top edge (269), so it printed over both the step title's first glyph and the panel's left edge. `sm:pl-12` (48px) clears it by 12px. This affected **all three** tinted wizards; all three now measure clear. Below `sm` the tab is `hidden`, so mobile is unaffected.

## 2. Every step card now derives from its page tone

The three fills were three hardcoded book literals — pilot sky-blue (`#6BB8D6`, pp.18–19), mech rust (`#B0553A`, pp.94–95), crawler peach (`#EC9C67`, pp.212–213). On the crawler that put an **orange** card on a wholly pink page: the masthead band, the `--ground` fill and the guided door all resolve from `--tone`, so the one blown-up element mid-screen was the only thing that did not belong.

They are now **one declaration** on the shared `.sheet--pilot, .sheet--mech, .sheet--crawler` rule:

```css
--tone-card: oklch(from var(--tone) calc(l + 0.13) calc(c * 0.62) h);
```

A fixed **step** off the tone, not a fixed colour, so each sheet keeps its own hue. A shared absolute lightness could not work — pilot's tone is already L=0.729, so any single target either collapsed against pilot's own RuleBrief band (a 0.031 gap) or blew past the legibility ceiling on the other two. `+0.13 L` keeps the `var(--tone)` band reading as a distinct band inside the card on all three; `×0.62 C` backs the fill off to something that reads as paper rather than a second band.

Measured from rendered pixels:

| sheet | tone | card | vs dark ink |
|---|---|---|---|
| pilot | `#EF894F` | `#F9BC99` | 9.67:1 |
| mech | `#7A978A` | `#A6B9B0` | 7.77:1 |
| crawler | `#CE5898` | `#DD93B7` | 6.81:1 |

### Two consequences, both deliberate

- **`--tone-card-ink` is now `--color-ink` everywhere.** Mech alone carried paper ink because rust was too dark to read against; that split is gone, so there is one fill rule and one ink rule instead of two.
- **The step title no longer hardcodes `text-paper`.** White was safe only while the cards were dark literals — on the derived pilot fill it lands at **1.47:1**, invisible. It now inherits `--tone-card-ink` via `text-current`, so title and body share one ink rule and a future dark card flips both together. The dark `text-shadow` went with it: it existed to lift white type off a saturated fill and only muddies dark type.

## Verification

Rendered geometry and pixel colours measured in headless Chrome at 1440 / 768 / 390, before and after, on all three wizards, driving the real app through the Guided door. The relative-colour syntax resolves in Chrome; clearance holds at 12px (40px below `sm`); every title renders dark with no shadow.

`lint`, `format:check`, `typecheck`, `test`, `knip`, `validate:all`, `check:tokens` and `check:styling` all exit 0. Note: the aggregate `check:all` script exits 1 even though every step inside it exits 0 — that reproduces on a pristine `main` checkout and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkmpubADC1FZPouxpXdpnB