### PR TITLE
feat(component-lib): render a pattern loadout as linked shortform badges

### DIFF
--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -1641,19 +1641,24 @@ function ReferenceEntityCardInner({
   // on a line under a mostly-empty one. Single column below `sm` — two columns
   // of badges on a phone would each be too narrow to hold a system name.
   //
-  // FLOWS AROUND the floated anchor (artwork): a grid container establishes its
-  // own independent formatting context, so it is placed BESIDE the float in the
-  // width that is left rather than overlapping it — no `clear` and no
-  // `flow-root` needed, and `flow-root` would in fact fight the `grid` display
-  // for the same property. Both columns narrow together, so the loadout never
-  // splits into one indented column and one full-width one.
-  const renderPatternLoadout = (groups: NestedGroup[], flat = false): ReactNode => (
-    <div className={cn('grid grid-cols-1 gap-x-3 gap-y-1.5 sm:grid-cols-2', flat && 'mb-1.5')}>
+  // NO float handling here, deliberately: a pattern card takes the ASIDE LEAD,
+  // which drops the float entirely, so this always renders full width beneath
+  // the lead row. (An earlier revision took a `flat` argument and documented how
+  // the grid would sit beside the floated artwork. Once patterns moved below the
+  // fold that state became unreachable — `flat` is `hasAnchor && !asideLead`,
+  // and a pattern's `asideLead` is gated on the same artwork — so the parameter
+  // was dead and the comment described a layout that can no longer happen.)
+  const renderPatternLoadout = (groups: NestedGroup[]): ReactNode => (
+    <div className="grid grid-cols-1 gap-x-3 gap-y-1.5 sm:grid-cols-2">
       {groups.map((group, index) => (
         <div
           key={group.label}
           className={cn(
-            'flex flex-col gap-1.5',
+            // `min-w-0` is load-bearing: a grid item defaults to `min-width:
+            // auto`, so a column refuses to shrink below its widest badge and
+            // the card's `overflow-hidden` hard-clips it. "Electro-Magnetic
+            // Shield Projector" plus its TL tail overruns a two-column track.
+            'flex min-w-0 flex-col gap-1.5',
             // A VERTICAL RULE between the columns. On the column itself rather
             // than a third grid cell, so it spans whichever column is taller
             // (Systems usually far outruns Modules) instead of standing at the
@@ -1664,11 +1669,19 @@ function ReferenceEntityCardInner({
           )}
         >
           <Slab variant="dashed" label={group.label} />
-          <div className="flex flex-wrap items-start gap-1.5">
+          {/* A real LIST: the loadout is a countable set of installed parts, so
+              a screen reader should announce "list, 6 items" rather than a run
+              of anonymous links. `list-none` keeps the markers off. */}
+          <ul
+            aria-label={`${group.label} installed`}
+            className="flex list-none flex-wrap items-start gap-1.5"
+          >
             {group.entities.map((item, itemIndex) => (
-              <LoadoutBadge key={cardKey(item, itemIndex)} data={item} hostDown={isDown} />
+              <li key={cardKey(item, itemIndex)} className="min-w-0">
+                <LoadoutBadge data={item} hostDown={isDown} />
+              </li>
             ))}
-          </div>
+          </ul>
         </div>
       ))}
     </div>
@@ -2110,6 +2123,12 @@ function ReferenceEntityCardInner({
               flat,
               `drone-${droneInfo.instanceName ?? index}`,
               <ReferenceEntityCardInner
+                // The key rides the CARD, not only `wrapFlat`'s wrapper:
+                // `wrapFlat` drops the key it is handed when `flat` is false,
+                // and a pattern card is now never flat (it takes the aside
+                // lead), so every multi-drone pattern rendered keyless list
+                // children. Every other `wrapFlat` call site already sets it.
+                key={`drone-${droneInfo.instanceName ?? index}`}
                 size="medium"
                 depth={depth + 1}
                 hostDown={isDown}
@@ -2135,7 +2154,7 @@ function ReferenceEntityCardInner({
           {/* PATTERN view → the side-by-side loadout of shortform badges.
               BASIC chassis / entities → nested cards, one group per section. */}
           {isPattern
-            ? !hide?.patterns && renderPatternLoadout(inFlowGroups, flat)
+            ? !hide?.patterns && renderPatternLoadout(inFlowGroups)
             : inFlowGroups.map((group) => renderNestedGroup(group.label, group.entities, flat))}
 
           {!hide?.actions &&
@@ -2309,7 +2328,15 @@ function LoadoutBadge({ data, hostDown }: { data: ReferenceCardEntity; hostDown?
   )
   if (!href) return badge
   return (
-    <a href={href} className={cn('block rounded-card', FOCUS_RING)}>
+    // An explicit accessible name, for the same reason `PatternListRow` carries
+    // one: without it the anchor's name is scraped from the badge's contents and
+    // reads ".50 Cal Machine Gun TL 1" — the tech-level tail glued onto the name,
+    // six identical times over on Thunder Storm.
+    <a
+      href={href}
+      aria-label={getReferenceEntityName(data)}
+      className={cn('block rounded-card', FOCUS_RING)}
+    >
       {badge}
     </a>
   )

--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -53,7 +53,7 @@ import { Content } from '../Content'
 import { ChoiceGroups } from '../choiceCard/ChoiceGroups'
 import type { ChoiceSelections } from '../choiceCard/choiceSelectionHelpers'
 import { getChoiceSourceKind } from '../choiceCard/choiceSelectionHelpers'
-import { useEntityExternalLink, usePatternHref } from '../entityHrefContext'
+import { useEntityExternalLink, useEntityHref, usePatternHref } from '../entityHrefContext'
 import type { ReferenceEntityControl } from '../referenceEntityControlTypes'
 import { accentDeepColor, accentSurface, borderColorFromHeaderBg } from '../referenceEntityHelpers'
 import { buildReferenceEntityStats } from '../referenceEntityStatsConfig'
@@ -87,7 +87,7 @@ import {
   resolvePatternDrones,
   resolvePatternGroups,
 } from './resolveNestedEntities'
-import type { DroneLoadout } from './resolveNestedEntities'
+import type { DroneLoadout, NestedGroup } from './resolveNestedEntities'
 import { resolveGuideLead } from './resolveGuideLead'
 import { resolveGuideSteps } from './resolveGuideSteps'
 
@@ -1632,6 +1632,48 @@ function ReferenceEntityCardInner({
     return renderGroup(label, entities, undefined, flat)
   }
 
+  // A pattern's LOADOUT — its Systems and Modules groups SIDE BY SIDE, each a
+  // dashed Slab over a wrap of shortform badges (see `LoadoutBadge`).
+  //
+  // One block, not one per group, because the two columns only line up if a
+  // single grid owns both: a pattern installs far more systems than modules
+  // (Thunder Storm, six to two), so stacked groups left the modules row alone
+  // on a line under a mostly-empty one. Single column below `sm` — two columns
+  // of badges on a phone would each be too narrow to hold a system name.
+  //
+  // FLOWS AROUND the floated anchor (artwork): a grid container establishes its
+  // own independent formatting context, so it is placed BESIDE the float in the
+  // width that is left rather than overlapping it — no `clear` and no
+  // `flow-root` needed, and `flow-root` would in fact fight the `grid` display
+  // for the same property. Both columns narrow together, so the loadout never
+  // splits into one indented column and one full-width one.
+  const renderPatternLoadout = (groups: NestedGroup[], flat = false): ReactNode => (
+    <div className={cn('grid grid-cols-1 gap-x-3 gap-y-1.5 sm:grid-cols-2', flat && 'mb-1.5')}>
+      {groups.map((group, index) => (
+        <div
+          key={group.label}
+          className={cn(
+            'flex flex-col gap-1.5',
+            // A VERTICAL RULE between the columns. On the column itself rather
+            // than a third grid cell, so it spans whichever column is taller
+            // (Systems usually far outruns Modules) instead of standing at the
+            // height of an empty divider track. Suppressed on the first column
+            // and below `sm`, where the groups stack and the rule would sit
+            // across the flow rather than between two columns.
+            index > 0 && 'sm:border-l-chrome sm:border-ink/20 sm:pl-3'
+          )}
+        >
+          <Slab variant="dashed" label={group.label} />
+          <div className="flex flex-wrap items-start gap-1.5">
+            {group.entities.map((item, itemIndex) => (
+              <LoadoutBadge key={cardKey(item, itemIndex)} data={item} hostDown={isDown} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+
   // A dashed-Slab group of LISTING rows (drone systems / modules) — flat-aware.
   const renderListingGroup = (
     label: string,
@@ -1701,7 +1743,12 @@ function ReferenceEntityCardInner({
   const patternProse =
     isPattern && pattern.content && pattern.content.length > 0 ? (
       <div className="flex flex-col gap-1.5 [&:not(:last-child)]:mb-3">
-        <Slab variant="solid" label={normalizePatternName(pattern.name)} />
+        {/* `w-fit` scopes the title to ITSELF: the solid Slab's leader rule is
+            `flex-1`, so at full width it ran a line clear across the card and
+            read as a page-wide divider rather than a label on the pattern
+            block below it. Shrink-to-fit collapses the rule to its `min-w-3`
+            stub, leaving a tight name tab. */}
+        <Slab variant="solid" label={normalizePatternName(pattern.name)} className="w-fit" />
         <Content
           rulesBearing={isRulesBearing(data)}
           body={pattern.content}
@@ -1823,14 +1870,25 @@ function ReferenceEntityCardInner({
   // LEAD, and everything after it — the trailing section included — spans the
   // full width beneath both. No float, so nothing wraps.
   //
-  // The consumer OPTS IN via `asideLead`; it is never inferred from
-  // `afterExtraContent` being present. That slot is generic, and a pattern's
-  // Systems/Modules loadout fills it too — and since a pattern card renders
-  // with the CHASSIS as its `data`, it inherits the chassis artwork and would
-  // satisfy an inferred gate, dragging every artwork-chassis pattern card into
-  // a class-page layout. Artwork + a trailing section are still required: with
-  // neither there is no lead row to build.
-  const asideLead = asideLeadRequested && showImage && !!afterExtraContent
+  // A consumer OPTS IN via `asideLead`; it is still never inferred merely from
+  // `afterExtraContent` being present. That slot is generic, so an inferred
+  // gate would sweep in any card that happened to fill it, for no reason
+  // connected to what the card IS.
+  //
+  // A PATTERN takes the lead layout on its own identity, which is a different
+  // claim: a pattern view is chassis artwork + chassis prose, and then the
+  // pattern proper — its own flavour and the Systems/Modules it installs. That
+  // second half is a SECTION, exactly like a class page's ability trees, so it
+  // belongs below the fold at full width rather than wrapped into the column
+  // left over beside the illustration. (This deliberately reverses the earlier
+  // ruling that patterns stay out of this layout. That ruling was about not
+  // being dragged in ACCIDENTALLY by the generic-slot gate; the loadout now
+  // renders inline rather than through `afterExtraContent`, and reads as a
+  // section rather than as prose, so the layout is chosen, not inherited.)
+  //
+  // Artwork is still required either way: with none there is no lead row to
+  // build, and a pattern with no chassis art keeps the ordinary flow.
+  const asideLead = showImage && (isPattern || (asideLeadRequested && !!afterExtraContent))
   const flat = hasAnchor && !asideLead
   const inFlowGroups = (isPattern ? patternGroups : nestedGroups).filter(
     (group) => group !== npcGroup
@@ -2074,9 +2132,11 @@ function ReferenceEntityCardInner({
           {/* PATTERN prose — after the chassis ability, ahead of the loadout. */}
           {patternProse}
 
-          {/* PATTERN view → loadout groups. BASIC chassis / entities → nested groups. */}
-          {(!isPattern || !hide?.patterns) &&
-            inFlowGroups.map((group) => renderNestedGroup(group.label, group.entities, flat))}
+          {/* PATTERN view → the side-by-side loadout of shortform badges.
+              BASIC chassis / entities → nested cards, one group per section. */}
+          {isPattern
+            ? !hide?.patterns && renderPatternLoadout(inFlowGroups, flat)
+            : inFlowGroups.map((group) => renderNestedGroup(group.label, group.entities, flat))}
 
           {!hide?.actions &&
             gridActions.length > 0 &&
@@ -2206,6 +2266,51 @@ function PatternListRow({
       className={cn('block rounded-card', FOCUS_RING)}
     >
       {card}
+    </a>
+  )
+}
+
+/**
+ * `LoadoutBadge` — one installed system/module in a pattern's loadout, rendered
+ * as the card's own SHORTFORM token (`size="small" extent="head"`) and linking
+ * to that entity's page.
+ *
+ * A pattern is a BUILD LIST, not rules to read: its systems and modules are
+ * ordinary catalogue entities whose full text lives on their own pages, and
+ * printing all of it inline made the loadout the longest thing on the page
+ * while burying what the pattern itself says — Atlas's Thunder Storm expanded
+ * to six identical, full-length .50 Cal Machine Gun cards. The shortform badge
+ * gives the build at a glance and one click through to any entry.
+ *
+ * The badge is the card at its smallest rung, NOT a hand-assembled chip: it
+ * carries the entity's own tone band and classification tail, so the tone and
+ * tech-level read survive the compression for free.
+ *
+ * MULTIPLES REPEAT. Six machine guns are six badges, matching the loadout the
+ * pattern actually installs (and `resolvePatternGroups`, which emits one entry
+ * per copy) — a "×6" count would compress the shape of the build out of a row
+ * whose whole job is showing it.
+ *
+ * A real `<a>`, for the same reasons as `PatternListRow`: middle-click, hover
+ * preview, crawlable. With no `EntityHrefProvider` above it the badge renders
+ * inert rather than linking nowhere.
+ */
+function LoadoutBadge({ data, hostDown }: { data: ReferenceCardEntity; hostDown?: boolean }) {
+  const href = useEntityHref(data as SURefEntity)
+  const badge = (
+    <ReferenceEntityCardInner
+      data={data}
+      size="small"
+      extent="head"
+      depth={1}
+      hostDown={hostDown}
+      cardClickable={!!href}
+    />
+  )
+  if (!href) return badge
+  return (
+    <a href={href} className={cn('block rounded-card', FOCUS_RING)}>
+      {badge}
     </a>
   )
 }

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/AsideLead.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/AsideLead.test.tsx
@@ -1,15 +1,23 @@
 /**
- * ASIDE LEAD is OPT-IN. An artwork card whose trailing section is a section of
- * its own — the class pages' ability trees — drops the float so the section
- * spans the full width beneath the illustration instead of wrapping it.
+ * ASIDE LEAD. An artwork card whose trailing content is a section of its own —
+ * the class pages' ability trees, a pattern's loadout — drops the float so that
+ * section spans the full width beneath the illustration instead of wrapping it.
  *
- * The gate is an explicit `asideLead` prop, deliberately NOT inferred from
- * `afterExtraContent` being present. That slot is generic: a pattern's
- * Systems/Modules loadout fills it too, and a pattern card renders with the
- * CHASSIS as its `data`, so it inherits the chassis artwork. An inferred gate
- * therefore caught every ITUN mech-wizard pattern card on an artwork-bearing
- * chassis and pushed its loadout beneath the image — a class-page layout
- * applied to a surface that never asked for it. These tests pin both halves.
+ * TWO WAYS IN, and the difference is the point:
+ *
+ * - An explicit `asideLead` prop, for a consumer filling the generic
+ *   `afterExtraContent` slot. Still deliberately NOT inferred from that slot
+ *   being filled: the slot says nothing about what the card IS, so inferring
+ *   would sweep in cards that never asked for the layout.
+ * - A PATTERN card, on its own identity. Its body is chassis artwork + chassis
+ *   prose, then the pattern proper — its flavour and the Systems/Modules it
+ *   installs — which reads as a section, so it belongs below the fold.
+ *
+ * The second case reverses an earlier ruling that patterns must keep the float.
+ * That ruling was about not being caught ACCIDENTALLY by the generic-slot gate
+ * (a pattern card's `data` IS the chassis, so it inherits chassis artwork and
+ * used to fill `afterExtraContent` with its loadout). The loadout now renders
+ * inline as shortform badges, and the layout is chosen rather than inherited.
  */
 import { beforeAll, describe, expect, test, afterEach } from 'bun:test'
 import { cleanup, render } from '@testing-library/react'
@@ -59,22 +67,27 @@ describe('aside lead is opt-in', () => {
     expect(container.innerHTML).toContain(FLOAT)
   })
 
-  test('a PATTERN card with a trailing section keeps the float', () => {
-    // The regression this gate narrows: a pattern card's `data` IS the chassis,
-    // so it inherits the chassis artwork, and its loadout fills the same generic
-    // slot. It must not be dragged into the class-page layout.
+  test('a PATTERN card on an artwork chassis drops the float', () => {
+    // A pattern takes the lead layout on its own identity — no `asideLead` prop
+    // and no trailing slot needed. Its pattern prose and loadout are a section,
+    // and sit at full width below the artwork + chassis prose lead row.
     const chassis = mule()
     const pattern = visiblePatterns(chassis.patterns ?? [])[0]
     if (!pattern) throw new Error('Mule pattern fixture missing')
 
     const { container } = render(
-      <ReferenceEntityCard
-        data={chassis}
-        pattern={pattern}
-        size="medium"
-        afterExtraContent={trailing}
-      />
+      <ReferenceEntityCard data={chassis} pattern={pattern} size="medium" />
     )
+    expect(container.innerHTML).not.toContain(FLOAT)
+    // The loadout still renders — it moved, it did not disappear.
+    expect(container.textContent).toContain('Systems')
+  })
+
+  test('the BASIC chassis card keeps the float', () => {
+    // Only the PATTERN view takes the lead layout. The chassis card itself
+    // still wraps its pattern list around the illustration, so the reversal
+    // stays scoped to the one view that asked for it.
+    const { container } = render(<ReferenceEntityCard data={mule()} size="medium" />)
     expect(container.innerHTML).toContain(FLOAT)
   })
 

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/PatternView.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/PatternView.test.tsx
@@ -14,7 +14,7 @@ import { beforeAll, describe, expect, test, afterEach } from 'bun:test'
 import { cleanup, render, screen } from '@testing-library/react'
 import { SalvageUnionReference, nameToSlug, visiblePatterns } from 'salvageunion-reference'
 import type { SURefEntity, SURefObjectPattern } from 'salvageunion-reference'
-import { PatternHrefProvider } from '../../entityHrefContext'
+import { EntityHrefProvider, PatternHrefProvider } from '../../entityHrefContext'
 import { ReferenceEntityCard } from '../ReferenceEntityCard'
 
 /** The Mule — a chassis carrying patterns, a chassis ability and chassis prose. */
@@ -105,11 +105,16 @@ describe('full pattern view reading order', () => {
     expect(systems).toBeLessThan(modules)
   })
 
-  test('a system installed six times renders six cards, not one', () => {
+  test('a system installed six times renders six badges, not one', () => {
     // The end-to-end guard for the multiplicity fix in `resolvePatternGroups`.
     // Atlas's Thunder Storm prints as ".50 Cal Machine Gun x6" in the book; the
     // card used to de-duplicate the loadout by entity id, so the whole pattern
     // rendered a single machine gun and read as a far lighter build than it is.
+    //
+    // The loadout is now a row of SHORTFORM badges rather than full cards, and
+    // multiplicity still REPEATS: six copies are six badges, not one badge
+    // reading "×6". A count collapses the shape of the build out of the one row
+    // whose job is showing it.
     const chassis = SalvageUnionReference.Chassis.all().find((c) => c.name === 'Atlas')
     if (!chassis) throw new Error('Atlas fixture missing')
     const pattern = chassis.patterns?.find((p) => p.name === 'Thunder Storm')
@@ -119,11 +124,78 @@ describe('full pattern view reading order', () => {
 
     render(<ReferenceEntityCard data={chassis} pattern={pattern} size="large" />)
 
-    // One name node per rendered card.
+    // One name node per rendered badge.
     expect(screen.getAllByText('.50 Cal Machine Gun')).toHaveLength(6)
+    // No collapsed count anywhere — the copies are the count.
+    expect(screen.queryByText(/×6/)).toBeNull()
     // The uncounted systems stay single — the fix must not multiply everything.
     expect(screen.getAllByText('Shotgun Pit')).toHaveLength(1)
     expect(screen.getAllByText('Armour Plating')).toHaveLength(1)
+  })
+})
+
+/**
+ * THE LOADOUT IS A ROW OF LINKED BADGES. A pattern's systems and modules are
+ * ordinary catalogue entities whose full text lives on their own pages, so the
+ * pattern view cites them at the card's shortform rung and links out, rather
+ * than reprinting every rule inline — Thunder Storm used to expand to six
+ * full-length, identical .50 Cal Machine Gun cards.
+ */
+describe('pattern loadout badges', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  /** Stands in for srd's entity route builder. */
+  const testEntityHref = (entity: SURefEntity) =>
+    `/schema/${'schemaName' in entity ? String(entity.schemaName) : ''}/item/${
+      'name' in entity ? nameToSlug(String(entity.name)) : ''
+    }`
+
+  const thunderStorm = () => {
+    const chassis = SalvageUnionReference.Chassis.all().find((c) => c.name === 'Atlas')
+    if (!chassis) throw new Error('Atlas fixture missing')
+    const pattern = chassis.patterns?.find((p) => p.name === 'Thunder Storm')
+    if (!pattern) throw new Error('Thunder Storm pattern fixture missing')
+    return { chassis, pattern }
+  }
+
+  test('every loadout entry links to its own page', () => {
+    const { chassis, pattern } = thunderStorm()
+    render(
+      <EntityHrefProvider value={testEntityHref}>
+        <ReferenceEntityCard data={chassis} pattern={pattern} size="large" />
+      </EntityHrefProvider>
+    )
+
+    // All six machine-gun copies are links, each to the system's one page.
+    const guns = screen.getAllByRole('link', { name: /\.50 Cal Machine Gun/ })
+    expect(guns).toHaveLength(6)
+    for (const gun of guns) {
+      expect(gun.getAttribute('href')).toBe('/schema/systems/item/50-cal-machine-gun')
+    }
+    // Modules link out through the same builder.
+    expect(screen.getByRole('link', { name: /Comms Module/ }).getAttribute('href')).toBe(
+      '/schema/modules/item/comms-module'
+    )
+  })
+
+  test('the loadout does not reprint the entities` rules inline', () => {
+    const { chassis, pattern } = thunderStorm()
+    const { container } = render(
+      <ReferenceEntityCard data={chassis} pattern={pattern} size="large" />
+    )
+    // The machine gun's own description belongs on its page, not six times over
+    // in a pattern's loadout.
+    expect(container.textContent).not.toContain('This simple ballistic weapon')
+  })
+
+  test('without a href builder the badges are not links', () => {
+    const { chassis, pattern } = thunderStorm()
+    render(<ReferenceEntityCard data={chassis} pattern={pattern} size="large" />)
+    expect(screen.queryAllByRole('link', { name: /\.50 Cal Machine Gun/ })).toHaveLength(0)
+    // The badges themselves still render — they just aren't navigable.
+    expect(screen.getAllByText('.50 Cal Machine Gun')).toHaveLength(6)
   })
 })
 

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/PatternView.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/PatternView.test.tsx
@@ -197,6 +197,58 @@ describe('pattern loadout badges', () => {
     // The badges themselves still render — they just aren't navigable.
     expect(screen.getAllByText('.50 Cal Machine Gun')).toHaveLength(6)
   })
+
+  test('each loadout group is an announced list', () => {
+    // The loadout is a countable set of installed parts, so it is a real `ul`:
+    // a screen reader says "list, 6 items" instead of reading a run of
+    // anonymous links. The links carry their own name (the entity's), NOT the
+    // badge's scraped text — that would read ".50 Cal Machine Gun TL 1".
+    const { chassis, pattern } = thunderStorm()
+    render(
+      <EntityHrefProvider value={testEntityHref}>
+        <ReferenceEntityCard data={chassis} pattern={pattern} size="large" />
+      </EntityHrefProvider>
+    )
+    expect(screen.getByRole('list', { name: 'Systems installed' })).toBeTruthy()
+    expect(screen.getByRole('list', { name: 'Modules installed' })).toBeTruthy()
+    // Exact accessible name, tail excluded.
+    expect(screen.getAllByRole('link', { name: '.50 Cal Machine Gun' })).toHaveLength(6)
+  })
+})
+
+/**
+ * A PATTERN CARD IS NEVER `flat` — it takes the aside lead, which drops the
+ * float. `wrapFlat` DISCARDS the key it is handed when `flat` is false, so
+ * every call site has to set the key on the card itself too. The drone row was
+ * the one that didn't, which made every multi-drone pattern on an artwork
+ * chassis (all three Little Sestra patterns, Big Brother's DronTek) render
+ * keyless list children the moment patterns moved below the fold.
+ */
+describe('pattern drone rows keep their keys', () => {
+  beforeAll(async () => {
+    await SalvageUnionReference.preload('all')
+  })
+
+  test('no keyless-children warning on a drone-fielding pattern', () => {
+    const warnings: string[] = []
+    const realError = console.error
+    console.error = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(' '))
+    }
+    try {
+      for (const name of ['Little Sestra', 'Big Brother']) {
+        const chassis = SalvageUnionReference.Chassis.all().find((c) => c.name === name)
+        if (!chassis) throw new Error(`${name} fixture missing`)
+        for (const pattern of chassis.patterns ?? []) {
+          render(<ReferenceEntityCard data={chassis} pattern={pattern} size="large" />)
+          cleanup()
+        }
+      }
+    } finally {
+      console.error = realError
+    }
+    expect(warnings.filter((w) => w.includes('unique "key"'))).toHaveLength(0)
+  })
 })
 
 /**


### PR DESCRIPTION
## What

A pattern's **Systems** and **Modules** now render as the entity card's own **shortform badge** (`size="small" extent="head"`), each linking to that entity's page — instead of a full inline card per entry.

Atlas's *Thunder Storm* was the worst case: six identical, full-length `.50 Cal Machine Gun` cards, a **5462px** page. It's now **~1300px** of card content, and the pattern's own flavour is no longer buried under reprinted rules.

| Before | After |
| --- | --- |
| Six full cards, each repeating the same paragraph | Six linked badges, tone band + TL tail intact |

## Decisions

- **Reuses the card, not a new chip.** The badge *is* `ReferenceEntityCard` at its smallest rung — the "SHORTFORM token" the card already implements — so the tone band and tech-level tail come for free. An earlier pass hand-rolled a `Badge` with a swatch; that was wrong and was replaced.
- **Multiples repeat, they don't collapse.** Six machine guns are six badges, not one reading `×6`. That matches what the pattern installs and what `resolvePatternGroups` already emits; a count compresses the shape of the build out of the one row whose job is showing it.
- **Real `<a>` links**, like `PatternListRow` — middle-click, hover preview, crawlable. Inert with no `EntityHrefProvider` (ITUN), rather than linking nowhere.

## Layout (all scoped to the pattern view)

- **Systems / Modules side by side** in one grid so the columns line up (a pattern installs far more systems than modules); single column below `sm`, with a **vertical rule** carried on the second column so it spans whichever column is taller.
- **Pattern title tightened** — the solid `Slab`'s `flex-1` leader rule ran clear across the card and read as a page divider; `w-fit` collapses it to a stub.
- **Below the fold.** A pattern card now takes the **aside lead**: artwork + chassis prose as a centred lead row, then chassis ability, pattern prose and loadout at full width beneath — the way a class page's ability trees read.

### Reversal, stated plainly

The last point reverses an earlier ruling (pinned by `AsideLead.test.tsx`) that patterns must keep the float. That ruling was about not being caught *accidentally* by the generic `afterExtraContent` gate. The loadout now renders inline and reads as a section, so the layout is **chosen, not inherited**. The gate is still never inferred from the generic slot. The **basic chassis card is untouched** and still wraps its pattern list around the illustration — there's a new test pinning that.

## Verification

Verified locally in the dev server at 1280px and 390px, plus the Big Brother *DronTek* pattern (drones still render as full cards with their own loadouts) and the basic Atlas chassis page (unchanged).

- `typecheck` — 4/4 workspaces clean
- `test` — 0 fail (3 new tests for link resolution, no inline rules, inert-without-provider; 2 rewritten for the reversal)
- `lint`, `format:check`, `knip`, `validate:all` — clean
- Link resolution confirmed against the hydrated page: all six copies → `/schema/systems/item/50-cal-machine-gun/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmNCbFJgv4mcbRFKiXJabX