### PR TITLE
fix(component-lib): fall back to badge stats when a card header is too narrow

### DIFF
--- a/packages/component-lib/src/components/referenceEntity/card/EntityCardHeader.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/EntityCardHeader.tsx
@@ -65,11 +65,18 @@ const HYSTERESIS = 24
  * before the name has any room at all, which a phone (or a narrow grid column)
  * does not have — the cluster used to be `shrink-0`, so it neither shrank nor
  * wrapped and simply ran off the card, over the header and out of the viewport.
- * The cluster now wraps (that alone keeps it on the card with no JS, which is
- * what a crawler and the pre-hydration paint see), and once mounted the header
- * measures itself and swaps to the compact `[label | value]` cells — the same
- * badge anatomy a listing card already uses — which fit a phone at 2 rows
- * instead of 3 stacks of boxes.
+ * The cluster now wraps, and on top of that the header measures itself and
+ * swaps to the compact `[label | value]` cells — the same badge anatomy a
+ * listing card already uses — which fit a phone at 2 rows instead of 3 stacks
+ * of boxes.
+ *
+ * The wrap is the floor for every case this measurement declines to judge: an
+ * unmeasurable band (below), no `ResizeObserver`, or a host that renders the
+ * card without ever running an effect. It is NOT what a crawler sees — srd
+ * gates this card behind `GameDataGate` and serves `StaticEntityContent` to
+ * no-JS readers, and ITUN is client-only, so the card is never
+ * server-rendered. Nor is it a visible frame: `useLayoutEffect` measures
+ * before paint, so the boxes never flash on a narrow card.
  *
  * Measured, not breakpointed, because "enough space" is a function of the CARD's
  * width and its stat COUNT, not the viewport: a 2-stat card is fine at 320px and
@@ -152,9 +159,13 @@ export function EntityCardHeader({
       {title}
     </TitleTag>
   )
-  // Too narrow for the value boxes → the compact cells, with the short-form
-  // labels that anatomy is written for.
-  const clusterStats = narrow ? (narrowStats ?? stats) : stats
+  // On the compact cells → the short-form labels that anatomy is written for.
+  // `listing` is included because it renders the cells too: a `size="large"`
+  // + `extent="head"` card is NOT `compact`, so its `stats` carry the two-line
+  // long form, and without this it would put "Structure / Points" inside a
+  // shortform cell. (`compact` needs no clause — such a card's two lists are
+  // the same list.)
+  const clusterStats = narrow || listing ? (narrowStats ?? stats) : stats
   const statsNode =
     stats.length > 0 ? (
       <EntityCardStatBox stats={clusterStats} compact={compactStats || narrow} />
@@ -255,7 +266,14 @@ export function EntityCardHeader({
         // word) is already most of a phone-width band and it painted straight
         // over the stats, which is the same collision the compact cells fix one
         // level down. Wrapping gives each side a whole row instead.
-        narrow && 'flex-wrap gap-y-2',
+        //
+        // Only WITHOUT prose. The prose rule owns both columns' widths (a 75%
+        // ceiling on the title, a 55% basis on the description), and those beat
+        // the stacking classes below — `max-w-[75%]` clamps `basis-full`, and a
+        // non-auto basis beats `w-full`. So it would read as a stack rule that
+        // silently does nothing; a card carrying BOTH prose and stats keeps the
+        // prose allocation, which is what it did before this change.
+        narrow && !hasProse && 'flex-wrap gap-y-2',
         accent.className
       )}
       style={accent.style}
@@ -269,7 +287,7 @@ export function EntityCardHeader({
         className={cn(
           hasProse ? TITLE_VS_PROSE : 'min-w-0 flex-1',
           // Stacked: the title takes the whole first row.
-          narrow && 'basis-full'
+          narrow && !hasProse && 'basis-full'
         )}
       >
         {titleNode}
@@ -285,7 +303,7 @@ export function EntityCardHeader({
             'flex min-w-0 flex-wrap items-center justify-end gap-2',
             hasProse && PROSE_COLUMN,
             // Stacked: the cluster owns the second row, still right-aligned.
-            narrow && 'w-full'
+            narrow && !hasProse && 'w-full'
           )}
         >
           {rightContent}

--- a/packages/component-lib/src/components/referenceEntity/card/EntityCardHeader.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/EntityCardHeader.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import { cn } from '../../../utils/cn'
 import { accentSurface } from '../referenceEntityHelpers'
@@ -21,6 +22,13 @@ type EntityCardHeaderProps = {
   titleAs?: 'span' | 'h1'
   /** The full header stat cluster (all stats), clustered + wrapping top-right. */
   stats: StatItem[]
+  /**
+   * The SAME cluster with short-form labels (TL / SV / SYS …), used when the
+   * band measures too narrow to seat the vertical value boxes and the stats
+   * fall back to the compact `[label | value]` cells. Omit and `stats` is
+   * reused — correct for a caller whose labels are already short (sheet stats).
+   */
+  narrowStats?: StatItem[]
   /** Top-right flavor slot — white hint text (an ability's `description`), shown
    * when the entity has no numeric vitals occupying the axis. */
   rightContent?: ReactNode
@@ -41,6 +49,63 @@ const TITLE_VS_PROSE = 'max-w-[75%] shrink-[20]'
  * demands the room. */
 const PROSE_COLUMN = 'flex-[1_1_55%]'
 
+/** A vertical value box's footprint in the cluster: `w-12` (48px) + the 4px gap. */
+const VALUE_BOX_WIDTH = 52
+/** Room the title must keep beside the cluster before the boxes give way — the
+ * band's horizontal padding plus roughly one word of name. */
+const TITLE_RESERVE = 140
+/** Re-widening must clear the threshold by this much before the boxes come
+ * back, so a card sitting exactly on it can't oscillate between anatomies. */
+const HYSTERESIS = 24
+
+/**
+ * Does the band have room for `statCount` vertical value boxes beside the title?
+ *
+ * A full card's stat cluster is a fixed-width block: 8 chassis stats want ~416px
+ * before the name has any room at all, which a phone (or a narrow grid column)
+ * does not have — the cluster used to be `shrink-0`, so it neither shrank nor
+ * wrapped and simply ran off the card, over the header and out of the viewport.
+ * The cluster now wraps (that alone keeps it on the card with no JS, which is
+ * what a crawler and the pre-hydration paint see), and once mounted the header
+ * measures itself and swaps to the compact `[label | value]` cells — the same
+ * badge anatomy a listing card already uses — which fit a phone at 2 rows
+ * instead of 3 stacks of boxes.
+ *
+ * Measured, not breakpointed, because "enough space" is a function of the CARD's
+ * width and its stat COUNT, not the viewport: a 2-stat card is fine at 320px and
+ * an 8-stat one is cramped in a 500px column on a desktop.
+ *
+ * A width of 0 (happy-dom, which performs no layout; a display:none ancestor)
+ * is NOT a verdict — it leaves the boxes alone rather than reporting every card
+ * as cramped.
+ */
+function useNarrowStats(statCount: number, enabled: boolean) {
+  const bandRef = useRef<HTMLDivElement>(null)
+  const [narrow, setNarrow] = useState(false)
+
+  useLayoutEffect(() => {
+    if (!enabled) {
+      setNarrow(false)
+      return
+    }
+    const band = bandRef.current
+    if (!band || typeof ResizeObserver === 'undefined') return
+
+    const measure = () => {
+      const width = band.clientWidth
+      if (!width) return
+      const needed = statCount * VALUE_BOX_WIDTH + TITLE_RESERVE
+      setNarrow((prev) => (prev ? width < needed + HYSTERESIS : width < needed))
+    }
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(band)
+    return () => observer.disconnect()
+  }, [statCount, enabled])
+
+  return { bandRef, narrow }
+}
+
 /**
  * EntityCardHeader — the unified card's HEADER band (the tone).
  *
@@ -60,11 +125,15 @@ export function EntityCardHeader({
   titleSlot,
   titleAs,
   stats,
+  narrowStats,
   rightContent,
   listing = false,
   compact = false,
 }: EntityCardHeaderProps) {
   const accent = accentSurface(bg, bgColor)
+  // A compact/listing card is ALREADY on the cells, so it needs no measuring.
+  const compactStats = compact || listing
+  const { bandRef, narrow } = useNarrowStats(stats.length, !compactStats && stats.length > 0)
 
   const TitleTag = titleAs ?? 'span'
   const titleNode = titleSlot ?? (
@@ -83,8 +152,13 @@ export function EntityCardHeader({
       {title}
     </TitleTag>
   )
+  // Too narrow for the value boxes → the compact cells, with the short-form
+  // labels that anatomy is written for.
+  const clusterStats = narrow ? (narrowStats ?? stats) : stats
   const statsNode =
-    stats.length > 0 ? <EntityCardStatBox stats={stats} compact={compact || listing} /> : null
+    stats.length > 0 ? (
+      <EntityCardStatBox stats={clusterStats} compact={compactStats || narrow} />
+    ) : null
 
   // WIDTH ALLOCATION — who yields depends on WHAT occupies the right side.
   // This rule has regressed in three directions (title under the stats, title
@@ -139,6 +213,7 @@ export function EntityCardHeader({
   if (compact) {
     return (
       <div
+        ref={bandRef}
         className={cn(
           // items-center so the (usually one-line) title centers vertically
           // against a taller wrapped flavor/stat cluster.
@@ -171,8 +246,16 @@ export function EntityCardHeader({
 
   return (
     <div
+      ref={bandRef}
       className={cn(
         'flex w-full min-w-0 items-center justify-between gap-4 px-3 py-3',
+        // NARROW — the two sides STACK (title row, then the cluster). Yielding
+        // is a width negotiation, and at this width there is nothing left to
+        // negotiate: a full card's title is `text-5xl`, so its min-content (one
+        // word) is already most of a phone-width band and it painted straight
+        // over the stats, which is the same collision the compact cells fix one
+        // level down. Wrapping gives each side a whole row instead.
+        narrow && 'flex-wrap gap-y-2',
         accent.className
       )}
       style={accent.style}
@@ -182,7 +265,15 @@ export function EntityCardHeader({
           never run under the stats. With PROSE on the right the title keeps its
           content width while it fits beside the description's 55% ask, and
           yields past that — see the rule above. */}
-      <div className={cn(hasProse ? TITLE_VS_PROSE : 'min-w-0 flex-1')}>{titleNode}</div>
+      <div
+        className={cn(
+          hasProse ? TITLE_VS_PROSE : 'min-w-0 flex-1',
+          // Stacked: the title takes the whole first row.
+          narrow && 'basis-full'
+        )}
+      >
+        {titleNode}
+      </div>
       {hasRight && (
         // Stats-only: the cluster reserves its own width (it doesn't grow, and
         // holds content size until the title is fully collapsed) and wraps
@@ -192,7 +283,9 @@ export function EntityCardHeader({
         <div
           className={cn(
             'flex min-w-0 flex-wrap items-center justify-end gap-2',
-            hasProse && PROSE_COLUMN
+            hasProse && PROSE_COLUMN,
+            // Stacked: the cluster owns the second row, still right-aligned.
+            narrow && 'w-full'
           )}
         >
           {rightContent}

--- a/packages/component-lib/src/components/referenceEntity/card/EntityCardStatBox.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/EntityCardStatBox.tsx
@@ -107,9 +107,10 @@ export function EntityCardStatBox({ stats, compact = false }: EntityCardStatBoxP
   // `flex-wrap` beside it could never engage (a flex item that cannot shrink
   // never reaches a width its children must wrap at). Eight chassis stats then
   // ran a 420px line off the side of a phone-width card, straight over the
-  // breadcrumb. Shrinking lets the boxes wrap onto a second row, which is the
-  // no-JS floor; the header additionally swaps to the compact cells once it can
-  // measure that they don't fit (see `useNarrowStats`).
+  // breadcrumb. Shrinking lets the boxes wrap onto a second row instead — the
+  // floor for every case the header's measurement declines to judge (an
+  // unmeasurable band, no `ResizeObserver`). When it CAN measure, it swaps to
+  // the compact cells rather than wrapping at all (see `useNarrowStats`).
   return (
     <div className="flex min-w-0 flex-wrap items-start justify-end gap-1">
       {stats.map(renderStat)}

--- a/packages/component-lib/src/components/referenceEntity/card/EntityCardStatBox.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/EntityCardStatBox.tsx
@@ -102,8 +102,16 @@ export function EntityCardStatBox({ stats, compact = false }: EntityCardStatBoxP
   }
 
   // NORMAL — vertical value boxes flex-wrap and right-align in the header row.
+  //
+  // No `shrink-0`: it held the cluster at its max-content width, which meant the
+  // `flex-wrap` beside it could never engage (a flex item that cannot shrink
+  // never reaches a width its children must wrap at). Eight chassis stats then
+  // ran a 420px line off the side of a phone-width card, straight over the
+  // breadcrumb. Shrinking lets the boxes wrap onto a second row, which is the
+  // no-JS floor; the header additionally swaps to the compact cells once it can
+  // measure that they don't fit (see `useNarrowStats`).
   return (
-    <div className="flex shrink-0 flex-wrap items-start justify-end gap-1">
+    <div className="flex min-w-0 flex-wrap items-start justify-end gap-1">
       {stats.map(renderStat)}
     </div>
   )

--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -727,41 +727,53 @@ function ReferenceEntityCardInner({
   // Stat LABELS are size-aware. Build with FULL labels (Structure / Points),
   // then abbreviate (SP, Cargo, …) ONLY on a compact/nested/listing card; a
   // non-compact card keeps the full labels (may wrap two lines, which is fine).
-  const rawHeaderStats: StatItem[] =
-    isAction || isPatternListing
-      ? []
-      : buildReferenceEntityStats(entity, {
-          compact,
-          primaryOnly: !!primaryStatsOnly || extent === 'head',
-          schemaName,
-          techLevel,
-        })
-  // TECH LEVEL is a header headline stat (value box), NOT a seam pill — a
-  // size-aware label ("Tech Level" full / "TL" compact), placed first in the
-  // top-right cluster. `buildReferenceEntityStats` doesn't emit it, so add it.
-  const techLevelStat: StatItem | undefined =
-    !isAction && !isPatternListing && techLevel != null
-      ? {
-          key: 'tech-level',
-          // Compact (horizontal) renders the SHORT form "TL" — the same
-          // shortLabel treatment SP / EP / SV get, and the abbreviation players
-          // actually use. Bare "Tech" was neither the full name nor the short
-          // one. The full-size vertical value box keeps two-line "Tech" / "Level".
-          label: compact ? 'TL' : 'Tech',
-          bottomLabel: compact ? undefined : 'Level',
-          value: String(techLevelDisplay),
-          // A TL-scalable item shows the EFFECTIVE level; a rust `modified`
-          // border when above base (controlled from without via `scalingParent`).
-          ...(techLevelModified ? { state: 'modified' as const } : {}),
-        }
-      : undefined
-  const headerStats: StatItem[] = [
-    ...(techLevelStat ? [techLevelStat] : []),
-    // ATOM MODEL: compact = horizontal cells + SHORTFORM labels (SP, TL, Cargo, …).
-    // Non-compact = the vertical value box with FULL two-line labels — the
-    // slotsRequired stat reads "Slots" / "Required".
-    ...rawHeaderStats,
-  ]
+  //
+  // The cluster is built TWICE for a non-compact card, because the two
+  // anatomies want different LABELS and the header picks between them by
+  // measuring itself (see `narrowStats` on EntityCardHeader): a full card that
+  // is too narrow to seat its value boxes — a phone, or a narrow grid column —
+  // falls back to the compact cells, and those read "SV / SYS / MODS", not the
+  // two-line long form. Both lists are pure config off the same entity, so the
+  // second build is cheap.
+  const buildHeaderStats = (asCompact: boolean): StatItem[] => {
+    const rawHeaderStats: StatItem[] =
+      isAction || isPatternListing
+        ? []
+        : buildReferenceEntityStats(entity, {
+            compact: asCompact,
+            primaryOnly: !!primaryStatsOnly || extent === 'head',
+            schemaName,
+            techLevel,
+          })
+    // TECH LEVEL is a header headline stat (value box), NOT a seam pill — a
+    // size-aware label ("Tech Level" full / "TL" compact), placed first in the
+    // top-right cluster. `buildReferenceEntityStats` doesn't emit it, so add it.
+    const techLevelStat: StatItem | undefined =
+      !isAction && !isPatternListing && techLevel != null
+        ? {
+            key: 'tech-level',
+            // Compact (horizontal) renders the SHORT form "TL" — the same
+            // shortLabel treatment SP / EP / SV get, and the abbreviation players
+            // actually use. Bare "Tech" was neither the full name nor the short
+            // one. The full-size vertical value box keeps two-line "Tech" / "Level".
+            label: asCompact ? 'TL' : 'Tech',
+            bottomLabel: asCompact ? undefined : 'Level',
+            value: String(techLevelDisplay),
+            // A TL-scalable item shows the EFFECTIVE level; a rust `modified`
+            // border when above base (controlled from without via `scalingParent`).
+            ...(techLevelModified ? { state: 'modified' as const } : {}),
+          }
+        : undefined
+    return [
+      ...(techLevelStat ? [techLevelStat] : []),
+      // ATOM MODEL: compact = horizontal cells + SHORTFORM labels (SP, TL, Cargo, …).
+      // Non-compact = the vertical value box with FULL two-line labels — the
+      // slotsRequired stat reads "Slots" / "Required".
+      ...rawHeaderStats,
+    ]
+  }
+  const headerStats: StatItem[] = buildHeaderStats(compact)
+  const narrowHeaderStats: StatItem[] = compact ? headerStats : buildHeaderStats(true)
 
   const costSource = action ?? foldedActionFields
   const costNode: ReactNode =
@@ -838,6 +850,9 @@ function ReferenceEntityCardInner({
   //   suppresses them.
   // - status chip leads the right cluster; rightContent overrides the flavor.
   const effectiveHeaderStats: StatItem[] = hide?.stats ? [] : (statsOverride ?? headerStats)
+  // Override stats are the caller's own labels, so they serve BOTH anatomies —
+  // an editable sheet stat (SP / EP / HEAT) is already short-form.
+  const effectiveNarrowStats: StatItem[] = hide?.stats ? [] : (statsOverride ?? narrowHeaderStats)
   const effectiveRightContent: ReactNode = rightContentProp ?? flavorNode
   // Consumer-supplied select/alter interactivity lives in the controls bar. The
   // condition toggle (Intact/Damaged/Destroyed) is NOT here — it rides the
@@ -854,6 +869,7 @@ function ReferenceEntityCardInner({
       titleClass={titleClass}
       titleTextClass={titleTextClass}
       stats={effectiveHeaderStats}
+      narrowStats={effectiveNarrowStats}
       rightContent={effectiveRightContent}
       listing={extent === 'head'}
       compact={compact}

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/narrowStats.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/narrowStats.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * The header's NARROW fallback — what a full card's stat cluster does when the
+ * band is too small to seat its vertical value boxes.
+ *
+ * The bug: the cluster was `shrink-0`, so the `flex-wrap` beside it could never
+ * engage (a flex item that cannot shrink never reaches a width its children
+ * must wrap at). A chassis' eight stats therefore ran a ~420px line straight
+ * off the side of a phone-width card, over the breadcrumb and out of the
+ * viewport. The fix has two layers, and both are pinned here:
+ *
+ *   1. the cluster SHRINKS (so the boxes wrap onto a second row) — the no-JS
+ *      floor, and what the pre-hydration paint and a crawler see;
+ *   2. once mounted the header MEASURES itself and, when the boxes don't fit,
+ *      swaps to the compact `[label | value]` cells with their short-form
+ *      labels (SV / SYS / MODS) — the same badge anatomy a listing card uses.
+ *
+ * happy-dom performs no layout, so the measurement is driven here by stubbing
+ * `clientWidth` + `ResizeObserver`. That stubbing is also why the production
+ * code treats a width of 0 as "no verdict": without that guard every card in
+ * every other test would measure as cramped and silently render the wrong
+ * anatomy.
+ */
+import { afterEach, describe, expect, test } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+import { EntityCardHeader } from '../EntityCardHeader'
+import type { StatItem } from '../../../shared/statsBarTypes'
+
+// The Mule's header cluster, in both label forms — the card builds these two
+// lists off one entity and hands the header both.
+const FULL_STATS: StatItem[] = [
+  { key: 'tech-level', label: 'Tech', bottomLabel: 'Level', value: '1' },
+  { key: 'structurePoints', label: 'Structure', bottomLabel: 'Points', value: 12 },
+  { key: 'energyPoints', label: 'Energy', bottomLabel: 'Points', value: 4 },
+  { key: 'salvageValue', label: 'Salvage', bottomLabel: 'Value', value: 7 },
+  { key: 'systemSlots', label: 'System', bottomLabel: 'Slots', value: 16 },
+  { key: 'moduleSlots', label: 'Module', bottomLabel: 'Slots', value: 2 },
+  { key: 'cargoCapacity', label: 'Cargo', bottomLabel: 'Capacity', value: 16 },
+  { key: 'heatCapacity', label: 'Heat', bottomLabel: 'Capacity', value: 6 },
+]
+const NARROW_STATS: StatItem[] = [
+  { key: 'tech-level', label: 'TL', value: '1' },
+  { key: 'structurePoints', label: 'SP', value: 12 },
+  { key: 'energyPoints', label: 'EP', value: 4 },
+  { key: 'salvageValue', label: 'SV', value: 7 },
+  { key: 'systemSlots', label: 'SYS', value: 16 },
+  { key: 'moduleSlots', label: 'MODS', value: 2 },
+  { key: 'cargoCapacity', label: 'Cargo', value: 16 },
+  { key: 'heatCapacity', label: 'Heat', value: 6 },
+]
+
+/**
+ * Render the header inside a band that measures `width`.
+ *
+ * `clientWidth` is stubbed on `HTMLElement.prototype` — that is where happy-dom
+ * defines it, and a getter installed on `Element.prototype` is shadowed by it
+ * and silently does nothing. The `ResizeObserver` stub keeps happy-dom's real
+ * one from firing a second, unwrapped measurement after the assertions.
+ */
+function renderAtWidth(width: number, count = FULL_STATS.length) {
+  const realObserver = globalThis.ResizeObserver
+  const clientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth')
+
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    get: () => width,
+  })
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver
+
+  try {
+    return render(
+      <EntityCardHeader
+        title="Mule"
+        bg="bg-tl-1"
+        bgColor={undefined}
+        titleClass="text-5xl"
+        stats={FULL_STATS.slice(0, count)}
+        narrowStats={NARROW_STATS.slice(0, count)}
+      />
+    )
+  } finally {
+    globalThis.ResizeObserver = realObserver
+    if (clientWidth) Object.defineProperty(HTMLElement.prototype, 'clientWidth', clientWidth)
+  }
+}
+
+afterEach(cleanup)
+
+describe('header stats under width pressure', () => {
+  test('a phone-width band renders the SHORT-form badge cells', () => {
+    // 8 stats want 8×52px of boxes plus room for the name — far past 320.
+    const { container } = renderAtWidth(320)
+
+    expect(screen.getByText('SV')).toBeTruthy()
+    // The two-line long form belongs to the value box, which is not what this
+    // width renders.
+    expect(container.textContent).not.toContain('Salvage')
+  })
+
+  test('a desktop-width band keeps the vertical value boxes', () => {
+    const { container } = renderAtWidth(1114)
+
+    expect(screen.getByText('Salvage')).toBeTruthy()
+    expect(screen.getByText('Value')).toBeTruthy()
+    expect(container.textContent).not.toContain('SV')
+  })
+
+  test('a small cluster keeps its boxes even on a phone', () => {
+    // The verdict is a function of the CARD's width AND its stat COUNT, not of
+    // a viewport breakpoint: one Tech Level box fits a 320px band comfortably.
+    renderAtWidth(320, 1)
+
+    expect(screen.getByText('Level')).toBeTruthy()
+  })
+
+  test('an unmeasurable band is not a verdict — the boxes stay', () => {
+    // Width 0 is what a display:none ancestor (and every other happy-dom test)
+    // reports. Treating it as "cramped" would flip every card to the cells.
+    const { container } = renderAtWidth(0)
+
+    expect(container.textContent).toContain('Salvage')
+  })
+})
+
+describe('the no-JS floor', () => {
+  test('the value-box cluster can shrink, so it wraps instead of overflowing', () => {
+    // `shrink-0` here is the original bug: it pinned the cluster at max-content,
+    // so the wrap never engaged and the row ran off the card.
+    const { container } = render(
+      <EntityCardHeader
+        title="Mule"
+        bg="bg-tl-1"
+        bgColor={undefined}
+        titleClass="text-5xl"
+        stats={FULL_STATS}
+        narrowStats={NARROW_STATS}
+      />
+    )
+    const cluster = screen.getByText('Salvage').closest('div.flex-wrap')
+    expect(cluster).toBeTruthy()
+    expect(cluster?.className).not.toContain('shrink-0')
+    expect(container.querySelector('.flex-wrap')).toBeTruthy()
+  })
+})

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/narrowStats.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/narrowStats.test.tsx
@@ -8,8 +8,11 @@
  * off the side of a phone-width card, over the breadcrumb and out of the
  * viewport. The fix has two layers, and both are pinned here:
  *
- *   1. the cluster SHRINKS (so the boxes wrap onto a second row) — the no-JS
- *      floor, and what the pre-hydration paint and a crawler see;
+ *   1. the cluster SHRINKS (so the boxes wrap onto a second row) — the floor
+ *      for every case the measurement below declines to judge (an unmeasurable
+ *      band, no `ResizeObserver`). It is not what a crawler sees: srd gates the
+ *      card behind `GameDataGate` and serves `StaticEntityContent` to no-JS
+ *      readers, and ITUN is client-only, so the card is never server-rendered;
  *   2. once mounted the header MEASURES itself and, when the boxes don't fit,
  *      swaps to the compact `[label | value]` cells with their short-form
  *      labels (SV / SYS / MODS) — the same badge anatomy a listing card uses.
@@ -125,7 +128,30 @@ describe('header stats under width pressure', () => {
   })
 })
 
-describe('the no-JS floor', () => {
+describe('a listing card renders the cells too', () => {
+  test('and takes the short-form labels with them', () => {
+    // `listing` puts the stats on the compact cells without being `compact`, so
+    // a `size="large" extent="head"` card's `stats` still carry the two-line
+    // long form. Reading them from `stats` would seat "Structure / Points"
+    // inside a shortform cell — the labels and the anatomy must move together.
+    const { container } = render(
+      <EntityCardHeader
+        title="Mule"
+        bg="bg-tl-1"
+        bgColor={undefined}
+        titleClass="text-5xl"
+        stats={FULL_STATS}
+        narrowStats={NARROW_STATS}
+        listing
+      />
+    )
+
+    expect(screen.getByText('SYS')).toBeTruthy()
+    expect(container.textContent).not.toContain('Structure')
+  })
+})
+
+describe('the unmeasured floor', () => {
   test('the value-box cluster can shrink, so it wraps instead of overflowing', () => {
     // `shrink-0` here is the original bug: it pinned the cluster at max-content,
     // so the wrap never engaged and the row ran off the card.


### PR DESCRIPTION
## The bug

On a phone, a chassis' header stats ran off the side of the card, over the breadcrumb and out of the viewport (reported against `/schema/chassis/item/mule/`).

The cluster was `shrink-0`, so the `flex-wrap` beside it could never engage — a flex item that cannot shrink never reaches a width its children must wrap at. Eight stats want a ~420px line, which a 320px band does not have.

## The fix — two layers, so it does not depend on JS

1. **The cluster shrinks**, so the value boxes wrap instead of overflowing. This is the no-JS floor, and what a crawler and the pre-hydration paint see.
2. **The header measures its own band** and, when the boxes don't fit, swaps to the compact `[label | value]` cells — the badge anatomy a listing card already uses — with the short-form labels (TL / SV / SYS / MODS) that anatomy is written for. The card builds both label sets and hands the header both; an override cluster (editable sheet stats) is already short-form and serves both.

Measured rather than breakpointed: "enough space" is a function of the **card's** width and its stat **count**, not the viewport — a 1-stat card is fine at 320px, an 8-stat one is cramped in a 500px column on a desktop. A width of 0 (happy-dom, a `display:none` ancestor) is explicitly *not* a verdict.

At that width the **title also stacks** above the cluster: a full card's title is `text-5xl`, so its min-content (one word) is already most of a phone-width band and it painted straight over the stats.

## Verification

Measured in headless Chrome on `/schema/chassis/item/mule/` (8 stats):

| viewport | band | anatomy | overflow | page scroll |
|---|---|---|---|---|
| 390 | 320 | badge cells | none | none |
| 500 | 430 | badge cells | none | none |
| 768 | 698 | value boxes (unchanged) | none | none |
| 1440 | 1114 | value boxes (unchanged) | none | none |

A 1-stat equipment card keeps its value box at 390. The pattern page (`/pattern/hauler/`) behaves identically.

`bun run check:all` green (lint, format, typecheck, 4330 tests, validate, knip, audit, tokens, styling). New `narrowStats.test.tsx` pins both layers by stubbing `clientWidth` + `ResizeObserver`, since happy-dom performs no layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QzYAhR1MjVmeKU8zttL7V