### PR TITLE
fix(component-lib): render one card per installed copy in a pattern loadout

### DIFF
--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/PatternView.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/PatternView.test.tsx
@@ -104,6 +104,27 @@ describe('full pattern view reading order', () => {
     expect(patternProse).toBeLessThan(systems)
     expect(systems).toBeLessThan(modules)
   })
+
+  test('a system installed six times renders six cards, not one', () => {
+    // The end-to-end guard for the multiplicity fix in `resolvePatternGroups`.
+    // Atlas's Thunder Storm prints as ".50 Cal Machine Gun x6" in the book; the
+    // card used to de-duplicate the loadout by entity id, so the whole pattern
+    // rendered a single machine gun and read as a far lighter build than it is.
+    const chassis = SalvageUnionReference.Chassis.all().find((c) => c.name === 'Atlas')
+    if (!chassis) throw new Error('Atlas fixture missing')
+    const pattern = chassis.patterns?.find((p) => p.name === 'Thunder Storm')
+    if (!pattern) throw new Error('Thunder Storm pattern fixture missing')
+    // Guard the fixture: the count is what drives the expansion.
+    expect(pattern.systems?.find((s) => s.name === '.50 Cal Machine Gun')?.count).toBe(6)
+
+    render(<ReferenceEntityCard data={chassis} pattern={pattern} size="large" />)
+
+    // One name node per rendered card.
+    expect(screen.getAllByText('.50 Cal Machine Gun')).toHaveLength(6)
+    // The uncounted systems stay single — the fix must not multiply everything.
+    expect(screen.getAllByText('Shotgun Pit')).toHaveLength(1)
+    expect(screen.getAllByText('Armour Plating')).toHaveLength(1)
+  })
 })
 
 /**

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/resolveNestedEntities.test.ts
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/resolveNestedEntities.test.ts
@@ -130,12 +130,64 @@ describe('resolvePatternGroups', () => {
     expect(names(group(groups, 'Systems')?.entities ?? [])).toEqual(['Green Laser'])
   })
 
-  test('duplicate entries within a group are de-duplicated', () => {
+  test('a `count` renders one card per installed copy', () => {
+    // Atlas's Thunder Storm is the printed case: the book's pattern block reads
+    // ".50 Cal Machine Gun x6". This resolver used to de-duplicate by entity id,
+    // so all six collapsed into one card and the pattern silently under-reported
+    // its armament.
+    const groups = resolvePatternGroups(pattern('Atlas', 'Thunder Storm'))
+    expect(names(group(groups, 'Systems')?.entities ?? [])).toEqual([
+      '.50 Cal Machine Gun',
+      '.50 Cal Machine Gun',
+      '.50 Cal Machine Gun',
+      '.50 Cal Machine Gun',
+      '.50 Cal Machine Gun',
+      '.50 Cal Machine Gun',
+      'Armour Plating',
+      'Escape Hatch',
+      'Locomotion System',
+      'Personnel Transport Pod',
+      'Shotgun Pit',
+    ])
+  })
+
+  test('several counted systems in one pattern each keep their own multiplicity', () => {
+    // Leviathan's Destroyer is the heaviest case in the dataset: three separate
+    // counted weapons, which the old de-dupe flattened to one card each.
+    const systems = names(
+      group(resolvePatternGroups(pattern('Leviathan', 'Destroyer')), 'Systems')?.entities ?? []
+    )
+    expect(systems.filter((n) => n === '.50 Cal Machine Gun')).toHaveLength(6)
+    expect(systems.filter((n) => n === 'Red Laser')).toHaveLength(3)
+    expect(systems.filter((n) => n === '30mm Autocannon')).toHaveLength(2)
+  })
+
+  test('a multiple spelled as REPEATED ENTRIES (no `count`) also survives', () => {
+    // The data spells multiplicity two ways. Trooper's DronTek lists
+    // `Articulated Rigging Arm` and `Chaff Launcher` twice each as separate
+    // entries rather than carrying a `count`, so a fix that only reads `count`
+    // would still drop these.
+    const systems = names(
+      group(resolvePatternGroups(pattern('Trooper', 'DronTek')), 'Systems')?.entities ?? []
+    )
+    expect(systems.filter((n) => n === 'Articulated Rigging Arm')).toHaveLength(2)
+    expect(systems.filter((n) => n === 'Chaff Launcher')).toHaveLength(2)
+  })
+
+  test('a count of 1 (or none) still renders exactly one card', () => {
     const groups = resolvePatternGroups({
       name: 'Fake',
-      systems: [{ name: 'Green Laser' }, { name: 'Green Laser' }],
+      systems: [{ name: 'Green Laser', count: 1 }, { name: 'Escape Hatch' }],
     } as SURefObjectPattern)
-    expect(group(groups, 'Systems')?.entities).toHaveLength(1)
+    expect(names(group(groups, 'Systems')?.entities ?? [])).toEqual(['Green Laser', 'Escape Hatch'])
+  })
+
+  test('a module `count` expands the same way a system count does', () => {
+    const groups = resolvePatternGroups({
+      name: 'Fake',
+      modules: [{ name: 'Comms Module', count: 3 }],
+    } as SURefObjectPattern)
+    expect(group(groups, 'Modules')?.entities).toHaveLength(3)
   })
 
   test('an empty pattern yields no groups', () => {

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/resolveNestedEntities.test.ts
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/resolveNestedEntities.test.ts
@@ -182,6 +182,24 @@ describe('resolvePatternGroups', () => {
     expect(names(group(groups, 'Systems')?.entities ?? [])).toEqual(['Green Laser', 'Escape Hatch'])
   })
 
+  test('an explicit `count` of 0 renders nothing, rather than one card', () => {
+    // The schema permits 0, and "zero installed" must not be clamped up to one —
+    // that would invent a card and diverge from `useChassisPatternConfig`.
+    const groups = resolvePatternGroups({
+      name: 'Fake',
+      systems: [{ name: 'Green Laser', count: 0 }, { name: 'Escape Hatch' }],
+    } as SURefObjectPattern)
+    expect(names(group(groups, 'Systems')?.entities ?? [])).toEqual(['Escape Hatch'])
+  })
+
+  test('a group whose every entry has count 0 is dropped entirely', () => {
+    const groups = resolvePatternGroups({
+      name: 'Fake',
+      systems: [{ name: 'Green Laser', count: 0 }],
+    } as SURefObjectPattern)
+    expect(group(groups, 'Systems')).toBeUndefined()
+  })
+
   test('a module `count` expands the same way a system count does', () => {
     const groups = resolvePatternGroups({
       name: 'Fake',

--- a/packages/component-lib/src/components/referenceEntity/card/resolveNestedEntities.ts
+++ b/packages/component-lib/src/components/referenceEntity/card/resolveNestedEntities.ts
@@ -120,9 +120,15 @@ export function resolveNestedEntities(entity: SURefMetaEntity): NestedGroup[] {
 export function resolvePatternGroups(pattern: SURefObjectPattern): NestedGroup[] {
   const groups = new Map<string, SURefEntity[]>()
 
+  // `count` defaults to 1 when ABSENT, but an explicit 0 renders nothing — the
+  // schema permits it (`NonNegativeIntegerSchema`) and "zero installed" is the
+  // only honest reading. Clamping it up to 1 would invent a card the loadout
+  // does not claim, and would disagree with `useChassisPatternConfig`, which
+  // this function is otherwise kept in step with.
   const push = (label: string, candidate: SURefEntity | undefined, count = 1): void => {
     if (!candidate) return
-    const copies = Array.from({ length: Math.max(1, count) }, () => candidate)
+    const copies = Array.from({ length: count }, () => candidate)
+    if (copies.length === 0) return
     const bucket = groups.get(label)
     if (bucket) bucket.push(...copies)
     else groups.set(label, copies)

--- a/packages/component-lib/src/components/referenceEntity/card/resolveNestedEntities.ts
+++ b/packages/component-lib/src/components/referenceEntity/card/resolveNestedEntities.ts
@@ -99,38 +99,46 @@ export function resolveNestedEntities(entity: SURefMetaEntity): NestedGroup[] {
 /**
  * A single pattern's loadout, grouped for the PATTERN view: its `systems` and
  * `modules` (and any named `drones`), resolved by name into real reference
- * entities and de-duplicated. Rendered as `Slab`-separated masonry groups of
- * compact cards under the pattern (with the chassis name as a seam stampseal).
+ * entities. Rendered as `Slab`-separated masonry groups of compact cards under
+ * the pattern (with the chassis name as a seam stampseal).
+ *
+ * MULTIPLICITY IS PRESERVED — one card per installed copy, matching the printed
+ * pattern block (Atlas's Thunder Storm reads ".50 Cal Machine Gun x6") and the
+ * wizard's own expansion in `useChassisPatternConfig`.
+ *
+ * This function used to de-duplicate by `label:schema:id`, which silently
+ * collapsed every multiple in the SRD pattern view — 60 of 209 patterns, so
+ * Leviathan's Destroyer showed one .50 Cal instead of six, one Red Laser
+ * instead of three, one 30mm Autocannon instead of two. It also swallowed the
+ * OTHER way the data spells a multiple: Trooper's DronTek pattern repeats
+ * `Articulated Rigging Arm` and `Chaff Launcher` as separate entries with no
+ * `count`, so both spellings have to survive the walk.
+ *
+ * Duplicate cards are safe to render: the card's `cardKey` disambiguates by
+ * index, not by entity id.
  */
 export function resolvePatternGroups(pattern: SURefObjectPattern): NestedGroup[] {
   const groups = new Map<string, SURefEntity[]>()
-  const seen = new Set<string>()
 
-  const push = (label: string, candidate: SURefEntity | undefined): void => {
+  const push = (label: string, candidate: SURefEntity | undefined, count = 1): void => {
     if (!candidate) return
-    const id = 'id' in candidate && typeof candidate.id === 'string' ? candidate.id : ''
-    const name = 'name' in candidate && typeof candidate.name === 'string' ? candidate.name : ''
-    const schema =
-      'schemaName' in candidate && typeof candidate.schemaName === 'string'
-        ? candidate.schemaName
-        : ''
-    const key = `${label}:${schema}:${id || name}`
-    if (seen.has(key)) return
-    seen.add(key)
+    const copies = Array.from({ length: Math.max(1, count) }, () => candidate)
     const bucket = groups.get(label)
-    if (bucket) bucket.push(candidate)
-    else groups.set(label, [candidate])
+    if (bucket) bucket.push(...copies)
+    else groups.set(label, copies)
   }
 
   for (const s of pattern.systems ?? [])
     push(
       'Systems',
-      SalvageUnionReference.findIn('systems', (x) => x.name === s.name)
+      SalvageUnionReference.findIn('systems', (x) => x.name === s.name),
+      s.count
     )
   for (const m of pattern.modules ?? [])
     push(
       'Modules',
-      SalvageUnionReference.findIn('modules', (x) => x.name === m.name)
+      SalvageUnionReference.findIn('modules', (x) => x.name === m.name),
+      m.count
     )
   for (const d of pattern.drones ?? [])
     push(


### PR DESCRIPTION
## What

A chassis pattern's systems and modules were de-duplicated before rendering, so **every multiple collapsed into a single card**.

Atlas's Thunder Storm prints as `.50 Cal Machine Gun x6` in the Core Book (Digital Edition 2.0a, p.125 — identical in 1.2). The SRD pattern view rendered one machine gun.

## Scope

**60 of the 209 patterns** in the dataset carry a multiple that was being dropped. The heaviest case, Leviathan / Destroyer, showed one `.50 Cal` instead of six, one `Red Laser` instead of three, and one `30mm Autocannon` instead of two — reading as a far lighter build than the book describes.

## Cause

`resolvePatternGroups` (`resolveNestedEntities.ts`) looked each system up **by name only**, never read `count`, and de-duplicated by `label:schema:id`.

The data spells multiplicity two ways, and both were swallowed:

- a `count` on the entry — the common case (`{ name: '.50 Cal Machine Gun', count: 6 }`)
- the **same name repeated as separate entries** — Trooper / DronTek lists `Articulated Rigging Arm` and `Chaff Launcher` twice each with no `count`

A fix that only read `count` would still have dropped the second. Removing the de-dupe and expanding `count` covers both.

## Why this shape

ITUN's wizard path (`useChassisPatternConfig`) **already** expanded counts into one card per copy. This brings the SRD pattern view in line with it rather than introducing a third behaviour. Rendering choice confirmed with @alxjrvs — one card per installed copy, not a `×6` badge.

Duplicate cards were already safe to render: the card's `cardKey` disambiguates by index, not by entity id.

## Tests

One test pinned the old behaviour (`'duplicate entries within a group are de-duplicated'`) and is replaced by its inverse. Added:

- `resolveNestedEntities.test.ts` — Atlas / Thunder Storm's full 11-entry system list; Leviathan / Destroyer's three independent counts; Trooper / DronTek's repeated-entry spelling; count-of-1 and module-count cases
- `PatternView.test.tsx` — end-to-end render assertion that six `.50 Cal Machine Gun` cards appear and that uncounted systems stay single

`bun run check:all` exits 0.

## Not in this PR

Two book-side findings surfaced while verifying, left alone deliberately:

1. The book annotates `Weapon Link` with the weapons it links (`.50 Cal Machine Gun × 6`, `FM-3 Flamethrower // Chainsaw Arm`). Our pattern-module shape is `{ name, count }`, so that designation isn't captured for any of the 19 patterns carrying one.
2. Thunder Storm needs **22 system slots on a 21-slot chassis**. Every slot value matches the book (verified pp. 164/165/171 against the `Slots Required / Salvage Value` legend), so this is an error in the published pattern, not in our data — but it would fail any future slot-budget validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuHFE7oDVDau2EZjy1Nmk3