### PR TITLE
fix(discord-bot): fail fast on a silent login hang, and unwedge the bot build

### DIFF
--- a/apps/discord-bot/src/__tests__/startupWatchdog.test.ts
+++ b/apps/discord-bot/src/__tests__/startupWatchdog.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'bun:test'
+import { armReadyWatchdog, READY_TIMEOUT_MS } from '../startupWatchdog.js'
+
+/**
+ * startupWatchdog — the guard against the bot being up and deaf.
+ *
+ * The failure it exists for is a silent one (see the module docs), so these
+ * tests care about exactly two things: that an undisarmed deadline actually
+ * fires, and that a disarmed one stays quiet forever. A watchdog that cried
+ * wolf would crash-loop a perfectly healthy bot, which is the worse of the two
+ * regressions — hence the disarm cases.
+ *
+ * Timers run for real at a few milliseconds rather than through a fake clock:
+ * the unit under test is a `setTimeout` and there is nothing left to assert
+ * once the clock is mocked away.
+ */
+
+const tick = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+describe('armReadyWatchdog', () => {
+  test('calls onExpire with an Error once the deadline passes', async () => {
+    const expirations: Error[] = []
+    armReadyWatchdog({ timeoutMs: 5, onExpire: (error) => expirations.push(error) })
+
+    await tick(30)
+
+    expect(expirations).toHaveLength(1)
+    expect(expirations[0]).toBeInstanceOf(Error)
+  })
+
+  test('names the elapsed budget in the error, so a log line explains itself', async () => {
+    const expirations: Error[] = []
+    armReadyWatchdog({ timeoutMs: 5, onExpire: (error) => expirations.push(error) })
+
+    await tick(30)
+
+    expect(expirations[0]?.message).toBe('Discord login did not reach ready within 5ms')
+  })
+
+  test('stays silent when disarmed before the deadline', async () => {
+    const expirations: Error[] = []
+    const disarm = armReadyWatchdog({ timeoutMs: 20, onExpire: (error) => expirations.push(error) })
+
+    disarm()
+    await tick(50)
+
+    expect(expirations).toEqual([])
+  })
+
+  test('disarming twice is safe — a reconnect re-firing ready must not throw', async () => {
+    const expirations: Error[] = []
+    const disarm = armReadyWatchdog({ timeoutMs: 20, onExpire: (error) => expirations.push(error) })
+
+    disarm()
+    expect(() => disarm()).not.toThrow()
+    await tick(50)
+
+    expect(expirations).toEqual([])
+  })
+
+  test('defaults to a budget far above a healthy 1.34s boot', () => {
+    expect(READY_TIMEOUT_MS).toBe(60_000)
+  })
+})

--- a/apps/discord-bot/src/index.ts
+++ b/apps/discord-bot/src/index.ts
@@ -5,6 +5,7 @@ import { commands } from './commands/index.js'
 import { handleReady } from './events/ready.js'
 import { handleInteractionCreate } from './events/interactionCreate.js'
 import { initObservability, captureException, flushObservability } from './observability.js'
+import { armReadyWatchdog } from './startupWatchdog.js'
 
 // Initialize error tracking as early as possible (no-op without SENTRY_DSN).
 initObservability()
@@ -17,8 +18,26 @@ const client = new Client({
 // Attach commands collection to client
 client.commands = commands
 
+// Startup deadline. Armed before preload so it covers everything between here
+// and a connected gateway, because a hang anywhere in that stretch looks
+// identical from the outside: a live process answering nothing. See
+// startupWatchdog.ts for the twelve-hour outage that motivated it.
+const disarmReadyWatchdog = armReadyWatchdog({
+  onExpire: (error) => {
+    console.error(error.message)
+    captureException(error, { source: 'startup-watchdog' })
+    // Same flush-then-exit as the uncaughtException path below: exiting non-zero
+    // is the whole point (Render restarts the worker), and a synchronous exit
+    // would drop the one event that explains why.
+    void flushObservability().finally(() => process.exit(1))
+  },
+})
+
 // Register event handlers
-client.once(Events.ClientReady, handleReady)
+client.once(Events.ClientReady, (readyClient) => {
+  disarmReadyWatchdog()
+  handleReady(readyClient)
+})
 client.on(Events.InteractionCreate, (interaction) => {
   void handleInteractionCreate(interaction)
 })

--- a/apps/discord-bot/src/startupWatchdog.ts
+++ b/apps/discord-bot/src/startupWatchdog.ts
@@ -1,0 +1,67 @@
+/**
+ * startupWatchdog — the deadline on "started" becoming "connected".
+ *
+ * A Discord login that never reaches ready is **silent**. `client.login()`
+ * neither resolves nor rejects, no `error` event fires, and a Render worker has
+ * no HTTP port to health-check, so nothing anywhere notices. The process stays
+ * alive, idle and holding the gateway socket, while every slash command in
+ * every guild answers "The application did not respond" — Discord's wording for
+ * an interaction nobody acknowledged.
+ *
+ * That is not hypothetical: on 2026-08-03 the worker logged
+ * "Starting Salvage Union Discord Bot..." at 11:28 UTC and never logged
+ * "Logged in as". It sat that way for over twelve hours, ~90MB resident and
+ * ~0% CPU, until a human noticed the bot was answering nothing. Every signal
+ * that should have caught it was shaped wrong: Render saw a live process,
+ * Sentry saw no exception, and the `discord-bot ready` liveness event that
+ * `handleReady` emits is only ever a *presence* — nothing alerts on its
+ * absence.
+ *
+ * So the process asserts its own liveness instead: reach ready inside the
+ * budget or exit non-zero and let Render restart the worker. A crash loop is a
+ * far better failure than a bot that is up and deaf, because a crash loop is
+ * visible.
+ */
+
+/**
+ * How long startup gets to reach ready before the worker gives up.
+ *
+ * Sized off the real thing rather than a guess: the last healthy boot went from
+ * "Starting" to "Logged in as" in 1.34 seconds, preload included. A minute is
+ * ~45x that, so this can only fire on a genuine hang, never on a slow morning
+ * for the gateway or a cold Render instance.
+ */
+export const READY_TIMEOUT_MS = 60_000
+
+export type ReadyWatchdogOptions = {
+  /** Defaults to {@link READY_TIMEOUT_MS}. */
+  timeoutMs?: number
+  /** Invoked once if the deadline passes undisarmed. */
+  onExpire: (error: Error) => void
+}
+
+/**
+ * Arms the startup deadline. Returns a **disarm** function to call from the
+ * ready handler; calling it more than once is safe, so a reconnect that
+ * re-fires ready can never resurrect an already-cleared timer.
+ */
+export function armReadyWatchdog({
+  timeoutMs = READY_TIMEOUT_MS,
+  onExpire,
+}: ReadyWatchdogOptions): () => void {
+  const timer = setTimeout(() => {
+    onExpire(new Error(`Discord login did not reach ready within ${timeoutMs}ms`))
+  }, timeoutMs)
+
+  // The watchdog must never be the reason the process is still running. If the
+  // event loop empties out the worker should exit (and be restarted) on the
+  // spot rather than idling here waiting to announce a hang it no longer has.
+  timer.unref?.()
+
+  let disarmed = false
+  return () => {
+    if (disarmed) return
+    disarmed = true
+    clearTimeout(timer)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "build": "bun run build:package && bun run build:web && bun run build:itun && bun run build:bot",
     "build:web": "bun --filter srd build",
     "build:itun": "bun --filter itun build",
-    "build:bot": "bun --filter discord-bot build",
+    "build:bot": "bun run --cwd apps/discord-bot build",
     "build:package": "bun --filter salvageunion-reference build",
     "build:package:watch": "bun --filter salvageunion-reference watch",
     "deploy-commands": "bun --filter discord-bot deploy-commands",

--- a/render.yaml
+++ b/render.yaml
@@ -7,6 +7,14 @@ services:
     # Command registration is intentionally NOT part of the deploy build.
     # Global slash commands are registered manually (an explicit step) only
     # when the command shape changes — see apps/discord-bot/README.md.
+    #
+    # `build:bot` runs `bun run --cwd apps/discord-bot build`, NOT
+    # `bun --filter discord-bot build`. The filter runner wedges here: the
+    # bundle itself takes ~20ms, but the build has twice hung on that exact
+    # line with no further output — 2026-07-28 (~2h, until Render SIGTERMed
+    # it, which is what drained the workspace's build-pipeline minutes) and
+    # again 2026-08-04. `--cwd` runs the same script with no filter runner in
+    # front of it and exits cleanly. Keep it that way.
     buildCommand: 'bun install --ignore-scripts && bun run build:bot'
     startCommand: 'node apps/discord-bot/dist/index.js'
     # Without this, every commit to main rebuilds and redeploys the bot —


### PR DESCRIPTION
Two production failures, both found while investigating "the discord bot is throwing errors". They compound: the first took the bot down, the second blocked the recovery.

---

## 1. The bot was up and deaf for 12.5 hours

On **2026-08-03** the `suref-discord-bot` worker logged:

```
11:28:41  [observability] Sentry tracking enabled
11:28:41  Starting Salvage Union Discord Bot...
```

…and then nothing. No `Logged in as`. The process sat alive at ~90MB and ~0% CPU, holding a gateway connection that never completed, while every slash command answered **"The application did not respond"** — Discord's wording for an interaction nobody acknowledged.

### Why nothing caught it

- **Render** saw a live process — a background worker has no HTTP port to health-check.
- **Sentry** saw no exception — `client.login()` neither resolved nor rejected, and no `error` event fired.
- The **`discord-bot ready`** event `handleReady` emits is only ever a *presence*. Nothing alerts on its absence, so the gap read as silence rather than as a signal.

The startup code was byte-identical to the last healthy boot (2026-07-28, `fe0a5cee`), which went `Starting` → `Logged in as` in **1.34s**. discord.js was unchanged at 14.27.0 (also the latest published), and `bun install --frozen-lockfile` is clean — a stuck connect, not a code regression. It will happen again.

### Fix

The process asserts its own liveness: reach ready within **60s**, or exit non-zero and let Render restart the worker.

- `src/startupWatchdog.ts` — `armReadyWatchdog()` returns a disarm function; idempotent, and `unref`'d so the watchdog is never itself the reason the process is still running.
- `src/index.ts` — armed **before** preload (a hang anywhere before a connected gateway looks identical from outside), disarmed by `ClientReady`. On expiry: log, report to Sentry, flush, `exit(1)`.

60s is ~45x a healthy boot, so it can only fire on a genuine hang. **A crash loop is a better failure than a bot that is up and deaf, because a crash loop is visible.**

---

## 2. `bun --filter` wedges the bot build on Render

Recovering needed a redeploy — and the redeploy hung for **17 minutes** on this line:

```
$ bun --filter discord-bot build
```

The bundle itself takes ~20ms. This has now happened twice, both times with no output after that line:

- **2026-07-28** — ran ~2h until Render SIGTERMed it. That is what drained the workspace's build-pipeline minutes, which cancelled the next 7 deploys and left the bot on a stale build for six days.
- **2026-08-04** — wedged the recovery deploy. Superseding it produced the identical signature, which is what confirmed the diagnosis:

```
error: script "build:bot" was terminated by signal SIGTERM (Polite quit request)
```

### Fix

`build:bot` now runs `bun run --cwd apps/discord-bot build` — the identical script with no filter runner in front of it. Bundles in 21ms and exits cleanly. `render.yaml` carries the reasoning so nobody "tidies" it back.

---

## Verification

- `bun --filter discord-bot test` — **182 pass, 0 fail** (5 new: fires undisarmed, silent when disarmed, disarm idempotent, error names the budget, default budget).
- `bun --filter discord-bot typecheck` clean; `biome lint` on changed files clean.
- Built the real bundle and ran `node dist/index.js`: an invalid token still fails fast and exits, so the watchdog does not interfere with the existing error path.
- Confirmed the new `build:bot` produces the same two entry points.

## Not in this PR

- **Production was restored by redeploying** (`dep-d9oito1t0dsc73b5ukp0`), not by this branch. This PR stops both failures recurring.
- The absent-`ready`-event alert is still unarmed — a Sentry-side config change, not code.
- The new `/su game`, `/crew` and `/account` commands from #653 still need a manual `deploy-commands:global`, unrelated to this outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019U1DfcdEKS1SqJ5T4sHAWH