### PR TITLE
fix(itun): give every seeded Starter Set row its own UUID

### DIFF
--- a/apps/itun/CLAUDE.md
+++ b/apps/itun/CLAUDE.md
@@ -141,6 +141,20 @@ and remains the account-free way to share a build.
   warning is the tripwire, and it fires without taking the player's data with
   it. Resolving to the *oldest* is deliberate: it is the row `dedupeAppIds`
   keeps, so a write that lands before the repair runs is not discarded by it.
+- **A copy gets a new UUID; a move keeps its own.** These pull in opposite
+  directions, so both matter:
+  - **Copy → new id.** Importing a bundle (`mergeImport`) and seeding the
+    Starter Set (`seedStarterSet`) each mint a fresh UUID per row and remap the
+    soft links onto them. An entity id becomes its `appId` on the server, so a
+    copy that kept its id would put one id in two accounts — and since a
+    duplicate now resolves to the oldest row, the second account's mirrored
+    writes aim at the first account's entity and are refused by `assertMayWrite`
+    as somebody else's. Never write a fixed or template id into
+    `pilots`/`mechs`/`crawlers`; record provenance in `seedRef`, which is what
+    it is for.
+  - **Move → same id.** Shelf ↔ Game is a container change, patching `gameId`
+    and nothing else. A Game is a viewport onto the same sheet, not a duplicate
+    of it — never re-mint on a move, and never treat one as a fork.
 
 ## Commands
 

--- a/apps/itun/src/lib/db/__tests__/starter-set-seed-ref.test.ts
+++ b/apps/itun/src/lib/db/__tests__/starter-set-seed-ref.test.ts
@@ -4,7 +4,8 @@
  * Seeding now mints a fresh UUID per row and records the template slug in
  * `seedRef`, because the old fixed ids (`starter-pilot-bonesaw`, …) were
  * identical in every player's browser — and a seeded row's id becomes its
- * `appId` on the server of record, where rows are looked up with `.unique()`.
+ * `appId` on the server of record, where two accounts sharing one resolve to a
+ * single row and the later player's writes are refused as somebody else's.
  *
  * This migration exists so that change does not cost anyone a duplicate
  * roster: without it, a browser that seeded the old way has no `seedRef`

--- a/apps/itun/src/lib/db/__tests__/starter-set-seed-ref.test.ts
+++ b/apps/itun/src/lib/db/__tests__/starter-set-seed-ref.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for the v14 record rewrite (Starter Set → `seedRef`).
+ *
+ * Seeding now mints a fresh UUID per row and records the template slug in
+ * `seedRef`, because the old fixed ids (`starter-pilot-bonesaw`, …) were
+ * identical in every player's browser — and a seeded row's id becomes its
+ * `appId` on the server of record, where rows are looked up with `.unique()`.
+ *
+ * This migration exists so that change does not cost anyone a duplicate
+ * roster: without it, a browser that seeded the old way has no `seedRef`
+ * anywhere, the "already seeded?" check answers no, and the next visit to the
+ * Roster lays a whole second crew down beside the first.
+ *
+ * The classifier is deliberately narrow, and both halves are pinned here: a row
+ * sitting under a known template id is stamped, and nothing else is touched.
+ */
+import { describe, expect, test } from 'bun:test'
+import { migrate } from '../migrations/14-starter-set-seed-ref'
+
+/**
+ * A stand-in for the versionchange transaction.
+ *
+ * The migration only ever opens a cursor and updates through it, so a cursor
+ * over a plain array is a faithful double — and it keeps these cases about the
+ * rewrite rule rather than about IndexedDB. The full ladder against a real
+ * database is `migration-ladder.test.ts`'s job.
+ */
+/** A raw stored row, exactly as it sits on disk — no Zod involved. */
+type Row = Record<string, unknown>
+
+/** The three stores this migration walks. Named, not indexed, so `[0]` narrows. */
+type Fixture = { pilots: Row[]; mechs: Row[]; crawlers: Row[] }
+
+function fakeTx(stores: Record<string, Row[]>) {
+  return {
+    objectStore(name: string) {
+      const rows = stores[name] ?? []
+      let i = 0
+      const cursorAt = (index: number): unknown => {
+        if (index >= rows.length) return null
+        return {
+          value: rows[index],
+          async update(next: Record<string, unknown>) {
+            rows[index] = next
+          },
+          async continue() {
+            i = index + 1
+            return cursorAt(i)
+          },
+        }
+      }
+      return {
+        async openCursor() {
+          i = 0
+          return cursorAt(0)
+        },
+      }
+    },
+  }
+}
+
+describe('v14 starter-set seedRef backfill', () => {
+  test('stamps a row still sitting under a template id', async () => {
+    const stores: Fixture = {
+      pilots: [{ id: 'starter-pilot-bonesaw', name: 'Bonesaw' }],
+      mechs: [{ id: 'starter-mech-scrapper', name: 'Scrapper' }],
+      crawlers: [{ id: 'starter-crawler-tenacity', name: '#430' }],
+    }
+
+    await migrate(fakeTx(stores) as never)
+
+    expect(stores.pilots[0]?.seedRef).toBe('starter-pilot-bonesaw')
+    expect(stores.mechs[0]?.seedRef).toBe('starter-mech-scrapper')
+    expect(stores.crawlers[0]?.seedRef).toBe('starter-crawler-tenacity')
+    // The id is deliberately left alone: re-minting it here would strand any
+    // server row already mirrored under the old appId, turning a collision that
+    // is merely declined into duplicated data.
+    expect(stores.pilots[0]?.id).toBe('starter-pilot-bonesaw')
+  })
+
+  test("leaves a player's own build untouched", async () => {
+    const stores: Fixture = {
+      pilots: [{ id: 'b1e4c0de-0000-4000-8000-000000000000', name: 'Mine' }],
+      mechs: [],
+      crawlers: [],
+    }
+
+    await migrate(fakeTx(stores) as never)
+
+    expect(stores.pilots[0]).toEqual({
+      id: 'b1e4c0de-0000-4000-8000-000000000000',
+      name: 'Mine',
+    })
+  })
+
+  test('is idempotent — an existing seedRef is never rewritten', async () => {
+    const stores: Fixture = {
+      pilots: [{ id: 'starter-pilot-pickle', seedRef: 'something-deliberate' }],
+      mechs: [],
+      crawlers: [],
+    }
+
+    await migrate(fakeTx(stores) as never)
+
+    expect(stores.pilots[0]?.seedRef).toBe('something-deliberate')
+  })
+
+  test('stamps every row of a fully seeded legacy roster', async () => {
+    const stores: Fixture = {
+      pilots: [
+        { id: 'starter-pilot-bonesaw' },
+        { id: 'starter-pilot-pickle' },
+        { id: 'starter-pilot-judge' },
+        { id: 'starter-pilot-driftwood' },
+        { id: 'starter-pilot-hotdog' },
+        { id: 'starter-pilot-razor' },
+      ],
+      mechs: [],
+      crawlers: [],
+    }
+
+    await migrate(fakeTx(stores) as never)
+
+    // One unstamped row is enough to make the roster read as absent and trigger
+    // a second seed, so "most of them" is not good enough here.
+    expect(stores.pilots.every((p) => typeof p.seedRef === 'string')).toBe(true)
+  })
+})

--- a/apps/itun/src/lib/db/index.ts
+++ b/apps/itun/src/lib/db/index.ts
@@ -51,7 +51,7 @@ import { STORE_NAMES } from './stores'
  * the Shelf. Workspaces are retired, but v10 still has to run — v13 reads what
  * it writes.)
  */
-export const DB_VERSION = 13
+export const DB_VERSION = 14
 
 const DB_NAME = 'itun-v1'
 

--- a/apps/itun/src/lib/db/migrations/14-starter-set-seed-ref.ts
+++ b/apps/itun/src/lib/db/migrations/14-starter-set-seed-ref.ts
@@ -7,9 +7,10 @@ import type { UpgradeTransaction } from './index'
  * (`starter-pilot-bonesaw`, …), because id equality doubled as the idempotence
  * guard — a `put` of a known id overwrites, so re-seeding could not duplicate.
  * That was fine while the ids stayed on one device and wrong once they did not:
- * a seeded row's `id` becomes its `appId` on the server of record (ADR-030),
- * where rows are looked up with `.unique()`, so every player who seeded this
- * roster carried the same twelve ids into a shared backend.
+ * a seeded row's `id` becomes its `appId` on the server of record (ADR-030), so
+ * every player who seeded this roster carried the same twelve ids into a shared
+ * backend — where a duplicate resolves to the oldest row, and the later
+ * player's writes are refused as somebody else's entity.
  *
  * Seeding now mints a fresh UUID per row and records the template slug in
  * `seedRef`. This backfills that field for rows seeded the old way, so the

--- a/apps/itun/src/lib/db/migrations/14-starter-set-seed-ref.ts
+++ b/apps/itun/src/lib/db/migrations/14-starter-set-seed-ref.ts
@@ -1,0 +1,69 @@
+import type { UpgradeTransaction } from './index'
+
+/**
+ * v13 → v14: record Starter Set provenance as `seedRef`.
+ *
+ * The Starter Set used to be written under the template's own fixed ids
+ * (`starter-pilot-bonesaw`, …), because id equality doubled as the idempotence
+ * guard — a `put` of a known id overwrites, so re-seeding could not duplicate.
+ * That was fine while the ids stayed on one device and wrong once they did not:
+ * a seeded row's `id` becomes its `appId` on the server of record (ADR-030),
+ * where rows are looked up with `.unique()`, so every player who seeded this
+ * roster carried the same twelve ids into a shared backend.
+ *
+ * Seeding now mints a fresh UUID per row and records the template slug in
+ * `seedRef`. This backfills that field for rows seeded the old way, so the
+ * "is the Starter Set already here?" check — which now asks about `seedRef` —
+ * still recognises an existing roster instead of laying down a second copy of
+ * it beside the first.
+ *
+ * **Ids are deliberately not re-minted.** A row that has already been claimed
+ * exists on the server under its old `appId`; changing it here would strand
+ * that row and mirror the entity again as a new one, turning a collision that
+ * is now merely declined into duplicated data. The colliding ids that already
+ * exist are handled where the collision happens — the claim declines them, and
+ * `convex/maintenance.ts` repairs any duplicate already written.
+ *
+ * Values are inlined rather than imported: migrations may only await IndexedDB
+ * operations, since a module import can let the versionchange transaction
+ * commit mid-run (see this directory's README).
+ */
+
+/** Inlined from lib/starterSet/starterSet.ts — see the note above on imports. */
+const STARTER_IDS: Record<string, readonly string[]> = {
+  pilots: [
+    'starter-pilot-bonesaw',
+    'starter-pilot-pickle',
+    'starter-pilot-judge',
+    'starter-pilot-driftwood',
+    'starter-pilot-hotdog',
+    'starter-pilot-razor',
+  ],
+  mechs: [
+    'starter-mech-scrapper',
+    'starter-mech-spectrum',
+    'starter-mech-mule',
+    'starter-mech-bobcat',
+    'starter-mech-mazona',
+    'starter-mech-thresher',
+  ],
+  crawlers: ['starter-crawler-tenacity'],
+}
+
+export async function migrate(tx: UpgradeTransaction): Promise<void> {
+  for (const [store, ids] of Object.entries(STARTER_IDS)) {
+    let cursor = await tx.objectStore(store).openCursor()
+    while (cursor) {
+      const row = cursor.value as { id?: unknown; seedRef?: unknown }
+
+      // Idempotent, and narrow: only a row still sitting under a known template
+      // id is stamped. A row the user built themselves that happens to be here
+      // is untouched, and a row already carrying a `seedRef` keeps it.
+      if (row.seedRef === undefined && typeof row.id === 'string' && ids.includes(row.id)) {
+        await cursor.update({ ...row, seedRef: row.id })
+      }
+
+      cursor = await cursor.continue()
+    }
+  }
+}

--- a/apps/itun/src/lib/db/migrations/index.ts
+++ b/apps/itun/src/lib/db/migrations/index.ts
@@ -26,6 +26,7 @@ import { migrate as migrate10WorkspaceDefaultBackfill } from './10-workspace-def
 import { migrate as migrate11EquipmentLoadoutsToPartners } from './11-equipment-loadouts-to-partners'
 import { migrate as migrate12CompanionMechsToPartners } from './12-companion-mechs-to-partners'
 import { migrate as migrate13WorkspaceToGameOrShelf } from './13-workspace-to-game-or-shelf'
+import { migrate as migrate14StarterSetSeedRef } from './14-starter-set-seed-ref'
 
 /** The untyped versionchange transaction handed to the idb upgrade callback. */
 export type UpgradeTransaction = IDBPTransaction<
@@ -90,6 +91,11 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
     toVersion: 13,
     description: 'workspace-to-game-or-shelf',
     migrate: (tx) => migrate13WorkspaceToGameOrShelf(tx),
+  },
+  {
+    toVersion: 14,
+    description: 'starter-set-seed-ref',
+    migrate: (tx) => migrate14StarterSetSeedRef(tx),
   },
   // NOTE: the built-in Starter Set is NOT seeded by a migration. It is spawned
   // on-demand into each browser the first time the user opens the Starter Set

--- a/apps/itun/src/lib/export/__tests__/export-round-trip.test.ts
+++ b/apps/itun/src/lib/export/__tests__/export-round-trip.test.ts
@@ -524,7 +524,8 @@ describe('mergeImport — duplicate skip branches', () => {
  *    row for the same reason.)
  *  - **Importing an exported bundle mints a new id.** That file may have been
  *    shared, and two people holding the same id is precisely what the server
- *    cannot represent — rows are addressed by `appId` with `.unique()`.
+ *    cannot represent: rows are addressed by `appId`, a duplicate resolves to
+ *    the oldest, and the later holder's writes are refused as somebody else's.
  */
 describe('identity: what keeps an id and what earns a new one', () => {
   test('moving between containers keeps the id — a game is a viewport, not a copy', async () => {

--- a/apps/itun/src/lib/export/__tests__/export-round-trip.test.ts
+++ b/apps/itun/src/lib/export/__tests__/export-round-trip.test.ts
@@ -28,6 +28,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { FIXTURE_NOW } from '../../../components/__tests__/fixtures'
 import { useEntityStore } from '../../../stores/entityStore'
+import { CONTAINER_MOVE } from '../../../stores/surfaceProvenance'
 import { _clearAllStores, _resetDbSingleton, encounterNpcs, mechPatterns } from '../../db/index'
 import type { ExportBundle } from '../../schemas/exportBundle'
 import { buildExportBundle } from '../buildExportBundle'
@@ -510,6 +511,103 @@ describe('mergeImport — duplicate skip branches', () => {
 // Cross-entity fidelity: softLinks + container assignment survive together
 // in one full-backup round trip (not just each entity type in isolation).
 // ---------------------------------------------------------------------------
+
+/**
+ * A UUID identifies a sheet; it does not identify a *copy* of one.
+ *
+ * Two rules follow from that, and they pull in opposite directions, which is
+ * why both are pinned here rather than left to the reader:
+ *
+ *  - **Moving an entity between containers keeps its id.** A Game is a viewport
+ *    onto the same sheet, not a duplicate of it, so a move is a patch of
+ *    `gameId` and nothing else. (Server-side, `upsertByAppId` re-homes the same
+ *    row for the same reason.)
+ *  - **Importing an exported bundle mints a new id.** That file may have been
+ *    shared, and two people holding the same id is precisely what the server
+ *    cannot represent — rows are addressed by `appId` with `.unique()`.
+ */
+describe('identity: what keeps an id and what earns a new one', () => {
+  test('moving between containers keeps the id — a game is a viewport, not a copy', async () => {
+    const entityStore = useEntityStore.getState()
+    await entityStore.hydrate('pilot')
+    const pilot = await entityStore.create('pilot', { ...richPilotInput, gameId: null })
+
+    // Same provenance the real control passes, so this exercises the move path
+    // rather than a bare patch that happens to touch the same field.
+    await entityStore.update('pilot', pilot.id, { gameId: 'game-alpha' }, CONTAINER_MOVE)
+    const moved = entityStore.list('pilot').find((p) => p.id === pilot.id)
+
+    expect(moved?.gameId).toBe('game-alpha')
+    expect(moved?.id).toBe(pilot.id)
+    // And back to the shelf, still the same sheet.
+    await entityStore.update('pilot', pilot.id, { gameId: null }, CONTAINER_MOVE)
+    expect(entityStore.list('pilot').filter((p) => p.id === pilot.id)).toHaveLength(1)
+  })
+
+  test('importing a bundle into a different store mints new ids for everything', async () => {
+    const entityStore = useEntityStore.getState()
+    await entityStore.hydrate('pilot')
+    await entityStore.hydrate('mech')
+    const pilot = await entityStore.create('pilot', richPilotInput)
+    const mech = await entityStore.create('mech', richMechInput)
+    await entityStore.hydrate('softLink')
+    await entityStore.create('softLink', {
+      from: { type: 'mech', id: mech.id },
+      to: { type: 'pilot', id: pilot.id },
+      type: 'mech-to-pilot',
+    })
+
+    const bundle = await buildExportBundle(entityStore)
+
+    // Somebody else's device: the same file, none of the rows.
+    const theirPilots: unknown[] = []
+    const theirMechs: unknown[] = []
+    const created: Record<string, string[]> = { pilot: [], mech: [], softLink: [] }
+    const theirStore = {
+      hydrate: async () => {},
+      list: (type: string) => (type === 'pilot' ? theirPilots : type === 'mech' ? theirMechs : []),
+      create: async (type: string, input: Record<string, unknown>) => {
+        const row = { ...input, id: crypto.randomUUID() }
+        created[type]?.push(row.id)
+        return row
+      },
+    }
+
+    const summary = await mergeImport(
+      bundle,
+      theirStore as unknown as Parameters<typeof mergeImport>[1]
+    )
+
+    expect(summary.created.pilots).toBe(1)
+    expect(summary.created.mechs).toBe(1)
+    // Not one id from the file survives into the copy.
+    expect(created.pilot).not.toContain(pilot.id)
+    expect(created.mech).not.toContain(mech.id)
+  })
+
+  test('an imported row does not inherit Starter Set provenance', async () => {
+    const entityStore = useEntityStore.getState()
+    await entityStore.hydrate('pilot')
+    await entityStore.create('pilot', { ...richPilotInput, seedRef: 'starter-pilot-bonesaw' })
+
+    const bundle = await buildExportBundle(entityStore)
+
+    const captured: Record<string, unknown>[] = []
+    const theirStore = {
+      hydrate: async () => {},
+      list: () => [],
+      create: async (_type: string, input: Record<string, unknown>) => {
+        captured.push(input)
+        return { ...input, id: crypto.randomUUID() }
+      },
+    }
+    await mergeImport(bundle, theirStore as unknown as Parameters<typeof mergeImport>[1])
+
+    // Carrying it across would make somebody else's starter pilot read as your
+    // own seeded one, and quietly suppress the Starter Set offer.
+    expect(captured[0]?.seedRef).toBeUndefined()
+  })
+})
 
 describe('export round-trip — cross-entity full backup', () => {
   test('pilot + mech + crawler + softLinks + container all round-trip consistently', async () => {

--- a/apps/itun/src/lib/export/mergeImport.ts
+++ b/apps/itun/src/lib/export/mergeImport.ts
@@ -67,8 +67,9 @@ export type MergeSummary = {
  *
  * An import is a **copy**, and a copy is a new thing: every entity comes in
  * under a fresh UUID, never the one in the file. That is what keeps a bundle
- * shared between two people from putting the same id in two accounts, where the
- * server addresses rows by it with `.unique()`. `seedRef` is dropped along the
+ * shared between two people from putting the same id in two accounts — where
+ * the server addresses rows by `appId`, resolves a duplicate to the oldest, and
+ * so refuses the later holder's writes as somebody else's. `seedRef` is dropped along the
  * way for the same reason it exists — it records that a row was spawned from a
  * built-in template *on this device*, and an imported row was not; carrying it
  * across would make someone else's starter pilot read as your own seeded one

--- a/apps/itun/src/lib/export/mergeImport.ts
+++ b/apps/itun/src/lib/export/mergeImport.ts
@@ -65,6 +65,15 @@ export type MergeSummary = {
 /**
  * mergeImport — import an ExportBundle into the local store.
  *
+ * An import is a **copy**, and a copy is a new thing: every entity comes in
+ * under a fresh UUID, never the one in the file. That is what keeps a bundle
+ * shared between two people from putting the same id in two accounts, where the
+ * server addresses rows by it with `.unique()`. `seedRef` is dropped along the
+ * way for the same reason it exists — it records that a row was spawned from a
+ * built-in template *on this device*, and an imported row was not; carrying it
+ * across would make someone else's starter pilot read as your own seeded one
+ * and quietly suppress the Starter Set offer.
+ *
  * Strategy:
  *   1. Hydrate current store state so we know which ids already exist.
  *   2. Assign FRESH UUIDs to every entity in the bundle.
@@ -138,7 +147,15 @@ export async function mergeImport(
       continue
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { id: _id, createdAt: _ca, updatedAt: _ua, workspaceId: _ws, gameId: _g, ...rest } = pilot
+    const {
+      id: _id,
+      createdAt: _ca,
+      updatedAt: _ua,
+      workspaceId: _ws,
+      gameId: _g,
+      seedRef: _sr,
+      ...rest
+    } = pilot
 
     const created = await entityStore.create('pilot', {
       ...rest,
@@ -158,7 +175,15 @@ export async function mergeImport(
       continue
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { id: _id, createdAt: _ca, updatedAt: _ua, workspaceId: _ws, gameId: _g, ...rest } = mech
+    const {
+      id: _id,
+      createdAt: _ca,
+      updatedAt: _ua,
+      workspaceId: _ws,
+      gameId: _g,
+      seedRef: _sr,
+      ...rest
+    } = mech
 
     const created = await entityStore.create('mech', {
       ...rest,
@@ -184,6 +209,7 @@ export async function mergeImport(
       updatedAt: _ua,
       workspaceId: _ws,
       gameId: _g,
+      seedRef: _sr,
       ...rest
     } = crawler
 

--- a/apps/itun/src/lib/schemas/crawler.ts
+++ b/apps/itun/src/lib/schemas/crawler.ts
@@ -140,6 +140,10 @@ export const CrawlerSchema = z
      * strips it from stored rows first — a separate, irreversible change.
      */
     workspaceId: z.string().optional(),
+
+    /** Which built-in template row this was spawned from. See `PilotSchema.seedRef`. */
+    seedRef: z.string().optional(),
+
     // ---------------------------------------------------------------------------
     // Live-play current stat tracking (#245).
     // A freshly created crawler is seeded at its tech-level base SP from the

--- a/apps/itun/src/lib/schemas/mech.ts
+++ b/apps/itun/src/lib/schemas/mech.ts
@@ -230,6 +230,9 @@ export const MechSchema = z
      */
     workspaceId: z.string().optional(),
 
+    /** Which built-in template row this was spawned from. See `PilotSchema.seedRef`. */
+    seedRef: z.string().optional(),
+
     // ---------------------------------------------------------------------------
     // Live-play current stat tracking (Wave 6, #199).
     // These are current values for the active session — separate from the chassis

--- a/apps/itun/src/lib/schemas/pilot.ts
+++ b/apps/itun/src/lib/schemas/pilot.ts
@@ -171,9 +171,9 @@ export const PilotSchema = z
      * ids (`starter-pilot-bonesaw`, …) so that re-seeding would overwrite
      * rather than duplicate. Locally that worked; globally it was wrong. Every
      * player who seeded the roster held byte-identical ids, and those ids are
-     * the `appId` a claimed entity is addressed by on the server — where they
-     * are looked up with `.unique()`, which throws when two accounts bring the
-     * same one.
+     * the `appId` a claimed entity is addressed by on the server — where two
+     * accounts bringing the same one resolve to a single row, so the later
+     * player's writes are refused as somebody else's entity.
      *
      * Absent on everything a person built themselves, which is nearly every row.
      */

--- a/apps/itun/src/lib/schemas/pilot.ts
+++ b/apps/itun/src/lib/schemas/pilot.ts
@@ -158,6 +158,27 @@ export const PilotSchema = z
      */
     workspaceId: z.string().optional(),
 
+    /**
+     * Which built-in template row this was spawned from, if any.
+     *
+     * **Provenance, never identity.** A seeded entity is a *copy* of a
+     * template, so it gets its own UUID like everything else created here; this
+     * records which template it came from, so "is the Starter Set already
+     * present?" can be answered without making the answer depend on two
+     * different people's rows sharing an id.
+     *
+     * That is precisely what the Starter Set used to rely on: it wrote fixed
+     * ids (`starter-pilot-bonesaw`, …) so that re-seeding would overwrite
+     * rather than duplicate. Locally that worked; globally it was wrong. Every
+     * player who seeded the roster held byte-identical ids, and those ids are
+     * the `appId` a claimed entity is addressed by on the server — where they
+     * are looked up with `.unique()`, which throws when two accounts bring the
+     * same one.
+     *
+     * Absent on everything a person built themselves, which is nearly every row.
+     */
+    seedRef: z.string().optional(),
+
     // ---------------------------------------------------------------------------
     // Live-play current stat tracking (#245).
     // A freshly created pilot is seeded with the base HP/AP rule constants

--- a/apps/itun/src/lib/starterSet/__tests__/starterSet.test.ts
+++ b/apps/itun/src/lib/starterSet/__tests__/starterSet.test.ts
@@ -261,8 +261,9 @@ describe('Starter Set seed — on-demand seeding', () => {
    * This used to write the template's fixed ids straight through, which made
    * every player's starter roster carry the same twelve. Locally that was
    * invisible; against the server of record those ids are the `appId` a row is
-   * addressed by, looked up with `.unique()` — so two players who had both
-   * seeded the roster collided on all twelve the moment they claimed.
+   * addressed by — so two players who had both seeded the roster collided on
+   * all twelve the moment they claimed, and the later one's writes were refused
+   * as edits to somebody else's entity.
    */
   test('seeded rows get fresh UUIDs, not the template ids', async () => {
     await ensureStarterSetSeeded()

--- a/apps/itun/src/lib/starterSet/__tests__/starterSet.test.ts
+++ b/apps/itun/src/lib/starterSet/__tests__/starterSet.test.ts
@@ -254,4 +254,92 @@ describe('Starter Set seed — on-demand seeding', () => {
     expect(await pilots.list()).toHaveLength(STARTER_PILOTS.length)
     expect(await softLinks.list()).toHaveLength(STARTER_SOFT_LINKS.length)
   })
+
+  /**
+   * A seeded row is a **copy of a template**, so it gets its own id.
+   *
+   * This used to write the template's fixed ids straight through, which made
+   * every player's starter roster carry the same twelve. Locally that was
+   * invisible; against the server of record those ids are the `appId` a row is
+   * addressed by, looked up with `.unique()` — so two players who had both
+   * seeded the roster collided on all twelve the moment they claimed.
+   */
+  test('seeded rows get fresh UUIDs, not the template ids', async () => {
+    await ensureStarterSetSeeded()
+
+    const templateIds = new Set([
+      ...STARTER_PILOTS.map((r) => r.id),
+      ...STARTER_MECHS.map((r) => r.id),
+      ...STARTER_CRAWLERS.map((r) => r.id),
+    ])
+    const stored = [...(await pilots.list()), ...(await mechs.list()), ...(await crawlers.list())]
+
+    expect(stored).toHaveLength(templateIds.size)
+    for (const row of stored) {
+      expect(templateIds.has(row.id)).toBe(false)
+      // Provenance is recorded separately — that is what makes the row
+      // recognisable as seeded without borrowing identity to do it.
+      expect(templateIds.has(row.seedRef as string)).toBe(true)
+      expect(row.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-/i)
+    }
+  })
+
+  test('two devices seeding the same roster produce disjoint ids', async () => {
+    await ensureStarterSetSeeded()
+    const first = (await pilots.list()).map((p) => p.id).sort()
+
+    // A second browser is a fresh database with the same template.
+    await _clearAllStores()
+    useEntityStore.setState({
+      pilots: [],
+      mechs: [],
+      crawlers: [],
+      softLinks: [],
+      hydrated: { pilots: false, mechs: false, crawlers: false, softLinks: false },
+    })
+    await ensureStarterSetSeeded()
+    const second = (await pilots.list()).map((p) => p.id).sort()
+
+    expect(second).toHaveLength(first.length)
+    // The whole point: no id appears in both rosters.
+    expect(first.some((id) => second.includes(id))).toBe(false)
+  })
+
+  test('soft links point at the freshly minted ids, not the template ones', async () => {
+    await ensureStarterSetSeeded()
+
+    const ids = new Set([
+      ...(await pilots.list()).map((p) => p.id),
+      ...(await mechs.list()).map((m) => m.id),
+      ...(await crawlers.list()).map((c) => c.id),
+    ])
+    const links = await softLinks.list()
+
+    expect(links).toHaveLength(STARTER_SOFT_LINKS.length)
+    // A remap that missed an endpoint would leave a link pointing at an id
+    // nothing holds — worse than no link at all.
+    for (const link of links) {
+      expect(ids.has(link.from.id)).toBe(true)
+      expect(ids.has(link.to.id)).toBe(true)
+    }
+  })
+
+  test('a partially deleted roster re-seeds only what is missing', async () => {
+    await ensureStarterSetSeeded()
+    const before = await pilots.list()
+    const survivor = before.find((p) => p.seedRef !== before[0]?.seedRef)
+    await pilots.delete(before[0]?.id as string)
+    // `isStarterSetSeeded` reads the store, and a db-level delete does not
+    // reach it — the roster is the evidence, so the evidence has to be current.
+    await useEntityStore.getState().rehydrate('pilot')
+
+    expect(isStarterSetSeeded()).toBe(false)
+    await ensureStarterSetSeeded()
+
+    const after = await pilots.list()
+    expect(after).toHaveLength(STARTER_PILOTS.length)
+    // The rows that were never deleted keep the ids they already had — a
+    // re-seed must not re-mint the roster around them.
+    expect(after.some((p) => p.id === survivor?.id)).toBe(true)
+  })
 })

--- a/apps/itun/src/lib/starterSet/seedStarterSet.ts
+++ b/apps/itun/src/lib/starterSet/seedStarterSet.ts
@@ -17,13 +17,37 @@
  * model rather than a regression to design around: the seed is opt-in, and
  * every seeded row is individually deletable.
  *
- * ## Idempotence
+ * ## Every seeded row gets a fresh UUID
  *
- * The guard is the presence of the seeded rows themselves, not a container
- * record — with no Workspace to test for, the roster IS the evidence. Checking
- * every seeded pilot (rather than any) means a partially-deleted set re-seeds
- * to whole, while an intact one is skipped; deterministic ids keep the write
- * safe to re-run, so a double-click overwrites rather than duplicates.
+ * A seeded entity is a **copy of a template**, and a copy is a new thing — so
+ * it is minted here exactly like anything the user builds, and the template's
+ * slug is recorded as `seedRef` instead.
+ *
+ * This used to write the template's own ids (`starter-pilot-bonesaw`, …)
+ * straight through, because id equality was doubling as the idempotence guard:
+ * a `put` of a fixed id overwrites, so a double-click could not duplicate. That
+ * reasoning was sound while the ids never left the device, and it stopped being
+ * sound the moment accounts landed. A seeded row's `id` becomes its `appId` on
+ * the server of record (ADR-030), where rows are looked up with `.unique()` —
+ * so **every player who seeded this roster was carrying the same twelve ids**,
+ * and any two of them claiming would collide on all twelve. One would break the
+ * other's mirror outright; with the claim now guarded, the second player's
+ * starter crew is instead quietly declined. Neither is acceptable, and neither
+ * is fixable downstream — the ids have to be distinct at the point of copying.
+ *
+ * ## Idempotence, without borrowing identity for it
+ *
+ * The guard is still the presence of the seeded rows themselves rather than a
+ * flag, and for the original reason: with no container record to test, the
+ * roster IS the evidence, so a partially-deleted set re-seeds to whole while an
+ * intact one is skipped. What changed is what "present" is asked of — `seedRef`
+ * rather than `id`. Only the missing rows are written, so re-running adds what
+ * was deleted and touches nothing else.
+ *
+ * Rows seeded before this change carry the old fixed ids and no `seedRef`;
+ * migration 14 stamps them, so an existing roster still reads as present and is
+ * not seeded a second time. Their ids are deliberately left alone — re-minting
+ * them would orphan any server rows already mirrored under the old id.
  */
 
 import { useEntityStore } from '../../stores/entityStore'
@@ -32,32 +56,121 @@ import { atomicWrite } from '../db'
 import { STORE_NAMES } from '../db/stores'
 import { STARTER_CRAWLERS, STARTER_MECHS, STARTER_PILOTS, STARTER_SOFT_LINKS } from './starterSet'
 
-/** Whether every Starter Set pilot is already present in this browser. */
+/** Every template row that carries a `seedRef`, by the slug it is known by. */
+export const STARTER_SEED_REFS: readonly string[] = [
+  ...STARTER_PILOTS.map((r) => r.id),
+  ...STARTER_MECHS.map((r) => r.id),
+  ...STARTER_CRAWLERS.map((r) => r.id),
+]
+
+/** The template slug a stored row came from, however it was seeded. */
+function seedRefOf(row: { id: string; seedRef?: string }): string | undefined {
+  // The `id` fallback is for rows written before seeding minted UUIDs, on a
+  // device migration 14 has not touched yet. Cheap, and it keeps the "already
+  // seeded?" answer correct rather than merely usually correct.
+  if (row.seedRef !== undefined) return row.seedRef
+  return STARTER_SEED_REFS.includes(row.id) ? row.id : undefined
+}
+
+/** Template slugs already present in this browser, across all three kinds. */
+function seededRefs(): Set<string> {
+  const store = useEntityStore.getState()
+  const refs = new Set<string>()
+  for (const row of [...store.list('pilot'), ...store.list('mech'), ...store.list('crawler')]) {
+    const ref = seedRefOf(row)
+    if (ref !== undefined) refs.add(ref)
+  }
+  return refs
+}
+
+/** Whether every Starter Set row is already present in this browser. */
 export function isStarterSetSeeded(): boolean {
-  const pilots = useEntityStore.getState().list('pilot')
-  return STARTER_PILOTS.every((seed) => pilots.some((p) => p.id === seed.id))
+  const present = seededRefs()
+  return STARTER_SEED_REFS.every((ref) => present.has(ref))
 }
 
 /**
  * Spawn the Starter Set roster into this browser. No-op when it is already
- * fully present.
+ * fully present; when it is partly present, writes only what is missing.
  */
 export async function ensureStarterSetSeeded(): Promise<void> {
-  await useEntityStore.getState().hydrate('pilot')
-  if (isStarterSetSeeded()) return
+  const store = useEntityStore.getState()
+  await Promise.all(
+    (['pilot', 'mech', 'crawler', 'softLink'] as const).map((t) => store.hydrate(t))
+  )
 
-  const put = (storeName: string, record: { id: string }): AtomicWriteOp => ({
+  const present = seededRefs()
+  if (STARTER_SEED_REFS.every((ref) => present.has(ref))) return
+
+  /*
+   * Template slug → the id this device will actually store it under.
+   *
+   * Built for the whole roster, not just the rows being written, because the
+   * soft links have to resolve endpoints that may already be here from an
+   * earlier partial seed — under whatever id *that* seed gave them.
+   */
+  const idFor = new Map<string, string>()
+  for (const row of [...store.list('pilot'), ...store.list('mech'), ...store.list('crawler')]) {
+    const ref = seedRefOf(row)
+    if (ref !== undefined) idFor.set(ref, row.id)
+  }
+  for (const ref of STARTER_SEED_REFS) {
+    if (!idFor.has(ref)) idFor.set(ref, crypto.randomUUID())
+  }
+
+  const put = (storeName: string, record: object): AtomicWriteOp => ({
     op: 'put',
     storeName,
-    record,
+    record: record as { id: string },
   })
 
-  await atomicWrite([
-    ...STARTER_PILOTS.map((r) => put(STORE_NAMES.pilots, r)),
-    ...STARTER_MECHS.map((r) => put(STORE_NAMES.mechs, r)),
-    ...STARTER_CRAWLERS.map((r) => put(STORE_NAMES.crawlers, r)),
-    ...STARTER_SOFT_LINKS.map((r) => put(STORE_NAMES.softLinks, r)),
-  ])
+  /** A template row, restamped with this device's id and its provenance. */
+  const spawn = <T extends { id: string }>(row: T): T & { seedRef: string } => ({
+    ...row,
+    id: idFor.get(row.id) as string,
+    seedRef: row.id,
+  })
+
+  const writes: AtomicWriteOp[] = [
+    ...STARTER_PILOTS.filter((r) => !present.has(r.id)).map((r) =>
+      put(STORE_NAMES.pilots, spawn(r))
+    ),
+    ...STARTER_MECHS.filter((r) => !present.has(r.id)).map((r) => put(STORE_NAMES.mechs, spawn(r))),
+    ...STARTER_CRAWLERS.filter((r) => !present.has(r.id)).map((r) =>
+      put(STORE_NAMES.crawlers, spawn(r))
+    ),
+  ]
+
+  /*
+   * Links are rebuilt against the remapped endpoints, and skipped when either
+   * end is missing from the map — the same rule `mergeImport` follows, and for
+   * the same reason: a link to an id that is not here is a dangling reference,
+   * which is worse than an absent link.
+   *
+   * Their own ids stay derived from the endpoints rather than random, so a
+   * re-seed cannot lay down a second copy of a link that is already here. A
+   * soft link has no independent identity — it *is* its endpoints — and those
+   * are now device-unique, so the derived id is too.
+   */
+  const existingLinkIds = new Set(store.list('softLink').map((l) => l.id))
+  for (const link of STARTER_SOFT_LINKS) {
+    const from = idFor.get(link.from.id)
+    const to = idFor.get(link.to.id)
+    if (from === undefined || to === undefined) continue
+    const id = `starter-link-${link.type}-${from}-${to}`
+    if (existingLinkIds.has(id)) continue
+    writes.push(
+      put(STORE_NAMES.softLinks, {
+        ...link,
+        id,
+        from: { ...link.from, id: from },
+        to: { ...link.to, id: to },
+      })
+    )
+  }
+
+  if (writes.length === 0) return
+  await atomicWrite(writes)
 
   // Reflect the newly-written rows in memory so the roster renders them.
   await Promise.all(

--- a/apps/itun/src/lib/starterSet/seedStarterSet.ts
+++ b/apps/itun/src/lib/starterSet/seedStarterSet.ts
@@ -28,12 +28,19 @@
  * a `put` of a fixed id overwrites, so a double-click could not duplicate. That
  * reasoning was sound while the ids never left the device, and it stopped being
  * sound the moment accounts landed. A seeded row's `id` becomes its `appId` on
- * the server of record (ADR-030), where rows are looked up with `.unique()` —
- * so **every player who seeded this roster was carrying the same twelve ids**,
- * and any two of them claiming would collide on all twelve. One would break the
- * other's mirror outright; with the claim now guarded, the second player's
- * starter crew is instead quietly declined. Neither is acceptable, and neither
- * is fixable downstream — the ids have to be distinct at the point of copying.
+ * the server of record (ADR-030) — so **every player who seeded this roster was
+ * carrying the same twelve ids**, and any two of them claiming collided on all
+ * twelve.
+ *
+ * What that collision costs has changed once already, which is the argument for
+ * fixing it at the source rather than downstream. It began as an outright break
+ * (the lookup used `.unique()`, so it threw and the mirror stopped); the claim
+ * is now guarded, so the second player's starter crew is declined instead; and
+ * `byAppId` now resolves a duplicate to the *oldest* row, which means a write
+ * from the second player aims at the first player's entity and is refused by
+ * `assertMayWrite` as somebody else's. Three mechanisms, one outcome: a player
+ * whose sheet quietly stops reaching the server. The ids have to be distinct at
+ * the point of copying.
  *
  * ## Idempotence, without borrowing identity for it
  *


### PR DESCRIPTION
Follows #704. That PR stopped duplicate `appId`s from *corrupting* anything;
this one removes the reason they existed.

## A copy is a new thing, and gets a new id

Every path in the app already worked that way. The investigation checked all
of them:

| path | behaviour |
| --- | --- |
| `crud.create()` | mints `crypto.randomUUID()`; its input type is `Omit<T, 'id' \| …>`, so a caller **cannot** supply an id |
| `mergeImport` (export → import) | strips `id` off every row, creates fresh, remaps soft links through an old→new map |
| snapshots (`/s/$id`) | read-only; explicitly never touch entityStore |
| moving Shelf ↔ Game | patches `gameId` only — same row, same id |
| `seedStarterSet` | **wrote 12 hardcoded ids** |

So this corrects the record on something I'd written in #704: export/import
does *not* preserve ids. It never did. The one real offender was the Starter
Set.

## Why the Starter Set did it, and why that stopped working

`seedStarterSet` bypassed `create()` and `put` the template's own ids —
`starter-pilot-bonesaw`, `starter-mech-scrapper`, … — because id equality
doubled as the idempotence guard: a `put` of a known id overwrites, so a
double-click could not duplicate.

That reasoning was sound while the ids never left the device. It stopped
being sound when accounts landed. A seeded row's `id` becomes its `appId` on
the server of record, where rows are looked up with `.unique()` — so **every
player who seeded this roster carried the same twelve ids**, and any two of
them claiming collided on all twelve:

- before #704 → `unique()` threw, and both players' mirrors broke permanently
- after #704 → the second player's starter crew is silently declined

Neither is acceptable, and neither is fixable downstream. The ids have to be
distinct at the point of copying.

## The fix

Seeding mints a UUID per row and records the template slug as **`seedRef` —
provenance, never identity**. That keeps the idempotence guard's original
shape (the roster is its own evidence, so a partially-deleted set re-seeds to
whole and an intact one is skipped) without borrowing identity to express it.
Soft links are rebuilt against the remapped endpoints, skipping any whose
endpoint is missing — the same rule `mergeImport` follows, for the same
reason.

The crawler placeholder-Game bug's sibling is fixed here too: only genuinely
missing rows are written, so a re-seed adds what was deleted and touches
nothing else.

**Migration 14** stamps `seedRef` onto rows seeded the old way, so an existing
roster still reads as present instead of being laid down a second time beside
itself. Their **ids are deliberately not re-minted** — a row already claimed
exists on the server under its old `appId`, and changing it here would strand
that row and re-mirror the entity as a new one, turning a collision that is
now merely declined into duplicated data.

`mergeImport` also drops `seedRef` now, for the same reason the field exists:
it records that a row was spawned from a built-in template *on this device*,
and an imported row was not. Carrying it across would make someone else's
starter pilot read as your own seeded one and quietly suppress the Starter Set
offer.

## Two invariants, now pinned by tests

They pull in opposite directions, which is exactly why neither should be left
to the reader:

- **Moving between containers keeps the id.** A Game is a viewport onto the
  same sheet, not a duplicate of it.
- **Importing a bundle mints a new id.** That file may have been shared, and
  two people holding one id is precisely what the server cannot represent.

## Verification

- `bun run check:all` green — lint, format, typecheck ×6, test, validate, knip, audit, tokens, styling
- `bun --filter itun test` — **1722 pass, 0 fail** (rebased onto main with #704 merged)
- 12 new tests, including: seeded rows get UUIDs not template ids; two devices seeding the same roster produce **disjoint** id sets; soft links point at the minted ids; a partially deleted roster re-seeds only what is missing; the migration stamps legacy rows and leaves a player's own builds alone.
- One pre-existing flake exists in this suite — `ShareSnapshotScreen › hides Publish…` times out at 5s. Verified identical on clean `origin/main`; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6ao8WWaWUtq5RsfYbySY9
