### PR TITLE
fix(data): stop two actions rendering their content twice

### DIFF
--- a/packages/salvageunion-reference/data/actions.json
+++ b/packages/salvageunion-reference/data/actions.json
@@ -1564,7 +1564,7 @@
     "content": [
       {
         "type": "paragraph",
-        "value": "You have learned to use the momentum and bulk of the vast weight of cargo you can carry to crush your enemies and see them driven before you. When you activate this Ability, choose a target in Range. You make a special charge attack against the target. Roll to hit as normal. On a hit, this deals HP damage equal to the amount of Inventory Slots your Pilot has filled, for example, if you have 6 Inventory Slots filled, it deals 6 HP damage. Non-Bio-Titan or Meld creatures hit by this attack are knocked Prone and gain the [[Vulnerable]] Trait. If you use this Ability whilst piloting a Mech, it deals SP damage equal to the amount of Cargo Slots you currently have filled on your Mech, for example, if you have 10 Cargo Slots filled, the attack deals 10 SP damage. Any target hit by this attack is knocked Prone and gains the [[Vulnerable]] Trait."
+        "value": "You have learned to use the momentum and bulk of the vast weight of cargo you can carry to crush your enemies and see them driven before you."
       },
       {
         "type": "paragraph",
@@ -1572,11 +1572,11 @@
       },
       {
         "type": "paragraph",
-        "value": "You make a special charge attack against the target. Roll to hit as normal. On a hit, this deals HP damage equal to the amount of Inventory Slots your Pilot has filled, for example, if you have 6 Inventory Slots filled, it deals 6 HP damage. Non-Bio-Titan or Meld creatures hit by this attack are knocked Prone and gain the Vulnerable Trait."
+        "value": "You make a special charge attack against the target. Roll to hit as normal. On a hit, this deals HP damage equal to the amount of Inventory Slots your Pilot has filled, for example, if you have 6 Inventory Slots filled, it deals 6 HP damage. Non-Bio-Titan or Meld creatures hit by this attack are knocked Prone and gain the [[Vulnerable]] Trait."
       },
       {
         "type": "paragraph",
-        "value": "If you use this Ability whilst piloting a Mech, it deals SP damage equal to the amount of Cargo Slots you currently have filled on your Mech, for example, if you have 10 Cargo Slots filled, the attack deals 10 SP damage. Any target hit by this attack is knocked Prone and gains the Vulnerable Trait."
+        "value": "If you use this Ability whilst piloting a Mech, it deals SP damage equal to the amount of Cargo Slots you currently have filled on your Mech, for example, if you have 10 Cargo Slots filled, the attack deals 10 SP damage. Any target hit by this attack is knocked Prone and gains the [[Vulnerable]] Trait."
       }
     ],
     "actionSource": "abilities"
@@ -5587,7 +5587,7 @@
         "type": "paragraph"
       },
       {
-        "value": "When you are in an area with Scrap at your disposal, you may craft any System or Module of your choice of a Tech Level equal to or lower than your Union Crawler. You must spend 1 Scrap of the Tech Level of the System or Module or higher to use this Ability. This System or Module gains the [[Unwieldy]] Trait, and is destroyed on any roll of 1-5 when used, in addition to any other setbacks.",
+        "value": "When you are in an area with Scrap at your disposal, you may craft any System or Module of your choice of a Tech Level equal to or lower than your Union Crawler. You must spend 1 Scrap of the Tech Level of the System or Module or higher to use this Ability.",
         "type": "paragraph"
       },
       {

--- a/packages/salvageunion-reference/package.json
+++ b/packages/salvageunion-reference/package.json
@@ -52,6 +52,7 @@
     "validate:actions": "bun tools/validateActionReferences.ts",
     "validate:action-backrefs": "bun tools/validateActionBackrefs.ts",
     "validate:orphans": "bun tools/validateOrphans.ts",
+    "validate:content-dupes": "bun tools/validateContentDupes.ts",
     "validate:traits": "bun tools/validateTraits.ts",
     "validate:schemas": "bun tools/validateSchemas.ts",
     "validate:all": "bun tools/validate.ts",

--- a/packages/salvageunion-reference/tools/validate.ts
+++ b/packages/salvageunion-reference/tools/validate.ts
@@ -2,9 +2,9 @@
 /**
  * Unified validation runner.
  *
- * Replaces chaining 8 separate `bun run validate:*` process invocations
+ * Replaces chaining 11 separate `bun run validate:*` process invocations
  * (each re-reading and re-parsing the ~1.3MB `data/*.json` corpus on its
- * own) with a single shared data-load pass, fed to all 8 checks:
+ * own) with a single shared data-load pass, fed to all 11 checks:
  *
  *   - ids              (checkUniqueIdsLogic.ts)
  *   - slugs            (validateSlugsLogic.ts)
@@ -12,6 +12,7 @@
  *   - actions          (validateActionReferencesLogic.ts)
  *   - action-backrefs  (validateActionBackrefsLogic.ts)
  *   - orphans          (validateOrphansLogic.ts)
+ *   - content-dupes    (validateContentDupesLogic.ts)
  *   - traits           (validateTraitsLogic.ts)
  *   - schemas          (validateSchemasLogic.ts)
  *   - parity           (validateParityLogic.ts)
@@ -44,6 +45,7 @@ import { findReferenceErrors } from './validateReferencesLogic.js'
 import { findActionReferenceErrors } from './validateActionReferencesLogic.js'
 import { runActionBackrefCheck } from './validateActionBackrefsLogic.js'
 import { runOrphanCheck } from './validateOrphansLogic.js'
+import { runContentDupeCheck } from './validateContentDupesLogic.js'
 import { findTraitIssues } from './validateTraitsLogic.js'
 import {
   KNOWN_UNRESOLVED,
@@ -173,6 +175,26 @@ function orphansCheck(data: DataBag): Diagnostic[] {
   return diagnostics
 }
 
+/**
+ * Intra-record content duplication: a paragraph that repeats another paragraph
+ * of the same record, or an un-split blob sitting alongside the split version
+ * of the same prose. Renders the text twice on the entity card.
+ */
+function contentDupesCheck(data: DataBag): Diagnostic[] {
+  return runContentDupeCheck(data).map((dupe) => ({
+    check: 'content-dupes',
+    file: dupe.file,
+    path: `"${dupe.record}" content[${dupe.paragraph}]`,
+    message:
+      `${
+        dupe.kind === 'exact'
+          ? `Repeats paragraph ${dupe.duplicateOf} verbatim`
+          : `Fully contains paragraph ${dupe.duplicateOf}`
+      } — the card renders this prose twice. Remove the redundant paragraph, or trim ` +
+      `the containing one to the text that is genuinely its own: "${dupe.excerpt}"`,
+  }))
+}
+
 function traitsCheck(data: DataBag): Diagnostic[] {
   return findTraitIssues(data).map((issue) => ({
     check: 'traits',
@@ -265,6 +287,7 @@ const CHECKS: CheckDefinition[] = [
   { id: 'actions', label: 'Action references', run: actionReferencesCheck },
   { id: 'action-backrefs', label: 'Namesake action back-references', run: actionBackrefsCheck },
   { id: 'orphans', label: 'Orphan detection', run: orphansCheck },
+  { id: 'content-dupes', label: 'Duplicated record content', run: contentDupesCheck },
   { id: 'traits', label: 'Trait data', run: traitsCheck },
   { id: 'parity', label: 'Rules parity', run: parityCheck },
   { id: 'double-encoding', label: 'One concept, one encoding', run: doubleEncodingCheck },

--- a/packages/salvageunion-reference/tools/validateContentDupes.test.ts
+++ b/packages/salvageunion-reference/tools/validateContentDupes.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'bun:test'
+import { loadAllDataFiles } from './loadData.js'
+import {
+  findDupesInContent,
+  normalizeParagraph,
+  runContentDupeCheck,
+  MIN_WORDS,
+} from './validateContentDupesLogic.js'
+
+/** A paragraph long enough to clear MIN_WORDS, so fixtures test the real path. */
+const LONG_A =
+  'You make a special charge attack against the target, rolling to hit as normal against it.'
+const LONG_B =
+  'If you use this Ability whilst piloting a Mech, it deals SP damage equal to your Cargo Slots.'
+
+const para = (value: string) => ({ type: 'paragraph', value })
+
+describe('normalizeParagraph', () => {
+  it('strips trait link markers so [[Vulnerable]] and Vulnerable compare equal', () => {
+    expect(normalizeParagraph('gains the [[Vulnerable]] Trait')).toBe(
+      normalizeParagraph('gains the Vulnerable Trait')
+    )
+  })
+
+  it('collapses whitespace and lowercases', () => {
+    expect(normalizeParagraph('  Roll   to\nhit  ')).toBe('roll to hit')
+  })
+})
+
+describe('findDupesInContent', () => {
+  it('flags a paragraph repeated verbatim, reporting only the later one', () => {
+    const dupes = findDupesInContent([para(LONG_A), para(LONG_A)])
+
+    expect(dupes).toHaveLength(1)
+    expect(dupes[0]?.kind).toBe('exact')
+    expect(dupes[0]?.paragraph).toBe(2)
+    expect(dupes[0]?.duplicateOf).toBe(1)
+  })
+
+  it('flags an un-split blob that swallows the split paragraphs (the #66 shape)', () => {
+    const blob = `Flavour text about crushing your enemies. ${LONG_A} ${LONG_B}`
+    const dupes = findDupesInContent([para(blob), para(LONG_A), para(LONG_B)])
+
+    expect(dupes).toHaveLength(2)
+    expect(dupes.every((d) => d.kind === 'contains')).toBe(true)
+    expect(dupes.every((d) => d.paragraph === 1)).toBe(true)
+    expect(dupes.map((d) => d.duplicateOf).sort()).toEqual([2, 3])
+  })
+
+  it('detects containment across differing trait markup', () => {
+    const split = 'Any target hit by this attack is knocked Prone and gains the Vulnerable Trait.'
+    const blob = `It deals damage equal to your Cargo Slots. Any target hit by this attack is knocked Prone and gains the [[Vulnerable]] Trait.`
+
+    const dupes = findDupesInContent([para(blob), para(split)])
+
+    expect(dupes).toHaveLength(1)
+    expect(dupes[0]?.kind).toBe('contains')
+  })
+
+  it('ignores short paragraphs below the MIN_WORDS floor', () => {
+    const short = 'Roll to hit.'
+    expect(short.split(' ').length).toBeLessThan(MIN_WORDS)
+
+    expect(findDupesInContent([para(short), para(short)])).toHaveLength(0)
+  })
+
+  it('accepts distinct paragraphs that merely share phrasing', () => {
+    const tech2 = 'Training during Downtime on your Union Crawler in a Tech 2 Pilot Bay grants one.'
+    const tech3 = 'Training during Downtime on your Union Crawler in a Tech 3 Pilot Bay grants two.'
+
+    expect(findDupesInContent([para(tech2), para(tech3)])).toHaveLength(0)
+  })
+
+  it('ignores content blocks with no string value', () => {
+    expect(findDupesInContent([{ type: 'table', rows: [] }, para(LONG_A)])).toHaveLength(0)
+  })
+})
+
+describe('runContentDupeCheck', () => {
+  it('reports the owning file and record name', () => {
+    const dupes = runContentDupeCheck({
+      'actions.json': [{ name: 'Some Action', content: [para(LONG_A), para(LONG_A)] }],
+    })
+
+    expect(dupes).toHaveLength(1)
+    expect(dupes[0]?.file).toBe('actions.json')
+    expect(dupes[0]?.record).toBe('Some Action')
+  })
+
+  it('does not flag identical prose shared across two different records', () => {
+    const dupes = runContentDupeCheck({
+      'actions.json': [
+        { name: 'First', content: [para(LONG_A)] },
+        { name: 'Second', content: [para(LONG_A)] },
+      ],
+    })
+
+    expect(dupes).toEqual([])
+  })
+
+  it('finds duplication in nested records, attributing the nested name', () => {
+    const dupes = runContentDupeCheck({
+      'chassis.json': [
+        {
+          name: 'Some Chassis',
+          patterns: [{ name: 'Some Pattern', content: [para(LONG_B), para(LONG_B)] }],
+        },
+      ],
+    })
+
+    expect(dupes).toHaveLength(1)
+    expect(dupes[0]?.record).toBe('Some Pattern')
+  })
+})
+
+describe('the real data corpus', () => {
+  it('has no record that duplicates its own content', () => {
+    const dupes = runContentDupeCheck(loadAllDataFiles())
+
+    // Named regressions from the `Break out Actions (#66)` migration. Listed
+    // explicitly so a re-introduction fails with a readable message rather than
+    // a bare count mismatch.
+    expect(dupes.map((d) => `${d.file} :: ${d.record}`)).toEqual([])
+  })
+})

--- a/packages/salvageunion-reference/tools/validateContentDupes.ts
+++ b/packages/salvageunion-reference/tools/validateContentDupes.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env tsx
+/**
+ * Detects records that duplicate their own `content[]` prose — a paragraph
+ * that repeats another paragraph of the same record verbatim, or an un-split
+ * "blob" paragraph sitting alongside the split version of the same text.
+ * Either way the entity card renders the prose twice.
+ *
+ * Thin CLI wrapper: all detection logic lives in validateContentDupesLogic.ts
+ * so this and the unified runner (tools/validate.ts) can never diverge.
+ */
+
+import { loadAllDataFiles } from './loadData.js'
+import { runContentDupeCheck } from './validateContentDupesLogic.js'
+
+function main(): void {
+  const filesByName = loadAllDataFiles()
+  const dupes = runContentDupeCheck(filesByName)
+
+  console.log(`Scanned ${Object.keys(filesByName).length} data file(s) for duplicated content.`)
+  console.log(`\n${'='.repeat(80)}`)
+
+  if (dupes.length === 0) {
+    console.log('No records duplicate their own content.')
+    process.exit(0)
+  }
+
+  console.error(`Found ${dupes.length} duplicated paragraph(s):\n`)
+
+  const byFile = new Map<string, typeof dupes>()
+  for (const dupe of dupes) {
+    const bucket = byFile.get(dupe.file)
+    if (bucket) bucket.push(dupe)
+    else byFile.set(dupe.file, [dupe])
+  }
+
+  for (const [file, fileDupes] of byFile) {
+    console.error(`${file}: ${fileDupes.length} issue(s)`)
+    for (const dupe of fileDupes) {
+      const relation =
+        dupe.kind === 'exact'
+          ? `repeats paragraph ${dupe.duplicateOf} verbatim`
+          : `fully contains paragraph ${dupe.duplicateOf}`
+      console.error(`  - "${dupe.record}" paragraph ${dupe.paragraph} ${relation}`)
+      console.error(`      ${dupe.excerpt}`)
+    }
+    console.error('')
+  }
+
+  console.error(
+    'Each of these renders the same prose twice on the entity card. Remove the\n' +
+      'redundant paragraph, or trim the containing one down to the text that is\n' +
+      'genuinely its own (usually the leading flavour sentence).'
+  )
+  process.exit(1)
+}
+
+if (import.meta.main) {
+  main()
+}

--- a/packages/salvageunion-reference/tools/validateContentDupesLogic.ts
+++ b/packages/salvageunion-reference/tools/validateContentDupesLogic.ts
@@ -1,0 +1,165 @@
+/**
+ * Pure logic for intra-record content duplication in Salvage Union data.
+ *
+ * A record duplicates its own content when one `content[]` paragraph repeats
+ * another paragraph of the SAME record — either verbatim, or by swallowing it
+ * whole (an un-split "blob" paragraph sitting alongside the split version of
+ * the same prose). Both shapes render the text twice on the entity card.
+ *
+ * This is exactly how "Can't Stop, Won't Stop" and "Mech-Gyver" regressed: the
+ * `Break out Actions (#66)` migration, which lifted action prose out of
+ * abilities.json into actions.json, emitted BOTH its un-split source blob and
+ * its paragraph-split output for those two records. Nine validators existed at
+ * the time and not one looked *inside* a single record's own content array, so
+ * it sat undetected. This check closes that gap.
+ *
+ * Deliberately scoped to a single record: repetition ACROSS records is normal
+ * and heavily used in this corpus (the Tech 2–6 Pilot Bay tiers, the
+ * Crawler/Pilot/Mech movement rates on the map guides, Minor/Major injury
+ * healing). Only self-duplication is a defect.
+ */
+
+/** How a paragraph duplicates another within the same record. */
+export type DupeKind =
+  /** Two paragraphs normalize to exactly the same text. */
+  | 'exact'
+  /** One paragraph fully contains another (the un-split "blob" shape). */
+  | 'contains'
+
+export type ContentDupe = {
+  file: string
+  /** `name` of the owning record, for a human-readable breadcrumb. */
+  record: string
+  kind: DupeKind
+  /** 1-based index of the paragraph that repeats/swallows the other. */
+  paragraph: number
+  /** 1-based index of the paragraph being repeated/swallowed. */
+  duplicateOf: number
+  /** Leading text of the duplicated prose, for the diagnostic message. */
+  excerpt: string
+}
+
+/**
+ * Paragraphs shorter than this (in words) are ignored.
+ *
+ * Short stock phrases legitimately recur inside one record — a stat line, a
+ * bare "Roll to hit as normal.", a repeated table caption. The duplication this
+ * check exists to catch is always a substantial block of rules prose, so a
+ * floor buys immunity to that noise at no cost to detection: both known
+ * regressions duplicate 20+ word sentences.
+ */
+export const MIN_WORDS = 8
+
+/**
+ * Normalize a paragraph for comparison.
+ *
+ * Strips `[[Trait]]` link markers, collapses whitespace, and lowercases. The
+ * marker-stripping is load-bearing rather than cosmetic: in the "Can't Stop,
+ * Won't Stop" regression the blob kept its `[[Vulnerable]]` links while the
+ * split copies had degraded to plain `Vulnerable`, so a marker-sensitive
+ * comparison would have missed the duplication entirely.
+ */
+export function normalizeParagraph(value: string): string {
+  return value
+    .replace(/\[\[|\]\]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase()
+}
+
+const wordCount = (normalized: string): number =>
+  normalized.length === 0 ? 0 : normalized.split(' ').length
+
+/** Extract the comparable paragraph strings from one `content[]` array. */
+function paragraphValues(content: unknown[]): (string | null)[] {
+  return content.map((block) => {
+    if (block === null || typeof block !== 'object') return null
+    const value = (block as Record<string, unknown>).value
+    return typeof value === 'string' ? value : null
+  })
+}
+
+const excerpt = (normalized: string): string =>
+  normalized.length <= 80 ? normalized : `${normalized.slice(0, 80)}…`
+
+/**
+ * Find self-duplicating paragraphs within a single `content[]` array.
+ *
+ * Reports each duplicated pair once. For an `exact` pair only the later
+ * paragraph is reported (the earlier one is treated as the original); for a
+ * `contains` pair the containing paragraph is reported against the one it
+ * swallows.
+ */
+export function findDupesInContent(content: unknown[]): Omit<ContentDupe, 'file' | 'record'>[] {
+  const raw = paragraphValues(content)
+  const normalized = raw.map((v) => (v === null ? null : normalizeParagraph(v)))
+  const eligible = normalized.map((n) => n !== null && wordCount(n) >= MIN_WORDS)
+
+  const dupes: Omit<ContentDupe, 'file' | 'record'>[] = []
+
+  for (let i = 0; i < normalized.length; i++) {
+    if (!eligible[i]) continue
+    const a = normalized[i] as string
+
+    for (let j = 0; j < normalized.length; j++) {
+      if (i === j || !eligible[j]) continue
+      const b = normalized[j] as string
+
+      if (a === b) {
+        // Exact pair: report only the later occurrence, so one pair yields one
+        // diagnostic rather than two mirror-image ones.
+        if (j < i) {
+          dupes.push({ kind: 'exact', paragraph: i + 1, duplicateOf: j + 1, excerpt: excerpt(b) })
+        }
+        continue
+      }
+
+      if (a.includes(b)) {
+        dupes.push({ kind: 'contains', paragraph: i + 1, duplicateOf: j + 1, excerpt: excerpt(b) })
+      }
+    }
+  }
+
+  return dupes
+}
+
+/**
+ * Walk an arbitrary data node, reporting self-duplication in every `content[]`
+ * array found. Recurses into nested structures (chassis patterns, choice
+ * blocks, etc.) so nested records are covered too, carrying the nearest
+ * enclosing `name` as the breadcrumb.
+ */
+function walk(node: unknown, file: string, recordName: string, out: ContentDupe[]): void {
+  if (Array.isArray(node)) {
+    for (const child of node) walk(child, file, recordName, out)
+    return
+  }
+  if (node === null || typeof node !== 'object') return
+
+  const record = node as Record<string, unknown>
+  const name = typeof record.name === 'string' ? record.name : recordName
+
+  if (Array.isArray(record.content)) {
+    for (const dupe of findDupesInContent(record.content)) {
+      out.push({ file, record: name, ...dupe })
+    }
+  }
+
+  for (const value of Object.values(record)) walk(value, file, name, out)
+}
+
+/**
+ * Orchestration entry point: given the full data bag (filename -> parsed
+ * array), return every intra-record content duplication. Both the standalone
+ * CLI (tools/validateContentDupes.ts) and the unified runner
+ * (tools/validate.ts) call this so the two can never diverge.
+ */
+export function runContentDupeCheck(
+  filesByName: Record<string, Record<string, unknown>[]>
+): ContentDupe[] {
+  const dupes: ContentDupe[] = []
+  for (const [file, records] of Object.entries(filesByName)) {
+    walk(records, file, '(unnamed)', dupes)
+  }
+  return dupes
+}

--- a/packages/salvageunion-reference/tools/validationTypes.ts
+++ b/packages/salvageunion-reference/tools/validationTypes.ts
@@ -3,7 +3,7 @@
  *
  * Every check (existing and new) converges on this shape so `tools/validate.ts`
  * can print one consistent report and group/filter uniformly, regardless of
- * which of the 8 checks produced a given diagnostic.
+ * which of the 11 checks produced a given diagnostic.
  */
 
 export type Diagnostic = {


### PR DESCRIPTION
## What

`Can't Stop, Won't Stop` and `Mech-Gyver` each rendered their rules text **twice** on the entity card. Both records carried an un-split "blob" paragraph *alongside* the split version of the same prose.

- **Can't Stop, Won't Stop** — p1 was the entire ability text; p2–p4 were that same text split into its natural paragraphs.
- **Mech-Gyver** — p2 ended with the complete text of p3.

## Why it happened

Both were introduced by de972e71 (`Break out Actions (#66)`), the migration that lifted action prose out of `abilities.json` into `actions.json`. For these two records it emitted *both* its un-split source blob *and* its paragraph-split output instead of choosing one.

The giveaway is the trait markup: the `Can't Stop, Won't Stop` blob kept its `[[Vulnerable]]` links while the split copies had degraded to plain `Vulnerable` — two different passes over the same text.

## The fix

Each blob is trimmed to the text that is genuinely its own (the leading flavour sentence), keeping the split paragraphs as the mechanics. This lands both records on the book's flavour-then-mechanics shape rather than deleting a paragraph outright. The `[[Vulnerable]]` links are restored on the two `Can't Stop, Won't Stop` paragraphs that had lost them.

The data change is 8 lines.

## Why nothing caught it

Nine validators existed and **none looked inside a single record's own `content` array**, so this sat undetected since November. This PR adds a `content-dupes` check to close that gap:

- Flags a paragraph that repeats another **of the same record** verbatim, or fully contains it.
- Compares with `[[Trait]]` markers stripped — load-bearing, since the blob kept its links while the copies had not, so a marker-sensitive comparison would have missed this entirely.
- Ignores paragraphs under 8 words, so short stock phrases don't produce noise.
- **Scoped to within-record duplication only.** Repetition *across* records is normal and heavily used in this corpus — the Tech 2–6 Pilot Bay tiers, the Crawler/Pilot/Mech movement rates on the map guides, Minor/Major injury healing. A cross-record check would be all false positives.

Wired into the unified runner (`validate:all`) and available standalone as `bun --filter salvageunion-reference validate:content-dupes`.

## Verification

- Run against the **pre-fix** data, the new check reports exactly these two records (4 paragraph diagnostics) and exits non-zero; clean and exit 0 after the fix.
- 12 new unit tests cover both dupe shapes, trait-marker insensitivity, the word floor, nested records, and the no-cross-record-false-positives guarantee — plus a regression test asserting the real corpus stays clean.
- A repo-wide fuzzy sweep (Jaccard ≥ 0.5 over paragraph shingles) found no other affected records; all 25 near-matches are legitimate parallel prose.
- `bun run check:all` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MXFAPGYPk765YeLGhNTYT