### PR TITLE
docs: document that main is behind a merge queue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,39 @@ Pre-commit runs: lint --fix, format (parallel). Typecheck does NOT run pre-commi
 Pre-push runs (parallel): typecheck, test, validate:all, knip, check:tokens,
 check:styling, lint, check:schemas.
 
+### Merging — `main` is behind a merge queue
+
+`main`'s ruleset (`deletion`, `non_fast_forward`, `required_linear_history`,
+`required_status_checks`, **`merge_queue`**) means a PR is **enqueued, never merged
+directly.** Enqueue with:
+
+```bash
+gh pr merge <pr> --auto --squash
+```
+
+**A plain `gh pr merge <pr> --squash` does not fail — and does not merge.** It prints
+only `! The merge strategy for main is set by the merge queue`, **exits 0**, and adds
+the PR to the queue. Every obvious success signal is absent afterwards: the PR is still
+`OPEN`, `mergedAt` is `null`, `mergeCommit` is `none`, and `autoMergeRequest` is `off`.
+That combination looks exactly like a silent no-op, so **do not conclude the merge
+failed and retry** — read the queue itself:
+
+```bash
+gh api graphql -f query='{repository(owner:"SalvageUnion-io",name:"SU-SRD"){
+  mergeQueue(branch:"main"){entries(first:20){nodes{position state
+  pullRequest{number}}}}}}'
+```
+
+A queued PR stays `OPEN` until the queue merges it, so **PR state alone is never proof
+of anything** here. The queue is also the reason a PR can go green and still sit
+unmerged: it re-tests each entry against the projected merge, and ejects any that
+conflicts rather than merging it.
+
+Note that `gh pr merge --auto` is what Dependabot PRs need too. A merge queue is
+mutually exclusive with a `GITHUB_TOKEN`-driven Dependabot auto-merge workflow, since
+that token cannot enqueue — so Dependabot PRs here require an enqueue from a PAT-backed
+session (or a human) and will otherwise sit open indefinitely.
+
 ### Project Skills (`.claude/skills/`)
 
 When to reach for which skill (overlap explained):


### PR DESCRIPTION
## Why

`main`'s ruleset carries an active **`merge_queue`** rule (alongside `deletion`, `non_fast_forward`, `required_linear_history`, `required_status_checks`). `CLAUDE.md` said nothing about it, and the failure mode is genuinely misleading.

Running `gh pr merge <pr> --squash` prints only:

```
! The merge strategy for main is set by the merge queue
```

…**exits 0**, and enqueues the PR. Afterwards every obvious success signal is absent — the PR is still `OPEN`, `mergedAt` is `null`, `mergeCommit` is `none`, `autoMergeRequest` is `off`. That reads as a silent no-op and invites a pointless retry. It cost real time on #695 during this session before the queue was inspected directly.

## What this adds

A `### Merging — main is behind a merge queue` section to `CLAUDE.md` recording:

- the correct incantation, `gh pr merge <pr> --auto --squash`
- the exit-0-but-not-merged trap, and that PR state alone proves nothing while queued
- a GraphQL query for reading the queue directly (**verified against this repo** — it returns the live entries as written)
- that the queue re-tests each entry against the projected merge and *ejects* conflicts, so a green PR can still sit unmerged
- the Dependabot consequence: a merge queue can't be driven by `GITHUB_TOKEN`, so Dependabot PRs sit open until something PAT-backed enqueues them

## Scope

Docs only — one file, 33 insertions, no code or config touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxGxcTsBieeKACQjb4YRwp