### PR TITLE
feat(itun): the Games lobby as a controls band over its list

### DIFF
--- a/apps/itun/convex/templates.ts
+++ b/apps/itun/convex/templates.ts
@@ -40,8 +40,15 @@ export type TemplateId = keyof typeof TEMPLATES
 export const list = query({
   args: {},
   handler: async () => {
+    // `id` is typed as the TemplateId union rather than `string` so a caller can
+    // pass the row straight to `createGame`. With a plain `string` the only way
+    // to satisfy that mutation's `v.literal` validator was to hardcode the id at
+    // the call site, which meant the lobby rendered one template and created
+    // another the moment a second one existed. Typed this way, adding a template
+    // widens the union and `createGame`'s validator becomes the type error —
+    // which is the right place to notice.
     return Object.entries(TEMPLATES).map(([id, t]) => ({
-      id,
+      id: id as TemplateId,
       name: t.name,
       description: t.description,
     }))

--- a/apps/itun/src/components/games/GamesScreen.tsx
+++ b/apps/itun/src/components/games/GamesScreen.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
-import { Button, Card, EntityRow, Text } from 'component-lib'
+import { Button, Card, EntityRow, ModalShell, Text } from 'component-lib'
 import { useMutation, useQuery } from 'convex/react'
+import type { FunctionReturnType } from 'convex/server'
 import { useNavigate } from '@tanstack/react-router'
 
 import { api } from '../../../convex/_generated/api'
@@ -8,7 +9,7 @@ import { useConnection } from '../../lib/connection/connectionContext'
 import { isConvexConfigured } from '../../lib/connection/convexClient'
 import { SignInControl } from '../account/SignInControl'
 import { GameRow } from './GameRow'
-import { STAMP } from './gameChrome'
+import { INPUT, STAMP } from './gameChrome'
 
 /**
  * Games — the shelf of tables you belong to.
@@ -23,11 +24,80 @@ import { STAMP } from './gameChrome'
  * would be a stale snapshot of a roster that may have changed.
  */
 
+type TemplateList = FunctionReturnType<typeof api.templates.list>
+
+/**
+ * "From a template" as a dialog rather than a third stacked card.
+ *
+ * The template list is fetched by the PARENT and handed down, deliberately:
+ * `open` is local state here, so toggling it re-renders only this component. If
+ * the query lived here too, that re-render would fire a Convex subscription read
+ * on its own — which is harmless in the app but makes the screen's query
+ * sequence depend on which child last changed state, and the connected tests
+ * answer queries by call order. Lifting it keeps the screen's reads to one
+ * fixed pass.
+ *
+ * A template is a *list to read* — each entry carries a name and a paragraph of
+ * description — and inlining that list put a wall of prose between the controls
+ * and the games it was meant to sit beside. Behind a button the band stays a
+ * band, and the reading happens when you have asked for it.
+ */
+function TemplatePicker({ templates }: { templates: TemplateList | undefined }) {
+  const createFromTemplate = useMutation(api.templates.createGame)
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <Button
+        variant="default"
+        size="compact"
+        // Nothing to choose from until the list lands, and an empty dialog reads
+        // as broken rather than as loading.
+        disabled={templates === undefined || templates.length === 0}
+        onClick={() => setOpen(true)}
+      >
+        From a template
+      </Button>
+      <ModalShell
+        open={open}
+        onOpenChange={setOpen}
+        title="Start from a template"
+        maxWidth="max-w-lg"
+      >
+        <div className="flex flex-col gap-5 bg-paper p-5">
+          {templates?.map((t) => (
+            <div key={t.id} className="flex flex-col gap-2">
+              <Text as="span" className={STAMP}>
+                {t.name}
+              </Text>
+              <Text variant="hint" className="text-left">
+                {t.description}
+              </Text>
+              <div>
+                <Button
+                  variant="primary"
+                  size="compact"
+                  // `t.id`, not a hardcoded template id — see the comment on
+                  // `templates.list`.
+                  onClick={() =>
+                    void createFromTemplate({ templateId: t.id }).then(() => setOpen(false))
+                  }
+                >
+                  Start this game
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </ModalShell>
+    </>
+  )
+}
+
 function ConnectedGames() {
   const games = useQuery(api.games.listMine, {})
   const templates = useQuery(api.templates.list, {})
   const create = useMutation(api.games.create)
-  const createFromTemplate = useMutation(api.templates.createGame)
   const redeem = useMutation(api.invites.redeem)
 
   const navigate = useNavigate()
@@ -56,14 +126,22 @@ function ConnectedGames() {
 
   return (
     <div className="flex flex-col gap-6">
-      <Card>
-        <div className="flex flex-wrap items-end gap-2 p-4">
+      {/* CONTROLS BAND — the Roster's rhythm (`components/roster/Roster.tsx`):
+          the things you can DO sit in one ink-ruled band across the top, and the
+          things you HAVE list directly beneath it.
+
+          This used to be three stacked Cards — start, template, join — so the
+          games you came here to open were pushed below a screenful of forms you
+          had already used. A lobby's subject is the list; creating is the
+          control on it, not the other way round. */}
+      <div className="flex flex-col gap-2.5 border-b-2 border-ink pb-5">
+        <div className="flex flex-wrap items-end gap-3">
           <label className="flex flex-col gap-1">
             <span className={STAMP}>Start a game</span>
             <input
               aria-label="New game name"
               placeholder="Union Crawler #430"
-              className="border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-1"
+              className={INPUT}
               value={newName}
               onChange={(e) => setNewName(e.target.value)}
             />
@@ -76,71 +154,40 @@ function ConnectedGames() {
           >
             Create
           </Button>
-        </div>
-      </Card>
 
-      <Card>
-        <div className="flex flex-col gap-3 p-4">
-          <span className={STAMP}>Or start from a template</span>
-          {templates?.map((t) => (
-            <div key={t.id} className="flex flex-col gap-2">
-              <Text as="span">{t.name}</Text>
-              <Text variant="hint" className="text-left">
-                {t.description}
-              </Text>
-              <div>
-                <Button
-                  variant="ghost"
-                  size="compact"
-                  onClick={() =>
-                    void createFromTemplate({
-                      templateId: 'starter-set',
-                      name: newName || undefined,
-                    })
-                  }
-                >
-                  Start this game
-                </Button>
-              </div>
-            </div>
-          ))}
-        </div>
-      </Card>
+          <TemplatePicker templates={templates} />
 
-      <Card>
-        <div className="flex flex-col gap-2 p-4">
-          <div className="flex flex-wrap items-end gap-2">
-            <label className="flex flex-col gap-1">
-              <span className={STAMP}>Join with a code</span>
-              <input
-                aria-label="Invite code"
-                placeholder="A1B2C3D4"
-                className="border-2 border-[var(--color-ink)] bg-[var(--color-paper)] px-2 py-1 tracking-caps-wide uppercase"
-                value={code}
-                onChange={(e) => setCode(e.target.value)}
-              />
-            </label>
-            <Button
-              variant="primary"
-              size="compact"
-              disabled={code.trim().length === 0}
-              onClick={join}
-            >
-              Join
-            </Button>
-          </div>
-          {joinError !== null && (
-            <Text variant="hint" className="text-left text-[var(--color-roll-cascade)]">
-              {joinError}
-            </Text>
-          )}
-          {joinNotice !== null && (
-            <Text variant="hint" className="text-left">
-              {joinNotice}
-            </Text>
-          )}
+          <label className="flex flex-col gap-1">
+            <span className={STAMP}>Join with a code</span>
+            <input
+              aria-label="Invite code"
+              placeholder="A1B2C3D4"
+              className={`${INPUT} tracking-caps-wide uppercase`}
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+            />
+          </label>
+          <Button
+            variant="primary"
+            size="compact"
+            disabled={code.trim().length === 0}
+            onClick={join}
+          >
+            Join
+          </Button>
         </div>
-      </Card>
+
+        {joinError !== null && (
+          <Text variant="hint" className="text-left text-[var(--color-roll-cascade)]">
+            {joinError}
+          </Text>
+        )}
+        {joinNotice !== null && (
+          <Text variant="hint" className="text-left">
+            {joinNotice}
+          </Text>
+        )}
+      </div>
 
       {games === undefined && <Text>Loading your games…</Text>}
       {games?.length === 0 && (

--- a/apps/itun/src/components/games/__tests__/GamesScreen.connected.test.tsx
+++ b/apps/itun/src/components/games/__tests__/GamesScreen.connected.test.tsx
@@ -170,11 +170,37 @@ describe('the Games index for a signed-in player', () => {
     expect(screen.queryByText(/Open the Mediator surface/)).toBeNull()
   })
 
-  test('offers a template to start from', () => {
+  test('offers a template to start from, behind a control rather than inline', () => {
     withQueries(queriesFor(GAME))
     wrap()
+
+    // A template is a list to READ — a name plus a paragraph each — so it sits
+    // in a dialog and the controls band stays a band. Inline, it wedged a
+    // screenful of prose between the controls and the games list.
+    expect(screen.queryByText('Reclamation of the Wastes')).toBeNull()
+
+    fireEvent.click(screen.getByText('From a template'))
+
     expect(screen.getByText('Reclamation of the Wastes')).toBeTruthy()
     expect(screen.getByText('Start this game')).toBeTruthy()
+  })
+
+  test('the creating controls come BEFORE the games they act on', () => {
+    withQueries(queriesFor(GAME))
+    const { container } = wrap()
+
+    // The point of the band (this is the Roster's rhythm): what you can DO is
+    // one ink-ruled row across the top, and what you HAVE lists beneath it.
+    // This screen used to stack three creation Cards, so the games you came to
+    // open sat below a screenful of forms you had already used.
+    const text = container.textContent ?? ''
+    const controls = text.indexOf('Start a game')
+    const joinControl = text.indexOf('Join with a code')
+    const list = text.indexOf('Union Crawler #430')
+
+    for (const index of [controls, joinControl, list]) expect(index).toBeGreaterThan(-1)
+    expect(controls).toBeLessThan(list)
+    expect(joinControl).toBeLessThan(list)
   })
 
   test('no games yet says so, and still offers the way in', () => {


### PR DESCRIPTION
## What

Reshapes the Games index to the Roster's rhythm: **what you can DO is one ink-ruled band across the top, and what you HAVE lists directly beneath it.**

Before, three creation Cards (start / from-a-template / join) stacked above the list, so the tables you came to open sat below a screenful of forms you had already used. A lobby's subject is the list; creating is a control on it.

```
BEFORE                              AFTER
+------------------------+          [Start a game ___] [Create] [From a template]
| Start a game  [Create] |          [Join with code ___] [Join]
+------------------------+          ------------------------------------ <- border-b-2
| Or start from a        |
| template ...           |          THE ELDRIDGE COAST      Organizer - Mediator
+------------------------+          Hamlet - 4 Pilots - 3 Mechs    [View]
| Join with a code [Join]|
+------------------------+
  ...games below the fold
```

Start-a-game and join-by-code stay one click, inline. The template list moves behind a dialog: it is a list to *read* — a name plus a paragraph each — and inlining it was exactly what wedged prose between the controls and the games.

## Two fixes on the way through

**`templates.list` types its `id` as the `TemplateId` union, not `string`.** With a plain `string` the only way to satisfy `createGame`'s `v.literal('starter-set')` validator was to hardcode the id at the call site — so the lobby rendered one template and would have created a *different* one the moment a second existed. Typed this way, adding a template widens the union and the validator becomes the type error, which is where you want to notice.

**The template query stays in the parent and is handed down.** `open` is local to the picker, so toggling it re-renders only that child. A query living there would make the screen's read sequence depend on which child last changed state — and the connected tests answer queries by call order. Found the hard way: mid-implementation the picker rendered the *games array* as its template list, showing "Union Crawler #430" as a template name.

## Tests

- `offers a template to start from` rewritten for the new contract: the template is **absent** until the control is clicked, then present.
- New `the creating controls come BEFORE the games they act on` — asserts document order, so the band-over-list arrangement is pinned rather than assumed.
- 88 games tests pass; `bun run check:all` exits 0.

## Not in this PR

The per-game dashboard at `/games/$gameId` (`GameScreen`) **already exists on main** — shipped by #656/#655 — so the second half of the original ask needed no work. This PR is only the lobby layout.

Separately: prod's Convex backend is missing `games.get`, `ownership.claim`, and the `invites.*` functions that the deployed frontend calls, which is why the live per-game page currently errors. That is a deploy-skew issue, not a code issue, and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AuHFE7oDVDau2EZjy1Nmk3