### PR TITLE
feat(about): rework the Special Thanks copy, and render bullet lists

### DIFF
--- a/SPECIAL_THANKS.md
+++ b/SPECIAL_THANKS.md
@@ -9,13 +9,25 @@
   second copy.
 
   Format contract (see `packages/component-lib/src/markdownSection/`): one `#`
-  heading, then blank-line-separated paragraphs. `[label](href)` links are the
-  only inline markdown the renderer interprets — bold, italics and lists would
-  ship as literal punctuation.
+  heading, then blank-line-separated blocks. A block is either a paragraph or a
+  `- ` bullet list — a list only when EVERY line in the block is an item, so
+  keep the blank line between the lead-in line and the list below it.
+  `[label](href)` links are the only inline markdown the renderer interprets —
+  bold and italics would ship as literal punctuation.
 -->
 
 # Special Thanks
 
-A special thanks to Panny from Leyline Press.
+Thank you to Panny and all the folks at [Leyline Press](https://leyline.press) for their continued support.
 
-A special thanks to the #salvage-union-io active testers: Tommy_Dude, lunarsignals, the puppetter, Grandowl, kindalas, decivre, Saving Throw.
+A special thanks to the #salvage-union-io crew:
+
+- Tommy_Dude
+- lunarsignals
+- the puppetter
+- Grandowl
+- kindalas
+- decivre
+- Saving Throw
+
+[Join the Discord](https://discord.gg/kMwD2bWgtC) to join the conversation!

--- a/packages/component-lib/src/markdownSection/MarkdownSection.stories.tsx
+++ b/packages/component-lib/src/markdownSection/MarkdownSection.stories.tsx
@@ -1,21 +1,28 @@
 import type { Story } from '@ladle/react'
 import aboutMd from '../../../../ABOUT_JRVS.md?raw'
 import statementMd from '../../../../LLM_STATEMENT.md?raw'
+import thanksMd from '../../../../SPECIAL_THANKS.md?raw'
 import { Caption } from '../stories/_harness'
 import { MarkdownSection } from './MarkdownSection'
 
 export default { title: 'Containers/Markdown Section' }
 
 /**
- * Both repo-root prose documents through the one renderer — a heading and its
- * paragraphs, with no inline markdown interpreted. The catalog therefore shows
- * the wording that actually ships, and a badly-shaped edit to either file is
- * visible here first.
+ * All three repo-root prose documents through the one renderer — a heading and
+ * its blocks, with `[label](href)` links the only inline markdown interpreted.
+ * The catalog therefore shows the wording that actually ships, and a
+ * badly-shaped edit to any of the files is visible here first.
+ *
+ * `SPECIAL_THANKS.md` is the one that exercises the `- ` list path: a block
+ * whose every line is an item renders as a real `<ul>`, and a missing blank
+ * line before it shows up here as literal dashes in a paragraph.
  */
 export const Default: Story = () => (
   <div className="flex max-w-2xl flex-col gap-6">
     <Caption>ABOUT_JRVS.md</Caption>
     <MarkdownSection markdown={aboutMd} />
+    <Caption>SPECIAL_THANKS.md</Caption>
+    <MarkdownSection markdown={thanksMd} />
     <Caption>LLM_STATEMENT.md</Caption>
     <MarkdownSection markdown={statementMd} />
   </div>

--- a/packages/component-lib/src/markdownSection/MarkdownSection.test.tsx
+++ b/packages/component-lib/src/markdownSection/MarkdownSection.test.tsx
@@ -6,32 +6,42 @@ import { MarkdownSection } from './MarkdownSection'
 import { parseInline, parseMarkdownSection } from './parseMarkdownSection'
 
 /** The repo-root prose documents both about pages render. */
-const DOCS = ['ABOUT_JRVS.md', 'LLM_STATEMENT.md'].map((name) => ({
+const DOCS = ['ABOUT_JRVS.md', 'LLM_STATEMENT.md', 'SPECIAL_THANKS.md'].map((name) => ({
   name,
   markdown: readFileSync(join(import.meta.dir, '../../../..', name), 'utf8'),
 }))
 
+/** The prose of a block, for assertions that don't care about list vs paragraph. */
+const textsOf = (content: ReturnType<typeof parseMarkdownSection>): string[] =>
+  content.blocks.flatMap((block) => (block.kind === 'list' ? block.items : [block.text]))
+
 describe('parseMarkdownSection', () => {
   test('drops the HTML comment header and reads each heading', () => {
     const headings = DOCS.map((doc) => parseMarkdownSection(doc.markdown).heading)
-    expect(headings).toEqual(['About the Dev', 'LLM Statement'])
+    expect(headings).toEqual(['About the Dev', 'LLM Statement', 'Special Thanks'])
   })
 
   test('joins soft-wrapped prose into one paragraph per block', () => {
-    const { paragraphs } = parseMarkdownSection('# Head\n\nfirst line\nsecond line\n\nnext block\n')
-    expect(paragraphs).toEqual(['first line second line', 'next block'])
+    const { blocks } = parseMarkdownSection('# Head\n\nfirst line\nsecond line\n\nnext block\n')
+    expect(blocks).toEqual([
+      { kind: 'paragraph', text: 'first line second line' },
+      { kind: 'paragraph', text: 'next block' },
+    ])
   })
 
   test('tolerates a file with no heading', () => {
-    expect(parseMarkdownSection('just prose')).toEqual({ heading: '', paragraphs: ['just prose'] })
+    expect(parseMarkdownSection('just prose')).toEqual({
+      heading: '',
+      blocks: [{ kind: 'paragraph', text: 'just prose' }],
+    })
   })
 
   test('drops a multi-line comment block even when blank lines split it', () => {
-    const { heading, paragraphs } = parseMarkdownSection(
+    const { heading, blocks } = parseMarkdownSection(
       '<!--\n  note\n\n  more note\n-->\n\n# Head\n\nbody\n'
     )
     expect(heading).toBe('Head')
-    expect(paragraphs).toEqual(['body'])
+    expect(blocks).toEqual([{ kind: 'paragraph', text: 'body' }])
   })
 
   test('never partially removes a comment span, so nothing can be spliced', () => {
@@ -40,7 +50,33 @@ describe('parseMarkdownSection', () => {
     // lines are kept or dropped here, so the line survives verbatim and is
     // rendered as literal text.
     const line = '<!<!-- comment -->-- still here'
-    expect(parseMarkdownSection(line).paragraphs).toEqual([line])
+    expect(parseMarkdownSection(line).blocks).toEqual([{ kind: 'paragraph', text: line }])
+  })
+})
+
+describe('parseMarkdownSection — bullet lists', () => {
+  test('an all-item block becomes one list, in order', () => {
+    const { blocks } = parseMarkdownSection('# Head\n\nlead in\n\n- one\n- two\n- three\n')
+    expect(blocks).toEqual([
+      { kind: 'paragraph', text: 'lead in' },
+      { kind: 'list', items: ['one', 'two', 'three'] },
+    ])
+  })
+
+  test('a block mixing prose and dashes stays a paragraph', () => {
+    // All-or-nothing keeps the change additive: a document written before lists
+    // existed parses to exactly the blocks it always did.
+    const { blocks } = parseMarkdownSection('lead in\n- one\n- two\n')
+    expect(blocks).toEqual([{ kind: 'paragraph', text: 'lead in - one - two' }])
+  })
+
+  test('a bare dash with no text is not an item', () => {
+    expect(parseMarkdownSection('-\n').blocks).toEqual([{ kind: 'paragraph', text: '-' }])
+  })
+
+  test('a list item may carry a link', () => {
+    const { blocks } = parseMarkdownSection('- see [the site](https://alxjrvs.com)\n')
+    expect(blocks).toEqual([{ kind: 'list', items: ['see [the site](https://alxjrvs.com)'] }])
   })
 })
 
@@ -71,19 +107,21 @@ describe('parseInline', () => {
 })
 
 describe('the repo-root prose documents', () => {
-  // Links are the only inline markdown the renderer interprets (see each file's
-  // own header comment); anything else would ship as literal punctuation.
-  test.each(DOCS)('$name uses no bold, italics, or bullets', ({ markdown }) => {
-    const { paragraphs } = parseMarkdownSection(markdown)
-    expect(paragraphs.length).toBeGreaterThan(0)
-    for (const paragraph of paragraphs) {
-      expect(paragraph).not.toMatch(/\*\*|^[-*]\s|^#/)
+  // Links and `- ` lists are all the renderer interprets (see each file's own
+  // header comment); bold and italics would ship as literal punctuation. A
+  // bullet that survives into block text means the list didn't parse — the
+  // failure this guards is a missing blank line before a list.
+  test.each(DOCS)('$name uses no bold or italics, and no stray bullets', ({ markdown }) => {
+    const texts = textsOf(parseMarkdownSection(markdown))
+    expect(texts.length).toBeGreaterThan(0)
+    for (const text of texts) {
+      expect(text).not.toMatch(/\*\*|^[-*]\s|^#/)
     }
   })
 
   test.each(DOCS)('$name links, if any, resolve to a real target', ({ markdown }) => {
-    const links = parseMarkdownSection(markdown)
-      .paragraphs.flatMap(parseInline)
+    const links = textsOf(parseMarkdownSection(markdown))
+      .flatMap(parseInline)
       .filter((node) => node.href)
     for (const link of links) {
       expect(link.href).toMatch(/^https?:\/\/|^\//)
@@ -93,20 +131,42 @@ describe('the repo-root prose documents', () => {
 })
 
 describe('MarkdownSection', () => {
-  test.each(DOCS)('renders the $name heading and every paragraph', ({ markdown }) => {
-    const { heading, paragraphs } = parseMarkdownSection(markdown)
+  test.each(DOCS)('renders the $name heading and every block', ({ markdown }) => {
+    const content = parseMarkdownSection(markdown)
     render(<MarkdownSection markdown={markdown} />)
 
-    expect(screen.getByRole('heading', { name: heading })).toBeTruthy()
+    expect(screen.getByRole('heading', { name: content.heading })).toBeTruthy()
 
     // Compared against the rendered text, not the raw source: link syntax is
     // replaced by its label, so `[Jrvs](https://…)` reads as "Jrvs".
-    const rendered = [...document.querySelectorAll('p')].map((p) => p.textContent)
-    for (const paragraph of paragraphs) {
-      const expected = parseInline(paragraph)
+    const rendered = [...document.querySelectorAll('p, li')].map((el) => el.textContent)
+    for (const text of textsOf(content)) {
+      const expected = parseInline(text)
         .map((node) => node.text)
         .join('')
       expect(rendered).toContain(expected)
+    }
+  })
+
+  test('renders a bullet block as a list, one item per entry', () => {
+    render(<MarkdownSection markdown={'# Head\n\n- Tommy_Dude\n- lunarsignals\n'} />)
+
+    const items = screen.getAllByRole('listitem').map((li) => li.textContent)
+    expect(items).toEqual(['Tommy_Dude', 'lunarsignals'])
+    expect(screen.getAllByRole('list')).toHaveLength(1)
+  })
+
+  test('the real SPECIAL_THANKS.md renders its crew as a list, not literal dashes', () => {
+    const markdown = DOCS.find((doc) => doc.name === 'SPECIAL_THANKS.md')?.markdown ?? ''
+    render(<MarkdownSection markdown={markdown} />)
+
+    const items = screen.getAllByRole('listitem').map((li) => li.textContent)
+    expect(items).toContain('Tommy_Dude')
+    expect(items).toContain('Saving Throw')
+    // The failure this catches: a list that didn't parse renders as one
+    // paragraph reading "- Tommy_Dude - lunarsignals - …".
+    for (const p of document.querySelectorAll('p')) {
+      expect(p.textContent ?? '').not.toContain('- ')
     }
   })
 

--- a/packages/component-lib/src/markdownSection/MarkdownSection.tsx
+++ b/packages/component-lib/src/markdownSection/MarkdownSection.tsx
@@ -11,29 +11,39 @@ type MarkdownSectionProps = {
 }
 
 /**
- * MarkdownSection — a `#` heading plus its paragraphs, rendered from a raw
- * markdown string. The heading is a solid `Slab`, the canonical section head on
- * the about/back pages. `[label](href)` links are interpreted; no other inline
- * markdown is.
+ * MarkdownSection — a `#` heading plus its blocks, rendered from a raw markdown
+ * string. The heading is a solid `Slab`, the canonical section head on the
+ * about/back pages. Blocks are paragraphs and `- ` bullet lists;
+ * `[label](href)` links are the only inline markdown interpreted.
  *
  * The prose is NOT held here: it lives in a repo-root document
- * (`ABOUT_JRVS.md`, `LLM_STATEMENT.md`) and is passed in raw, so the two sites
+ * (`ABOUT_JRVS.md`, `LLM_STATEMENT.md`, `SPECIAL_THANKS.md`) and is passed in raw, so the two sites
  * cannot drift apart and the wording can be edited without touching component
  * code. This mirrors `Changelog`, the other shared markdown-backed surface —
  * the library stays data-source agnostic, and each app reads the file the way
  * its build allows (srd via `node:fs`, ITUN via a Vite `?raw` import).
  */
 export function MarkdownSection({ markdown, className }: MarkdownSectionProps) {
-  const { heading, paragraphs } = parseMarkdownSection(markdown)
+  const { heading, blocks } = parseMarkdownSection(markdown)
 
   return (
     <section className={cn('flex flex-col gap-3 text-sm leading-relaxed', className)}>
       {heading && <Slab as="h2" variant="solid" label={heading} className="mb-0" />}
-      {paragraphs.map((paragraph) => (
-        <p key={paragraph}>
-          <InlineMarkdown text={paragraph} />
-        </p>
-      ))}
+      {blocks.map((block) =>
+        block.kind === 'list' ? (
+          <ul key={block.items.join('|')} className="flex list-disc flex-col gap-1 pl-5">
+            {block.items.map((item) => (
+              <li key={item}>
+                <InlineMarkdown text={item} />
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p key={block.text}>
+            <InlineMarkdown text={block.text} />
+          </p>
+        )
+      )}
     </section>
   )
 }

--- a/packages/component-lib/src/markdownSection/parseMarkdownSection.ts
+++ b/packages/component-lib/src/markdownSection/parseMarkdownSection.ts
@@ -1,8 +1,17 @@
+/**
+ * One blank-line-separated block: a paragraph, or a `- ` bullet list.
+ *
+ * A block becomes a list only when EVERY line in it is an item, so a block
+ * mixing prose and dashes stays a paragraph and renders exactly as it did
+ * before lists existed.
+ */
+export type MarkdownBlock = { kind: 'paragraph'; text: string } | { kind: 'list'; items: string[] }
+
 export type MarkdownSectionContent = {
   /** The `#` heading, used as the section head. */
   heading: string
-  /** Blank-line-separated blocks, each rendered as one `<p>`. */
-  paragraphs: string[]
+  /** Blank-line-separated blocks, in document order. */
+  blocks: MarkdownBlock[]
 }
 
 /**
@@ -120,6 +129,28 @@ export function parseInline(text: string): InlineNode[] {
   return nodes
 }
 
+/**
+ * The items of a `- ` bullet block, or null if this block isn't one.
+ *
+ * All-or-nothing by design: one non-item line and the whole block stays prose.
+ * That keeps the change additive — every document written before lists existed
+ * parses to exactly the blocks it did before — and it means a stray hyphen at
+ * the start of a wrapped line can't silently eat the paragraph around it.
+ * Prefix checks only, so this stays regex-free like the rest of this file.
+ */
+function listItemsOf(block: string[]): string[] | null {
+  const items: string[] = []
+
+  for (const line of block) {
+    if (!line.startsWith('- ')) return null
+    const item = line.slice(2).trim()
+    if (!item) return null
+    items.push(item)
+  }
+
+  return items.length > 0 ? items : null
+}
+
 /** The heading text of a `# …` block, or null if this block isn't one. */
 function headingOf(block: string[]): string | null {
   if (block.length !== 1) return null
@@ -136,19 +167,21 @@ function headingOf(block: string[]): string | null {
 
 /**
  * Parse one of the repo-root prose documents (`ABOUT_JRVS.md`,
- * `LLM_STATEMENT.md`) into its heading + paragraphs.
+ * `LLM_STATEMENT.md`, `SPECIAL_THANKS.md`) into its heading + blocks.
  *
  * Deliberately minimal, like `parseChangelog`: these are short documents we
  * control, so they have a fixed shape and need no markdown library.
  *
- * This splits blocks only. Inline markdown is `parseInline`'s job, and
- * `[label](href)` links are the ONE inline form it interprets — the contract
- * stated in each source file's own header comment. Bold, italics and lists
- * render as literal punctuation rather than silently breaking.
+ * This splits blocks only — paragraphs, plus `- ` bullet lists (added for
+ * `SPECIAL_THANKS.md`'s crew credits, which are a list in substance and read
+ * as one). Inline markdown is `parseInline`'s job, and `[label](href)` links
+ * are the ONE inline form it interprets — the contract stated in each source
+ * file's own header comment. Bold and italics still render as literal
+ * punctuation rather than silently breaking.
  */
 export function parseMarkdownSection(markdown: string): MarkdownSectionContent {
   let heading = ''
-  const paragraphs: string[] = []
+  const blocks: MarkdownBlock[] = []
 
   for (const block of blocksOf(dropCommentLines(markdown))) {
     if (!heading) {
@@ -158,9 +191,16 @@ export function parseMarkdownSection(markdown: string): MarkdownSectionContent {
         continue
       }
     }
+
+    const items = listItemsOf(block)
+    if (items) {
+      blocks.push({ kind: 'list', items })
+      continue
+    }
+
     // Soft-wrapped prose joins into a single paragraph, matching markdown.
-    paragraphs.push(block.join(' '))
+    blocks.push({ kind: 'paragraph', text: block.join(' ') })
   }
 
-  return { heading, paragraphs }
+  return { heading, blocks }
 }


### PR DESCRIPTION
Updates the Special Thanks copy on both about pages, and teaches the shared markdown renderer to render bullet lists.

## The copy

```
Thank you to Panny and all the folks at [Leyline Press] for their continued support.

A special thanks to the #salvage-union-io crew:

- Tommy_Dude
- lunarsignals
- the puppetter
- Grandowl
- kindalas
- decivre
- Saving Throw

[Join the Discord] to join the conversation!
```

The Discord invite (`discord.gg/kMwD2bWgtC`) is the one **Leyline Press publishes on its own Salvage Union Discord page** — there was no invite anywhere in this repo, and it is not a guessed code.

## Why a renderer change was needed

`MarkdownSection` had no list support. Its `blocksOf` joins consecutive lines with a space, so the crew block would have rendered as a single paragraph reading `- Tommy_Dude - lunarsignals - the puppetter …`, dashes and all. The copy as requested was not expressible.

So `parseMarkdownSection` now returns **ordered blocks** (`{kind:'paragraph'} | {kind:'list'}`) instead of a flat `paragraphs: string[]`, and `MarkdownSection` renders a list block as a real `<ul>`.

**All-or-nothing by design:** a block becomes a list only when *every* line in it is a `- ` item. A block mixing prose and dashes stays a paragraph, so every document written before lists existed parses to exactly the blocks it did before, and a wrapped line beginning with a hyphen can't silently swallow the paragraph around it. Prefix checks only — this file is deliberately regex-free after CodeQL's `js/polynomial-redos` alerts, and that property is preserved.

## Verification

Checked against the **real built output** (`apps/srd/dist/about/index.html`), not just source:

```html
<p>Thank you to Panny and all the folks at <a href="https://leyline.press" …>Leyline Press</a> for their continued support.</p>
<p>A special thanks to the #salvage-union-io crew:</p>
<ul class="flex list-disc flex-col gap-1 pl-5">
  <li>Tommy_Dude</li> … <li>Saving Throw</li>
</ul>
<p><a href="https://discord.gg/kMwD2bWgtC" …>Join the Discord</a> to join the conversation!</p>
```

Still sits between "About the Dev" and "Support the Project", on both srd `/about` and ITUN `/about`.

- `bun run check:fast` — lint, `validate:all`, knip, typecheck across all six workspaces: green
- `bun run test` — 0 failures; component-lib 751 → **761** (10 new tests)
- `bun ssg/build.ts` — 1,039 pages, 900 endpoints

New tests cover: an all-item block becoming one ordered list; a mixed block staying a paragraph; a bare `-` not counting as an item; a link inside an item; the rendered `<ul>`/`<li>`; and a guard asserting the **real** `SPECIAL_THANKS.md` renders no literal `- ` in any paragraph — which is exactly the failure a missing blank line before the list would cause. `SPECIAL_THANKS.md` is also now in the `DOCS` set the existing document-shape tests run over, and in the Ladle story.

## Note on `ssg/parity.ts`

Not run — the baseline is gitignored and absent in a fresh worktree. It would flag `about/index.html` regardless, since this deliberately changes visible prose on that page and the baseline is frozen at the last Astro commit. Expected for any intentional post-migration copy edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123FhUCSo53Qx3aiJ3k71t8
