### PR TITLE
feat(itun): a mech's drones are granted, live, and tied to their chassis

### DIFF
--- a/apps/itun/src/components/mech/MechWizard.tsx
+++ b/apps/itun/src/components/mech/MechWizard.tsx
@@ -34,6 +34,7 @@ import type { MechWizardFormState } from '../../lib/wizard/mechFormState'
 import {
   EMPTY_MECH_FORM_STATE,
   mechFormToCreateInput,
+  mechFormToPartners,
   mechFormToUpdatePatch,
 } from '../../lib/wizard/mechFormState'
 import {
@@ -42,6 +43,7 @@ import {
   useWizardDraftSync,
   wizardDraftKey,
 } from '../../lib/wizard/wizardDraft'
+import { WIZARD_TXN } from '../../stores/surfaceProvenance'
 import { useWizardFlow } from '../wizard/useWizardFlow'
 import { CraftItemsStep } from './CraftItemsStep'
 import { InstallStep } from './InstallStep'
@@ -218,6 +220,17 @@ export function MechWizard({
     schema: MechSchema,
     toCreateInput: mechFormToCreateInput,
     toUpdatePatch: mechFormToUpdatePatch,
+    // Drones follow the chassis that grants them: change the chassis or the
+    // pattern and the roster changes with it — a drone the new chassis does not
+    // grant is dropped, one it does is added, and a drone that survives keeps
+    // its structure, energy, heat, name and cargo while its loadout is re-cut
+    // from the new pattern (exactly as the mech's own loadout already is).
+    // Runs here rather than in the patch because that live state has to be read
+    // before it can be preserved, and `before` is where it lives.
+    afterUpdate: async (store, id, before) => {
+      const partners = mechFormToPartners(form, before?.partners)
+      await store.update('mech', id, { partners }, WIZARD_TXN)
+    },
     failureMessage: 'Failed to save mech. Please retry.',
     onComplete,
   })

--- a/apps/itun/src/components/pilot/PilotWizard.tsx
+++ b/apps/itun/src/components/pilot/PilotWizard.tsx
@@ -34,6 +34,7 @@ import type { PilotWizardFormState } from '../../lib/wizard/pilotFormState'
 import {
   EMPTY_PILOT_FORM_STATE,
   pilotFormToCreateInput,
+  pilotFormToPartners,
   pilotFormToUpdatePatch,
 } from '../../lib/wizard/pilotFormState'
 import {
@@ -42,6 +43,7 @@ import {
   useWizardDraftSync,
   wizardDraftKey,
 } from '../../lib/wizard/wizardDraft'
+import { WIZARD_TXN } from '../../stores/surfaceProvenance'
 import { pilotInventoryCapacity, pilotInventoryUsed } from '../sheet/pilotInventory'
 import { useWizardFlow } from '../wizard/useWizardFlow'
 import { ReviewStep } from './ReviewStep'
@@ -231,6 +233,15 @@ export function PilotWizard({
     schema: PilotSchema,
     toCreateInput: pilotFormToCreateInput,
     toUpdatePatch: pilotFormToUpdatePatch,
+    // A partner cannot outlive its grant: dropping the Survey Drone equipment
+    // drops the drone, and adding it back grants a fresh one. Runs here rather
+    // than in the patch because a partner holds live-play state (structure,
+    // energy, heat, cargo) that reconciliation has to preserve, and that means
+    // reading the stored partners — which `before` carries.
+    afterUpdate: async (store, id, before) => {
+      const partners = pilotFormToPartners(form, before?.partners)
+      await store.update('pilot', id, { partners }, WIZARD_TXN)
+    },
     failureMessage: 'Failed to save pilot. Please retry.',
     onComplete,
   })

--- a/apps/itun/src/components/sheet/MechSheet.tsx
+++ b/apps/itun/src/components/sheet/MechSheet.tsx
@@ -456,13 +456,6 @@ export function MechSheet({
                 fielded={(mech.partners ?? []).filter((p) => p.hostRef === partner.hostRef).length}
                 readOnly={readOnly}
                 store={store}
-                onRemove={
-                  readOnly
-                    ? undefined
-                    : () => {
-                        actions.removePartner(partner.id)
-                      }
-                }
               />
             ))}
           </div>

--- a/apps/itun/src/components/sheet/PartnerCard.tsx
+++ b/apps/itun/src/components/sheet/PartnerCard.tsx
@@ -76,7 +76,6 @@ type PartnerCardProps = {
   /** How many of this same stat block the host fields, for the "2 of 2" note. */
   fielded?: number
   readOnly?: boolean
-  onRemove?: () => void
   store?: typeof useEntityStore
 }
 
@@ -87,7 +86,6 @@ export function PartnerCard({
   hostAbilityRefs = [],
   fielded = 1,
   readOnly = false,
-  onRemove,
   store = useEntityStore,
 }: PartnerCardProps) {
   const { partner, hostKind, host } = found
@@ -187,15 +185,11 @@ export function PartnerCard({
   if (fielded > 1 || fielded > cap) {
     controls.push({ key: 'cap', badge: `${fielded} of ${cap}` })
   }
-  if (editable && onRemove) {
-    controls.push({
-      key: 'remove',
-      label: 'Remove',
-      ariaLabel: `Remove ${partnerDisplayName(partner)}`,
-      onClick: onRemove,
-      variant: 'danger',
-    })
-  }
+  // NO remove control, deliberately. A partner cannot outlive its grant, and it
+  // cannot be dropped independently of one either: nothing would ever grant it
+  // back, so a removed drone would be gone for good. Unequip the granting
+  // equipment (pilot) or change the chassis/pattern (mech) — see
+  // `lib/rules/partnerGrants.ts`.
 
   const conditionsFor = (kind: 'system' | 'module') =>
     (kind === 'system' ? partner.systemConditions : partner.moduleConditions) ?? {}

--- a/apps/itun/src/components/sheet/PilotSheet.tsx
+++ b/apps/itun/src/components/sheet/PilotSheet.tsx
@@ -437,13 +437,6 @@ export function PilotSheet({
                 fielded={model.fieldedByRef[partner.hostRef] ?? 1}
                 readOnly={readOnly}
                 store={store}
-                onRemove={
-                  readOnly
-                    ? undefined
-                    : () => {
-                        actions.removePartner(partner.id)
-                      }
-                }
               />
             ))}
           </div>

--- a/apps/itun/src/components/sheet/__tests__/MechSheet-partners.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/MechSheet-partners.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * MechSheet — the Partners region, i.e. the drones a chassis ability fields.
+ *
+ * This region existed before anything could populate it: nothing in the app
+ * created a `PartnerInstance`, so a Little Sestra was built without its Sestra
+ * Drone and the whole block was unreachable. These tests render it from the
+ * seeds `mechPartnerSeeds` now produces, so they fail if the grant path breaks
+ * OR if the card stops rendering a drone as a live entity.
+ *
+ * What "live entity" has to mean here, and why each assertion is present:
+ *   - its own structure/energy/heat, editable on the card (not the mech's);
+ *   - its installed systems and modules, integrated + pattern-fitted;
+ *   - no standalone remove control — a partner cannot be dropped independently
+ *     of the chassis that grants it (see lib/rules/partnerGrants.ts).
+ *
+ * Conventions: toBeTruthy() not toBeInTheDocument(), dep-injected store.
+ */
+
+import { describe, expect, mock, test } from 'bun:test'
+import { render, screen, within } from '@testing-library/react'
+import { mechPartnerSeeds, syncPartners } from '../../../lib/rules/partnerGrants'
+import type { Mech } from '../../../lib/schemas/mech'
+import { mechFixture } from '../../__tests__/fixtures'
+import { makeEntityStoreMock } from '../../__tests__/mockEntityStore'
+import { must } from '../../__tests__/must'
+import { MechSheet } from '../MechSheet'
+
+/** A mech built the way the wizard builds one, drones and all. */
+function seededMech(chassisRef: string, patternName: string, overrides: Partial<Mech> = {}): Mech {
+  const partners = syncPartners(undefined, mechPartnerSeeds(chassisRef, patternName), {
+    exact: true,
+  })
+  return mechFixture({
+    id: 'mech-partners-1',
+    name: 'Custos',
+    chassisRef,
+    patternName,
+    ...(partners !== undefined ? { partners } : {}),
+    ...overrides,
+  })
+}
+
+function makeStore(mech: Mech) {
+  return makeEntityStoreMock({
+    mechs: [mech],
+    hydrated: { pilots: false, mechs: true, crawlers: false, softLinks: false },
+    hydrate: mock(async () => {}),
+    list: mock(() => [mech]),
+    get: mock((type: string, id: string) => (type === 'mech' && id === mech.id ? mech : null)),
+    create: mock(async () => mech),
+    update: mock(async () => mech),
+    delete: mock(async () => {}),
+  })
+}
+
+/** The Partners section slab, which must exist for any of this to mean anything. */
+function partnersRegion(): HTMLElement {
+  const heading = screen.getByText(/^Partners$/i)
+  return must(heading.closest('section') ?? heading.parentElement?.parentElement) as HTMLElement
+}
+
+describe('MechSheet — Partners', () => {
+  test('a Little Sestra fields its Sestra Drone as a live entity', () => {
+    const mech = seededMech('little-sestra', 'Surveyor')
+    expect(mech.partners).toHaveLength(1)
+    render(<MechSheet mech={mech} store={makeStore(mech)} />)
+
+    const region = partnersRegion()
+    // getAllByText: a card spells its name in more than one place (title plus
+    // the control labels that reference it), so uniqueness is not the claim —
+    // presence is.
+    expect(within(region).getAllByText(/Sestra Drone/i).length).toBeGreaterThan(0)
+    // Its own loadout: the integrated system AND the pattern's fitted picks,
+    // rendered inside the drone rather than among the mech's systems.
+    expect(within(region).getAllByText(/Hover Locomotion System/i).length).toBeGreaterThan(0)
+    expect(within(region).getAllByText(/Long Barrelled Green Laser/i).length).toBeGreaterThan(0)
+    expect(within(region).getAllByText(/Survey Scanner/i).length).toBeGreaterThan(0)
+  })
+
+  test('the drone carries its OWN structure, not the mech chassis stats', () => {
+    const mech = seededMech('little-sestra', 'Surveyor')
+    render(<MechSheet mech={mech} store={makeStore(mech)} />)
+
+    // Sestra Drone: SP 7 / EP 8 / Heat 6 — none of which are the Little
+    // Sestra's own numbers. A gauge showing the mech's would mean the card is
+    // reading the wrong stat block.
+    const region = partnersRegion()
+    expect(region.textContent).toMatch(/7/)
+    expect(region.textContent).toMatch(/8/)
+  })
+
+  test('Big Brother fields FOUR drones, each under its own instance name', () => {
+    const mech = seededMech('big-brother', 'DronTek', { name: 'Panopticon' })
+    expect(mech.partners).toHaveLength(4)
+    render(<MechSheet mech={mech} store={makeStore(mech)} />)
+
+    const region = partnersRegion()
+    for (const name of [
+      'Shield Drone',
+      'Anti-Missile Drone',
+      'Fire Support Drone',
+      'Minelayer Drone',
+    ]) {
+      expect(within(region).getAllByText(new RegExp(name, 'i')).length).toBeGreaterThan(0)
+    }
+  })
+
+  test('four fielded drones read as "4 of 4", not over-cap', () => {
+    // partnerCap knew only Mecha Packmaster, so every one of these would have
+    // read "4 of 1" the moment seeding started working.
+    const mech = seededMech('big-brother', 'DronTek', { name: 'Panopticon' })
+    render(<MechSheet mech={mech} store={makeStore(mech)} />)
+    expect(within(partnersRegion()).getAllByText(/4 of 4/i).length).toBe(4)
+  })
+
+  test('offers no standalone remove — a drone dies with the chassis that grants it', () => {
+    const mech = seededMech('little-sestra', 'Surveyor')
+    render(<MechSheet mech={mech} store={makeStore(mech)} />)
+    expect(within(partnersRegion()).queryByRole('button', { name: /remove sestra drone/i })).toBe(
+      null
+    )
+  })
+
+  test('a chassis that grants no drone renders no Partners region at all', () => {
+    const mech = seededMech('bad-penny', 'Hauler')
+    expect(mech.partners).toBeUndefined()
+    render(<MechSheet mech={mech} store={makeStore(mech)} />)
+    expect(screen.queryByText(/^Partners$/i)).toBe(null)
+  })
+})

--- a/apps/itun/src/components/sheet/__tests__/MechSheet-partners.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/MechSheet-partners.test.tsx
@@ -28,7 +28,7 @@ import { MechSheet } from '../MechSheet'
 /** A mech built the way the wizard builds one, drones and all. */
 function seededMech(chassisRef: string, patternName: string, overrides: Partial<Mech> = {}): Mech {
   const partners = syncPartners(undefined, mechPartnerSeeds(chassisRef, patternName), {
-    exact: true,
+    reseedLoadout: true,
   })
   return mechFixture({
     id: 'mech-partners-1',

--- a/apps/itun/src/components/sheet/__tests__/pilotSheetActions-partnerGrants.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/pilotSheetActions-partnerGrants.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * The pilot live sheet's equipment toggle IS the partner's lifecycle.
+ *
+ * A partner cannot outlive its grant, and no card offers to remove one on its
+ * own — so unequipping the granting item is the ONLY way a pilot's drone goes
+ * away, and equipping it is the only way one arrives. That makes this three-line
+ * wiring the single point where a pilot partner is born or dies, which is why it
+ * is pinned here rather than left to the reconciliation unit tests.
+ *
+ * The write must be ONE patch. Equipment and partners landing as two writes
+ * would leave a window where the pilot has the drone but not the equipment that
+ * justifies it (or worse, the reverse, which reads as a silently lost drone).
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { act, cleanup, renderHook } from '@testing-library/react'
+import type { Pilot } from '../../../lib/schemas/pilot'
+import { pilotFixture } from '../../__tests__/fixtures'
+import { makeEntityStoreMock } from '../../__tests__/mockEntityStore'
+import { must } from '../../__tests__/must'
+import { usePilotSheetActions } from '../pilotSheetActions'
+import type { SheetStoreState } from '../sheetViewProps'
+
+afterEach(() => {
+  cleanup()
+})
+
+type Captured = { patch: Record<string, unknown> }
+
+function setup(pilot: Pilot) {
+  const captured: Captured[] = []
+  const storeState = {
+    ...makeEntityStoreMock({ pilots: [pilot] }).getState(),
+    get: (type: string, id: string) => (type === 'pilot' && id === pilot.id ? pilot : null),
+    update: async (_type: string, _id: string, patch: Record<string, unknown>) => {
+      captured.push({ patch })
+      return pilot
+    },
+  } as unknown as SheetStoreState
+
+  const { result } = renderHook(() =>
+    usePilotSheetActions({
+      pilot,
+      store: makeEntityStoreMock({ pilots: [pilot] }) as never,
+      storeState,
+    })
+  )
+  return { captured, result }
+}
+
+describe('toggleEquipment — the grant is the lifecycle', () => {
+  test('equipping a Survey Drone grants a live partner in the SAME write', async () => {
+    const pilot = pilotFixture({ id: 'pilot-1', equipment: [] })
+    const { captured, result } = setup(pilot)
+
+    await act(async () => {
+      result.current.toggleEquipment('survey-drone')
+    })
+
+    expect(captured).toHaveLength(1)
+    const { patch } = must(captured[0])
+    expect(patch.equipment).toEqual(['survey-drone'])
+    const partners = patch.partners as { hostRef: string; hostSchema: string }[]
+    expect(partners).toHaveLength(1)
+    expect(must(partners[0]).hostRef).toBe('survey-drone')
+    expect(must(partners[0]).hostSchema).toBe('equipment')
+  })
+
+  test('unequipping it takes the drone with it', async () => {
+    const pilot = pilotFixture({
+      id: 'pilot-1',
+      equipment: ['survey-drone'],
+      partners: [
+        {
+          id: 'p-custos',
+          hostRef: 'survey-drone',
+          hostSchema: 'equipment',
+          name: 'Custos',
+          systems: [],
+          modules: [],
+          conditions: [],
+        },
+      ],
+    })
+    const { captured, result } = setup(pilot)
+
+    await act(async () => {
+      result.current.toggleEquipment('survey-drone')
+    })
+
+    const { patch } = must(captured[0])
+    expect(patch.equipment).toEqual([])
+    expect(patch.partners).toEqual([])
+  })
+
+  test('ordinary gear never touches partners at all', async () => {
+    const pilot = pilotFixture({ id: 'pilot-1', equipment: [] })
+    const { captured, result } = setup(pilot)
+
+    await act(async () => {
+      result.current.toggleEquipment('first-aid-kit')
+    })
+
+    const { patch } = must(captured[0])
+    expect(patch.equipment).toEqual(['first-aid-kit'])
+    // Absent, not `[]` — an unrelated toggle must not rewrite the field and
+    // wipe a drone granted by something else.
+    expect(patch).not.toHaveProperty('partners')
+  })
+
+  test('toggling ordinary gear leaves an existing partner alone', async () => {
+    const pilot = pilotFixture({
+      id: 'pilot-1',
+      equipment: ['survey-drone'],
+      partners: [
+        {
+          id: 'p-custos',
+          hostRef: 'survey-drone',
+          hostSchema: 'equipment',
+          systems: [],
+          modules: [],
+          conditions: [],
+        },
+      ],
+    })
+    const { captured, result } = setup(pilot)
+
+    await act(async () => {
+      result.current.toggleEquipment('rifle')
+    })
+
+    expect(must(captured[0]).patch).not.toHaveProperty('partners')
+  })
+
+  test('the actions surface offers no partner removal of its own', () => {
+    const pilot = pilotFixture({ id: 'pilot-1', equipment: [] })
+    const { result } = setup(pilot)
+    expect(result.current).not.toHaveProperty('removePartner')
+  })
+})

--- a/apps/itun/src/components/sheet/mechSheetActions.ts
+++ b/apps/itun/src/components/sheet/mechSheetActions.ts
@@ -57,7 +57,6 @@ export type MechSheetActions = {
   repairItem: (kind: ItemKind, slug: string, deductTl: number | null, cost: number) => Promise<void>
   saveQuirk: (next: string) => void
   saveAppearance: (next: string) => void
-  removePartner: (partnerId: string) => void
   /** Advisory soft-warning state for the confirm dialog. */
   warnings: SoftWarning[]
   warningSubtitle: string | null
@@ -231,25 +230,6 @@ export function useMechSheetActions({
     write({ appearance: next.trim() || undefined, description: undefined })
   }
 
-  /** Drop one chassis-ability-granted partner instance. */
-  function removePartner(partnerId: string) {
-    const partners = mech.partners ?? []
-    // `store.getState()` rather than the render-time snapshot: preserved from
-    // the pre-split JSX handler, where this was the only write reaching for the
-    // live state directly. On a Zustand store the two resolve to the same
-    // `update` function, so this is a spelling difference, not a behavioural one.
-    runWrite(() =>
-      store.getState().update(
-        'mech',
-        mech.id,
-        {
-          partners: partners.filter((p) => p.id !== partnerId),
-        },
-        LIVE_SHEET_MANUAL
-      )
-    )
-  }
-
   return {
     patchMech,
     overrideMechMax,
@@ -260,7 +240,6 @@ export function useMechSheetActions({
     repairItem,
     saveQuirk,
     saveAppearance,
-    removePartner,
     warnings: softWarnings.warnings,
     warningSubtitle,
     cancelBuildEdit: () => {

--- a/apps/itun/src/components/sheet/pilotSheetActions.ts
+++ b/apps/itun/src/components/sheet/pilotSheetActions.ts
@@ -171,12 +171,21 @@ export function usePilotSheetActions({
   // the Advanced/Legendary prerequisites surface in a confirm dialog and the
   // user may always proceed.
   function toggleAbility(abilityId: string) {
-    const abilities = freshPilot().abilities
-    const removing = abilities.includes(abilityId)
+    const current = freshPilot()
+    const removing = current.abilities.includes(abilityId)
     const name = resolveAbility(abilityId)?.name ?? abilityId
+    const abilities = removing
+      ? current.abilities.filter((a) => a !== abilityId)
+      : [...current.abilities, abilityId]
     saveBuildEdit(
       {
-        abilities: removing ? abilities.filter((a) => a !== abilityId) : [...abilities, abilityId],
+        abilities,
+        // Abilities are the second grant-lifecycle edge, because they carry the
+        // COUNT: Mecha Packmaster's `grants` lists Mecha Companion twice, so
+        // taking it fields a second companion and dropping it retires one. The
+        // equipment slug does not move either way — it is a set, and it was
+        // already there.
+        partners: syncPartners(current.partners, pilotPartnerSeeds(current.equipment, abilities)),
       },
       `${removing ? 'Remove' : 'Add'} ${name}`
     )
@@ -199,7 +208,12 @@ export function usePilotSheetActions({
     write({
       equipment,
       ...(isPartnerEquipment(equipmentId)
-        ? { partners: syncPartners(current.partners, pilotPartnerSeeds(equipment)) }
+        ? {
+            partners: syncPartners(
+              current.partners,
+              pilotPartnerSeeds(equipment, current.abilities)
+            ),
+          }
         : {}),
     })
   }

--- a/apps/itun/src/components/sheet/pilotSheetActions.ts
+++ b/apps/itun/src/components/sheet/pilotSheetActions.ts
@@ -30,6 +30,7 @@
 import { useState } from 'react'
 import { enrichPilotSnapshot } from 'salvageunion-reference/rules'
 import { pilotMaxAP } from '../../lib/rules/derivedStats'
+import { isPartnerEquipment, pilotPartnerSeeds, syncPartners } from '../../lib/rules/partnerGrants'
 import type { SoftWarning } from '../../lib/rules/types'
 import type { ItemCondition } from '../../lib/schemas/mech'
 import type { GenericInventoryEntry, Pilot } from '../../lib/schemas/pilot'
@@ -68,7 +69,6 @@ export type PilotSheetActions = {
   handleSpendAP: (cost: number) => Promise<void>
   handleAbilityUsedChange: (slug: string, next: boolean) => Promise<void>
   handleGenericInventoryChange: (next: GenericInventoryEntry[]) => Promise<void>
-  removePartner: (partnerId: string) => void
   /** Advisory soft-warning state for the confirm dialog. */
   warnings: SoftWarning[]
   warningSubtitle: string | null
@@ -182,12 +182,25 @@ export function usePilotSheetActions({
     )
   }
 
+  /**
+   * Equip / unequip, granting or revoking a partner in the SAME write.
+   *
+   * Auto-Turret, Survey Drone and Mecha Companion are not inventory: each is a
+   * statted partner that renders in place of its equipment card (ADR-028). The
+   * equipment slug IS the grant, so unequipping it takes the partner with it and
+   * re-equipping grants a fresh one — that is the only lifecycle a partner has,
+   * which is why no card offers a bare "remove" of its own.
+   */
   function toggleEquipment(equipmentId: string) {
-    const equipment = freshPilot().equipment
+    const current = freshPilot()
+    const equipment = current.equipment.includes(equipmentId)
+      ? current.equipment.filter((e) => e !== equipmentId)
+      : [...current.equipment, equipmentId]
     write({
-      equipment: equipment.includes(equipmentId)
-        ? equipment.filter((e) => e !== equipmentId)
-        : [...equipment, equipmentId],
+      equipment,
+      ...(isPartnerEquipment(equipmentId)
+        ? { partners: syncPartners(current.partners, pilotPartnerSeeds(equipment)) }
+        : {}),
     })
   }
 
@@ -231,12 +244,6 @@ export function usePilotSheetActions({
     await writeAwait({ genericInventory: next })
   }
 
-  /** Drop one ability-granted partner instance. */
-  function removePartner(partnerId: string) {
-    const partners = pilot.partners ?? []
-    write({ partners: partners.filter((p) => p.id !== partnerId) })
-  }
-
   return {
     patchPilot,
     overridePilotMax,
@@ -249,7 +256,6 @@ export function usePilotSheetActions({
     handleSpendAP,
     handleAbilityUsedChange,
     handleGenericInventoryChange,
-    removePartner,
     warnings: softWarnings.warnings,
     warningSubtitle,
     cancelBuildEdit: () => {

--- a/apps/itun/src/lib/db/__tests__/partner-equipment-backfill.test.ts
+++ b/apps/itun/src/lib/db/__tests__/partner-equipment-backfill.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for the v15 record rewrite (partner-equipment backfill).
+ *
+ * This migration exists to prevent data loss, so its failure mode is the thing
+ * to pin. Once partners reconcile against their grant, a pilot partner whose
+ * `hostRef` is missing from `pilot.equipment` answers to no grant and is reaped
+ * on the owner's next edit. v12 minted exactly that shape — it converted
+ * companion-mech rows without ever adding the granting slug — so without this
+ * backfill, Eldridge Coast's Custos / Incitatus / PR-1 / Rek Jet would vanish
+ * the first time their pilot was edited.
+ *
+ * The rule is append-only and one-directional: restore the grant the earlier
+ * migration dropped, and never delete a partner to make the data consistent.
+ */
+import { describe, expect, test } from 'bun:test'
+import { missingGrantSlugs } from '../migrations/15-partner-equipment-backfill'
+
+const partner = (hostRef: string, over: Record<string, unknown> = {}) => ({
+  id: `p-${hostRef}`,
+  hostRef,
+  hostSchema: 'equipment',
+  systems: [],
+  modules: [],
+  conditions: [],
+  ...over,
+})
+
+describe('missingGrantSlugs (v15)', () => {
+  test('reports the slug a v12-shaped partner needs', () => {
+    // Exactly the Custos shape: a partner, and an equipment array that never
+    // heard of it.
+    expect(missingGrantSlugs({ equipment: [], partners: [partner('survey-drone')] })).toEqual([
+      'survey-drone',
+    ])
+  })
+
+  test('reports nothing when the grant is already held (the v11 shape)', () => {
+    expect(
+      missingGrantSlugs({ equipment: ['survey-drone'], partners: [partner('survey-drone')] })
+    ).toEqual([])
+  })
+
+  test('deduplicates — two companions need the slug added once, not twice', () => {
+    expect(
+      missingGrantSlugs({
+        equipment: [],
+        partners: [
+          partner('mecha-companion', { id: 'a' }),
+          partner('mecha-companion', { id: 'b' }),
+        ],
+      })
+    ).toEqual(['mecha-companion'])
+  })
+
+  test('handles a pilot with several partners and a partially-correct array', () => {
+    const missing = missingGrantSlugs({
+      equipment: ['first-aid-kit', 'auto-turret'],
+      partners: [partner('auto-turret'), partner('survey-drone'), partner('mecha-companion')],
+    })
+    expect(missing.sort()).toEqual(['mecha-companion', 'survey-drone'])
+  })
+
+  test('a pilot with no partners is untouched', () => {
+    expect(missingGrantSlugs({ equipment: ['rifle'], partners: [] })).toEqual([])
+    expect(missingGrantSlugs({ equipment: ['rifle'] })).toEqual([])
+  })
+
+  test('ignores a drones-hosted partner — its grant is a chassis ability', () => {
+    // Never appears on a pilot, but the check is explicit rather than assumed:
+    // adding 'sestra-drone' to a pilot's EQUIPMENT would invent an inventory
+    // item that does not exist.
+    expect(
+      missingGrantSlugs({
+        equipment: [],
+        partners: [partner('sestra-drone', { hostSchema: 'drones' })],
+      })
+    ).toEqual([])
+  })
+
+  test('ignores a hostRef that is not a known partner-granting slug', () => {
+    // Refuses to guess. An unrecognised ref is a repair job, not an equipment
+    // entry to invent.
+    expect(missingGrantSlugs({ equipment: [], partners: [partner('not-a-real-slug')] })).toEqual([])
+  })
+
+  test('survives malformed rows rather than throwing mid-versionchange', () => {
+    expect(
+      missingGrantSlugs({
+        equipment: ['ok', 42],
+        partners: [null, 'nonsense', { hostSchema: 'equipment' }, partner('survey-drone')],
+      })
+    ).toEqual(['survey-drone'])
+  })
+})

--- a/apps/itun/src/lib/db/index.ts
+++ b/apps/itun/src/lib/db/index.ts
@@ -51,7 +51,7 @@ import { STORE_NAMES } from './stores'
  * the Shelf. Workspaces are retired, but v10 still has to run — v13 reads what
  * it writes.)
  */
-export const DB_VERSION = 14
+export const DB_VERSION = 15
 
 const DB_NAME = 'itun-v1'
 

--- a/apps/itun/src/lib/db/migrations/15-partner-equipment-backfill.ts
+++ b/apps/itun/src/lib/db/migrations/15-partner-equipment-backfill.ts
@@ -1,0 +1,101 @@
+/**
+ * v15 — a pilot partner's granting equipment slug must be IN `pilot.equipment`.
+ *
+ * ── The invariant, and why it only now matters ───────────────────────────────
+ *
+ * A partner is a projection of its grant: it is created when the grant appears
+ * and reaped when the grant goes (`lib/rules/partnerGrants.ts`). For a pilot the
+ * grant is membership in `pilot.equipment` — so a partner whose `hostRef` is
+ * absent from that array answers to no grant at all, and reconciliation reaps
+ * it on the owner's next edit.
+ *
+ * Until reconciliation existed, nothing read the relationship and the breach was
+ * invisible. It is not invisible now, and it is not hypothetical:
+ *
+ *   - **v11** (`equipmentLoadouts` → partners) is clean. Its own header says so:
+ *     "The equipment slug stays in `pilot.equipment[]`. The partner is the
+ *     loadout, not the grant." A loadout only existed because the item was
+ *     equipped.
+ *   - **v12** (companion-mechs → partners) is not. It minted partners from mech
+ *     rows whose `chassisRef` held an equipment slug, and never touched
+ *     `pilot.equipment` — a companion wearing a mech costume is precisely the
+ *     case where the player did NOT also equip the item. Eldridge Coast shipped
+ *     four such rows (Custos, Incitatus, PR-1, Rek Jet).
+ *
+ * So this backfills the missing slug rather than deleting the partner. The
+ * partner is the evidence: a `PartnerInstance` exists only because something
+ * once granted it, and the honest repair is to restore the grant the earlier
+ * migration dropped, not to destroy what it created.
+ *
+ * ── What it deliberately does NOT do ─────────────────────────────────────────
+ *
+ * It never removes a slug, never touches mech-hosted partners (their grant is a
+ * chassis ability, not an equipment array), and never mints a partner. It only
+ * ever appends, so running it against an already-consistent database is a no-op.
+ *
+ * One honest cost: granting equipment occupies an inventory slot, so a healed
+ * pilot's inventory usage goes up by one per backfilled partner and may show as
+ * over capacity. That is advisory, never blocking (ADR-007/021), and it is the
+ * true reading — a v11-migrated pilot with the same companion has always paid
+ * that slot. Under-reporting it was the bug, not the fix.
+ *
+ * IMPORTANT: versionchange semantics — only IndexedDB operations on `tx` may be
+ * awaited here. Reference data is NOT loadable, which is why the granting slugs
+ * are hardcoded (identically to v12) rather than derived from `equipment.json`.
+ */
+
+import { isRecord } from '../../isRecord'
+import { STORE_NAMES } from '../stores'
+import type { UpgradeTransaction } from './index'
+
+/**
+ * The `equipment` records carrying a mech-shaped stat block — the only slugs a
+ * pilot-hosted partner can legitimately answer to. Hardcoded for the same reason
+ * v12 hardcodes them: a migration runs inside a versionchange transaction and
+ * may only await IndexedDB, so it cannot ask the ORM.
+ */
+const PARTNER_EQUIPMENT_SLUGS = new Set(['auto-turret', 'survey-drone', 'mecha-companion'])
+
+/**
+ * The slugs missing from `equipment` that this pilot's partners require.
+ * Pure, exposed for tests. Returns [] when nothing is missing.
+ */
+export function missingGrantSlugs(pilot: Record<string, unknown>): string[] {
+  const partners = Array.isArray(pilot.partners) ? pilot.partners : []
+  const equipment = Array.isArray(pilot.equipment)
+    ? pilot.equipment.filter((e): e is string => typeof e === 'string')
+    : []
+  const held = new Set(equipment)
+
+  const missing = new Set<string>()
+  for (const partner of partners) {
+    if (!isRecord(partner)) continue
+    // Mech-hosted partners never appear on a pilot, but `hostSchema` is the
+    // disambiguator everywhere else in this codebase and skipping the check
+    // here would be the one place that assumed instead of asking.
+    if (partner.hostSchema !== 'equipment') continue
+    const ref = partner.hostRef
+    if (typeof ref !== 'string') continue
+    if (!PARTNER_EQUIPMENT_SLUGS.has(ref)) continue
+    if (held.has(ref)) continue
+    missing.add(ref)
+  }
+  return [...missing]
+}
+
+export async function migrate(tx: UpgradeTransaction): Promise<void> {
+  const { db } = tx
+  if (!db.objectStoreNames.contains(STORE_NAMES.pilots)) return
+
+  const pilotStore = tx.objectStore(STORE_NAMES.pilots)
+  const pilots = (await pilotStore.getAll()) as Record<string, unknown>[]
+
+  for (const pilot of pilots) {
+    const missing = missingGrantSlugs(pilot)
+    if (missing.length === 0) continue
+    const equipment = Array.isArray(pilot.equipment)
+      ? pilot.equipment.filter((e): e is string => typeof e === 'string')
+      : []
+    await pilotStore.put({ ...pilot, equipment: [...equipment, ...missing] })
+  }
+}

--- a/apps/itun/src/lib/db/migrations/index.ts
+++ b/apps/itun/src/lib/db/migrations/index.ts
@@ -27,6 +27,7 @@ import { migrate as migrate11EquipmentLoadoutsToPartners } from './11-equipment-
 import { migrate as migrate12CompanionMechsToPartners } from './12-companion-mechs-to-partners'
 import { migrate as migrate13WorkspaceToGameOrShelf } from './13-workspace-to-game-or-shelf'
 import { migrate as migrate14StarterSetSeedRef } from './14-starter-set-seed-ref'
+import { migrate as migrate15PartnerEquipmentBackfill } from './15-partner-equipment-backfill'
 
 /** The untyped versionchange transaction handed to the idb upgrade callback. */
 export type UpgradeTransaction = IDBPTransaction<
@@ -96,6 +97,11 @@ const MIGRATIONS: ReadonlyArray<Migration> = [
     toVersion: 14,
     description: 'starter-set-seed-ref',
     migrate: (tx) => migrate14StarterSetSeedRef(tx),
+  },
+  {
+    toVersion: 15,
+    description: 'partner-equipment-backfill',
+    migrate: (tx) => migrate15PartnerEquipmentBackfill(tx),
   },
   // NOTE: the built-in Starter Set is NOT seeded by a migration. It is spawned
   // on-demand into each browser the first time the user opens the Starter Set

--- a/apps/itun/src/lib/rules/__tests__/partnerGrants.test.ts
+++ b/apps/itun/src/lib/rules/__tests__/partnerGrants.test.ts
@@ -1,0 +1,218 @@
+/**
+ * A partner is a projection of its grant, and every interesting case here is one
+ * where that projection is NOT one-to-one:
+ *
+ *   - Big Brother's DronTek pattern fields FOUR drones over ONE stat block, each
+ *     under its own instance name. The bug this replaced read `drones[0]`.
+ *   - A drone's integrated hardware lives on the stat block while its fitted
+ *     loadout lives on the pattern, so the live drone's systems are the union of
+ *     two different sources.
+ *   - A Custom build has no pattern at all, but the CHASSIS ABILITY still grants
+ *     the drone — a Little Sestra without a pattern is still a Little Sestra.
+ *
+ * The reconciliation tests pin the property that matters most in play: a drone
+ * that survives an edit keeps its damage. Re-seeding a mech's drones on a
+ * pattern change is correct; re-seeding their structure is data loss.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import type { PartnerInstance } from '../../schemas/partner'
+import {
+  isPartnerEquipment,
+  mechPartnerSeeds,
+  pilotPartnerSeeds,
+  syncPartners,
+} from '../partnerGrants'
+
+/** Deterministic ids so a reconciliation result can be asserted whole. */
+const mintSequential = () => {
+  let n = 0
+  return () => `new-${++n}`
+}
+
+describe('mechPartnerSeeds — the chassis ability grants, the pattern kits', () => {
+  test('Little Sestra / Surveyor: one drone, integrated system PLUS pattern loadout', () => {
+    const seeds = mechPartnerSeeds('little-sestra', 'Surveyor')
+    expect(seeds).toHaveLength(1)
+    const [drone] = seeds
+    expect(drone?.hostRef).toBe('sestra-drone')
+    expect(drone?.hostSchema).toBe('drones')
+    // The config names the stat block directly, so no instance name.
+    expect(drone?.name).toBeUndefined()
+    // Integrated first, then the pattern's three picks.
+    expect(drone?.systems).toEqual([
+      'hover-locomotion-system',
+      'long-barrelled-green-laser',
+      'high-gain-antenna',
+      'cargo-pod',
+    ])
+    expect(drone?.modules).toEqual(['survey-scanner', 'm315-motion-scanner'])
+  })
+
+  test('a Custom build still gets the drone the chassis ability grants, bare', () => {
+    const seeds = mechPartnerSeeds('little-sestra', '')
+    expect(seeds).toHaveLength(1)
+    expect(seeds[0]?.hostRef).toBe('sestra-drone')
+    // Integrated hardware only — nothing was fitted.
+    expect(seeds[0]?.systems).toEqual(['hover-locomotion-system'])
+    expect(seeds[0]?.modules).toEqual([])
+  })
+
+  test('Big Brother / DronTek: FOUR drones, one stat block, four instance names', () => {
+    const seeds = mechPartnerSeeds('big-brother', 'DronTek')
+    expect(seeds).toHaveLength(4)
+    expect(seeds.map((s) => s.name)).toEqual([
+      'Shield Drone',
+      'Anti-Missile Drone',
+      'Fire Support Drone',
+      'Minelayer Drone',
+    ])
+    // All four ride the same stat block — that is what `ref` is for.
+    expect(new Set(seeds.map((s) => s.hostRef))).toEqual(new Set(['big-brother-drone']))
+    expect(seeds[0]?.systems).toEqual([
+      'hover-locomotion-system',
+      'refractive-shield-projector',
+      'electro-magnetic-shield-projector',
+    ])
+    expect(seeds[0]?.modules).toEqual(['energy-cell'])
+  })
+
+  test('a chassis with no drone-granting ability grants nothing', () => {
+    expect(mechPartnerSeeds('bad-penny', 'Hauler')).toEqual([])
+  })
+
+  test('an unresolvable chassis returns [] rather than throwing', () => {
+    expect(mechPartnerSeeds('no-such-chassis', 'Whatever')).toEqual([])
+  })
+})
+
+describe('pilotPartnerSeeds — equipment carrying a stat block is a partner', () => {
+  test('the three partner equipment records are recognised', () => {
+    expect(isPartnerEquipment('auto-turret')).toBe(true)
+    expect(isPartnerEquipment('survey-drone')).toBe(true)
+    expect(isPartnerEquipment('mecha-companion')).toBe(true)
+  })
+
+  test('ordinary gear is not', () => {
+    expect(isPartnerEquipment('cutting-torch')).toBe(false)
+    expect(isPartnerEquipment('no-such-equipment')).toBe(false)
+  })
+
+  test('seeds one bare partner per granting slug, ignoring ordinary gear', () => {
+    const seeds = pilotPartnerSeeds(['cutting-torch', 'survey-drone', 'auto-turret'])
+    expect(seeds.map((s) => s.hostRef)).toEqual(['survey-drone', 'auto-turret'])
+    expect(seeds.every((s) => s.hostSchema === 'equipment')).toBe(true)
+    // Pilot partners arrive empty; a mech's arrives wearing its pattern.
+    expect(seeds.every((s) => s.systems.length === 0 && s.modules.length === 0)).toBe(true)
+  })
+})
+
+describe('syncPartners — the grant is the lifecycle', () => {
+  const existing = (over: Partial<PartnerInstance>): PartnerInstance => ({
+    id: 'p1',
+    hostRef: 'sestra-drone',
+    hostSchema: 'drones',
+    systems: [],
+    modules: [],
+    conditions: [],
+    ...over,
+  })
+
+  test('a host with no grant and no partners stays absent, not an empty array', () => {
+    expect(syncPartners(undefined, [])).toBeUndefined()
+  })
+
+  test('losing the grant clears the field to [] so the write actually lands', () => {
+    expect(syncPartners([existing({})], [])).toEqual([])
+  })
+
+  test('a new grant mints an instance carrying its seed loadout', () => {
+    const [drone] = syncPartners(undefined, mechPartnerSeeds('little-sestra', 'Surveyor'), {
+      exact: true,
+      mintId: mintSequential(),
+    }) as PartnerInstance[]
+    expect(drone?.id).toBe('new-1')
+    expect(drone?.hostRef).toBe('sestra-drone')
+    expect(drone?.systems).toContain('long-barrelled-green-laser')
+    expect(drone?.conditions).toEqual([])
+  })
+
+  test('EXACT: a surviving drone keeps its live state but re-cuts its loadout', () => {
+    const damaged = existing({
+      id: 'keep-me',
+      name: 'Custos',
+      currentSP: 2,
+      currentHeat: 3,
+      conditions: ['jammed'],
+      systems: ['hover-locomotion-system', 'long-barrelled-green-laser'],
+    })
+    const [drone] = syncPartners([damaged], mechPartnerSeeds('little-sestra', 'Scrounger'), {
+      exact: true,
+    }) as PartnerInstance[]
+
+    // Identity and damage survive the pattern change...
+    expect(drone?.id).toBe('keep-me')
+    expect(drone?.name).toBe('Custos')
+    expect(drone?.currentSP).toBe(2)
+    expect(drone?.currentHeat).toBe(3)
+    expect(drone?.conditions).toEqual(['jammed'])
+    // ...but the loadout is the NEW pattern's, exactly as the mech's own is.
+    expect(drone?.systems).toEqual([
+      'hover-locomotion-system',
+      'red-laser',
+      'fabrication-arm',
+      'high-gain-antenna',
+    ])
+  })
+
+  test('EXACT: named instances match by name, so Big Brother keeps four distinct drones', () => {
+    const seeds = mechPartnerSeeds('big-brother', 'DronTek')
+    const first = syncPartners(undefined, seeds, {
+      exact: true,
+      mintId: mintSequential(),
+    }) as PartnerInstance[]
+    const damaged = first.map((p) => (p.name === 'Minelayer Drone' ? { ...p, currentSP: 1 } : p))
+
+    const second = syncPartners(damaged, seeds, { exact: true }) as PartnerInstance[]
+    expect(second.map((p) => p.id)).toEqual(first.map((p) => p.id))
+    expect(second.find((p) => p.name === 'Minelayer Drone')?.currentSP).toBe(1)
+    // The other three were never touched.
+    expect(second.filter((p) => p.currentSP !== undefined)).toHaveLength(1)
+  })
+
+  test('EXACT: a chassis swap drops the drone the new chassis does not grant', () => {
+    const result = syncPartners([existing({})], mechPartnerSeeds('bad-penny', 'Hauler'), {
+      exact: true,
+    })
+    expect(result).toEqual([])
+  })
+
+  test('ADDITIVE: a surplus partner of a still-granted stat block survives', () => {
+    // Mecha Packmaster fields two Mecha Companions off ONE equipment slug, so
+    // the seed count can legitimately understate the roster.
+    const two = [
+      existing({ id: 'a', hostRef: 'mecha-companion', hostSchema: 'equipment' }),
+      existing({ id: 'b', hostRef: 'mecha-companion', hostSchema: 'equipment' }),
+    ]
+    const result = syncPartners(two, pilotPartnerSeeds(['mecha-companion'])) as PartnerInstance[]
+    expect(result.map((p) => p.id).sort()).toEqual(['a', 'b'])
+  })
+
+  test('ADDITIVE: unequipping the granting item still takes every instance with it', () => {
+    const two = [
+      existing({ id: 'a', hostRef: 'mecha-companion', hostSchema: 'equipment' }),
+      existing({ id: 'b', hostRef: 'mecha-companion', hostSchema: 'equipment' }),
+    ]
+    expect(syncPartners(two, pilotPartnerSeeds([]))).toEqual([])
+  })
+
+  test('ADDITIVE: an existing partner never has its loadout rewritten', () => {
+    const kitted = existing({
+      hostRef: 'survey-drone',
+      hostSchema: 'equipment',
+      systems: ['red-laser'],
+    })
+    const [drone] = syncPartners([kitted], pilotPartnerSeeds(['survey-drone'])) as PartnerInstance[]
+    expect(drone?.systems).toEqual(['red-laser'])
+  })
+})

--- a/apps/itun/src/lib/rules/__tests__/partnerGrants.test.ts
+++ b/apps/itun/src/lib/rules/__tests__/partnerGrants.test.ts
@@ -20,6 +20,7 @@ import type { PartnerInstance } from '../../schemas/partner'
 import {
   isPartnerEquipment,
   mechPartnerSeeds,
+  partnerGrantCount,
   pilotPartnerSeeds,
   syncPartners,
 } from '../partnerGrants'
@@ -105,6 +106,44 @@ describe('pilotPartnerSeeds — equipment carrying a stat block is a partner', (
     // Pilot partners arrive empty; a mech's arrives wearing its pattern.
     expect(seeds.every((s) => s.systems.length === 0 && s.modules.length === 0)).toBe(true)
   })
+
+  test('Mecha Packmaster turns one equipment entry into TWO seeds', () => {
+    const seeds = pilotPartnerSeeds(['mecha-companion'], ['mecha-companion', 'mecha-packmaster'])
+    expect(seeds).toHaveLength(2)
+    expect(seeds.every((s) => s.hostRef === 'mecha-companion')).toBe(true)
+  })
+})
+
+describe('partnerGrantCount — MAX across abilities, never the sum', () => {
+  test('Packmaster grants Mecha Companion twice, and that is the count', () => {
+    expect(partnerGrantCount('mecha-companion', ['mecha-packmaster'])).toBe(2)
+  })
+
+  test('holding BOTH Ranger abilities is still two, not three', () => {
+    // The trap. Mecha Companion (Ranger L1) grants one and Packmaster grants
+    // two; a Legendary Ranger normally holds both, so summing would field a
+    // third companion that Packmaster's own text denies — "gain a SECOND Mecha
+    // Companion in addition to your first". The two entries are the TOTAL.
+    expect(partnerGrantCount('mecha-companion', ['mecha-companion', 'mecha-packmaster'])).toBe(2)
+  })
+
+  test('the L1 ability alone grants one', () => {
+    expect(partnerGrantCount('mecha-companion', ['mecha-companion'])).toBe(1)
+  })
+
+  test('floors at one — equipped without the granting ability is still a partner', () => {
+    expect(partnerGrantCount('mecha-companion', [])).toBe(1)
+    expect(partnerGrantCount('survey-drone', ['mecha-packmaster'])).toBe(1)
+  })
+
+  test('Packmaster does not raise anything but Mecha Companion', () => {
+    expect(partnerGrantCount('auto-turret', ['mecha-packmaster'])).toBe(1)
+  })
+
+  test('an unresolvable slug or ability degrades to one rather than throwing', () => {
+    expect(partnerGrantCount('no-such-equipment', ['mecha-packmaster'])).toBe(1)
+    expect(partnerGrantCount('mecha-companion', ['no-such-ability'])).toBe(1)
+  })
 })
 
 describe('syncPartners — the grant is the lifecycle', () => {
@@ -128,7 +167,7 @@ describe('syncPartners — the grant is the lifecycle', () => {
 
   test('a new grant mints an instance carrying its seed loadout', () => {
     const [drone] = syncPartners(undefined, mechPartnerSeeds('little-sestra', 'Surveyor'), {
-      exact: true,
+      reseedLoadout: true,
       mintId: mintSequential(),
     }) as PartnerInstance[]
     expect(drone?.id).toBe('new-1')
@@ -137,7 +176,7 @@ describe('syncPartners — the grant is the lifecycle', () => {
     expect(drone?.conditions).toEqual([])
   })
 
-  test('EXACT: a surviving drone keeps its live state but re-cuts its loadout', () => {
+  test('MECH: a surviving drone keeps its live state but re-cuts its loadout', () => {
     const damaged = existing({
       id: 'keep-me',
       name: 'Custos',
@@ -147,7 +186,7 @@ describe('syncPartners — the grant is the lifecycle', () => {
       systems: ['hover-locomotion-system', 'long-barrelled-green-laser'],
     })
     const [drone] = syncPartners([damaged], mechPartnerSeeds('little-sestra', 'Scrounger'), {
-      exact: true,
+      reseedLoadout: true,
     }) as PartnerInstance[]
 
     // Identity and damage survive the pattern change...
@@ -165,48 +204,71 @@ describe('syncPartners — the grant is the lifecycle', () => {
     ])
   })
 
-  test('EXACT: named instances match by name, so Big Brother keeps four distinct drones', () => {
+  test('MECH: named instances match by name, so Big Brother keeps four distinct drones', () => {
     const seeds = mechPartnerSeeds('big-brother', 'DronTek')
     const first = syncPartners(undefined, seeds, {
-      exact: true,
+      reseedLoadout: true,
       mintId: mintSequential(),
     }) as PartnerInstance[]
     const damaged = first.map((p) => (p.name === 'Minelayer Drone' ? { ...p, currentSP: 1 } : p))
 
-    const second = syncPartners(damaged, seeds, { exact: true }) as PartnerInstance[]
+    const second = syncPartners(damaged, seeds, { reseedLoadout: true }) as PartnerInstance[]
     expect(second.map((p) => p.id)).toEqual(first.map((p) => p.id))
     expect(second.find((p) => p.name === 'Minelayer Drone')?.currentSP).toBe(1)
     // The other three were never touched.
     expect(second.filter((p) => p.currentSP !== undefined)).toHaveLength(1)
   })
 
-  test('EXACT: a chassis swap drops the drone the new chassis does not grant', () => {
+  test('MECH: a chassis swap drops the drone the new chassis does not grant', () => {
     const result = syncPartners([existing({})], mechPartnerSeeds('bad-penny', 'Hauler'), {
-      exact: true,
+      reseedLoadout: true,
     })
     expect(result).toEqual([])
   })
 
-  test('ADDITIVE: a surplus partner of a still-granted stat block survives', () => {
-    // Mecha Packmaster fields two Mecha Companions off ONE equipment slug, so
-    // the seed count can legitimately understate the roster.
-    const two = [
-      existing({ id: 'a', hostRef: 'mecha-companion', hostSchema: 'equipment' }),
-      existing({ id: 'b', hostRef: 'mecha-companion', hostSchema: 'equipment' }),
-    ]
-    const result = syncPartners(two, pilotPartnerSeeds(['mecha-companion'])) as PartnerInstance[]
+  const twoCompanions = () => [
+    existing({ id: 'a', hostRef: 'mecha-companion', hostSchema: 'equipment' }),
+    existing({ id: 'b', hostRef: 'mecha-companion', hostSchema: 'equipment' }),
+  ]
+
+  test('PILOT: Mecha Packmaster keeps BOTH companions off one equipment slug', () => {
+    const result = syncPartners(
+      twoCompanions(),
+      pilotPartnerSeeds(['mecha-companion'], ['mecha-companion', 'mecha-packmaster'])
+    ) as PartnerInstance[]
     expect(result.map((p) => p.id).sort()).toEqual(['a', 'b'])
   })
 
-  test('ADDITIVE: unequipping the granting item still takes every instance with it', () => {
-    const two = [
-      existing({ id: 'a', hostRef: 'mecha-companion', hostSchema: 'equipment' }),
-      existing({ id: 'b', hostRef: 'mecha-companion', hostSchema: 'equipment' }),
-    ]
-    expect(syncPartners(two, pilotPartnerSeeds([]))).toEqual([])
+  test('PILOT: dropping Packmaster retires the second companion, keeping the first', () => {
+    const result = syncPartners(
+      twoCompanions(),
+      pilotPartnerSeeds(['mecha-companion'], ['mecha-companion'])
+    ) as PartnerInstance[]
+    expect(result).toHaveLength(1)
+    // The FIRST survives — reaping takes from the tail, so the companion the
+    // pilot has had longest is the one that stays.
+    expect(result[0]?.id).toBe('a')
   })
 
-  test('ADDITIVE: an existing partner never has its loadout rewritten', () => {
+  test('PILOT: taking Packmaster mints the second, leaving the first untouched', () => {
+    const one = [
+      existing({ id: 'a', hostRef: 'mecha-companion', hostSchema: 'equipment', currentSP: 4 }),
+    ]
+    const result = syncPartners(
+      one,
+      pilotPartnerSeeds(['mecha-companion'], ['mecha-companion', 'mecha-packmaster']),
+      { mintId: mintSequential() }
+    ) as PartnerInstance[]
+    expect(result.map((p) => p.id)).toEqual(['a', 'new-1'])
+    expect(result[0]?.currentSP).toBe(4)
+    expect(result[1]?.currentSP).toBeUndefined()
+  })
+
+  test('PILOT: unequipping the granting item takes BOTH instances with it', () => {
+    expect(syncPartners(twoCompanions(), pilotPartnerSeeds([], ['mecha-packmaster']))).toEqual([])
+  })
+
+  test('PILOT: an existing partner never has its loadout rewritten', () => {
     const kitted = existing({
       hostRef: 'survey-drone',
       hostSchema: 'equipment',

--- a/apps/itun/src/lib/rules/partnerGrants.ts
+++ b/apps/itun/src/lib/rules/partnerGrants.ts
@@ -42,7 +42,7 @@
  */
 
 import { nameToSlug, normalizePatternName, SalvageUnionReference } from 'salvageunion-reference'
-import { matchesRef, resolveChassisRef } from 'salvageunion-reference/rules'
+import { resolveChassisRef, resolveRef } from 'salvageunion-reference/rules'
 import type { PartnerInstance } from '../schemas/partner'
 
 /**
@@ -164,11 +164,13 @@ export function mechPartnerSeeds(chassisRef: string, patternName?: string): Part
  * Requires `equipment` preloaded.
  */
 function resolvePartnerEquipment(slug: string) {
-  return SalvageUnionReference.Equipment.find(
-    (entry) =>
-      matchesRef(entry, slug) &&
-      typeof (entry as { systemSlots?: unknown }).systemSlots === 'number'
-  )
+  // `resolveRef`, not `Equipment.find((e) => matchesRef(e, slug))` — the latter
+  // is a full-schema scan wearing a predicate's clothes, and this runs per
+  // partner card per render via `partnerCap`.
+  const record = resolveRef(SalvageUnionReference.Equipment, slug)
+  return record !== null && typeof (record as { systemSlots?: unknown }).systemSlots === 'number'
+    ? record
+    : undefined
 }
 
 /** Whether equipping this slug grants a partner. */
@@ -203,7 +205,7 @@ export function partnerGrantCount(hostRef: string, abilityRefs: readonly string[
 
   let most = 0
   for (const ref of abilityRefs) {
-    const ability = SalvageUnionReference.Abilities.find((entry) => matchesRef(entry, ref))
+    const ability = resolveRef(SalvageUnionReference.Abilities, ref)
     if (!ability) continue
     const granted = (ability.grants ?? []).filter(
       (grant) => grant.schema === 'equipment' && nameToSlug(grant.name) === wanted

--- a/apps/itun/src/lib/rules/partnerGrants.ts
+++ b/apps/itun/src/lib/rules/partnerGrants.ts
@@ -24,19 +24,21 @@
  * "remove this partner" control, because a partner that could be removed on its
  * own would immediately be unrecoverable — nothing would ever grant it back.
  *
- * ── The two hosts reconcile differently, and the asymmetry is the rules ──────
+ * ── Both rosters are exact; only the SOURCE of the count differs ─────────────
  *
- * A MECH's roster is EXACT. The pattern says how many drones are fielded and
- * what each carries (Big Brother's DronTek fields four), so a pattern change
- * rewrites the roster and each drone's loadout, exactly as the mech wizard
- * already rewrites the mech's own systems/modules from the pattern.
+ * A MECH's count comes from its pattern, which says how many drones are fielded
+ * and what each carries (Big Brother's DronTek fields four).
  *
- * A PILOT's roster is ADDITIVE. `pilot.equipment` records WHICH stat blocks are
- * granted but not how many: Mecha Packmaster (p. 69) raises the Mecha Companion
- * cap to two off a second ability while the equipment slug stays singular. So an
- * equipment slug that is gone takes its partners with it, and a slug that is
- * present gets at least one — but a surplus instance is left alone rather than
- * reaped, because this module cannot prove it was not legitimately fielded.
+ * A PILOT's count comes from their ABILITIES, while `pilot.equipment` is only
+ * the gate. It has to work that way: `pilot.equipment` is a set, so it could
+ * never express "two Mecha Companions", and Mecha Packmaster's `grants` already
+ * lists Mecha Companion twice. See `partnerGrantCount` — including why it takes
+ * the MAX across abilities rather than the sum.
+ *
+ * So one rule covers both: the seeds are the whole roster. What differs is
+ * whether a surviving instance's loadout is re-cut from its seed
+ * (`reseedLoadout`) — true for a mech, whose drones wear the pattern; false for
+ * a pilot, whose partners are kitted out in play.
  */
 
 import { nameToSlug, normalizePatternName, SalvageUnionReference } from 'salvageunion-reference'
@@ -152,38 +154,90 @@ export function mechPartnerSeeds(chassisRef: string, patternName?: string): Part
 // ─── Pilot-granted partners ──────────────────────────────────────────────────
 
 /**
- * Whether an equipment slug carries a mech-shaped stat block, i.e. whether
- * equipping it grants a partner. Derived from the data rather than hardcoded:
- * `systemSlots` is what separates Auto-Turret / Survey Drone / Mecha Companion
- * from every other piece of gear, and a fourth such record should light this up
- * without an edit here.
+ * The `equipment` record a slug resolves to, when that record carries a
+ * mech-shaped stat block — i.e. when equipping it grants a partner.
+ *
+ * Derived from the data rather than hardcoded: `systemSlots` is what separates
+ * Auto-Turret / Survey Drone / Mecha Companion from every other piece of gear,
+ * and a fourth such record should light this up without an edit here.
  *
  * Requires `equipment` preloaded.
  */
-export function isPartnerEquipment(slug: string): boolean {
-  return (
-    SalvageUnionReference.Equipment.find(
-      (entry) =>
-        matchesRef(entry, slug) &&
-        typeof (entry as { systemSlots?: unknown }).systemSlots === 'number'
-    ) !== undefined
+function resolvePartnerEquipment(slug: string) {
+  return SalvageUnionReference.Equipment.find(
+    (entry) =>
+      matchesRef(entry, slug) &&
+      typeof (entry as { systemSlots?: unknown }).systemSlots === 'number'
   )
 }
 
+/** Whether equipping this slug grants a partner. */
+export function isPartnerEquipment(slug: string): boolean {
+  return resolvePartnerEquipment(slug) !== undefined
+}
+
 /**
- * One seed per partner-granting equipment slug the pilot has equipped.
+ * How many of one partner a pilot's ABILITIES entitle them to.
  *
- * The equipment records carry no `systems`/`modules` of their own, so these
- * seeds are always bare — a pilot's partner starts empty and is kitted out in
- * play, unlike a mech's, which arrives wearing its pattern.
+ * The multiplicity is in the data and always was: Mecha Packmaster's `grants`
+ * lists Mecha Companion **twice**, and it is the only ability in the whole
+ * dataset that grants the same thing more than once. Nothing read it — `grants`
+ * fed the SRD's display layer and nothing else — so the second companion had no
+ * way to exist.
+ *
+ * MAX, NOT SUM, and the distinction is load-bearing. The Ranger tree's Level 1
+ * ability is `Mecha Companion` (one grant) and Packmaster is Legendary Ranger,
+ * so a pilot who has Packmaster normally holds both abilities. Summing would
+ * give three, contradicting Packmaster's own text — "Gain a second Mecha
+ * Companion in addition to your first" — and the two entries therefore encode
+ * the TOTAL a pilot ends up with, not an increment on top of the first ability.
+ *
+ * Floors at 1: a pilot may have equipped the item without the granting ability
+ * (the live sheet is a Free-Edit surface, ADR-021), and that is still one
+ * partner, not zero.
  */
-export function pilotPartnerSeeds(equipment: readonly string[]): PartnerSeed[] {
-  return equipment.filter(isPartnerEquipment).map((slug) => ({
-    hostRef: slug,
-    hostSchema: 'equipment' as const,
-    systems: [],
-    modules: [],
-  }))
+export function partnerGrantCount(hostRef: string, abilityRefs: readonly string[]): number {
+  const record = resolvePartnerEquipment(hostRef)
+  if (!record) return 1
+  const wanted = nameToSlug(record.name)
+
+  let most = 0
+  for (const ref of abilityRefs) {
+    const ability = SalvageUnionReference.Abilities.find((entry) => matchesRef(entry, ref))
+    if (!ability) continue
+    const granted = (ability.grants ?? []).filter(
+      (grant) => grant.schema === 'equipment' && nameToSlug(grant.name) === wanted
+    ).length
+    if (granted > most) most = granted
+  }
+  return Math.max(1, most)
+}
+
+/**
+ * One seed per partner a pilot's equipment grants — `partnerGrantCount` copies
+ * of each granting slug.
+ *
+ * Equipment membership is the GATE and abilities are the COUNT: unequipping the
+ * item takes every instance with it, while Mecha Packmaster turns the one
+ * equipment entry into two companions. `pilot.equipment` is a set (it is
+ * toggled), so it could never have carried the count itself.
+ *
+ * The equipment records have no `systems`/`modules` of their own, so these seeds
+ * are always bare — a pilot's partner starts empty and is kitted out in play,
+ * unlike a mech's, which arrives wearing its pattern.
+ */
+export function pilotPartnerSeeds(
+  equipment: readonly string[],
+  abilityRefs: readonly string[] = []
+): PartnerSeed[] {
+  return equipment.filter(isPartnerEquipment).flatMap((slug) =>
+    Array.from({ length: partnerGrantCount(slug, abilityRefs) }, () => ({
+      hostRef: slug,
+      hostSchema: 'equipment' as const,
+      systems: [],
+      modules: [],
+    }))
+  )
 }
 
 // ─── Reconciliation ──────────────────────────────────────────────────────────
@@ -211,14 +265,16 @@ function matchesSeed(partner: PartnerInstance, seed: PartnerSeed): boolean {
 
 export type SyncPartnersOptions = {
   /**
-   * EXACT (mech): the seed list is the whole roster — surplus instances of a
-   * granted stat block are dropped, and every kept instance has its loadout
-   * rewritten from its seed.
+   * Re-cut every surviving instance's `systems`/`modules` from its seed.
    *
-   * ADDITIVE (pilot, the default): a granted stat block keeps whatever
-   * instances it has, and loadouts are never touched.
+   * TRUE for a mech, whose drones wear the pattern — the wizard already
+   * rewrites the mech's own loadout on a pattern change, and a drone still
+   * carrying the previous pattern's guns would be the odd one out.
+   *
+   * FALSE for a pilot, whose partners have bare seeds and are kitted out in
+   * play. Re-seeding those would delete a loadout nothing can restore.
    */
-  exact?: boolean
+  reseedLoadout?: boolean
   /** Injectable for deterministic tests. */
   mintId?: () => string
 }
@@ -226,11 +282,22 @@ export type SyncPartnersOptions = {
 /**
  * Reconcile a host's `partners` against what it currently grants.
  *
+ * THE SEED LIST IS THE WHOLE ROSTER, for both hosts. A partner with no seed to
+ * answer to is dropped — that is what makes unequipping the Survey Drone take
+ * the drone with it, and dropping Mecha Packmaster take the second companion.
+ * This is only safe because the count is now derivable on both sides: a mech's
+ * from its pattern, a pilot's from `partnerGrantCount`.
+ *
+ * It also relies on a data invariant that was NOT true before this change: a
+ * pilot partner's `hostRef` must appear in `pilot.equipment`. The v12 migration
+ * minted partners from companion-mech rows without adding the granting slug, so
+ * those partners answered to no seed and would have been reaped on the owner's
+ * next edit. Migration v15 heals them; see
+ * `lib/db/migrations/15-partner-equipment-backfill.ts`.
+ *
  * Live state is never collateral damage: a matched instance keeps its id,
  * structure, energy, heat, conditions, name, appearance, A.I. personality and
- * cargo. In `exact` mode its `systems`/`modules` are re-seeded — the mech wizard
- * already rewrites the mech's own loadout from the pattern on every save, and a
- * drone that kept a previous pattern's guns would be the odd one out.
+ * cargo. Only `reseedLoadout` touches anything else.
  *
  * Returns `undefined` when the host has, and should have, no partners, so the
  * field stays absent rather than persisting an empty array.
@@ -240,7 +307,7 @@ export function syncPartners(
   seeds: readonly PartnerSeed[],
   options: SyncPartnersOptions = {}
 ): PartnerInstance[] | undefined {
-  const { exact = false, mintId = () => crypto.randomUUID() } = options
+  const { reseedLoadout = false, mintId = () => crypto.randomUUID() } = options
   const current = existing ?? []
 
   const unclaimed = [...current]
@@ -251,25 +318,22 @@ export function syncPartners(
     return claimed
   }
 
-  const next = seeds.map((seed) => {
-    const claimed = claim(seed)
-    if (!claimed) return newInstance(seed, mintId())
-    if (!exact) return claimed
+  // Two passes: every seed claims an existing instance BEFORE any seed mints a
+  // new one. A single pass would let an unnamed seed claim the instance a named
+  // seed needed, renaming a drone the player had already customised.
+  const claimed = seeds.map((seed) => ({ seed, instance: claim(seed) }))
+
+  const next = claimed.map(({ seed, instance }) => {
+    if (!instance) return newInstance(seed, mintId())
+    if (!reseedLoadout) return instance
     return {
-      ...claimed,
+      ...instance,
       // The seed owns the LOADOUT; the instance owns everything lived-in.
       systems: [...seed.systems],
       modules: [...seed.modules],
       ...(seed.name !== undefined ? { name: seed.name } : {}),
     }
   })
-
-  if (!exact) {
-    // Additive: anything left over survives if its grant is still present.
-    // Only an ungranted stat block is reaped.
-    const grantedRefs = new Set(seeds.map((seed) => seed.hostRef))
-    next.push(...unclaimed.filter((partner) => grantedRefs.has(partner.hostRef)))
-  }
 
   if (next.length === 0) return current.length === 0 ? undefined : []
   return next

--- a/apps/itun/src/lib/rules/partnerGrants.ts
+++ b/apps/itun/src/lib/rules/partnerGrants.ts
@@ -1,0 +1,276 @@
+/**
+ * partnerGrants — where a partner comes from, and when it goes away.
+ *
+ * A partner has no independent existence: it is granted, and it "cannot outlive
+ * the thing that grants it" (see `lib/schemas/partner.ts`). Until now that
+ * sentence was only a comment — nothing in the app ever CREATED a
+ * `PartnerInstance`, so the two grant paths both leaked:
+ *
+ *   - Building a Little Sestra silently dropped its Sestra Drone, and a Big
+ *     Brother on the DronTek pattern dropped all four of its drones. The mech
+ *     sheet's Partners region was live code that could never render.
+ *   - Equipping a pilot's Survey Drone / Auto-Turret / Mecha Companion produced
+ *     an inert equipment card with no structure, no energy and no loadout.
+ *
+ * This module is the missing half. It answers "what does this host's current
+ * configuration grant?" as a list of SEEDS, and reconciles that list against
+ * whatever instances the host already carries.
+ *
+ * ── The grant is the lifecycle ───────────────────────────────────────────────
+ *
+ * Removal is tied to the grant, never to the partner card: you drop a pilot's
+ * Survey Drone equipment and the drone goes with it; you change a mech's
+ * chassis and its drones change with it. There is deliberately no standalone
+ * "remove this partner" control, because a partner that could be removed on its
+ * own would immediately be unrecoverable — nothing would ever grant it back.
+ *
+ * ── The two hosts reconcile differently, and the asymmetry is the rules ──────
+ *
+ * A MECH's roster is EXACT. The pattern says how many drones are fielded and
+ * what each carries (Big Brother's DronTek fields four), so a pattern change
+ * rewrites the roster and each drone's loadout, exactly as the mech wizard
+ * already rewrites the mech's own systems/modules from the pattern.
+ *
+ * A PILOT's roster is ADDITIVE. `pilot.equipment` records WHICH stat blocks are
+ * granted but not how many: Mecha Packmaster (p. 69) raises the Mecha Companion
+ * cap to two off a second ability while the equipment slug stays singular. So an
+ * equipment slug that is gone takes its partners with it, and a slug that is
+ * present gets at least one — but a surplus instance is left alone rather than
+ * reaped, because this module cannot prove it was not legitimately fielded.
+ */
+
+import { nameToSlug, normalizePatternName, SalvageUnionReference } from 'salvageunion-reference'
+import { matchesRef, resolveChassisRef } from 'salvageunion-reference/rules'
+import type { PartnerInstance } from '../schemas/partner'
+
+/**
+ * An id-less partner: what a grant entitles the host to, before it becomes a
+ * live instance with structure, heat and per-item conditions.
+ */
+export type PartnerSeed = {
+  hostRef: string
+  hostSchema: PartnerInstance['hostSchema']
+  /** Set only when the pattern names the instance ("Shield Drone"). */
+  name?: string
+  systems: string[]
+  modules: string[]
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string'
+}
+
+function slugList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter(isString).map(nameToSlug) : []
+}
+
+// ─── Mech-granted drones ─────────────────────────────────────────────────────
+
+/**
+ * The drone stat blocks a chassis ability names. A chassis carries the GRANT
+ * (Little Sestra's "Sestra Drone Controller"); a pattern only kits it out.
+ */
+function grantedDroneNames(chassisRef: string): string[] {
+  const chassis = resolveChassisRef(chassisRef)
+  if (!chassis) return []
+  const abilities = SalvageUnionReference.resolveActions(chassis) ?? []
+  return abilities.map((ability) => ability.drone).filter(isString)
+}
+
+/**
+ * Build a seed from a drone record plus the pattern's fitted loadout.
+ *
+ * The record's OWN `systems` are integrated hardware — both player-facing drones
+ * carry a Hover Locomotion System that is part of the chassis, not a fitted
+ * choice — so they ride alongside the pattern's picks rather than being replaced
+ * by them. This is a deliberate divergence from the SRD pattern card, which
+ * renders `config.systems` alone: the reference card is describing the pattern,
+ * whereas a live drone has to account for every slot it is actually using.
+ */
+function seedFromDrone(
+  statBlockName: string,
+  fitted: { systems?: string[]; modules?: string[]; instanceName?: string }
+): PartnerSeed[] {
+  const record = SalvageUnionReference.getByNameIn('drones', statBlockName)
+  if (!record) return []
+
+  const fittedSystems = (fitted.systems ?? []).map(nameToSlug)
+  const fittedModules = (fitted.modules ?? []).map(nameToSlug)
+  // Guard against a pattern that re-lists integrated hardware: the same slug
+  // twice would read as two installs and double-count against the slot cap.
+  const integratedSystems = slugList(record.systems).filter((s) => !fittedSystems.includes(s))
+  const integratedModules = slugList(record.modules).filter((m) => !fittedModules.includes(m))
+
+  return [
+    {
+      hostRef: nameToSlug(record.name),
+      hostSchema: 'drones',
+      ...(fitted.instanceName !== undefined ? { name: fitted.instanceName } : {}),
+      systems: [...integratedSystems, ...fittedSystems],
+      modules: [...integratedModules, ...fittedModules],
+    },
+  ]
+}
+
+/**
+ * Every drone a mech's chassis + pattern fields.
+ *
+ * A pattern with `drones[]` is authoritative — one seed per config, which is
+ * what gives Big Brother's DronTek its four. Without one (a Custom build, or a
+ * pattern that fields none) the chassis ability still grants its drone bare:
+ * the ability is the grant, and "I built it custom" is not a reason to lose a
+ * drone the chassis comes with.
+ */
+export function mechPartnerSeeds(chassisRef: string, patternName?: string): PartnerSeed[] {
+  const droneNames = grantedDroneNames(chassisRef)
+  if (droneNames.length === 0) return []
+
+  const chassis = resolveChassisRef(chassisRef)
+  const pattern =
+    patternName && patternName.trim() !== ''
+      ? (chassis?.patterns ?? []).find(
+          (p) => normalizePatternName(p.name) === normalizePatternName(patternName)
+        )
+      : undefined
+
+  const configs = pattern?.drones ?? []
+  if (configs.length > 0) {
+    return configs.flatMap((config) =>
+      seedFromDrone(config.ref ?? config.name, {
+        systems: config.systems,
+        modules: config.modules,
+        // A `ref` means the config's name is an INSTANCE name riding over a
+        // shared stat block; without one the config already names the record.
+        ...(config.ref ? { instanceName: config.name } : {}),
+      })
+    )
+  }
+
+  return droneNames.flatMap((name) => seedFromDrone(name, {}))
+}
+
+// ─── Pilot-granted partners ──────────────────────────────────────────────────
+
+/**
+ * Whether an equipment slug carries a mech-shaped stat block, i.e. whether
+ * equipping it grants a partner. Derived from the data rather than hardcoded:
+ * `systemSlots` is what separates Auto-Turret / Survey Drone / Mecha Companion
+ * from every other piece of gear, and a fourth such record should light this up
+ * without an edit here.
+ *
+ * Requires `equipment` preloaded.
+ */
+export function isPartnerEquipment(slug: string): boolean {
+  return (
+    SalvageUnionReference.Equipment.find(
+      (entry) =>
+        matchesRef(entry, slug) &&
+        typeof (entry as { systemSlots?: unknown }).systemSlots === 'number'
+    ) !== undefined
+  )
+}
+
+/**
+ * One seed per partner-granting equipment slug the pilot has equipped.
+ *
+ * The equipment records carry no `systems`/`modules` of their own, so these
+ * seeds are always bare — a pilot's partner starts empty and is kitted out in
+ * play, unlike a mech's, which arrives wearing its pattern.
+ */
+export function pilotPartnerSeeds(equipment: readonly string[]): PartnerSeed[] {
+  return equipment.filter(isPartnerEquipment).map((slug) => ({
+    hostRef: slug,
+    hostSchema: 'equipment' as const,
+    systems: [],
+    modules: [],
+  }))
+}
+
+// ─── Reconciliation ──────────────────────────────────────────────────────────
+
+function newInstance(seed: PartnerSeed, id: string): PartnerInstance {
+  return {
+    id,
+    hostRef: seed.hostRef,
+    hostSchema: seed.hostSchema,
+    ...(seed.name !== undefined ? { name: seed.name } : {}),
+    systems: [...seed.systems],
+    modules: [...seed.modules],
+    conditions: [],
+  }
+}
+
+/** Whether an existing instance answers to a seed. */
+function matchesSeed(partner: PartnerInstance, seed: PartnerSeed): boolean {
+  if (partner.hostRef !== seed.hostRef || partner.hostSchema !== seed.hostSchema) return false
+  // An unnamed seed matches any instance of its stat block — a player who
+  // renamed their Sestra Drone "Custos" still owns the drone the chassis grants.
+  // A NAMED seed must match its name, so Big Brother's four stay distinct.
+  return seed.name === undefined || partner.name === seed.name
+}
+
+export type SyncPartnersOptions = {
+  /**
+   * EXACT (mech): the seed list is the whole roster — surplus instances of a
+   * granted stat block are dropped, and every kept instance has its loadout
+   * rewritten from its seed.
+   *
+   * ADDITIVE (pilot, the default): a granted stat block keeps whatever
+   * instances it has, and loadouts are never touched.
+   */
+  exact?: boolean
+  /** Injectable for deterministic tests. */
+  mintId?: () => string
+}
+
+/**
+ * Reconcile a host's `partners` against what it currently grants.
+ *
+ * Live state is never collateral damage: a matched instance keeps its id,
+ * structure, energy, heat, conditions, name, appearance, A.I. personality and
+ * cargo. In `exact` mode its `systems`/`modules` are re-seeded — the mech wizard
+ * already rewrites the mech's own loadout from the pattern on every save, and a
+ * drone that kept a previous pattern's guns would be the odd one out.
+ *
+ * Returns `undefined` when the host has, and should have, no partners, so the
+ * field stays absent rather than persisting an empty array.
+ */
+export function syncPartners(
+  existing: readonly PartnerInstance[] | undefined,
+  seeds: readonly PartnerSeed[],
+  options: SyncPartnersOptions = {}
+): PartnerInstance[] | undefined {
+  const { exact = false, mintId = () => crypto.randomUUID() } = options
+  const current = existing ?? []
+
+  const unclaimed = [...current]
+  const claim = (seed: PartnerSeed): PartnerInstance | undefined => {
+    const index = unclaimed.findIndex((partner) => matchesSeed(partner, seed))
+    if (index === -1) return undefined
+    const [claimed] = unclaimed.splice(index, 1)
+    return claimed
+  }
+
+  const next = seeds.map((seed) => {
+    const claimed = claim(seed)
+    if (!claimed) return newInstance(seed, mintId())
+    if (!exact) return claimed
+    return {
+      ...claimed,
+      // The seed owns the LOADOUT; the instance owns everything lived-in.
+      systems: [...seed.systems],
+      modules: [...seed.modules],
+      ...(seed.name !== undefined ? { name: seed.name } : {}),
+    }
+  })
+
+  if (!exact) {
+    // Additive: anything left over survives if its grant is still present.
+    // Only an ungranted stat block is reaped.
+    const grantedRefs = new Set(seeds.map((seed) => seed.hostRef))
+    next.push(...unclaimed.filter((partner) => grantedRefs.has(partner.hostRef)))
+  }
+
+  if (next.length === 0) return current.length === 0 ? undefined : []
+  return next
+}

--- a/apps/itun/src/lib/rules/partnerStats.ts
+++ b/apps/itun/src/lib/rules/partnerStats.ts
@@ -33,6 +33,7 @@ import { SalvageUnionReference } from 'salvageunion-reference'
 import type { StatBreakdown } from 'salvageunion-reference/rules'
 import { matchesRef } from 'salvageunion-reference/rules'
 import type { PartnerInstance } from '../schemas/partner'
+import { partnerGrantCount } from './partnerGrants'
 
 /** Mecha Companion's floor — "equal to your Union Crawler (Tech 3 minimum)". */
 const MECHA_COMPANION_MIN_TECH_LEVEL = 3
@@ -189,22 +190,24 @@ export function partnerDerivedStatsParts(
  * and the Little Sestra's Sestra Drone). Two things raise it, and neither is
  * legible from the stat block:
  *
- *   - A SECOND ABILITY. Mecha Packmaster (p. 69) "allows you to have up to two
- *     Mecha Companions active in the field at any one time", so the cap is a
- *     property of the host's ability set and cannot be read off `hostRef` alone.
+ *   - A PILOT ABILITY THAT GRANTS MORE THAN ONE. This used to string-match
+ *     `mecha-packmaster`, which was both a hardcode and a duplicate: the fact
+ *     already lives in the data, since Packmaster's `grants` lists Mecha
+ *     Companion twice. Reading it means the cap and the number actually seeded
+ *     can no longer drift apart, and a future ability that grants two needs no
+ *     edit here. See `partnerGrantCount` for why it is a MAX, not a sum.
  *   - THE STAT BLOCK'S OWN CONTROLLER. The Big Brother "can control up to 4 Big
  *     Brother Drones", and its DronTek pattern fields exactly that many — so
  *     without this, every one of those four would read "4 of 1" the moment the
- *     mech was built.
+ *     mech was built. This one stays hardcoded: it is a chassis ability's prose,
+ *     not a countable grant, and deriving it from "the most any pattern fields"
+ *     would report 1 for a Custom build that is still allowed four.
  *
  * Advisory only. The Live Sheet is a Free-Edit surface (ADR-021) and the
  * automation boundary (ADR-007) keeps rules like this displayed rather than
  * enforced, so callers render `used/max` and never block.
  */
 export function partnerCap(hostRef: string, hostAbilityRefs: readonly string[]): number {
-  if (hostRef === MECHA_COMPANION_REF && hostAbilityRefs.some((a) => a === 'mecha-packmaster')) {
-    return 2
-  }
   if (hostRef === BIG_BROTHER_DRONE_REF) return BIG_BROTHER_DRONE_CAP
-  return 1
+  return partnerGrantCount(hostRef, hostAbilityRefs)
 }

--- a/apps/itun/src/lib/rules/partnerStats.ts
+++ b/apps/itun/src/lib/rules/partnerStats.ts
@@ -40,6 +40,12 @@ const MECHA_COMPANION_MIN_TECH_LEVEL = 3
 /** Slug of the one partner carrying a tech-level floor. */
 const MECHA_COMPANION_REF = 'mecha-companion'
 
+/** Slug of the one partner whose own controller fields more than one. */
+const BIG_BROTHER_DRONE_REF = 'big-brother-drone'
+
+/** "The Big Brother can control up to 4 Big Brother Drones" (False Flag p. 62). */
+const BIG_BROTHER_DRONE_CAP = 4
+
 /** The stat keys a partner scales, all present on `bonusPerTechLevel`. */
 const SCALED_STATS = [
   'structurePoints',
@@ -178,13 +184,18 @@ export function partnerDerivedStatsParts(
 /**
  * How many of a given partner a host may field at once.
  *
- * Every partner is capped at one by its own text ("You may only ever have one
- * Auto-Turret at a time", and the same for Survey Drone, Mecha Companion, and
- * the Little Sestra's Sestra Drone). The cap is raised by a SECOND ability
- * rather than by the partner's own record — Mecha Packmaster (p. 69): "allows
- * you to have up to two Mecha Companions active in the field at any one time" —
- * so it is a property of the host's ability set, not a constant on the stat
- * block, and cannot be read off `hostRef` alone.
+ * Almost every partner is capped at one by its own text ("You may only ever have
+ * one Auto-Turret at a time", and the same for Survey Drone, Mecha Companion,
+ * and the Little Sestra's Sestra Drone). Two things raise it, and neither is
+ * legible from the stat block:
+ *
+ *   - A SECOND ABILITY. Mecha Packmaster (p. 69) "allows you to have up to two
+ *     Mecha Companions active in the field at any one time", so the cap is a
+ *     property of the host's ability set and cannot be read off `hostRef` alone.
+ *   - THE STAT BLOCK'S OWN CONTROLLER. The Big Brother "can control up to 4 Big
+ *     Brother Drones", and its DronTek pattern fields exactly that many — so
+ *     without this, every one of those four would read "4 of 1" the moment the
+ *     mech was built.
  *
  * Advisory only. The Live Sheet is a Free-Edit surface (ADR-021) and the
  * automation boundary (ADR-007) keeps rules like this displayed rather than
@@ -194,5 +205,6 @@ export function partnerCap(hostRef: string, hostAbilityRefs: readonly string[]):
   if (hostRef === MECHA_COMPANION_REF && hostAbilityRefs.some((a) => a === 'mecha-packmaster')) {
     return 2
   }
+  if (hostRef === BIG_BROTHER_DRONE_REF) return BIG_BROTHER_DRONE_CAP
   return 1
 }

--- a/apps/itun/src/lib/wizard/__tests__/mechFormState.test.ts
+++ b/apps/itun/src/lib/wizard/__tests__/mechFormState.test.ts
@@ -131,4 +131,51 @@ describe('mechFormToCreateInput', () => {
     expect(input.currentHeat).toBe(0)
     expect(input.conditions).toEqual([])
   })
+
+  it('grants no partners to a chassis whose ability does not field a drone', () => {
+    const input = mechFormToCreateInput({
+      ...EMPTY_MECH_FORM_STATE,
+      name: 'Iron Fist',
+      chassisName: 'Mule',
+    })
+    // Absent, not an empty array — the field only exists when it means something.
+    expect(input).not.toHaveProperty('partners')
+  })
+
+  it('seeds the drone a chassis ability grants, kitted by the chosen pattern', () => {
+    // The regression this closes: building a Little Sestra used to silently drop
+    // its Sestra Drone, because nothing in the app ever created a partner.
+    const input = mechFormToCreateInput({
+      ...EMPTY_MECH_FORM_STATE,
+      name: 'Custos',
+      chassisName: 'little-sestra',
+      patternName: 'Surveyor',
+    })
+    expect(input.partners).toHaveLength(1)
+    const [drone] = input.partners ?? []
+    expect(drone?.hostRef).toBe('sestra-drone')
+    expect(drone?.hostSchema).toBe('drones')
+    expect(drone?.id).toBeTruthy()
+    expect(drone?.systems).toContain('long-barrelled-green-laser')
+    // Integrated hardware rides along with the pattern's picks.
+    expect(drone?.systems).toContain('hover-locomotion-system')
+  })
+
+  it('seeds all FOUR of Big Brother/DronTek, each under its own instance name', () => {
+    const input = mechFormToCreateInput({
+      ...EMPTY_MECH_FORM_STATE,
+      name: 'Panopticon',
+      chassisName: 'big-brother',
+      patternName: 'DronTek',
+    })
+    expect(input.partners).toHaveLength(4)
+    expect((input.partners ?? []).map((p) => p.name)).toEqual([
+      'Shield Drone',
+      'Anti-Missile Drone',
+      'Fire Support Drone',
+      'Minelayer Drone',
+    ])
+    // Distinct ids, or they would collide in the host's array.
+    expect(new Set((input.partners ?? []).map((p) => p.id)).size).toBe(4)
+  })
 })

--- a/apps/itun/src/lib/wizard/__tests__/pilotFormState.test.ts
+++ b/apps/itun/src/lib/wizard/__tests__/pilotFormState.test.ts
@@ -99,5 +99,24 @@ describe('pilotFormToCreateInput', () => {
     expect(input.currentAP).toBe(5)
     expect(input.conditions).toEqual([])
     expect(input.classRef).toBe('class-engineer')
+    // No partner-granting equipment, so the field stays absent entirely.
+    expect(input).not.toHaveProperty('partners')
+  })
+
+  it('grants a live partner for equipment carrying a stat block, not an inert card', () => {
+    const input = pilotFormToCreateInput({
+      ...EMPTY_PILOT_FORM_STATE,
+      name: 'Mira Voss',
+      callsign: 'Sparks',
+      classId: 'class-engineer',
+      equipment: ['cutting-torch', 'survey-drone'],
+    })
+    expect(input.partners).toHaveLength(1)
+    expect(input.partners?.[0]?.hostRef).toBe('survey-drone')
+    // `equipment` resolves the PLAYER's Survey Drone, never the opposition
+    // stat block of the same name in drones.json.
+    expect(input.partners?.[0]?.hostSchema).toBe('equipment')
+    // Ordinary gear stays ordinary gear.
+    expect(input.equipment).toContain('cutting-torch')
   })
 })

--- a/apps/itun/src/lib/wizard/mechFormState.ts
+++ b/apps/itun/src/lib/wizard/mechFormState.ts
@@ -108,15 +108,15 @@ export function mechFormToUpdatePatch(form: MechWizardFormState): MechWizardPatc
  * preserve. Reconciliation needs the stored partners as input, so the wizard
  * runs it on the update path via `afterUpdate` instead.
  *
- * `exact` because a mech's drone roster is fully determined by its chassis and
- * pattern — see `syncPartners`.
+ * `reseedLoadout` because a mech's drones wear the pattern: a pattern change
+ * re-cuts their systems and modules exactly as it re-cuts the mech's own.
  */
 export function mechFormToPartners(
   form: MechWizardFormState,
   existing?: readonly PartnerInstance[]
 ) {
   return syncPartners(existing, mechPartnerSeeds(form.chassisName, form.patternName), {
-    exact: true,
+    reseedLoadout: true,
   })
 }
 

--- a/apps/itun/src/lib/wizard/mechFormState.ts
+++ b/apps/itun/src/lib/wizard/mechFormState.ts
@@ -16,8 +16,10 @@
  */
 
 import { resolveChassisRef } from 'salvageunion-reference/rules'
+import { mechPartnerSeeds, syncPartners } from '../rules/partnerGrants'
 import type { CargoLot } from '../schemas/cargoLot'
 import type { Mech } from '../schemas/mech'
+import type { PartnerInstance } from '../schemas/partner'
 
 /** Shape of form state carried through the mech wizard. */
 export type MechWizardFormState = {
@@ -98,11 +100,37 @@ export function mechFormToUpdatePatch(form: MechWizardFormState): MechWizardPatc
 }
 
 /**
+ * Reconcile a mech's drones against the chassis + pattern it now carries.
+ *
+ * Kept OUT of `mechFormToUpdatePatch` on purpose: that patch is the set of
+ * fields an edit may overwrite blind, and a partner carries live-play state
+ * (structure, energy, heat, per-item conditions, cargo) that an edit must
+ * preserve. Reconciliation needs the stored partners as input, so the wizard
+ * runs it on the update path via `afterUpdate` instead.
+ *
+ * `exact` because a mech's drone roster is fully determined by its chassis and
+ * pattern — see `syncPartners`.
+ */
+export function mechFormToPartners(
+  form: MechWizardFormState,
+  existing?: readonly PartnerInstance[]
+) {
+  return syncPartners(existing, mechPartnerSeeds(form.chassisName, form.patternName), {
+    exact: true,
+  })
+}
+
+/**
  * Create payload for a fresh mech. Fresh mechs start at full SP/EP from the
  * chassis and Heat 0 (plan 2.3, gap 7) — never Heat-at-capacity.
+ *
+ * Drones granted by the chassis ability (and kitted by the pattern) are seeded
+ * here: they are part of the machine being built, not something the player adds
+ * afterwards — there is no "add a drone" control, by design.
  */
 export function mechFormToCreateInput(form: MechWizardFormState) {
   const chassis = resolveChassisRef(form.chassisName)
+  const partners = mechFormToPartners(form)
   return {
     schemaVersion: 1 as const,
     ...mechFormToUpdatePatch(form),
@@ -110,5 +138,6 @@ export function mechFormToCreateInput(form: MechWizardFormState) {
     currentSP: chassis?.structurePoints,
     currentEP: chassis?.energyPoints,
     currentHeat: 0,
+    ...(partners !== undefined ? { partners } : {}),
   }
 }

--- a/apps/itun/src/lib/wizard/pilotFormState.ts
+++ b/apps/itun/src/lib/wizard/pilotFormState.ts
@@ -99,14 +99,16 @@ export function pilotFormToUpdatePatch(form: PilotWizardFormState): PilotWizardP
  * partner holds live-play state an edit must not clobber, and reconciliation
  * needs the stored partners as input. The wizard runs it via `afterUpdate`.
  *
- * Additive, not exact — `pilot.equipment` says which stat blocks are granted,
- * never how many are fielded (Mecha Packmaster). See `syncPartners`.
+ * Equipment gates, abilities count: Mecha Packmaster turns one Mecha Companion
+ * entry into two companions (`partnerGrantCount`). No `reseedLoadout` — a
+ * pilot's partner is kitted out in play, and re-cutting it from a bare seed
+ * would delete a loadout nothing can restore.
  */
 export function pilotFormToPartners(
   form: PilotWizardFormState,
   existing?: readonly PartnerInstance[]
 ) {
-  return syncPartners(existing, pilotPartnerSeeds(form.equipment))
+  return syncPartners(existing, pilotPartnerSeeds(form.equipment, form.abilities))
 }
 
 /**

--- a/apps/itun/src/lib/wizard/pilotFormState.ts
+++ b/apps/itun/src/lib/wizard/pilotFormState.ts
@@ -15,6 +15,8 @@
  */
 
 import { PILOT_BASE_AP, PILOT_BASE_HP } from '../rules/derivedStats'
+import { pilotPartnerSeeds, syncPartners } from '../rules/partnerGrants'
+import type { PartnerInstance } from '../schemas/partner'
 import type { Pilot } from '../schemas/pilot'
 
 /** Shape of form state carried through the pilot wizard. */
@@ -91,15 +93,38 @@ export function pilotFormToUpdatePatch(form: PilotWizardFormState): PilotWizardP
 }
 
 /**
+ * Reconcile a pilot's partners against the equipment they now carry.
+ *
+ * Kept OUT of `pilotFormToUpdatePatch` for the same reason as the mech's: a
+ * partner holds live-play state an edit must not clobber, and reconciliation
+ * needs the stored partners as input. The wizard runs it via `afterUpdate`.
+ *
+ * Additive, not exact — `pilot.equipment` says which stat blocks are granted,
+ * never how many are fielded (Mecha Packmaster). See `syncPartners`.
+ */
+export function pilotFormToPartners(
+  form: PilotWizardFormState,
+  existing?: readonly PartnerInstance[]
+) {
+  return syncPartners(existing, pilotPartnerSeeds(form.equipment))
+}
+
+/**
  * Create payload for a fresh pilot. Fresh pilots start at full HP/AP
  * (core-rules base — no injuries or training modifiers exist at creation).
+ *
+ * Equipment carrying a mech-shaped stat block (Auto-Turret, Survey Drone, Mecha
+ * Companion) is granted as a live partner here rather than as an inert
+ * inventory card.
  */
 export function pilotFormToCreateInput(form: PilotWizardFormState) {
+  const partners = pilotFormToPartners(form)
   return {
     schemaVersion: 1 as const,
     ...pilotFormToUpdatePatch(form),
     conditions: [],
     currentHP: PILOT_BASE_HP,
     currentAP: PILOT_BASE_AP,
+    ...(partners !== undefined ? { partners } : {}),
   }
 }

--- a/docs/adrs/ADR-028-partners-render-in-place.md
+++ b/docs/adrs/ADR-028-partners-render-in-place.md
@@ -42,7 +42,7 @@ sheet and no partner route.
   `titleOverride` for the instance name, `statsOverride` for SP/EP/Heat (a
   `StatItem` carrying an `onChange` renders as an editable +/- cell, so the
   card's own stat axis is the vitals editor), `controls` for the advisory cap
-  badge and removal, and `afterExtraContent` for the identity fields, the Hold,
+  badge, and `afterExtraContent` for the identity fields, the Hold,
   and the installed systems/modules. No new visual language was invented.
 - **Capability is preserved, not reduced.** Everything the live sheet did — name
   / A.I. personality / appearance, SP/EP/Heat, derived tech level and slot
@@ -92,3 +92,52 @@ sheet and no partner route.
   the Immobile trait means it is not a container with nothing in it — the Hold
   and the Cargo stat are both omitted rather than rendered as `0/0`.
 - **Carrier→carrier handoff remains unbuilt**, exactly as ADR-027 left it.
+
+## Amendment — the grant is the lifecycle
+
+ADR-027 and this record both describe a partner as a thing that "cannot outlive
+what grants it", and both were right about the model and silent about the
+lifecycle. That silence was load-bearing: **nothing in the app ever created a
+`PartnerInstance`.** The only writers were `removePartner` and the two v11/v12
+migrations, so every partner in existence was a converted legacy record.
+Building a Little Sestra dropped its Sestra Drone and a Big Brother on the
+DronTek pattern dropped all four, which made the `Partners` region on the mech
+sheet live code that could never render; equipping a pilot's Survey Drone
+produced an inert equipment card with no structure, energy or loadout.
+
+`apps/itun/src/lib/rules/partnerGrants.ts` closes it, and settles the lifecycle
+question the earlier records left open:
+
+- **A partner is a projection of its grant, in both directions.** It is created
+  when the grant appears and destroyed when the grant goes — unequip the Survey
+  Drone equipment and the drone goes with it; change a mech's chassis and its
+  drones change with it. Reconciliation runs on the pilot sheet's equipment
+  toggle and on both wizards' create and `afterUpdate` paths.
+- **There is therefore no standalone remove control**, and its absence is the
+  point rather than an omission. A partner that could be dropped on its own
+  would be unrecoverable, because nothing would ever grant it back. This is
+  what replaces `removePartner` on both sheet action sets.
+- **A mech's roster is exact; a pilot's is additive.** The pattern determines
+  how many drones a mech fields and what each carries, so a pattern change
+  re-cuts the roster and each drone's loadout — exactly as the wizard already
+  re-cuts the mech's own. `pilot.equipment` records only *which* stat blocks are
+  granted, never how many are fielded (Mecha Packmaster raises the Mecha
+  Companion cap off a second ability), so a surplus instance is left alone.
+- **Reconciliation never costs live state.** A surviving partner keeps its id,
+  structure, energy, heat, conditions, name, appearance, A.I. personality and
+  cargo. Re-seeding a drone's guns on a pattern change is correct; re-seeding
+  its damage is data loss.
+- **A drone's systems are the union of two sources.** Integrated hardware lives
+  on the `drones` record (both player-facing drones carry a Hover Locomotion
+  System); the fitted loadout lives on `pattern.drones[].systems`. A live drone
+  needs both, which is a deliberate divergence from the SRD pattern card —
+  that card is describing a pattern, not accounting for slots in play.
+- **`partnerCap` gained a second raiser.** It knew Mecha Packmaster but assumed
+  every stat block capped at one, so the moment Big Brother's four were seeded
+  each would have read "4 of 1". The Big Brother's own controller fields four
+  (False Flag p. 62).
+
+One thing this does **not** fix: Mecha Packmaster's second Mecha Companion still
+has no creation path, because a pilot's equipment list is a set and the cap
+lives on an ability. It had none before either — the additive rule exists so
+that reconciliation cannot destroy one if it ever gains one.

--- a/docs/adrs/ADR-028-partners-render-in-place.md
+++ b/docs/adrs/ADR-028-partners-render-in-place.md
@@ -117,12 +117,17 @@ question the earlier records left open:
   point rather than an omission. A partner that could be dropped on its own
   would be unrecoverable, because nothing would ever grant it back. This is
   what replaces `removePartner` on both sheet action sets.
-- **A mech's roster is exact; a pilot's is additive.** The pattern determines
-  how many drones a mech fields and what each carries, so a pattern change
-  re-cuts the roster and each drone's loadout — exactly as the wizard already
-  re-cuts the mech's own. `pilot.equipment` records only *which* stat blocks are
-  granted, never how many are fielded (Mecha Packmaster raises the Mecha
-  Companion cap off a second ability), so a surplus instance is left alone.
+- **Both rosters are exact; only the source of the count differs.** A mech's
+  count comes from its pattern. A pilot's comes from their **abilities**, with
+  `pilot.equipment` acting only as the gate — it is a set, so it could never
+  express "two Mecha Companions". Mecha Packmaster's `grants` already lists
+  Mecha Companion **twice**, and it is the only ability in the dataset that
+  grants the same thing more than once; reading it is what fields the second
+  companion. The resolution is a **max** across the pilot's abilities, never a
+  sum: the Ranger L1 ability grants one and Packmaster grants two, so a
+  Legendary Ranger holding both would otherwise field three, which Packmaster's
+  own text denies. Abilities are therefore a second lifecycle edge alongside
+  equipment — taking Packmaster fields a companion, dropping it retires one.
 - **Reconciliation never costs live state.** A surviving partner keeps its id,
   structure, energy, heat, conditions, name, appearance, A.I. personality and
   cargo. Re-seeding a drone's guns on a pattern change is correct; re-seeding
@@ -132,12 +137,24 @@ question the earlier records left open:
   System); the fitted loadout lives on `pattern.drones[].systems`. A live drone
   needs both, which is a deliberate divergence from the SRD pattern card —
   that card is describing a pattern, not accounting for slots in play.
-- **`partnerCap` gained a second raiser.** It knew Mecha Packmaster but assumed
-  every stat block capped at one, so the moment Big Brother's four were seeded
-  each would have read "4 of 1". The Big Brother's own controller fields four
-  (False Flag p. 62).
-
-One thing this does **not** fix: Mecha Packmaster's second Mecha Companion still
-has no creation path, because a pilot's equipment list is a set and the cap
-lives on an ability. It had none before either — the additive rule exists so
-that reconciliation cannot destroy one if it ever gains one.
+- **`partnerCap` is now derived, not hardcoded.** It used to string-match
+  `mecha-packmaster`, which was both a hardcode and a duplicate of a fact
+  already in the data — so the cap and the number actually seeded could drift
+  apart. It now reads the same grant count, and a future ability granting two
+  needs no code change. One hardcode survives on purpose: the Big Brother
+  controls four drones (False Flag p. 62), which is a chassis ability's prose
+  rather than a countable grant, and deriving it from "the most any pattern
+  fields" would report 1 for a Custom build that is still allowed four.
+- **Migration v15 makes the pilot invariant true.** Exact reconciliation means a
+  pilot partner whose `hostRef` is absent from `pilot.equipment` answers to no
+  grant and is reaped. v11 was careful about this ("the equipment slug stays in
+  `pilot.equipment[]`"); **v12 was not** — it minted partners from companion-mech
+  rows and never added the granting slug, which is precisely the case where the
+  player had not equipped the item. Left alone, Eldridge Coast's Custos,
+  Incitatus, PR-1 and Rek Jet would have disappeared on their pilot's next edit.
+  v15 backfills the missing slug rather than deleting the partner: the partner is
+  the evidence that something once granted it, so the honest repair is to restore
+  the grant. It is append-only, so it is a no-op on a consistent database. The
+  one real cost is that granting equipment occupies an inventory slot, so a
+  healed pilot's usage rises by one and may read as over capacity — advisory
+  only (ADR-007/021), and the true reading: under-reporting it was the bug.

--- a/packages/salvageunion-reference/data/actions.json
+++ b/packages/salvageunion-reference/data/actions.json
@@ -12269,7 +12269,7 @@
       },
       {
         "type": "paragraph",
-        "value": "The Big Brother Drones act separately to [(CHASSIS)] on their own turn, and are controlled by the Pilot. They function effectively as Mechs, but cannot Push. They can be installed with Systems and Modules and restore their SP and EP in a T3 or higher Mech Bay during Downtime. If the Drones are damaged they can be repaired as though they were Mechs. If they are destroyed you may craft new Big Brother Drones for 2 Tech 5 Scrap as per the crafting rules. [(CHASSIS)] may have up to 4 active Big Brother Drones at a time. Big Brother Drone Stats: 3 SP, 4 EP, 4 Heat Cap, 4 System Slots, 1 Module Slot, 2 Cargo Cap, Tech Level 5, Salvage Value 1. Integrated Hover Locomotion System."
+        "value": "The Big Brother Drones act separately to [(CHASSIS)] on their own turn, and are controlled by the Pilot. They function effectively as Mechs, but cannot Push. They can be installed with Systems and Modules and restore their SP and EP in a T3 or higher Mech Bay during Downtime. If the Drones are damaged they can be repaired as though they were Mechs. If they are destroyed you may craft new Big Brother Drones for 2 Tech 5 Scrap as per the crafting rules. [(CHASSIS)] may have up to 4 active Big Brother Drones at a time."
       }
     ],
     "actionSource": "chassis",


### PR DESCRIPTION
## What

A chassis pattern's drone had nowhere to live on the mech sheet. The controller ability rendered in the identity band carrying its stat block **as free text** — Big Brother's prose literally reads `"3 SP, 4 EP, 4 Heat Cap…"` beside the mech's own lozenges — while the drone itself was never instantiated at all.

That second half was the real gap: **nothing in the app ever created a `PartnerInstance`.** The only writers were `removePartner` and the v11/v12 migrations, so every partner in existence was a converted legacy record. Building a Little Sestra dropped its Sestra Drone and a Big Brother on DronTek dropped all four, which made `MechSheet`'s Partners region live code that could never render. Equipping a pilot's Survey Drone produced an inert equipment card with no structure, energy or loadout.

## How

`apps/itun/src/lib/rules/partnerGrants.ts` answers "what does this host's configuration grant?" as a list of seeds, and reconciles that list against the instances the host already carries. It settles the lifecycle question ADR-027/028 left open.

**The grant is the lifecycle.** A partner is created when its grant appears and destroyed when it goes — unequip the Survey Drone equipment and the drone goes with it; change a mech's chassis and its drones change with it. There is therefore **no standalone remove control**: one would be unrecoverable, since nothing would ever grant it back. `removePartner` is gone from both sheet action sets.

**The two hosts reconcile differently, and the asymmetry is the rules.**

| | roster | on reconcile |
|---|---|---|
| **Mech** | exact — the pattern says how many and what each carries | re-cuts the roster and each drone's loadout, as the wizard already re-cuts the mech's own |
| **Pilot** | additive — `equipment` says *which* stat blocks, never *how many* (Mecha Packmaster) | a surplus instance is left alone rather than reaped |

Reconciliation never costs live state: a surviving drone keeps its id, structure, energy, heat, conditions, name and cargo.

## Also

- **A drone's systems are the union of two sources** — integrated hardware on the `drones` record (both player drones carry a Hover Locomotion System) plus the pattern's fitted picks. A deliberate divergence from the SRD pattern card, which describes a pattern rather than accounting for slots in play.
- **`partnerCap` gained a second raiser.** It knew Mecha Packmaster but assumed every stat block capped at one, so Big Brother's four would each have read "4 of 1" the moment seeding worked. The Big Brother controls four (False Flag p. 62).
- **Stripped the duplicated stat sentence** from the Big Brother controller's prose in `actions.json`. Every number in it is already structured on the drone record, including the integrated system — it was the same block twice, once as data and once as text in the mech's identity band.
- **ADR-028 gains an amendment** recording the lifecycle rule, and loses its now-false claim that `controls` carries removal.

## Not fixed, and it was not fixed before either

Mecha Packmaster's second Mecha Companion still has no creation path, because a pilot's equipment list is a set and the cap lives on an ability. The additive rule exists so reconciliation cannot destroy one if it ever gains one.

## Verification

`bun run check:all` green — 14/14 steps: lint, format, typecheck ×6, test, validate:all, knip, audit, tokens, styling, schemas.

New coverage (28 tests): `partnerGrants.test.ts` (seeds + reconciliation), `MechSheet-partners.test.tsx` (the region renders a live drone with its own stats and loadout, four named drones at "4 of 4", no remove control), `pilotSheetActions-partnerGrants.test.tsx` (equip/unequip grants and revokes in one write), plus create-payload cases on both wizard form-state suites.

Note: `apps/srd/ssg/parity.ts` will report a diff on the Big Brother action text. That is the intended data change, and parity runs against an archived Astro baseline — it is not wired into CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZ5hMJuWv9acvpkJebhZKg

---

# Follow-up in this PR: Mecha Packmaster's second companion

The original version of this PR left one gap open, and it turned out the fix was
already sitting in the data.

**`Mecha Packmaster.grants` lists `Mecha Companion` twice** — and it is the only
ability in the whole dataset that grants the same thing more than once. Nothing
read it: `grants` fed the SRD display layer and nothing else. So the second
companion had no way to exist, and `partnerCap` restated the same fact by
string-matching `'mecha-packmaster'`, letting the cap and the number actually
fielded drift apart.

**Equipment gates, abilities count.** `pilot.equipment` is a set, so it could
never express "two Mecha Companions" — but it still decides whether the companion
exists at all. `partnerGrantCount` reads the grants, `pilotPartnerSeeds` emits
that many, and `partnerCap` derives from the same call, so a future ability that
grants two needs no code change.

**MAX, not sum.** The Ranger tree's L1 ability is `Mecha Companion` (one grant)
and Packmaster is Legendary Ranger, so a pilot holding Packmaster normally holds
both. Summing fields three, which Packmaster's own text denies — *"Gain a second
Mecha Companion in addition to your first."* The two entries encode the **total**.

Abilities become a second lifecycle edge: `toggleAbility` reconciles alongside
`toggleEquipment`, so taking Packmaster fields a companion and dropping it
retires one (the newest — reaping takes from the tail).

## The data-loss bug this had to fix first

Making the pilot roster exact means a partner with no seed is reaped — which
turned an unnoticed invariant breach into real data loss. A pilot partner's
`hostRef` must appear in `pilot.equipment`. **v11 was careful about this** and
says so in its own header; **v12 was not** — it converted companion-mech rows
without ever adding the granting slug, which is precisely the case where the
player had *not* equipped the item. Left alone, Eldridge Coast's Custos,
Incitatus, PR-1 and Rek Jet would have disappeared on their pilot's next edit.

**Migration v15** backfills the missing slug rather than deleting the partner:
the partner is the evidence that something once granted it, so the honest repair
is to restore the grant. Append-only, so it is a no-op on a consistent database,
and it never touches mech-hosted partners or invents a partner. One real cost —
granting equipment occupies an inventory slot, so a healed pilot's usage rises by
one and may read as over capacity. Advisory only (ADR-007/021), and it is the
true reading: under-reporting it was the bug.

## Also in the follow-up

- **`syncPartners`'s `exact` flag split in two.** It conflated "the seeds are the
  whole roster" with "re-cut the loadout". Pilots need the first and must *not*
  have the second, since a pilot's partner is kitted out in play and its seed is
  bare. Only `reseedLoadout` survives as an option.
- **Seed claiming is now two passes.** A single pass let an unnamed seed claim the
  instance a named seed needed, renaming a drone the player had customised.
- **Indexed lookups.** `partnerCap` runs per card per render and was reaching the
  ORM via `Model.find((e) => matchesRef(e, ref))` — the shape the package's
  CLAUDE.md calls "a SEARCH wearing a predicate's clothes". Now `resolveRef`.

## Why this is not a stacked PR

I said I'd stack this. I can't: `ci.yml` fires `pull_request` only on
`branches: ['main']`, so a PR based on this branch runs **no CI** and could never
satisfy the required `quality-checks` gate.

Verification: `bun run check:all` green. Partner coverage is now 45 tests across
four files, including the max-vs-sum rule and the v15 backfill classifier.
