### PR TITLE
fix(itun): sweep invite rows on game deletion, and correct the ADR citation

### DIFF
--- a/apps/itun/convex/__tests__/invites.test.ts
+++ b/apps/itun/convex/__tests__/invites.test.ts
@@ -379,6 +379,35 @@ describe('knock and approve', () => {
   })
 })
 
+describe('deleting a game', () => {
+  test('sweeps redemptions and pending knocks along with the invites', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const joiner = await makeUser(t, 'Sam')
+    const knocker = await makeUser(t, 'Knocker')
+
+    const open = await organizer.as.mutation(api.invites.create, { gameId })
+    await joiner.as.mutation(api.invites.redeem, { code: open })
+
+    const gated = await organizer.as.mutation(api.invites.create, {
+      gameId,
+      requiresApproval: true,
+    })
+    await knocker.as.mutation(api.invites.redeem, { code: gated })
+
+    await organizer.as.mutation(api.games.destroy, { gameId })
+
+    // A knock at a door that no longer exists would otherwise sit pending
+    // forever, and a redemption row would point at a deleted Game.
+    const leftovers = await t.run(async (ctx) => ({
+      invites: (await ctx.db.query('invites').collect()).length,
+      redemptions: (await ctx.db.query('inviteRedemptions').collect()).length,
+      requests: (await ctx.db.query('joinRequests').collect()).length,
+    }))
+    expect(leftovers).toEqual({ invites: 0, redemptions: 0, requests: 0 })
+  })
+})
+
 describe('games.get and the row summary', () => {
   test('summarize carries the crawler name and the entity counts', async () => {
     const t = testConvex()

--- a/apps/itun/convex/games.ts
+++ b/apps/itun/convex/games.ts
@@ -199,12 +199,17 @@ export const destroy = mutation({
       }
     }
 
-    // Game-scoped rows with no personal counterpart just go.
+    // Game-scoped rows with no personal counterpart just go. `inviteRedemptions`
+    // and `joinRequests` belong here for the same reason `invites` does: they
+    // describe a way into a Game that no longer exists, and an unanswered knock
+    // at a deleted door would sit pending forever.
     for (const table of [
       'crawlers',
       'encounterNpcs',
       'softLinks',
       'invites',
+      'inviteRedemptions',
+      'joinRequests',
       'memberships',
       'presence',
     ] as const) {

--- a/apps/itun/convex/invites.ts
+++ b/apps/itun/convex/invites.ts
@@ -8,7 +8,9 @@ import { NotAuthorized, getMembership, requireOrganizer, requireUser } from './m
 import { logOwnershipChange } from './ownership'
 
 /**
- * Invite codes (ADR-030 §2) — how a player joins a Game.
+ * Invite codes (ADR-030 §3, and the invite amendment) — how a player joins a
+ * Game. Not §2: that section is Containers, and its only mention of invites is
+ * that a shelf has none.
  *
  * Codes reuse `generateUniqueId` from the snapshot module rather than growing a
  * second generator: it is already Crockford base32 (no I/L/O/U, so a code read

--- a/apps/itun/convex/schema.ts
+++ b/apps/itun/convex/schema.ts
@@ -181,6 +181,10 @@ export default defineSchema({
     decidedAt: v.optional(v.number()),
   })
     .index('by_game_state', ['gameId', 'state'])
+    // Plain `by_game` as well as the compound: deleting a Game sweeps every
+    // request regardless of state, and a prefix scan of `by_game_state` would
+    // read as "pending only" to the next person who touched it.
+    .index('by_game', ['gameId'])
     .index('by_user', ['userId'])
     .index('by_invite_user', ['inviteId', 'userId']),
 

--- a/docs/adrs/ADR-030-accounts-games-server-of-record.md
+++ b/docs/adrs/ADR-030-accounts-games-server-of-record.md
@@ -214,9 +214,10 @@ is not built — the crew vitals strip carries that information for now.
 
 ## Amendment — an invite carries what the Organizer decided
 
-§2 describes an invite code as sufficient to join, and §3 leaves the seat and
-the hand-out as separate acts performed after the fact. Both are amended in one
-direction: **an invite now expresses a decision the Organizer has already made.**
+§3 gives the Organizer "invites, membership" and stops there, leaving a code as
+a bare key and the seat and the hand-out as separate acts performed after the
+fact. That is amended in one direction: **an invite now expresses a decision the
+Organizer has already made.**
 
 **An invite may be minted as a request.** With approval required, the code
 identifies the Game and grants nothing until the Organizer lets the knocker in.

--- a/docs/design/game-invites-and-membership-plan.md
+++ b/docs/design/game-invites-and-membership-plan.md
@@ -499,7 +499,8 @@ harness (`convex/__tests__/harness.ts`), and `invites` is covered there today:
   Log entry with `actorId` = inviter; **a stale grant still joins**; re-redeem
   stays idempotent and consumes no use; `preview` leaks nothing beyond §4.2.
 - 5: knock creates no membership; approval seats with the invite's role and
-  grants; knock consumes no use, approval does; decline is terminal.
+  grants; knock consumes no use, approval does; a declined knocker may ask
+  again (an Organizer who declined by mistake should not need a fresh code).
 
 ---
 


### PR DESCRIPTION
Follow-up to #655. Two findings from that PR's recorded review that were real against the merged code — the merge queue landed #655 before these could be folded in.

## The leak

`games.destroy` deletes `invites` but was never extended for the two tables added beside it. Deleting a Game left:

- `inviteRedemptions` rows pointing at a Game that no longer exists, and
- **a pending `joinRequests` knock at a door that is gone** — unanswerable forever, since the only surface that could approve or decline it went with the Game.

Both now go with the Game. `joinRequests` gains a plain `by_game` index for the sweep: a prefix scan of `by_game_state` would have worked, but it reads as "pending only" to whoever touches it next, which is exactly the kind of thing that quietly stops sweeping declined rows later.

Covered by a test that fails without the fix — it seeds a redemption and a pending knock, destroys the Game, and asserts all three tables are empty.

## The citation

The amendment opened by attributing to ADR-030 §2 a claim §2 does not make. §2 is *Containers*, and its only mention of invites is that a shelf has none; the authority is §3, which grants the Organizer "invites, membership" and stops there.

The mis-citation was inherited from the module header in `convex/invites.ts`, which said the same thing — fixed at the source too, since that comment is what an implementer reads first.

Also corrects the design doc's "decline is terminal", which the built behaviour deliberately contradicts: a declined knocker may ask again, so an Organizer who declined by mistake need not mint a fresh code.

## Verification

`bun --filter itun typecheck` clean; all 174 Convex tests pass, including the new destroy case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxsNxRvv4nDHZuZ9SqyNYG