### PR TITLE
docs(ci): correct the audit comment with measured advisory facts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,12 +244,15 @@ jobs:
     # HOW ADVISORIES GET CLEARED HERE. Most resolve on their own when the
     # lockfile moves. The rest are held above the vulnerable range by the
     # `overrides` block in the root package.json — those entries are SECURITY
-    # FLOORS, not compatibility pins, and several high advisories currently
-    # depend on them. (`sharp` is the one exception: it is a real pinned
-    # dependency mirrored in the root and apps/srd devDependencies, so it stays
-    # exact.) No `--ignore` is needed: the formerly ignored GHSA-gv7w-rqvm-qjhr
-    # left the resolved lockfile with the vite 8 upgrade, and the residual
-    # esbuild advisory from the vite-7-pinned srd subtree is `low`, below this
+    # FLOORS, and the block is load-bearing: delete it, re-resolve, and two high
+    # advisories come straight back — `sharp` (GHSA-f88m-g3jw-g9cj, reached via
+    # workspace:srd -> astro) and `undici` (GHSA-vxpw-j846-p89q, via discord.js).
+    # The other floors do not bind on a fresh resolve today; they are kept as
+    # cheap insurance against a parent range drifting back down.
+    #
+    # No `--ignore` is needed: the formerly ignored GHSA-gv7w-rqvm-qjhr left the
+    # resolved lockfile with the vite 8 upgrade, and the residual esbuild
+    # advisory from the vite-7-pinned srd subtree is `low`, below this
     # `--audit-level=high` gate.
     #
     # WHEN THIS JOB FAILS ON A TRANSITIVE DEP, the fix is `bun update <pkg>`
@@ -261,6 +264,12 @@ jobs:
     # hand-bumped that way twice — 5.0.7 -> 5.0.8 (#565) and 5.0.8 -> 5.0.9
     # (#673) — each time after the exact pin had blocked every open PR.
     # Raise the floor, never freeze it.
+    #
+    # `sharp` is the one deliberate exception: it is ALSO a real pinned
+    # devDependency in the root and apps/srd, so its override is kept exact and
+    # in lockstep with those pins rather than floated. It is still a security
+    # floor (see the advisory above) — do not drop it. The cost of that choice
+    # is that a future sharp advisory needs all three pins bumped by hand.
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Comment-only follow-up to #674. No workflow behaviour changes.

Reviewing #674's own comment against reality turned up two inaccuracies — the
same failure mode #674 exists to prevent: a durable comment asserting something
nobody had checked. Both are now measured rather than assumed, by deleting the
`overrides` block, re-resolving, and re-running `bun audit --audit-level=high`:

**1. "several high advisories currently depend on them"** — vague, and high.
Exactly **two** come back:

| package | advisory | reached via |
| --- | --- | --- |
| `sharp` | GHSA-f88m-g3jw-g9cj | `workspace:srd` → `astro` |
| `undici` | GHSA-vxpw-j846-p89q | `discord.js` |

The remaining floors do not bind on a fresh resolve today. They're kept as cheap
insurance against a parent range drifting back down — which is now what the
comment says, instead of implying they're all load-bearing.

**2. `sharp` was described as a compatibility pin and "the one exception"** —
implying it does no security work. It does: its override is exactly what clears
GHSA-f88m-g3jw-g9cj on the transitive `astro → sharp` path. A reader trusting
the old wording could have dropped it as redundant and quietly reintroduced a
high advisory. It's now documented as **both** — kept exact because it mirrors
the root and `apps/srd` devDependency pins, and load-bearing for security
regardless — along with the cost of that choice: a future sharp advisory needs
all three pins bumped by hand.

## Verification

`ci.yml` re-parsed (17 jobs; the `audit` job's `needs` and `run` unchanged),
`bun install --frozen-lockfile`, `bun audit --audit-level=high`, and
`format:check` all exit 0. The scratch experiment's repo state was restored and
confirmed clean before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjnpNmFP7UfWUjvwsyipmT