### PR TITLE
fix(srd): stop two unactionable browser errors filling Sentry

### DIFF
--- a/apps/srd/src/lib/__tests__/observability.test.ts
+++ b/apps/srd/src/lib/__tests__/observability.test.ts
@@ -82,6 +82,16 @@ describe('observability', () => {
     // `tools/check-observability.ts` asserts against both netlify.tomls.
     expect(options.tracesSampleRate).toBe(0)
 
+    // Cross-document view transitions reject their `finished` promise with an
+    // AbortError whenever a navigation supersedes an in-flight one. It is not
+    // ours to catch (the promise is the browser's) and it means nothing went
+    // wrong, so it must never reach Sentry. Asserted on the substring Sentry
+    // actually matches against `${type}: ${value}`, so the real event shape
+    // "AbortError: Transition was skipped" is covered.
+    const ignored = options.ignoreErrors as string[]
+    expect(ignored).toContain('Transition was skipped')
+    expect('AbortError: Transition was skipped').toContain(ignored[0] as string)
+
     const boom = new Error('boom')
     captureException(boom, { where: 'island' })
 

--- a/apps/srd/src/lib/observability.ts
+++ b/apps/srd/src/lib/observability.ts
@@ -23,6 +23,26 @@ let initialized = false
 let sentryModule: typeof import('@sentry/browser') | null = null
 
 /**
+ * Browser noise that is not this site's to fix, dropped before it is sent.
+ *
+ * The bar for adding to this list is deliberately high: a filtered error is one
+ * nobody will ever see again, so anything here has to be something we could not
+ * act on even if we wanted to. Each entry names the mechanism, not just the
+ * string.
+ *
+ * - **`Transition was skipped`** — srd opts into *cross-document* view
+ *   transitions declaratively, with `@view-transition { navigation: auto }` in
+ *   `src/styles/global.css`. When a second navigation supersedes an in-flight
+ *   transition (a fast click, or a click during page load) the browser rejects
+ *   the transition's `finished` promise with an `AbortError`. That promise
+ *   belongs to the user agent — there is no JS handle of ours to `.catch()`, so
+ *   the SDK is the only place it can be dropped. The navigation itself
+ *   completes normally; the "error" is the feature working as specified
+ *   (issue SRD-A).
+ */
+const IGNORED_ERRORS = ['Transition was skipped']
+
+/**
  * Initializes browser Sentry when `PUBLIC_SENTRY_DSN` is configured.
  * Idempotent and safe to call once on every page load. Resolves immediately
  * (no-op) when the DSN is absent.
@@ -49,6 +69,7 @@ export async function initBrowserObservability(): Promise<void> {
     // Errors only — no performance tracing or session replay. Keeps network
     // chatter minimal and avoids additional CSP surface.
     tracesSampleRate: 0,
+    ignoreErrors: IGNORED_ERRORS,
   })
 }
 

--- a/apps/srd/ssg/pwa.ts
+++ b/apps/srd/ssg/pwa.ts
@@ -39,16 +39,31 @@ import { join } from 'node:path'
 import { generateSW } from 'workbox-build'
 
 /**
- * Byte-for-byte what `vite-plugin-pwa` emitted for
- * `registerType: 'autoUpdate'` + `injectRegister: 'script-defer'`.
+ * What `vite-plugin-pwa` emitted for `registerType: 'autoUpdate'` +
+ * `injectRegister: 'script-defer'`, plus a `.catch()`.
  * `BaseLayout.tsx` loads it with `<script defer src="/registerSW.js">`.
  *
- * No trailing newline: 134 bytes, byte-identical to the baseline's. That is
- * checkable — the precache entry's revision hash for `registerSW.js` must come
- * out as `1872c500de691dce40960bb85481de07`, exactly as in the baseline `sw.js`.
+ * **The `.catch()` is the whole reason this is no longer byte-identical to the
+ * Astro baseline's 134 bytes.** `register()` returns a promise that rejects for
+ * reasons entirely outside this site's control — a browser with service workers
+ * disabled, a locked-down enterprise profile, an extension intercepting the
+ * request — and `vite-plugin-pwa`'s snippet never handled it. Every one of those
+ * rejections became an *unhandled* rejection, which Sentry's `globalHandlers`
+ * integration dutifully reported as `Error: Rejected`: no stack worth reading,
+ * no user impact, and nothing anyone could act on. Nine of them in a week (issue
+ * SRD-2) for a feature that is meant to degrade silently.
+ *
+ * Swallowing is correct rather than lazy here. A failed registration means no
+ * offline caching, which is a progressive enhancement this site works fine
+ * without — there is no fallback to attempt and nothing to tell the user.
+ *
+ * Parity is unaffected: `ssg/parity.ts` compares the emitted **file set**, head
+ * metadata, JSON-LD, `<main>` text, the JSON endpoints and `llms.txt`. It never
+ * compares `registerSW.js` or `sw.js` bytes, so only the precache revision hash
+ * in `sw.js` moves, and nothing asserts on that.
  */
 const REGISTER_SW =
-  "if('serviceWorker' in navigator) {window.addEventListener('load', () => {navigator.serviceWorker.register('/sw.js', { scope: '/' })})}"
+  "if('serviceWorker' in navigator) {window.addEventListener('load', () => {navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch(() => {})})}"
 
 /**
  * Write `dist/registerSW.js`, then generate `dist/sw.js` (plus its


### PR DESCRIPTION
Every srd issue open in Sentry today was one of these two, and neither is
actionable — both are features working as specified.

## `Error: Rejected` (SRD-2, 9 events in a week)

`registerSW.js` registered the service worker with no `.catch()`. Any
rejection outside this site's control — service workers disabled, a
locked-down enterprise profile, an extension intercepting the request —
became an *unhandled* rejection, which Sentry's `globalHandlers`
integration reported as `Error: Rejected`: no stack worth reading, no user
impact, nothing anyone could do.

Swallowing is the correct handling here rather than the lazy one. A failed
registration means no offline caching, which is a progressive enhancement
the site works fine without — there is no fallback to attempt and nothing
to tell the user.

## `AbortError: Transition was skipped` (SRD-A)

srd opts into *cross-document* view transitions declaratively, via
`@view-transition { navigation: auto }` in `global.css`. When a second
navigation supersedes an in-flight transition (a fast click, or a click
during page load) the browser rejects the transition's `finished` promise
with an `AbortError`. **That promise is the user agent's** — there is no JS
handle of ours to `.catch()` — so the SDK's `ignoreErrors` is the only
place it can be dropped. The navigation itself completes normally.

The new `IGNORED_ERRORS` list is deliberately hard to add to: a filtered
error is one nobody will ever see again, so each entry names the mechanism
rather than just the string.

## On parity

The `.catch()` moves `registerSW.js` off the Astro baseline's 134 bytes.
**The gate is unaffected**: `ssg/parity.ts` compares the emitted file set,
head metadata, JSON-LD, `<main>` text, the 899 JSON endpoints and
`llms.txt` — never `registerSW.js` or `sw.js` bytes. Only the precache
revision hash in `sw.js` moves, and nothing asserts on it. The comment's
now-false "byte-identical to the baseline's" claim is corrected in place
rather than left to mislead the next reader.

## Verification

- `bun run check:all` green (lint, format, typecheck ×6, test, validate, knip, audit, tokens, styling)
- `bun --filter srd test` — 1152 pass
- `bun ssg/build.ts` + `bun ssg/parity.ts` against a freshly regenerated baseline: the only mismatch is `changelog/index.html`, which is **pre-existing drift unrelated to this PR** — `676078fa release srd 2.0.1` added a changelog entry that the frozen Astro-era baseline cannot contain. Flagged separately; it will fail on every PR until the baseline story for that page is decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6ao8WWaWUtq5RsfYbySY9