### PR TITLE
fix(about): spell The_Puppeteer correctly in Special Thanks

### DIFF
--- a/SPECIAL_THANKS.md
+++ b/SPECIAL_THANKS.md
@@ -24,7 +24,7 @@ A special thanks to the #salvage-union-io crew:
 
 - Tommy_Dude
 - lunarsignals
-- the puppetter
+- The_Puppeteer
 - Grandowl
 - kindalas
 - decivre


### PR DESCRIPTION
The `#salvage-union-io` credits list in `SPECIAL_THANKS.md` read `- the puppetter`. It's **The_Puppeteer** — and every other entry in that list is a bare handle (`Tommy_Dude`, `lunarsignals`, `Grandowl`, …), so this matches the surrounding style rather than keeping the lowercase "the ".

One line, no code touched. The file's format contract is preserved: the block is still all `- ` items, so `parseMarkdownSection` keeps rendering it as a bullet list.

### Heads-up: this will merge but not deploy

`SPECIAL_THANKS.md` lives at the repo root, and the `ignore` commands in both `apps/srd/netlify.toml` and `apps/itun/netlify.toml` diff only `apps/<app>`, `packages/*`, `bun.lock`, `package.json`, `bunfig.toml` and `tsconfig.json`. A root-only commit is classified "no relevant changes" and skipped on **both** sites (confirmed on #721). After this merges, force the deploys with a cache-cleared build:

```
netlify api createSiteBuild --data '{"site_id":"62482841-12dd-4e35-a4ed-900f357675dc","clear_cache":true}'  # suindex (srd)
netlify api createSiteBuild --data '{"site_id":"801d6f8d-1ad4-42c1-a29d-126b2d69ee69","clear_cache":true}'  # in-the-union-now (itun)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hx5Mg9JGaC7MbfyQmrKzg