### PR TITLE
fix(itun): stop claimLocal duplicating rosters, and let refusals say why

### DIFF
--- a/apps/itun/CLAUDE.md
+++ b/apps/itun/CLAUDE.md
@@ -110,11 +110,26 @@ and remains the account-free way to share a build.
   (`src/lib/observability.ts`) and the Netlify Functions
   (`netlify/functions/_observability.ts`) each own one; Convex instead uses its
   first-party Exception Reporting integration, enabled in the Convex dashboard
-  with no application code. Queries and mutations run in a deterministic runtime
-  with no `fetch`, so an in-function SDK could not report from them at all —
-  rationale and the enable-it runbook are in
+  with no application code (**on for production since 2026-08-05**). Queries and
+  mutations run in a deterministic runtime with no `fetch`, so an in-function SDK
+  could not report from them at all — rationale and the enable-it runbook are in
   [docs/architecture/accounts-and-games.md](../../docs/architecture/accounts-and-games.md)
   ("Convex error reporting — a dashboard toggle, not code").
+- **Throw `ConvexError` when the message is for a player; plain `Error` when it
+  is not.** Convex redacts every non-`ConvexError` throw to
+  `"[CONVEX M(fn)] […] Server Error"` before the client sees it, so a
+  user-facing message thrown as a plain `Error` is written and then discarded.
+  `NotAuthorized` (`convex/model/permissions.ts`) extends `ConvexError` for
+  exactly this reason; parse failures and broken invariants stay plain. On the
+  client, read it with `serverMessage()` / `isServerRefusal()` from
+  `src/lib/connection/serverError.ts` — never by string-matching `'Server Error'`,
+  and never by rendering `String(err)` from a mutation.
+- **Never insert into an `appId`-addressed table without checking first.**
+  `pilots`, `mechs` and `crawlers` are looked up by the client's `appId` with
+  `.unique()`, which **throws** on a second row — and since mirrored writes are
+  fire-and-forget, that throw is invisible: local writes keep succeeding while
+  the server of record silently stops receiving them. `convex/maintenance.ts`
+  repairs rows already in that state (`dedupeAppIds`, dry-run by default).
 
 ## Commands
 

--- a/apps/itun/convex/_generated/api.d.ts
+++ b/apps/itun/convex/_generated/api.d.ts
@@ -19,6 +19,7 @@ import type * as entities from "../entities.js";
 import type * as games from "../games.js";
 import type * as http from "../http.js";
 import type * as invites from "../invites.js";
+import type * as maintenance from "../maintenance.js";
 import type * as mediator from "../mediator.js";
 import type * as model_bot from "../model/bot.js";
 import type * as model_entities from "../model/entities.js";
@@ -45,6 +46,7 @@ declare const fullApi: ApiFromModules<{
   games: typeof games;
   http: typeof http;
   invites: typeof invites;
+  maintenance: typeof maintenance;
   mediator: typeof mediator;
   "model/bot": typeof model_bot;
   "model/entities": typeof model_entities;

--- a/apps/itun/convex/entities.ts
+++ b/apps/itun/convex/entities.ts
@@ -301,6 +301,33 @@ export const removeCrawler = mutation({
 })
 
 /**
+ * Whether this table already holds a row carrying this app id.
+ *
+ * Deliberately `.first()` and not `.unique()`, which is the opposite of
+ * `byAppId` two hundred lines down, and the difference is the point: this
+ * function's job is to run correctly **on a table that is already duplicated**.
+ * `.unique()` throws when it finds more than one row, so using it here would
+ * make the claim that repairs nothing also fail outright on exactly the accounts
+ * that need repairing most.
+ *
+ * Existence is asked without reference to who owns the row. A row with this app
+ * id belonging to somebody else is still a reason not to insert: `byAppId` is a
+ * **global** lookup, so a second row would break the mirror for both accounts
+ * rather than one. See the note on app-id collisions in `claimLocal`.
+ */
+async function appIdTaken(
+  ctx: MutationCtx,
+  table: 'pilots' | 'mechs' | 'crawlers',
+  appId: string
+): Promise<boolean> {
+  const existing = await ctx.db
+    .query(table)
+    .withIndex('by_app_id', (q) => q.eq('appId', appId))
+    .first()
+  return existing !== null
+}
+
+/**
  * Upload local entities into this account on first sign-in (D11).
  *
  * Everything lands on the **shelf**, never straight into a Game. A person
@@ -311,6 +338,40 @@ export const removeCrawler = mutation({
  * rather than aborting the claim**. A single corrupt local record should not
  * cost somebody their whole roster — the count of skipped rows comes back so
  * the UI can say what did not make it.
+ *
+ * ## Claiming twice is now a no-op, and it has to be
+ *
+ * Every insert below is guarded on identity, because this mutation is **not**
+ * called once per account no matter how the UI is written. The only thing that
+ * used to stop a second run was a `localStorage` marker on one device, and the
+ * card that writes it is deliberately re-offered on a second device — so a
+ * player signing in on their laptop after their phone, or in a fresh browser
+ * profile, or after clearing site data, ran the whole claim again.
+ *
+ * The consequence was not a cosmetic double-up. Pilots, mechs and crawlers are
+ * addressed by `appId`, and the lookups that address them (`byAppId`,
+ * `patchCrawlerByAppId`) use `.unique()`, which **throws** on a second row.
+ * From the moment a roster was claimed twice, every mirrored write for those
+ * entities failed with an opaque server error, silently and permanently: the
+ * local write still succeeded, so the app looked fine while IndexedDB and the
+ * declared server of record drifted apart for good. That is the failure this
+ * guard exists to make impossible, and a client-side marker was never the right
+ * place to enforce it — the damage is server-side and forever, so the check
+ * belongs here.
+ *
+ * Identity per kind: `appId` for pilots, mechs and crawlers; the
+ * (from, to, kind) triple for soft links; the body's own id for patterns.
+ *
+ * ## The residual sharp edge: app ids are not globally unique
+ *
+ * `appId` is a UUID the client minted, and export/import copies a build between
+ * people **keeping its id**. Two accounts can therefore legitimately hold the
+ * same app id, which the `by_app_id` + `.unique()` pairing assumes cannot
+ * happen. This mutation takes the safe side of that — an app id already present
+ * anywhere is reported as `alreadyPresent` rather than inserted, so a claim can
+ * decline to copy a build instead of corrupting the mirror for two people. That
+ * is a real limitation, not a fix; closing it means keying the index on
+ * (ownerId, appId), which is a schema change and its own piece of work.
  */
 export const claimLocal = mutation({
   args: {
@@ -323,11 +384,17 @@ export const claimLocal = mutation({
   handler: async (
     ctx,
     args
-  ): Promise<{ claimed: number; skipped: number; byKind: Record<string, number> }> => {
+  ): Promise<{
+    claimed: number
+    skipped: number
+    alreadyPresent: number
+    byKind: Record<string, number>
+  }> => {
     const userId = await requireUser(ctx)
     const now = Date.now()
     let claimed = 0
     let skipped = 0
+    let alreadyPresent = 0
     const byKind: Record<string, number> = {}
 
     const bump = (kind: string) => {
@@ -349,6 +416,12 @@ export const claimLocal = mutation({
           typeof (body as { id?: unknown }).id === 'string'
             ? (body as { id: string }).id
             : undefined
+
+        if (appId !== undefined && (await appIdTaken(ctx, table, appId))) {
+          alreadyPresent += 1
+          continue
+        }
+
         await ctx.db.insert(table, {
           gameId: null,
           ownerId: userId,
@@ -374,9 +447,33 @@ export const claimLocal = mutation({
      * discarded: the shelf cannot hold it, and inventing a crawler-shaped shelf
      * would be a third container the model does not have.
      */
+    /*
+     * The crawler pass resolves what it will write BEFORE it raises the
+     * placeholder Game, because that Game is itself a write that must not
+     * repeat. Raising it up front — as this did — meant a re-claim with nothing
+     * new to say still left behind an empty "Claimed crawler" Game and a
+     * membership in it, so a player's game list grew by one every time they
+     * signed in somewhere new.
+     */
     const crawlers = args.crawlers ?? []
+    const claimableCrawlers: Array<{ appId: string | undefined; body: unknown }> = []
+    for (const body of crawlers) {
+      const parsed = CrawlerSchema.safeParse(body)
+      if (!parsed.success) {
+        skipped += 1
+        continue
+      }
+      const appId =
+        typeof (body as { id?: unknown }).id === 'string' ? (body as { id: string }).id : undefined
+      if (appId !== undefined && (await appIdTaken(ctx, 'crawlers', appId))) {
+        alreadyPresent += 1
+        continue
+      }
+      claimableCrawlers.push({ appId, body: parsed.data })
+    }
+
     let shelfGameId: Id<'games'> | null = null
-    if (crawlers.length > 0) {
+    if (claimableCrawlers.length > 0) {
       shelfGameId = await ctx.db.insert('games', { name: 'Claimed crawler' })
       await ctx.db.insert('memberships', {
         gameId: shelfGameId,
@@ -386,18 +483,15 @@ export const claimLocal = mutation({
         joinedAt: now,
       })
     }
-    for (const body of crawlers) {
-      const parsed = CrawlerSchema.safeParse(body)
-      if (!parsed.success || shelfGameId === null) {
+    for (const crawler of claimableCrawlers) {
+      if (shelfGameId === null) {
         skipped += 1
         continue
       }
-      const appId =
-        typeof (body as { id?: unknown }).id === 'string' ? (body as { id: string }).id : undefined
       await ctx.db.insert('crawlers', {
         gameId: shelfGameId,
-        appId,
-        body: parsed.data,
+        appId: crawler.appId,
+        body: crawler.body,
         updatedAt: now,
       })
       bump('crawlers')
@@ -427,14 +521,54 @@ export const claimLocal = mutation({
         skipped += 1
         continue
       }
-      await ctx.db.insert('softLinks', {
-        gameId: shelfGameId,
-        from: { type: l.from.type, id: l.from.id },
-        to: { type: l.to.type, id: l.to.id },
-        type: l.type,
-      })
+      /*
+       * A soft link has no `appId` of its own — it IS its endpoints — so
+       * identity is the (from, to, kind) triple, and that is what a re-claim
+       * has to match on. Duplicates here are less destructive than a duplicate
+       * entity (nothing calls `.unique()` on this table) but they are not
+       * harmless: `listForGame` returns every row, so a roster would draw the
+       * same mech-to-pilot link twice.
+       */
+      // Bound into locals: the checks above narrowed `l.from`/`l.to`, but that
+      // narrowing does not survive the `await` and the closure below.
+      const from = { type: l.from.type, id: l.from.id }
+      const to = { type: l.to.type, id: l.to.id }
+      const linkType = l.type
+
+      const duplicateLink = (
+        await ctx.db
+          .query('softLinks')
+          .withIndex('by_from', (q) => q.eq('from.id', from.id))
+          .collect()
+      ).some((row) => row.to.id === to.id && row.type === linkType)
+      if (duplicateLink) {
+        alreadyPresent += 1
+        continue
+      }
+
+      await ctx.db.insert('softLinks', { gameId: shelfGameId, from, to, type: linkType })
       bump('softLinks')
     }
+
+    /*
+     * Patterns are the one claimed kind with no `appId` column at all, so the
+     * repeat-claim check reads the id out of the body and compares against this
+     * user's own patterns. `by_owner` keeps that to one indexed read of a set
+     * that is per-person and small — a pattern is a saved mech loadout, not a
+     * log.
+     */
+    const ownPatterns =
+      (args.mechPatterns ?? []).length > 0
+        ? await ctx.db
+            .query('mechPatterns')
+            .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+            .collect()
+        : []
+    const ownPatternIds = new Set(
+      ownPatterns
+        .map((row) => (row.body as { id?: unknown }).id)
+        .filter((id): id is string => typeof id === 'string')
+    )
 
     for (const body of args.mechPatterns ?? []) {
       // Patterns are parsed like every other claimed body. They were the one
@@ -445,6 +579,13 @@ export const claimLocal = mutation({
         skipped += 1
         continue
       }
+      const patternId = (body as { id?: unknown }).id
+      if (typeof patternId === 'string' && ownPatternIds.has(patternId)) {
+        alreadyPresent += 1
+        continue
+      }
+      if (typeof patternId === 'string') ownPatternIds.add(patternId)
+
       await ctx.db.insert('mechPatterns', {
         ownerId: userId,
         gameId: null,
@@ -454,7 +595,7 @@ export const claimLocal = mutation({
       bump('mechPatterns')
     }
 
-    return { claimed, skipped, byKind }
+    return { claimed, skipped, alreadyPresent, byKind }
   },
 })
 

--- a/apps/itun/convex/maintenance.ts
+++ b/apps/itun/convex/maintenance.ts
@@ -1,0 +1,190 @@
+import { v } from 'convex/values'
+import type { Doc, Id } from './_generated/dataModel'
+import type { MutationCtx } from './_generated/server'
+import { internalMutation } from './_generated/server'
+
+/**
+ * One-off repairs that operate on the whole deployment.
+ *
+ * Everything here is an `internalMutation`: not reachable from any client, only
+ * from `bunx convex run` with deployment credentials. That is deliberate — these
+ * are operator tools that bypass the per-entity authorization every mutation in
+ * `entities.ts` pays, so the boundary has to be "you hold the deploy key", not a
+ * role check.
+ *
+ * ## The duplicate-appId repair
+ *
+ * `pilots`, `mechs` and `crawlers` are addressed by the client's own `appId`,
+ * and the lookups that address them — `byAppId` and `patchCrawlerByAppId` —
+ * use `.unique()`, which **throws** when a second row shares an app id. Because
+ * mirrored writes are fire-and-forget, that throw never reached a player: the
+ * local write succeeded, the UI looked correct, and every subsequent edit to
+ * that entity silently failed to reach the server of record. An account in that
+ * state does not recover on its own and does not get better with time.
+ *
+ * `claimLocal` is what created the duplicates (it inserted unconditionally, and
+ * a device-local marker was all that stopped it running twice) and it no longer
+ * can. This is the other half: the rows already written are still there, and
+ * still breaking every write, until something removes them.
+ *
+ * **Run the dry run first.** With no arguments this reports and changes
+ * nothing:
+ *
+ *     bunx convex run maintenance:dedupeAppIds --prod
+ *     bunx convex run maintenance:dedupeAppIds '{"apply": true}' --prod
+ */
+
+/** Tables addressed by a client-minted `appId`, and therefore duplicable. */
+const APP_ID_TABLES = ['pilots', 'mechs', 'crawlers'] as const
+type AppIdTable = (typeof APP_ID_TABLES)[number]
+
+type Row = Doc<'pilots'> | Doc<'mechs'> | Doc<'crawlers'>
+
+/** What a single duplicated app id looked like, and what was done about it. */
+type GroupReport = {
+  table: AppIdTable
+  appId: string
+  rows: number
+  kept: string
+  deleted: string[]
+  /**
+   * `changeLog` rows still pointing at a row this repair would delete.
+   *
+   * That table is the audit trail and the proposal bus at once — a Mediator's
+   * pending proposal is a row in `proposed` state — and it addresses an entity
+   * by **Convex id**, not by `appId` (see `loadOwnable`). So deleting the loser
+   * of a duplicate pair can leave a proposal aimed at nothing, and can detach
+   * history from the surviving row.
+   *
+   * It degrades gracefully rather than corrupting: applying such a proposal
+   * answers "That entity no longer exists". But it is a real consequence, so it
+   * is counted and reported up front instead of being discovered afterwards.
+   */
+  orphanedChangeLogRows: number
+}
+
+/**
+ * Which row survives.
+ *
+ * The order matters more than it looks. An owned row beats an unowned one
+ * because an unclaimed entity is an offer nobody took up, whereas an owned one
+ * is somebody's character. Among rows that tie on that, the most recently
+ * written wins — with the caveat that *these* rows have not been written since
+ * the duplication broke their mirror, so in practice the tiebreak that usually
+ * decides it is creation time, and the oldest row is the one the player has
+ * been looking at.
+ *
+ * Returns the survivor first, losers after.
+ */
+function rankForKeeping(rows: Row[]): Row[] {
+  return [...rows].sort((a, b) => {
+    const aOwned = 'ownerId' in a && a.ownerId !== null ? 1 : 0
+    const bOwned = 'ownerId' in b && b.ownerId !== null ? 1 : 0
+    if (aOwned !== bOwned) return bOwned - aOwned
+    if (a.updatedAt !== b.updatedAt) return b.updatedAt - a.updatedAt
+    return a._creationTime - b._creationTime
+  })
+}
+
+/** Rows of one table grouped by app id, keeping only the genuinely duplicated. */
+function duplicateGroups(rows: Row[]): Map<string, Row[]> {
+  const byAppId = new Map<string, Row[]>()
+  for (const row of rows) {
+    if (typeof row.appId !== 'string') continue
+    const group = byAppId.get(row.appId)
+    if (group === undefined) byAppId.set(row.appId, [row])
+    else group.push(row)
+  }
+  for (const [appId, group] of byAppId) {
+    if (group.length < 2) byAppId.delete(appId)
+  }
+  return byAppId
+}
+
+/** How many `changeLog` rows (audit entries and proposals alike) name this row. */
+async function changeLogRowsFor(
+  ctx: MutationCtx,
+  id: Id<'pilots'> | Id<'mechs'> | Id<'crawlers'>
+): Promise<number> {
+  const rows = await ctx.db
+    .query('changeLog')
+    .withIndex('by_entity', (q) => q.eq('entityId', id))
+    .collect()
+  return rows.length
+}
+
+export const dedupeAppIds = internalMutation({
+  args: {
+    /** Write the deletions. Omitted or false = report only, change nothing. */
+    apply: v.optional(v.boolean()),
+  },
+  handler: async (
+    ctx,
+    args
+  ): Promise<{
+    applied: boolean
+    scanned: number
+    duplicatedAppIds: number
+    rowsDeleted: number
+    orphanedChangeLogRows: number
+    groups: GroupReport[]
+  }> => {
+    const apply = args.apply === true
+    const groups: GroupReport[] = []
+    let scanned = 0
+    let rowsDeleted = 0
+    let orphanedChangeLogRows = 0
+
+    for (const table of APP_ID_TABLES) {
+      /*
+       * A full scan, on purpose: the whole question is "which app ids appear
+       * more than once", and an index on `appId` answers "where is this one"
+       * rather than "which are repeated". These tables hold one row per built
+       * character, so the scan is small — but it is a scan, and if these ever
+       * grow to where `.collect()` strains, this becomes a paginated job rather
+       * than a bigger read.
+       */
+      const rows = (await ctx.db.query(table).collect()) as Row[]
+      scanned += rows.length
+
+      for (const [appId, group] of duplicateGroups(rows)) {
+        const [keep, ...losers] = rankForKeeping(group)
+        if (keep === undefined) continue
+
+        let orphaned = 0
+        for (const loser of losers) {
+          orphaned += await changeLogRowsFor(ctx, loser._id)
+        }
+
+        groups.push({
+          table,
+          appId,
+          rows: group.length,
+          kept: keep._id,
+          deleted: losers.map((row) => row._id),
+          orphanedChangeLogRows: orphaned,
+        })
+        orphanedChangeLogRows += orphaned
+
+        if (apply) {
+          for (const loser of losers) {
+            await ctx.db.delete(loser._id)
+            rowsDeleted += 1
+          }
+        }
+      }
+    }
+
+    return {
+      applied: apply,
+      scanned,
+      duplicatedAppIds: groups.length,
+      // Honest in dry-run: nothing was deleted, so this is 0 and `groups`
+      // carries what *would* go. A report that pre-counted its own hypothetical
+      // deletions reads exactly like one that already made them.
+      rowsDeleted,
+      orphanedChangeLogRows,
+      groups,
+    }
+  },
+})

--- a/apps/itun/convex/model/permissions.ts
+++ b/apps/itun/convex/model/permissions.ts
@@ -1,4 +1,5 @@
 import { getAuthUserId } from '@convex-dev/auth/server'
+import { ConvexError } from 'convex/values'
 import type { Doc, Id } from '../_generated/dataModel'
 import type { MutationCtx, QueryCtx } from '../_generated/server'
 
@@ -25,8 +26,34 @@ import type { MutationCtx, QueryCtx } from '../_generated/server'
 
 type AnyCtx = QueryCtx | MutationCtx
 
-/** Thrown for every authorization failure, so callers can map it to a 403. */
-export class NotAuthorized extends Error {
+/**
+ * Thrown for every authorization failure, so callers can map it to a 403.
+ *
+ * **It extends `ConvexError`, and that is the only reason any of the messages
+ * in this repo reach a player.** Convex redacts a plain `Error` thrown from a
+ * production function down to `"[CONVEX M(fn)] Server Error"` before the client
+ * ever sees it — deliberately, so an unhandled crash cannot leak internals.
+ * `ConvexError` is the documented opt-out: its `data` is sent over the wire
+ * intact.
+ *
+ * Until this changed, every carefully-worded refusal here — "This game has no
+ * Union Crawler yet — the Mediator raises one before the crew joins it", "You
+ * cannot edit another player's entity" — was written, thrown, and then thrown
+ * away at the boundary. A player who tried something the rules disallow got the
+ * same opaque "Server Error" as a genuine crash, and so did the operator
+ * reading Sentry.
+ *
+ * The distinction this draws is the one worth keeping: a `NotAuthorized` is an
+ * **expected answer** to a request the rules refuse, and it says so out loud. A
+ * plain `Error` remains what it was — a defect nobody planned for, opaque to
+ * the client on purpose and legible only in the Convex logs and Sentry.
+ *
+ * Note the subclass itself does not survive the wire: the client receives a
+ * plain `ConvexError` whose `data` is this message, so it narrows with
+ * `instanceof ConvexError`, never `instanceof NotAuthorized`. See
+ * `src/lib/connection/serverError.ts`.
+ */
+export class NotAuthorized extends ConvexError<string> {
   constructor(message: string) {
     super(message)
     this.name = 'NotAuthorized'

--- a/apps/itun/src/components/account/ClaimLocalData.tsx
+++ b/apps/itun/src/components/account/ClaimLocalData.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import { useConnection } from '../../lib/connection/connectionContext'
 import { isConvexConfigured } from '../../lib/connection/convexClient'
+import { serverMessage } from '../../lib/connection/serverError'
+import { captureException } from '../../lib/observability'
 import { useEntityStore } from '../../stores/entityStore'
 import { usePatternStore } from '../../stores/patternStore'
 
@@ -25,11 +27,18 @@ import { usePatternStore } from '../../stores/patternStore'
  *
  * ## Why it is one-time
  *
- * Claiming twice would duplicate the roster: `claimLocal` inserts, and the
- * local records keep their ids, so a second run creates a second copy of
- * everything. The completion marker is per **account**, not per device — the
- * same person on a second device should still be offered their local data
- * there, but should never be asked twice for the same upload on the same one.
+ * The completion marker is per **account**, not per device — the same person on
+ * a second device should still be offered their local data there, but should
+ * never be asked twice for the same upload on the same one.
+ *
+ * **That marker is a courtesy, not the guard.** It used to be the only thing
+ * standing between a player and a duplicated roster, and it could not be: it
+ * lives in `localStorage`, so a second device, a fresh profile or a cleared
+ * cache ran the whole claim again — and because entities are addressed by
+ * `appId` through a `.unique()` lookup, a second copy broke every subsequent
+ * mirrored write for those entities, silently and for good. `claimLocal` now
+ * skips anything it already holds (see its header), so re-claiming is a no-op
+ * on the server and this marker only decides whether to *ask*.
  */
 
 const CLAIMED_KEY_PREFIX = 'itun.claimedLocalData.'
@@ -52,7 +61,12 @@ function markClaimed(userKey: string): void {
   }
 }
 
-type Summary = { claimed: number; skipped: number; byKind: Record<string, number> }
+type Summary = {
+  claimed: number
+  skipped: number
+  alreadyPresent: number
+  byKind: Record<string, number>
+}
 
 function ConnectedClaim() {
   const claimLocal = useMutation(api.entities.claimLocal)
@@ -66,6 +80,7 @@ function ConnectedClaim() {
   const [summary, setSummary] = useState<Summary | null>(null)
   const [busy, setBusy] = useState(false)
   const [dismissed, setDismissed] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const total = pilots.length + mechs.length + crawlers.length + patterns.length
   // Keyed on the roster itself rather than a user id the client does not hold:
@@ -103,6 +118,7 @@ function ConnectedClaim() {
                 disabled={busy}
                 onClick={() => {
                   setBusy(true)
+                  setError(null)
                   void claimLocal({
                     pilots: pilots as unknown[],
                     mechs: mechs as unknown[],
@@ -114,6 +130,17 @@ function ConnectedClaim() {
                       markClaimed(userKey)
                       setSummary(result as Summary)
                     })
+                    .catch((err: unknown) => {
+                      // Without this the promise rejected unhandled: the button
+                      // simply stopped saying "Copying…" and the player was left
+                      // to guess whether their roster had been copied. Deliberately
+                      // NOT marked as claimed — a failed claim must stay on offer.
+                      setError(
+                        serverMessage(err) ??
+                          'Your builds could not be copied just now. They are still on this device — try again in a moment.'
+                      )
+                      captureException(err, { source: 'claimLocal' })
+                    })
                     .finally(() => setBusy(false))
                 }}
               >
@@ -123,12 +150,28 @@ function ConnectedClaim() {
                 Not now
               </Button>
             </div>
+            {error !== null && (
+              <Text variant="hint" className="text-left">
+                {error}
+              </Text>
+            )}
           </>
         ) : (
           <>
             <Text>
               Copied {summary.claimed} item{summary.claimed === 1 ? '' : 's'} to your account.
             </Text>
+            {summary.alreadyPresent > 0 && (
+              // Claiming the same roster twice is now a no-op rather than a
+              // second copy, so this line is what tells a player that "0 copied"
+              // means "already done", not "nothing happened".
+              <Text variant="hint" className="text-left">
+                {summary.alreadyPresent}{' '}
+                {summary.alreadyPresent === 1 ? 'was already' : 'were already'} in your account and{' '}
+                {summary.alreadyPresent === 1 ? 'was' : 'were'} left as{' '}
+                {summary.alreadyPresent === 1 ? 'it is' : 'they are'}.
+              </Text>
+            )}
             {summary.skipped > 0 && (
               <Text variant="hint" className="text-left">
                 {summary.skipped} could not be read and {summary.skipped === 1 ? 'was' : 'were'}{' '}

--- a/apps/itun/src/lib/connection/__tests__/serverError.test.ts
+++ b/apps/itun/src/lib/connection/__tests__/serverError.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test'
+import { ConvexError } from 'convex/values'
+import { isServerRefusal, serverMessage } from '../serverError'
+
+/**
+ * Telling a refusal apart from a defect on the client.
+ *
+ * The distinction is not cosmetic. Convex sends a `ConvexError`'s data across
+ * intact and redacts everything else to `"[CONVEX M(fn)] […] Server Error"`, so
+ * "did the backend choose to say this?" is the only honest basis for deciding
+ * whether a string is fit to show a player. Getting it wrong in the permissive
+ * direction is how an opaque internal error ends up rendered in the UI.
+ */
+describe('serverMessage', () => {
+  test('returns the message the backend deliberately sent', () => {
+    // What `NotAuthorized` becomes by the time it reaches the browser: the
+    // subclass does not survive serialization, only the data does.
+    const refusal = new ConvexError(
+      'This game has no Union Crawler yet — the Mediator raises one before the crew joins it'
+    )
+
+    expect(serverMessage(refusal)).toBe(
+      'This game has no Union Crawler yet — the Mediator raises one before the crew joins it'
+    )
+    expect(isServerRefusal(refusal)).toBe(true)
+  })
+
+  test('returns null for a redacted server error, so nothing leaks to the UI', () => {
+    // The real shape of a defect: the cause is stripped before it leaves the
+    // deployment, so this string is all the client ever gets. Showing it to a
+    // player is strictly worse than saying nothing.
+    const defect = new Error('[CONVEX M(entities:upsertByAppId)] [Request ID: abc] Server Error')
+
+    expect(serverMessage(defect)).toBeNull()
+    expect(isServerRefusal(defect)).toBe(false)
+  })
+
+  test('non-Error values are not refusals', () => {
+    expect(serverMessage('a bare string')).toBeNull()
+    expect(serverMessage(null)).toBeNull()
+    expect(serverMessage(undefined)).toBeNull()
+  })
+
+  test('a non-string or empty payload counts as no message', () => {
+    // `ConvexError.data` is any Convex value. A structured payload would
+    // stringify to something no player should read, and an empty string is not
+    // a message at all — both take the "there is nothing to show" path rather
+    // than rendering as a blank or a JSON blob.
+    expect(serverMessage(new ConvexError({ code: 'nope' }))).toBeNull()
+    expect(serverMessage(new ConvexError(''))).toBeNull()
+  })
+})

--- a/apps/itun/src/lib/connection/serverError.ts
+++ b/apps/itun/src/lib/connection/serverError.ts
@@ -1,0 +1,54 @@
+import { ConvexError } from 'convex/values'
+
+/**
+ * Telling a server refusal apart from a server defect, on the client.
+ *
+ * Convex draws exactly one line across everything `convex/` can throw, and it
+ * draws it at the wire:
+ *
+ * - a **`ConvexError`** arrives with its `data` intact, because the backend
+ *   declared the message fit to show;
+ * - **anything else** arrives as `"[CONVEX M(fn)] […] Server Error"`, with the
+ *   real message stripped so a crash cannot leak internals.
+ *
+ * `convex/model/permissions.ts` puts the domain refusals on the first side of
+ * that line (`NotAuthorized extends ConvexError`) and leaves genuine defects on
+ * the second. This module is the client half: it turns "which side of the line
+ * was this?" into an answer a component can act on, so nobody has to
+ * string-match `'Server Error'` at a call site to find out.
+ *
+ * The subclass does not survive serialization — the client gets a plain
+ * `ConvexError` carrying the message as `data` — so `instanceof ConvexError` is
+ * the only narrowing that works here. `instanceof NotAuthorized` would compile
+ * and always be false.
+ */
+
+/**
+ * The player-facing message the server chose to send, or `null` when it sent
+ * none.
+ *
+ * `null` is the meaningful case: it means the throw was **not** a deliberate
+ * refusal, so there is no sanctioned copy to show and the honest options are a
+ * generic message plus a Sentry report. Never fall back to `String(err)` for
+ * display — that is where the opaque `"[CONVEX M(entities:upsertByAppId)] […]
+ * Server Error"` string comes from, and showing it to a player is strictly
+ * worse than saying nothing.
+ */
+export function serverMessage(err: unknown): string | null {
+  if (!(err instanceof ConvexError)) return null
+  // `data` is typed `Value` — any Convex value. Everything this backend throws
+  // uses a string, but a non-string would stringify to something unreadable,
+  // so it is treated as "no message" rather than shown.
+  return typeof err.data === 'string' && err.data.length > 0 ? err.data : null
+}
+
+/**
+ * Whether this error is a deliberate refusal rather than a defect.
+ *
+ * Worth having as its own verb because the two call for opposite handling:
+ * a refusal is the system working (show the message, do not alert an operator),
+ * a defect is not (generic message, report it).
+ */
+export function isServerRefusal(err: unknown): boolean {
+  return serverMessage(err) !== null
+}

--- a/apps/itun/src/stores/entityBackend.ts
+++ b/apps/itun/src/stores/entityBackend.ts
@@ -7,6 +7,7 @@ import {
   usesServerOfRecord,
 } from '../lib/connection/connectionMode'
 import { convexClient } from '../lib/connection/convexClient'
+import { serverMessage } from '../lib/connection/serverError'
 import { captureException } from '../lib/observability'
 
 /**
@@ -172,8 +173,25 @@ export async function mirrorWrite(
     // a mirror failure means IndexedDB has diverged from Convex, the declared
     // server of record (ADR-030), and a console line in one player's browser
     // is not a signal anyone will ever see.
-    console.warn('[itun] failed to mirror write to the server of record', err)
-    captureException(err, { source: 'mirrorWrite', type, op: op.kind })
+    //
+    // `refusal` is what the server was willing to say (see
+    // `lib/connection/serverError.ts`). Both kinds are still reported, because
+    // both mean the same thing about the data — the mirror did not land — but
+    // they are not the same thing to whoever reads the report, so the tag makes
+    // them separable:
+    //
+    //   - a **refusal** carries the rule that stopped it, in words. It is the
+    //     backend working as designed, and the fix (if any) is a product one.
+    //   - a **defect** arrives redacted as "Server Error" no matter what went
+    //     wrong, so the message is worthless and the Convex logs are the only
+    //     place the cause exists.
+    //
+    // That distinction is exactly what was missing when a duplicate-appId
+    // `unique()` violation spent an evening looking indistinguishable from a
+    // permission denial.
+    const refusal = serverMessage(err)
+    console.warn('[itun] failed to mirror write to the server of record', refusal ?? err)
+    captureException(err, { source: 'mirrorWrite', type, op: op.kind, refusal })
   }
 }
 
@@ -222,9 +240,14 @@ export async function mirrorCrawlerWrite(
       await convexClient.mutation(api.entities.removeCrawlerByAppId, { appId: op.appId })
     }
   } catch (err) {
-    // See mirrorWrite: swallowed for the user, reported to operators.
-    console.warn('[itun] failed to mirror crawler write to the server of record', err)
-    captureException(err, { source: 'mirrorCrawlerWrite', op: op.kind })
+    // See mirrorWrite: swallowed for the user, reported to operators, and
+    // tagged with whatever the server was willing to say. This path is the one
+    // that most needs it — "Only the Mediator can do that" is a routine answer
+    // here (a player editing a communal crawler), and it should never read like
+    // a crash.
+    const refusal = serverMessage(err)
+    console.warn('[itun] failed to mirror crawler write to the server of record', refusal ?? err)
+    captureException(err, { source: 'mirrorCrawlerWrite', op: op.kind, refusal })
   }
 }
 

--- a/apps/itun/test/convex/entities.test.ts
+++ b/apps/itun/test/convex/entities.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { ConvexError } from 'convex/values'
 import { api } from '../../convex/_generated/api'
 import type { Id } from '../../convex/_generated/dataModel'
 import { testConvex } from './harness'
@@ -492,5 +493,158 @@ describe('claiming a legacy roster carries the whole thing', () => {
     })
     expect(result.byKind.pilots).toBe(1)
     expect(result.skipped).toBe(1)
+  })
+})
+
+/**
+ * Whether a refusal is fit to leave the deployment.
+ *
+ * Convex redacts a plain `Error` thrown from a production function down to
+ * "[CONVEX M(fn)] Server Error" before any client sees it, and propagates a
+ * `ConvexError`'s `data` intact. Every authorization message in this repo was
+ * therefore written, thrown, and discarded at the boundary — a player who tried
+ * something the rules refuse got the same opaque string as a genuine crash.
+ *
+ * This cannot be observed through `convex-test`, which runs in-process and so
+ * never serializes anything. What it *can* pin is the property the wire
+ * behaviour depends on: the error carries its message as `ConvexError` data.
+ */
+describe('refusals say why', () => {
+  test('an authorization failure crosses the wire as ConvexError data', async () => {
+    const t = testConvex()
+    const owner = await makeUser(t, 'Owner')
+    const stranger = await makeUser(t, 'Stranger')
+
+    await owner.as.mutation(api.entities.claimLocal, { pilots: [pilotBody()], mechs: [] })
+    const pilotId = await t.run(async (ctx) => (await ctx.db.query('pilots').first())?._id)
+
+    const err = await stranger.as
+      .mutation(api.entities.update, {
+        table: 'pilots',
+        entityId: pilotId as string,
+        body: pilotBody({ name: 'not yours' }),
+      })
+      .then(
+        () => null,
+        (e: unknown) => e
+      )
+
+    expect(err).toBeInstanceOf(ConvexError)
+    // The `data` field is the whole mechanism: it is what Convex sends on, and
+    // what `serverMessage()` reads on the client.
+    expect((err as ConvexError<string>).data).toMatch(/cannot edit another player/i)
+  })
+})
+
+/**
+ * Claiming the same roster twice.
+ *
+ * This is not a hypothetical: the only thing that ever stopped a second claim
+ * was a `localStorage` marker, and the card that writes it is deliberately
+ * re-offered on a second device. A player signing in on a laptop after their
+ * phone ran the whole claim again.
+ *
+ * The cost was permanent and silent. `byAppId` and `patchCrawlerByAppId` use
+ * `.unique()`, which throws on a second row with the same app id, so from the
+ * moment a roster was duplicated **every mirrored write for those entities
+ * failed** — while the local write kept succeeding, leaving the app looking
+ * healthy as IndexedDB and the server of record drifted apart for good.
+ */
+describe('claiming twice is a no-op, not a second copy', () => {
+  const crawler = crawlerBody()
+
+  test('the second claim copies nothing and says so', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    const roster = { pilots: [pilotBody(), pilotBody({ id: 'p2' })], mechs: [mechBody()] }
+
+    const first = await u.as.mutation(api.entities.claimLocal, roster)
+    const second = await u.as.mutation(api.entities.claimLocal, roster)
+
+    expect(first.claimed).toBe(3)
+    expect(second.claimed).toBe(0)
+    // Reported separately from `skipped`, which means "could not be read" —
+    // telling a player their roster was unreadable when it is simply already
+    // there would be a worse lie than the silence this replaced.
+    expect(second.alreadyPresent).toBe(3)
+    expect(second.skipped).toBe(0)
+
+    const pilots = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    const mechs = await t.run(async (ctx) => await ctx.db.query('mechs').collect())
+    expect(pilots).toHaveLength(2)
+    expect(mechs).toHaveLength(1)
+  })
+
+  test('the mirror still works after a repeat claim — the bug this fixes', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    await u.as.mutation(api.entities.claimLocal, { pilots: [pilotBody()], mechs: [] })
+    await u.as.mutation(api.entities.claimLocal, { pilots: [pilotBody()], mechs: [] })
+
+    // Before the guard this threw `unique() query returned more than one
+    // result from table pilots`, redacted to an opaque "Server Error" on the
+    // client and swallowed by the fire-and-forget mirror. Every edit to this
+    // pilot was lost from that point on, with nothing shown to anyone.
+    await u.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'p1',
+      gameId: null,
+      body: pilotBody({ name: 'Edited after the second claim' }),
+    })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(1)
+    expect((rows[0]?.body as { name: string } | undefined)?.name).toBe(
+      'Edited after the second claim'
+    )
+  })
+
+  test('a repeat claim does not raise a second placeholder game', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    await u.as.mutation(api.entities.claimLocal, { pilots: [], mechs: [], crawlers: [crawler] })
+    await u.as.mutation(api.entities.claimLocal, { pilots: [], mechs: [], crawlers: [crawler] })
+
+    // The placeholder Game used to be raised before anything checked whether
+    // there was a crawler left to put in it, so a re-claim grew the player's
+    // game list by one empty "Claimed crawler" every time.
+    const crawlers = await t.run(async (ctx) => await ctx.db.query('crawlers').collect())
+    const games = await t.run(async (ctx) => await ctx.db.query('games').collect())
+    const memberships = await t.run(async (ctx) => await ctx.db.query('memberships').collect())
+    expect(crawlers).toHaveLength(1)
+    expect(games).toHaveLength(1)
+    expect(memberships).toHaveLength(1)
+  })
+
+  test('soft links and patterns are not duplicated either', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    const roster = {
+      pilots: [],
+      mechs: [],
+      crawlers: [crawler],
+      softLinks: [
+        {
+          from: { type: 'pilot', id: 'p1' },
+          to: { type: 'crawler', id: 'c1' },
+          type: 'pilot-to-crawler',
+        },
+      ],
+      mechPatterns: [patternBody()],
+    }
+
+    await u.as.mutation(api.entities.claimLocal, roster)
+    const second = await u.as.mutation(api.entities.claimLocal, roster)
+
+    expect(second.claimed).toBe(0)
+    const links = await t.run(async (ctx) => await ctx.db.query('softLinks').collect())
+    const patterns = await t.run(async (ctx) => await ctx.db.query('mechPatterns').collect())
+    // A link has no app id — it IS its endpoints — so identity is the
+    // (from, to, kind) triple. Nothing calls `.unique()` here, but a roster
+    // that drew the same pilot-to-crawler link twice is still wrong.
+    expect(links).toHaveLength(1)
+    expect(patterns).toHaveLength(1)
   })
 })

--- a/apps/itun/test/convex/harness.ts
+++ b/apps/itun/test/convex/harness.ts
@@ -51,6 +51,7 @@ const modules: Record<string, () => Promise<unknown>> = {
   './games.ts': () => import('../../convex/games'),
   './mediator.ts': () => import('../../convex/mediator'),
   './invites.ts': () => import('../../convex/invites'),
+  './maintenance.ts': () => import('../../convex/maintenance'),
   './ownership.ts': () => import('../../convex/ownership'),
   './proposals.ts': () => import('../../convex/proposals'),
   './templates.ts': () => import('../../convex/templates'),

--- a/apps/itun/test/convex/maintenance.test.ts
+++ b/apps/itun/test/convex/maintenance.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from 'bun:test'
+import { api, internal } from '../../convex/_generated/api'
+import type { Id } from '../../convex/_generated/dataModel'
+import { testConvex } from './harness'
+
+/**
+ * Repairing rows that were duplicated before `claimLocal` stopped duplicating.
+ *
+ * `claimLocal` no longer inserts a second row for an app id it already holds,
+ * which closes the hole — but every account claimed twice before that fix still
+ * carries the damage, and the damage is not self-healing. `byAppId` and
+ * `patchCrawlerByAppId` call `.unique()`, so a duplicated app id makes **every
+ * mirrored write for that entity throw, forever**. The mirror is
+ * fire-and-forget, so the player sees nothing at all: local writes keep
+ * succeeding while the server of record silently stops receiving them.
+ *
+ * The first case below pins that mechanism rather than assuming it — a repair
+ * whose premise is untested is a repair nobody can trust.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+function pilotBody(over: Record<string, unknown> = {}) {
+  return {
+    id: 'p1',
+    schemaVersion: 1,
+    name: 'Roach-Boy',
+    callsign: 'Roach-Boy',
+    classRef: 'salvager',
+    abilities: [],
+    equipment: [],
+    motto: '',
+    keepsake: '',
+    appearance: '',
+    conditions: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...over,
+  }
+}
+
+/**
+ * Write the damage directly.
+ *
+ * `claimLocal` cannot produce this any more, which is the point of the fix — so
+ * reproducing a pre-fix account means inserting the second row by hand, exactly
+ * as the old unconditional insert did.
+ */
+async function duplicatePilot(t: Ctx, ownerId: Id<'users'>, appId: string, count: number) {
+  await t.run(async (ctx) => {
+    for (let i = 0; i < count; i += 1) {
+      await ctx.db.insert('pilots', {
+        gameId: null,
+        ownerId,
+        appId,
+        body: pilotBody({ id: appId, name: `copy ${i}` }),
+        updatedAt: 1_000 + i,
+      })
+    }
+  })
+}
+
+describe('duplicate app ids break the mirror', () => {
+  test('a second row with the same app id makes every upsert throw', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    await duplicatePilot(t, u.userId, 'p1', 2)
+
+    // This is the production failure, reproduced: an opaque server error on
+    // every edit, from a mutation that swallows it.
+    await expect(
+      u.as.mutation(api.entities.upsertByAppId, {
+        table: 'pilots',
+        appId: 'p1',
+        gameId: null,
+        body: pilotBody(),
+      })
+    ).rejects.toThrow(/unique/i)
+  })
+})
+
+describe('dedupeAppIds', () => {
+  test('the dry run reports what it would do and changes nothing', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    await duplicatePilot(t, u.userId, 'p1', 3)
+
+    const report = await t.mutation(internal.maintenance.dedupeAppIds, {})
+
+    expect(report.applied).toBe(false)
+    expect(report.duplicatedAppIds).toBe(1)
+    expect(report.groups[0]?.rows).toBe(3)
+    expect(report.groups[0]?.deleted).toHaveLength(2)
+    // A report that pre-counted its own hypothetical deletions would read
+    // exactly like one that had already made them.
+    expect(report.rowsDeleted).toBe(0)
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(3)
+  })
+
+  test('applying it leaves one row and the mirror works again', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    await duplicatePilot(t, u.userId, 'p1', 3)
+
+    const report = await t.mutation(internal.maintenance.dedupeAppIds, { apply: true })
+    expect(report.applied).toBe(true)
+    expect(report.rowsDeleted).toBe(2)
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(1)
+
+    // The whole point: the entity is writable again.
+    await u.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'p1',
+      gameId: null,
+      body: pilotBody({ name: 'Writable again' }),
+    })
+    const after = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect((after[0]?.body as { name: string } | undefined)?.name).toBe('Writable again')
+  })
+
+  test('an owned row outlives an unclaimed one', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    await t.run(async (ctx) => {
+      // The unclaimed row is written LAST and with the newer timestamp, so only
+      // the ownership rule can save the right one here.
+      await ctx.db.insert('pilots', {
+        gameId: null,
+        ownerId: u.userId,
+        appId: 'p1',
+        body: pilotBody({ name: 'somebody’s character' }),
+        updatedAt: 1,
+      })
+      await ctx.db.insert('pilots', {
+        gameId: null,
+        ownerId: null,
+        appId: 'p1',
+        body: pilotBody({ name: 'an offer nobody took' }),
+        updatedAt: 999,
+      })
+    })
+
+    await t.mutation(internal.maintenance.dedupeAppIds, { apply: true })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(1)
+    expect((rows[0]?.body as { name: string } | undefined)?.name).toBe('somebody’s character')
+  })
+
+  test('change-log rows left pointing at a deleted copy are counted, not hidden', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    await duplicatePilot(t, u.userId, 'p1', 2)
+
+    const doomed = await t.run(async (ctx) => {
+      const rows = await ctx.db.query('pilots').collect()
+      // Whichever row loses is decided by the same rule the repair uses: equal
+      // ownership, so the newer `updatedAt` survives and the older is deleted.
+      const loser = rows.find((r) => r.updatedAt === 1_000)
+      await ctx.db.insert('changeLog', {
+        gameId: null,
+        entityType: 'pilot',
+        entityId: loser?._id ?? '',
+        ts: Date.now(),
+        kind: 'manual',
+        field: 'name',
+        before: 'a',
+        after: 'b',
+        source: 'live-sheet',
+        actorId: u.userId,
+        state: 'applied',
+      })
+      return loser?._id
+    })
+
+    expect(doomed).toBeDefined()
+    const report = await t.mutation(internal.maintenance.dedupeAppIds, {})
+    // Proposals and history address an entity by Convex id, not app id, so a
+    // repair that says nothing about them would be quietly detaching history.
+    expect(report.orphanedChangeLogRows).toBe(1)
+  })
+
+  test('a clean deployment reports nothing to do', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    await u.as.mutation(api.entities.claimLocal, { pilots: [pilotBody()], mechs: [] })
+
+    const report = await t.mutation(internal.maintenance.dedupeAppIds, {})
+    expect(report.duplicatedAppIds).toBe(0)
+    expect(report.groups).toEqual([])
+    expect(report.scanned).toBe(1)
+  })
+})

--- a/docs/architecture/accounts-and-games.md
+++ b/docs/architecture/accounts-and-games.md
@@ -285,6 +285,56 @@ repo):
   Convex errors will not carry a commit SHA the way the Netlify and Render
   surfaces do.
 
+**Status: enabled on production** (`exuberant-porpoise-183` → the `itun-convex`
+Sentry project), 2026-08-05.
+
+#### What reaches Sentry, and what reaches the player
+
+Convex splits everything `convex/` can throw in two, at the wire, and the split
+is not configurable:
+
+| thrown              | the client receives                       | good for                       |
+| ------------------- | ----------------------------------------- | ------------------------------ |
+| `ConvexError`       | its `data`, intact                        | refusals the rules make        |
+| anything else       | `"[CONVEX M(fn)] […] Server Error"`        | defects nobody planned for     |
+
+Both still reach Sentry and the function logs. The difference is entirely about
+what a **player** may see, and the repo takes a deliberate position on it:
+
+- **`NotAuthorized` extends `ConvexError`** (`convex/model/permissions.ts`), so
+  every authorization message — around thirty-five of them — is copy that
+  actually arrives. Until 2026-08-05 it did not: each one was written, thrown,
+  and discarded at the boundary, and a player who tried something the rules
+  refuse got the same opaque string as a crash.
+- **Everything else stays a plain `Error`.** A Zod parse failure or a broken
+  invariant is not a message to show anyone; it belongs in the logs.
+
+On the client, `src/lib/connection/serverError.ts` is the only sanctioned way to
+ask which one you have (`serverMessage` / `isServerRefusal`). Never string-match
+`'Server Error'` at a call site, and never render `String(err)` from a mutation —
+that string is the redacted one.
+
+#### Repairing duplicated app ids
+
+`convex/maintenance.ts` holds operator-only repairs, reachable through
+`bunx convex run` and not from any client. The one that exists today undoes the
+damage described under "Claiming twice" in `convex/entities.ts`: rows sharing an
+`appId`, which make `byAppId`'s `.unique()` throw and so break every mirrored
+write for that entity, permanently and silently.
+
+```bash
+# report only — changes nothing
+bunx convex run maintenance:dedupeAppIds --prod
+# then, having read the report
+bunx convex run maintenance:dedupeAppIds '{"apply": true}' --prod
+```
+
+It keeps one row per app id (an owned row over an unclaimed one, then the most
+recently written) and reports how many `changeLog` rows — audit history and
+pending Mediator proposals alike — still point at a copy it would delete. Those
+address entities by Convex id rather than `appId`, so they do not follow the
+survivor.
+
 ### Netlify
 
 | Site               | Serves                           | Notes                                                                                                                                        |


### PR DESCRIPTION
Both findings from today's Sentry triage. They presented as one thing: an
opaque `[CONVEX M(entities:upsertByAppId)] Server Error`, 12 events over
~50 minutes, spanning a deploy that did not fix it. The real cause existed
only in the Convex logs:

```
Uncaught Error: unique() query returned more than one result from table pilots:
 [m172sf321pxbr3hv51y732f7j98br9t7, m1725mycjgy3k35dp7ezsb8xv98btb52, ...]
    at async byAppId (convex/entities.ts:524)
```

---

## 1. `claimLocal` duplicated rosters, and the duplicate broke writes forever

`claimLocal` inserted unconditionally. The only thing stopping a second run
was a `localStorage` marker — and the card that writes it is **deliberately
re-offered on a second device**, so a laptop after a phone, a fresh browser
profile, or cleared site data ran the whole claim again. The file's own doc
comment said as much ("Claiming twice would duplicate the roster") while
relying on a client-side flag to prevent it.

The consequence was not a cosmetic double-up. Pilots, mechs and crawlers
are addressed by `appId`, and `byAppId` / `patchCrawlerByAppId` use
`.unique()`, which **throws** on a second row. From the moment a roster was
claimed twice, every mirrored write for those entities failed — silently,
because the mirror is fire-and-forget. The local write still succeeded, the
app looked completely healthy, and IndexedDB drifted from the declared
server of record (ADR-030) permanently. It does not self-heal.

**Every insert in the claim is now guarded on identity**, per kind:

| kind | identity |
| --- | --- |
| pilots, mechs, crawlers | `appId` |
| soft links | the (from, to, kind) triple — a link has no id, it *is* its endpoints |
| patterns | the body's own id (no `appId` column exists) |

It reports a new `alreadyPresent` count, kept distinct from `skipped`
(which means "could not be read") — telling someone their roster was
unreadable when it is simply already there would be a worse lie than the
silence it replaces. The UI now says so, so "0 copied" reads as "already
done" rather than "nothing happened".

The crawler pass also resolves what it will write **before** raising the
placeholder Game, which was itself a repeated write: a re-claim used to
leave behind an empty "Claimed crawler" Game and a membership every time.

### Repairing what is already broken

`convex/maintenance.ts` — operator-only (`internalMutation`, reachable only
via `bunx convex run`), **dry-run by default**:

```bash
bunx convex run maintenance:dedupeAppIds --prod              # report only
bunx convex run maintenance:dedupeAppIds '{"apply": true}' --prod
```

It keeps one row per app id (an owned row over an unclaimed one, then most
recently written) and reports how many `changeLog` rows — audit history and
pending Mediator proposals alike — still point at a copy it would delete.
Those address entities by **Convex id**, not `appId`, so they do not follow
the survivor; it degrades gracefully rather than corrupting, but it is a
real consequence and is reported up front instead of discovered later.

**Not run against production in this PR** — that is a destructive operation
on player data and wants a human on the dry-run output first.

### Known limitation, deliberately not fixed here

`appId` is a client-minted UUID, and export/import copies a build between
people *keeping its id* — so two accounts can legitimately hold the same
app id, which the `by_app_id` + `.unique()` pairing assumes cannot happen.
This PR takes the safe side (report `alreadyPresent`, never insert a
second) rather than corrupting the mirror for two people. Closing it
properly means keying the index on `(ownerId, appId)`, which is a schema
change and its own piece of work.

## 2. Server errors could not say anything

Convex redacts every non-`ConvexError` throw to `"[CONVEX M(fn)] Server
Error"` before the client sees it. The repo used `ConvexError` **nowhere**,
so all ~35 carefully-worded refusals — "This game has no Union Crawler yet
— the Mediator raises one before the crew joins it" — were written, thrown,
and discarded at the boundary. A player who tried something the rules
refuse got the same opaque string as a genuine crash. (A real
`NotAuthorized: Only the Mediator can do that` fired during the same
session and reached neither the player nor Sentry.)

`NotAuthorized` now extends `ConvexError`, so those messages arrive.
Genuine defects — parse failures, broken invariants — stay plain `Error`:
opaque to clients on purpose, legible in the Convex logs and now in Sentry.

`src/lib/connection/serverError.ts` is the client half, and the only
sanctioned way to ask which kind you have. Never string-match
`'Server Error'`, and never render `String(err)` from a mutation — that is
the redacted one. Both mirror-write handlers now tag their Sentry reports
with the refusal text, so an operator sees *why* rather than "Server Error".

`ClaimLocalData` had no `.catch()` at all: a failed claim just stopped
saying "Copying…" and left the player to guess. It now says what happened
and stays on offer.

## Notes

- **No Sentry SDK was added to `convex/`** — `apps/itun/CLAUDE.md` forbids it, correctly (queries/mutations run in a deterministic runtime with no `fetch`). Convex's first-party Exception Reporting integration was enabled in the dashboard instead; docs updated to record it as live and to state the `ConvexError` contract.
- `convex/_generated/api.d.ts` is regenerated (`convex codegen`) because the new module must be registered — `tools/check-convex-codegen.ts` catches this, and did.

## Verification

- `bun run check:all` green — lint, format, typecheck ×6, test, validate, knip, audit, tokens, styling
- `bun --filter itun test` — **1711 pass, 0 fail**
- 11 new tests. The premise is pinned, not assumed: `maintenance.test.ts` first proves a duplicate row really does make `upsertByAppId` throw `/unique/i`, then that the repair restores writability — a repair whose premise is untested is one nobody can trust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6ao8WWaWUtq5RsfYbySY9
