### PR TITLE
docs(itun): an entity is never copied into a game — amend ADR-030's fork clause

### DIFF
--- a/apps/itun/src/components/container/MoveToContainerControl.tsx
+++ b/apps/itun/src/components/container/MoveToContainerControl.tsx
@@ -6,14 +6,26 @@
  * not a dialog, so a move is one tap — with Workspaces swapped for the two real
  * containers.
  *
- * ## What this does NOT do
+ * ## A move is one field, and that is the whole design
  *
- * ADR-030 says a cross-container move is an explicit **fork**, and no fork
- * mutation exists yet (`convex/entities.ts` has create/update/claimLocal, not
- * fork). So this keeps exactly the semantics of the control it replaces: it
- * re-stamps the local record's container in place. Turning that into a fork is
- * a separate change with its own server surface, not something to smuggle in
- * behind a rename.
+ * Re-stamping `gameId` in place is not a shortcut pending something better —
+ * it is the model. There is **one entity**. The pilot on your shelf and that
+ * same pilot in a Game are one record with one field set differently, so a move
+ * changes that field and nothing else: same id, same body, same history.
+ *
+ * This header used to say the opposite, because ADR-030 §2 originally called a
+ * cross-container move an explicit **fork** and this control was documented as
+ * holding the line until a fork mutation existed. That clause was amended
+ * (2026-08-06): forking guarded against a "shared pilot" that the schema makes
+ * unrepresentable — `gameId` is a single nullable column, so an entity is in at
+ * most one Game by construction — and it would have bought that non-protection
+ * with a duplicate character to reconcile.
+ *
+ * So there is no missing fork mutation to add. `entities.upsertByAppId` re-homes
+ * the existing server row for the same reason (`existing.gameId !== args.gameId`
+ * patches the column rather than inserting), and the two halves must keep
+ * agreeing: if either ever starts copying, a player ends up with two of
+ * themselves and no way to tell which one the table can see.
  *
  * ## Solo renders nothing
  *

--- a/docs/adrs/ADR-030-accounts-games-server-of-record.md
+++ b/docs/adrs/ADR-030-accounts-games-server-of-record.md
@@ -97,9 +97,50 @@ An entity is in exactly one container, encoded as two nullable columns:
 | null     | set       | on the owner's shelf                                   |
 | null     | null      | **invalid** — must be unreachable through any mutation |
 
-An entity belongs to **one Game at a time**; a pilot's crawler level, scrap, TP,
-and injuries are Game-specific, so a shared pilot would be incoherent rather than
-convenient. Moving one is an explicit **fork** that copies and records its origin.
+An entity belongs to **one Game at a time**, and moving it between containers is
+a **change to `gameId`, not a copy**. There is one entity. A pilot on your shelf
+and that same pilot in a Game are the same record with one field set
+differently — never an original and a duplicate to be kept in step.
+
+**Move and copy are different verbs, and the difference is the point.**
+
+| Verb     | Result                                                                                                                             |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| **Move** | The **same** entity. Same id, same body, same history; only `gameId` changes. Nothing is duplicated and nothing needs reconciling.   |
+| **Copy** | A **new** entity. New id, named `COPY OF <name>`, always `gameId: null`, and carrying no relationship to the source or to its Game. |
+
+A copy is deliberate, explicit and user-initiated — "I want my own one of these"
+— and once made it is simply a build of yours like any other. It does not track
+its origin, does not sync with it, and does not follow it into or out of a Game.
+That is what keeps copying safe: there is no ongoing relationship to get out of
+step, which is exactly the property a fork would not have had.
+
+So a character in somebody else's Game can be copied to your shelf without
+copying the Game, and editing your copy can never touch theirs.
+
+> **Amended 2026-08-06.** This clause previously read: _"a pilot's crawler
+> level, scrap, TP, and injuries are Game-specific, so a shared pilot would be
+> incoherent rather than convenient. Moving one is an explicit **fork** that
+> copies and records its origin."_
+>
+> The conclusion did not follow from the premise. Game-specific state is only
+> incoherent if one entity can be in two Games at once, and the container model
+> makes that unrepresentable: `gameId` is a **single nullable column**, so an
+> entity is in at most one Game by construction. Forking solved a problem the
+> schema already prevents.
+>
+> Note that a fork is **not** the same thing as the copy sanctioned above, and
+> the difference is the origin it "records". A copy is a clean break — a new
+> build of yours with no tie to what it came from. A fork keeps a relationship,
+> and a relationship between two records of one character is precisely the thing
+> that has to be reconciled, watched, and eventually gets out of step. The verb
+> that survives is the one with nothing to keep in sync.
+>
+> No fork was ever built, so this amendment does not change behaviour;
+> `MoveToContainerControl` re-stamps `gameId` in place and
+> `entities.upsertByAppId` re-homes the existing row. What it changes is the
+> instruction: that in-place move **is** the design, and the absence of a fork
+> mutation is not a gap for somebody to close later.
 
 ### 3. Roles: a base role plus one modifier
 

--- a/docs/architecture/accounts-and-games.md
+++ b/docs/architecture/accounts-and-games.md
@@ -38,7 +38,7 @@ In brief, grouped:
 | ------------ | ------------------------------------------------------------------------------------------------------ |
 | Truth        | Convex is the server of record; IndexedDB becomes a cache. Offline writes are **blocked**.             |
 | Identity     | Discord OAuth only, reusing the bot's existing Discord application.                                    |
-| Containers   | **Game** (shared) and **Shelf** (personal). One entity, one container. Moving is an explicit fork.     |
+| Containers   | **Game** (shared) and **Shelf** (personal). One entity, one container. **Move** sets `gameId`; **copy** mints a new unrelated `COPY OF …`. |
 | Roles        | Base role Player \| Mediator, plus an orthogonal **Organizer** flag. Organizer ⇒ no content authority. |
 | Cross-player | **Propose → player confirms.** Never a direct write, never force-applied.                              |
 | Ownership    | Nullable. Mediator assigns; owners release; **players self-claim what nobody holds**.                  |
@@ -97,7 +97,9 @@ what de-risks the rest.
   Solo surfaces render unfiltered — see the note in `activeContainerStore.ts`.
 - The three storage modes + the **NOT CONNECTED** banner
 - Claim-local-data flow on first sign-in
-- "Fork into Game" and "copy to shelf"
+- Move between Shelf and Game (`MoveToContainerControl` — one field, not a copy)
+- **Copy to shelf** — mints a NEW `COPY OF <name>` entity, `gameId: null`, with
+  no tie to the source or its Game (ADR-030 §2). Not built yet.
 - Starter Set re-homed as a Game template, its entities unclaimed
 - Account management: profile, My Games, export, delete
 


### PR DESCRIPTION
> I do not want games to "Copy" these fields. Entities in your shelf can or can not belong to a game, but they are always the same entity, not copies that need to be mirrored.

The code already worked this way. **ADR-030 did not**, and that mismatch was pointed the wrong direction: `MoveToContainerControl` re-stamps `gameId` in place and `entities.upsertByAppId` re-homes the existing row, while the ADR called a cross-container move *"an explicit **fork** that copies and records its origin"* — and the control's own header apologised for not having built one yet. That is the setup for somebody later "fixing" correct code to match a doc.

## The fork clause did not follow from its own premise

It justified forking with: *a pilot's crawler level, scrap, TP and injuries are Game-specific, so a shared pilot would be incoherent.*

But `gameId` is a **single nullable column**, so an entity is in at most one Game *by construction*. There is no shared pilot to be incoherent about. Forking guarded a state the schema cannot represent, and would have paid for it with two records of one character to keep in step.

## Move and copy, as two different verbs

| Verb | Result |
|---|---|
| **Move** | The **same** entity. Same id, body and history; only `gameId` changes. Nothing to reconcile. |
| **Copy** | A **new** entity. New id, `COPY OF <name>`, always `gameId: null`, no tie to the source or its Game. |

Copying is explicitly fine and wanted — it is a deliberate, user-initiated "I want my own one of these." What makes it safe is that it keeps **no relationship**: it does not track its origin, sync with it, or follow it into or out of a Game. That is also exactly what separates it from the fork being removed here, which "records its origin" — and a retained relationship between two records of one character is the part that rots.

Copy-to-shelf is **not built**; it is recorded in the phase list in `accounts-and-games.md`.

## Changes

- `ADR-030` §2 — amended in place with a dated note quoting the original clause, so the reasoning is auditable rather than just gone.
- `accounts-and-games.md` — decision table and phase list corrected ("Fork into Game" → move/copy).
- `MoveToContainerControl.tsx` — header rewritten so in-place re-stamping reads as the design, not a stopgap, and notes that it and `upsertByAppId` must keep agreeing.

**No behaviour change.** `check:fast` green.

## One open question, deliberately not decided here

The request said a copy should land "unclaimed". Taken literally as `ownerId: null` that collides with a documented schema invariant — `gameId: null && ownerId: null` is listed in ADR-030 as the one **invalid** combination ("a shelf is a person's, so an unclaimed shelf entity would be owned by nobody and reachable by nobody"), and `entities.create` throws on it. This PR therefore reads "unclaimed" as *unattached to any Game* and leaves `ownerId` as the copier. Flagging it rather than quietly picking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zyFsCRwKhBrZNGdh9BHkM
