### PR TITLE
feat(observability): report su-assets Blobs failures to Sentry, document the Convex route

### DIFF
--- a/apps/itun/CLAUDE.md
+++ b/apps/itun/CLAUDE.md
@@ -106,6 +106,15 @@ and remains the account-free way to share a build.
   ([ADR-010](../../docs/adrs/ADR-010-srd-choices-ephemeral-vs-persisted.md)).
 - Backup nudge (`src/lib/backupNudge.ts`) tracks un-exported writes — the
   local-first analogue of durability.
+- **Do not add a Sentry SDK to `convex/`.** The browser bundle
+  (`src/lib/observability.ts`) and the Netlify Functions
+  (`netlify/functions/_observability.ts`) each own one; Convex instead uses its
+  first-party Exception Reporting integration, enabled in the Convex dashboard
+  with no application code. Queries and mutations run in a deterministic runtime
+  with no `fetch`, so an in-function SDK could not report from them at all —
+  rationale and the enable-it runbook are in
+  [docs/architecture/accounts-and-games.md](../../docs/architecture/accounts-and-games.md)
+  ("Convex error reporting — a dashboard toggle, not code").
 
 ## Commands
 

--- a/apps/su-assets/netlify/functions/__tests__/_observability.test.ts
+++ b/apps/su-assets/netlify/functions/__tests__/_observability.test.ts
@@ -1,0 +1,126 @@
+/**
+ * _observability — the artwork host's only channel for finding out that
+ * production broke. It is entirely env-gated, and the gate is the interesting
+ * part: with no DSN every export must be a silent no-op (local dev, CI and
+ * forks all run that way), and with one it must actually report. A regression
+ * in either direction is invisible until the day you need it — a host that has
+ * stopped reporting looks exactly like a host with no errors.
+ *
+ * `@sentry/node` is mocked and **restored in `afterAll`**: `mock.module` is
+ * process-global in Bun, not file-scoped, so leaving it in place would hand
+ * this fake to `asset.test.ts` too. The DSN is driven through `process.env`
+ * because that is what the module actually reads, and it is deleted again
+ * before the mock is restored so no later file inherits a live DSN.
+ *
+ * Assertion style: toBe() / toEqual() — not toBeInTheDocument().
+ */
+
+import { afterAll, beforeAll, describe, expect, mock, test } from 'bun:test'
+
+const sentryCalls: Array<{ fn: string; args: unknown[] }> = []
+
+const realSentry = { ...(await import('@sentry/node')) }
+
+mock.module('@sentry/node', () => ({
+  init: (...args: unknown[]) => sentryCalls.push({ fn: 'init', args }),
+  captureException: (...args: unknown[]) => sentryCalls.push({ fn: 'captureException', args }),
+}))
+
+let obs: typeof import('../_observability')
+
+beforeAll(async () => {
+  obs = await import('../_observability')
+})
+
+afterAll(() => {
+  delete process.env.SENTRY_DSN
+  delete process.env.COMMIT_REF
+  mock.module('@sentry/node', () => realSentry)
+})
+
+function calls(fn: string): Array<{ fn: string; args: unknown[] }> {
+  return sentryCalls.filter((c) => c.fn === fn)
+}
+
+/**
+ * These run in order against one module instance, because `initialized` /
+ * `enabled` are module-level state and the transition from off to on is
+ * exactly what is being tested.
+ */
+describe('with no DSN configured', () => {
+  test('init reports nothing and does not enable Sentry', () => {
+    delete process.env.SENTRY_DSN
+    obs.initObservability()
+    expect(calls('init')).toHaveLength(0)
+  })
+
+  test('captureException is a no-op rather than an unconfigured send', () => {
+    obs.captureException(new Error('boom'))
+    expect(calls('captureException')).toHaveLength(0)
+  })
+
+  test('a later init with a DSN stays off — the gate latches on first call', () => {
+    // Netlify Functions call `initObservability()` at the top of every
+    // invocation, so the first call of a cold start decides. A DSN appearing
+    // afterwards cannot happen in production, and pretending otherwise would
+    // let this test file mask a real "we never read the DSN" bug.
+    process.env.SENTRY_DSN = 'https://key@example.ingest.sentry.io/1'
+    obs.initObservability()
+    expect(calls('init')).toHaveLength(0)
+    expect(calls('captureException')).toHaveLength(0)
+  })
+})
+
+/**
+ * A fresh module instance, because the gate above has latched. `import()`
+ * dedupes by specifier, so a query string is the way to get a second
+ * evaluation of the same file. It is held in a variable rather than written
+ * inline because TypeScript resolves *literal* specifiers and has no module
+ * declaration for a cache-busted one; a non-literal specifier is untyped, so
+ * the cast restores the real shape.
+ */
+const FRESH_SPECIFIER = '../_observability?fresh'
+
+describe('once a DSN is configured before the first init', () => {
+  let fresh: typeof import('../_observability')
+
+  beforeAll(async () => {
+    process.env.SENTRY_DSN = 'https://key@example.ingest.sentry.io/1'
+    process.env.COMMIT_REF = 'abc123'
+    fresh = (await import(FRESH_SPECIFIER)) as typeof import('../_observability')
+  })
+
+  test('init passes the DSN, environment and release through', () => {
+    fresh.initObservability()
+
+    const init = calls('init')[0]
+    expect(init).toBeDefined()
+    expect(init?.args[0]).toMatchObject({
+      dsn: 'https://key@example.ingest.sentry.io/1',
+      // bunfig.toml pins NODE_ENV = "test" for this workspace; the point is
+      // that the environment is never blank — an untagged event is
+      // indistinguishable from one raised in dev.
+      environment: 'test',
+      release: 'abc123',
+    })
+  })
+
+  test('a second call is a no-op, so every invocation can call it freely', () => {
+    fresh.initObservability()
+    expect(calls('init')).toHaveLength(1)
+  })
+
+  test('exceptions are reported, with context as extra when given', () => {
+    const error = new Error('blobs down')
+    fresh.captureException(error, { fn: 'asset', key: 'chassis/iron-mongrel.png' })
+
+    const c = calls('captureException')[0]
+    expect(c?.args[0]).toBe(error)
+    expect(c?.args[1]).toEqual({ extra: { fn: 'asset', key: 'chassis/iron-mongrel.png' } })
+  })
+
+  test('no context sends undefined rather than an empty extra bag', () => {
+    fresh.captureException(new Error('bare'))
+    expect(calls('captureException')[1]?.args[1]).toBeUndefined()
+  })
+})

--- a/apps/su-assets/netlify/functions/__tests__/asset.test.ts
+++ b/apps/su-assets/netlify/functions/__tests__/asset.test.ts
@@ -34,9 +34,21 @@ function makeStore(contents: Record<string, string>) {
   return { store, requested }
 }
 
+/** Collects what the handler reported, so a test can assert on silence too. */
+function makeReporter() {
+  const reported: Array<{ error: unknown; context?: Record<string, unknown> }> = []
+  return {
+    reported,
+    report: (error: unknown, context?: Record<string, unknown>) => {
+      reported.push({ error, context })
+    },
+  }
+}
+
 function handlerWith(contents: Record<string, string> = {}) {
   const { store, requested } = makeStore(contents)
-  return { handler: makeAssetHandler(() => store), requested }
+  const { reported, report } = makeReporter()
+  return { handler: makeAssetHandler(() => store, report), requested, reported }
 }
 
 const get = (path: string) => new Request(`${BASE}${path}`)
@@ -162,4 +174,72 @@ describe('asset function — hits', () => {
     expect(await res.text()).toBe('Not found')
     expect(requested).toEqual(['chassis/nope.png'])
   })
+})
+
+describe('asset function — error reporting', () => {
+  it('reports a failing Blobs read as a 503, with the key as context', async () => {
+    // This is the failure that is currently invisible: artwork stops resolving
+    // in both srd and itun at once, and nothing anywhere says so.
+    const failure = new Error('blobs unavailable')
+    const { reported, report } = makeReporter()
+    const handler = makeAssetHandler(
+      () => ({
+        get: async () => {
+          throw failure
+        },
+      }),
+      report
+    )
+
+    const res = await handler(get('/chassis/iron-mongrel.png'))
+
+    expect(res.status).toBe(503)
+    expect(await res.text()).toBe('Asset storage unavailable')
+    expect(reported).toHaveLength(1)
+    expect(reported[0]?.error).toBe(failure)
+    expect(reported[0]?.context).toEqual({
+      fn: 'asset',
+      op: 'blobs.get',
+      key: 'chassis/iron-mongrel.png',
+    })
+  })
+
+  it('reports a store that cannot even be opened', async () => {
+    // `getStore` throws outside the Netlify Blobs runtime context or when the
+    // store binding is missing — a deploy-shaped failure, not a request-shaped
+    // one, and the one worth waking up for.
+    const failure = new Error('missing blobs context')
+    const { reported, report } = makeReporter()
+    const handler = makeAssetHandler(() => {
+      throw failure
+    }, report)
+
+    const res = await handler(get('/chassis/iron-mongrel.png'))
+
+    expect(res.status).toBe(503)
+    expect(reported).toHaveLength(1)
+    expect(reported[0]?.error).toBe(failure)
+  })
+
+  // A 404 is an ordinary outcome on a public host that answers every path.
+  // Reporting these is how a Sentry project becomes a crawler log that nobody
+  // reads — at which point the Blobs outage above is invisible again.
+  const silent: Array<[label: string, path: string]> = [
+    ['a missing asset', '/chassis/nope.png'],
+    ['an unsupported extension', '/notes.txt'],
+    ['an extensionless path', '/chassis/iron-mongrel'],
+    ['an encoded traversal attempt', '/chassis/..%2Fsecrets.png'],
+    ['a dotfile probe', '/.env.png'],
+    ['the site root', '/'],
+  ]
+
+  for (const [label, path] of silent) {
+    it(`reports nothing for ${label}`, async () => {
+      const { handler, reported } = handlerWith()
+      const res = await handler(get(path))
+
+      expect(res.status).toBe(404)
+      expect(reported).toEqual([])
+    })
+  }
 })

--- a/apps/su-assets/netlify/functions/_observability.ts
+++ b/apps/su-assets/netlify/functions/_observability.ts
@@ -1,0 +1,45 @@
+/**
+ * _observability — optional Sentry error tracking for the artwork function.
+ *
+ * Mirrors apps/itun/netlify/functions/_observability.ts exactly; this is the
+ * same shape of surface (one Netlify Function, `@sentry/node`, a Blobs store
+ * behind it) and there is no reason for the two to drift.
+ *
+ * Entirely env-gated: when SENTRY_DSN is unset (local dev, tests, forks) every
+ * export here is a no-op and no Sentry network calls are made. No DSN is ever
+ * committed — it is supplied via the `su-assets` Netlify site environment. The
+ * leading underscore keeps this out of the deployed function routes (Netlify
+ * ignores `_`-prefixed files as endpoints), which matters more here than on
+ * itun: `asset.ts` claims `path: '/*'`, so a second routable function in this
+ * directory would be an unclaimed endpoint on the artwork host.
+ */
+
+import * as Sentry from '@sentry/node'
+
+let initialized = false
+let enabled = false
+
+/** Initializes Sentry once per cold start, if SENTRY_DSN is configured. */
+export function initObservability(): void {
+  if (initialized) return
+  initialized = true
+  const dsn = process.env.SENTRY_DSN
+  if (!dsn) return
+  Sentry.init({
+    dsn,
+    environment: process.env.NODE_ENV ?? 'production',
+    // Tags events with the deployed commit so an error maps back to a
+    // specific deploy. COMMIT_REF is a Netlify-provided deploy-metadata var;
+    // whether it reaches the Function's *runtime* environment is unconfirmed
+    // (see the itun module for the same caveat and its fallback).
+    release: process.env.COMMIT_REF,
+  })
+  enabled = true
+}
+
+/** Reports an error to Sentry when enabled; otherwise a no-op. */
+export function captureException(error: unknown, context?: Record<string, unknown>): void {
+  if (enabled) {
+    Sentry.captureException(error, context ? { extra: context } : undefined)
+  }
+}

--- a/apps/su-assets/netlify/functions/asset.ts
+++ b/apps/su-assets/netlify/functions/asset.ts
@@ -14,6 +14,7 @@
  * mutated in place (a new image gets a new name).
  */
 import { getStore } from '@netlify/blobs'
+import { captureException, initObservability } from './_observability'
 
 const CONTENT_TYPES: Record<string, string> = {
   png: 'image/png',
@@ -36,11 +37,27 @@ export type AssetBlobStore = {
 }
 
 /**
+ * How a failure is reported. Injected for the same reason the store is — the
+ * tests assert *which* outcomes reach Sentry and which deliberately do not,
+ * and doing that with `mock.module('@sentry/node')` would rewrite the module
+ * registry for the whole test process.
+ */
+export type AssetFailureReporter = (error: unknown, context?: Record<string, unknown>) => void
+
+/**
  * Handler factory. The store getter is invoked per request (never at module
  * scope) because `getStore` requires the Netlify Functions runtime context.
+ *
+ * On reporting: a 404 is not an error here. A request for a key that is not in
+ * the store, a path that fails the traversal guard, or an extension outside the
+ * allowlist are all ordinary outcomes on a public, crawler-visible host — this
+ * function answers every path on `assets.salvageunion.io`, so alerting on them
+ * would turn the Sentry project into a scanner log. What IS reported is the
+ * store failing to answer at all, which is the failure mode that silently
+ * breaks entity artwork in both srd and itun.
  */
 export const makeAssetHandler =
-  (openStore: () => AssetBlobStore) =>
+  (openStore: () => AssetBlobStore, report: AssetFailureReporter = captureException) =>
   async (req: Request): Promise<Response> => {
     const { pathname } = new URL(req.url)
     const key = decodeURIComponent(pathname.replace(/^\/+/, ''))
@@ -56,8 +73,19 @@ export const makeAssetHandler =
       return new Response('Unsupported asset type', { status: 404 })
     }
 
-    const store = openStore()
-    const stream = await store.get(key, { type: 'stream' })
+    // Opening the store and reading from it are one failure domain: `getStore`
+    // throws when the Blobs runtime context or the store binding is missing,
+    // and `get` rejects on a Blobs outage. Either way artwork stops serving for
+    // every visitor at once, so it surfaces as a controlled 503 with a Sentry
+    // event rather than an unhandled 500 nobody sees.
+    let stream: ReadableStream | null
+    try {
+      stream = await openStore().get(key, { type: 'stream' })
+    } catch (error) {
+      report(error, { fn: 'asset', op: 'blobs.get', key })
+      return new Response('Asset storage unavailable', { status: 503 })
+    }
+
     if (!stream) {
       return new Response('Not found', { status: 404 })
     }
@@ -73,7 +101,21 @@ export const makeAssetHandler =
     })
   }
 
-export default makeAssetHandler(() => getStore('lp-assets'))
+const handler = makeAssetHandler(() => getStore('lp-assets'))
+
+/** @public Netlify Functions handler — invoked by the platform, not imported. */
+export default async function (req: Request): Promise<Response> {
+  initObservability()
+  try {
+    return await handler(req)
+  } catch (error) {
+    // Nothing above should reach here — the store call has its own catch — so
+    // anything that does is a bug in this function rather than a Blobs outage,
+    // and is worth an event precisely because it was never anticipated.
+    captureException(error, { fn: 'asset' })
+    return new Response('Internal Server Error', { status: 500 })
+  }
+}
 
 // Functions v2 in-code routing: this function handles every path on the site.
 export const config = {

--- a/apps/su-assets/package.json
+++ b/apps/su-assets/package.json
@@ -9,6 +9,7 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@netlify/blobs": "^10.7.10"
+    "@netlify/blobs": "^10.7.10",
+    "@sentry/node": "10.68.0"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -106,6 +106,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@netlify/blobs": "^10.7.10",
+        "@sentry/node": "10.68.0",
       },
     },
     "packages/component-lib": {
@@ -144,7 +145,7 @@
     },
     "packages/salvageunion-reference": {
       "name": "salvageunion-reference",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "dependencies": {
         "jsonc-parser": "^3.3.1",
         "zod": "^4.4.3",

--- a/docs/architecture/accounts-and-games.md
+++ b/docs/architecture/accounts-and-games.md
@@ -232,6 +232,59 @@ public by design. The client _secret_ lives only on the Convex deployments.
 Project: `alex-jarvis:suref-itun` ·
 [dashboard](https://dashboard.convex.dev/t/alex-jarvis/suref-itun)
 
+### Convex error reporting — a dashboard toggle, not code
+
+Every other surface in this repo reports errors through a hand-written
+`observability.ts` (`apps/srd`, `apps/itun`'s browser bundle and Netlify
+Functions, `apps/discord-bot`, `apps/su-assets`). **Convex is deliberately not
+one of them.** It has a first-party
+[Exception Reporting integration](https://docs.convex.dev/production/integrations/exception-reporting)
+that is enabled in the Convex dashboard and needs no application code at all.
+
+That is not merely the tidier option — it is the only one that covers the
+surface:
+
+- **Queries and mutations cannot report from inside a function.** They run in
+  Convex's deterministic runtime, which has no `fetch` and no network egress by
+  design. That is most of `convex/` (`games.ts`, `invites.ts`, `proposals.ts`,
+  `crew.ts`, `ownership.ts`, …), so a code-level SDK could never see the bulk of
+  the errors we would be adding it for.
+- **`@sentry/node` does not run there either.** The default Convex runtime is
+  not Node; this deployment has no `'use node'` actions, so adding the Node SDK
+  would mean converting modules to the Node runtime purely to instrument them.
+- **What is left is HTTP actions** (`http.ts`, `botHttp.ts`), where a
+  hand-rolled `fetch` to Sentry's ingest endpoint would duplicate a built-in
+  that already tags events with function name, function type, runtime, request
+  id, deployment name, environment tier, and the caller's `tokenIdentifier` —
+  none of which application code can reconstruct.
+
+So the deliverable here is the runbook, not a module.
+
+**Enabling it** (a human has to click this; it cannot be scripted from the
+repo):
+
+1. Create a Sentry project in the `susrd` org — **EU region**
+   (`https://de.sentry.io`), like every other project here — and set its
+   platform to **Node.js**, which is what Convex's integration expects for
+   stack-trace processing. Suggested slug: `itun-convex`, sitting alongside
+   `itun` (browser) and `itun-functions` (Netlify).
+2. Convex dashboard → the deployment → **Settings → Integrations → Sentry** →
+   paste that project's DSN. Do it **per deployment**: `dev/alex-jarvis` and
+   `exuberant-porpoise-183` are configured separately, and production is the one
+   that matters.
+3. Optionally add a tag to distinguish the two deployments in Sentry.
+
+**Two caveats worth knowing before you go looking for events:**
+
+- **Exception Reporting is a Convex Pro feature.** On the free plan the Sentry
+  card is not available, and the honest state of this repo is then "Convex
+  errors are visible in the Convex dashboard's function logs only". Do not
+  paper over that with code — see above for why the code would not work.
+- Events take a minute or two to propagate, and Convex does not expose the
+  Sentry SDK for customisation. There is no release tagging to wire up, so
+  Convex errors will not carry a commit SHA the way the Netlify and Render
+  surfaces do.
+
 ### Netlify
 
 | Site               | Serves                           | Notes                                                                                                                                        |


### PR DESCRIPTION
Closes the two SU-SRD surfaces that had no error tracking at all: the artwork host and the Convex backend. One of them needed code; the other needed a decision and a runbook.

## `apps/su-assets` — wired

`assets.salvageunion.io` serves every entity-card image in **both** srd and itun, and until now its failures were completely invisible — a Blobs outage surfaced as an unhandled 500 that nobody was watching, and the artwork simply stopped resolving in two apps at once.

- **`netlify/functions/_observability.ts`** — a near-verbatim mirror of `apps/itun/netlify/functions/_observability.ts`. `@sentry/node` pinned to `10.68.0`, identical to `itun`, `srd` and `discord-bot`. Entirely env-gated on `SENTRY_DSN`: with no DSN, `initObservability()` returns before `Sentry.init` and `captureException` is a no-op, so local dev, CI and forks ship and run exactly as before. No DSN is committed — it is already provisioned on the `su-assets` Netlify site.
- **`asset.ts`** — opening the store and reading from it are now one try/catch. That single catch covers both real failure modes: `getStore` throwing (missing Blobs runtime context or store binding — a deploy-shaped failure) and `get` rejecting (a Blobs outage). Both report with `{ fn, op: 'blobs.get', key }` and return a controlled **503** instead of an unhandled 500, mirroring `snapshot-retrieve.ts`. The default export calls `initObservability()` per cold start and catches anything unanticipated as a reported 500.

### What is deliberately NOT reported

**Every 404.** This function answers `/*` on a public, crawler-visible host, so all of these are ordinary outcomes, not errors:

| Outcome | Why it stays silent |
| --- | --- |
| Key absent from the store | A missing asset is a normal result, not a fault. |
| Extension outside the allowlist (`.txt`, `.html`, `.js`, extensionless) | Client asked for something this host does not serve. |
| Traversal probe (`..%2F…`) | Scanner traffic. Constant, and the guard already handled it. |
| Dotfile probe (`/.env.png`) | Same. |
| Site root / empty key | Same. |

Alerting on those is how the channel becomes noise — at which point the Blobs outage above is invisible again, which is the exact problem this PR exists to fix. There are tests asserting the silence, not just the reporting.

### Tests

`__tests__/_observability.test.ts` in the style of `apps/discord-bot/src/__tests__/observability.test.ts` — mocks `@sentry/node` and **restores it in `afterAll`** (`mock.module` is process-global in Bun), and deletes `SENTRY_DSN` before restoring so no later file inherits a live DSN. Covers the gate in both directions, including that it latches on the first init.

`__tests__/asset.test.ts` gains an error-reporting block. The reporter is injected through `makeAssetHandler`'s new second parameter — the same dependency-injection seam the store already used, chosen over `mock.module()` for the same reason.

## Convex — documentation, not code

**Decision: no application code. This is a Convex dashboard toggle plus a runbook.**

Convex has a first-party [Exception Reporting integration](https://docs.convex.dev/production/integrations/exception-reporting) that needs no application code. That is not merely the tidier option — it is the only one that covers the surface:

- **Queries and mutations cannot report from inside a function.** They run in Convex's deterministic runtime, which has no `fetch` and no network egress by design. That is most of `convex/` (`games.ts`, `invites.ts`, `proposals.ts`, `crew.ts`, `ownership.ts`, …), so a code-level SDK could never see the bulk of the errors we would be adding it for.
- **`@sentry/node` does not run there either.** The default Convex runtime is not Node, and this deployment has **no `'use node'` actions** (verified) — so adding the Node SDK would mean converting modules to the Node runtime purely to instrument them.
- **What is left is HTTP actions** (`http.ts`, `botHttp.ts`), where a hand-rolled `fetch` to Sentry's ingest endpoint would duplicate a built-in that already tags events with function name, function type, runtime, request id, deployment name, environment tier, and the caller's `tokenIdentifier` — none of which application code can reconstruct.

Documented in `docs/architecture/accounts-and-games.md` §6 (a new "Convex error reporting — a dashboard toggle, not code" subsection carrying the rationale and the enable-it steps), with a short "do not add a Sentry SDK to `convex/`" note in `apps/itun/CLAUDE.md` pointing at it.

## Human steps still required

1. **Convex (blocking, cannot be scripted):** create a Sentry project in `susrd` — EU region, platform **Node.js** (suggested slug `itun-convex`; confirmed absent today, the org has `srd`, `itun`, `itun-functions`, `su-discord`, `su-assets`), then Convex dashboard → Settings → Integrations → Sentry → paste the DSN. **Per deployment** — `dev/alex-jarvis` and `exuberant-porpoise-183` are configured separately.
2. **Convex caveat:** Exception Reporting is a **Convex Pro** feature. On the free plan the Sentry card is unavailable and Convex errors stay visible only in the Convex dashboard's function logs. The docs say so plainly rather than papering over it — and per the reasoning above, code would not be a workaround.
3. **su-assets:** nothing. The DSN is already provisioned on the Netlify site; it starts reporting on the next deploy.

## Follow-up (not done here, deliberately)

`tools/check-observability.ts` is untouched — it is being changed in in-flight #689. It currently guards the two browser apps' module→entry→CSP wiring. It could reasonably be extended to assert that `apps/su-assets`'s function imports its observability module (the same "the module exists but nothing calls it" failure it already catches elsewhere), and that `@sentry/node` stays version-locked across the now-four workspaces that pin it. Worth doing once #689 lands.

## Verification

`bun run check:all` exits **0** (lint, format:check, typecheck across all 6 workspaces, tests, validate:all, knip, audit, tokens, styling). `bun run knip` exits **0** with no report — the new `@sentry/node` dependency is not flagged. su-assets: **32 pass, 0 fail** (up from 17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kVVMrzRkXMGpvcB44HyJM