### PR TITLE
feat(itun): copy an entity to your shelf, and stop calling a shelved build unclaimed

### DIFF
--- a/apps/itun/convex/ownership.ts
+++ b/apps/itun/convex/ownership.ts
@@ -184,7 +184,23 @@ export const release = mutation({
   handler: async (ctx, args): Promise<void> => {
     const doc = await loadOwnable(ctx, args.table, args.entityId)
     if (doc.gameId === null) {
-      throw new NotAuthorized('An entity on a shelf is already unclaimed')
+      /*
+       * A shelved entity is NOT unclaimed, and this used to say it was.
+       *
+       * ADR-030 §2 allows three states, and they are not interchangeable:
+       * `gameId` set + `ownerId` null is **unclaimed** — in a Game, waiting for
+       * somebody to take it; `gameId` null + `ownerId` set is **on the owner's
+       * shelf** — already somebody's. Both null is the one invalid combination,
+       * which is exactly what releasing a shelved entity would produce, and is
+       * why this refuses rather than no-ops.
+       *
+       * The message matters now that it reaches a player: `NotAuthorized`
+       * extends `ConvexError`, so this string is shown rather than redacted, and
+       * it was teaching the wrong model to the person least able to check it.
+       */
+      throw new NotAuthorized(
+        'A build on your shelf is already yours — there is no crew here to release it to. Move it into a game first.'
+      )
     }
     if (doc.ownerId === null) return
 

--- a/apps/itun/src/components/games/GameRoster.tsx
+++ b/apps/itun/src/components/games/GameRoster.tsx
@@ -47,6 +47,7 @@ import {
   ModalShell,
   PageHeading,
   Text,
+  toast,
 } from 'component-lib'
 import { useMutation, useQuery } from 'convex/react'
 import { Bot, UserRound, Warehouse } from 'lucide-react'
@@ -56,6 +57,7 @@ import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
 import { useCrawlers, useHydrateEntities, useMechs, usePilots } from '../../hooks/queries'
 import { resolveClassName } from '../../lib/classRef'
+import { copyForShelf } from '../../lib/copyEntity'
 import type { RosterKind, RosterRow } from '../../lib/games/gameRoster'
 import { crawlerRows, ownableRows, tableCapabilities } from '../../lib/games/gameRoster'
 import type { OwnerChip } from '../../lib/ownership/ownerChip'
@@ -333,6 +335,31 @@ export function GameRoster({ gameId, gameName }: GameRosterProps) {
     return id
   }
 
+  /**
+   * Take a copy of this row onto your own shelf.
+   *
+   * Offered on **every** row, including a crewmate's and an unclaimed pre-gen,
+   * because it is derived from what you may already read: membership of the Game
+   * grants the frozen crew view of every row, and copying what is on your screen
+   * escalates nothing. It is also the only way to keep a character when you
+   * leave — `ownership.leaveGame` has documented this act since before it
+   * existed.
+   *
+   * Deliberately no confirm. Copying destroys nothing and the result is one more
+   * build on your shelf, so a modal would be friction guarding an undo-by-delete.
+   *
+   * Crawlers are excluded at the call site rather than here: `crawlers.gameId` is
+   * **non-nullable** in the Convex schema, so a shelved crawler has no server row
+   * to be — which is why `claimLocal` parks a claimed one on a placeholder Game
+   * instead. Copying one to a shelf is not a thing the model can express.
+   */
+  async function copyToShelf(row: RosterRow) {
+    const created = await useEntityStore
+      .getState()
+      .create(row.kind === 'pilot' ? 'pilot' : 'mech', copyForShelf(row.body, row.name) as never)
+    toast.success(`Copied ${created.name} to your shelf.`)
+  }
+
   async function run(key: string, work: () => Promise<void>) {
     setBusy(key)
     setError(null)
@@ -541,6 +568,18 @@ export function GameRoster({ gameId, gameName }: GameRosterProps) {
                                   }
                                 >
                                   Offer to the crew
+                                </Button>
+                              )}
+                              {row.kind !== 'crawler' && (
+                                <Button
+                                  variant="ghost"
+                                  size="mini"
+                                  disabled={busy !== null}
+                                  onClick={() =>
+                                    void run(`copy-${row.serverId}`, () => copyToShelf(row))
+                                  }
+                                >
+                                  Copy to shelf
                                 </Button>
                               )}
                               {row.can.delete && (

--- a/apps/itun/src/components/games/__tests__/GameRoster.connected.test.tsx
+++ b/apps/itun/src/components/games/__tests__/GameRoster.connected.test.tsx
@@ -202,4 +202,34 @@ describe('what the game will accept', () => {
   })
 })
 
+describe('copy to shelf', () => {
+  test('every character offers it, including ones you do not own', () => {
+    renderAs(ME, listing({ pilots: [MY_PILOT, THEIR_PILOT, PRE_GEN] }))
+
+    // Derived from what you may already read: membership grants the frozen crew
+    // view of every row, so copying what is on screen escalates nothing. It is
+    // also the only way to keep a character when you leave the table —
+    // `ownership.leaveGame` has documented this act since before it existed.
+    expect(screen.getAllByRole('button', { name: 'Copy to shelf' })).toHaveLength(3)
+  })
+
+  test('the crawler does not, because a shelved crawler cannot exist', () => {
+    renderAs(ME, listing({ crawlers: [CRAWLER] }))
+
+    // `crawlers.gameId` is NON-nullable in the Convex schema, so there is no
+    // server row a shelved crawler could be — which is why `claimLocal` parks a
+    // claimed one on a placeholder Game rather than shelving it.
+    expect(screen.queryByRole('button', { name: 'Copy to shelf' })).toBeNull()
+  })
+
+  test('it is not a destructive verb, so it does not ask first', () => {
+    renderAs(ME, listing({ pilots: [MY_PILOT] }))
+    fireEvent.click(screen.getByRole('button', { name: 'Copy to shelf' }))
+
+    // Delete opens a danger confirm; copying destroys nothing and its result is
+    // one more build on your shelf, so a modal would guard an undo-by-delete.
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+})
+
 afterAll(convexMocks.restore)

--- a/apps/itun/src/lib/__tests__/copyEntity.test.ts
+++ b/apps/itun/src/lib/__tests__/copyEntity.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'bun:test'
+import { containerOf } from '../container'
+import { copyForShelf, copyName } from '../copyEntity'
+
+/**
+ * Copying an entity onto your shelf (ADR-030 §2).
+ *
+ * The properties worth pinning are all about what a copy does NOT keep. A copy
+ * that carried its id would be a duplicate `appId` — the exact condition that
+ * took a play session down — and a copy that carried its container would follow
+ * the source back into the Game it was explicitly copied out of.
+ */
+
+const SOURCE = {
+  id: 'source-uuid',
+  schemaVersion: 1,
+  name: 'Babe',
+  callsign: 'Babe',
+  classRef: 'salvager',
+  gameId: 'game-123',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-02-02T00:00:00.000Z',
+  conditions: ['injured'],
+  abilities: [],
+  equipment: [],
+}
+
+describe('copyForShelf', () => {
+  test('lands on the shelf even when the source was in a game', () => {
+    const copy = copyForShelf(SOURCE, 'Pilot')
+
+    // `null`, not absent. `undefined` would mean "not decided", which sends it
+    // through the legacy fallback AND lets `entityStore.create` stamp whatever
+    // container is open — for a copy made from a Game roster, the Game it just
+    // came out of.
+    expect(copy.gameId).toBeNull()
+    expect(containerOf(copy).kind).toBe('shelf')
+  })
+
+  test('announces itself as a copy', () => {
+    expect(copyForShelf(SOURCE, 'Pilot').name).toBe('COPY OF Babe')
+  })
+
+  test('keeps no identity from the source', () => {
+    const copy = copyForShelf(SOURCE, 'Pilot')
+
+    // The db layer mints these on create. Carrying `id` through would produce a
+    // second row claiming to be the original — a duplicate appId by hand.
+    expect(copy.id).toBeUndefined()
+    expect(copy.createdAt).toBeUndefined()
+    expect(copy.updatedAt).toBeUndefined()
+  })
+
+  test('drops a legacy workspaceId rather than carrying it', () => {
+    // `containerOf` still reads `workspaceId` as a pre-ADR-030 fallback, so a
+    // stale one riding along could resolve the copy back into a Game.
+    const copy = copyForShelf({ ...SOURCE, gameId: undefined, workspaceId: 'ws-9' }, 'Pilot')
+
+    expect(copy.workspaceId).toBeUndefined()
+    expect(containerOf(copy).kind).toBe('shelf')
+  })
+
+  test('copies the body verbatim otherwise', () => {
+    const copy = copyForShelf(SOURCE, 'Pilot')
+
+    // A copy of a character mid-campaign IS that character mid-campaign.
+    // Starting fresh is what the wizard is for.
+    expect(copy.conditions).toEqual(['injured'])
+    expect(copy.classRef).toBe('salvager')
+    expect(copy.callsign).toBe('Babe')
+  })
+
+  test('falls back rather than naming something COPY OF nothing', () => {
+    expect(copyForShelf({ ...SOURCE, name: '' }, 'Pilot').name).toBe('COPY OF Pilot')
+    expect(copyForShelf({ ...SOURCE, name: undefined }, 'Mech').name).toBe('COPY OF Mech')
+  })
+
+  test('does not mutate the source', () => {
+    const source = { ...SOURCE }
+    copyForShelf(source, 'Pilot')
+
+    // The Game roster hands this its live row body; mutating it would rewrite
+    // the crewmate's name on screen.
+    expect(source.name).toBe('Babe')
+    expect(source.id).toBe('source-uuid')
+    expect(source.gameId).toBe('game-123')
+  })
+
+  test('a copy of a copy is honest about it', () => {
+    const once = copyForShelf(SOURCE, 'Pilot')
+    const twice = copyForShelf(once, 'Pilot')
+
+    expect(twice.name).toBe('COPY OF COPY OF Babe')
+  })
+})
+
+describe('copyName', () => {
+  test('prefixes rather than suffixes', () => {
+    // Prefixed so a copy never sorts next to the original and gets mistaken
+    // for it in a list.
+    expect(copyName('Reaper')).toBe('COPY OF Reaper')
+  })
+})

--- a/apps/itun/src/lib/copyEntity.ts
+++ b/apps/itun/src/lib/copyEntity.ts
@@ -1,0 +1,99 @@
+/**
+ * Copying an entity onto your own shelf (ADR-030 §2).
+ *
+ * ## Copy is not move, and the difference is the whole point
+ *
+ * **Move** changes `gameId` on the same record — same id, same body, same
+ * history. **Copy** mints a genuinely new entity that has no relationship to
+ * what it came from: new id, `COPY OF <name>`, always on the shelf, never in a
+ * Game. It does not track its origin, sync with it, or follow it anywhere.
+ *
+ * That absence of a relationship is what makes copying safe, and it is exactly
+ * what separates it from the **fork** ADR-030 originally specified and has since
+ * dropped. A fork "records its origin", and a retained link between two records
+ * of one character is the part that rots — something has to reconcile it, and
+ * eventually something does not.
+ *
+ * ## Why it exists
+ *
+ * `ownership.leaveGame` has always documented this as the escape hatch —
+ * *"a player who wants to keep a character copies it to their shelf first,
+ * which is a separate, explicit act"* — while the act did not exist. Leaving a
+ * Game left your character behind unclaimed with no way to keep one.
+ *
+ * ## The container it lands in follows from the ownership table
+ *
+ * ADR-030 §2 allows exactly three states, and a copy is unambiguously the third:
+ *
+ * | `gameId` | `ownerId` | State                     |
+ * | -------- | --------- | ------------------------- |
+ * | set      | set       | claimed and in play       |
+ * | set      | null      | unclaimed, awaiting a taker |
+ * | **null** | **set**   | **on the owner's shelf**  |
+ * | null     | null      | invalid                   |
+ *
+ * So a copy is `gameId: null` with the copier as owner. It cannot be
+ * "unclaimed" in the `ownerId: null` sense — that is the invalid row, and the
+ * server refuses it (`entities.create`: *"A shelf has no crew to pick anything
+ * up — shelved builds are yours"*). Unclaimed is a thing a character can be
+ * **inside a Game**, waiting for somebody to take it; a shelf is already
+ * somebody's.
+ */
+
+/** The loosest shape this needs: an opaque body that may carry a name. */
+export type CopyableBody = Record<string, unknown>
+
+/**
+ * Fields the copy must not inherit.
+ *
+ * `id`/`createdAt`/`updatedAt` are minted by the db layer on create, so
+ * carrying them through would either be overwritten or — worse for `id` —
+ * produce a second record claiming to be the original, which is the exact
+ * duplicate-`appId` condition that took a play session down.
+ *
+ * `workspaceId` is the retired pre-ADR-030 container. It is dropped rather than
+ * copied because `containerOf` still reads it as a fallback, so a stale one
+ * riding along on a copy could resolve the new entity back into a Game it was
+ * explicitly copied out of.
+ */
+const DROPPED_FIELDS = ['id', 'createdAt', 'updatedAt', 'workspaceId'] as const
+
+/** How a copy announces itself. Prefixed, so it sorts beside nothing and reads as derived. */
+export function copyName(name: string): string {
+  return `COPY OF ${name}`
+}
+
+/**
+ * Build the create-input for a copy of `source`, destined for the copier's shelf.
+ *
+ * Takes an opaque body rather than a typed entity because both call sites hand
+ * it one: a Game roster row carries the **server's** body (`listForGame`
+ * returns `v.any()`), not a parsed local record. Validation is not skipped, it
+ * is deferred to where it already happens — `entityStore.create` Zod-parses
+ * every write, so a malformed source fails there with the same error any other
+ * bad write would produce.
+ *
+ * `fallbackName` is used when the body carries no usable name, so a copy is
+ * never called `COPY OF ` with nothing after it. Callers pass the name they are
+ * already displaying.
+ *
+ * The body is otherwise copied **verbatim** — conditions, damage, scrap, TP and
+ * all. A copy of a character mid-campaign is that character mid-campaign; a
+ * pristine one is what the wizard is for.
+ */
+export function copyForShelf(source: CopyableBody, fallbackName: string): CopyableBody {
+  const copy: CopyableBody = { ...source }
+  for (const field of DROPPED_FIELDS) delete copy[field]
+
+  const sourceName = typeof source.name === 'string' && source.name.length > 0 ? source.name : null
+  copy.name = copyName(sourceName ?? fallbackName)
+
+  // Explicitly null, never absent: `null` IS the shelf, while `undefined` means
+  // "not decided yet" and would send the copy through `containerOf`'s legacy
+  // fallback — and, worse, would let `entityStore.create` stamp whatever
+  // container happens to be open, which for a copy made from a Game roster is
+  // the Game it was just copied out of.
+  copy.gameId = null
+
+  return copy
+}

--- a/apps/itun/test/convex/permissions.test.ts
+++ b/apps/itun/test/convex/permissions.test.ts
@@ -484,14 +484,39 @@ describe('a shelved entity is not assignable', () => {
     ).rejects.toThrow(/shelf/i)
   })
 
-  test('releasing one is refused for the same reason', async () => {
+  test('releasing one is refused, because null + null is the invalid state', async () => {
     const t = testConvex()
     const { organizer } = await seedGame(t)
     const shelved = await seedPilot(t, null, organizer.userId)
 
+    // Release sets `ownerId: null`. On a shelved entity that would produce
+    // `gameId: null && ownerId: null` — the one combination ADR-030 §2 calls
+    // invalid and requires to be unreachable through any mutation. Hence a
+    // refusal rather than a no-op.
     await expect(
       organizer.as.mutation(api.ownership.release, { table: 'pilots', entityId: shelved })
-    ).rejects.toThrow(/already unclaimed/i)
+    ).rejects.toThrow(/already yours/i)
+
+    const pilot = await t.run(async (ctx) => await ctx.db.get(shelved))
+    expect(pilot?.ownerId).toBe(organizer.userId)
+    expect(pilot?.gameId).toBeNull()
+  })
+
+  test('and the refusal does not call a shelved build "unclaimed"', async () => {
+    const t = testConvex()
+    const { organizer } = await seedGame(t)
+    const shelved = await seedPilot(t, null, organizer.userId)
+
+    // The message used to be "An entity on a shelf is already unclaimed", which
+    // teaches the wrong model to the person least able to check it: unclaimed
+    // is `ownerId: null` *inside a Game*, waiting for a taker; a shelf is
+    // already somebody's. It matters more now that `NotAuthorized` extends
+    // `ConvexError` and the string actually reaches the player.
+    const err = await organizer.as
+      .mutation(api.ownership.release, { table: 'pilots', entityId: shelved })
+      .catch((e: unknown) => e)
+
+    expect(String((err as { data?: unknown })?.data ?? err)).not.toMatch(/unclaimed/i)
   })
 })
 


### PR DESCRIPTION
> A game can have either a null ownerId or a null gameId. if ownerId null, it is unclaimed. If gameId null, it is on the owners shelf. if both are set, it is a claimed entity in a game. if neither are set, that is invalid.

Both changes here fall straight out of that table, which is ADR-030 §2 verbatim. I checked the invariant is already enforced at all four paths that can write `ownerId: null` (`entities.create` unassigned, `templates` seeding, `ownership.release`, `ownership.leaveGame`) — it is. These are the two places the *model* was not being told correctly.

## 1. Copy to shelf

`ownership.leaveGame` has documented this act since before it existed:

> Entities stay behind, unclaimed, so the crew survives a departure... **a player who wants to keep a character copies it to their shelf first, which is a separate, explicit act.**

That act did not exist. So leaving a game meant your character stayed behind unclaimed and you had **no way to keep one** — a flow shipped without its own documented escape hatch.

A copy is a **new entity with no relationship to its source**: new id, `COPY OF <name>`, always `gameId: null`, owned by the copier. It does not track its origin, sync with it, or follow it into or out of a Game. That absence of a relationship is precisely what makes copying safe — and what separates it from the **fork** ADR-030 dropped in #710. A fork "records its origin", and a retained link between two records of one character is the part that rots.

**Where it appears:** every row in the Game roster, including a crewmate's and an unclaimed pre-gen. It is derived from what you may already read — membership grants the frozen crew view of every row, so copying what is on your screen escalates nothing. No confirm dialog: copying destroys nothing, so a modal would be friction guarding an undo-by-delete.

**Crawlers are excluded**, and not arbitrarily: `crawlers.gameId` is **non-nullable** in the Convex schema, so a shelved crawler has no server row it could be. That is the same constraint that makes `claimLocal` park a claimed crawler on a placeholder Game rather than shelving it.

**On "unclaimed".** The request said a copy should land unclaimed. Read as `ownerId: null` that is row 4 — the invalid one — and `entities.create` already refuses it ("A shelf has no crew to pick anything up — shelved builds are yours"). Unclaimed is a thing a character can be *inside a Game*, waiting for somebody to take it; a shelf is already somebody's. So a copy lands row 3: `gameId: null`, owner = copier.

## 2. `release` was telling players the opposite of that table

Its refusal on a shelved entity read:

> An entity on a shelf is already unclaimed

A shelved build is `gameId: null, ownerId: set` — **on the owner's shelf**, not unclaimed. The guard itself was correct (releasing it would set `ownerId: null` alongside `gameId: null`, which is the invalid row, so refusing is right) — only the sentence was wrong. It matters more now that #704 made `NotAuthorized` extend `ConvexError`, so this string is *shown* to the player rather than redacted.

Rewritten, and the existing test strengthened to assert the invariant and that the message no longer says "unclaimed", rather than asserting the old wording.

## Testing

- `check:all` green (exit 0).
- 9 new unit tests on `copyForShelf` — the ones that matter are what a copy does **not** keep: no `id` (a copy carrying its id is a duplicate `appId` by hand — the exact condition that took the play session down), no `gameId`, and no legacy `workspaceId`, which `containerOf` still reads as a fallback and could resolve a copy back into the Game it was copied out of.
- 3 new `GameRoster` tests; 2 rewritten in `permissions.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zyFsCRwKhBrZNGdh9BHkM
