### PR TITLE
feat(srd): server-render the entity card on the 82% of pages that are documents

### DIFF
--- a/apps/srd/src/components/EntityCardStatic.tsx
+++ b/apps/srd/src/components/EntityCardStatic.tsx
@@ -1,0 +1,61 @@
+import {
+  ClassAbilityTree,
+  EntityDetailLinkProvider,
+  EntityHrefProvider,
+  getClassSelections,
+  PatternHrefProvider,
+  ReferenceEntityCard,
+} from 'component-lib'
+import type { SURefEntity, SURefObjectPattern } from 'salvageunion-reference'
+import { srdEntityHref } from '../lib/entityHref'
+import { srdPatternHref } from '../lib/patternHref'
+
+type EntityCardStaticProps = {
+  item: SURefEntity
+  pattern?: SURefObjectPattern
+  titleAs?: 'span' | 'h1'
+}
+
+/**
+ * The reference entity card, rendered to HTML at build time.
+ *
+ * This is the same `ReferenceEntityCard` the builder app uses — NOT a
+ * simplified stand-in. It carries no `client:*` directive, so Astro renders it
+ * to static markup and ships no JS for it, exactly as `SiteHeader` does.
+ *
+ * That is only possible because the SRD is a Reference surface (ADR-021): it
+ * passes no `controls`, and `EntityDetailLinkProvider` puts nested entities in
+ * link mode, so every affordance on the card is a navigation rather than client
+ * state. The card must therefore never be given a `client:*` directive here —
+ * hydrating it would re-introduce the React #418 mismatch that the old
+ * island + `GameDataGate` arrangement existed to avoid.
+ *
+ * Callers must `await SalvageUnionReference.preload(...)` in their Astro
+ * frontmatter before rendering this, so the ORM lookups the card makes for
+ * nested entities resolve synchronously during the build.
+ */
+export function EntityCardStatic({ item, pattern, titleAs }: EntityCardStaticProps) {
+  const classSelections = getClassSelections(item)
+  const classEntity = classSelections.selectedClass || classSelections.selectedAdvancedClass
+
+  return (
+    <div className="mx-auto w-full max-w-6xl p-4">
+      <EntityHrefProvider value={srdEntityHref}>
+        <EntityDetailLinkProvider value={true}>
+          <PatternHrefProvider value={srdPatternHref}>
+            <ReferenceEntityCard
+              data={item}
+              pattern={pattern}
+              size="large"
+              titleAs={titleAs}
+              afterExtraContent={
+                classEntity ? <ClassAbilityTree classEntity={classEntity} /> : undefined
+              }
+              asideLead={!!classEntity}
+            />
+          </PatternHrefProvider>
+        </EntityDetailLinkProvider>
+      </EntityHrefProvider>
+    </div>
+  )
+}

--- a/apps/srd/src/components/EntityView.astro
+++ b/apps/srd/src/components/EntityView.astro
@@ -1,20 +1,32 @@
 ---
 import type { SURefEntity, SURefObjectPattern } from 'salvageunion-reference'
+import { SalvageUnionReference } from 'salvageunion-reference'
 import { ReferenceEntityIsland } from './islands/ReferenceEntityIsland'
+import { EntityCardStatic } from './EntityCardStatic'
 import { StaticEntityContent } from 'component-lib'
+import { cardNeedsHydration } from '../lib/cardNeedsHydration'
 import { extractStaticEntitySummary } from '../lib/gameData'
 import { patternStaticSummary } from '../lib/patternSummary'
 import { getSchemaPreloadList } from '../lib/schemaPreloadDeps'
 import { resolveTraitHref } from '../lib/staticLinks'
 
 /**
- * EntityView — the reference entity as ONE render unit: the interactive island
- * card plus its own static SEO / no-JS sub-content, rendered alongside it.
+ * EntityView — the reference entity, rendered the lightest way it can be.
  *
- * The static block is the Entity's sub-content, not a separate page concern:
- * BaseLayout's pre-paint `.js` class hides `[data-static-fallback]` for JS
- * users via global.css (no text flash), and the island removes it once game
- * data is ready — no-JS users and crawlers keep the content for SEO.
+ * Most SRD entities are documents: prose, stats and links, with nothing on the
+ * card that needs a click handler. Those render to HTML at build time and ship
+ * no JS at all — the real `ReferenceEntityCard`, not a simplified stand-in.
+ *
+ * A minority embed something genuinely interactive (a roll table's Roll button,
+ * a disclosure, a nested-entity click target). Those keep the original island:
+ * a `client:visible` card gated on a browser-side preload, paired with
+ * `StaticEntityContent` so crawlers and no-JS readers still get the text.
+ *
+ * The island cannot simply be dropped for them. `useGameData`'s server snapshot
+ * is hardcoded `false` on purpose, so a hydrating card renders the fallback on
+ * the client's first pass while the server rendered the real thing — the React
+ * #418 mismatch. Server-rendering is therefore only sound where nothing needs
+ * to hydrate afterwards, which is exactly what `cardNeedsHydration` decides.
  */
 
 type Props = {
@@ -25,16 +37,36 @@ type Props = {
 }
 
 const { item, schemaId, pattern } = Astro.props
-const staticSummary = pattern
-  ? patternStaticSummary(item, pattern)
-  : extractStaticEntitySummary(item)
+
+// Both paths need the ORM: the static one renders the card here and now, and
+// the probe below has to render it to find out which path we are on. `preload`
+// caches per schema, so across a 1,000-page build this costs one load per
+// schema, not one per page.
+const preloadSchemas = getSchemaPreloadList(schemaId)
+await SalvageUnionReference.preload(preloadSchemas)
+
+const needsHydration = cardNeedsHydration(item, pattern)
+
+const staticSummary = needsHydration
+  ? pattern
+    ? patternStaticSummary(item, pattern)
+    : extractStaticEntitySummary(item)
+  : null
 ---
 
-<ReferenceEntityIsland
-  client:visible
-  item={item}
-  pattern={pattern}
-  titleAs="h1"
-  preloadSchemas={getSchemaPreloadList(schemaId)}
-/>
-<StaticEntityContent summary={staticSummary} resolveTraitHref={resolveTraitHref} />
+{
+  needsHydration ? (
+    <>
+      <ReferenceEntityIsland
+        client:visible
+        item={item}
+        pattern={pattern}
+        titleAs="h1"
+        preloadSchemas={preloadSchemas}
+      />
+      <StaticEntityContent summary={staticSummary!} resolveTraitHref={resolveTraitHref} />
+    </>
+  ) : (
+    <EntityCardStatic item={item} pattern={pattern} titleAs="h1" />
+  )
+}

--- a/apps/srd/src/components/islands/__tests__/hydration-directives.test.ts
+++ b/apps/srd/src/components/islands/__tests__/hydration-directives.test.ts
@@ -8,16 +8,49 @@ function readAstroFile(relativePath: string): string {
   return readFileSync(resolve(srcDir, relativePath), 'utf-8')
 }
 
+/**
+ * Just the markup of an `.astro` file — everything after the closing `---` of
+ * its frontmatter.
+ *
+ * Hydration directives only mean anything in the template, and these guards
+ * assert on the ABSENCE of things. Matching the raw file would let a prose
+ * comment explaining why an island was removed fail the very test asserting it
+ * is gone, so the two halves are read separately.
+ */
+function readAstroTemplate(relativePath: string): string {
+  const content = readAstroFile(relativePath)
+  const match = content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n([\s\S]*)$/)
+  return match?.[1] ?? content
+}
+
 describe('hydration directives', () => {
-  describe('below-fold islands use client:visible', () => {
-    it('ReferenceEntityIsland in EntityView uses client:visible', () => {
+  describe('the entity card is server-rendered unless it needs a listener', () => {
+    // Most SRD entities are documents and render to HTML at build time with no
+    // JS. Only cards that emit something needing a click handler keep the
+    // island. Both halves of that are load-bearing: dropping the island for an
+    // interactive card leaves a rendered-but-dead control, and hydrating a
+    // static one re-introduces the React #418 mismatch that `useGameData`'s
+    // hardcoded-false server snapshot exists to prevent.
+    it('EntityView preloads the ORM and branches on cardNeedsHydration', () => {
       const content = readAstroFile('src/components/EntityView.astro')
-      expect(content).toContain('ReferenceEntityIsland')
-      expect(content).toContain('client:visible')
-      expect(content).not.toMatch(/ReferenceEntityIsland[^>]*client:idle/)
-      expect(content).not.toMatch(/ReferenceEntityIsland[^>]*client:load/)
+      expect(content).toMatch(/await\s+SalvageUnionReference\.preload\(/)
+      expect(content).toMatch(/cardNeedsHydration\(/)
     })
 
+    it('the static path carries no client directive', () => {
+      const template = readAstroTemplate('src/components/EntityView.astro')
+      const staticBranch = template.slice(template.indexOf('EntityCardStatic'))
+      expect(staticBranch).not.toMatch(/client:(load|idle|visible|only|media)/)
+    })
+
+    it('the interactive path keeps client:visible and its no-JS fallback', () => {
+      const template = readAstroTemplate('src/components/EntityView.astro')
+      expect(template).toMatch(/ReferenceEntityIsland[\s\S]{0,160}client:visible/)
+      expect(template).toContain('StaticEntityContent')
+    })
+  })
+
+  describe('below-fold islands use client:visible', () => {
     it('SchemaViewerIsland in schema index page uses client:visible', () => {
       const content = readAstroFile('src/pages/schema/[schemaId]/index.astro')
       expect(content).toContain('SchemaViewerIsland')

--- a/apps/srd/src/lib/cardNeedsHydration.tsx
+++ b/apps/srd/src/lib/cardNeedsHydration.tsx
@@ -1,0 +1,42 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { SURefEntity, SURefObjectPattern } from 'salvageunion-reference'
+import { EntityCardStatic } from '../components/EntityCardStatic'
+
+/**
+ * Markup that only does something once React is attached.
+ *
+ * `<a href>` is deliberately absent: an anchor works in a document that never
+ * hydrates, and anchors are how the SRD's card reaches nested entities in link
+ * mode. Everything here, by contrast, is inert without a listener — a rendered
+ * `<button>` with no handler is a defect under the ruleset's "rust means
+ * action" rule, not a cosmetic wart.
+ */
+const NEEDS_A_LISTENER =
+  /<button\b|<input\b|<select\b|<textarea\b|role="button"|aria-expanded=|aria-haspopup=/
+
+/**
+ * Does this entity's card contain anything that needs JS to work?
+ *
+ * Answered by *rendering the card and reading the result*, not by inspecting
+ * the entity's data. The card decides what controls to emit deep inside its own
+ * recursion (roll tables, disclosures, nested-entity click targets), so any
+ * data-shape heuristic would drift the moment that logic changed — and drift
+ * here is silent, shipping a dead button rather than failing a build.
+ *
+ * Cost is one extra static render per entity page at build time, which is
+ * cheap: the full 1,039-page build runs in a few seconds.
+ *
+ * Fails SAFE. If the probe render throws, the answer is "yes, hydrate" — the
+ * island path is the status quo and always correct, just heavier. The static
+ * path is the optimization, and an optimization must never be the fallback.
+ */
+export function cardNeedsHydration(item: SURefEntity, pattern?: SURefObjectPattern): boolean {
+  try {
+    const markup = renderToStaticMarkup(
+      <EntityCardStatic item={item} pattern={pattern} titleAs="h1" />
+    )
+    return NEEDS_A_LISTENER.test(markup)
+  } catch {
+    return true
+  }
+}

--- a/packages/component-lib/src/components/referenceEntity/card/EntityCardHeader.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/EntityCardHeader.tsx
@@ -72,11 +72,18 @@ const HYSTERESIS = 24
  *
  * The wrap is the floor for every case this measurement declines to judge: an
  * unmeasurable band (below), no `ResizeObserver`, or a host that renders the
- * card without ever running an effect. It is NOT what a crawler sees — srd
- * gates this card behind `GameDataGate` and serves `StaticEntityContent` to
- * no-JS readers, and ITUN is client-only, so the card is never
- * server-rendered. Nor is it a visible frame: `useLayoutEffect` measures
- * before paint, so the boxes never flash on a narrow card.
+ * card without ever running an effect.
+ *
+ * That floor is load-bearing, not an edge case. srd renders most entity cards
+ * to HTML at build time and ships no JS for them (only cards carrying a real
+ * control keep an island), so on those pages the effect never runs at all and
+ * the wrap IS what the reader gets. Treat it as the real layout and the
+ * measurement as a progressive refinement for hosts that hydrate — ITUN, which
+ * is client-only, and srd's interactive minority. Anything that must be legible
+ * on a phone has to survive the wrap alone.
+ *
+ * Where the effect does run it is not a visible frame: `useLayoutEffect`
+ * measures before paint, so the boxes never flash on a narrow card.
  *
  * Measured, not breakpointed, because "enough space" is a function of the CARD's
  * width and its stat COUNT, not the viewport: a 2-stat card is fine at 320px and

--- a/packages/component-lib/src/components/referenceEntity/card/__tests__/narrowStats.test.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/__tests__/narrowStats.test.tsx
@@ -10,9 +10,11 @@
  *
  *   1. the cluster SHRINKS (so the boxes wrap onto a second row) — the floor
  *      for every case the measurement below declines to judge (an unmeasurable
- *      band, no `ResizeObserver`). It is not what a crawler sees: srd gates the
- *      card behind `GameDataGate` and serves `StaticEntityContent` to no-JS
- *      readers, and ITUN is client-only, so the card is never server-rendered;
+ *      band, no `ResizeObserver`). This is the layer srd actually ships on most
+ *      entity pages: it renders the card to HTML at build time with no client
+ *      JS, so the measurement in layer 2 never runs there and the wrap is what
+ *      the reader gets. Layer 2 refines it only on hosts that hydrate — ITUN,
+ *      and the srd cards that carry a real control;
  *   2. once mounted the header MEASURES itself and, when the boxes don't fit,
  *      swaps to the compact `[label | value]` cells with their short-form
  *      labels (SV / SYS / MODS) — the same badge anatomy a listing card uses.


### PR DESCRIPTION
## What

ADR-012 promises "entity pages are server-pre-rendered". They were not. The entity card was a `client:visible` island gated on a browser-side `SalvageUnionReference.preload()`, and `useGameData`'s server snapshot is hardcoded `false` — deliberately, to prevent a React #418 hydration mismatch — so Astro could only ever emit a **loading skeleton** where the card should be.

The readable content came from `StaticEntityContent`, a separate simplified renderer that the island hid on hydration and deleted once data arrived. Every entity page shipped three representations of one entity: skeleton, serialized props, shadow copy. The real card was unreachable to crawlers and no-JS readers.

The data is static JSON in this repo, so it is available during the build. `EntityView.astro` now awaits `preload()` in its frontmatter and renders the real `ReferenceEntityCard` with **no `client:*` directive**, so Astro emits it as markup and ships no JS for it — the same shape `SiteHeader` already uses.

## The gate

This could not be done for every page, and that is the important part of the change.

Most SRD entities are documents — prose, stats, links, nothing needing a click handler. A minority embed a real control: a roll table's Roll button, a disclosure, a nested-entity click target. Removing the island for those would leave a **rendered-but-dead rust action button**, which `docs/design-system/ruleset.md` treats as a defect ("rust means action, and only action"). Measured before gating, an ungated change would have shipped **257 dead buttons across 174 pages**, plus 140 nested-card click targets and 30 disclosures.

Hydrating the static ones is equally unsound — that is exactly the #418 mismatch the hardcoded `false` exists to prevent. So server-rendering is applied only where nothing hydrates afterwards.

`cardNeedsHydration` decides by **rendering the card and inspecting the markup** for anything needing a listener, rather than reading the entity's data shape. The card decides what controls to emit deep inside its own recursion, so a data-shape heuristic would drift the moment that logic changed — and drift here is silent, shipping a dead button instead of failing a build. It costs one extra static render per page against a build that runs in seconds, and it **fails safe**: if the probe throws, the answer is "hydrate", because the island is the status quo and the static path is only ever an optimization.

## Measured

Over the full 1,039-page build, verified against the built HTML:

|                                                | |
| ---------------------------------------------- | --- |
| entity pages server-rendering the real card    | **819 / 1,004 (81.6%)** |
| dead controls in those pages                   | **0** |
| pages keeping the island (unchanged)           | 185 |
| readable text, `/schema/chassis/item/forge/`   | ~490 → **1,939 chars** |

The chassis ability and all four patterns now appear in the HTML. Previously **neither did** — `grep -c "Pattern"` on that built page returned `0`. Those pages also no longer fetch the game-data corpus at all: the card's island chunk and its schema preload are gone, and `SearchIsland` already defers.

The 185 interactive pages are byte-for-byte unchanged, so this is a strict improvement with no user-visible regression.

## Notes for review

- `apps/srd/src/lib/cardNeedsHydration.tsx` is the load-bearing file. The comment there explains why it probes rather than guesses, and why `<a href>` is deliberately absent from the "needs a listener" pattern — anchors work fine in a document that never hydrates.
- The `hydration-directives` guard test now pins both halves: the static path carries no directive, the interactive path keeps `client:visible` **and** its no-JS fallback. Its helper reads the `.astro` template separately from the frontmatter, so a prose comment can no longer fail the very test asserting a symbol is gone.
- Two comments in `component-lib` claimed "the card is never server-rendered". That is now false for most srd pages, and the `narrow` stat-cluster wrap is the layout srd actually ships rather than an edge case. Both corrected.

## Base

Stacked on #684 rather than `main`, so the diff is this commit alone. **CI will not run while the base is a feature branch** — `.github/workflows/ci.yml` triggers on `pull_request: branches: ['main']` only. Re-target to `main` once #684 lands and checks will fire.

Full `bun run check:all` is green locally on this base: lint, format, typecheck across all 5 workspaces, tests, validate, knip, audit, tokens, styling.
