### PR TITLE
docs: scope the no-LLMs-in-play line to my own playing

### DIFF
--- a/LLM_STATEMENT.md
+++ b/LLM_STATEMENT.md
@@ -17,7 +17,7 @@
 
 This project was conceived and created before the popularization of LLM coding tools. In its continued development, I have made use of various LLM coding tools to aid in the production of code, features, design, API documentation, deployments, and bug fixes. These have included AugmentCode, Kilo, Claude, and various open weight models. All LLM changes were directed, reviewed, and deployed by me, in addition to any actions taken by the LLMs. The [GitHub](https://github.com/SalvageUnion-io/SU-SRD) shows the full extent of LLM involvement. Bugs and errors are my responsibility, and the blame for them falls on me.
 
-The data schema and the entity dataset are hand-authored and hand-corrected; where an LLM has touched them, it was to apply a change I specified, not to originate one. All game content is sourced from Leyline Press, and no LLMs have been used in the production of game rules or content on this site. No LLMs are in use or being called while using this site. No LLMs are used in the playing of this game, nor should they be.
+The data schema and the entity dataset are hand-authored and hand-corrected; where an LLM has touched them, it was to apply a change I specified, not to originate one. All game content is sourced from Leyline Press, and no LLMs have been used in the production of game rules or content on this site. No LLMs are in use or being called while using this site. No LLMs are used in my playing of this game, nor should they be.
 
 I support open-weight models. I am against consolidated ownership of LLM infrastructure, and against the obtrusive, environmentally unsound data centers built to serve it.
 


### PR DESCRIPTION
One-word copy change in `LLM_STATEMENT.md`:

> No LLMs are used in ~~the~~ **my** playing of this game, nor should they be.

The original read as a claim about every table running this game; the revision states what the author can actually vouch for. The prescriptive tail ("nor should they be") is unchanged.

## Verification

- `bun --filter component-lib test` → **761 pass / 0 fail**, including `MarkdownSection.test.tsx`, which reads the real `LLM_STATEMENT.md` off disk.

## Deploy note

⚠️ This commit touches **only** a repo-root prose file, and neither `netlify.toml` `ignore` filter includes the repo root — so merging this will produce **no deploy on either site** (same as #721). Both sites need a cache-cleared build afterward:

```
netlify api createSiteBuild --data '{"site_id":"<id>","clear_cache":true}'
```

A plain re-trigger does not work: the ignore command runs on every build regardless of trigger, and the path diff is empty. The durable fix is adding the root prose files to both ignore filters — not done here, as it is out of scope for a copy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018wq3syswSkrVtcY1YBJBVe