### PR TITLE
feat(itun): read a crewmate's sheet, and stamp ownership on every crew row

### DIFF
--- a/apps/itun/src/components/games/GameEntitySheet.tsx
+++ b/apps/itun/src/components/games/GameEntitySheet.tsx
@@ -1,0 +1,159 @@
+/**
+ * GameEntitySheet — a crewmate's build, read-only (ADR-030 §5).
+ *
+ * ## Why this surface exists
+ *
+ * A Game's roster used to be a list of rows most of which went nowhere: only
+ * what you owned offered a sheet, so a player looking at their crew could see
+ * four names and open one of them. That is the wrong answer to "who am I
+ * playing with" — the whole point of a shared table is that the table is
+ * shared. What was actually unsafe was not *reading* a crewmate's pilot but
+ * being handed ITUN's live sheet for it, which is an editing surface whose
+ * writes the server refuses (`assertMayWrite`).
+ *
+ * So the sheet opens, and it is frozen. `readOnly` suppresses every edit
+ * affordance, and the store behind it is the one from `frozenSheet.ts`, which
+ * holds this single entity and throws on any write. There is no path from here
+ * to a mutation, which is what makes the surface honest rather than merely
+ * discouraging.
+ *
+ * ## Nothing is cached locally
+ *
+ * The row is read straight from `entities.listForGame` and parsed. It is
+ * deliberately NOT adopted into IndexedDB: a crewmate's pilot in the viewer's
+ * own stores would show up among their builds, under a container they do not
+ * control, and would go stale the moment its owner touched it. Reading is not
+ * owning.
+ *
+ * The trade is a round trip — this re-queries the game listing rather than
+ * reading a local copy — which is the correct cost for a surface you visit to
+ * look something up.
+ */
+
+import { useMemo } from 'react'
+import { useQuery } from 'convex/react'
+import { Card, Text } from 'component-lib'
+
+import { api } from '../../../convex/_generated/api'
+import type { Id } from '../../../convex/_generated/dataModel'
+import { useConnection } from '../../lib/connection/connectionContext'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+import type { RosterKind } from '../../lib/games/gameRoster'
+import { makeFrozenStore, parseFrozenEntity } from '../sheet/frozenSheet'
+import { Sheet } from '../sheet/Sheet'
+import { AppLink } from '../shared/AppLink'
+import { PAGE, TITLE } from './gameChrome'
+
+type GameEntitySheetProps = {
+  gameId: string
+  kind: RosterKind
+  /** The Convex row id — what the crew roster addresses every row by. */
+  entityId: string
+}
+
+/** A framed message with the way back to the crew, for every state but success. */
+export function GameSheetNotice({
+  gameId,
+  children,
+}: {
+  gameId: string
+  children: React.ReactNode
+}) {
+  return (
+    <main className={PAGE}>
+      <Text as="h1" className={TITLE}>
+        Crew sheet
+      </Text>
+      <Card>
+        <div className="flex flex-col items-start gap-3 p-4">
+          <Text>{children}</Text>
+          <AppLink href={`/games/${gameId}`} className="font-cond text-sm font-bold uppercase">
+            ← Back to the crew
+          </AppLink>
+        </div>
+      </Card>
+    </main>
+  )
+}
+
+function GameEntityBody({ gameId, kind, entityId }: GameEntitySheetProps) {
+  // The same query the roster uses, so this surface is governed by exactly the
+  // membership check that decides whether the row was listable in the first
+  // place — a non-member gets `null` here for the same reason they get an empty
+  // roster, with no second permission rule to drift from the first.
+  const listing = useQuery(api.entities.listForGame, { gameId: gameId as Id<'games'> })
+
+  const row = useMemo(() => {
+    if (listing === undefined) return undefined
+    const rows =
+      kind === 'pilot' ? listing.pilots : kind === 'mech' ? listing.mechs : listing.crawlers
+    return rows.find((r) => r._id === entityId) ?? null
+  }, [listing, kind, entityId])
+
+  const parsed = useMemo(
+    () => (row === undefined || row === null ? null : parseFrozenEntity(kind, row.body)),
+    [row, kind]
+  )
+  const store = useMemo(() => (parsed?.ok ? makeFrozenStore(parsed) : null), [parsed])
+
+  if (listing === undefined) {
+    return <GameSheetNotice gameId={gameId}>Loading this sheet…</GameSheetNotice>
+  }
+
+  if (row === null) {
+    // Covers "not in this game", "no such entity", and "it was scrapped"
+    // identically — a non-member must not be able to tell them apart.
+    return (
+      <GameSheetNotice gameId={gameId}>
+        That {kind} is not in this game. It may have been removed, or you may no longer be a member.
+      </GameSheetNotice>
+    )
+  }
+
+  if (parsed === null || !parsed.ok || store === null) {
+    return (
+      <GameSheetNotice gameId={gameId}>
+        This {kind}&rsquo;s data doesn&rsquo;t match anything this app knows how to show. It may
+        have been built in a newer version.
+      </GameSheetNotice>
+    )
+  }
+
+  return (
+    <div>
+      {/* The read-only banner, in the same shape the snapshot surface uses.
+          Saying WHY it is read-only matters more than saying that it is: a
+          player who cannot edit a crewmate's pilot should understand that as
+          the rule of the table, not as something broken. */}
+      <div
+        role="note"
+        aria-label="Read-only crew sheet"
+        className="border-b-2 border-ink bg-caution px-4 py-2 font-body text-sm font-semibold text-ink sm:px-[30px]"
+      >
+        You are reading a crewmate&rsquo;s sheet. Only whoever holds it can make changes.
+      </div>
+
+      <Sheet
+        kind={parsed.kind}
+        id={parsed.entity.id}
+        store={store}
+        back={{ href: `/games/${gameId}`, label: 'the crew' }}
+        readOnly
+      />
+    </div>
+  )
+}
+
+export function GameEntitySheet(props: GameEntitySheetProps) {
+  const { mode } = useConnection()
+
+  if (!isConvexConfigured || mode !== 'connected') {
+    return (
+      <GameSheetNotice gameId={props.gameId}>
+        A Game is shared state, so reading a crewmate&rsquo;s sheet needs a connected account.
+      </GameSheetNotice>
+    )
+  }
+
+  return <GameEntityBody {...props} />
+}

--- a/apps/itun/src/components/games/GameRoster.tsx
+++ b/apps/itun/src/components/games/GameRoster.tsx
@@ -492,7 +492,7 @@ export function GameRoster({ gameId, gameName }: GameRosterProps) {
                               {row.can.openSheet && (
                                 <Button
                                   variant="default"
-                                  size="compact"
+                                  size="mini"
                                   disabled={busy !== null}
                                   onClick={() =>
                                     void run(`open-${row.serverId}`, () => openSheet(row))
@@ -504,7 +504,7 @@ export function GameRoster({ gameId, gameName }: GameRosterProps) {
                               {row.kind === 'mech' && row.can.openSheet && (
                                 <Button
                                   variant="primary"
-                                  size="compact"
+                                  size="mini"
                                   disabled={busy !== null}
                                   onClick={() =>
                                     void run(`dash-${row.serverId}`, () => launchDashboard(row))
@@ -521,7 +521,7 @@ export function GameRoster({ gameId, gameName }: GameRosterProps) {
                               {row.can.release && (
                                 <Button
                                   variant="ghost"
-                                  size="compact"
+                                  size="mini"
                                   disabled={busy !== null}
                                   onClick={() =>
                                     void run(`offer-${row.serverId}`, async () => {
@@ -546,7 +546,7 @@ export function GameRoster({ gameId, gameName }: GameRosterProps) {
                               {row.can.scrap && (
                                 <Button
                                   variant="ghost"
-                                  size="compact"
+                                  size="mini"
                                   disabled={busy !== null}
                                   onClick={() =>
                                     void run(`scrap-${row.serverId}`, async () => {

--- a/apps/itun/src/components/games/GameRoster.tsx
+++ b/apps/itun/src/components/games/GameRoster.tsx
@@ -51,6 +51,7 @@ import {
   ModalShell,
   Text,
 } from 'component-lib'
+import type { EntityRowDetail } from 'component-lib'
 
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
@@ -161,24 +162,24 @@ function statsFor(row: RosterRow): Array<{ label: string; value: string | number
 }
 
 /**
- * The row's caption parts — callsign, class, chassis — each rendered by
- * `EntityRow` as its own quiet chip.
+ * The row's body details — `CALLSIGN | Ghost`, `CLASS | Salvager` — each
+ * rendered by `EntityRow` as a horizontal `Stat` with its label plate tinted by
+ * ontology.
  *
- * Ownership is NOT among them any more: it is the row's seal, stamped in the
- * top-right corner (see `OwnerSeal`). It used to be a toned chip down here
- * beside the callsign, which put the single most consequential fact about a
- * row — whose character is this — in the same visual register as their
- * nickname.
+ * Ownership is NOT among them: it is the row's seal, stamped on the top border
+ * (see `OwnerSeal`). It used to be a toned chip down here beside the callsign,
+ * which put the single most consequential fact about a row — whose character is
+ * this — in the same visual register as their nickname.
  */
-function captionFor(row: RosterRow): string[] {
-  const parts: string[] = []
+function captionFor(row: RosterRow): EntityRowDetail[] {
+  const parts: EntityRowDetail[] = []
   if (row.kind === 'pilot') {
     const callsign = row.body.callsign
     if (typeof callsign === 'string' && callsign.length > 0 && callsign !== row.name) {
-      parts.push(`"${callsign}"`)
+      parts.push({ label: 'Callsign', value: callsign })
     }
     const className = resolveClassName(String(row.body.classRef ?? ''))
-    if (className) parts.push(className)
+    if (className) parts.push({ label: 'Class', value: className, tone: 'pilot' })
   }
   // A mech's chassis is NOT here: it is a `CHASSIS | Iron Mongrel` stat in the
   // header band. It is a named property of the mech, which is what a Stat is

--- a/apps/itun/src/components/games/GameRoster.tsx
+++ b/apps/itun/src/components/games/GameRoster.tsx
@@ -135,6 +135,17 @@ function statsFor(row: RosterRow): Array<{ label: string; value: string | number
     if (num('currentAP') !== undefined) out.push({ label: 'AP', value: num('currentAP') as number })
   }
   if (row.kind === 'mech') {
+    // The chassis leads: it is what the mech IS, where SP and Heat are how it
+    // is doing. Rendered as `CHASSIS | Iron Mongrel` rather than a bare chip,
+    // so the name arrives labelled.
+    const chassis = row.body.chassisRef
+    if (typeof chassis === 'string' && chassis.length > 0) {
+      const resolved = chassisOf(chassis)
+      out.push({ label: 'Chassis', value: resolved.name })
+      // TL is its own stat rather than a suffix on the chassis value: two facts
+      // crammed into one value box is the thing `Stat` exists to stop.
+      if (resolved.techLevel != null) out.push({ label: 'TL', value: resolved.techLevel })
+    }
     if (num('currentSP') !== undefined) out.push({ label: 'SP', value: num('currentSP') as number })
     if (num('currentHeat') !== undefined) {
       out.push({ label: 'Heat', value: num('currentHeat') as number })
@@ -169,27 +180,28 @@ function captionFor(row: RosterRow): string[] {
     const className = resolveClassName(String(row.body.classRef ?? ''))
     if (className) parts.push(className)
   }
-  if (row.kind === 'mech') {
-    const chassis = row.body.chassisRef
-    // Resolved, not printed raw. The home Roster reads "Iron Mongrel · TL 1"
-    // where this said "iron-mongrel" — the stored value is a slug, and showing
-    // the slug is the surface admitting it never looked the chassis up.
-    if (typeof chassis === 'string' && chassis.length > 0) parts.push(chassisLabel(chassis))
-  }
+  // A mech's chassis is NOT here: it is a `CHASSIS | Iron Mongrel` stat in the
+  // header band. It is a named property of the mech, which is what a Stat is
+  // for — a bare chip saying "Iron Mongrel" left the reader to infer what the
+  // word was doing there.
   return parts
 }
 
-/** A mech's chassis as "Name · TL n", falling back to the raw ref. */
-function chassisLabel(chassisRef: string): string {
+/**
+ * A mech's chassis, resolved. The stored value is a SLUG, and printing the slug
+ * is the surface admitting it never looked the chassis up — the home Roster has
+ * always resolved it, and this said "iron-mongrel" where that said "Iron
+ * Mongrel".
+ */
+function chassisOf(chassisRef: string): { name: string; techLevel?: number } {
   // `resolveChassisRef` throws when the Chassis model is not preloaded (test
   // and snapshot contexts), so this falls back rather than taking the screen
   // down with it — the same guard the Roster's `mechChassisMeta` uses.
   try {
     const chassis = resolveChassisRef(chassisRef) as { name: string; techLevel?: number } | null
-    if (!chassis) return chassisRef
-    return chassis.techLevel != null ? `${chassis.name} · TL ${chassis.techLevel}` : chassis.name
+    return chassis ?? { name: chassisRef }
   } catch {
-    return chassisRef
+    return { name: chassisRef }
   }
 }
 
@@ -231,16 +243,20 @@ function OwnerSeal({
   disabled: boolean
   onClaim: () => void
 }) {
+  // The default stamp plate: ink ground, paper text, at the smallest rung —
+  // a plate riveted across the row's top border, subordinate to the name it
+  // sits beside. It was `inverse` (paper ground, ink text) at `compact`, which
+  // read as another chip floating near the corner rather than as a mark
+  // stamped ON the record.
   const stamp = (
-    <Badge shape="stamp" size="compact" surface="inverse" className="tracking-caps-wide">
+    <Badge shape="stamp" size="mini" className="tracking-caps-wide">
       {owner.label}
     </Badge>
   )
 
   if (!claimable) {
-    // Inert: a fact about the row, not a control. Rotated the same few degrees
-    // so a held row and a free one read as the same kind of mark.
-    return <span className="rotate-[-4deg]">{stamp}</span>
+    // Inert: a fact about the row, not a control.
+    return stamp
   }
 
   return (
@@ -250,8 +266,8 @@ function OwnerSeal({
       disabled={disabled}
       aria-label={`${owner.label} — pick this up`}
       className={cn(
-        'rotate-[-4deg] cursor-pointer border-0 bg-transparent p-0',
-        'transition-transform duration-200 hover:rotate-0 disabled:cursor-default disabled:opacity-50'
+        'cursor-pointer border-0 bg-transparent p-0',
+        'transition-transform duration-200 hover:-translate-y-px disabled:cursor-default disabled:opacity-50'
       )}
     >
       {stamp}

--- a/apps/itun/src/components/games/GameRoster.tsx
+++ b/apps/itun/src/components/games/GameRoster.tsx
@@ -41,6 +41,7 @@ import { useState } from 'react'
 import { useRouter } from '@tanstack/react-router'
 import { Bot, UserRound, Warehouse } from 'lucide-react'
 import { useMutation, useQuery } from 'convex/react'
+import { resolveChassisRef } from 'salvageunion-reference/rules'
 import {
   Badge,
   Button,
@@ -62,6 +63,7 @@ import {
   type RosterRow,
   type RosterKind,
 } from '../../lib/games/gameRoster'
+import type { OwnerChip } from '../../lib/ownership/ownerChip'
 import type { Crawler } from '../../lib/schemas/crawler'
 import type { Mech } from '../../lib/schemas/mech'
 import type { Pilot } from '../../lib/schemas/pilot'
@@ -147,8 +149,17 @@ function statsFor(row: RosterRow): Array<{ label: string; value: string | number
   return out
 }
 
-/** The muted caption under the name: callsign / chassis, then the owner chip. */
-function metaLineFor(row: RosterRow) {
+/**
+ * The row's caption parts — callsign, class, chassis — each rendered by
+ * `EntityRow` as its own quiet chip.
+ *
+ * Ownership is NOT among them any more: it is the row's seal, stamped in the
+ * top-right corner (see `OwnerSeal`). It used to be a toned chip down here
+ * beside the callsign, which put the single most consequential fact about a
+ * row — whose character is this — in the same visual register as their
+ * nickname.
+ */
+function captionFor(row: RosterRow): string[] {
   const parts: string[] = []
   if (row.kind === 'pilot') {
     const callsign = row.body.callsign
@@ -160,55 +171,90 @@ function metaLineFor(row: RosterRow) {
   }
   if (row.kind === 'mech') {
     const chassis = row.body.chassisRef
-    if (typeof chassis === 'string' && chassis.length > 0) parts.push(chassis)
+    // Resolved, not printed raw. The home Roster reads "Iron Mongrel · TL 1"
+    // where this said "iron-mongrel" — the stored value is a slug, and showing
+    // the slug is the surface admitting it never looked the chassis up.
+    if (typeof chassis === 'string' && chassis.length > 0) parts.push(chassisLabel(chassis))
   }
+  return parts
+}
 
-  return (
-    <span className="flex flex-wrap items-center gap-1.5">
-      {parts.length > 0 && <span>{parts.join(' · ')}</span>}
-      {/* Ownership is a STATE, not a blank (ADR-030 D32). An UNCLAIMED row
-          carries its state as a stamp seal in the row's trailing controls
-          instead of a chip here — see `UnclaimedSeal`. */}
-      {row.owner !== null && !row.owner.unclaimed && (
-        <Badge shape="chip" surface="tone" tone={row.kind} className="max-w-full truncate">
-          {row.owner.label}
-        </Badge>
-      )}
-    </span>
-  )
+/** A mech's chassis as "Name · TL n", falling back to the raw ref. */
+function chassisLabel(chassisRef: string): string {
+  // `resolveChassisRef` throws when the Chassis model is not preloaded (test
+  // and snapshot contexts), so this falls back rather than taking the screen
+  // down with it — the same guard the Roster's `mechChassisMeta` uses.
+  try {
+    const chassis = resolveChassisRef(chassisRef) as { name: string; techLevel?: number } | null
+    if (!chassis) return chassisRef
+    return chassis.techLevel != null ? `${chassis.name} · TL ${chassis.techLevel}` : chassis.name
+  } catch {
+    return chassisRef
+  }
 }
 
 /**
- * The UNCLAIMED seal: a stamped mark on the right of the row, and the way in
- * to picking that character up.
+ * The ownership seal: one stamp in the row's top-right corner saying who holds
+ * this character — `UNCLAIMED`, `YOU`, or a crewmate's name.
  *
- * It is one control rather than a chip plus a button because it is one fact.
- * An unclaimed pre-gen is an *offer*, so the thing that announces it should
- * also be the thing you press — a row that read "Unclaimed" in muted grey next
- * to a separate "Pick up" said the same thing twice and buried the invitation
- * in the quieter half.
+ * ## One mark, three states
  *
- * Stamped rather than chipped for the same reason a document is stamped: it is
- * a mark applied ON the record about its status, not a property of the
- * character. It opens a confirm rather than claiming outright — taking a
- * character is a commitment at the table, and the modal is where the surface
- * says what happens next (it becomes yours, and it lands in this browser).
+ * Ownership is one fact, so it gets one mark. The surface previously said it
+ * two ways at once: an owner chip in the caption for held characters, and a
+ * separate UNCLAIMED stamp among the buttons for free ones — two vocabularies
+ * for a single field, in two different places, so scanning a column meant
+ * checking both. A seal that is always present and always in the same corner
+ * can be read down a list without reading anything else.
+ *
+ * Stamped rather than chipped for the reason documents are stamped: it is a
+ * mark applied ON the record about its status, not a property of the character
+ * itself.
+ *
+ * ## Why UNCLAIMED is the pressable one
+ *
+ * An unclaimed pre-gen is an *offer*, so the thing that announces it is also
+ * the thing you press. The other two states are statements of fact with nothing
+ * to do — pressing "MARA" should not do anything, and it does not.
+ *
+ * It opens a confirm rather than claiming outright: taking a character is a
+ * commitment at the table, and the modal is where the surface says what happens
+ * next (it becomes yours, and it lands in this browser).
  */
-function UnclaimedSeal({ onClick, disabled }: { onClick: () => void; disabled: boolean }) {
+function OwnerSeal({
+  owner,
+  claimable,
+  disabled,
+  onClaim,
+}: {
+  owner: OwnerChip
+  claimable: boolean
+  disabled: boolean
+  onClaim: () => void
+}) {
+  const stamp = (
+    <Badge shape="stamp" size="compact" surface="inverse" className="tracking-caps-wide">
+      {owner.label}
+    </Badge>
+  )
+
+  if (!claimable) {
+    // Inert: a fact about the row, not a control. Rotated the same few degrees
+    // so a held row and a free one read as the same kind of mark.
+    return <span className="rotate-[-4deg]">{stamp}</span>
+  }
+
   return (
     <button
       type="button"
-      onClick={onClick}
+      onClick={onClaim}
       disabled={disabled}
-      aria-label="Unclaimed — pick this up"
+      aria-label={`${owner.label} — pick this up`}
       className={cn(
         'rotate-[-4deg] cursor-pointer border-0 bg-transparent p-0',
         'transition-transform duration-200 hover:rotate-0 disabled:cursor-default disabled:opacity-50'
       )}
     >
-      <Badge shape="stamp" size="compact" surface="inverse" className="tracking-caps-wide">
-        Unclaimed
-      </Badge>
+      {stamp}
     </button>
   )
 }
@@ -418,8 +464,25 @@ export function GameRoster({ gameId, gameName }: GameRosterProps) {
                           entityType={row.kind}
                           name={row.name}
                           stats={statsFor(row)}
-                          metaLine={metaLineFor(row)}
+                          metaLine={captionFor(row)}
                           linkAs={AppLink}
+                          /* Every row is a door now. View goes to the frozen
+                             crew sheet (`GameEntitySheet`) for EVERY row,
+                             including your own: it is a plain anchor to a
+                             read-only surface, so it needs no adoption round
+                             trip and behaves like the Roster's View. Editing
+                             is the separate, owner-only verb beside it. */
+                          sheetHref={`/games/${gameId}/view/${row.kind}/${row.serverId}`}
+                          seal={
+                            row.owner === null ? undefined : (
+                              <OwnerSeal
+                                owner={row.owner}
+                                claimable={row.can.claim}
+                                disabled={busy !== null}
+                                onClaim={() => setClaimTarget(row)}
+                              />
+                            )
+                          }
                           actions={
                             <>
                               {row.can.openSheet && (
@@ -431,7 +494,7 @@ export function GameRoster({ gameId, gameName }: GameRosterProps) {
                                     void run(`open-${row.serverId}`, () => openSheet(row))
                                   }
                                 >
-                                  Sheet
+                                  Edit
                                 </Button>
                               )}
                               {row.kind === 'mech' && row.can.openSheet && (
@@ -446,13 +509,8 @@ export function GameRoster({ gameId, gameName }: GameRosterProps) {
                                   Dashboard
                                 </Button>
                               )}
-                              {row.can.claim && (
-                                <UnclaimedSeal
-                                  disabled={busy !== null}
-                                  onClick={() => setClaimTarget(row)}
-                                />
-                              )}
-                              {/* Any owner, not just the table runner: ADR-030
+                              {/* Picking up is the SEAL's job, not a button's —
+                                  see `OwnerSeal`. Any owner, not just the table runner: ADR-030
                                   §4 says ownership is voluntary in the outward
                                   direction, and the pick-up confirm promises
                                   exactly this as the way back out. */}

--- a/apps/itun/src/components/games/GameRoster.tsx
+++ b/apps/itun/src/components/games/GameRoster.tsx
@@ -51,7 +51,6 @@ import {
   ModalShell,
   Text,
 } from 'component-lib'
-import type { EntityRowDetail } from 'component-lib'
 
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
@@ -123,7 +122,18 @@ const TONE_TEXT: Record<RosterKind, string> = {
   crawler: 'text-sheet-crawler-deep',
 }
 
-/** Vitals for the row's stat strip. Absent numbers are omitted, never zeroed. */
+/**
+ * Everything the row states as `label | value`, all of it in the header band.
+ *
+ * There is no second place for these any more: a stat is a stat whether it is a
+ * number or a name, so `CLASS | Salvager` sits in the band beside `SP | 12`
+ * rather than in a separate register below it. The body is left to the verbs.
+ *
+ * **HP and AP are deliberately absent.** A roster answers "what have I got",
+ * not "how hurt is it": live vitals belong to the sheet and the Dashboard, and
+ * a number that changes every round is stale on a listing the moment it renders.
+ * Absent numbers are omitted, never zeroed.
+ */
 function statsFor(row: RosterRow): Array<{ label: string; value: string | number }> {
   const num = (key: string): number | undefined => {
     const value = row.body[key]
@@ -132,8 +142,13 @@ function statsFor(row: RosterRow): Array<{ label: string; value: string | number
   const out: Array<{ label: string; value: string | number }> = []
 
   if (row.kind === 'pilot') {
-    if (num('currentHP') !== undefined) out.push({ label: 'HP', value: num('currentHP') as number })
-    if (num('currentAP') !== undefined) out.push({ label: 'AP', value: num('currentAP') as number })
+    // What the pilot IS — the class leads, the callsign names them.
+    const className = resolveClassName(String(row.body.classRef ?? ''))
+    if (className) out.push({ label: 'Class', value: className })
+    const callsign = row.body.callsign
+    if (typeof callsign === 'string' && callsign.length > 0 && callsign !== row.name) {
+      out.push({ label: 'Callsign', value: callsign })
+    }
   }
   if (row.kind === 'mech') {
     // The chassis leads: it is what the mech IS, where SP and Heat are how it
@@ -159,33 +174,6 @@ function statsFor(row: RosterRow): Array<{ label: string; value: string | number
     out.push({ label: 'Bays', value: bays })
   }
   return out
-}
-
-/**
- * The row's body details — `CALLSIGN | Ghost`, `CLASS | Salvager` — each
- * rendered by `EntityRow` as a horizontal `Stat` with its label plate tinted by
- * ontology.
- *
- * Ownership is NOT among them: it is the row's seal, stamped on the top border
- * (see `OwnerSeal`). It used to be a toned chip down here beside the callsign,
- * which put the single most consequential fact about a row — whose character is
- * this — in the same visual register as their nickname.
- */
-function captionFor(row: RosterRow): EntityRowDetail[] {
-  const parts: EntityRowDetail[] = []
-  if (row.kind === 'pilot') {
-    const callsign = row.body.callsign
-    if (typeof callsign === 'string' && callsign.length > 0 && callsign !== row.name) {
-      parts.push({ label: 'Callsign', value: callsign })
-    }
-    const className = resolveClassName(String(row.body.classRef ?? ''))
-    if (className) parts.push({ label: 'Class', value: className, tone: 'pilot' })
-  }
-  // A mech's chassis is NOT here: it is a `CHASSIS | Iron Mongrel` stat in the
-  // header band. It is a named property of the mech, which is what a Stat is
-  // for — a bare chip saying "Iron Mongrel" left the reader to infer what the
-  // word was doing there.
-  return parts
 }
 
 /**
@@ -481,7 +469,6 @@ export function GameRoster({ gameId, gameName }: GameRosterProps) {
                           entityType={row.kind}
                           name={row.name}
                           stats={statsFor(row)}
-                          metaLine={captionFor(row)}
                           linkAs={AppLink}
                           /* Every row is a door now. View goes to the frozen
                              crew sheet (`GameEntitySheet`) for EVERY row,

--- a/apps/itun/src/components/games/GameRow.tsx
+++ b/apps/itun/src/components/games/GameRow.tsx
@@ -28,31 +28,39 @@ export type GameRowGame = {
 }
 
 /**
- * What the table IS, as `label | value` stats in the header band.
+ * What the TABLE is — the band's register, scanned down the column.
  *
- * These answer "what is this table" before you open it: which crawler the crew
- * rides, how much is built, who you are at it, and how many of you there are.
- *
- * They were body badges (`#430 Tenacity`, `4 Pilots`, `3 Mechs`) over a caption
- * that joined the rest with ' · ' separators — `Mediator · Organizer · 4
- * members · from the starter-set template`. Both are the vocabulary the entity
- * rows left behind: a count is a `label | value` fact, and a separator-joined
- * run is several facts wearing one chip. The band states them the way every
- * other row now does.
- *
- * A brand-new Game reads `CRAWLER | None` rather than dropping the stat: a row
- * with nothing beside the name looks broken rather than empty.
+ * Which crawler the crew rides, and how much is built. A brand-new Game reads
+ * `CRAWLER | None` rather than dropping the stat: a row with nothing beside its
+ * name looks broken rather than new.
  */
-function statsOf(game: GameRowGame): EntityRowStat[] {
-  const stats: EntityRowStat[] = [
+function tableStats(game: GameRowGame): EntityRowStat[] {
+  return [
     { label: 'Crawler', value: game.crawlerName ?? 'None' },
     { label: 'Pilots', value: game.pilotCount },
     { label: 'Mechs', value: game.mechCount },
-    // Your standing at the table, not a count — but still one label, one value.
+  ]
+}
+
+/**
+ * What YOU are at the table — the body's register, beside the controls.
+ *
+ * Your role, the size of the crew, and where the game came from. These are
+ * facts about the row, but not what a reader scans a list of games FOR: you
+ * scan for which table, and how much is on it. All six cells briefly sat in the
+ * band together, which made the one line meant to be scanned the longest line
+ * on the row.
+ *
+ * They were a single caption chip joining the lot with ' · ' separators —
+ * `Mediator · Organizer · 4 members · from the starter-set template` — which is
+ * several facts wearing one chip.
+ */
+function standingStats(game: GameRowGame): EntityRowStat[] {
+  const stats: EntityRowStat[] = [
     { label: 'Role', value: game.mediator ? 'Mediator' : game.organizer ? 'Organizer' : 'Player' },
     { label: 'Members', value: game.memberCount },
   ]
-  // Provenance is only worth a cell when there IS a template behind the game.
+  // Provenance earns a cell only when there IS a template behind the game.
   if (game.templateOrigin !== undefined) {
     stats.push({ label: 'From', value: `${game.templateOrigin} template` })
   }
@@ -66,7 +74,8 @@ export function GameRow({ game }: { game: GameRowGame }) {
       name={game.name}
       sheetHref={`/games/${game._id}`}
       linkAs={AppLink}
-      stats={statsOf(game)}
+      stats={tableStats(game)}
+      bodyStats={standingStats(game)}
     />
   )
 }

--- a/apps/itun/src/components/games/GameRow.tsx
+++ b/apps/itun/src/components/games/GameRow.tsx
@@ -1,4 +1,5 @@
 import { EntityRow } from 'component-lib'
+import type { EntityRowStat } from 'component-lib'
 
 import type { Id } from '../../../convex/_generated/dataModel'
 import { AppLink } from '../shared/AppLink'
@@ -9,11 +10,6 @@ import { AppLink } from '../shared/AppLink'
  * A Game is not game data, so it does not render through `ReferenceEntityDisplay`
  * — but it *is* another thing you own and open, so it gets the same `EntityRow`
  * the player entities use, with its own blue ontology tone (ADR-030).
- *
- * The three badges answer "what is this table" before you open it: which
- * crawler the crew rides, and how much is built. A brand-new Game reads
- * "No crawler · 0 Pilots · 0 Mechs" rather than dropping the badges, because a
- * row with nothing under the name looks broken rather than empty.
  *
  * Deleting is deliberately absent. `games.destroy` ends a shared campaign for
  * everyone in it, which needs a confirm that names what is being destroyed —
@@ -31,15 +27,36 @@ export type GameRowGame = {
   mechCount: number
 }
 
-/** Join the row's caption segments with the Roster's separator, dropping blanks. */
-function captionOf(game: GameRowGame): string {
-  const role = game.mediator ? 'Mediator' : 'Player'
-  const segments = [
-    game.organizer ? `${role} · Organizer` : role,
-    `${game.memberCount} ${game.memberCount === 1 ? 'member' : 'members'}`,
-    game.templateOrigin === undefined ? null : `from the ${game.templateOrigin} template`,
+/**
+ * What the table IS, as `label | value` stats in the header band.
+ *
+ * These answer "what is this table" before you open it: which crawler the crew
+ * rides, how much is built, who you are at it, and how many of you there are.
+ *
+ * They were body badges (`#430 Tenacity`, `4 Pilots`, `3 Mechs`) over a caption
+ * that joined the rest with ' · ' separators — `Mediator · Organizer · 4
+ * members · from the starter-set template`. Both are the vocabulary the entity
+ * rows left behind: a count is a `label | value` fact, and a separator-joined
+ * run is several facts wearing one chip. The band states them the way every
+ * other row now does.
+ *
+ * A brand-new Game reads `CRAWLER | None` rather than dropping the stat: a row
+ * with nothing beside the name looks broken rather than empty.
+ */
+function statsOf(game: GameRowGame): EntityRowStat[] {
+  const stats: EntityRowStat[] = [
+    { label: 'Crawler', value: game.crawlerName ?? 'None' },
+    { label: 'Pilots', value: game.pilotCount },
+    { label: 'Mechs', value: game.mechCount },
+    // Your standing at the table, not a count — but still one label, one value.
+    { label: 'Role', value: game.mediator ? 'Mediator' : game.organizer ? 'Organizer' : 'Player' },
+    { label: 'Members', value: game.memberCount },
   ]
-  return segments.filter((segment) => segment !== null).join(' · ')
+  // Provenance is only worth a cell when there IS a template behind the game.
+  if (game.templateOrigin !== undefined) {
+    stats.push({ label: 'From', value: `${game.templateOrigin} template` })
+  }
+  return stats
 }
 
 export function GameRow({ game }: { game: GameRowGame }) {
@@ -49,12 +66,7 @@ export function GameRow({ game }: { game: GameRowGame }) {
       name={game.name}
       sheetHref={`/games/${game._id}`}
       linkAs={AppLink}
-      meta={[
-        game.crawlerName ?? 'No crawler',
-        `${game.pilotCount} ${game.pilotCount === 1 ? 'Pilot' : 'Pilots'}`,
-        `${game.mechCount} ${game.mechCount === 1 ? 'Mech' : 'Mechs'}`,
-      ]}
-      metaLine={captionOf(game)}
+      stats={statsOf(game)}
     />
   )
 }

--- a/apps/itun/src/components/games/GameScreen.tsx
+++ b/apps/itun/src/components/games/GameScreen.tsx
@@ -25,7 +25,7 @@ import { DowntimePanel } from './DowntimePanel'
 import { GameRoster } from './GameRoster'
 import { InvitePanel } from './InvitePanel'
 import { ProposalInbox } from './ProposalInbox'
-import { TITLE } from './gameChrome'
+import { PAGE, TITLE } from './gameChrome'
 import { AppLink } from '../shared/AppLink'
 
 function GameBody({ gameId }: { gameId: string }) {
@@ -77,7 +77,7 @@ export function GameScreen({ gameId }: { gameId: string }) {
   const { mode } = useConnection()
 
   return (
-    <main className="mx-auto flex max-w-6xl flex-col gap-6 p-4 sm:p-8">
+    <main className={PAGE}>
       <Text as="h1" className={TITLE}>
         Game
       </Text>

--- a/apps/itun/src/components/games/GamesScreen.tsx
+++ b/apps/itun/src/components/games/GamesScreen.tsx
@@ -9,7 +9,7 @@ import { useConnection } from '../../lib/connection/connectionContext'
 import { isConvexConfigured } from '../../lib/connection/convexClient'
 import { SignInControl } from '../account/SignInControl'
 import { GameRow } from './GameRow'
-import { INPUT, STAMP } from './gameChrome'
+import { INPUT, PAGE, STAMP } from './gameChrome'
 
 /**
  * Games — the shelf of tables you belong to.
@@ -246,7 +246,7 @@ function GamesBody() {
 
 export function GamesScreen() {
   return (
-    <main className="mx-auto flex max-w-2xl flex-col gap-6 p-4">
+    <main className={PAGE}>
       <Text as="h1" className="font-cond text-2xl font-bold tracking-caps uppercase">
         Games
       </Text>

--- a/apps/itun/src/components/games/JoinScreen.tsx
+++ b/apps/itun/src/components/games/JoinScreen.tsx
@@ -8,7 +8,7 @@ import { useConnection } from '../../lib/connection/connectionContext'
 import { isConvexConfigured } from '../../lib/connection/convexClient'
 import { SignInControl } from '../account/SignInControl'
 import { AppLink } from '../shared/AppLink'
-import { STAMP, TITLE } from './gameChrome'
+import { PAGE, STAMP, TITLE } from './gameChrome'
 
 /**
  * `/join/$code` — the link half of an invite.
@@ -203,11 +203,15 @@ export function JoinScreen({ code }: { code: string }) {
   }
 
   return (
-    <main className="mx-auto flex max-w-lg flex-col gap-6 p-4">
+    <main className={PAGE}>
       <Text as="h1" className={TITLE}>
         Join a game
       </Text>
-      {body()}
+      {/* The page shell is the full-width one every Game surface now uses, but
+          the form inside is capped: a Game screen is wide because it lists a
+          crew, and this one holds a six-character code. Stretching the card to
+          1440px would make the shells match by making the content worse. */}
+      <div className="w-full max-w-xl">{body()}</div>
     </main>
   )
 }

--- a/apps/itun/src/components/games/MediatorScreen.tsx
+++ b/apps/itun/src/components/games/MediatorScreen.tsx
@@ -9,7 +9,7 @@ import { isConvexConfigured } from '../../lib/connection/convexClient'
 import { CrewVitals } from './CrewVitals'
 import { DowntimePanel } from './DowntimePanel'
 import { GameRoster } from './GameRoster'
-import { INPUT, ROW, SECTION, STAMP, TITLE } from './gameChrome'
+import { INPUT, PAGE, ROW, SECTION, STAMP, TITLE } from './gameChrome'
 
 /**
  * The Mediator surface — the layer ADR-021 deferred and ADR-030 §6 specifies.
@@ -304,7 +304,7 @@ export function MediatorScreen({ gameId }: { gameId: string }) {
   return (
     // Wider than it was: the surface now leads with a three-column roster, and
     // the old 3xl column squeezed it to one column on every screen size.
-    <main className="mx-auto flex max-w-6xl flex-col gap-6 p-4 sm:p-8">
+    <main className={PAGE}>
       <Text as="h1" className={TITLE}>
         Mediator
       </Text>

--- a/apps/itun/src/components/games/__tests__/GameRoster.connected.test.tsx
+++ b/apps/itun/src/components/games/__tests__/GameRoster.connected.test.tsx
@@ -98,10 +98,12 @@ function renderAs(me: unknown, rows: ReturnType<typeof listing>, members: unknow
 afterEach(cleanup)
 
 describe('what a row offers', () => {
-  test('your own pilot opens its sheet', () => {
+  test('your own pilot offers the editable sheet', () => {
     renderAs(ME, listing({ pilots: [MY_PILOT] }))
     expect(screen.getByText('Roach-Boy')).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Sheet' })).toBeTruthy()
+    // Edit, not View: View is the read-only crew sheet every row carries, and
+    // the editable one is the extra verb ownership buys.
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeTruthy()
   })
 
   test('your own mech also offers the Dashboard', () => {
@@ -121,15 +123,29 @@ describe('what a row offers', () => {
     expect(screen.queryByRole('button', { name: 'Offer to the crew' })).toBeNull()
   })
 
-  test("a crewmate's pilot shows who holds it and opens nothing", () => {
+  test("a crewmate's pilot names its holder and opens READ-ONLY", () => {
     renderAs(ME, listing({ pilots: [THEIR_PILOT] }))
 
     expect(screen.getByText('Ash')).toBeTruthy()
-    // Naming the owner is the point of the chip; opening their sheet would
-    // hand over an editor whose every save the server refuses.
+    // The seal names who holds it — the row's one ownership mark.
     expect(screen.getByText('Mediator')).toBeTruthy()
-    expect(screen.queryByRole('button', { name: 'Sheet' })).toBeNull()
+    // Readable: a shared table whose crew you cannot look at is not shared.
+    // The link goes to the frozen crew sheet, addressed by the SERVER id.
+    const view = screen.getByRole('link', { name: 'View' })
+    expect(view.getAttribute('href')).toBe('/games/g1/view/pilot/s-theirs')
+    // But not editable — that would hand over an editor the server refuses.
+    expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull()
+    // Nor is it takeable: somebody already holds it.
     expect(screen.queryByRole('button', { name: /Unclaimed/i })).toBeNull()
+  })
+
+  test('a crewmate has no delete affordance on your screen', () => {
+    renderAs(ME, listing({ pilots: [THEIR_PILOT] }))
+
+    // Game rows carry no trash at all — leaving a character you hold is
+    // "Offer to the crew", and the crawler's Scrap is the table runner's.
+    // Nothing here can destroy somebody else's build.
+    expect(screen.queryByRole('button', { name: /Delete Ash/i })).toBeNull()
   })
 })
 
@@ -198,8 +214,10 @@ describe('what the game will accept', () => {
     renderAs(ME, listing({ crawlers: [CRAWLER] }))
 
     expect(screen.getByText('#430 Tenacity')).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Sheet' })).toBeTruthy()
-    // It has no owner at all, so nothing invites anyone to claim it.
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeTruthy()
+    // It has no owner at all, so it carries no ownership seal — neither a
+    // claim invitation nor a holder's name. "Who owns the crawler" is not a
+    // question the game asks.
     expect(screen.queryByRole('button', { name: /Unclaimed/i })).toBeNull()
   })
 })

--- a/apps/itun/src/components/games/__tests__/GamesScreen.connected.test.tsx
+++ b/apps/itun/src/components/games/__tests__/GamesScreen.connected.test.tsx
@@ -124,24 +124,36 @@ describe('the Games index for a signed-in player', () => {
     expect(screen.getByText('Union Crawler #430')).toBeTruthy()
   })
 
-  test('the row badges say what the table is', () => {
+  test('the row stats say what the table is', () => {
     withQueries(queriesFor(GAME))
     wrap()
 
-    // A Game row answers "what is this table" before you open it.
+    // A Game row answers "what is this table" before you open it. These are
+    // `label | value` stats in the header band now, not body badges, so the
+    // label and the value are separate cells — "4 Pilots" is `PILOTS | 4`.
+    expect(screen.getByText('Crawler')).toBeTruthy()
     expect(screen.getByText('Hamlet')).toBeTruthy()
-    expect(screen.getByText('4 Pilots')).toBeTruthy()
-    expect(screen.getByText('3 Mechs')).toBeTruthy()
+    expect(screen.getByText('Pilots')).toBeTruthy()
+    expect(screen.getByText('4')).toBeTruthy()
+    expect(screen.getByText('Mechs')).toBeTruthy()
+    // `3` is deliberately counted, not fetched: this game has three mechs AND
+    // three members, so the bare value is ambiguous by design. Splitting a
+    // label from its value is what makes it so — the trade for cells that can
+    // be scanned down a column.
+    expect(screen.getAllByText('3').length).toBe(2)
+    expect(screen.getByText('Members')).toBeTruthy()
   })
 
-  test('a game with nothing in it still renders all three badges', () => {
+  test('a game with nothing in it still renders all three stats', () => {
     withQueries(queriesFor({ ...GAME, crawlerName: null, pilotCount: 0, mechCount: 0 }))
     wrap()
 
-    // Dropping the badges would make a new Game's row look broken rather than empty.
-    expect(screen.getByText('No crawler')).toBeTruthy()
-    expect(screen.getByText('0 Pilots')).toBeTruthy()
-    expect(screen.getByText('0 Mechs')).toBeTruthy()
+    // Dropping the stats would make a new Game's row look broken rather than
+    // empty — an absent crawler reads as a value ("None"), never as a gap.
+    expect(screen.getByText('None')).toBeTruthy()
+    expect(screen.getByText('Pilots')).toBeTruthy()
+    expect(screen.getByText('Mechs')).toBeTruthy()
+    expect(screen.getAllByText('0').length).toBe(2)
   })
 
   test('the row links to the game, not to a modal', () => {

--- a/apps/itun/src/components/games/gameChrome.ts
+++ b/apps/itun/src/components/games/gameChrome.ts
@@ -14,6 +14,17 @@
  * unpick.
  */
 
+/**
+ * The page shell every Game surface sits on — the Roster's, verbatim.
+ *
+ * The Game screens used to be a centred `max-w-6xl` column while the Roster ran
+ * the full width of the window. Both are the same kind of surface (three
+ * ontology columns of entity rows), so at any desktop width the crew view read
+ * as a narrower, punier version of the home page — and its three columns went
+ * cramped exactly where the Roster's had room. Same shape, same shell.
+ */
+export const PAGE = 'min-h-screen bg-wk-bg px-4 py-5 sm:px-8 sm:py-10 lg:px-12 flex flex-col gap-6'
+
 /** Small stamped label above a group. */
 export const STAMP = 'font-cond text-xs font-bold tracking-caps-wide uppercase'
 

--- a/apps/itun/src/components/roster/Roster.tsx
+++ b/apps/itun/src/components/roster/Roster.tsx
@@ -21,6 +21,7 @@ import type { ReactNode } from 'react'
 import { Bot, UserRound, Warehouse } from 'lucide-react'
 import { resolveChassisRef } from 'salvageunion-reference/rules'
 import { Badge, Button, buttonVariants, EmptyState, EntityRow } from 'component-lib'
+import type { EntityRowStat } from 'component-lib'
 
 import {
   useCrawlers,
@@ -52,28 +53,45 @@ import { ModalShell } from 'component-lib'
 // Row-meta helpers
 // ---------------------------------------------------------------------------
 
-/** Roster row meta segment for a mech: "Chassis · TL n". */
-function mechChassisMeta(chassisRef: string): string | undefined {
-  // resolveChassisRef is slug/name/id tolerant; stored refs are slugs, so a
-  // name-only match here would fall through to the raw slug for every mech. Wrap
-  // in try/catch: resolveChassisRef throws when the Chassis model isn't preloaded
-  // (some test/snapshot contexts) — fall back to the raw ref rather than crash.
+/**
+ * A mech row's stats: `CHASSIS | Iron Mongrel`, and `TL | 1` beside it.
+ *
+ * These used to be one caption string, "Iron Mongrel · TL 1" — two facts joined
+ * by a separator, which is the shape `Stat` exists to replace. TL is its own
+ * stat rather than a suffix for the same reason.
+ *
+ * resolveChassisRef is slug/name/id tolerant; stored refs are slugs, so a
+ * name-only match here would fall through to the raw slug for every mech. Wrap
+ * in try/catch: resolveChassisRef throws when the Chassis model isn't preloaded
+ * (some test/snapshot contexts) — fall back to the raw ref rather than crash.
+ */
+function mechChassisStats(chassisRef: string): EntityRowStat[] | undefined {
+  if (!chassisRef) return undefined
+  let resolved: { name: string; techLevel?: number } | null = null
   try {
-    const c = resolveChassisRef(chassisRef) as { name: string; techLevel?: number } | null
-    if (!c) return chassisRef || undefined
-    return c.techLevel != null ? `${c.name} · TL ${c.techLevel}` : c.name
+    resolved = resolveChassisRef(chassisRef) as { name: string; techLevel?: number } | null
   } catch {
-    return chassisRef || undefined
+    resolved = null
   }
+
+  const stats: EntityRowStat[] = [{ label: 'Chassis', value: resolved?.name ?? chassisRef }]
+  if (resolved?.techLevel != null) stats.push({ label: 'TL', value: resolved.techLevel })
+  return stats
 }
 
-/** Roster row meta segment for a crawler: "TL n · m bays". */
-function crawlerTypeMeta(techLevel: string, bayCount: number): string {
+/**
+ * A crawler row's stats: `TL | 2`, `BAYS | 3`.
+ *
+ * Was the caption string "TL 2 · 3 bays" — the same two-facts-one-separator
+ * shape the chassis had, and the same fix. These are the labels the crew roster
+ * already used, so the two surfaces now read identically.
+ */
+function crawlerStats(techLevel: string, bayCount: number): EntityRowStat[] {
   const tl = techLevel.replace(/[^0-9]/g, '')
-  const parts: string[] = []
-  if (tl) parts.push(`TL ${tl}`)
-  parts.push(`${bayCount} ${bayCount === 1 ? 'bay' : 'bays'}`)
-  return parts.join(' · ')
+  const stats: EntityRowStat[] = []
+  if (tl) stats.push({ label: 'TL', value: tl })
+  stats.push({ label: 'Bays', value: bayCount })
+  return stats
 }
 
 /**
@@ -398,8 +416,12 @@ export function Roster() {
                         sheetHref={`/sheet/mech/${m.id}`}
                         linkAs={AppLink}
                         onDeleteClick={() => openDeleteDialog('mech', m.id, m.name)}
+                        // The chassis is a STAT (`CHASSIS | Iron Mongrel`), not
+                        // a caption chip: it is a named property of the mech,
+                        // and a bare chip left the reader to infer what the word
+                        // was doing there. Same call the crew roster makes.
+                        stats={mechChassisStats(m.chassisRef)}
                         metaLine={metaParts([
-                          mechChassisMeta(m.chassisRef),
                           linkSegment(
                             'pilot',
                             pilotLink?.to.id,
@@ -433,8 +455,8 @@ export function Roster() {
                         sheetHref={`/sheet/crawler/${c.id}`}
                         linkAs={AppLink}
                         onDeleteClick={() => openDeleteDialog('crawler', c.id, c.name)}
+                        stats={crawlerStats(c.techLevel, c.crawlerBays?.length ?? 0)}
                         metaLine={metaParts([
-                          crawlerTypeMeta(c.techLevel, c.crawlerBays?.length ?? 0),
                           ...crewLinks.map((l) =>
                             linkSegment('pilot', l.from.id, pilotNameById.get(l.from.id))
                           ),

--- a/apps/itun/src/components/roster/Roster.tsx
+++ b/apps/itun/src/components/roster/Roster.tsx
@@ -21,7 +21,7 @@ import type { ReactNode } from 'react'
 import { Bot, UserRound, Warehouse } from 'lucide-react'
 import { resolveChassisRef } from 'salvageunion-reference/rules'
 import { Button, buttonVariants, EmptyState, EntityRow, Stat } from 'component-lib'
-import type { EntityRowDetail, EntityRowStat } from 'component-lib'
+import type { EntityRowStat } from 'component-lib'
 
 import {
   useCrawlers,
@@ -94,10 +94,22 @@ function crawlerStats(techLevel: string, bayCount: number): EntityRowStat[] {
   return stats
 }
 
-/** `CLASS | Scavenger`, tinted pilot-orange. Omitted when the ref won't resolve. */
-function classDetail(classRef: string): EntityRowDetail | null {
-  const name = resolveClassName(classRef)
-  return name ? { label: 'Class', value: name, tone: 'pilot' } : null
+/**
+ * A pilot row's header stats: `CLASS | Scavenger`, `CALLSIGN | Ghost`.
+ *
+ * These lived in the body as tone-tinted chips. They are `label | value` facts
+ * like any other, so they belong in the band with the rest, on the plain ink
+ * label plate every other stat uses — the tint was a second way of saying what
+ * the band already says.
+ *
+ * No HP/AP here: a roster answers "what have I got", not "how hurt is it".
+ */
+function pilotStats(classRef: string, callsign?: string): EntityRowStat[] | undefined {
+  const stats: EntityRowStat[] = []
+  const className = resolveClassName(classRef)
+  if (className) stats.push({ label: 'Class', value: className })
+  if (callsign) stats.push({ label: 'Callsign', value: callsign })
+  return stats.length > 0 ? stats : undefined
 }
 
 /**
@@ -107,9 +119,7 @@ function classDetail(classRef: string): EntityRowDetail | null {
  * chips, and are now `label | value` stats — each step removing an inference the
  * reader was making on the row's behalf.
  */
-function metaParts(
-  parts: Array<ReactNode | EntityRowDetail | null | undefined>
-): Array<ReactNode | EntityRowDetail> | undefined {
+function metaParts(parts: Array<ReactNode | null | undefined>): ReactNode[] | undefined {
   const kept = parts.filter((part) => part != null && part !== '')
   return kept.length === 0 ? undefined : kept
 }
@@ -411,9 +421,8 @@ export function Roster() {
                         sheetHref={`/sheet/pilot/${p.id}`}
                         linkAs={AppLink}
                         onDeleteClick={() => openDeleteDialog('pilot', p.id, p.name)}
+                        stats={pilotStats(p.classRef, p.callsign)}
                         metaLine={metaParts([
-                          p.callsign ? { label: 'Callsign', value: p.callsign } : null,
-                          classDetail(p.classRef),
                           linkSegment(
                             'mech',
                             mechLink?.from.id,

--- a/apps/itun/src/components/roster/Roster.tsx
+++ b/apps/itun/src/components/roster/Roster.tsx
@@ -20,8 +20,8 @@ import { useState } from 'react'
 import type { ReactNode } from 'react'
 import { Bot, UserRound, Warehouse } from 'lucide-react'
 import { resolveChassisRef } from 'salvageunion-reference/rules'
-import { Badge, Button, buttonVariants, EmptyState, EntityRow } from 'component-lib'
-import type { EntityRowStat } from 'component-lib'
+import { Button, buttonVariants, EmptyState, EntityRow, Stat } from 'component-lib'
+import type { EntityRowDetail, EntityRowStat } from 'component-lib'
 
 import {
   useCrawlers,
@@ -94,15 +94,22 @@ function crawlerStats(techLevel: string, bayCount: number): EntityRowStat[] {
   return stats
 }
 
+/** `CLASS | Scavenger`, tinted pilot-orange. Omitted when the ref won't resolve. */
+function classDetail(classRef: string): EntityRowDetail | null {
+  const name = resolveClassName(classRef)
+  return name ? { label: 'Class', value: name, tone: 'pilot' } : null
+}
+
 /**
- * The row's caption parts, blanks dropped.
+ * The row's body details, blanks dropped.
  *
- * These used to be joined into one muted line with ' · ' separators. `EntityRow`
- * now chips each part itself — every piece of text on a row is a badge — so the
- * separator characters have nothing left to separate, and a string part arrives
- * as its own chip rather than as a run of grey prose.
+ * These used to be joined into one muted line with ' · ' separators, then became
+ * chips, and are now `label | value` stats — each step removing an inference the
+ * reader was making on the row's behalf.
  */
-function metaParts(parts: Array<ReactNode | null | undefined>): ReactNode[] | undefined {
+function metaParts(
+  parts: Array<ReactNode | EntityRowDetail | null | undefined>
+): Array<ReactNode | EntityRowDetail> | undefined {
   const kept = parts.filter((part) => part != null && part !== '')
   return kept.length === 0 ? undefined : kept
 }
@@ -118,6 +125,23 @@ type DeleteTarget = {
 }
 
 type SegmentKind = 'pilot' | 'mech' | 'crawler'
+
+/**
+ * Label-plate tints for a cross-link, keyed to the TARGET's ontology — the same
+ * `--color-sheet-*` tokens `EntityRow` bands itself with, so a link to a mech
+ * is the green a mech row wears. Crawler takes paper text; it is the one dark
+ * fill in the ramp.
+ */
+const TONE_BG: Record<SegmentKind, string> = {
+  pilot: 'var(--color-sheet-pilot)',
+  mech: 'var(--color-sheet-mech)',
+  crawler: 'var(--color-sheet-crawler)',
+}
+const TONE_INK: Record<SegmentKind, string> = {
+  pilot: 'var(--color-ink)',
+  mech: 'var(--color-ink)',
+  crawler: 'var(--color-paper)',
+}
 
 const SEGMENTS: ReadonlyArray<{ kind: SegmentKind; label: string }> = [
   { kind: 'pilot', label: 'Pilots' },
@@ -154,6 +178,18 @@ export function Roster() {
   const pilotNameById = new Map(allPilots.map((p) => [p.id, p.name]))
   const mechNameById = new Map(allMechs.map((m) => [m.id, m.name]))
   const crawlerNameById = new Map(allCrawlers.map((c) => [c.id, c.name]))
+  // …and the one fact each cross-link states about its target, so a link reads
+  // `IRON JAW | Titan` rather than naming a thing and saying nothing about it.
+  const pilotClassById = new Map(allPilots.map((p) => [p.id, resolveClassName(p.classRef)]))
+  const mechChassisNameById = new Map(
+    allMechs.map((m) => [m.id, mechChassisStats(m.chassisRef)?.[0]?.value as string | undefined])
+  )
+  const crawlerTlById = new Map(
+    allCrawlers.map((c) => {
+      const tl = c.techLevel.replace(/[^0-9]/g, '')
+      return [c.id, tl ? `TL ${tl}` : undefined]
+    })
+  )
 
   /**
    * A cross-link to another entity's live sheet, as a Badge tinted with THAT
@@ -173,7 +209,8 @@ export function Roster() {
   function linkSegment(
     kind: SegmentKind,
     id: string | undefined,
-    name: string | undefined
+    name: string | undefined,
+    detail: string | undefined
   ): ReactNode | undefined {
     if (!id || !name) return undefined
     return (
@@ -182,9 +219,19 @@ export function Roster() {
         className="inline-flex max-w-full align-middle no-underline"
         aria-label={`Open ${name}'s ${kind} sheet`}
       >
-        <Badge shape="chip" surface="tone" tone={kind} className="max-w-full truncate">
-          {name}
-        </Badge>
+        {/* `NAME | detail` — the linked entity names ITSELF on the label plate
+            (a mech's name IS its pattern, SU rules), with its defining fact as
+            the value: a mech's chassis, a pilot's class, a crawler's TL. The
+            plate is tinted with the TARGET's ontology, never the row's, so the
+            kind of thing you are about to open is seen rather than read. */}
+        <Stat
+          label={name}
+          value={detail ?? '—'}
+          orientation="horizontal"
+          size="mini"
+          bgColor={TONE_BG[kind]}
+          textColor={TONE_INK[kind]}
+        />
       </AppLink>
     )
   }
@@ -365,17 +412,19 @@ export function Roster() {
                         linkAs={AppLink}
                         onDeleteClick={() => openDeleteDialog('pilot', p.id, p.name)}
                         metaLine={metaParts([
-                          p.callsign ? `"${p.callsign}"` : null,
-                          resolveClassName(p.classRef),
+                          p.callsign ? { label: 'Callsign', value: p.callsign } : null,
+                          classDetail(p.classRef),
                           linkSegment(
                             'mech',
                             mechLink?.from.id,
-                            mechLink && mechNameById.get(mechLink.from.id)
+                            mechLink && mechNameById.get(mechLink.from.id),
+                            mechLink && mechChassisNameById.get(mechLink.from.id)
                           ),
                           linkSegment(
                             'crawler',
                             crawlerLink?.to.id,
-                            crawlerLink && crawlerNameById.get(crawlerLink.to.id)
+                            crawlerLink && crawlerNameById.get(crawlerLink.to.id),
+                            crawlerLink && crawlerTlById.get(crawlerLink.to.id)
                           ),
                         ])}
                       />
@@ -425,7 +474,8 @@ export function Roster() {
                           linkSegment(
                             'pilot',
                             pilotLink?.to.id,
-                            pilotLink && pilotNameById.get(pilotLink.to.id)
+                            pilotLink && pilotNameById.get(pilotLink.to.id),
+                            pilotLink && pilotClassById.get(pilotLink.to.id)
                           ),
                         ])}
                       />
@@ -458,7 +508,12 @@ export function Roster() {
                         stats={crawlerStats(c.techLevel, c.crawlerBays?.length ?? 0)}
                         metaLine={metaParts([
                           ...crewLinks.map((l) =>
-                            linkSegment('pilot', l.from.id, pilotNameById.get(l.from.id))
+                            linkSegment(
+                              'pilot',
+                              l.from.id,
+                              pilotNameById.get(l.from.id),
+                              pilotClassById.get(l.from.id)
+                            )
                           ),
                         ])}
                       />

--- a/apps/itun/src/components/roster/Roster.tsx
+++ b/apps/itun/src/components/roster/Roster.tsx
@@ -16,7 +16,7 @@
  *      listing immediately (Zustand in-memory update is synchronous).
  */
 
-import { Fragment, useState } from 'react'
+import { useState } from 'react'
 import type { ReactNode } from 'react'
 import { Bot, UserRound, Warehouse } from 'lucide-react'
 import { resolveChassisRef } from 'salvageunion-reference/rules'
@@ -76,17 +76,17 @@ function crawlerTypeMeta(techLevel: string, bayCount: number): string {
   return parts.join(' · ')
 }
 
-/** Join meta segments with the design's ' · ' separator, dropping blanks. */
-function joinMeta(parts: Array<ReactNode | null | undefined>): ReactNode | undefined {
+/**
+ * The row's caption parts, blanks dropped.
+ *
+ * These used to be joined into one muted line with ' · ' separators. `EntityRow`
+ * now chips each part itself — every piece of text on a row is a badge — so the
+ * separator characters have nothing left to separate, and a string part arrives
+ * as its own chip rather than as a run of grey prose.
+ */
+function metaParts(parts: Array<ReactNode | null | undefined>): ReactNode[] | undefined {
   const kept = parts.filter((part) => part != null && part !== '')
-  if (kept.length === 0) return undefined
-  return kept.map((part, i) => (
-    // biome-ignore lint/suspicious/noArrayIndexKey: meta parts are positional ReactNodes with no stable identity; the joined caption never reorders
-    <Fragment key={i}>
-      {i > 0 && ' · '}
-      {part}
-    </Fragment>
-  ))
+  return kept.length === 0 ? undefined : kept
 }
 
 // ---------------------------------------------------------------------------
@@ -346,7 +346,7 @@ export function Roster() {
                         sheetHref={`/sheet/pilot/${p.id}`}
                         linkAs={AppLink}
                         onDeleteClick={() => openDeleteDialog('pilot', p.id, p.name)}
-                        metaLine={joinMeta([
+                        metaLine={metaParts([
                           p.callsign ? `"${p.callsign}"` : null,
                           resolveClassName(p.classRef),
                           linkSegment(
@@ -398,7 +398,7 @@ export function Roster() {
                         sheetHref={`/sheet/mech/${m.id}`}
                         linkAs={AppLink}
                         onDeleteClick={() => openDeleteDialog('mech', m.id, m.name)}
-                        metaLine={joinMeta([
+                        metaLine={metaParts([
                           mechChassisMeta(m.chassisRef),
                           linkSegment(
                             'pilot',
@@ -433,7 +433,7 @@ export function Roster() {
                         sheetHref={`/sheet/crawler/${c.id}`}
                         linkAs={AppLink}
                         onDeleteClick={() => openDeleteDialog('crawler', c.id, c.name)}
-                        metaLine={joinMeta([
+                        metaLine={metaParts([
                           crawlerTypeMeta(c.techLevel, c.crawlerBays?.length ?? 0),
                           ...crewLinks.map((l) =>
                             linkSegment('pilot', l.from.id, pilotNameById.get(l.from.id))

--- a/apps/itun/src/components/roster/__tests__/Roster.test.tsx
+++ b/apps/itun/src/components/roster/__tests__/Roster.test.tsx
@@ -327,10 +327,12 @@ describe('Roster — entity listing', () => {
     expect(toMech.textContent).toContain('Iron Fist')
     expect(toPilot.textContent).toContain('Mara Vex')
 
-    // The tone is the destination's, not the row's — a pilot row's mech badge
-    // is mech-toned. This is the whole point of the change.
-    expect(toMech.querySelector('.bg-mech')).toBeTruthy()
-    expect(toPilot.querySelector('.bg-pilot')).toBeTruthy()
+    // The tone is the destination's, not the row's — a pilot row's mech link is
+    // mech-toned. This is the whole point of the change. It is now carried as
+    // the Stat label plate's inline tint rather than a Badge tone class, so the
+    // assertion reads the token: same rule, different mechanism.
+    expect(toMech.innerHTML).toContain('--color-sheet-mech')
+    expect(toPilot.innerHTML).toContain('--color-sheet-pilot')
   })
 })
 

--- a/apps/itun/src/components/sheet/Sheet.tsx
+++ b/apps/itun/src/components/sheet/Sheet.tsx
@@ -87,6 +87,14 @@ type SheetProps = {
   /** Hides publish + disables all stat editing (snapshot contexts). */
   readOnly?: boolean
   /**
+   * Where the sheet's back link goes. Defaults to the Roster.
+   *
+   * A sheet reached from a Game's crew list belongs to that game for the length
+   * of the visit, and sending its back link to the personal Roster would strand
+   * the viewer one surface away from the crew they were reading.
+   */
+  back?: { href: string; label: string }
+  /**
    * Pilot ability refs to use instead of the composition's.
    *
    * A published snapshot shares a LIVE INSTANCE but carries a private read-only
@@ -109,6 +117,7 @@ export function Sheet({
   softLinkStore,
   store = useEntityStore,
   readOnly = false,
+  back = { href: '/', label: 'Roster' },
   pilotAbilities,
 }: SheetProps) {
   const storeState = store()
@@ -140,10 +149,10 @@ export function Sheet({
             This {kind} may have been deleted, or the link may be stale.
           </p>
           <AppLink
-            href="/"
+            href={back.href}
             className={cn(buttonVariants({ variant: 'ghost', size: 'compact' }), 'no-underline')}
           >
-            &larr; Back to Roster
+            &larr; Back to {back.label}
           </AppLink>
         </div>
       </main>
@@ -152,7 +161,6 @@ export function Sheet({
 
   const { entity } = resolved
   const wired = composition.mode === 'wired'
-  const back = { href: '/', label: 'Roster' }
   // Top-bar trailing actions (app-bar right group, design source
   // clean-pilot.html `.bar-actions`): Share (publish) stays inline; Print,
   // Export and the container control tuck into the "⋯" overflow at every width — the app

--- a/apps/itun/src/components/sheet/SnapshotSheet.tsx
+++ b/apps/itun/src/components/sheet/SnapshotSheet.tsx
@@ -10,6 +10,10 @@
  * fully independent of local state. With no SoftLinks the resolver yields
  * the single-entity mode — no rail chips to other people's data.
  *
+ * The frozen store and the Zod parse both live in `frozenSheet.ts`, shared with
+ * the Game crew view (`GameEntitySheet`), which needs the same
+ * read-without-owning mechanism for a crewmate's build.
+ *
  * Snapshot payload shape (as published by PublishButton v1):
  *   { kind: 'pilot' | 'mech' | 'crawler', entity: <entity object> }
  *
@@ -17,19 +21,10 @@
  */
 
 import { useMemo } from 'react'
-import { create } from 'zustand'
 
 import { isRecord } from '../../lib/isRecord'
-import type { Crawler } from '../../lib/schemas/crawler'
-import type { Mech } from '../../lib/schemas/mech'
-import type { Pilot } from '../../lib/schemas/pilot'
-import { CrawlerSchema } from '../../lib/schemas/crawler'
-import { MechSchema } from '../../lib/schemas/mech'
-import { PilotSchema, normalizeLegacyPilotRecord } from '../../lib/schemas/pilot'
-import { normalizeLegacyCargoRecord } from '../../lib/schemas/cargoLot'
-import type { useEntityStore } from '../../stores/entityStore'
-import type { EntityType } from '../../stores/entityStore'
 import { AppLink } from '../shared/AppLink'
+import { makeFrozenStore, parseFrozenEntity } from './frozenSheet'
 
 import { Sheet } from './Sheet'
 
@@ -56,104 +51,10 @@ function parseContext(snapshot: Record<string, unknown>): string[] | undefined {
   return refs.filter((r): r is string => typeof r === 'string')
 }
 
-type ParseResult =
-  | { ok: true; kind: 'pilot'; entity: Pilot }
-  | { ok: true; kind: 'mech'; entity: Mech; pilotAbilities?: string[] }
-  | { ok: true; kind: 'crawler'; entity: Crawler }
-  | { ok: false; reason: string }
-
-function parseSnapshot(snapshot: Record<string, unknown>): ParseResult {
-  const kind = snapshot.kind
-  const entity = snapshot.entity
-
-  if (!isRecord(entity) || Array.isArray(entity)) {
-    return { ok: false, reason: 'Snapshot entity is missing or invalid.' }
-  }
-
-  if (kind === 'pilot') {
-    // Snapshots published before the vestigial `rollResults` removal still
-    // carry the field — same rewrite parseImportBundle applies.
-    const parsed = PilotSchema.safeParse(normalizeLegacyPilotRecord(entity))
-    if (!parsed.success) {
-      return {
-        ok: false,
-        reason: `Invalid pilot data: ${parsed.error.message}`,
-      }
-    }
-    return { ok: true, kind: 'pilot', entity: parsed.data }
-  }
-
-  if (kind === 'mech') {
-    // Snapshots published before the cargo→cargoLots rename carry a legacy
-    // `cargo: string[]` field — same rewrite parseImportBundle applies.
-    const parsed = MechSchema.safeParse(normalizeLegacyCargoRecord(entity))
-    if (!parsed.success) {
-      return {
-        ok: false,
-        reason: `Invalid mech data: ${parsed.error.message}`,
-      }
-    }
-    return { ok: true, kind: 'mech', entity: parsed.data, pilotAbilities: parseContext(snapshot) }
-  }
-
-  if (kind === 'crawler') {
-    const parsed = CrawlerSchema.safeParse(entity)
-    if (!parsed.success) {
-      return {
-        ok: false,
-        reason: `Invalid crawler data: ${parsed.error.message}`,
-      }
-    }
-    return { ok: true, kind: 'crawler', entity: parsed.data }
-  }
-
-  return { ok: false, reason: `Unknown entity kind: ${String(kind)}` }
-}
-
-type EntityState = ReturnType<typeof useEntityStore.getState>
-
-/**
- * A read-only entity store containing ONLY the snapshot entity. Reads serve
- * the frozen record; writes throw (unreachable behind `readOnly`).
- */
-function makeSnapshotStore(parsed: Extract<ParseResult, { ok: true }>): typeof useEntityStore {
-  const readOnlyWrite = async (): Promise<never> => {
-    throw new Error('Snapshots are read-only.')
-  }
-
-  const byType = (type: EntityType): Array<Pilot | Mech | Crawler> => {
-    if (type === parsed.kind) return [parsed.entity]
-    return []
-  }
-
-  const state: EntityState = {
-    pilots: parsed.kind === 'pilot' ? [parsed.entity] : [],
-    mechs: parsed.kind === 'mech' ? [parsed.entity] : [],
-    crawlers: parsed.kind === 'crawler' ? [parsed.entity] : [],
-    softLinks: [],
-    hydrated: { pilots: true, mechs: true, crawlers: true, softLinks: true },
-    hydrate: async () => {},
-    rehydrate: async () => {},
-    list: ((type: EntityType) => byType(type)) as EntityState['list'],
-    get: ((type: EntityType, id: string) =>
-      byType(type).find((e) => e.id === id) ?? null) as EntityState['get'],
-    create: readOnlyWrite,
-    // A snapshot is frozen and container-less (ADR-004), so there is no server
-    // row it could be a cache of — adoption is as unavailable as any other write.
-    adopt: readOnlyWrite,
-    forget: readOnlyWrite,
-    update: readOnlyWrite,
-    updateCrawlerBay: readOnlyWrite,
-    delete: readOnlyWrite,
-    transfer: readOnlyWrite,
-  }
-
-  return create<EntityState>(() => state)
-}
-
 export function SnapshotSheet({ snapshot }: SnapshotSheetProps) {
-  const result = useMemo(() => parseSnapshot(snapshot), [snapshot])
-  const store = useMemo(() => (result.ok ? makeSnapshotStore(result) : null), [result])
+  const result = useMemo(() => parseFrozenEntity(snapshot.kind, snapshot.entity), [snapshot])
+  const store = useMemo(() => (result.ok ? makeFrozenStore(result) : null), [result])
+  const pilotAbilities = useMemo(() => parseContext(snapshot), [snapshot])
 
   if (!result.ok || !store) {
     // Styled validation-failure state (plan 5.2) — invalid payloads land
@@ -191,7 +92,7 @@ export function SnapshotSheet({ snapshot }: SnapshotSheetProps) {
         kind={result.kind}
         id={result.entity.id}
         store={store}
-        pilotAbilities={result.kind === 'mech' ? result.pilotAbilities : undefined}
+        pilotAbilities={result.kind === 'mech' ? pilotAbilities : undefined}
         readOnly
       />
     </div>

--- a/apps/itun/src/components/sheet/frozenSheet.ts
+++ b/apps/itun/src/components/sheet/frozenSheet.ts
@@ -1,0 +1,128 @@
+/**
+ * The frozen-sheet path: render an entity nobody in this browser owns, without
+ * writing it anywhere.
+ *
+ * ## Why this is a module rather than a prop on Sheet
+ *
+ * Two surfaces need to show a build read-only, and they arrive at it from
+ * opposite directions. A published snapshot (`/s/$id`, ADR-004) is a frozen
+ * payload fetched from the snapshot Functions with no account behind it; a
+ * crewmate's pilot on a Game roster (ADR-030 §5) is a live server row the
+ * viewer may read but never write. What they share is the mechanism — a
+ * private, read-only Zustand store holding exactly one entity, threaded through
+ * the same `Sheet` the live surfaces use — so the mechanism lives here and each
+ * surface keeps its own framing.
+ *
+ * ## The thing this deliberately does NOT do
+ *
+ * It never calls `entityStore.adopt`. Caching a crewmate's pilot into IndexedDB
+ * to render it would put somebody else's character among the viewer's own
+ * builds, under a container they do not control, with a local copy that goes
+ * stale the moment its owner edits it — and `gameRoster.ts` already refuses to
+ * hand out an editor whose writes the server rejects. Reading is not owning, so
+ * a read leaves no trace.
+ */
+
+import { create } from 'zustand'
+
+import { isRecord } from '../../lib/isRecord'
+import type { Crawler } from '../../lib/schemas/crawler'
+import type { Mech } from '../../lib/schemas/mech'
+import type { Pilot } from '../../lib/schemas/pilot'
+import { CrawlerSchema } from '../../lib/schemas/crawler'
+import { MechSchema } from '../../lib/schemas/mech'
+import { PilotSchema, normalizeLegacyPilotRecord } from '../../lib/schemas/pilot'
+import { normalizeLegacyCargoRecord } from '../../lib/schemas/cargoLot'
+import type { EntityType, useEntityStore } from '../../stores/entityStore'
+
+/** A parsed frozen entity, or the reason it could not be parsed. */
+export type FrozenParse =
+  | { ok: true; kind: 'pilot'; entity: Pilot }
+  | { ok: true; kind: 'mech'; entity: Mech }
+  | { ok: true; kind: 'crawler'; entity: Crawler }
+  | { ok: false; reason: string }
+
+/**
+ * Validate an untrusted entity body against the schema for its kind.
+ *
+ * Untrusted in both callers, and for the same reason: a snapshot payload was
+ * published by some other version of this app, and a server row was written by
+ * some other player's browser. Neither is a record this session created, so
+ * both go through Zod rather than a cast — a mismatch renders an explanation,
+ * never a crash mid-sheet.
+ */
+export function parseFrozenEntity(kind: unknown, entity: unknown): FrozenParse {
+  if (!isRecord(entity) || Array.isArray(entity)) {
+    return { ok: false, reason: 'Entity data is missing or invalid.' }
+  }
+
+  if (kind === 'pilot') {
+    // Records written before the vestigial `rollResults` removal still carry
+    // the field — the same rewrite parseImportBundle applies.
+    const parsed = PilotSchema.safeParse(normalizeLegacyPilotRecord(entity))
+    return parsed.success
+      ? { ok: true, kind: 'pilot', entity: parsed.data }
+      : { ok: false, reason: `Invalid pilot data: ${parsed.error.message}` }
+  }
+
+  if (kind === 'mech') {
+    // Records written before the cargo→cargoLots rename carry a legacy
+    // `cargo: string[]` field — the same rewrite parseImportBundle applies.
+    const parsed = MechSchema.safeParse(normalizeLegacyCargoRecord(entity))
+    return parsed.success
+      ? { ok: true, kind: 'mech', entity: parsed.data }
+      : { ok: false, reason: `Invalid mech data: ${parsed.error.message}` }
+  }
+
+  if (kind === 'crawler') {
+    const parsed = CrawlerSchema.safeParse(entity)
+    return parsed.success
+      ? { ok: true, kind: 'crawler', entity: parsed.data }
+      : { ok: false, reason: `Invalid crawler data: ${parsed.error.message}` }
+  }
+
+  return { ok: false, reason: `Unknown entity kind: ${String(kind)}` }
+}
+
+type EntityState = ReturnType<typeof useEntityStore.getState>
+
+/**
+ * A read-only entity store containing ONLY the frozen entity. Reads serve the
+ * one record; every write throws.
+ *
+ * The throws are unreachable in practice — `readOnly` suppresses every edit
+ * affordance on the sheet — and that is exactly why they throw rather than
+ * no-op: a silent no-op would let a future editing control look like it saved.
+ */
+export function makeFrozenStore(parsed: Extract<FrozenParse, { ok: true }>): typeof useEntityStore {
+  const readOnlyWrite = async (): Promise<never> => {
+    throw new Error('This sheet is read-only.')
+  }
+
+  const byType = (type: EntityType): Array<Pilot | Mech | Crawler> =>
+    type === parsed.kind ? [parsed.entity] : []
+
+  const state: EntityState = {
+    pilots: parsed.kind === 'pilot' ? [parsed.entity] : [],
+    mechs: parsed.kind === 'mech' ? [parsed.entity] : [],
+    crawlers: parsed.kind === 'crawler' ? [parsed.entity] : [],
+    softLinks: [],
+    hydrated: { pilots: true, mechs: true, crawlers: true, softLinks: true },
+    hydrate: async () => {},
+    rehydrate: async () => {},
+    list: ((type: EntityType) => byType(type)) as EntityState['list'],
+    get: ((type: EntityType, id: string) =>
+      byType(type).find((e) => e.id === id) ?? null) as EntityState['get'],
+    create: readOnlyWrite,
+    // Adoption is a write like any other: this store exists precisely so that
+    // reading somebody else's build does not put a copy of it anywhere.
+    adopt: readOnlyWrite,
+    forget: readOnlyWrite,
+    update: readOnlyWrite,
+    updateCrawlerBay: readOnlyWrite,
+    delete: readOnlyWrite,
+    transfer: readOnlyWrite,
+  }
+
+  return create<EntityState>(() => state)
+}

--- a/apps/itun/src/lib/games/gameRoster.ts
+++ b/apps/itun/src/lib/games/gameRoster.ts
@@ -45,7 +45,7 @@ export type GameMember = {
 
 /** What the viewer may do with one row. */
 export type RowCapabilities = {
-  /** There is a sheet to open — either already in this browser, or fetchable. */
+  /** The viewer may open the row's EDITABLE live sheet. Mirrors `assertMayWrite`. */
   openSheet: boolean
   /** Free, and the viewer is in the Game: they can take it. */
   claim: boolean
@@ -148,14 +148,18 @@ function bodyOf(body: unknown): Record<string, unknown> {
  * whether a row can open a sheet *without a round trip*, not whether it may —
  * see `openSheet` below.
  *
- * The `openSheet` rule is the one place this file is stricter than it strictly
- * has to be, and deliberately: only what the viewer **owns** offers a sheet.
- * ADR-030 §5 does allow reading a crewmate's sheet, but ITUN's sheet is a
- * *live, editing* surface backed by local storage — caching a crewmate's pilot
- * into it would hand the viewer an editor whose writes the server then refuses,
- * and a sheet that silently stops saving is worse than no link at all. A
- * read-only drill-in is its own surface and is not built yet; the crew strip
- * carries the vitals in the meantime.
+ * `openSheet` means the EDITABLE live sheet, so it mirrors `assertMayWrite`:
+ * only the owner. That is not the same as "only the owner may look" — ADR-030
+ * §5 allows reading a crewmate's sheet, and every row is now readable through
+ * the frozen crew view (`GameEntitySheet`), which renders the server body
+ * behind a store that throws on write and caches nothing locally.
+ *
+ * The distinction is the whole point. What was never safe was handing a
+ * non-owner ITUN's *live* sheet — an editing surface backed by local storage,
+ * whose writes the server then refuses, so it would silently stop saving. A
+ * read-only surface has no such failure mode, so reading needs no capability
+ * flag here: membership in the Game is the only gate, and the server's own
+ * listing query already enforces it.
  */
 export function ownableRows(args: {
   kind: 'pilot' | 'mech'

--- a/apps/itun/src/routeTree.gen.ts
+++ b/apps/itun/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as SIdRouteImport } from './routes/s/$id'
 import { Route as MechsPatternsIndexRouteImport } from './routes/mechs/patterns/index'
 import { Route as SheetKindIdRouteImport } from './routes/sheet/$kind/$id'
 import { Route as SheetKindIdShareRouteImport } from './routes/sheet/$kind/$id_.share'
+import { Route as GamesGameIdViewKindEntityIdRouteImport } from './routes/games_.$gameId_.view.$kind.$entityId'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -130,6 +131,12 @@ const SheetKindIdShareRoute = SheetKindIdShareRouteImport.update({
   path: '/sheet/$kind/$id/share',
   getParentRoute: () => rootRouteImport,
 } as any)
+const GamesGameIdViewKindEntityIdRoute =
+  GamesGameIdViewKindEntityIdRouteImport.update({
+    id: '/games_/$gameId_/view/$kind/$entityId',
+    path: '/games/$gameId/view/$kind/$entityId',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -152,6 +159,7 @@ export interface FileRoutesByFullPath {
   '/sheet/$kind/$id': typeof SheetKindIdRoute
   '/mechs/patterns/': typeof MechsPatternsIndexRoute
   '/sheet/$kind/$id/share': typeof SheetKindIdShareRoute
+  '/games/$gameId/view/$kind/$entityId': typeof GamesGameIdViewKindEntityIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -174,6 +182,7 @@ export interface FileRoutesByTo {
   '/sheet/$kind/$id': typeof SheetKindIdRoute
   '/mechs/patterns': typeof MechsPatternsIndexRoute
   '/sheet/$kind/$id/share': typeof SheetKindIdShareRoute
+  '/games/$gameId/view/$kind/$entityId': typeof GamesGameIdViewKindEntityIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -197,6 +206,7 @@ export interface FileRoutesById {
   '/sheet/$kind/$id': typeof SheetKindIdRoute
   '/mechs/patterns/': typeof MechsPatternsIndexRoute
   '/sheet/$kind/$id_/share': typeof SheetKindIdShareRoute
+  '/games_/$gameId_/view/$kind/$entityId': typeof GamesGameIdViewKindEntityIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -221,6 +231,7 @@ export interface FileRouteTypes {
     | '/sheet/$kind/$id'
     | '/mechs/patterns/'
     | '/sheet/$kind/$id/share'
+    | '/games/$gameId/view/$kind/$entityId'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -243,6 +254,7 @@ export interface FileRouteTypes {
     | '/sheet/$kind/$id'
     | '/mechs/patterns'
     | '/sheet/$kind/$id/share'
+    | '/games/$gameId/view/$kind/$entityId'
   id:
     | '__root__'
     | '/'
@@ -265,6 +277,7 @@ export interface FileRouteTypes {
     | '/sheet/$kind/$id'
     | '/mechs/patterns/'
     | '/sheet/$kind/$id_/share'
+    | '/games_/$gameId_/view/$kind/$entityId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -288,6 +301,7 @@ export interface RootRouteChildren {
   SheetKindIdRoute: typeof SheetKindIdRoute
   MechsPatternsIndexRoute: typeof MechsPatternsIndexRoute
   SheetKindIdShareRoute: typeof SheetKindIdShareRoute
+  GamesGameIdViewKindEntityIdRoute: typeof GamesGameIdViewKindEntityIdRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -432,6 +446,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SheetKindIdShareRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/games_/$gameId_/view/$kind/$entityId': {
+      id: '/games_/$gameId_/view/$kind/$entityId'
+      path: '/games/$gameId/view/$kind/$entityId'
+      fullPath: '/games/$gameId/view/$kind/$entityId'
+      preLoaderRoute: typeof GamesGameIdViewKindEntityIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -456,6 +477,7 @@ const rootRouteChildren: RootRouteChildren = {
   SheetKindIdRoute: SheetKindIdRoute,
   MechsPatternsIndexRoute: MechsPatternsIndexRoute,
   SheetKindIdShareRoute: SheetKindIdShareRoute,
+  GamesGameIdViewKindEntityIdRoute: GamesGameIdViewKindEntityIdRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/itun/src/routes/games_.$gameId_.view.$kind.$entityId.tsx
+++ b/apps/itun/src/routes/games_.$gameId_.view.$kind.$entityId.tsx
@@ -1,0 +1,46 @@
+import { createFileRoute, useParams } from '@tanstack/react-router'
+
+import { GameEntitySheet, GameSheetNotice } from '../components/games/GameEntitySheet'
+import type { RosterKind } from '../lib/games/gameRoster'
+
+/**
+ * One crewmate's build, read-only (ADR-030 §5).
+ *
+ * The trailing `_` on BOTH `games_` and `$gameId_` opts this route out of
+ * nesting twice over: once from `routes/games.tsx` (the lobby, which renders no
+ * `<Outlet />`), and once from `games_.$gameId.tsx` (the crew roster, likewise).
+ * Without the second underscore TanStack would treat the crew screen as this
+ * route's layout and render the roster above every sheet — or, since it has no
+ * Outlet, render nothing at all.
+ *
+ * Addressed by the Convex row id rather than the local entity id: the viewer
+ * has no local copy of a crewmate's build, and the whole point of this surface
+ * is that visiting it does not create one.
+ */
+export const Route = createFileRoute('/games_/$gameId_/view/$kind/$entityId')({
+  component: GameEntityViewRoute,
+})
+
+/** The three roster ontologies, as the URL is allowed to spell them. */
+const KINDS: readonly RosterKind[] = ['pilot', 'mech', 'crawler']
+
+function isRosterKind(value: string): value is RosterKind {
+  return (KINDS as readonly string[]).includes(value)
+}
+
+function GameEntityViewRoute() {
+  const { gameId, kind, entityId } = useParams({ from: '/games_/$gameId_/view/$kind/$entityId' })
+
+  // `kind` comes off the URL and selects a Zod schema downstream, so a
+  // hand-typed or stale path is narrowed here rather than cast — it earns an
+  // explanation and a way back, not a crash inside the parser.
+  if (!isRosterKind(kind)) {
+    return (
+      <GameSheetNotice gameId={gameId}>
+        “{kind}” is not something a game holds. The crew has pilots, mechs and a crawler.
+      </GameSheetNotice>
+    )
+  }
+
+  return <GameEntitySheet gameId={gameId} kind={kind} entityId={entityId} />
+}

--- a/packages/component-lib/src/components/shared/EntityRow.tsx
+++ b/packages/component-lib/src/components/shared/EntityRow.tsx
@@ -1,4 +1,4 @@
-import { Fragment, isValidElement } from 'react'
+import { Fragment } from 'react'
 import type { ElementType, ReactNode } from 'react'
 import { Bot, type LucideIcon, Trash2, UserRound, Users, Warehouse } from 'lucide-react'
 import { cn } from '../../utils/cn'
@@ -24,13 +24,16 @@ import { Stat } from './Stat'
  *   │   thing IS, and how it is doing. The title follows the entity card's own
  *   │   rule (`EntityCardHeader`): paper-white text directly on the tone, no
  *   │   ink block behind it, at the size ladder's `small` rung.
- *   │ ▸ BODY — paper. Ontology-toned meta badges, quiet caption chips, and the
- *   │   trailing View / Delete controls. Details, and verbs.
+ *   │ ▸ BODY — paper. Cross-links, and the trailing View / Delete controls.
+ *   │   Where you GO and what you DO.
  *   └──────────────────────────────────┘
  *
- * Vitals live in the BAND, not the body, because they are what a roster is
- * scanned for: a column of forty rows should let the eye run down HP or SP
- * without crossing the buttons. The body is where the things you press live.
+ * EVERY `label | value` fact lives in the band — the class and callsign as much
+ * as SP and Heat, because a stat is a stat whether its value is a number or a
+ * name. Splitting them across two registers meant `CLASS | Salvager` and
+ * `SP | 12` were the same kind of statement rendered two different ways in two
+ * different places. It also means a column of forty rows can be scanned down
+ * one edge without the eye crossing the buttons.
  *
  * It previously said its ontology twice and in neither of the card's ways: a
  * 6px deep-tone rail down the left edge, over a body tinted ~10% with the same
@@ -66,28 +69,6 @@ export type EntityRowStat = {
   value: string | number
 }
 
-/**
- * A `label | value` DETAIL in the row's body — the same horizontal `Stat` cell
- * the band uses, tinted on its label plate by ontology.
- *
- * Details are the body's whole vocabulary. They were loose badges (`"GHOST"`,
- * `SCAVENGER`, `IRON JAW`) which stated a value with no name attached: the
- * reader had to infer that one was a callsign, one a class and one a linked
- * mech, from nothing but position and colour. A `Stat` says which is which —
- * `CALLSIGN | Ghost`, `CLASS | Scavenger` — and it is the primitive every other
- * `label | value` in the system already renders through (ruleset §3.7).
- *
- * `tone` tints the LABEL plate only, which is the sanctioned chip role for
- * `Stat` (see its `bgColor` docs): the value stays ink-canonical, so a cell
- * carries its ontology without spending the value's legibility on it.
- */
-export type EntityRowDetail = {
-  label: string | number
-  value: string | number
-  /** Ontology tint for the label plate. Omit for the quiet default. */
-  tone?: EntityRowType
-}
-
 /** The filled row: a linked player entity. */
 type FilledEntityRowProps = {
   /** Entity ontology driving the header band's tone. */
@@ -113,20 +94,19 @@ type FilledEntityRowProps = {
    */
   meta?: ReactNode | ReactNode[]
   /**
-   * The row's DETAILS, rendered in the body beneath the band.
+   * Body content beneath the band — nodes, rendered as given.
    *
-   * Each entry is either an `EntityRowDetail` (`label | value`, rendered as a
-   * tinted horizontal `Stat`) or a ReactNode, rendered as given — which is how
-   * a cross-link arrives, since only the app knows how to build its own router
-   * link. Bare strings still render as quiet chips, for a caller with a value
-   * and genuinely no name for it.
+   * This is how a CROSS-LINK arrives: only the app can build its own router
+   * link, so it hands over an anchor wrapping its own `Stat`. Bare strings
+   * render as quiet chips, for a value with genuinely no name to give it.
    *
-   * It began as one free-form node that callers joined with ' · ' separators
-   * into a muted grey line, became a row of chips, and is now stats: each step
-   * removed an inference the reader was making for the row. A chip saying
-   * "Ghost" is a value with its name rubbed off.
+   * Anything that is a `label | value` FACT belongs in `stats`, in the band —
+   * not here. That is where the class, the callsign and the chassis went: a
+   * stat is a stat whether its value is a number or a name, and splitting them
+   * across two registers meant `CLASS | Salvager` and `SP | 12` were the same
+   * kind of statement rendered two different ways in two different places.
    */
-  metaLine?: ReactNode | Array<ReactNode | EntityRowDetail>
+  metaLine?: ReactNode | ReactNode[]
   /**
    * A stamp pinned to the row's TOP-RIGHT corner — the mark applied ON the
    * record about its status, as distinct from `actions` (things you do to it)
@@ -228,35 +208,9 @@ const TONE: Record<EntityRowType, { band: string; ink: string }> = {
  * passing `undefined` (or a falsy conditional) renders nothing rather than an
  * empty chip.
  */
-function toEntries(
-  value: ReactNode | Array<ReactNode | EntityRowDetail>
-): Array<ReactNode | EntityRowDetail> {
-  return (Array.isArray(value) ? value : [value]).filter(
-    (node) => node !== null && node !== undefined && node !== false && node !== ''
-  )
-}
-
-/** The node-only flavour, for `meta` — which never carries details. */
 function toNodes(value: ReactNode | ReactNode[]): ReactNode[] {
   return (Array.isArray(value) ? value : [value]).filter(
     (node) => node !== null && node !== undefined && node !== false && node !== ''
-  )
-}
-
-/**
- * Is this entry a `label | value` detail rather than something to render as-is?
- *
- * `isValidElement` is checked FIRST because a React element is also a plain
- * object, and a component whose props happened to include `label` would
- * otherwise be mistaken for a detail and rendered as a stat.
- */
-function isDetail(entry: ReactNode | EntityRowDetail): entry is EntityRowDetail {
-  return (
-    !isValidElement(entry) &&
-    typeof entry === 'object' &&
-    entry !== null &&
-    'label' in entry &&
-    'value' in entry
   )
 }
 
@@ -327,7 +281,7 @@ export function EntityRow(props: EntityRowProps) {
   // a caller passing `undefined` (or a falsy conditional) renders no badge at
   // all rather than an empty one.
   const metaBadges = toNodes(meta)
-  const captionParts = toEntries(metaLine)
+  const captionParts = toNodes(metaLine)
   const hasStats = (stats?.length ?? 0) > 0
   const hasBody =
     captionParts.length > 0 ||
@@ -374,7 +328,13 @@ export function EntityRow(props: EntityRowProps) {
             // border half above the frame, so its intrusion is vertical, and
             // clearing it downward frees the band's right edge for the stats
             // (which a `pr-24` reserve had stranded in the middle of the band).
-            seal && 'pt-3'
+            //
+            // The clearance is generous on purpose. The stats sit at the same
+            // right edge the seal hangs over, so a tight allowance left the
+            // stamp appearing to rest ON the first stat plate rather than on
+            // the border above it — two black plates a hair apart, reading as
+            // one smudged stack.
+            seal && 'pt-5'
           )}
           style={{ background: tone.band, color: tone.ink }}
         >
@@ -448,22 +408,9 @@ export function EntityRow(props: EntityRowProps) {
                 </Badge>
               ))}
               {captionParts.map((part, i) =>
-                isDetail(part) ? (
-                  <Stat
-                    // biome-ignore lint/suspicious/noArrayIndexKey: positional detail cells that never reorder; a callsign is a worse key than its slot
-                    key={i}
-                    label={part.label}
-                    value={part.value}
-                    orientation="horizontal"
-                    size="mini"
-                    // Tint the LABEL plate only — the value stays ink-canonical,
-                    // which is the sanctioned chip role for a Stat.
-                    bgColor={part.tone ? TONE[part.tone].band : undefined}
-                    textColor={part.tone ? TONE[part.tone].ink : undefined}
-                  />
-                ) : typeof part === 'string' || typeof part === 'number' ? (
+                typeof part === 'string' || typeof part === 'number' ? (
                   <Badge
-                    // biome-ignore lint/suspicious/noArrayIndexKey: as above
+                    // biome-ignore lint/suspicious/noArrayIndexKey: positional caption parts that never reorder; a value is a worse key than its slot
                     key={i}
                     surface="quiet"
                     className="max-w-full truncate"

--- a/packages/component-lib/src/components/shared/EntityRow.tsx
+++ b/packages/component-lib/src/components/shared/EntityRow.tsx
@@ -20,8 +20,10 @@ import { Stat } from './Stat'
  *   ┌────────────────╨───────╨─────────┐
  *   │ ▸ HEADER BAND — solid ontology tone (pilot → orange, mech → green,
  *   │   crawler → pink, game → blue, the `--color-sheet-*` tokens), carrying
- *   │   the black name stamp on the left and the row's `stats` on the right.
- *   │   What the thing IS, and how it is doing.
+ *   │   the TITLE on the left and the row's `stats` on the right. What the
+ *   │   thing IS, and how it is doing. The title follows the entity card's own
+ *   │   rule (`EntityCardHeader`): paper-white text directly on the tone, no
+ *   │   ink block behind it, at the size ladder's `small` rung.
  *   │ ▸ BODY — paper. Ontology-toned meta badges, quiet caption chips, and the
  *   │   trailing View / Delete controls. Details, and verbs.
  *   └──────────────────────────────────┘
@@ -376,12 +378,32 @@ export function EntityRow(props: EntityRowProps) {
           )}
           style={{ background: tone.band, color: tone.ink }}
         >
-          {/* Black name tab — the canonical stamp, not a hand-rolled span. It
-              was the latter (rounded-pip, its own padding/size), which is the
-              drift the stamp atom exists to prevent. */}
-          <Badge shape="stamp" size="full" className="block max-w-full truncate align-middle">
+          {/* The title, under the ENTITY CARD's title rule (`EntityCardHeader`):
+              plain paper-white text sitting directly ON the tone — no ink
+              name-tab block behind it — condensed, bold, uppercase, tight caps
+              tracking, hugging its own text rather than filling the band.
+
+              It was a black stamp plate, which is the treatment cards use for
+              their SEAM tags and eyebrows, not for a name. Two different
+              answers to "how does an entity announce itself" in one system was
+              the drift; the card's is the one that wins, so a row's title and a
+              card's title are now the same object at a different rung.
+
+              `text-base` is the ladder's `small` rung at depth 0 — a row is the
+              card's compact translation, so it sits where a small card sits,
+              and it is meaningfully larger than the stamp it replaces.
+
+              `break-words` so an unbreakable token wraps instead of running
+              under the stat cluster beside it. */}
+          <span
+            className={cn(
+              'w-fit min-w-0 self-center break-words',
+              'font-cond text-base font-bold uppercase leading-none tracking-caps-tight',
+              'text-paper'
+            )}
+          >
             {name}
-          </Badge>
+          </span>
           {hasStats && (
             <div className="ml-auto flex flex-wrap items-center justify-end gap-x-2 gap-y-1">
               {stats?.map((stat) => (

--- a/packages/component-lib/src/components/shared/EntityRow.tsx
+++ b/packages/component-lib/src/components/shared/EntityRow.tsx
@@ -78,11 +78,27 @@ type FilledEntityRowProps = {
   /** Entity name rendered in the black pseudoheader name tab. */
   name: string
   /**
-   * Subheader stat content. Each entry renders through the canonical
-   * Stat (horizontal `label | value` mode) — never hand-assembled text
-   * (see the stats-render-through-Stat law, ruleset §3).
+   * The stats carried in the HEADER BAND, opposite the title. Each renders
+   * through the canonical Stat (horizontal `label | value` mode) — never
+   * hand-assembled text (see the stats-render-through-Stat law, ruleset §3).
+   *
+   * This is the row's PRIMARY register: what a reader scans a column of forty
+   * rows for. Keep it short. A band asked to carry six cells stops being a
+   * scannable edge and becomes a queue — put the rest in `bodyStats`.
    */
   stats?: EntityRowStat[]
+  /**
+   * The SECONDARY stats, rendered in the body beside the controls.
+   *
+   * Same cell, same primitive, lower billing — for facts that belong to the row
+   * but are not what you scan it for. A Game states what the table IS in the
+   * band (its crawler, its pilots, its mechs) and your standing at it down here
+   * (your role, the member count, the template it came from).
+   *
+   * The split is the point. Everything was briefly in the band, which made the
+   * one line a reader is meant to scan the longest line on the row.
+   */
+  bodyStats?: EntityRowStat[]
   /**
    * Class/role label(s) beside the stats — rendered as ontology-toned Badges
    * (pilot → orange, mech → green, crawler → pink, game → blue), never plain
@@ -269,6 +285,7 @@ export function EntityRow(props: EntityRowProps) {
     entityType,
     name,
     stats,
+    bodyStats,
     meta,
     metaLine,
     seal,
@@ -286,6 +303,7 @@ export function EntityRow(props: EntityRowProps) {
   const hasBody =
     captionParts.length > 0 ||
     metaBadges.length > 0 ||
+    (bodyStats?.length ?? 0) > 0 ||
     !!actions ||
     sheetHref !== undefined ||
     !!onDeleteClick
@@ -394,6 +412,17 @@ export function EntityRow(props: EntityRowProps) {
                 with four buttons truncated its chips rather than dropping the
                 controls to their own line. */}
             <div className="flex min-w-[9rem] flex-1 flex-wrap items-center gap-x-2 gap-y-1">
+              {/* The SECONDARY stats — the same cell as the band's, in the
+                  quieter register. See `bodyStats`. */}
+              {bodyStats?.map((stat) => (
+                <Stat
+                  key={String(stat.label)}
+                  label={stat.label}
+                  value={stat.value}
+                  orientation="horizontal"
+                  size="mini"
+                />
+              ))}
               {/* The class/role badge is keyed to the entity's ontology tone
                   (pilot → orange, mech → green, crawler → pink, game → blue). */}
               {metaBadges.map((badge, i) => (
@@ -435,7 +464,7 @@ export function EntityRow(props: EntityRowProps) {
                 <Link
                   href={sheetHref}
                   className={cn(
-                    buttonVariants({ variant: 'default', size: 'compact' }),
+                    buttonVariants({ variant: 'default', size: 'mini' }),
                     'no-underline'
                   )}
                 >
@@ -445,7 +474,7 @@ export function EntityRow(props: EntityRowProps) {
               {onDeleteClick && (
                 <Button
                   variant="ghost"
-                  size="compact"
+                  size="mini"
                   aria-label={`Delete ${name}`}
                   onClick={onDeleteClick}
                   className="border-transparent px-2 text-status-bad hover:bg-transparent hover:text-status-bad"

--- a/packages/component-lib/src/components/shared/EntityRow.tsx
+++ b/packages/component-lib/src/components/shared/EntityRow.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react'
+import { Fragment, isValidElement } from 'react'
 import type { ElementType, ReactNode } from 'react'
 import { Bot, type LucideIcon, Trash2, UserRound, Users, Warehouse } from 'lucide-react'
 import { cn } from '../../utils/cn'
@@ -64,6 +64,28 @@ export type EntityRowStat = {
   value: string | number
 }
 
+/**
+ * A `label | value` DETAIL in the row's body — the same horizontal `Stat` cell
+ * the band uses, tinted on its label plate by ontology.
+ *
+ * Details are the body's whole vocabulary. They were loose badges (`"GHOST"`,
+ * `SCAVENGER`, `IRON JAW`) which stated a value with no name attached: the
+ * reader had to infer that one was a callsign, one a class and one a linked
+ * mech, from nothing but position and colour. A `Stat` says which is which —
+ * `CALLSIGN | Ghost`, `CLASS | Scavenger` — and it is the primitive every other
+ * `label | value` in the system already renders through (ruleset §3.7).
+ *
+ * `tone` tints the LABEL plate only, which is the sanctioned chip role for
+ * `Stat` (see its `bgColor` docs): the value stays ink-canonical, so a cell
+ * carries its ontology without spending the value's legibility on it.
+ */
+export type EntityRowDetail = {
+  label: string | number
+  value: string | number
+  /** Ontology tint for the label plate. Omit for the quiet default. */
+  tone?: EntityRowType
+}
+
 /** The filled row: a linked player entity. */
 type FilledEntityRowProps = {
   /** Entity ontology driving the header band's tone. */
@@ -89,26 +111,20 @@ type FilledEntityRowProps = {
    */
   meta?: ReactNode | ReactNode[]
   /**
-   * Caption under the name tab — a wrapping row of quiet chips.
+   * The row's DETAILS, rendered in the body beneath the band.
    *
-   * **Every piece of text on a row is a badge.** Plain strings and numbers
-   * passed here are wrapped in a quiet chip for you; nodes are rendered as
-   * given, because a caller passing a node is passing something already
-   * chipped (a `↳ Name` cross-link is an anchor wrapping a toned Badge, and
-   * re-wrapping it would nest one badge inside another).
+   * Each entry is either an `EntityRowDetail` (`label | value`, rendered as a
+   * tinted horizontal `Stat`) or a ReactNode, rendered as given — which is how
+   * a cross-link arrives, since only the app knows how to build its own router
+   * link. Bare strings still render as quiet chips, for a caller with a value
+   * and genuinely no name for it.
    *
-   * Pass an ARRAY to render several chips. It used to be one free-form node
-   * that callers joined with ' · ' separators into a single muted line, which
-   * left the row with two vocabularies — stamped name, badged class/stats, and
-   * then a run of loose grey prose underneath carrying the callsign, the
-   * chassis and the owner. The separator characters were doing the work a chip
-   * boundary does better.
-   *
-   * Distinct from `meta`: `meta` is the entity's CLASS/ROLE and takes the
-   * ontology tone, whereas these are quiet — the row's tone belongs to what the
-   * entity IS, not to its incidental facts.
+   * It began as one free-form node that callers joined with ' · ' separators
+   * into a muted grey line, became a row of chips, and is now stats: each step
+   * removed an inference the reader was making for the row. A chip saying
+   * "Ghost" is a value with its name rubbed off.
    */
-  metaLine?: ReactNode | ReactNode[]
+  metaLine?: ReactNode | Array<ReactNode | EntityRowDetail>
   /**
    * A stamp pinned to the row's TOP-RIGHT corner — the mark applied ON the
    * record about its status, as distinct from `actions` (things you do to it)
@@ -210,9 +226,35 @@ const TONE: Record<EntityRowType, { band: string; ink: string }> = {
  * passing `undefined` (or a falsy conditional) renders nothing rather than an
  * empty chip.
  */
+function toEntries(
+  value: ReactNode | Array<ReactNode | EntityRowDetail>
+): Array<ReactNode | EntityRowDetail> {
+  return (Array.isArray(value) ? value : [value]).filter(
+    (node) => node !== null && node !== undefined && node !== false && node !== ''
+  )
+}
+
+/** The node-only flavour, for `meta` — which never carries details. */
 function toNodes(value: ReactNode | ReactNode[]): ReactNode[] {
   return (Array.isArray(value) ? value : [value]).filter(
     (node) => node !== null && node !== undefined && node !== false && node !== ''
+  )
+}
+
+/**
+ * Is this entry a `label | value` detail rather than something to render as-is?
+ *
+ * `isValidElement` is checked FIRST because a React element is also a plain
+ * object, and a component whose props happened to include `label` would
+ * otherwise be mistaken for a detail and rendered as a stat.
+ */
+function isDetail(entry: ReactNode | EntityRowDetail): entry is EntityRowDetail {
+  return (
+    !isValidElement(entry) &&
+    typeof entry === 'object' &&
+    entry !== null &&
+    'label' in entry &&
+    'value' in entry
   )
 }
 
@@ -283,7 +325,7 @@ export function EntityRow(props: EntityRowProps) {
   // a caller passing `undefined` (or a falsy conditional) renders no badge at
   // all rather than an empty one.
   const metaBadges = toNodes(meta)
-  const captionParts = toNodes(metaLine)
+  const captionParts = toEntries(metaLine)
   const hasStats = (stats?.length ?? 0) > 0
   const hasBody =
     captionParts.length > 0 ||
@@ -384,9 +426,22 @@ export function EntityRow(props: EntityRowProps) {
                 </Badge>
               ))}
               {captionParts.map((part, i) =>
-                typeof part === 'string' || typeof part === 'number' ? (
+                isDetail(part) ? (
+                  <Stat
+                    // biome-ignore lint/suspicious/noArrayIndexKey: positional detail cells that never reorder; a callsign is a worse key than its slot
+                    key={i}
+                    label={part.label}
+                    value={part.value}
+                    orientation="horizontal"
+                    size="mini"
+                    // Tint the LABEL plate only — the value stays ink-canonical,
+                    // which is the sanctioned chip role for a Stat.
+                    bgColor={part.tone ? TONE[part.tone].band : undefined}
+                    textColor={part.tone ? TONE[part.tone].ink : undefined}
+                  />
+                ) : typeof part === 'string' || typeof part === 'number' ? (
                   <Badge
-                    // biome-ignore lint/suspicious/noArrayIndexKey: positional caption parts that never reorder; a callsign is a worse key than its slot
+                    // biome-ignore lint/suspicious/noArrayIndexKey: as above
                     key={i}
                     surface="quiet"
                     className="max-w-full truncate"
@@ -394,8 +449,8 @@ export function EntityRow(props: EntityRowProps) {
                     {part}
                   </Badge>
                 ) : (
-                  // Already a node — a cross-link anchor wrapping its own toned
-                  // Badge — so it renders as given rather than nested in a chip.
+                  // A node — a cross-link anchor wrapping its own Stat — so it
+                  // renders as given rather than nested inside another cell.
                   // biome-ignore lint/suspicious/noArrayIndexKey: as above
                   <Fragment key={i}>{part}</Fragment>
                 )

--- a/packages/component-lib/src/components/shared/EntityRow.tsx
+++ b/packages/component-lib/src/components/shared/EntityRow.tsx
@@ -1,4 +1,5 @@
-import type { CSSProperties, ElementType, ReactNode } from 'react'
+import { Fragment } from 'react'
+import type { ElementType, ReactNode } from 'react'
 import { Bot, type LucideIcon, Trash2, UserRound, Users, Warehouse } from 'lucide-react'
 import { cn } from '../../utils/cn'
 import { Badge } from '../chrome/Badge'
@@ -10,14 +11,33 @@ import { Stat } from './Stat'
  * EntityRow — a header-only clickable listing ROW: the compact, one-line
  * translation of a `Card` for roster / index surfaces.
  *
- * Anatomy (grounded in ITUN's `EntityListItem`, re-composed on canon atoms):
- * a hover-lift frame (2px ink border, faint tone-wash background) fronted by a
- * 6px deep-tone LEFT accent rail keyed to entity ontology (pilot → orange,
- * mech → green, crawler → pink, game → blue — the `--color-sheet-*` tokens), a black name
- * tab (Barlow Semi Condensed, white-on-ink, caps at 0.04em tracking), an
- * optional muted meta caption beneath it, and trailing View (link) + Delete
- * (ghost trash) actions. Neither action is the rust action colour — a row
- * navigates and removes, it never performs a true game action.
+ * Anatomy — the CARD's, compressed. A row is built from the same bands an
+ * entity card is, in the same order, at the same frame weight
+ * (`--bw-entity`):
+ *
+ *   ┌──────────────────────────────────┐
+ *   │ ▸ HEADER BAND — solid ontology tone, carrying the black name stamp
+ *   │   (pilot → orange, mech → green, crawler → pink, game → blue, the
+ *   │   `--color-sheet-*` tokens). The seal, when present, is pinned to this
+ *   │   band's top-right corner.
+ *   │ ▸ BODY — paper. Caption chips, ontology-toned meta badges, `Stat`s, and
+ *   │   the trailing View / Delete controls.
+ *   └──────────────────────────────────┘
+ *
+ * It previously said its ontology twice and in neither of the card's ways: a
+ * 6px deep-tone rail down the left edge, over a body tinted ~10% with the same
+ * tone. Both are gone. A card states its kind in a band across the top and puts
+ * its content on paper, so a row does too — which also means every chip, stat
+ * and button on a row sits on ONE ground instead of four faintly different
+ * ones.
+ *
+ * Neither trailing action is the rust action colour — a row navigates and
+ * removes, it never performs a true game action.
+ *
+ * **Every piece of text on the row is a badge**: the name is a stamp, the
+ * class/role is a toned badge, stats render through `Stat`, and the caption is
+ * a row of quiet chips. Nothing on a row is loose prose, so the eye reads one
+ * vocabulary down a column of forty of them.
  *
  * Data-source agnostic: View renders `linkAs` (a plain `<a>` by default) styled
  * with `buttonVariants`, so the primitive works with any router or none — an
@@ -40,7 +60,7 @@ export type EntityRowStat = {
 
 /** The filled row: a linked player entity. */
 type FilledEntityRowProps = {
-  /** Entity ontology driving the accent rail + tone wash. */
+  /** Entity ontology driving the header band's tone. */
   entityType: EntityRowType
   /** Filled is the default; omit or pass `false`. */
   empty?: false
@@ -63,14 +83,41 @@ type FilledEntityRowProps = {
    */
   meta?: ReactNode | ReactNode[]
   /**
-   * Free-form caption under the name tab — muted, single-line, truncating.
+   * Caption under the name tab — a wrapping row of quiet chips.
    *
-   * Distinct from `meta`: `meta` is the entity's CLASS/ROLE and renders as an
-   * ontology-toned Badge, whereas this line carries arbitrary nodes such as a
-   * callsign and `↳ Name` cross-links to other sheets. Links inside a toned
-   * Badge would be illegible, which is why these are two props and not one.
+   * **Every piece of text on a row is a badge.** Plain strings and numbers
+   * passed here are wrapped in a quiet chip for you; nodes are rendered as
+   * given, because a caller passing a node is passing something already
+   * chipped (a `↳ Name` cross-link is an anchor wrapping a toned Badge, and
+   * re-wrapping it would nest one badge inside another).
+   *
+   * Pass an ARRAY to render several chips. It used to be one free-form node
+   * that callers joined with ' · ' separators into a single muted line, which
+   * left the row with two vocabularies — stamped name, badged class/stats, and
+   * then a run of loose grey prose underneath carrying the callsign, the
+   * chassis and the owner. The separator characters were doing the work a chip
+   * boundary does better.
+   *
+   * Distinct from `meta`: `meta` is the entity's CLASS/ROLE and takes the
+   * ontology tone, whereas these are quiet — the row's tone belongs to what the
+   * entity IS, not to its incidental facts.
    */
-  metaLine?: ReactNode
+  metaLine?: ReactNode | ReactNode[]
+  /**
+   * A stamp pinned to the row's TOP-RIGHT corner — the mark applied ON the
+   * record about its status, as distinct from `actions` (things you do to it)
+   * and `meta` (what it is).
+   *
+   * A slot rather than a typed prop for the same reason `actions` is one: what
+   * a row is stamped with belongs to the surface listing it. The Game roster
+   * stamps ownership here (`UNCLAIMED` / `YOU` / a crewmate's name, ADR-030
+   * D32); a personal roster stamps nothing at all.
+   *
+   * It is pinned to the header band's top-right corner and taken out of the
+   * flow, so nothing on the row can push it elsewhere; the band reserves the
+   * width for it, which is what stops a long name sliding underneath.
+   */
+  seal?: ReactNode
   /**
    * Destination for the View link. **Omit when there is nothing to open.**
    *
@@ -105,7 +152,7 @@ type FilledEntityRowProps = {
 
 /**
  * The EMPTY row: a dashed placeholder slot for an unfilled link (e.g. a pilot
- * with no assigned mech). Keeps the ontology tone wash + a black role tab, over
+ * with no assigned mech). Keeps the ontology header band + a black role tab, over
  * a helper message and optional create/link actions.
  */
 type EmptyEntityRowProps = {
@@ -125,27 +172,42 @@ type EmptyEntityRowProps = {
 type EntityRowProps = FilledEntityRowProps | EmptyEntityRowProps
 
 /**
- * Per-ontology tone pair (see `--color-sheet-*` in theme.css): `rail` is the
- * deep tone driving the 6px accent bar; `wash` is a faint tint of the base tone
- * mixed into paper so the row reads coloured without fighting the ink text.
+ * Per-ontology tone (see `--color-sheet-*` in theme.css), read as `Card` reads
+ * it: `band` is the header fill, `ink` the text that sits legibly on it.
+ *
+ * ## Why there is no longer a `rail` or a `wash`
+ *
+ * The row used to carry its ontology two ways at once — a 6px deep-tone bar
+ * down the left edge, over a body tinted ~10% with the same tone — and neither
+ * is how a card says it. A card states its ontology **in a solid band across
+ * the top**, over a paper body: the tone is a header, not an edge, and the
+ * content sits on paper so black text is black text everywhere in the system.
+ * Rows are the compact translation of that card, so they say it the same way.
+ *
+ * The practical gain is legibility, not just consistency. A tinted body meant
+ * every quiet chip, stat and button on the row sat on a slightly different
+ * ground per ontology, and the rail put a hard 6px of `crawler-deep` against a
+ * pink wash — the highest-contrast element on the row spent on decoration.
+ *
+ * `crawler` takes paper text for the same reason its Badge tone does: it is the
+ * one dark fill in the ramp.
  */
-const TONE: Record<EntityRowType, { rail: string; wash: string }> = {
-  pilot: {
-    rail: 'var(--color-sheet-pilot-deep)',
-    wash: 'color-mix(in srgb, var(--color-sheet-pilot) 10%, var(--color-paper))',
-  },
-  mech: {
-    rail: 'var(--color-sheet-mech-deep)',
-    wash: 'color-mix(in srgb, var(--color-sheet-mech) 12%, var(--color-paper))',
-  },
-  crawler: {
-    rail: 'var(--color-sheet-crawler-deep)',
-    wash: 'color-mix(in srgb, var(--color-sheet-crawler) 11%, var(--color-paper))',
-  },
-  game: {
-    rail: 'var(--color-sheet-game-deep)',
-    wash: 'color-mix(in srgb, var(--color-sheet-game) 11%, var(--color-paper))',
-  },
+const TONE: Record<EntityRowType, { band: string; ink: string }> = {
+  pilot: { band: 'var(--color-sheet-pilot)', ink: 'var(--color-ink)' },
+  mech: { band: 'var(--color-sheet-mech)', ink: 'var(--color-ink)' },
+  crawler: { band: 'var(--color-sheet-crawler)', ink: 'var(--color-paper)' },
+  game: { band: 'var(--color-sheet-game)', ink: 'var(--color-ink)' },
+}
+
+/**
+ * Normalise a one-or-many node prop to a list, dropping the empties so a caller
+ * passing `undefined` (or a falsy conditional) renders nothing rather than an
+ * empty chip.
+ */
+function toNodes(value: ReactNode | ReactNode[]): ReactNode[] {
+  return (Array.isArray(value) ? value : [value]).filter(
+    (node) => node !== null && node !== undefined && node !== false && node !== ''
+  )
 }
 
 /** Per-ontology "missing entity" glyph for the empty variant (decorative). */
@@ -166,23 +228,27 @@ export function EntityRow(props: EntityRowProps) {
     return (
       <div
         className={cn(
-          'flex min-w-0 flex-col overflow-hidden rounded-card border-2 border-dashed border-ink',
+          'flex min-w-0 flex-col overflow-hidden rounded-card bg-paper',
+          'border-[length:var(--bw-entity)] border-dashed border-ink',
           className
         )}
-        style={{ background: tone.wash }}
       >
-        {/* Black role tab — the same canonical stamp atom the filled variant's
-            name tab uses, not a hand-rolled span. */}
-        <Badge shape="stamp" size="compact" className="self-start">
-          {roleLabel}
-        </Badge>
+        {/* The role tab rides its own tone band, the same way the filled row's
+            name does — an empty slot is still a slot for a KIND of thing, and
+            it should announce which one in the same place its filled sibling
+            would. Dashed frame is what marks it empty; the band is not. */}
+        <div
+          className="flex items-center px-2.5 py-1.5"
+          style={{ background: tone.band, color: tone.ink }}
+        >
+          <Badge shape="stamp" size="compact">
+            {roleLabel}
+          </Badge>
+        </div>
         <div className="flex flex-wrap items-center gap-3 px-2.5 py-2">
-          <EmptyGlyph aria-hidden="true" className="size-6 shrink-0" style={{ color: tone.rail }} />
+          <EmptyGlyph aria-hidden="true" className="size-6 shrink-0" style={{ color: tone.band }} />
           {mock}
-          <p
-            className="m-0 min-w-[140px] flex-1 font-body text-note leading-snug"
-            style={{ color: tone.rail }}
-          >
+          <p className="m-0 min-w-[140px] flex-1 font-body text-note leading-snug text-ink">
             {message}
           </p>
         </div>
@@ -201,102 +267,144 @@ export function EntityRow(props: EntityRowProps) {
     stats,
     meta,
     metaLine,
+    seal,
     sheetHref,
     onDeleteClick,
     actions,
     linkAs: Link = 'a',
   } = props
-  const frameStyle: CSSProperties = { background: tone.wash }
-
   // `meta` accepts one node or several. Normalise to a list, dropping empties so
   // a caller passing `undefined` (or a falsy conditional) renders no badge at
   // all rather than an empty one.
-  const metaBadges = (Array.isArray(meta) ? meta : [meta]).filter(
-    (node) => node !== null && node !== undefined && node !== false && node !== ''
-  )
+  const metaBadges = toNodes(meta)
+  const captionParts = toNodes(metaLine)
+  const hasBody = captionParts.length > 0 || metaBadges.length > 0 || (stats?.length ?? 0) > 0
 
   return (
     <div
       className={cn(
-        'group relative flex items-stretch overflow-hidden rounded-card border-2 border-ink',
+        'group relative flex flex-col overflow-hidden rounded-card bg-paper',
+        // The frame is the card's, at the card's weight — a row is the compact
+        // translation of an entity card, not a lighter-weight cousin of one.
+        'border-[length:var(--bw-entity)] border-ink',
         'shadow-[0_1px_0_var(--color-ink-8)] transition-all duration-200',
         'md:hover:-translate-y-0.5 md:hover:shadow-[0_7px_18px_var(--color-ink-20)]'
       )}
-      style={frameStyle}
     >
-      {/* Deep-tone accent rail — the entity card's left body accent, in row form */}
-      <span
-        aria-hidden="true"
-        className="w-[6px] shrink-0 self-stretch"
-        style={{ background: tone.rail }}
-      />
-
-      <div className="flex min-w-0 flex-1 items-center gap-3 px-3 py-2.5">
-        <div className="min-w-0 flex-1">
-          {/* Black name tab — the canonical stamp, not a hand-rolled span. It
-              was the latter (rounded-pip, its own padding/size), which is the
-              drift the stamp atom exists to prevent. */}
-          <Badge shape="stamp" size="full" className="block max-w-full truncate align-middle">
-            {name}
-          </Badge>
-          {metaLine && (
-            <div className="mt-1.5 truncate font-body text-xs text-wk-muted">{metaLine}</div>
-          )}
-          {(metaBadges.length > 0 || (stats && stats.length > 0)) && (
-            <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1">
-              {/* Subheader info is only stats or toned badges — the class/role
-                  line is a badge keyed to the entity's ontology tone (pilot →
-                  orange, mech → green, crawler → pink, game → blue). */}
-              {metaBadges.map((badge, i) => (
-                <Badge
-                  // biome-ignore lint/suspicious/noArrayIndexKey: static per-render list that never reorders; a count badge's text changes as the count does, so content is a worse key than position
-                  key={i}
-                  surface="tone"
-                  tone={entityType}
-                  className="max-w-full truncate"
-                >
-                  {badge}
-                </Badge>
-              ))}
-              {stats?.map((stat) => (
-                <Stat
-                  key={String(stat.label)}
-                  label={stat.label}
-                  value={stat.value}
-                  orientation="horizontal"
-                  size="mini"
-                />
-              ))}
-            </div>
-          )}
-        </div>
-
-        <div className="flex shrink-0 flex-wrap items-center justify-end gap-1.5">
-          {actions}
-          {sheetHref !== undefined && (
-            <Link
-              href={sheetHref}
-              className={cn(
-                buttonVariants({ variant: 'default', size: 'compact' }),
-                'no-underline'
-              )}
-            >
-              View
-            </Link>
-          )}
-          {onDeleteClick && (
-            <Button
-              variant="ghost"
-              size="compact"
-              aria-label={`Delete ${name}`}
-              onClick={onDeleteClick}
-              className="border-transparent px-2 text-status-bad hover:bg-transparent hover:text-status-bad"
-            >
-              <Trash2 aria-hidden="true" className="size-4" />
-            </Button>
-          )}
-        </div>
+      {/* HEADER BAND — the card's, in row form: a solid strip of the ontology
+          tone carrying the name stamp. This is where the row states what kind
+          of thing it is, replacing the left rail + tinted body it used to say
+          it with. `pr-24` reserves the corner the seal is pinned to. */}
+      <div
+        className={cn('flex min-w-0 items-center px-2.5 py-1.5', seal && 'pr-24')}
+        style={{ background: tone.band, color: tone.ink }}
+      >
+        {/* Black name tab — the canonical stamp, not a hand-rolled span. It
+            was the latter (rounded-pip, its own padding/size), which is the
+            drift the stamp atom exists to prevent. */}
+        <Badge shape="stamp" size="full" className="block max-w-full truncate align-middle">
+          {name}
+        </Badge>
       </div>
+
+      {/* BODY — paper, like a card's. Everything that is not the name lives
+          here, so chips, stats and buttons all sit on one ground regardless of
+          ontology. Rendered only when there is something to put in it: a row
+          with nothing but a name closes at the band rather than opening an
+          empty strip under it. */}
+      {(hasBody || actions || sheetHref !== undefined || onDeleteClick) && (
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-2 px-2.5 py-2">
+          {/* `min-w` is a wrap TRIGGER, not a width: without it the caption
+              block shrinks to whatever the controls leave behind, and a row
+              with four buttons truncated "Iron Mongrel" to "IRON-MON…" rather
+              than dropping the controls to their own line. */}
+          <div className="flex min-w-[9rem] flex-1 flex-col gap-1.5">
+            {captionParts.length > 0 && (
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                {captionParts.map((part, i) =>
+                  typeof part === 'string' || typeof part === 'number' ? (
+                    <Badge
+                      // biome-ignore lint/suspicious/noArrayIndexKey: positional caption parts that never reorder; a callsign or chassis name is a worse key than its slot
+                      key={i}
+                      surface="quiet"
+                      className="max-w-full truncate"
+                    >
+                      {part}
+                    </Badge>
+                  ) : (
+                    // Already a node — a cross-link anchor wrapping its own toned
+                    // Badge — so it renders as given rather than nested in a chip.
+                    // biome-ignore lint/suspicious/noArrayIndexKey: as above
+                    <Fragment key={i}>{part}</Fragment>
+                  )
+                )}
+              </div>
+            )}
+            {(metaBadges.length > 0 || (stats && stats.length > 0)) && (
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                {/* Subheader info is only stats or toned badges — the class/role
+                    line is a badge keyed to the entity's ontology tone (pilot →
+                    orange, mech → green, crawler → pink, game → blue). */}
+                {metaBadges.map((badge, i) => (
+                  <Badge
+                    // biome-ignore lint/suspicious/noArrayIndexKey: static per-render list that never reorders; a count badge's text changes as the count does, so content is a worse key than position
+                    key={i}
+                    surface="tone"
+                    tone={entityType}
+                    className="max-w-full truncate"
+                  >
+                    {badge}
+                  </Badge>
+                ))}
+                {stats?.map((stat) => (
+                  <Stat
+                    key={String(stat.label)}
+                    label={stat.label}
+                    value={stat.value}
+                    orientation="horizontal"
+                    size="mini"
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* The controls, trailing the body. They no longer compete with the
+              name for width — the name has its own band above — so this is a
+              plain right-aligned cluster that wraps when it must. */}
+          <div className="ml-auto flex flex-wrap items-center justify-end gap-1.5">
+            {actions}
+            {sheetHref !== undefined && (
+              <Link
+                href={sheetHref}
+                className={cn(
+                  buttonVariants({ variant: 'default', size: 'compact' }),
+                  'no-underline'
+                )}
+              >
+                View
+              </Link>
+            )}
+            {onDeleteClick && (
+              <Button
+                variant="ghost"
+                size="compact"
+                aria-label={`Delete ${name}`}
+                onClick={onDeleteClick}
+                className="border-transparent px-2 text-status-bad hover:bg-transparent hover:text-status-bad"
+              >
+                <Trash2 aria-hidden="true" className="size-4" />
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* The seal owns the top-right corner outright — pulled out of the flow
+          so no amount of name, caption or controls can push it somewhere else.
+          The name block reserves its width with `pr-24` above, which is what
+          keeps a long name from sliding underneath it. */}
+      {seal && <span className="absolute right-2.5 top-2.5 z-10">{seal}</span>}
     </div>
   )
 }

--- a/packages/component-lib/src/components/shared/EntityRow.tsx
+++ b/packages/component-lib/src/components/shared/EntityRow.tsx
@@ -5,6 +5,7 @@ import { cn } from '../../utils/cn'
 import { Badge } from '../chrome/Badge'
 import { Button } from '../chrome/Button'
 import { buttonVariants } from '../chrome/buttonVariants'
+import { STAMP_SEAM } from '../chrome/stampSeam'
 import { Stat } from './Stat'
 
 /**
@@ -15,14 +16,19 @@ import { Stat } from './Stat'
  * entity card is, in the same order, at the same frame weight
  * (`--bw-entity`):
  *
- *   ┌──────────────────────────────────┐
- *   │ ▸ HEADER BAND — solid ontology tone, carrying the black name stamp
- *   │   (pilot → orange, mech → green, crawler → pink, game → blue, the
- *   │   `--color-sheet-*` tokens). The seal, when present, is pinned to this
- *   │   band's top-right corner.
- *   │ ▸ BODY — paper. Caption chips, ontology-toned meta badges, `Stat`s, and
- *   │   the trailing View / Delete controls.
+ *                    ╔═══════╗  ← `seal`, riding the top border (STAMP_SEAM)
+ *   ┌────────────────╨───────╨─────────┐
+ *   │ ▸ HEADER BAND — solid ontology tone (pilot → orange, mech → green,
+ *   │   crawler → pink, game → blue, the `--color-sheet-*` tokens), carrying
+ *   │   the black name stamp on the left and the row's `stats` on the right.
+ *   │   What the thing IS, and how it is doing.
+ *   │ ▸ BODY — paper. Ontology-toned meta badges, quiet caption chips, and the
+ *   │   trailing View / Delete controls. Details, and verbs.
  *   └──────────────────────────────────┘
+ *
+ * Vitals live in the BAND, not the body, because they are what a roster is
+ * scanned for: a column of forty rows should let the eye run down HP or SP
+ * without crossing the buttons. The body is where the things you press live.
  *
  * It previously said its ontology twice and in neither of the card's ways: a
  * 6px deep-tone rail down the left edge, over a body tinted ~10% with the same
@@ -278,12 +284,22 @@ export function EntityRow(props: EntityRowProps) {
   // all rather than an empty one.
   const metaBadges = toNodes(meta)
   const captionParts = toNodes(metaLine)
-  const hasBody = captionParts.length > 0 || metaBadges.length > 0 || (stats?.length ?? 0) > 0
+  const hasStats = (stats?.length ?? 0) > 0
+  const hasBody =
+    captionParts.length > 0 ||
+    metaBadges.length > 0 ||
+    !!actions ||
+    sheetHref !== undefined ||
+    !!onDeleteClick
 
   return (
     <div
       className={cn(
-        'group relative flex flex-col overflow-hidden rounded-card bg-paper',
+        // `overflow-visible`, so the seal can ride the top border: a clipped
+        // frame would slice the stamp in half along the seam it is meant to
+        // straddle. The inner wrapper does the clipping instead — the same
+        // split `Card` uses for its callout.
+        'group relative flex flex-col overflow-visible rounded-card bg-paper',
         // The frame is the card's, at the card's weight — a row is the compact
         // translation of an entity card, not a lighter-weight cousin of one.
         'border-[length:var(--bw-entity)] border-ink',
@@ -291,120 +307,139 @@ export function EntityRow(props: EntityRowProps) {
         'md:hover:-translate-y-0.5 md:hover:shadow-[0_7px_18px_var(--color-ink-20)]'
       )}
     >
-      {/* HEADER BAND — the card's, in row form: a solid strip of the ontology
-          tone carrying the name stamp. This is where the row states what kind
-          of thing it is, replacing the left rail + tinted body it used to say
-          it with. `pr-24` reserves the corner the seal is pinned to. */}
+      {/* Inner wrapper clips the bands to the frame's radius. */}
       <div
-        className={cn('flex min-w-0 items-center px-2.5 py-1.5', seal && 'pr-24')}
-        style={{ background: tone.band, color: tone.ink }}
+        className="flex flex-col overflow-hidden"
+        style={{ borderRadius: 'calc(var(--radius-card) - var(--bw-entity))' }}
       >
-        {/* Black name tab — the canonical stamp, not a hand-rolled span. It
-            was the latter (rounded-pip, its own padding/size), which is the
-            drift the stamp atom exists to prevent. */}
-        <Badge shape="stamp" size="full" className="block max-w-full truncate align-middle">
-          {name}
-        </Badge>
-      </div>
+        {/* HEADER BAND — the card's, in row form: a solid strip of the ontology
+            tone carrying the name stamp on the left and the row's vitals on the
+            right. This is where the row states what kind of thing it is and how
+            it is doing, replacing the left rail + tinted body it used to say the
+            first half with.
 
-      {/* BODY — paper, like a card's. Everything that is not the name lives
-          here, so chips, stats and buttons all sit on one ground regardless of
-          ontology. Rendered only when there is something to put in it: a row
-          with nothing but a name closes at the band rather than opening an
-          empty strip under it. */}
-      {(hasBody || actions || sheetHref !== undefined || onDeleteClick) && (
-        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-2 px-2.5 py-2">
-          {/* `min-w` is a wrap TRIGGER, not a width: without it the caption
-              block shrinks to whatever the controls leave behind, and a row
-              with four buttons truncated "Iron Mongrel" to "IRON-MON…" rather
-              than dropping the controls to their own line. */}
-          <div className="flex min-w-[9rem] flex-1 flex-col gap-1.5">
-            {captionParts.length > 0 && (
-              <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                {captionParts.map((part, i) =>
-                  typeof part === 'string' || typeof part === 'number' ? (
-                    <Badge
-                      // biome-ignore lint/suspicious/noArrayIndexKey: positional caption parts that never reorder; a callsign or chassis name is a worse key than its slot
-                      key={i}
-                      surface="quiet"
-                      className="max-w-full truncate"
-                    >
-                      {part}
-                    </Badge>
-                  ) : (
-                    // Already a node — a cross-link anchor wrapping its own toned
-                    // Badge — so it renders as given rather than nested in a chip.
-                    // biome-ignore lint/suspicious/noArrayIndexKey: as above
-                    <Fragment key={i}>{part}</Fragment>
-                  )
-                )}
-              </div>
-            )}
-            {(metaBadges.length > 0 || (stats && stats.length > 0)) && (
-              <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                {/* Subheader info is only stats or toned badges — the class/role
-                    line is a badge keyed to the entity's ontology tone (pilot →
-                    orange, mech → green, crawler → pink, game → blue). */}
-                {metaBadges.map((badge, i) => (
+            Stats sit HERE rather than in the body because they are what you scan
+            a roster for — HP, SP, Heat, the chassis — and the body is where the
+            things you press live. The top padding grows when a seal is present,
+            clearing the stamp riding the border above (the same allowance
+            `Card` makes for its callout). */}
+        <div
+          className={cn(
+            'flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1.5 px-2.5 py-1.5',
+            // Only extra TOP padding, no right reserve: the seal rides the
+            // border half above the frame, so its intrusion is vertical, and
+            // clearing it downward frees the band's right edge for the stats
+            // (which a `pr-24` reserve had stranded in the middle of the band).
+            seal && 'pt-3'
+          )}
+          style={{ background: tone.band, color: tone.ink }}
+        >
+          {/* Black name tab — the canonical stamp, not a hand-rolled span. It
+              was the latter (rounded-pip, its own padding/size), which is the
+              drift the stamp atom exists to prevent. */}
+          <Badge shape="stamp" size="full" className="block max-w-full truncate align-middle">
+            {name}
+          </Badge>
+          {hasStats && (
+            <div className="ml-auto flex flex-wrap items-center justify-end gap-x-2 gap-y-1">
+              {stats?.map((stat) => (
+                <Stat
+                  key={String(stat.label)}
+                  label={stat.label}
+                  value={stat.value}
+                  orientation="horizontal"
+                  size="mini"
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* BODY — paper, like a card's. The row's DETAILS and its VERBS: the
+            class/role badges, the caption chips, and the controls. Vitals are
+            not here; they are in the band above, where they can be scanned down
+            a column without reading past the buttons.
+
+            Rendered only when there is something to put in it — a row that is
+            just a name and its stats closes at the band rather than opening an
+            empty strip beneath it. */}
+        {hasBody && (
+          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-2 px-2.5 py-2">
+            {/* `min-w` is a wrap TRIGGER, not a width: without it the detail
+                block shrinks to whatever the controls leave behind, and a row
+                with four buttons truncated its chips rather than dropping the
+                controls to their own line. */}
+            <div className="flex min-w-[9rem] flex-1 flex-wrap items-center gap-x-2 gap-y-1">
+              {/* The class/role badge is keyed to the entity's ontology tone
+                  (pilot → orange, mech → green, crawler → pink, game → blue). */}
+              {metaBadges.map((badge, i) => (
+                <Badge
+                  // biome-ignore lint/suspicious/noArrayIndexKey: static per-render list that never reorders; a count badge's text changes as the count does, so content is a worse key than position
+                  key={i}
+                  surface="tone"
+                  tone={entityType}
+                  className="max-w-full truncate"
+                >
+                  {badge}
+                </Badge>
+              ))}
+              {captionParts.map((part, i) =>
+                typeof part === 'string' || typeof part === 'number' ? (
                   <Badge
-                    // biome-ignore lint/suspicious/noArrayIndexKey: static per-render list that never reorders; a count badge's text changes as the count does, so content is a worse key than position
+                    // biome-ignore lint/suspicious/noArrayIndexKey: positional caption parts that never reorder; a callsign is a worse key than its slot
                     key={i}
-                    surface="tone"
-                    tone={entityType}
+                    surface="quiet"
                     className="max-w-full truncate"
                   >
-                    {badge}
+                    {part}
                   </Badge>
-                ))}
-                {stats?.map((stat) => (
-                  <Stat
-                    key={String(stat.label)}
-                    label={stat.label}
-                    value={stat.value}
-                    orientation="horizontal"
-                    size="mini"
-                  />
-                ))}
-              </div>
-            )}
-          </div>
+                ) : (
+                  // Already a node — a cross-link anchor wrapping its own toned
+                  // Badge — so it renders as given rather than nested in a chip.
+                  // biome-ignore lint/suspicious/noArrayIndexKey: as above
+                  <Fragment key={i}>{part}</Fragment>
+                )
+              )}
+            </div>
 
-          {/* The controls, trailing the body. They no longer compete with the
-              name for width — the name has its own band above — so this is a
-              plain right-aligned cluster that wraps when it must. */}
-          <div className="ml-auto flex flex-wrap items-center justify-end gap-1.5">
-            {actions}
-            {sheetHref !== undefined && (
-              <Link
-                href={sheetHref}
-                className={cn(
-                  buttonVariants({ variant: 'default', size: 'compact' }),
-                  'no-underline'
-                )}
-              >
-                View
-              </Link>
-            )}
-            {onDeleteClick && (
-              <Button
-                variant="ghost"
-                size="compact"
-                aria-label={`Delete ${name}`}
-                onClick={onDeleteClick}
-                className="border-transparent px-2 text-status-bad hover:bg-transparent hover:text-status-bad"
-              >
-                <Trash2 aria-hidden="true" className="size-4" />
-              </Button>
-            )}
+            {/* The controls, trailing the body. They no longer compete with the
+                name for width — the name has its own band above — so this is a
+                plain right-aligned cluster that wraps when it must. */}
+            <div className="ml-auto flex flex-wrap items-center justify-end gap-1.5">
+              {actions}
+              {sheetHref !== undefined && (
+                <Link
+                  href={sheetHref}
+                  className={cn(
+                    buttonVariants({ variant: 'default', size: 'compact' }),
+                    'no-underline'
+                  )}
+                >
+                  View
+                </Link>
+              )}
+              {onDeleteClick && (
+                <Button
+                  variant="ghost"
+                  size="compact"
+                  aria-label={`Delete ${name}`}
+                  onClick={onDeleteClick}
+                  className="border-transparent px-2 text-status-bad hover:bg-transparent hover:text-status-bad"
+                >
+                  <Trash2 aria-hidden="true" className="size-4" />
+                </Button>
+              )}
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
 
-      {/* The seal owns the top-right corner outright — pulled out of the flow
-          so no amount of name, caption or controls can push it somewhere else.
-          The name block reserves its width with `pr-24` above, which is what
-          keeps a long name from sliding underneath it. */}
-      {seal && <span className="absolute right-2.5 top-2.5 z-10">{seal}</span>}
+      {/* The seal RIDES THE TOP BORDER — the canonical stamp-seam placement
+          (`STAMP_SEAM`), half above the frame and half over it, like a label
+          plate riveted across the seam. It is outside the clipping wrapper for
+          exactly that reason; the band's extra top padding is what keeps its
+          contents clear of the half that overhangs them. */}
+      {seal && <span className={cn(STAMP_SEAM, 'right-3')}>{seal}</span>}
     </div>
   )
 }

--- a/packages/component-lib/src/components/shared/__tests__/EntityRow.test.tsx
+++ b/packages/component-lib/src/components/shared/__tests__/EntityRow.test.tsx
@@ -55,12 +55,14 @@ describe('EntityRow — meta arity', () => {
 })
 
 describe('EntityRow — the game ontology', () => {
-  test('a game row paints the game rail, not the crawler rail', () => {
+  test('a game row paints the game band, not the crawler band', () => {
     const { container } = render(
       <EntityRow entityType="game" name="Union Crawler #430" sheetHref="#/games/430" />
     )
     const html = container.innerHTML
-    expect(html).toContain('--color-sheet-game-deep')
+    // A Game named after a crawler is exactly where the two tones could be
+    // confused, which is why this asserts the token rather than the look.
+    expect(html).toContain('--color-sheet-game')
     expect(html).not.toContain('--color-sheet-crawler')
   })
 

--- a/packages/component-lib/src/index.ts
+++ b/packages/component-lib/src/index.ts
@@ -64,7 +64,11 @@ export { ModalShell } from './components/shared/ModalShell'
 export { EntitySearcher } from './components/shared/EntitySearcher'
 export { EntityGrid, EntityGridRow } from './components/shared/EntityGrid'
 export { EntityRow } from './components/shared/EntityRow'
-export type { EntityRowStat, EntityRowType } from './components/shared/EntityRow'
+export type {
+  EntityRowDetail,
+  EntityRowStat,
+  EntityRowType,
+} from './components/shared/EntityRow'
 export { TECH_LEVEL_STYLES, techLevelLabel } from './components/shared/techLevelStyles'
 
 // Skeletons

--- a/packages/component-lib/src/index.ts
+++ b/packages/component-lib/src/index.ts
@@ -64,6 +64,7 @@ export { ModalShell } from './components/shared/ModalShell'
 export { EntitySearcher } from './components/shared/EntitySearcher'
 export { EntityGrid, EntityGridRow } from './components/shared/EntityGrid'
 export { EntityRow } from './components/shared/EntityRow'
+export type { EntityRowStat, EntityRowType } from './components/shared/EntityRow'
 export { TECH_LEVEL_STYLES, techLevelLabel } from './components/shared/techLevelStyles'
 
 // Skeletons

--- a/packages/component-lib/src/index.ts
+++ b/packages/component-lib/src/index.ts
@@ -64,11 +64,7 @@ export { ModalShell } from './components/shared/ModalShell'
 export { EntitySearcher } from './components/shared/EntitySearcher'
 export { EntityGrid, EntityGridRow } from './components/shared/EntityGrid'
 export { EntityRow } from './components/shared/EntityRow'
-export type {
-  EntityRowDetail,
-  EntityRowStat,
-  EntityRowType,
-} from './components/shared/EntityRow'
+export type { EntityRowStat, EntityRowType } from './components/shared/EntityRow'
 export { TECH_LEVEL_STYLES, techLevelLabel } from './components/shared/techLevelStyles'
 
 // Skeletons


### PR DESCRIPTION
The Game crew view listed rows that mostly went nowhere, said ownership two ways at once, and ran in a narrower column than the Roster it is a twin of.

## What changed

**One ownership seal, three states.** `UNCLAIMED` / `YOU` / the holder's name, stamped in the row's top-right corner. It replaces an owner chip in the caption *plus* a separate UNCLAIMED stamp among the buttons — one field said twice, in two registers, in two places. `UNCLAIMED` is the pressable one (an unclaimed pre-gen is an offer); the other two are inert facts. A crawler carries no seal — it is communal, so "who owns it" is not a question the game asks.

**Every row is a door.** New read-only crew sheet at `/games/$gameId/view/$kind/$entityId`, rendering a crewmate's build from the server body through a frozen store extracted to `sheet/frozenSheet.ts` and shared with the snapshot surface. **Nothing is adopted into IndexedDB** — reading a crewmate's pilot leaves no copy among your own builds. What was never safe was handing a non-owner ITUN's *live* sheet, whose writes the server refuses; that stays owner-only, now labelled **Edit**.

**Rows speak the card's language.** `EntityRow` drops the 6px left rail and the tinted body. A card states its ontology in a band across the top over a paper body, so a row does too, at the card's `--bw-entity` frame weight. Every piece of text on a row is now a badge: strings in `metaLine` are chipped automatically, nodes (cross-links) pass through un-nested.

**Game surfaces run full width** on the Roster's own page shell (`PAGE` in `gameChrome`). Join keeps a capped form inside the wide shell — a six-character code does not want 1440px.

Also resolves the mech chassis slug to its real name on the crew roster, the way the Roster already did ("Iron Mongrel · TL 1", not "iron-mongrel").

## Blast radius

`EntityRow` is shared, so the home Roster and the three live sheets change with it — that is the point (the two surfaces were drifting), but it is the thing to review hardest.

## Verification

Full `check:all` green. Both surfaces were rendered from the **real** components against the **built** CSS and measured at 1440 / 768 / 390: no horizontal overflow at any width, no truncated names. Two truncation regressions were caught and fixed that way ("IR…" on desktop, "IRON MONG…" on mobile).

Draft until the screenshots are reviewed.