### PR TITLE
ci: arm auto-merge on release-please PRs so releases stop stalling

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,14 @@ name: release-please
 on:
   push:
     branches: [main]
+  # Self-heal without needing a push. Both open release PRs edit
+  # `.release-please-manifest.json`, so whichever merges second gets rebased —
+  # and a PR ejected from the merge queue loses its auto-merge. On push alone,
+  # that PR would sit dead until someone happened to merge something else. The
+  # daily run re-arms it on its own; workflow_dispatch is the manual kick.
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
 permissions:
   contents: write
   pull-requests: write
@@ -17,3 +25,46 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # ADR-024 says release PRs "land via the existing squash-only + auto-merge
+      # flow" — but nothing ever turned auto-merge ON, so they sat open (srd
+      # #688 for a day, itun #677 for two) while `main`'s CHANGELOG.md went
+      # stale. This is that missing half.
+      #
+      # Deliberately NOT gated on the action's `prs_created` output. That output
+      # is false whenever release-please merely refreshes an already-open PR,
+      # which is the common case, so gating on it would arm auto-merge once and
+      # never notice if it lapsed. Re-asserting on every run is idempotent and
+      # self-healing: any push to main repairs a release PR that lost its
+      # auto-merge (release-please force-pushes these branches on each update).
+      #
+      # The PAT is required, not cosmetic: `main` requires a merge queue, and
+      # GITHUB_TOKEN cannot add a PR to one. GH_REPO is required because this
+      # job never checks out the repo, so `gh` has no remote to infer.
+      - name: Keep auto-merge armed on every open release PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          failed=0
+          pending=$(gh pr list --state open --limit 100 \
+            --json number,headRefName,autoMergeRequest \
+            --jq '.[]
+                  | select(.headRefName | startswith("release-please--"))
+                  | select(.autoMergeRequest == null)
+                  | .number')
+          if [ -z "$pending" ]; then
+            echo "No release PR needs auto-merge armed."
+            exit 0
+          fi
+          # One bad PR (a conflict, say) must not skip the others, but the run
+          # still goes red so a broken release path is loud rather than silent.
+          for pr in $pending; do
+            echo "Arming auto-merge on #$pr"
+            gh pr merge "$pr" --auto --squash || {
+              echo "::error::Could not enable auto-merge on #$pr"
+              failed=1
+            }
+          done
+          exit "$failed"

--- a/docs/adrs/ADR-024-derived-release-changelogs.md
+++ b/docs/adrs/ADR-024-derived-release-changelogs.md
@@ -93,6 +93,18 @@ config.
   pass the suite cleanly, and land via the existing squash-only + auto-merge
   flow.
 
+- **Auto-merge is armed by the workflow, not by a human.** This sentence used to
+  read as though "the existing auto-merge flow" would pick release PRs up on its
+  own. It does not: nothing enables auto-merge on a PR unless something asks it
+  to, so the release PRs simply sat open — `srd` #688 for a day, `itun` #677 for
+  two — and `main`'s `CHANGELOG.md` fell behind by exactly that much. The
+  release-please workflow now re-arms auto-merge on every open
+  `release-please--*` PR on each run, so a release lands as soon as
+  `quality-checks` is green with no human step. It is re-asserted every run
+  rather than only on creation, because a PR ejected from the merge queue (both
+  release PRs edit `.release-please-manifest.json`, so one always rebases) loses
+  auto-merge silently; a daily `schedule:` covers the case where no push follows.
+
 ## Consequences
 
 - **Less ongoing work than today** — no per-PR prose — and **ITUN gains a


### PR DESCRIPTION
## The actual bug

release-please is **healthy**. It ran successfully on every push to `main` and kept its open PRs current — #688 was refreshed at 17:54, two minutes after #689 merged at 17:52.

**Nothing ever merged its PRs.** That's the entire defect:

| PR | Release | Open since | Checks | Mergeable |
|---|---|---|---|---|
| #688 | `srd 2.0.0` | Aug 5 | all green | yes |
| #677 | `itun 1.0.0` | Aug 4 | all green | yes |

So `main`'s `CHANGELOG.md` stops at Jul 29 (`srd`) / Aug 3 (`itun`), and the Releases list matches. There is no gap in the *generation* — the lag is purely unmerged release PRs, and it grows until someone clicks merge by hand.

[ADR-024](docs/adrs/ADR-024-derived-release-changelogs.md) already specified that release PRs "land via the existing squash-only + auto-merge flow." That half was never built — nothing enables auto-merge on a PR unless something asks it to.

## The fix

One step in `release-please.yml` that re-arms auto-merge on every open `release-please--*` PR.

Three choices worth reviewing:

- **Not gated on `prs_created`.** That output is false whenever release-please merely *refreshes* an already-open PR — the common case. Gating on it would arm auto-merge once and never notice if it lapsed. Re-asserting every run is idempotent and self-healing.
- **PAT, not `GITHUB_TOKEN`.** `main` requires a merge queue, and `GITHUB_TOKEN` cannot add a PR to one. `GH_REPO` is set because this job never checks out the repo, so `gh` has no remote to infer.
- **Added `schedule:` + `workflow_dispatch:`.** Both release PRs edit `.release-please-manifest.json`, so whichever merges second gets rebased — and a PR ejected from the merge queue loses auto-merge silently. On `push:` alone it would sit dead until someone merged something unrelated. The daily run re-arms it unattended; `workflow_dispatch` is the manual kick.

A failed arm marks the run red rather than passing quietly, and one bad PR does not skip the others.

## Verification

- Workflow YAML parses; the new step's `run` body is **shellcheck-clean**.
- The `jq` selector was run against **live** repo data: it returns exactly `688` and `677`, and correctly excludes the two open Dependabot PRs.
- Prettier clean on both files. No source files touched, so no typecheck/test surface.
- `merge_group:` is already wired in `ci.yml`, so queued PRs do get their required `quality-checks` — the queue is not the blocker.

## ⚠️ Read before merging

When this lands, release-please runs and arms **#688 (`srd` 2.0.0)** and **#677 (`itun` 1.0.0)** — both **major** bumps, `srd`'s carrying the breaking Astro→Vite SSG migration. They will merge and publish on their own once green. That is the requested behavior, but it is the first thing this change does, so it should be a conscious call rather than a surprise.

If you'd rather majors stay manual, say so and I'll add a guard that skips arming when the PR title implies a major bump.

## Out of scope (noted, not fixed)

- Dependabot PRs #691/#692 sit open for the same class of reason — no auto-merge workflow, and the merge queue means `GITHUB_TOKEN` couldn't enqueue them anyway.
- `main` carries **both** a ruleset and classic branch protection. GitHub takes the union, so editing one leaves the other silently in force.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxGxcTsBieeKACQjb4YRwp