### PR TITLE
feat(about): add a Special Thanks section to both about pages

### DIFF
--- a/SPECIAL_THANKS.md
+++ b/SPECIAL_THANKS.md
@@ -1,0 +1,21 @@
+<!--
+  The project's acknowledgements.
+
+  Rendered verbatim in the colophon on both about pages, between `ABOUT_JRVS.md`
+  and the Ko-fi support block — srd's `/about`
+  (`apps/srd/src/pages/about.page.tsx`, read at build time with node:fs) and
+  ITUN's `/about` (`apps/itun/src/routes/about.tsx`, inlined via a Vite `?raw`
+  import). Edit the wording here and both sites change together; there is no
+  second copy.
+
+  Format contract (see `packages/component-lib/src/markdownSection/`): one `#`
+  heading, then blank-line-separated paragraphs. `[label](href)` links are the
+  only inline markdown the renderer interprets — bold, italics and lists would
+  ship as literal punctuation.
+-->
+
+# Special Thanks
+
+A special thanks to Panny from Leyline Press.
+
+A special thanks to the #salvage-union-io active testers: Tommy_Dude, lunarsignals, the puppetter, Grandowl, kindalas, decivre, Saving Throw.

--- a/apps/itun/src/routes/about.tsx
+++ b/apps/itun/src/routes/about.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { AboutScreen } from 'component-lib'
 import aboutJrvsMd from '../../../../ABOUT_JRVS.md?raw'
 import llmStatementMd from '../../../../LLM_STATEMENT.md?raw'
+import specialThanksMd from '../../../../SPECIAL_THANKS.md?raw'
 import { version } from '../../package.json'
 
 export const Route = createFileRoute('/about')({
@@ -9,5 +10,12 @@ export const Route = createFileRoute('/about')({
 })
 
 function AboutPage() {
-  return <AboutScreen version={version} aboutJrvs={aboutJrvsMd} llmStatement={llmStatementMd} />
+  return (
+    <AboutScreen
+      version={version}
+      aboutJrvs={aboutJrvsMd}
+      llmStatement={llmStatementMd}
+      specialThanks={specialThanksMd}
+    />
+  )
 }

--- a/apps/srd/src/components/islands/ColophonIsland.tsx
+++ b/apps/srd/src/components/islands/ColophonIsland.tsx
@@ -3,11 +3,12 @@ import { Colophon } from 'component-lib'
 type ColophonIslandProps = {
   aboutMarkdown: string
   llmMarkdown: string
+  specialThanksMarkdown: string
 }
 
 /**
- * ColophonIsland — hydrates the shared about-page colophon (author bio, LLM
- * statement, Ko-fi support button).
+ * ColophonIsland — hydrates the shared about-page colophon (author bio, special
+ * thanks, LLM statement, Ko-fi support button).
  *
  * An island rather than a static render because the Ko-fi widget needs client
  * JS: the shared KofiButton loads Ko-fi's script and swaps in `getHTML()` from
@@ -23,6 +24,17 @@ type ColophonIslandProps = {
  * prose with no SRD data and no async work, so there is nothing here that can
  * throw at render. The boundary is for islands that resolve reference data.
  */
-export function ColophonIsland({ aboutMarkdown, llmMarkdown }: ColophonIslandProps) {
-  return <Colophon aboutMarkdown={aboutMarkdown} llmMarkdown={llmMarkdown} kofiCode="C3Z82382ZC" />
+export function ColophonIsland({
+  aboutMarkdown,
+  llmMarkdown,
+  specialThanksMarkdown,
+}: ColophonIslandProps) {
+  return (
+    <Colophon
+      aboutMarkdown={aboutMarkdown}
+      llmMarkdown={llmMarkdown}
+      specialThanksMarkdown={specialThanksMarkdown}
+      kofiCode="C3Z82382ZC"
+    />
+  )
 }

--- a/apps/srd/src/pages/about.page.tsx
+++ b/apps/srd/src/pages/about.page.tsx
@@ -39,6 +39,7 @@ const repoRootFile = (name: string): string =>
 // site and ITUN render the same words.
 const aboutJrvsMd = readFileSync(repoRootFile('ABOUT_JRVS.md'), 'utf8')
 const llmStatementMd = readFileSync(repoRootFile('LLM_STATEMENT.md'), 'utf8')
+const specialThanksMd = readFileSync(repoRootFile('SPECIAL_THANKS.md'), 'utf8')
 
 const TITLE = 'About - Salvage Union System Reference Document'
 const DESCRIPTION =
@@ -277,15 +278,24 @@ function page({ builtAssets }: RouteContext<Record<string, string>, unknown>): P
               </p>
             </section>
 
-            {/* Colophon: About the Dev + support | LLM Statement (shared with ITUN).
+            {/* Colophon: About the Dev + Special Thanks + support | LLM Statement
+                (shared with ITUN).
                 `ssr` per DESIGN.md's per-island table — the prose is worth indexing. */}
             <Island
               name="ColophonIsland"
               client="visible"
               ssr
-              props={{ aboutMarkdown: aboutJrvsMd, llmMarkdown: llmStatementMd }}
+              props={{
+                aboutMarkdown: aboutJrvsMd,
+                llmMarkdown: llmStatementMd,
+                specialThanksMarkdown: specialThanksMd,
+              }}
             >
-              <ColophonIsland aboutMarkdown={aboutJrvsMd} llmMarkdown={llmStatementMd} />
+              <ColophonIsland
+                aboutMarkdown={aboutJrvsMd}
+                llmMarkdown={llmStatementMd}
+                specialThanksMarkdown={specialThanksMd}
+              />
             </Island>
           </div>
         </div>

--- a/packages/component-lib/src/components/shared/AboutScreen.stories.tsx
+++ b/packages/component-lib/src/components/shared/AboutScreen.stories.tsx
@@ -1,6 +1,7 @@
 import type { Story } from '@ladle/react'
 import aboutMd from '../../../../../ABOUT_JRVS.md?raw'
 import statementMd from '../../../../../LLM_STATEMENT.md?raw'
+import thanksMd from '../../../../../SPECIAL_THANKS.md?raw'
 import { AboutScreen } from './AboutScreen'
 
 export default {
@@ -8,10 +9,16 @@ export default {
 }
 
 /**
- * The app's About page. `version`, `aboutJrvs` and `llmStatement` are props
- * rather than imports, so the screen is app-agnostic — each app passes its own
- * version and inlines the repo-root documents the way its build allows.
+ * The app's About page. `version`, `aboutJrvs`, `llmStatement` and
+ * `specialThanks` are props rather than imports, so the screen is app-agnostic —
+ * each app passes its own version and inlines the repo-root documents the way
+ * its build allows.
  */
 export const Default: Story = () => (
-  <AboutScreen version="1.4.2" aboutJrvs={aboutMd} llmStatement={statementMd} />
+  <AboutScreen
+    version="1.4.2"
+    aboutJrvs={aboutMd}
+    llmStatement={statementMd}
+    specialThanks={thanksMd}
+  />
 )

--- a/packages/component-lib/src/components/shared/AboutScreen.tsx
+++ b/packages/component-lib/src/components/shared/AboutScreen.tsx
@@ -2,8 +2,8 @@
  * AboutScreen — the /about page for In the Union Now.
  *
  * Static content page: what ITUN is, its local-first stance, links to the SRD
- * and the official game, and the shared `Colophon` (author bio, LLM statement,
- * Ko-fi support widget). Styled in the ITUN paper/ink Workshop-Manual idiom
+ * and the official game, and the shared `Colophon` (author bio, special thanks,
+ * LLM statement, Ko-fi support widget). Styled in the ITUN paper/ink Workshop-Manual idiom
  * (mirrors the Roster main layout) rather than the SRD reference-site look, so
  * it reads as part of this app.
  */
@@ -22,9 +22,11 @@ type AboutScreenProps = {
   aboutJrvs: string
   /** Raw `LLM_STATEMENT.md`, same contract as `aboutJrvs`. */
   llmStatement: string
+  /** Raw `SPECIAL_THANKS.md`, same contract as `aboutJrvs`. */
+  specialThanks: string
 }
 
-export function AboutScreen({ version, aboutJrvs, llmStatement }: AboutScreenProps) {
+export function AboutScreen({ version, aboutJrvs, llmStatement, specialThanks }: AboutScreenProps) {
   return (
     <main className="min-h-screen bg-wk-bg px-4 py-8 sm:px-8 sm:py-12 lg:px-12">
       <div className="mx-auto flex w-full max-w-3xl flex-col gap-8">
@@ -98,6 +100,7 @@ export function AboutScreen({ version, aboutJrvs, llmStatement }: AboutScreenPro
         <Colophon
           aboutMarkdown={aboutJrvs}
           llmMarkdown={llmStatement}
+          specialThanksMarkdown={specialThanks}
           kofiCode="C3Z82382ZC"
           className="border-t-2 border-ink pt-6 font-body text-ink"
           footer={<p className="font-body text-xs text-wk-muted">Version {version}</p>}

--- a/packages/component-lib/src/components/shared/Colophon.stories.tsx
+++ b/packages/component-lib/src/components/shared/Colophon.stories.tsx
@@ -1,19 +1,22 @@
 import type { Story } from '@ladle/react'
 import aboutMd from '../../../../../ABOUT_JRVS.md?raw'
 import statementMd from '../../../../../LLM_STATEMENT.md?raw'
+import thanksMd from '../../../../../SPECIAL_THANKS.md?raw'
 import { Colophon } from './Colophon'
 
 export default { title: 'Compositions/Colophon' }
 
 /**
- * The real repo-root `ABOUT_JRVS.md` + `LLM_STATEMENT.md`, rendered through the
- * same block both about pages use — so the catalog shows the wording that
- * actually ships, and a badly-shaped edit to either file is visible here first.
+ * The real repo-root `ABOUT_JRVS.md` + `SPECIAL_THANKS.md` + `LLM_STATEMENT.md`,
+ * rendered through the same block both about pages use — so the catalog shows
+ * the wording that actually ships, and a badly-shaped edit to any of the three
+ * files is visible here first.
  */
 export const Default: Story = () => (
   <Colophon
     aboutMarkdown={aboutMd}
     llmMarkdown={statementMd}
+    specialThanksMarkdown={thanksMd}
     kofiCode="C3Z82382ZC"
     className="font-body text-ink"
   />

--- a/packages/component-lib/src/components/shared/Colophon.tsx
+++ b/packages/component-lib/src/components/shared/Colophon.tsx
@@ -9,6 +9,9 @@ type ColophonProps = {
   aboutMarkdown: string
   /** Raw contents of the repo-root `LLM_STATEMENT.md` (right column). */
   llmMarkdown: string
+  /** Raw contents of the repo-root `SPECIAL_THANKS.md` (left column, between
+   * the bio and the support block). Same contract as `aboutMarkdown`. */
+  specialThanksMarkdown: string
   /** Ko-fi page code — the `<code>` in `ko-fi.com/<code>`. */
   kofiCode: string
   /** Optional line under the support button (ITUN puts its version there). */
@@ -21,12 +24,12 @@ type ColophonProps = {
  * Colophon — who made this, how, and how to support it; shared by both about
  * pages.
  *
- * Two columns that stack on narrow screens: the author bio and the support
- * section on the left, the LLM statement on the right. The Ko-fi button rides
- * in the support slab's `actions` slot, so it sits on the heading line opposite
- * the label rather than below it. Neither piece of prose lives here — both are
- * repo-root markdown documents passed in raw (see `MarkdownSection`), so the
- * two sites always show the same words.
+ * Two columns that stack on narrow screens: the author bio, the special thanks
+ * and the support section on the left, the LLM statement on the right. The
+ * Ko-fi button rides in the support slab's `actions` slot, so it sits on the
+ * heading line opposite the label rather than below it. None of the prose lives
+ * here — all three are repo-root markdown documents passed in raw (see
+ * `MarkdownSection`), so the two sites always show the same words.
  *
  * The Ko-fi button needs client JS to swap in the widget, so an Astro consumer
  * must hydrate this block rather than render it statically — srd does that via
@@ -35,6 +38,7 @@ type ColophonProps = {
 export function Colophon({
   aboutMarkdown,
   llmMarkdown,
+  specialThanksMarkdown,
   kofiCode,
   footer,
   className,
@@ -43,6 +47,8 @@ export function Colophon({
     <div className={cn('grid gap-8 md:grid-cols-2', className)}>
       <div className="flex flex-col gap-8">
         <MarkdownSection markdown={aboutMarkdown} />
+
+        <MarkdownSection markdown={specialThanksMarkdown} />
 
         <section className="flex flex-col items-start gap-3 text-sm leading-relaxed">
           <Slab


### PR DESCRIPTION
Adds a **Special Thanks** section to the About page, between "About the Dev" and the Ko-fi support block.

It goes into the shared `Colophon`, so it appears on **both** about pages — `salvageunion.io/about` and ITUN's `/about` — the same way the author bio and LLM statement already do.

## Content

New repo-root `SPECIAL_THANKS.md`, following the existing `ABOUT_JRVS.md` / `LLM_STATEMENT.md` contract: one document, no second copy, read by srd at build time via `node:fs` and by ITUN via a Vite `?raw` import. Editing the wording changes both sites together, with no component change.

## Rendered order on `/about`

```
About the Dev
Special Thanks      ← new
Support the Project (Ko-fi)
```

Verified against the real built output (`apps/srd/dist/about/index.html`), not just the source.

## Verification

- `bun run check:fast` — lint, `validate:all`, knip, typecheck across all six workspaces: green
- `bun run test` — 0 failures
- `bun run format` — clean
- `bun ssg/build.ts` — 1,039 pages, 900 endpoints

## Note on `ssg/parity.ts`

Not run: the baseline is gitignored and absent in a fresh worktree. It would report a `<main>` text difference on `about/index.html` either way — this PR deliberately adds visible prose to that page, and the parity baseline is frozen at the last Astro commit. That is expected for any intentional post-migration content edit, not a regression introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123FhUCSo53Qx3aiJ3k71t8
