### PR TITLE
fix(srd): stop entity artwork rendering at opacity 0 on every static page

### DIFF
--- a/packages/component-lib/src/components/shared/CardImage.tsx
+++ b/packages/component-lib/src/components/shared/CardImage.tsx
@@ -31,7 +31,17 @@ type CardImageProps = {
  */
 export function CardImage({ url, alt, compact, aside }: CardImageProps) {
   const [showImage, setShowImage] = useState(true)
-  const [loaded, setLoaded] = useState(false)
+  // The fade-in is a CLIENT-ONLY enhancement, so it starts already-`loaded` on
+  // the server. On srd an entity card is rendered by the ZERO-JS static path
+  // (`EntityCardStatic`) — it is not an island, so React never mounts over it
+  // and neither `onLoad` nor the cached-load effect below can ever run. A
+  // server-rendered `opacity: 0` therefore stays 0 forever, and every piece of
+  // entity artwork on the site downloads in full and then paints nothing.
+  //
+  // Diverging from the client's initial state is safe HERE specifically because
+  // srd's islands mount with `createRoot`, never `hydrateRoot` (see
+  // `apps/srd/ssg/DESIGN.md`), so there is no hydration pass to mismatch.
+  const [loaded, setLoaded] = useState(() => typeof window === 'undefined')
   const imgRef = useRef<HTMLImageElement>(null)
 
   // Reset the fade-in when the image URL changes so a swapped image fades in

--- a/packages/component-lib/src/components/shared/__tests__/CardImage.ssr.test.tsx
+++ b/packages/component-lib/src/components/shared/__tests__/CardImage.ssr.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test'
+
+/**
+ * The artwork fade-in must not survive into SERVER-rendered markup.
+ *
+ * srd renders entity cards through its zero-JS static path — the card is not an
+ * island, so React never mounts over it and `CardImage`'s `onLoad` / cached-load
+ * effect can never run. When the server emitted `style="opacity:0"`, nothing was
+ * left to clear it: every piece of entity artwork on the site downloaded in full
+ * (a ~500 KB webp for a chassis) and then painted nothing, leaving a blank column
+ * beside the description on all 57 artwork-bearing entity pages.
+ *
+ * This is asserted in a SUBPROCESS on purpose. Every bunfig in this repo preloads
+ * happy-dom, so `window` is defined in-process and the server branch is
+ * unreachable from an ordinary test — the bug would stay green. A bare `bun -e`
+ * child has no preload and therefore no DOM, which is exactly the environment
+ * `apps/srd/ssg` renders under (Bun directly, never through Vite).
+ */
+describe('CardImage server rendering', () => {
+  test('emits visible artwork when rendered without a DOM', () => {
+    const script = `
+      const { renderToStaticMarkup } = await import('react-dom/server')
+      const { createElement } = await import('react')
+      const { CardImage } = await import('${import.meta.dir}/../CardImage.tsx')
+      if (typeof window !== 'undefined') throw new Error('expected a DOM-free process')
+      process.stdout.write(
+        renderToStaticMarkup(
+          createElement(CardImage, {
+            url: 'https://assets.salvageunion.io/chassis/mule.webp',
+            alt: 'Mule illustration',
+          })
+        )
+      )
+    `
+    const proc = Bun.spawnSync(['bun', '-e', script], { stdout: 'pipe', stderr: 'pipe' })
+    const stderr = proc.stderr.toString()
+    expect(stderr).toBe('')
+    expect(proc.exitCode).toBe(0)
+
+    const markup = proc.stdout.toString()
+    // The image is present...
+    expect(markup).toContain('https://assets.salvageunion.io/chassis/mule.webp')
+    // ...and nothing hides it. `opacity:0` here is the defect itself, not a
+    // detail of how the fade is implemented — with no client runtime it is
+    // permanent.
+    expect(markup).not.toContain('opacity:0')
+  })
+})


### PR DESCRIPTION
Reported on Discord as "Viewing the details of a mech chassis seems to cause an image ERROR 404".

## It is not a 404

The image is not 404ing. All **57** artwork URLs return `200` from `assets.salvageunion.io`, and a sweep of **all 51** chassis pages on the live site found no failed request of any kind. The bytes arrive — a 503 KB webp for the Mule — and are then rendered invisible.

## Root cause

`CardImage` fades its image in by holding `opacity: 0` until React sets `loaded`, via either `onLoad` or a cached-load `useEffect`.

On srd an entity card is rendered by the **zero-JS static path** (`EntityCardStatic`). It is not an island — the only islands on a chassis page are `MobileNavIsland`, `MobileSearchIsland` and `SearchIsland` — so React never mounts over the card and **neither handler can ever run**. The server-rendered `opacity: 0` was therefore permanent.

Live HTML before the fix:

```html
<img src="https://assets.salvageunion.io/chassis/mule.webp" alt="Mule illustration"
     class="block h-auto w-full object-contain transition-opacity duration-300"
     style="opacity:0" loading="lazy" decoding="async"/>
```

Measured in a headless browser on `salvageunion.io`: `complete: true`, `natural: 3611x4752`, **`opacity: "0"`**. Every artwork-bearing entity page downloaded its full illustration and painted nothing, leaving the blank column beside the description that the reporter screenshotted.

## Fix

The fade-in is a client-only enhancement, so it starts already-`loaded` when there is no `window`.

Diverging from the client's initial state is safe **here specifically** because srd's islands mount with `createRoot`, never `hydrateRoot` (`apps/srd/ssg/DESIGN.md`), so there is no hydration pass to mismatch. Client behaviour — itun, and any island — is unchanged: in a browser `window` is defined, the initial state is `false` exactly as before, and the fade still runs.

## Verification

- Rebuilt the site: artwork now emits `style="opacity:1"`; **zero** `opacity:0` remain across 1,039 pages; 182 pages emit entity artwork.
- Screenshotted the built page — the Mule illustration renders in the previously-blank column, layout otherwise identical to production.
- `check:fast` green (lint, validate:all, knip, typecheck across all 6 workspaces); full `bun run test` green, 0 failures.
- `ssg/parity.ts` could **not** run: its archived Astro baseline (`.parity-baseline/`) is not checked in, so it is unavailable in a fresh worktree. It should run on a checkout that has one.

## About the test

`CardImage.ssr.test.tsx` asserts in a **subprocess** on purpose. Every bunfig in this repo preloads happy-dom, so `window` is defined in-process and the server branch is unreachable from an ordinary test — the bug would stay green. A bare `bun -e` child has no preload and no DOM, which is exactly what `apps/srd/ssg` renders under.

Confirmed it fails against the unfixed component, reporting the defective `style="opacity:0"` markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QunKeBj1xCvWTL8kVK3mvs