### PR TITLE
fix(itun): stop game entities silently desyncing, and give the game roster its missing verbs

### DIFF
--- a/apps/itun/CLAUDE.md
+++ b/apps/itun/CLAUDE.md
@@ -125,11 +125,22 @@ and remains the account-free way to share a build.
   `src/lib/connection/serverError.ts` — never by string-matching `'Server Error'`,
   and never by rendering `String(err)` from a mutation.
 - **Never insert into an `appId`-addressed table without checking first.**
-  `pilots`, `mechs` and `crawlers` are looked up by the client's `appId` with
-  `.unique()`, which **throws** on a second row — and since mirrored writes are
-  fire-and-forget, that throw is invisible: local writes keep succeeding while
-  the server of record silently stops receiving them. `convex/maintenance.ts`
-  repairs rows already in that state (`dedupeAppIds`, dry-run by default).
+  `pilots`, `mechs` and `crawlers` are looked up by the client's `appId`, and
+  `by_app_id` is an ordinary index — **not** a uniqueness constraint — so
+  nothing in the database stops a second row. Prevention is the rule:
+  `appIdTaken` before any insert. `convex/maintenance.ts` repairs rows already
+  in that state (`dedupeAppIds`, dry-run by default).
+
+  The **lookups themselves no longer throw** on a duplicate. `byAppId` /
+  `crawlerByAppId` resolve to the oldest match and `console.warn`, because
+  mirrored writes are fire-and-forget: a throw here is invisible to the player,
+  so it does not fail the write, it just stops the write from ever reaching the
+  server while every surface keeps rendering it as saved. That is how an
+  evening of play went missing. A duplicate is a repair job — it is not a reason
+  to refuse the write that would have kept client and server in step. The
+  warning is the tripwire, and it fires without taking the player's data with
+  it. Resolving to the *oldest* is deliberate: it is the row `dedupeAppIds`
+  keeps, so a write that lands before the repair runs is not discarded by it.
 
 ## Commands
 

--- a/apps/itun/convex/entities.ts
+++ b/apps/itun/convex/entities.ts
@@ -18,6 +18,7 @@ import {
   requireTableRunner,
   requireUser,
 } from './model/permissions'
+import { entityRefType, softLinkType } from './schema'
 
 /**
  * Entity reads and writes against the server of record (ADR-030 §1).
@@ -242,6 +243,28 @@ export const update = mutation({
     const body = parseBody(args.table, args.body)
 
     await ctx.db.patch(doc._id, { body, updatedAt: Date.now() })
+  },
+})
+
+/**
+ * Delete an entity, addressed by its **server** id. Owner only.
+ *
+ * The twin of `removeByAppId`, which the mirror uses, and necessary because the
+ * Game roster cannot use that one: it is looking at rows this browser may never
+ * have held, and at pre-gens seeded from a template that have no `appId` at all
+ * (production holds a dozen). Addressing by `_id` is the only way to name those,
+ * and it is exactly how `update`, `ownership.release` and `removeCrawler`
+ * already address a row from that surface.
+ */
+export const remove = mutation({
+  args: { table: OWNABLE, entityId: v.string() },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    const doc = await loadOwnable(ctx, args.table, args.entityId)
+
+    assertMayWrite(doc, userId)
+    await ctx.db.delete(doc._id)
+    if (doc.appId !== undefined) await pruneSoftLinksFor(ctx, doc.appId)
   },
 })
 
@@ -525,23 +548,20 @@ export const claimLocal = mutation({
        * A soft link has no `appId` of its own — it IS its endpoints — so
        * identity is the (from, to, kind) triple, and that is what a re-claim
        * has to match on. Duplicates here are less destructive than a duplicate
-       * entity (nothing calls `.unique()` on this table) but they are not
-       * harmless: `listForGame` returns every row, so a roster would draw the
-       * same mech-to-pilot link twice.
+       * entity but they are not harmless: `listForGame` returns every row, so a
+       * roster would draw the same mech-to-pilot link twice.
+       *
+       * Shares `findSoftLink` with the mirror mutations below rather than
+       * repeating the lookup inline — the triple is the link's identity in both
+       * places, and two copies of that rule could disagree.
        */
       // Bound into locals: the checks above narrowed `l.from`/`l.to`, but that
-      // narrowing does not survive the `await` and the closure below.
+      // narrowing does not survive the `await` below.
       const from = { type: l.from.type, id: l.from.id }
       const to = { type: l.to.type, id: l.to.id }
       const linkType = l.type
 
-      const duplicateLink = (
-        await ctx.db
-          .query('softLinks')
-          .withIndex('by_from', (q) => q.eq('from.id', from.id))
-          .collect()
-      ).some((row) => row.to.id === to.id && row.type === linkType)
-      if (duplicateLink) {
+      if ((await findSoftLink(ctx, from.id, to.id, linkType)) !== null) {
         alreadyPresent += 1
         continue
       }
@@ -605,16 +625,55 @@ export const claimLocal = mutation({
  * This is the whole point of the `appId` column: a client that only knows its
  * local UUID can still address the server row, so updates and deletes work
  * without a mapping table. One indexed lookup, not a scan.
+ *
+ * ## Why this tolerates duplicates instead of asking for `.unique()`
+ *
+ * `by_app_id` is an ordinary Convex index, **not a uniqueness constraint** —
+ * nothing in the database has ever stopped two rows sharing an `appId`, and in
+ * production several did (`claimLocal` blind-inserts, and its only guard is a
+ * per-device localStorage marker, so claiming the same shelf from a second
+ * browser duplicates the roster).
+ *
+ * `.unique()` turned that *data* condition into a thrown `Server Error` on
+ * every subsequent mirrored write. `mirrorWrite` is fire-and-forget, so it
+ * swallowed the throw: the local copy went on accepting edits, the server never
+ * heard another one, and the two silently diverged forever — with the entity
+ * still rendering perfectly on the shelf that had already saved it. That is the
+ * worst failure this app can produce, and it was reachable from a duplicate row.
+ *
+ * A duplicate is a repair job. It is not a reason to refuse the write that
+ * would have kept client and server in step, so this resolves one row and lets
+ * the write land.
+ *
+ * **The oldest row wins, deterministically.** It is the row every earlier
+ * mirror already wrote to, so choosing it keeps editing the copy the client has
+ * been addressing all along rather than silently migrating to a younger one.
+ * `_creationTime` is used rather than index order because index order is not a
+ * documented guarantee, and a winner that moves between calls would be worse
+ * than the throw it replaces.
  */
 async function byAppId(
   ctx: MutationCtx,
   table: OwnableTable,
   appId: string
 ): Promise<Doc<'pilots'> | Doc<'mechs'> | null> {
-  return (await ctx.db
+  const matches = (await ctx.db
     .query(table)
     .withIndex('by_app_id', (q) => q.eq('appId', appId))
-    .unique()) as Doc<'pilots'> | Doc<'mechs'> | null
+    .collect()) as Array<Doc<'pilots'> | Doc<'mechs'>>
+
+  if (matches.length === 0) return null
+  if (matches.length === 1) return matches[0] ?? null
+
+  // Logged every time rather than silently absorbed: the write now succeeds, so
+  // this line is the only remaining signal that a roster needs de-duplicating.
+  // It lands in the deployment log stream, which is the one place a Convex
+  // server-side message is readable at all (there is no Sentry SDK in here).
+  console.warn(
+    `[itun] ${matches.length} ${table} rows share appId="${appId}" — resolving to the oldest; this roster needs de-duplicating`
+  )
+
+  return matches.reduce((oldest, row) => (row._creationTime < oldest._creationTime ? row : oldest))
 }
 
 /**
@@ -701,10 +760,7 @@ export const upsertByAppId = mutation({
 export const patchCrawlerByAppId = mutation({
   args: { appId: v.string(), patch: v.any() },
   handler: async (ctx, args): Promise<void> => {
-    const existing = await ctx.db
-      .query('crawlers')
-      .withIndex('by_app_id', (q) => q.eq('appId', args.appId))
-      .unique()
+    const existing = await crawlerByAppId(ctx, args.appId)
     if (existing === null) return
 
     await requireMember(ctx, existing.gameId)
@@ -723,13 +779,147 @@ export const patchCrawlerByAppId = mutation({
 export const removeCrawlerByAppId = mutation({
   args: { appId: v.string() },
   handler: async (ctx, args): Promise<void> => {
-    const existing = await ctx.db
-      .query('crawlers')
-      .withIndex('by_app_id', (q) => q.eq('appId', args.appId))
-      .unique()
+    const existing = await crawlerByAppId(ctx, args.appId)
     if (existing === null) return
 
     await requireTableRunner(ctx, existing.gameId)
+    await ctx.db.delete(existing._id)
+  },
+})
+
+/**
+ * The crawler mirroring a local build, addressed by app id.
+ *
+ * Tolerant of duplicates for exactly the reasons `byAppId` is — same
+ * non-unique index, same fire-and-forget mirror, same silent divergence if it
+ * throws. The crawler has no duplicates in production today, and that is luck
+ * rather than a constraint: `claimLocal` inserts one per claim, so a second
+ * claim from a second device would have produced them here too.
+ */
+async function crawlerByAppId(ctx: MutationCtx, appId: string): Promise<Doc<'crawlers'> | null> {
+  const matches = await ctx.db
+    .query('crawlers')
+    .withIndex('by_app_id', (q) => q.eq('appId', appId))
+    .collect()
+
+  if (matches.length === 0) return null
+  if (matches.length === 1) return matches[0] ?? null
+
+  console.warn(
+    `[itun] ${matches.length} crawlers share appId="${appId}" — resolving to the oldest; this game needs de-duplicating`
+  )
+
+  return matches.reduce((oldest, row) => (row._creationTime < oldest._creationTime ? row : oldest))
+}
+
+/**
+ * The server row for a soft link, addressed the way the client addresses one.
+ *
+ * Soft links carry no `appId` and need none: `from.id` and `to.id` already ARE
+ * app-level ids, so the (from, to, kind) triple is the link's identity. Two
+ * links with the same endpoints and the same kind are the same link, whichever
+ * browser drew it — which is what makes the mirror idempotent for free.
+ */
+async function findSoftLink(
+  ctx: MutationCtx,
+  fromId: string,
+  toId: string,
+  type: SoftLink['type']
+): Promise<Doc<'softLinks'> | null> {
+  const candidates = await ctx.db
+    .query('softLinks')
+    .withIndex('by_from', (q) => q.eq('from.id', fromId))
+    .collect()
+
+  return candidates.find((l) => l.to.id === toId && l.type === type) ?? null
+}
+
+/**
+ * Which ownable table a link's `from` endpoint lives in.
+ *
+ * The `from` end is always ownable — a mech in `mech-to-pilot`, a pilot in
+ * `pilot-to-crawler` — which is what lets one lookup answer both questions the
+ * mirror has to ask: may this user draw the link, and which container does it
+ * belong to.
+ */
+const SOFT_LINK_FROM_TABLE: Record<SoftLink['type'], OwnableTable> = {
+  'mech-to-pilot': 'mechs',
+  'pilot-to-crawler': 'pilots',
+}
+
+/**
+ * Mirror a soft link to the server of record.
+ *
+ * ## Why this exists
+ *
+ * Soft links were the one part of a roster that never left the browser.
+ * `mirrorEntityWrite` returned early for them — they were called "derived", and
+ * for a shelf they effectively are — while `listForGame` *read* them back. So a
+ * Game showed whatever links existed when the account was claimed, and every
+ * wiring change made afterwards was invisible to the rest of the table: you
+ * assigned a pilot to the crawler, your own sheet updated, and nobody else ever
+ * saw it. A link is not derived once a Game shares it; it is the assignment.
+ *
+ * ## Permission and container both come from the `from` end
+ *
+ * You may draw a link out of an entity you may write, and the link lands in
+ * that entity's container. Both fall out of one lookup, and both are the
+ * answers you want: wiring your own mech to a crewmate's pilot is your business
+ * because the mech is yours, and the link belongs wherever the mech does.
+ *
+ * A `from` entity with no server row means a purely local build — Solo, or
+ * shelved before a claim — so there is nothing to anchor a link to and this
+ * no-ops rather than inventing one.
+ */
+export const upsertSoftLink = mutation({
+  args: {
+    from: v.object({ type: entityRefType, id: v.string() }),
+    to: v.object({ type: entityRefType, id: v.string() }),
+    type: softLinkType,
+  },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+
+    const anchor = await byAppId(ctx, SOFT_LINK_FROM_TABLE[args.type], args.from.id)
+    if (anchor === null) return
+    assertMayWrite(anchor, userId)
+
+    const existing = await findSoftLink(ctx, args.from.id, args.to.id, args.type)
+    if (existing !== null) {
+      // The link is already here; only its container can have moved, and it
+      // moves with the entity it was drawn out of.
+      if (existing.gameId !== anchor.gameId) {
+        await ctx.db.patch(existing._id, { gameId: anchor.gameId })
+      }
+      return
+    }
+
+    await ctx.db.insert('softLinks', {
+      gameId: anchor.gameId,
+      from: args.from,
+      to: args.to,
+      type: args.type,
+    })
+  },
+})
+
+/** Unwire a soft link. Addressed by endpoints; already-gone is not an error. */
+export const removeSoftLink = mutation({
+  args: {
+    from: v.object({ type: entityRefType, id: v.string() }),
+    to: v.object({ type: entityRefType, id: v.string() }),
+    type: softLinkType,
+  },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+
+    const anchor = await byAppId(ctx, SOFT_LINK_FROM_TABLE[args.type], args.from.id)
+    if (anchor === null) return
+    assertMayWrite(anchor, userId)
+
+    const existing = await findSoftLink(ctx, args.from.id, args.to.id, args.type)
+    if (existing === null) return
+
     await ctx.db.delete(existing._id)
   },
 })
@@ -744,5 +934,30 @@ export const removeByAppId = mutation({
 
     assertMayWrite(existing, userId)
     await ctx.db.delete(existing._id)
+    await pruneSoftLinksFor(ctx, args.appId)
   },
 })
+
+/**
+ * Drop every link with this entity on either end.
+ *
+ * The client has cascaded this since well before Games existed
+ * (`deleteEntityWithSoftLinks`), and the server not doing the same is how a
+ * Game accumulates wires to characters that are gone — rendered as the "Unknown
+ * pilot (id)" rows the local cascade was written to abolish. Both ends are
+ * swept because a link is directional but a deletion is not.
+ */
+async function pruneSoftLinksFor(ctx: MutationCtx, appId: string): Promise<void> {
+  const [outgoing, incoming] = await Promise.all([
+    ctx.db
+      .query('softLinks')
+      .withIndex('by_from', (q) => q.eq('from.id', appId))
+      .collect(),
+    ctx.db
+      .query('softLinks')
+      .withIndex('by_to', (q) => q.eq('to.id', appId))
+      .collect(),
+  ])
+
+  await Promise.all([...outgoing, ...incoming].map((link) => ctx.db.delete(link._id)))
+}

--- a/apps/itun/convex/schema.ts
+++ b/apps/itun/convex/schema.ts
@@ -43,11 +43,17 @@ import { v } from 'convex/values'
  * there, each kept in step with its Zod counterpart in `src/lib/schemas/`.
  */
 
-/** Mirrors `EntityRefSchema.type` (src/lib/schemas/entity.ts) — ADR-027. */
-const entityRefType = v.union(v.literal('pilot'), v.literal('mech'), v.literal('crawler'))
+/**
+ * Mirrors `EntityRefSchema.type` (src/lib/schemas/entity.ts) — ADR-027.
+ *
+ * Exported so a mutation that takes an endpoint as an *argument* validates it
+ * against this same union rather than a hand-copied one. `entities.upsertSoftLink`
+ * is the caller; a second copy there is exactly the drift the header warns about.
+ */
+export const entityRefType = v.union(v.literal('pilot'), v.literal('mech'), v.literal('crawler'))
 
-/** Mirrors `SoftLinkSchema.type` (src/lib/schemas/softLink.ts). */
-const softLinkType = v.union(v.literal('mech-to-pilot'), v.literal('pilot-to-crawler'))
+/** Mirrors `SoftLinkSchema.type` (src/lib/schemas/softLink.ts). Exported: see above. */
+export const softLinkType = v.union(v.literal('mech-to-pilot'), v.literal('pilot-to-crawler'))
 
 /**
  * Mirrors `ChangeLogEntityTypeSchema` (src/lib/schemas/changeLog.ts), plus

--- a/apps/itun/src/components/games/GameRoster.tsx
+++ b/apps/itun/src/components/games/GameRoster.tsx
@@ -268,6 +268,8 @@ export function GameRoster({ gameId, gameName }: GameRosterProps) {
   const [error, setError] = useState<string | null>(null)
   /** The row whose UNCLAIMED seal was pressed, awaiting confirmation. */
   const [claimTarget, setClaimTarget] = useState<RosterRow | null>(null)
+  /** The row whose Delete was pressed, awaiting confirmation. */
+  const [deleteTarget, setDeleteTarget] = useState<RosterRow | null>(null)
 
   const me = useQuery(api.account.me, {})
   const members = useQuery(api.games.members, { gameId: gameId as Id<'games'> })
@@ -276,6 +278,7 @@ export function GameRoster({ gameId, gameName }: GameRosterProps) {
   const claim = useMutation(api.ownership.claim)
   const release = useMutation(api.ownership.release)
   const scrapCrawler = useMutation(api.entities.removeCrawler)
+  const removeEntity = useMutation(api.entities.remove)
 
   // Local copies decide what opens without a round trip, so the columns need
   // the local stores hydrated even though the listing itself is remote.
@@ -540,6 +543,16 @@ export function GameRoster({ gameId, gameName }: GameRosterProps) {
                                   Offer to the crew
                                 </Button>
                               )}
+                              {row.can.delete && (
+                                <Button
+                                  variant="ghost"
+                                  size="mini"
+                                  disabled={busy !== null}
+                                  onClick={() => setDeleteTarget(row)}
+                                >
+                                  Delete
+                                </Button>
+                              )}
                               {row.can.scrap && (
                                 <Button
                                   variant="ghost"
@@ -580,6 +593,64 @@ export function GameRoster({ gameId, gameName }: GameRosterProps) {
           Back to your builds
         </AppLink>
       </p>
+
+      {/* The destructive twin of the pick-up confirm, in the danger tone the
+          Roster's own delete uses. It names the alternative on purpose: at a
+          shared table, "I am done with this character" almost always means
+          somebody else could have them, and a player who deletes when they
+          meant to hand over cannot undo it. */}
+      <ModalShell
+        open={deleteTarget !== null}
+        onOpenChange={(next) => {
+          if (!next) setDeleteTarget(null)
+        }}
+        title={`Delete ${deleteTarget?.name ?? ''}?`}
+        tone="danger"
+        maxWidth="max-w-md"
+      >
+        <div className="flex flex-col gap-4 bg-paper p-5">
+          <div className="font-body text-sm text-wk-muted">
+            This cannot be undone. {deleteTarget?.name ?? 'This character'} will be removed from
+            this game for everyone, and from this browser.
+          </div>
+          <div className="font-body text-xs text-wk-muted">
+            Only leaving the table? “Offer to the crew” hands them back instead — they stay in the
+            game for somebody else to pick up.
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" size="compact" onClick={() => setDeleteTarget(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="danger"
+              size="compact"
+              disabled={busy !== null}
+              onClick={() => {
+                const row = deleteTarget
+                if (row === null || row.kind === 'crawler') return
+                void run(`delete-${row.serverId}`, async () => {
+                  // Server first, addressed by server id: the row may never
+                  // have been in this browser, and a template pre-gen has no
+                  // appId for the mirror to address it by.
+                  await removeEntity({
+                    table: row.kind === 'pilot' ? 'pilots' : 'mechs',
+                    entityId: row.serverId,
+                  })
+                  // Then drop the cached copy, exactly as release and scrap do.
+                  // `forget`, not `delete`: the server row is already gone, so
+                  // a second mirrored destruction would be a no-op at best.
+                  if (row.localId !== null) {
+                    await useEntityStore.getState().forget(row.kind, row.localId)
+                  }
+                  setDeleteTarget(null)
+                })
+              }}
+            >
+              Delete
+            </Button>
+          </div>
+        </div>
+      </ModalShell>
 
       {/* Picking a character up is constructive, not destructive, so this is an
           `action`-toned confirm rather than the danger one the delete flows use.

--- a/apps/itun/src/components/sheet/SheetCrawler.tsx
+++ b/apps/itun/src/components/sheet/SheetCrawler.tsx
@@ -23,6 +23,7 @@ import { pilotingContext } from '../../lib/rules/pilotingContext'
 import type { Crawler } from '../../lib/schemas/crawler'
 import { LIVE_SHEET_OVERRIDE } from '../../stores/surfaceProvenance'
 import { AppLink } from '../shared/AppLink'
+import { AssignPilotToCrawler } from '../wiring/AssignPilotToCrawler'
 import type { CrawlerEconomyDialog } from './CrawlerEconomyControl'
 import { CrawlerEconomyControl } from './CrawlerEconomyControl'
 import { CrawlerSheet } from './CrawlerSheet'
@@ -206,24 +207,52 @@ export function SheetCrawler({
           entityType="mech"
           className="flex-[1_1_0%]"
           roleLabel="Docked Mechs"
-          message="No mechs in the bay — dock one to repair, re-arm and track it from here."
+          /* Says how a mech actually gets here. The old copy — "dock one to
+             repair, re-arm and track it from here" — named a verb this surface
+             does not have: there is no mech→crawler link, so a mech arrives by
+             its pilot joining the crew. Promising "dock one" beside a button
+             that only creates a new mech is what "you couldn't assign them to a
+             crawler" felt like from the outside. */
+          message="No mechs in the bay. A mech arrives with its pilot — add that pilot to the crew and their mech docks here."
           actions={editable ? <RailCta href="/mechs/new" label="+ Create" primary /> : undefined}
         />
       )}
       {composition.crawlerPilots.length > 0 ? (
-        composition.crawlerPilots.map((crewPilot) => (
-          <EntityRow
-            key={crewPilot.id}
-            entityType="pilot"
-            className="flex-[1_1_0%]"
-            name={crewPilot.name}
-            sheetHref={`/sheet/pilot/${crewPilot.id}`}
-            linkAs={AppLink}
-            meta="Pilot"
-            stats={rowStats(pilotRailItems(crewPilot))}
-            onDeleteClick={unlinkPilot(crewPilot.id)}
-          />
-        ))
+        <>
+          {composition.crawlerPilots.map((crewPilot) => (
+            <EntityRow
+              key={crewPilot.id}
+              entityType="pilot"
+              className="flex-[1_1_0%]"
+              name={crewPilot.name}
+              sheetHref={`/sheet/pilot/${crewPilot.id}`}
+              linkAs={AppLink}
+              meta="Pilot"
+              stats={rowStats(pilotRailItems(crewPilot))}
+              onDeleteClick={unlinkPilot(crewPilot.id)}
+            />
+          ))}
+          {/* A crew of one is not a full crew, so the way to add the second has
+              to survive the first. Rendered as the same `empty` EntityRow the
+              no-pilots branch uses rather than a bare button, so it inherits the
+              rail's sizing instead of introducing a second layout to keep in
+              step. */}
+          {editable && (
+            <EntityRow
+              empty
+              entityType="pilot"
+              className="flex-[1_1_0%]"
+              roleLabel="Crew"
+              message="Bring another pilot aboard."
+              actions={
+                <>
+                  <AssignPilotToCrawler crawlerId={crawler.id} />
+                  <RailCta href="/pilots/new" label="+ Create" />
+                </>
+              }
+            />
+          )}
+        </>
       ) : (
         <EntityRow
           empty
@@ -231,7 +260,17 @@ export function SheetCrawler({
           className="flex-[1_1_0%]"
           roleLabel="Pilots"
           message="No pilots wired to this crawler yet."
-          actions={editable ? <RailCta href="/pilots/new" label="+ Create" primary /> : undefined}
+          /* Both verbs, because they answer different questions. `+ Create` was
+             the only one here, which quietly assumed the pilot you wanted did
+             not exist yet — at a table, they almost always already do. */
+          actions={
+            editable ? (
+              <>
+                <AssignPilotToCrawler crawlerId={crawler.id} />
+                <RailCta href="/pilots/new" label="+ Create" primary />
+              </>
+            ) : undefined
+          }
         />
       )}
     </>

--- a/apps/itun/src/components/wiring/AssignPilotToCrawler.tsx
+++ b/apps/itun/src/components/wiring/AssignPilotToCrawler.tsx
@@ -1,0 +1,198 @@
+/**
+ * AssignPilotToCrawler — button that opens a pilot selector dialog, then
+ * creates a pilot-to-crawler SoftLink on confirm.
+ *
+ * ## Why this exists when AssignCrawlerToPilot already does
+ *
+ * They are the same link drawn from opposite ends, and only one of the two ends
+ * had a control. From a pilot you could pick a crawler; from a crawler you could
+ * only ever **create a new pilot** — the rails offered `+ Create` and nothing
+ * else. So the ordinary thing a player wants to do at a table, put an existing
+ * character aboard the crew's crawler, had no path from the crawler at all.
+ *
+ * That gap is also why "you couldn't assign them to a crawler" is true of
+ * **mechs**, which is how it was reported. A mech reaches a bay through its
+ * pilot (`mech-to-pilot` + `pilot-to-crawler` — the two-hop `SheetCrawler`
+ * resolves); `resolveLinkType` has no mech→crawler pairing and throws if asked
+ * for one. With no way to add crew from here, there was no way to get a mech
+ * into the bay from here either, and the empty rail said "dock one" while
+ * offering nothing that could.
+ *
+ * The direction is fixed by the schema, not by which button you pressed: the
+ * pilot is always the `from` end. So this hangs `useSoftLinks` off the selected
+ * pilot rather than off the crawler it is rendered on.
+ *
+ * Props:
+ *   crawlerId   — id of the crawler being crewed
+ *   store       — injectable store for testability (omit in production)
+ *   onAssigned  — optional callback fired after the link is created
+ *   className   — optional class override for the trigger button
+ */
+
+import { Button, FieldError, ModalShell, Radio } from 'component-lib'
+import { useState } from 'react'
+import { usePilots } from '../../hooks/queries'
+import type { Pilot } from '../../lib/schemas/pilot'
+import { cn } from '../../lib/utils'
+import { useEntityStore } from '../../stores/entityStore'
+import type { SoftLinkStore } from './useSoftLinks'
+import { resolveLinkType } from './useSoftLinks'
+
+/**
+ * Extended injectable store that also exposes pilot listing.
+ *
+ * Named for the crew rather than the pilot because `AssignPilotToMech` already
+ * exports an `AssignPilotStore`, and a test that reached for both would have
+ * had to rename one at the import site.
+ */
+export type AssignCrewStore = SoftLinkStore & {
+  pilots: Pilot[]
+}
+
+type AssignPilotToCrawlerProps = {
+  crawlerId: string
+  /** Inject to avoid Zustand global in tests. */
+  store?: AssignCrewStore
+  onAssigned?: () => void
+  className?: string
+}
+
+export function AssignPilotToCrawler({
+  crawlerId,
+  store,
+  onAssigned,
+  className,
+}: AssignPilotToCrawlerProps) {
+  const [open, setOpen] = useState(false)
+  const [selectedPilotId, setSelectedPilotId] = useState<string>('')
+  const [pending, setPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Subscribe to pilots from the real store when not injected.
+  const zustandPilots = usePilots()
+  const pilots: Pilot[] = store ? store.pilots : zustandPilots
+
+  /*
+   * Already-crewed pilots are filtered out rather than shown and refused.
+   * Re-drawing a link that exists is harmless (the mirror is idempotent by
+   * endpoints), but offering it implies something would happen, and a list of
+   * mostly-inert options is how a picker stops being readable.
+   */
+  // Always call the hook (Rules of Hooks); prefer the injected snapshot when
+  // there is one, exactly as `useSoftLinks` does.
+  const subscribedLinks = useEntityStore((s) => s.softLinks)
+  const links = store ? store.softLinks : subscribedLinks
+  const crewed = new Set(
+    links
+      .filter((l) => l.type === 'pilot-to-crawler' && l.to.id === crawlerId)
+      .map((l) => l.from.id)
+  )
+  const available = pilots.filter((p) => !crewed.has(p.id))
+
+  function openDialog() {
+    setSelectedPilotId('')
+    setError(null)
+    setOpen(true)
+  }
+
+  function closeDialog() {
+    setOpen(false)
+    setError(null)
+  }
+
+  async function handleConfirm() {
+    if (!selectedPilotId) {
+      setError('Please select a pilot.')
+      return
+    }
+    setPending(true)
+    setError(null)
+    try {
+      // Written against the store directly rather than through `useSoftLinks`:
+      // that hook binds its `from` end at render time, and the `from` end here
+      // is the pilot the player just picked, which is not known until now.
+      const s: SoftLinkStore = store ?? useEntityStore.getState()
+      await s.create('softLink', {
+        from: { type: 'pilot', id: selectedPilotId },
+        to: { type: 'crawler', id: crawlerId },
+        type: resolveLinkType('pilot', 'crawler'),
+      })
+      setOpen(false)
+      onAssigned?.()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add that pilot to the crew.')
+    } finally {
+      setPending(false)
+    }
+  }
+
+  return (
+    <>
+      <Button
+        size="compact"
+        onClick={openDialog}
+        className={cn(className)}
+        aria-label="Add an existing pilot to this crawler's crew"
+      >
+        + Add Crew
+      </Button>
+
+      <ModalShell
+        open={open}
+        onOpenChange={(next) => {
+          if (!next) closeDialog()
+        }}
+        title="Add Pilot to Crew"
+        maxWidth="max-w-md"
+      >
+        <div className="flex flex-col gap-4 bg-paper p-5">
+          {available.length === 0 ? (
+            <p className="font-body text-sm text-wk-muted">
+              {pilots.length === 0
+                ? 'No pilots yet. Create one first, then bring them aboard.'
+                : 'Every pilot you have is already crewing this crawler.'}
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {available.map((pilot) => (
+                <Radio
+                  key={pilot.id}
+                  name="pilot-select"
+                  value={pilot.id}
+                  checked={selectedPilotId === pilot.id}
+                  onChange={() => setSelectedPilotId(pilot.id)}
+                  label={pilot.name}
+                  description={pilot.callsign}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* The two-hop, said once, where the question actually arises: a
+              player looking for their mech in the bay is looking at this list
+              and wondering why it asks about pilots. */}
+          <p className="font-body text-xs text-wk-muted">
+            A pilot brings their mech with them — anything they are wired to appears in the bay.
+          </p>
+
+          {error && <FieldError>{error}</FieldError>}
+
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" size="compact" onClick={closeDialog} disabled={pending}>
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              size="compact"
+              onClick={() => void handleConfirm()}
+              disabled={pending || available.length === 0}
+              aria-label="Confirm crew assignment"
+            >
+              {pending ? 'Adding…' : 'Add to Crew'}
+            </Button>
+          </div>
+        </div>
+      </ModalShell>
+    </>
+  )
+}

--- a/apps/itun/src/components/wiring/__tests__/assignPilotToCrawler.test.tsx
+++ b/apps/itun/src/components/wiring/__tests__/assignPilotToCrawler.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * AssignPilotToCrawler — adding existing crew from the crawler's own sheet.
+ *
+ * The gap this closes: `AssignCrawlerToPilot` let you pick a crawler *from a
+ * pilot*, but from a crawler the rails offered `+ Create` and nothing else. So
+ * the ordinary move at a table — put a character who already exists aboard —
+ * had no path from the surface where you would look for it.
+ *
+ * It is also why the complaint arrived as a **mech** problem. A mech reaches a
+ * bay through its pilot (`mech-to-pilot` + `pilot-to-crawler`), and
+ * `resolveLinkType` throws if asked for a mech→crawler pairing, so with no way
+ * to add crew there was no way to dock a mech either — beside an empty rail
+ * that said "dock one".
+ *
+ * Dep-injected stores, no `mock.module()`, matching `wiringComponents.test.tsx`.
+ */
+
+import { describe, expect, mock, test } from 'bun:test'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import type { Pilot } from '../../../lib/schemas/pilot'
+import type { SoftLink } from '../../../lib/schemas/softLink'
+import { FIXTURE_NOW } from '../../__tests__/fixtures'
+import type { AssignCrewStore } from '../AssignPilotToCrawler'
+import { AssignPilotToCrawler } from '../AssignPilotToCrawler'
+
+function pilot(id: string, name: string): Pilot {
+  return {
+    id,
+    schemaVersion: 1,
+    name,
+    // Deliberately NOT the name: the Radio renders the callsign as its
+    // description, so equal values would make every `getByText(name)` below
+    // ambiguous rather than assertive.
+    callsign: `${id}-callsign`,
+    classRef: 'scavenger',
+    abilities: [],
+    equipment: [],
+    motto: '',
+    keepsake: '',
+    appearance: '',
+    background: '',
+    conditions: [],
+    createdAt: FIXTURE_NOW,
+    updatedAt: FIXTURE_NOW,
+  }
+}
+
+function makeStore(over: Partial<AssignCrewStore> = {}): AssignCrewStore {
+  return {
+    pilots: [pilot('pilot-1', 'Yara Voss')],
+    softLinks: [],
+    create: mock(async () => ({}) as SoftLink),
+    delete: mock(async () => {}),
+    ...over,
+  }
+}
+
+const CRAWLER_ID = 'crawler-1'
+
+describe('AssignPilotToCrawler', () => {
+  test('confirming wires the pilot to the crawler, pilot-end first', async () => {
+    const store = makeStore()
+    render(<AssignPilotToCrawler crawlerId={CRAWLER_ID} store={store} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /add an existing pilot/i }))
+    fireEvent.click(screen.getByRole('radio'))
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /confirm crew assignment/i }))
+    })
+
+    // The direction is fixed by the schema, not by which end you pressed: the
+    // pilot is always `from`. Getting this backwards would write a link no
+    // resolver reads.
+    expect(store.create).toHaveBeenCalledWith('softLink', {
+      from: { type: 'pilot', id: 'pilot-1' },
+      to: { type: 'crawler', id: CRAWLER_ID },
+      type: 'pilot-to-crawler',
+    })
+  })
+
+  test('pilots already crewing this crawler are not offered again', () => {
+    const store = makeStore({
+      pilots: [pilot('pilot-1', 'Yara Voss'), pilot('pilot-2', 'Dag')],
+      softLinks: [
+        {
+          id: 'l1',
+          from: { type: 'pilot', id: 'pilot-1' },
+          to: { type: 'crawler', id: CRAWLER_ID },
+          type: 'pilot-to-crawler',
+          createdAt: FIXTURE_NOW,
+        },
+      ],
+    })
+    render(<AssignPilotToCrawler crawlerId={CRAWLER_ID} store={store} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /add an existing pilot/i }))
+
+    // Re-drawing an existing link is harmless — the mirror is idempotent by
+    // endpoints — but offering it implies something would happen.
+    expect(screen.queryByText('Yara Voss')).toBeNull()
+    expect(screen.getByText('Dag')).toBeTruthy()
+    expect(screen.getAllByRole('radio')).toHaveLength(1)
+  })
+
+  test('a pilot crewing a DIFFERENT crawler is still offered', () => {
+    const store = makeStore({
+      softLinks: [
+        {
+          id: 'l1',
+          from: { type: 'pilot', id: 'pilot-1' },
+          to: { type: 'crawler', id: 'some-other-crawler' },
+          type: 'pilot-to-crawler',
+          createdAt: FIXTURE_NOW,
+        },
+      ],
+    })
+    render(<AssignPilotToCrawler crawlerId={CRAWLER_ID} store={store} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /add an existing pilot/i }))
+    expect(screen.getByText('Yara Voss')).toBeTruthy()
+  })
+
+  test('confirming nothing asks rather than writing', async () => {
+    const store = makeStore()
+    render(<AssignPilotToCrawler crawlerId={CRAWLER_ID} store={store} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /add an existing pilot/i }))
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /confirm crew assignment/i }))
+    })
+
+    expect(store.create).not.toHaveBeenCalled()
+    expect(screen.getByText(/please select a pilot/i)).toBeTruthy()
+  })
+
+  test('says which kind of empty it is', () => {
+    const none = makeStore({ pilots: [] })
+    const { unmount } = render(<AssignPilotToCrawler crawlerId={CRAWLER_ID} store={none} />)
+    fireEvent.click(screen.getByRole('button', { name: /add an existing pilot/i }))
+    // "You have no pilots" and "they are all already aboard" are different
+    // problems with different next actions.
+    expect(screen.getByText(/create one first/i)).toBeTruthy()
+    unmount()
+
+    const allCrewed = makeStore({
+      softLinks: [
+        {
+          id: 'l1',
+          from: { type: 'pilot', id: 'pilot-1' },
+          to: { type: 'crawler', id: CRAWLER_ID },
+          type: 'pilot-to-crawler',
+          createdAt: FIXTURE_NOW,
+        },
+      ],
+    })
+    render(<AssignPilotToCrawler crawlerId={CRAWLER_ID} store={allCrewed} />)
+    fireEvent.click(screen.getByRole('button', { name: /add an existing pilot/i }))
+    expect(screen.getByText(/already crewing this crawler/i)).toBeTruthy()
+  })
+})

--- a/apps/itun/src/lib/games/__tests__/gameRoster.test.ts
+++ b/apps/itun/src/lib/games/__tests__/gameRoster.test.ts
@@ -141,6 +141,42 @@ describe('rows carry ownership as a state, never a blank', () => {
   })
 })
 
+describe('deleting from a game', () => {
+  const rows = [
+    { _id: 's1', appId: 'a1', ownerId: 'u-play', body: { name: 'Roach-Boy' } },
+    { _id: 's2', appId: null, ownerId: null, body: { name: 'Pre-gen' } },
+    { _id: 's3', appId: 'a3', ownerId: 'u-med', body: { name: "Someone else's" } },
+  ]
+
+  const built = (viewerId: string | null) =>
+    ownableRows({ kind: 'pilot', rows, viewerId, members: ALL, localIds: new Set() })
+
+  test('the owner may delete their own', () => {
+    // A Game had no delete at all before this — only "Offer to the crew", which
+    // hands a character over rather than ending it. The reported version was
+    // blunter: "u can't delete pilots or mechs".
+    const [mine] = built('u-play')
+    expect(mine?.can.delete).toBe(true)
+  })
+
+  test("nobody may delete a crewmate's, or an unclaimed pre-gen", () => {
+    const [, pregen, theirs] = built('u-play')
+    // Mirrors `assertMayWrite`: an unclaimed row has no owner to be, and
+    // somebody else's is theirs. Both refuse on the server, so neither offers.
+    expect(pregen?.can.delete).toBe(false)
+    expect(theirs?.can.delete).toBe(false)
+  })
+
+  test('delete is not release — a row that can do one can do both', () => {
+    // They are separate verbs on purpose: releasing is generous and reversible,
+    // deleting is neither. A surface that collapsed them would guess wrong in
+    // the one direction that cannot be undone.
+    const [mine] = built('u-play')
+    expect(mine?.can.release).toBe(true)
+    expect(mine?.can.delete).toBe(true)
+  })
+})
+
 describe('crawler rows are communal', () => {
   const rows = [{ _id: 'c1', appId: 'ca1', body: { name: '#430 Tenacity' } }]
 
@@ -156,5 +192,14 @@ describe('crawler rows are communal', () => {
   test('only the table runner may scrap one', () => {
     expect(crawlerRows({ rows, tableRunner: false, localIds: new Set() })[0]?.can.scrap).toBe(false)
     expect(crawlerRows({ rows, tableRunner: true, localIds: new Set() })[0]?.can.scrap).toBe(true)
+  })
+
+  test('and scrapping is the only way to destroy one', () => {
+    // No second delete verb beside Scrap: it would be the same destruction
+    // under a name the rules do not use, and for the table runner alone either
+    // way.
+    for (const tableRunner of [false, true]) {
+      expect(crawlerRows({ rows, tableRunner, localIds: new Set() })[0]?.can.delete).toBe(false)
+    }
   })
 })

--- a/apps/itun/src/lib/games/gameRoster.ts
+++ b/apps/itun/src/lib/games/gameRoster.ts
@@ -53,6 +53,22 @@ export type RowCapabilities = {
   release: boolean
   /** Crawler only: the table runner may scrap it. */
   scrap: boolean
+  /**
+   * The viewer may destroy this row outright. Mirrors `removeByAppId`, so:
+   * the owner, and nobody else.
+   *
+   * A Game had no delete at all until now — only "Offer to the crew", which
+   * hands a character over rather than ending it. That left the ordinary case
+   * of a mistaken build with no way out except leaving it on the roster
+   * forever, and the feedback was the blunt version: "u can't delete pilots or
+   * mechs". The server has always allowed it; only the surface was missing.
+   *
+   * Deliberately distinct from `release`. Releasing is generous and reversible
+   * — somebody else picks the character up. Deleting is neither, which is why
+   * the two are separate verbs with separate confirms rather than one control
+   * that guesses.
+   */
+  delete: boolean
 }
 
 export type RosterRow = {
@@ -191,6 +207,7 @@ export function ownableRows(args: {
         claim: memberOfGame && owner.unclaimed,
         release: mine,
         scrap: false,
+        delete: mine,
       },
     }
   })
@@ -222,6 +239,10 @@ export function crawlerRows(args: {
       claim: false,
       release: false,
       scrap: args.tableRunner,
+      // A crawler is destroyed by scrapping it, which is the table runner's act
+      // and already has its own control. A second delete verb beside it would
+      // be the same destruction under a name the rules do not use.
+      delete: false,
     },
   }))
 }

--- a/apps/itun/src/stores/entityBackend.ts
+++ b/apps/itun/src/stores/entityBackend.ts
@@ -1,3 +1,4 @@
+import { toast } from 'component-lib'
 import { api } from '../../convex/_generated/api'
 import type { Id } from '../../convex/_generated/dataModel'
 import type { ConnectionMode } from '../lib/connection/connectionMode'
@@ -9,6 +10,8 @@ import {
 import { convexClient } from '../lib/connection/convexClient'
 import { serverMessage } from '../lib/connection/serverError'
 import { captureException } from '../lib/observability'
+import type { EntityRef } from '../lib/schemas/entity'
+import type { SoftLink } from '../lib/schemas/softLink'
 
 /**
  * Where entity writes actually go (ADR-030 §1).
@@ -127,6 +130,75 @@ export class WritesBlockedOffline extends Error {
 }
 
 /**
+ * How long one mirror failure speaks for. A burst is one condition, not N
+ * problems, and a per-write toast during a Downtime scramble would bury the
+ * sheet under duplicates of the same sentence.
+ */
+const MIRROR_TOAST_WINDOW_MS = 30_000
+
+/** When the last mirror-failure toast was shown; `0` means "not yet". */
+let lastMirrorToastAt = 0
+
+/**
+ * What to do when a mirror fails.
+ *
+ * ## Why this is louder than a console warning
+ *
+ * A failed mirror means IndexedDB has diverged from Convex, the declared server
+ * of record (ADR-030) — and the local write already succeeded, so **every
+ * surface keeps rendering the change as saved**. That is the most dangerous
+ * state this app has: the player is told, by the entire UI, that their work is
+ * safe, while the table sees none of it.
+ *
+ * It stayed invisible for a real session. `byAppId` threw on a duplicate row,
+ * this path swallowed it into `console.warn`, and a player edited two pilots
+ * for the better part of an hour with nothing reaching the game. The only trace
+ * was twelve Sentry events nobody was watching, and the feedback that came back
+ * was "the game mechs didn't save" — which is exactly what happened, with no
+ * way for them to have known it at the time.
+ *
+ * So the local write still stands (rolling it back would lose work that is
+ * genuinely on disk), but the player is told. Being told a change did not sync
+ * is recoverable; not being told is not.
+ *
+ * ## Refusal and defect are reported the same and *said* differently
+ *
+ * `serverMessage` (`lib/connection/serverError.ts`) answers which side of
+ * Convex's one line this was: a `ConvexError` arrives with its message intact
+ * because the backend declared it fit to show, and everything else arrives
+ * redacted as `"[CONVEX M(fn)] […] Server Error"`.
+ *
+ * Both are reported to Sentry, tagged, because both mean the same thing about
+ * the data — the mirror did not land. But they are not the same thing to *say*:
+ *
+ *   - a **refusal** carries the rule that stopped it, in words the backend
+ *     wrote for a player ("Only the Mediator can do that"). Showing it is
+ *     strictly more useful than any generic sentence, and it reads as the
+ *     system working rather than breaking.
+ *   - a **defect** has no usable message by construction, so the generic copy
+ *     is the honest one. Never render `String(err)` here: that is where the
+ *     opaque `Server Error` string comes from.
+ *
+ * Throttled either way: a burst is one condition, and the useful signal is
+ * "syncing is broken right now" rather than a taxonomy the player cannot act on.
+ */
+function reportMirrorFailure(err: unknown, context: Record<string, string>): void {
+  const refusal = serverMessage(err)
+  console.warn('[itun] failed to mirror write to the server of record', refusal ?? err)
+  captureException(err, { ...context, refusal: refusal ?? 'none' })
+
+  const now = Date.now()
+  if (now - lastMirrorToastAt < MIRROR_TOAST_WINDOW_MS) return
+  lastMirrorToastAt = now
+
+  toast.error(refusal ?? 'That change was saved on this device, but the game did not accept it.', {
+    description:
+      'Your work is safe here and nothing was lost. Reload to see what the game has — and if this keeps happening, the build may need re-syncing.',
+    duration: 10_000,
+  })
+}
+
+/**
  * Mirror a local write to the server of record, addressed by **app id**.
  *
  * An earlier attempt at this could not work: Convex mints its own `_id`, so a
@@ -168,30 +240,9 @@ export async function mirrorWrite(
       await convexClient.mutation(api.entities.removeByAppId, { table, appId: op.appId })
     }
   } catch (err) {
-    // Never surfaced as a failed user action: the local write stands. But
-    // "don't interrupt the user" is not a reason to hide it from operators —
-    // a mirror failure means IndexedDB has diverged from Convex, the declared
-    // server of record (ADR-030), and a console line in one player's browser
-    // is not a signal anyone will ever see.
-    //
-    // `refusal` is what the server was willing to say (see
-    // `lib/connection/serverError.ts`). Both kinds are still reported, because
-    // both mean the same thing about the data — the mirror did not land — but
-    // they are not the same thing to whoever reads the report, so the tag makes
-    // them separable:
-    //
-    //   - a **refusal** carries the rule that stopped it, in words. It is the
-    //     backend working as designed, and the fix (if any) is a product one.
-    //   - a **defect** arrives redacted as "Server Error" no matter what went
-    //     wrong, so the message is worthless and the Convex logs are the only
-    //     place the cause exists.
-    //
-    // That distinction is exactly what was missing when a duplicate-appId
-    // `unique()` violation spent an evening looking indistinguishable from a
-    // permission denial.
-    const refusal = serverMessage(err)
-    console.warn('[itun] failed to mirror write to the server of record', refusal ?? err)
-    captureException(err, { source: 'mirrorWrite', type, op: op.kind, refusal })
+    // Never a failed user action — the local write stands — but never silent
+    // either, in EITHER direction. See `reportMirrorFailure`.
+    reportMirrorFailure(err, { source: 'mirrorWrite', type, op: op.kind })
   }
 }
 
@@ -240,14 +291,44 @@ export async function mirrorCrawlerWrite(
       await convexClient.mutation(api.entities.removeCrawlerByAppId, { appId: op.appId })
     }
   } catch (err) {
-    // See mirrorWrite: swallowed for the user, reported to operators, and
-    // tagged with whatever the server was willing to say. This path is the one
-    // that most needs it — "Only the Mediator can do that" is a routine answer
-    // here (a player editing a communal crawler), and it should never read like
-    // a crash.
-    const refusal = serverMessage(err)
-    console.warn('[itun] failed to mirror crawler write to the server of record', refusal ?? err)
-    captureException(err, { source: 'mirrorCrawlerWrite', op: op.kind, refusal })
+    reportMirrorFailure(err, { source: 'mirrorCrawlerWrite', op: op.kind })
+  }
+}
+
+/**
+ * Mirror a **soft link** to the server of record.
+ *
+ * Links used to be excluded from mirroring entirely, on the grounds that they
+ * are "derived". On a shelf that is nearly true. In a Game it is not true at
+ * all: `entities.listForGame` reads links back, so the crew saw whatever wiring
+ * existed at claim time and never saw a single change after it. Assigning a
+ * pilot to the crawler updated your sheet and nobody else's — the assignment
+ * simply never left the browser.
+ *
+ * Addressed by endpoints rather than by id: the server has no `appId` column
+ * for links and needs none, because `from.id`/`to.id` already are app ids. That
+ * also makes the mirror naturally idempotent, so a replayed write is a no-op
+ * rather than a duplicate wire.
+ *
+ * Fire-and-forget with the same contract as the other two mirrors — the local
+ * write already landed and is what the UI reads.
+ */
+export async function mirrorSoftLinkWrite(
+  op:
+    | { kind: 'upsert'; from: EntityRef; to: EntityRef; type: SoftLink['type'] }
+    | { kind: 'delete'; from: EntityRef; to: EntityRef; type: SoftLink['type'] }
+): Promise<void> {
+  if (selectBackend() !== 'remote' || convexClient === null) return
+
+  const args = { from: op.from, to: op.to, type: op.type }
+  try {
+    if (op.kind === 'upsert') {
+      await convexClient.mutation(api.entities.upsertSoftLink, args)
+    } else {
+      await convexClient.mutation(api.entities.removeSoftLink, args)
+    }
+  } catch (err) {
+    reportMirrorFailure(err, { source: 'mirrorSoftLinkWrite', op: op.kind })
   }
 }
 

--- a/apps/itun/src/stores/entityStore.ts
+++ b/apps/itun/src/stores/entityStore.ts
@@ -38,7 +38,12 @@ import type { Mech } from '../lib/schemas/mech'
 import type { Pilot } from '../lib/schemas/pilot'
 import type { SoftLink } from '../lib/schemas/softLink'
 import { getActiveContainer } from './activeContainerStore'
-import { mirrorCrawlerWrite, mirrorWrite, requireWritableBackend } from './entityBackend'
+import {
+  mirrorCrawlerWrite,
+  mirrorSoftLinkWrite,
+  mirrorWrite,
+  requireWritableBackend,
+} from './entityBackend'
 import type { CreateInput, EntityForType, EntityType } from './types'
 
 // Re-exported so consumers can import the type alongside the store itself.
@@ -284,21 +289,30 @@ const DB_STORES: { [K in EntityType]: DbStoreApi<K> } = {
 /**
  * Mirror a just-persisted record to the server of record.
  *
- * SoftLinks are derived and never mirrored. Pilots and mechs upsert their whole
- * body; the crawler takes the other path (`mirrorCrawlerWrite`) because it is
- * communal — its edits merge per field and only its table runner may raise or
- * scrap one. Fire-and-forget by design: the local write is what the UI reads,
- * so a mirror failure must not undo it.
+ * Pilots and mechs upsert their whole body; the crawler takes the other path
+ * (`mirrorCrawlerWrite`) because it is communal — its edits merge per field and
+ * only its table runner may raise or scrap one; a SoftLink takes a third
+ * (`mirrorSoftLinkWrite`) because it is addressed by its endpoints rather than
+ * by an id. Fire-and-forget by design: the local write is what the UI reads, so
+ * a mirror failure must not undo it.
  *
  * `patch` is passed on an update so a crawler mirrors the *changed fields*
  * rather than its whole body; sending everything would turn a merge back into
  * last-write-wins and lose whatever a crewmate changed in the same minute.
+ *
+ * SoftLinks used to be excluded here as "derived". They are not, once a Game is
+ * involved — `listForGame` reads them back, so an unmirrored link meant the
+ * crew's view of who crews what froze at claim time. See `mirrorSoftLinkWrite`.
  */
 function mirrorEntityWrite(
   type: EntityType,
   record: { id: string; gameId?: string | null },
   patch?: object
 ): void {
+  if (type === 'softLink') {
+    mirrorSoftLink('upsert', record as unknown as SoftLink)
+    return
+  }
   if (type === 'crawler') {
     const gameId = record.gameId ?? null
     // Shelf and Solo crawlers have no server row to merge into.
@@ -317,6 +331,24 @@ function mirrorEntityWrite(
     gameId: record.gameId ?? null,
     body: record,
   })
+}
+
+/**
+ * Send one link's endpoints up, in whichever direction.
+ *
+ * Split out because a link is mirrored from two places that hold it in
+ * different shapes — `mirrorEntityWrite` gets the freshly persisted record,
+ * while `delete` has to read the record back *before* removing it, since the
+ * endpoints are the only address the server has for it.
+ *
+ * Guarded rather than assumed: a link whose endpoints did not survive a
+ * salvage-tolerant read has nothing to address, and sending a half link would
+ * fail validation server-side for no benefit.
+ */
+function mirrorSoftLink(kind: 'upsert' | 'delete', link: SoftLink | null): void {
+  if (link === null) return
+  if (link.from?.id === undefined || link.to?.id === undefined) return
+  void mirrorSoftLinkWrite({ kind, from: link.from, to: link.to, type: link.type })
 }
 
 function dbStoreFor<T extends EntityType>(type: T): DbStoreApi<T> {
@@ -623,6 +655,9 @@ export const useEntityStore = create<EntityState>((set, get) => ({
   async delete(type, id) {
     const key = storeKeyFor(type)
     requireWritableBackend()
+    // Read BEFORE the delete: a link is addressed on the server by its
+    // endpoints, and after the row is gone there is nothing left to name it by.
+    if (type === 'softLink') mirrorSoftLink('delete', get().get('softLink', id))
     if (type === 'pilot' || type === 'mech') void mirrorWrite(type, { kind: 'delete', appId: id })
     // Scrapping a crawler is the table runner's act; the server refuses anyone
     // else, which is why this mirrors rather than deleting only locally.

--- a/apps/itun/test/convex/duplicateAppId.test.ts
+++ b/apps/itun/test/convex/duplicateAppId.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from 'bun:test'
+import { api } from '../../convex/_generated/api'
+import { testConvex } from './harness'
+
+/**
+ * Surviving duplicate `appId` rows that already exist.
+ *
+ * This is the **second** half of the duplicate-appId story, and deliberately
+ * not the first. Preventing new duplicates (`claimLocal` + `appIdTaken`) and
+ * repairing old ones (`maintenance.dedupeAppIds`) are covered by
+ * `entities.test.ts` and `maintenance.test.ts`. What is pinned here is what
+ * happens to a player whose roster is duplicated *right now*, before anyone has
+ * run the repair.
+ *
+ * That case mattered enough to earn its own answer. `byAppId` asked for
+ * `.unique()` on `by_app_id` — an ordinary Convex index, not a uniqueness
+ * constraint — so it threw; and because mirrored writes are fire-and-forget,
+ * `mirrorWrite` swallowed the throw. The local copy went on accepting edits,
+ * every surface went on rendering them as saved, and nothing reached the game
+ * for the better part of an hour. Production held four `Babe`s and four
+ * `Reaper`s, and the feedback was "the game mechs didn't save".
+ *
+ * So a duplicate is treated as a repair job rather than a reason to refuse the
+ * write that would have kept client and server in step: the lookup resolves to
+ * the oldest row and logs, the write lands, and `maintenance.dedupeAppIds`
+ * clears up afterwards. Prevention closes the front door; this makes the
+ * failure survivable if anything ever opens it again.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+function pilotBody(over: Record<string, unknown> = {}) {
+  return {
+    id: 'p1',
+    schemaVersion: 1,
+    name: 'Babe',
+    callsign: 'Babe',
+    classRef: 'salvager',
+    abilities: [],
+    equipment: [],
+    motto: '',
+    keepsake: '',
+    appearance: '',
+    conditions: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...over,
+  }
+}
+
+describe('byAppId tolerates duplicate rows', () => {
+  test('an edit still lands when two rows share an appId', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    // Exactly what a second claim produced: two rows, same appId, same owner.
+    await t.run(async (ctx) => {
+      for (const _ of [0, 1]) {
+        await ctx.db.insert('pilots', {
+          gameId: null,
+          ownerId: u.userId,
+          appId: 'dupe-1',
+          body: pilotBody(),
+          updatedAt: Date.now(),
+        })
+      }
+    })
+
+    // Before this, `unique() query returned more than one result` — swallowed.
+    await u.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'dupe-1',
+      gameId: null,
+      body: pilotBody({ name: 'Babe Renamed' }),
+    })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    const names = rows.map((r) => (r.body as { name: string }).name)
+
+    // The write landed on exactly one row and did not fan out across the
+    // duplicates or create a third.
+    expect(rows).toHaveLength(2)
+    expect(names).toContain('Babe Renamed')
+    expect(names.filter((n) => n === 'Babe Renamed')).toHaveLength(1)
+  })
+
+  test('the oldest row wins, so the winner does not move between calls', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    const [first] = await t.run(async (ctx) => {
+      const a = await ctx.db.insert('pilots', {
+        gameId: null,
+        ownerId: u.userId,
+        appId: 'dupe-2',
+        body: pilotBody({ name: 'Oldest' }),
+        updatedAt: Date.now(),
+      })
+      const b = await ctx.db.insert('pilots', {
+        gameId: null,
+        ownerId: u.userId,
+        appId: 'dupe-2',
+        body: pilotBody({ name: 'Newer' }),
+        updatedAt: Date.now(),
+      })
+      return [a, b]
+    })
+
+    await u.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'dupe-2',
+      gameId: null,
+      body: pilotBody({ name: 'Written' }),
+    })
+
+    // Deterministic, and the SAME row `maintenance.dedupeAppIds` keeps — so a
+    // write that lands before the repair runs is not thrown away by it.
+    const oldest = await t.run(async (ctx) => await ctx.db.get(first))
+    expect(oldest).not.toBeNull()
+    expect((oldest?.body as { name: string } | undefined)?.name).toBe('Written')
+  })
+
+  test('a delete addressed by appId still finds its row', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    await t.run(async (ctx) => {
+      for (const _ of [0, 1]) {
+        await ctx.db.insert('pilots', {
+          gameId: null,
+          ownerId: u.userId,
+          appId: 'dupe-3',
+          body: pilotBody(),
+          updatedAt: Date.now(),
+        })
+      }
+    })
+
+    await u.as.mutation(api.entities.removeByAppId, { table: 'pilots', appId: 'dupe-3' })
+
+    // One removed — not zero, which is what a throw produced.
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(1)
+  })
+})

--- a/apps/itun/test/convex/maintenance.test.ts
+++ b/apps/itun/test/convex/maintenance.test.ts
@@ -67,22 +67,61 @@ async function duplicatePilot(t: Ctx, ownerId: Id<'users'>, appId: string, count
   })
 }
 
-describe('duplicate app ids break the mirror', () => {
-  test('a second row with the same app id makes every upsert throw', async () => {
+describe('duplicate app ids no longer break the mirror', () => {
+  /*
+   * This block used to assert the opposite — that a second row made every
+   * upsert throw `unique()` — as a reproduction of the production failure and
+   * the justification for `dedupeAppIds`.
+   *
+   * The reproduction was accurate and the conclusion was half of one. A throw
+   * here is INVISIBLE: mirrored writes are fire-and-forget, so it never failed
+   * an edit the player could see, it just stopped their edits ever reaching the
+   * server while every surface went on rendering them as saved. An evening of
+   * play went missing that way. Refusing to sync is a strictly worse answer to
+   * "there are two rows" than syncing to one of them and logging it.
+   *
+   * So `byAppId` now resolves to the oldest match instead of throwing, and this
+   * block pins that. `dedupeAppIds` is still needed and still the fix — a
+   * duplicate double-renders on a roster and leaves one copy going stale — but
+   * a roster waiting on it keeps saving in the meantime.
+   */
+  test('a second row with the same app id no longer stops the write', async () => {
     const t = testConvex()
     const u = await makeUser(t, 'A')
     await duplicatePilot(t, u.userId, 'p1', 2)
 
-    // This is the production failure, reproduced: an opaque server error on
-    // every edit, from a mutation that swallows it.
-    await expect(
-      u.as.mutation(api.entities.upsertByAppId, {
-        table: 'pilots',
-        appId: 'p1',
-        gameId: null,
-        body: pilotBody(),
-      })
-    ).rejects.toThrow(/unique/i)
+    await u.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'p1',
+      gameId: null,
+      body: pilotBody({ name: 'still saving' }),
+    })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    const names = rows.map((r) => (r.body as { name: string }).name)
+    // Landed on exactly one row — not fanned out, and not a third row.
+    expect(rows).toHaveLength(2)
+    expect(names.filter((n) => n === 'still saving')).toHaveLength(1)
+  })
+
+  test('and the write lands on the row dedupeAppIds will keep', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    await duplicatePilot(t, u.userId, 'p1', 3)
+
+    await u.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'p1',
+      gameId: null,
+      body: pilotBody({ name: 'written before the repair' }),
+    })
+    await t.mutation(internal.maintenance.dedupeAppIds, { apply: true })
+
+    // The two rules have to agree, or the repair would silently discard work
+    // that landed while the roster was waiting for it.
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(1)
+    expect((rows[0]?.body as { name: string } | undefined)?.name).toBe('written before the repair')
   })
 })
 

--- a/apps/itun/test/convex/softLinkMirror.test.ts
+++ b/apps/itun/test/convex/softLinkMirror.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from 'bun:test'
+import { api } from '../../convex/_generated/api'
+import type { Id } from '../../convex/_generated/dataModel'
+import { testConvex } from './harness'
+
+/**
+ * Soft links against the server of record.
+ *
+ * Links were the one part of a roster that never left the browser.
+ * `mirrorEntityWrite` returned early for them as "derived" — which is nearly
+ * true of a shelf and not true at all of a Game, because `listForGame` reads
+ * them back. So the crew saw whatever wiring existed when the account was
+ * claimed and never saw a single change afterwards: you assigned a pilot to the
+ * crawler, your own sheet updated, and nobody else's did.
+ *
+ * That is the second half of "you couldn't assign them to a crawler" — the
+ * first being that the crawler had no control to assign *with*.
+ *
+ * The properties pinned here are the ones that make a link safe to mirror:
+ * it is identified by its endpoints (so replaying a write is a no-op rather
+ * than a duplicate wire), it belongs to the container its `from` end belongs
+ * to, and only somebody who may write that end may draw or cut it.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+function pilotBody(over: Record<string, unknown> = {}) {
+  return {
+    id: 'p1',
+    schemaVersion: 1,
+    name: 'Babe',
+    callsign: 'Babe',
+    classRef: 'salvager',
+    abilities: [],
+    equipment: [],
+    motto: '',
+    keepsake: '',
+    appearance: '',
+    conditions: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...over,
+  }
+}
+
+/** A pilot row owned by `userId`, addressable by `appId`. */
+async function seedPilot(t: Ctx, userId: Id<'users'>, appId: string, gameId: Id<'games'> | null) {
+  return await t.run(
+    async (ctx) =>
+      await ctx.db.insert('pilots', {
+        gameId,
+        ownerId: userId,
+        appId,
+        body: pilotBody({ id: appId }),
+        updatedAt: Date.now(),
+      })
+  )
+}
+
+const LINK = {
+  from: { type: 'pilot' as const, id: 'pilot-app-1' },
+  to: { type: 'crawler' as const, id: 'crawler-app-1' },
+  type: 'pilot-to-crawler' as const,
+}
+
+describe('upsertSoftLink', () => {
+  test('writes the link and inherits the container of its from end', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    const gameId = await t.run(async (ctx) => await ctx.db.insert('games', { name: 'Table' }))
+    await seedPilot(t, u.userId, 'pilot-app-1', gameId)
+
+    await u.as.mutation(api.entities.upsertSoftLink, LINK)
+
+    const links = await t.run(async (ctx) => await ctx.db.query('softLinks').collect())
+    expect(links).toHaveLength(1)
+    expect(links[0]?.gameId).toBe(gameId)
+    expect(links[0]?.type).toBe('pilot-to-crawler')
+  })
+
+  test('is idempotent — the same wire drawn twice is one wire', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    await seedPilot(t, u.userId, 'pilot-app-1', null)
+
+    await u.as.mutation(api.entities.upsertSoftLink, LINK)
+    await u.as.mutation(api.entities.upsertSoftLink, LINK)
+
+    const links = await t.run(async (ctx) => await ctx.db.query('softLinks').collect())
+    expect(links).toHaveLength(1)
+  })
+
+  test('re-homes an existing link when its from end moves into a game', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    const pilotId = await seedPilot(t, u.userId, 'pilot-app-1', null)
+
+    await u.as.mutation(api.entities.upsertSoftLink, LINK)
+
+    const gameId = await t.run(async (ctx) => await ctx.db.insert('games', { name: 'Table' }))
+    await t.run(async (ctx) => await ctx.db.patch(pilotId, { gameId }))
+    await u.as.mutation(api.entities.upsertSoftLink, LINK)
+
+    const links = await t.run(async (ctx) => await ctx.db.query('softLinks').collect())
+    // Moved, not duplicated: a link that stayed behind on the shelf would be
+    // invisible to the crew the pilot just joined.
+    expect(links).toHaveLength(1)
+    expect(links[0]?.gameId).toBe(gameId)
+  })
+
+  test('no-ops when the from end has no server row', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    // A purely local build: Solo, or shelved and never claimed. There is
+    // nothing to anchor a link to, and inventing one would be worse.
+    await u.as.mutation(api.entities.upsertSoftLink, LINK)
+
+    const links = await t.run(async (ctx) => await ctx.db.query('softLinks').collect())
+    expect(links).toHaveLength(0)
+  })
+
+  test("refuses to wire another player's pilot", async () => {
+    const t = testConvex()
+    const owner = await makeUser(t, 'A')
+    const other = await makeUser(t, 'B')
+    await seedPilot(t, owner.userId, 'pilot-app-1', null)
+
+    await expect(other.as.mutation(api.entities.upsertSoftLink, LINK)).rejects.toThrow()
+  })
+})
+
+describe('removeSoftLink', () => {
+  test('cuts the wire', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    await seedPilot(t, u.userId, 'pilot-app-1', null)
+
+    await u.as.mutation(api.entities.upsertSoftLink, LINK)
+    await u.as.mutation(api.entities.removeSoftLink, LINK)
+
+    const links = await t.run(async (ctx) => await ctx.db.query('softLinks').collect())
+    expect(links).toHaveLength(0)
+  })
+
+  test('a wire that is already gone is not an error', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    await seedPilot(t, u.userId, 'pilot-app-1', null)
+
+    await u.as.mutation(api.entities.removeSoftLink, LINK)
+
+    const links = await t.run(async (ctx) => await ctx.db.query('softLinks').collect())
+    expect(links).toHaveLength(0)
+  })
+})
+
+describe('entities.remove', () => {
+  test('the owner may delete their own entity from a game', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    const gameId = await t.run(async (ctx) => await ctx.db.insert('games', { name: 'Table' }))
+    const pilotId = await seedPilot(t, u.userId, 'pilot-app-1', gameId)
+
+    await u.as.mutation(api.entities.remove, { table: 'pilots', entityId: pilotId })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(0)
+  })
+
+  test("nobody may delete a crewmate's entity", async () => {
+    const t = testConvex()
+    const owner = await makeUser(t, 'A')
+    const other = await makeUser(t, 'B')
+    const pilotId = await seedPilot(t, owner.userId, 'pilot-app-1', null)
+
+    await expect(
+      other.as.mutation(api.entities.remove, { table: 'pilots', entityId: pilotId })
+    ).rejects.toThrow()
+  })
+
+  test('deleting an entity takes its wires with it', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    const pilotId = await seedPilot(t, u.userId, 'pilot-app-1', null)
+    await u.as.mutation(api.entities.upsertSoftLink, LINK)
+
+    await u.as.mutation(api.entities.remove, { table: 'pilots', entityId: pilotId })
+
+    // The client has cascaded this for as long as soft links have existed; a
+    // server that did not would leave the Game rendering "Unknown pilot (id)".
+    const links = await t.run(async (ctx) => await ctx.db.query('softLinks').collect())
+    expect(links).toHaveLength(0)
+  })
+})

--- a/docs/architecture/accounts-and-games.md
+++ b/docs/architecture/accounts-and-games.md
@@ -179,13 +179,45 @@ The design pass Phase 3 deferred, plus the ownership rules it exposed as missing
   reads and moved no number. Both fixed, both pinned by tests that build their
   fixtures by parsing the real schema rather than hand-writing field names.
 
-**Known gaps, deliberately left:**
+**Closed since, and worth knowing why:**
 
-- **A refused mirror is only a console warning.** If the server rejects a
-  mirrored write (a player creating into a Game with no crawler, an edit to
-  something they no longer own), the local copy stands and nothing tells them.
-  The surfaces avoid offering those actions, so this is reachable mainly by
-  going around them; surfacing it as a toast is the next step.
+- **A refused mirror used to be only a console warning** — listed here as a
+  known gap on the reasoning that the surfaces avoid offering the actions that
+  would be refused, so it was reachable mainly by going around them. That
+  reasoning was wrong, and a play session proved it: the refusal did not come
+  from a player doing something the UI discouraged, it came from **the data**.
+  Duplicate `appId` rows (see below) made `byAppId` throw on every mirrored
+  write, and because the local write had already succeeded, every surface went
+  on rendering the work as saved while nothing reached the game for the better
+  part of an hour. The feedback was "the game mechs didn't save".
+
+  The lesson is that "only reachable by misuse" is not a safety property when
+  the trigger can be a row rather than a click. `reportMirrorFailure`
+  (`entityBackend.ts`) now warns, reports to Sentry **and** toasts, throttled to
+  one message per 30s so a burst reads as one condition.
+
+- **Duplicate `appId` rows are survivable.** Prevention (`appIdTaken` before any
+  insert) and repair (`maintenance.dedupeAppIds`) close the front door and clean
+  up behind it. This is the third leg: `byAppId` / `crawlerByAppId` no longer
+  ask for `.unique()` on an index that was never a uniqueness constraint, so a
+  duplicate that reaches them resolves to the **oldest** match and logs rather
+  than throwing.
+
+  Worth stating why all three exist. A throw here is invisible — mirrored writes
+  are fire-and-forget — so it does not fail the write, it stops the write ever
+  reaching the server while every surface keeps rendering it as saved. Refusing
+  to sync is a strictly worse answer to "there are two rows" than syncing to one
+  of them and saying so. Oldest is chosen to match what `dedupeAppIds` keeps, so
+  a write landing before the repair runs is not discarded by it.
+
+- **Soft links mirror.** They were excluded as "derived", which is nearly true
+  of a shelf and not true at all of a Game — `listForGame` reads them back, so
+  the crew saw the wiring as it stood at claim time and no change after it.
+  `entities.upsertSoftLink` / `removeSoftLink` address a link by its endpoints
+  (no `appId` needed, and idempotent as a result), and `removeByAppId` /
+  `remove` now cascade link pruning the way the client always has.
+
+**Known gaps, deliberately left:**
 - **No read-only drill-in.** ADR-030 §5 permits reading a crewmate's sheet;
   `crew.readEntity` exists on the server with no consumer, because ITUN's sheet
   is an editing surface. Rows for entities you do not own therefore offer


### PR DESCRIPTION
Play-session feedback:

> The game mechs didn't save / You couldn't assign them to a crawler / U can't delete pilots or mechs / I think the shelf ones were fine / But the game specific ones desynced from the main page

**Rebased onto #704**, which has since merged into `main`. Redundancies resolved — see the reconciliation section.

## Root cause, confirmed in production

`claimLocal` inserted blindly, guarded only by a **per-device localStorage marker**, so claiming the same shelf from a second browser duplicated the roster. `byAppId` then asked for `.unique()` on `by_app_id`, an ordinary Convex index and **not** a uniqueness constraint, so it threw. `mirrorWrite` swallowed the throw, because a mirror failure must not undo a local write.

Net effect: the local copy kept accepting edits, **every surface kept rendering them as saved**, and nothing reached the game.

Measured, not inferred:

| Evidence | Finding |
|---|---|
| Prod snapshot (read-only) | 31 pilots under **13** appIds (`Babe` ×4, `Stucky Bolter` ×4); 31 mechs under **14** (`Reaper` ×4, `Harlequin` ×3) |
| Convex prod logs | 12× `unique() query returned more than one result from table pilots at byAppId` |
| Sentry ITUN-2 / ITUN-3 | 12 events, `source: mirrorWrite`, `handled: yes` — the two event URLs are **exactly** the two duplicated pilot appIds |

## What this adds on top of #704

#704 closed the front door (prevention) and cleans up behind it (`maintenance.dedupeAppIds`). This adds the parts it did not cover:

1. **`byAppId` / `crawlerByAppId` survive a duplicate** — resolve to the oldest match and log, instead of throwing. ⚠️ *See the note below; this reverses a deliberate choice in #704.*
2. **Mirror failures reach the player.** #704 made the Sentry report better (refusal vs defect); the player was still told nothing. `reportMirrorFailure` now warns, reports **and** toasts — showing #704's `serverMessage(err)` when the server said why, generic copy when it did not, throttled to one per 30s.
3. **Soft links mirror.** They were excluded as "derived" while `listForGame` read them back, so a Game froze its wiring at claim time. `upsertSoftLink`/`removeSoftLink` address a link by endpoints (idempotent for free); `remove`/`removeByAppId` cascade link pruning as the client always has.
4. **Game roster gains Delete** — owner only, own danger confirm, kept distinct from "Offer to the crew" (releasing is reversible, deleting is not). `entities.remove` addresses by **server id**, because the roster sees rows this browser never held and template pre-gens with no `appId` at all (a dozen in prod).
5. **The crawler sheet gains "+ Add Crew."** A mech reaches a bay only through its pilot (`resolveLinkType` throws for mech→crawler), and the crawler had no way to add an *existing* pilot — beside an empty rail that said "dock one".

## ⚠️ One deliberate override of #704 — worth a look

#704 keeps `.unique()` on the `appId` lookups as an intentional tripwire, and documents that in `apps/itun/CLAUDE.md`. **This PR softens it**, and rewrites #704's characterization test (`maintenance.test.ts` → "duplicate app ids no longer break the mirror").

Reasoning: a throw there is *invisible* — mirrored writes are fire-and-forget, so it never fails an edit the player can see; it just stops their edits reaching the server while the UI reports success. That is the exact failure that lost an evening of play. Refusing to sync is a worse answer to "there are two rows" than syncing to one and logging it loudly. Prevention and repair still do the real work; this only makes the window survivable.

The two rules are pinned as agreeing: `byAppId` keeps the **oldest**, which is the row `dedupeAppIds` keeps, so a write landing before the repair is not discarded by it. There is a new test for exactly that.

Happy to drop this piece if you'd rather keep the tripwire hard.

## Reconciliation with #704

- **Dropped my `convex/repair.ts`** in favour of #704's `maintenance.ts`.
- **Dropped my `claimLocal` idempotency** in favour of #704's `appIdTaken` + `alreadyPresent` counter (better — it separates "already there" from "malformed").
- **Kept #704's `serverError.ts`** and fed it into the toast, so a refusal shows the backend's own words.
- Claim-time soft-link dedupe now shares my `findSoftLink` helper instead of an inline copy.
- One note, **not** actioned: `dedupeAppIds` keeps the oldest row, so for `Babe` (3 shelf copies + 1 in a game) it keeps a *shelf* row and the character leaves the crew roster until the client re-mirrors. Self-heals via `upsertByAppId`'s re-homing, but you may want to prefer the in-game copy.

## Testing

- `check:all` green (exit 0), 1734 itun tests pass.
- New tests verified to **bite**: reverting `byAppId` fails them.

## Not done

**The production data repair was NOT run** — only a read-only snapshot export. `maintenance:dedupeAppIds` is ready behind an explicit `apply: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zyFsCRwKhBrZNGdh9BHkM