### PR TITLE
fix(ci): one release PR for all components so releases stop deadlocking

### DIFF
--- a/docs/adrs/ADR-024-derived-release-changelogs.md
+++ b/docs/adrs/ADR-024-derived-release-changelogs.md
@@ -93,6 +93,30 @@ config.
   pass the suite cleanly, and land via the existing squash-only + auto-merge
   flow.
 
+- **One release PR for all components, not one per component.**
+  `separate-pull-requests` is **`false`**. It was `true`, and that was the
+  systemic cause of the release lag this ADR was meant to eliminate: all three
+  components share a single `.release-please-manifest.json`, and their version
+  entries are **adjacent lines**, so any two open release PRs conflict by
+  construction. The moment one merged, every other open release PR went
+  `CONFLICTING` — and release-please does not repair them, because it only
+  force-pushes a release branch when _its own_ component has new commits. A
+  component with no new commits keeps a stale manifest forever.
+
+  Observed three times in one evening: #677 (itun) died when `srd 2.0.0` landed,
+  its recreation #698 died when `srd 2.0.1` landed, and #698 stayed frozen
+  through two successful release-please runs afterwards. The only recovery is to
+  close the PR and let it be recreated, which is a human step — exactly what
+  this ADR set out to avoid.
+
+  A single PR removes the contention: one branch, one manifest edit, nothing to
+  conflict with. Versioning is **unchanged** — each component still gets its own
+  independent version bump, its own `CHANGELOG.md` section, and its own
+  component-tagged GitHub Release on merge. Only PR granularity changes. The
+  cost is that one component's release notes can no longer be reviewed or
+  delayed in isolation; given the alternative was releases silently not shipping
+  at all, that is the right trade.
+
 - **Auto-merge is armed by the workflow, not by a human.** This sentence used to
   read as though "the existing auto-merge flow" would pick release PRs up on its
   own. It does not: nothing enables auto-merge on a PR unless something asks it

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "separate-pull-requests": true,
+  "separate-pull-requests": false,
   "include-component-in-tag": true,
   "bootstrap-sha": "1ee3a27ad49aeb3b5b7ae29e582e1a20733dde0c",
   "packages": {


### PR DESCRIPTION
Follow-up to #693. That PR armed auto-merge on release PRs — necessary, but **not sufficient**.

## The deeper cause

All three components share one `.release-please-manifest.json`, and their version entries are **adjacent lines**:

```json
{
  "apps/srd": "2.0.1",
  "apps/itun": "0.10.0",
  "packages/salvageunion-reference": "2.9.1"
}
```

With `separate-pull-requests: true`, each component gets its own release PR — so **any two open release PRs conflict by construction**. The moment one merges, every other open release PR goes `CONFLICTING`.

release-please does **not** repair them. It only force-pushes a release branch when *its own* component has new commits, so a component with no new commits keeps a stale manifest **forever**. The only recovery is closing the PR to force recreation — a human step, which is precisely what ADR-024 set out to eliminate.

## Observed three times in one evening

| PR | Died when | Evidence |
|---|---|---|
| #677 `itun 1.0.0` | `srd 2.0.0` (#688) landed | branch pinned `apps/srd: 1.4.0` vs `2.0.0` on main |
| #698 (recreation of #677) | `srd 2.0.1` (#697) landed | same collision, one version later |
| #698 again | — | stayed frozen through **two** successful release-please runs, `updatedAt` never moving off its creation timestamp |

This is the mechanism behind "the release PRs lag, creating gaps in the changelog." Only one release PR can ever merge cleanly; the rest silently deadlock.

## The fix

`"separate-pull-requests": false` — one branch, one manifest edit, nothing to conflict with.

**Versioning is unchanged.** Each component still gets:

- its own independent version bump (no lockstep)
- its own `CHANGELOG.md` section
- its own component-tagged GitHub Release on merge (`include-component-in-tag` untouched)

Only **PR granularity** changes. ADR-024's "two separate site streams" decision — one changelog per site, never merged — is about the changelog _files_ and is preserved exactly.

## Trade-off

One component's release notes can no longer be reviewed or held back in isolation; they arrive batched. Given the alternative was releases silently not shipping at all, that's the right trade — and ADR-024 already names the release PR as a _batched_ curation point, so this is consistent with its intent.

## Verification

- Config parses; `separate-pull-requests: false`, 3 packages intact.
- Biome-formatted (repo `format` is `biome format --write .`); ADR run through the prose formatter.
- No source touched — no typecheck/test surface.
- Live proof the rest of the pipeline works: #688 (`srd 2.0.0`) and #697 (`srd 2.0.1`) both released tonight, armed and merged with no human step. #699 (`itun 1.0.0`) is armed and mergeable right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxGxcTsBieeKACQjb4YRwp
