### PR TITLE
docs: update the LLM statement copy

### DIFF
--- a/LLM_STATEMENT.md
+++ b/LLM_STATEMENT.md
@@ -15,14 +15,10 @@
 
 # LLM Statement
 
-This was started as a hand-made project, and it predates the LLMs now used to work on it. The site and its schema are still shaped by hand.
+This project was conceived and created before the popularization of LLM coding tools. In its continued development, I have made use of various LLM coding tools to aid in the production of code, features, design, API documentation, deployments, and bug fixes. These have included AugmentCode, Kilo, Claude, and various open weight models. All LLM changes were directed, reviewed, and deployed by me, in addition to any actions taken by the LLMs. The [GitHub](https://github.com/SalvageUnion-io/SU-SRD) shows the full extent of LLM involvement. Bugs and errors are my responsibility, and the blame for them falls on me.
 
-Much of the code since then has been written with LLM assistance. Every change is directed, read, run, and merged by me, and the commit history shows which parts.
-
-The content described in the SRD is all sourced from Leyline Press, and none of it has been authored by me or any of my LLM coding assistants.
-
-My job requires proficiency in these tools, and I best gain proficiency through passion projects like this. It has been my intention to use LLMs as a force multiplier, not as a replacement for my own judgment: to more consistently and efficiently implement my changes, not to decide on the changes themselves. Bugs or issues in this project are solely my responsibility and my fault.
+The data schema and the entity dataset are hand-authored and hand-corrected; where an LLM has touched them, it was to apply a change I specified, not to originate one. All game content is sourced from Leyline Press, and no LLMs have been used in the production of game rules or content on this site. No LLMs are in use or being called while using this site. No LLMs are used in the playing of this game, nor should they be.
 
 I support open-weight models. I am against consolidated ownership of LLM infrastructure, and against the obtrusive, environmentally unsound data centers built to serve it.
 
-Software is, and will always be, a human endeavor.
+Software, like games, will eternally be a human endeavor.


### PR DESCRIPTION
Rewrites `LLM_STATEMENT.md` — the single canonical file rendered verbatim in the colophon on both about pages (srd reads it at build time with `node:fs`; ITUN inlines it via a Vite `?raw` import), so both sites change together.

## What changed

- **Names the specific tools** used: AugmentCode, Kilo, Claude, and open weight models.
- **Adds a link to this repo** as the receipt for the review claim — `[GitHub](…)` is the one inline markdown form the colophon renderer interprets.
- **Draws an explicit boundary around game content and runtime**: no LLM authored the rules, none is called while using the site, and none belongs in play.
- **States the judgment boundary on data**: the schema and entity dataset are hand-authored; an LLM only ever applied a specified change there, never originated one.
- Keeps the open-weights paragraph verbatim, and closes on "Software, like games, will eternally be a human endeavor."

## Why this shape

Checked against [Anthropic's AI diligence statement guidance](https://claude.com/resources/tutorials/writing-an-ai-diligence-statement). The revision covers all five of its essential elements — what AI assisted with, which tools, review and involvement, changes the author made, and accountability — where the previous copy left elements 2 and 4 unaddressed.

## Verification

- `bun --filter component-lib test` → **761 pass / 0 fail**, including `MarkdownSection.test.tsx`, which reads the real `LLM_STATEMENT.md` off disk and asserts its heading parses.
- Format contract held: one `#` heading, blank-line-separated paragraphs, no bold/italic/list markup (which would ship as literal punctuation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wq3syswSkrVtcY1YBJBVe