### PR TITLE
test(itun): land the Convex backend suite that was written and never merged

### DIFF
--- a/apps/itun/convex/__tests__/account.test.ts
+++ b/apps/itun/convex/__tests__/account.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from 'bun:test'
+import { api } from '../_generated/api'
+import type { Id } from '../_generated/dataModel'
+import { testConvex } from './harness'
+
+/**
+ * Account management, and in particular the promise D27 makes:
+ * **a campaign never dies because one person quit.**
+ *
+ * Deletion is the operation with no undo, so the cases below are less about
+ * "does it delete" and more about "does it delete *only* the right things" —
+ * the crew's Game, the communal crawler, and other people's characters all
+ * have to survive somebody exercising their right to be forgotten.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+async function seedPilot(t: Ctx, gameId: Id<'games'> | null, ownerId: Id<'users'> | null) {
+  return await t.run(
+    async (ctx) =>
+      await ctx.db.insert('pilots', { gameId, ownerId, body: { callsign: 'X' }, updatedAt: 1 })
+  )
+}
+
+describe('profile', () => {
+  test('displayName falls back to the Discord name when unset', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Roach-Boy')
+    await u.as.mutation(api.account.updateProfile, { displayName: null })
+
+    const me = await u.as.query(api.account.me, {})
+    // Cleared means "fall back", not "blank" — a nameless owner chip is worse
+    // than a stale one.
+    expect(me?.displayName).toBe('Roach-Boy')
+  })
+
+  test('a set displayName overrides the Discord name', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Roach-Boy')
+    await u.as.mutation(api.account.updateProfile, { displayName: '  Beefcake  ' })
+
+    const me = await u.as.query(api.account.me, {})
+    expect(me?.displayName).toBe('Beefcake')
+  })
+
+  test('an anonymous caller has no profile to read', async () => {
+    const t = testConvex()
+    await expect(t.query(api.account.me, {})).rejects.toThrow(/not signed in/i)
+  })
+})
+
+describe('export is scoped to what you own', () => {
+  test('excludes a crewmate pilot you can merely see', async () => {
+    const t = testConvex()
+    const owner = await makeUser(t, 'Owner')
+    const other = await makeUser(t, 'Other')
+    const gameId = await owner.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await owner.as.mutation(api.invites.create, { gameId })
+    await other.as.mutation(api.invites.redeem, { code })
+
+    await seedPilot(t, gameId, owner.userId)
+    await seedPilot(t, gameId, other.userId)
+
+    const mine = await owner.as.query(api.account.exportMine, {})
+    // Readable inside a Game is not the same as yours to take away.
+    expect(mine.pilots).toHaveLength(1)
+  })
+})
+
+describe('deleteAccount — the campaign survives', () => {
+  test('Organizer passes to the longest-standing remaining member', async () => {
+    const t = testConvex()
+    const organizer = await makeUser(t, 'Organizer')
+    const early = await makeUser(t, 'Early')
+    const late = await makeUser(t, 'Late')
+
+    const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await early.as.mutation(api.invites.redeem, { code })
+    await late.as.mutation(api.invites.redeem, { code })
+
+    // Make the ordering unambiguous rather than relying on clock resolution.
+    await t.run(async (ctx) => {
+      for (const m of await ctx.db.query('memberships').collect()) {
+        if (m.userId === early.userId) await ctx.db.patch(m._id, { joinedAt: 100 })
+        if (m.userId === late.userId) await ctx.db.patch(m._id, { joinedAt: 200 })
+      }
+    })
+
+    await organizer.as.mutation(api.account.deleteAccount, {})
+
+    const roster = await early.as.query(api.games.members, { gameId })
+    const organizers = roster.filter((m) => m.organizer)
+    expect(organizers).toHaveLength(1)
+    expect(organizers[0]?.userId).toBe(early.userId)
+  })
+
+  test('the Game and the communal crawler survive', async () => {
+    const t = testConvex()
+    const organizer = await makeUser(t, 'Organizer')
+    const player = await makeUser(t, 'Player')
+    const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await player.as.mutation(api.invites.redeem, { code })
+
+    const crawlerId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('crawlers', { gameId, body: { name: '#430' }, updatedAt: 1 })
+    )
+
+    await organizer.as.mutation(api.account.deleteAccount, {})
+
+    const game = await t.run(async (ctx) => await ctx.db.get(gameId))
+    const crawler = await t.run(async (ctx) => await ctx.db.get(crawlerId))
+    expect(game).not.toBeNull()
+    // The crawler belongs to the table, not to whoever set the Game up.
+    expect(crawler).not.toBeNull()
+  })
+
+  test("another member's pilot is untouched", async () => {
+    const t = testConvex()
+    const organizer = await makeUser(t, 'Organizer')
+    const player = await makeUser(t, 'Player')
+    const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await player.as.mutation(api.invites.redeem, { code })
+
+    const theirs = await seedPilot(t, gameId, player.userId)
+    await organizer.as.mutation(api.account.deleteAccount, {})
+
+    const pilot = await t.run(async (ctx) => await ctx.db.get(theirs))
+    expect(pilot).not.toBeNull()
+    expect(pilot?.ownerId).toBe(player.userId)
+  })
+
+  test('the departing account’s own entities go, in a Game and on the shelf alike', async () => {
+    const t = testConvex()
+    const organizer = await makeUser(t, 'Organizer')
+    const player = await makeUser(t, 'Player')
+    const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await player.as.mutation(api.invites.redeem, { code })
+
+    const inGame = await seedPilot(t, gameId, organizer.userId)
+    const onShelf = await seedPilot(t, null, organizer.userId)
+
+    await organizer.as.mutation(api.account.deleteAccount, {})
+
+    expect(await t.run(async (ctx) => await ctx.db.get(inGame))).toBeNull()
+    expect(await t.run(async (ctx) => await ctx.db.get(onShelf))).toBeNull()
+  })
+
+  test('the last member out takes the Game with them', async () => {
+    const t = testConvex()
+    const solo = await makeUser(t, 'Solo')
+    const gameId = await solo.as.mutation(api.games.create, { name: 'Alone' })
+    const crawlerId = await t.run(
+      async (ctx) => await ctx.db.insert('crawlers', { gameId, body: {}, updatedAt: 1 })
+    )
+    const unclaimed = await seedPilot(t, gameId, null)
+
+    await solo.as.mutation(api.account.deleteAccount, {})
+
+    // An empty Game is not a campaign anybody can come back to, and its
+    // unclaimed entities have no shelf to fall back to.
+    expect(await t.run(async (ctx) => await ctx.db.get(gameId))).toBeNull()
+    expect(await t.run(async (ctx) => await ctx.db.get(crawlerId))).toBeNull()
+    expect(await t.run(async (ctx) => await ctx.db.get(unclaimed))).toBeNull()
+  })
+
+  test('the user row and its auth rows are gone', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Gone')
+
+    // A session with a refresh token hanging off it — the ordering hazard.
+    await t.run(async (ctx) => {
+      const sessionId = await ctx.db.insert('authSessions', {
+        userId: u.userId,
+        expirationTime: Date.now() + 1000,
+      })
+      await ctx.db.insert('authRefreshTokens', {
+        sessionId,
+        expirationTime: Date.now() + 1000,
+      })
+      await ctx.db.insert('authAccounts', {
+        userId: u.userId,
+        provider: 'discord',
+        providerAccountId: 'abc123',
+      })
+    })
+
+    await u.as.mutation(api.account.deleteAccount, {})
+
+    const left = await t.run(async (ctx) => ({
+      user: await ctx.db.get(u.userId),
+      sessions: (await ctx.db.query('authSessions').collect()).length,
+      tokens: (await ctx.db.query('authRefreshTokens').collect()).length,
+      accounts: (await ctx.db.query('authAccounts').collect()).length,
+    }))
+
+    expect(left.user).toBeNull()
+    expect(left.sessions).toBe(0)
+    // Refresh tokens are keyed by session, not user — they are the rows most
+    // likely to be left behind pointing at something deleted.
+    expect(left.tokens).toBe(0)
+    expect(left.accounts).toBe(0)
+  })
+})

--- a/apps/itun/convex/__tests__/appId.test.ts
+++ b/apps/itun/convex/__tests__/appId.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from 'bun:test'
+import { api } from '../_generated/api'
+import { testConvex } from './harness'
+
+/**
+ * Addressing server rows by the client's own app id.
+ *
+ * This exists because the first write-mirroring attempt could not work at all:
+ * Convex mints its own `_id`, so a client holding only its local UUID had
+ * nothing to address a row by. Creates mirrored and edits silently no-opped —
+ * a mirror that looked synced and was not.
+ *
+ * The cases below pin the two properties that fix it: **an edit finds its row**,
+ * and **a missing row is created rather than dropped**, which is what makes the
+ * mirror converge for entities built while Solo and claimed afterwards.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+function pilotBody(over: Record<string, unknown> = {}) {
+  return {
+    id: 'local-uuid-1',
+    schemaVersion: 1,
+    name: 'Roach-Boy',
+    callsign: 'Roach-Boy',
+    classRef: 'salvager',
+    abilities: [],
+    equipment: [],
+    motto: '',
+    keepsake: '',
+    appearance: '',
+    conditions: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...over,
+  }
+}
+
+describe('upsertByAppId', () => {
+  test('creates when no row carries that app id', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    // The Solo-then-claim path: the entity exists locally long before the
+    // server has ever heard of it.
+    await u.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'local-uuid-1',
+      gameId: null,
+      body: pilotBody(),
+    })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.appId).toBe('local-uuid-1')
+  })
+
+  test('a second write updates rather than duplicating', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    await u.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'local-uuid-1',
+      gameId: null,
+      body: pilotBody(),
+    })
+    await u.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'local-uuid-1',
+      gameId: null,
+      body: pilotBody({ name: 'Renamed' }),
+    })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    // The bug this replaces: an edit that could not find its row. One row, new
+    // name — not two rows, and not a silent no-op.
+    expect(rows).toHaveLength(1)
+    expect((rows[0]?.body as { name: string } | undefined)?.name).toBe('Renamed')
+  })
+
+  test("cannot overwrite another player's row that happens to share an app id", async () => {
+    const t = testConvex()
+    const owner = await makeUser(t, 'Owner')
+    const other = await makeUser(t, 'Other')
+
+    await owner.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'local-uuid-1',
+      gameId: null,
+      body: pilotBody(),
+    })
+
+    // Addressing by a client-supplied id must not become a way to write
+    // somebody else's data by guessing theirs.
+    await expect(
+      other.as.mutation(api.entities.upsertByAppId, {
+        table: 'pilots',
+        appId: 'local-uuid-1',
+        gameId: null,
+        body: pilotBody({ name: 'Hijacked' }),
+      })
+    ).rejects.toThrow(/another player/i)
+  })
+
+  test('a malformed body is still rejected', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    await expect(
+      u.as.mutation(api.entities.upsertByAppId, {
+        table: 'pilots',
+        appId: 'local-uuid-1',
+        gameId: null,
+        body: { nonsense: true },
+      })
+    ).rejects.toThrow(/invalid pilots payload/i)
+  })
+})
+
+describe('removeByAppId', () => {
+  test('deletes the addressed row', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    await u.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'local-uuid-1',
+      gameId: null,
+      body: pilotBody(),
+    })
+
+    await u.as.mutation(api.entities.removeByAppId, { table: 'pilots', appId: 'local-uuid-1' })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(0)
+  })
+
+  test('a row that is already gone is not an error', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    // The mirror is fire-and-forget and may retry or arrive out of order; a
+    // delete of something already deleted must be a no-op, not a throw.
+    await u.as.mutation(api.entities.removeByAppId, { table: 'pilots', appId: 'never-existed' })
+  })
+
+  test("cannot delete another player's row", async () => {
+    const t = testConvex()
+    const owner = await makeUser(t, 'Owner')
+    const other = await makeUser(t, 'Other')
+    await owner.as.mutation(api.entities.upsertByAppId, {
+      table: 'pilots',
+      appId: 'local-uuid-1',
+      gameId: null,
+      body: pilotBody(),
+    })
+
+    await expect(
+      other.as.mutation(api.entities.removeByAppId, { table: 'pilots', appId: 'local-uuid-1' })
+    ).rejects.toThrow(/another player/i)
+  })
+})

--- a/apps/itun/convex/__tests__/crew.test.ts
+++ b/apps/itun/convex/__tests__/crew.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from 'bun:test'
+import { api } from '../_generated/api'
+import { testConvex } from './harness'
+
+/**
+ * Crew visibility (D12).
+ *
+ * The privacy boundary is what these tests are for. "Every member sees every
+ * crewmate" is easy to get right; the cases that matter are the two things that
+ * must stay *out* — a non-member seeing anything at all, and a shelved entity
+ * (which belongs to one person and to no crew) being reachable through a
+ * Game-scoped read.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+async function seedGame(t: Ctx) {
+  const organizer = await makeUser(t, 'Organizer')
+  const player = await makeUser(t, 'Beefcake')
+  const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+  const code = await organizer.as.mutation(api.invites.create, { gameId })
+  await player.as.mutation(api.invites.redeem, { code })
+  return { organizer, player, gameId }
+}
+
+describe('vitals', () => {
+  test('shows every crewmate, with owner names resolved', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    await t.run(async (ctx) => {
+      await ctx.db.insert('pilots', {
+        gameId,
+        ownerId: player.userId,
+        // Casing is the point, not an incidental. `src/lib/schemas/` defines
+        // `currentHP` / `currentAP`, and `crew.vitals` once read `currentHp` /
+        // `currentAp` — so every pilot's HP came back null and the crew strip
+        // rendered a row of em-dashes, which looks exactly like "nobody has
+        // taken damage yet". The body is `v.any()` across the wire, so this
+        // fixture is the only thing standing between that bug and production.
+        body: { callsign: 'Roach-Boy', currentHP: 7, currentAP: 3 },
+        updatedAt: 1,
+      })
+    })
+
+    const crew = await organizer.as.query(api.crew.vitals, { gameId })
+    expect(crew.pilots).toHaveLength(1)
+    expect(crew.pilots[0]?.name).toBe('Roach-Boy')
+    expect(crew.pilots[0]?.currentHP).toBe(7)
+    // The chip needs a name, not just an id.
+    expect(crew.pilots[0]?.ownerName).toBe('Beefcake')
+  })
+
+  test('an unclaimed pilot has a null owner name rather than a missing row', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    await t.run(async (ctx) => {
+      await ctx.db.insert('pilots', {
+        gameId,
+        ownerId: null,
+        body: { callsign: 'Pre-gen' },
+        updatedAt: 1,
+      })
+    })
+
+    const crew = await organizer.as.query(api.crew.vitals, { gameId })
+    // Unclaimed pre-gens must still appear — they are what the Mediator hands
+    // out, so hiding them would hide the onboarding path.
+    expect(crew.pilots).toHaveLength(1)
+    expect(crew.pilots[0]?.ownerId).toBeNull()
+    expect(crew.pilots[0]?.ownerName).toBeNull()
+  })
+
+  test('a missing numeric field reads as null, not NaN or zero', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    await t.run(async (ctx) => {
+      await ctx.db.insert('pilots', { gameId, ownerId: null, body: {}, updatedAt: 1 })
+    })
+
+    const crew = await organizer.as.query(api.crew.vitals, { gameId })
+    // Bodies are opaque, so the projection must not trust their shape. Zero
+    // would render as "dead" on a vitals strip, which is worse than blank.
+    expect(crew.pilots[0]?.currentHP).toBeNull()
+  })
+
+  test('a non-member gets nothing', async () => {
+    const t = testConvex()
+    const { gameId } = await seedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+
+    await expect(outsider.as.query(api.crew.vitals, { gameId })).rejects.toThrow(/not a member/i)
+  })
+})
+
+describe('readEntity', () => {
+  test("a member can read a crewmate's sheet", async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    const pilotId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('pilots', {
+          gameId,
+          ownerId: player.userId,
+          body: { callsign: 'Roach-Boy' },
+          updatedAt: 1,
+        })
+    )
+
+    // "Lean over and look at their sheet", which is what a table does.
+    const seen = await organizer.as.query(api.crew.readEntity, {
+      table: 'pilots',
+      entityId: pilotId,
+    })
+    expect(seen).not.toBeNull()
+    expect((seen?.body as { callsign: string } | undefined)?.callsign).toBe('Roach-Boy')
+  })
+
+  test('a non-member cannot', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+    const pilotId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('pilots', {
+          gameId,
+          ownerId: player.userId,
+          body: {},
+          updatedAt: 1,
+        })
+    )
+
+    await expect(
+      outsider.as.query(api.crew.readEntity, { table: 'pilots', entityId: pilotId })
+    ).rejects.toThrow(/not a member/i)
+  })
+
+  test('a shelved entity is not reachable through this query at all', async () => {
+    const t = testConvex()
+    const { organizer, player } = await seedGame(t)
+    const shelved = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('pilots', {
+          gameId: null,
+          ownerId: player.userId,
+          body: { callsign: 'Private draft' },
+          updatedAt: 1,
+        })
+    )
+
+    // A shelf belongs to one person and to no crew. There is no membership that
+    // could grant access, so the answer is "nothing here" rather than a check
+    // that might one day be loosened.
+    const seen = await organizer.as.query(api.crew.readEntity, {
+      table: 'pilots',
+      entityId: shelved,
+    })
+    expect(seen).toBeNull()
+  })
+})

--- a/apps/itun/convex/__tests__/downtime.test.ts
+++ b/apps/itun/convex/__tests__/downtime.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from 'bun:test'
+import { api } from '../_generated/api'
+import { testConvex } from './harness'
+
+/**
+ * Crew-wide Downtime (Phase 5).
+ *
+ * The two properties worth the most here are the ones that made per-player
+ * Downtime unworkable in the first place: **upkeep charged once rather than
+ * once per member**, and **step completion that means "done with THIS step"
+ * rather than "done at some point".**
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+async function seedTable(t: Ctx) {
+  const gm = await makeUser(t, 'Mediator')
+  const a = await makeUser(t, 'Ash')
+  const b = await makeUser(t, 'Bex')
+  const gameId = await gm.as.mutation(api.games.create, { name: 'Tenacity' })
+  const code = await gm.as.mutation(api.invites.create, { gameId })
+  await a.as.mutation(api.invites.redeem, { code })
+  await b.as.mutation(api.invites.redeem, { code })
+  await gm.as.mutation(api.games.setMediator, { gameId, userId: gm.userId, mediator: true })
+  return { gm, a, b, gameId }
+}
+
+describe('the phase is table-wide and Mediator-driven', () => {
+  test('not-running is a reported state, not a null', async () => {
+    const t = testConvex()
+    const { a, gameId } = await seedTable(t)
+
+    // Reporting it saves every caller inventing the same default.
+    const s = await a.as.query(api.downtime.state, { gameId })
+    expect(s.running).toBe(false)
+    expect(s.stepIndex).toBeNull()
+  })
+
+  test('the Mediator begins and advances; everybody sees it', async () => {
+    const t = testConvex()
+    const { gm, a, gameId } = await seedTable(t)
+
+    await gm.as.mutation(api.downtime.begin, { gameId })
+    expect((await a.as.query(api.downtime.state, { gameId })).stepIndex).toBe(0)
+
+    await gm.as.mutation(api.downtime.advance, { gameId })
+    expect((await a.as.query(api.downtime.state, { gameId })).stepIndex).toBe(1)
+  })
+
+  test('a player cannot begin, advance or end it', async () => {
+    const t = testConvex()
+    const { gm, a, gameId } = await seedTable(t)
+
+    await expect(a.as.mutation(api.downtime.begin, { gameId })).rejects.toThrow(/mediator/i)
+    await gm.as.mutation(api.downtime.begin, { gameId })
+    await expect(a.as.mutation(api.downtime.advance, { gameId })).rejects.toThrow(/mediator/i)
+    await expect(a.as.mutation(api.downtime.end, { gameId })).rejects.toThrow(/mediator/i)
+  })
+
+  test('advancing before it starts is refused', async () => {
+    const t = testConvex()
+    const { gm, gameId } = await seedTable(t)
+    await expect(gm.as.mutation(api.downtime.advance, { gameId })).rejects.toThrow(/not running/i)
+  })
+})
+
+describe('completion is per step, not cumulative', () => {
+  test('marking done shows up for the whole table', async () => {
+    const t = testConvex()
+    const { gm, a, b, gameId } = await seedTable(t)
+    await gm.as.mutation(api.downtime.begin, { gameId })
+
+    await a.as.mutation(api.downtime.markStepDone, { gameId, done: true })
+
+    // The point of a shared phase: Bex can see Ash is finished.
+    const seen = await b.as.query(api.downtime.state, { gameId })
+    expect(seen.completedBy.map((c) => c.displayName)).toContain('Ash')
+  })
+
+  test('advancing clears it', async () => {
+    const t = testConvex()
+    const { gm, a, gameId } = await seedTable(t)
+    await gm.as.mutation(api.downtime.begin, { gameId })
+    await a.as.mutation(api.downtime.markStepDone, { gameId, done: true })
+
+    await gm.as.mutation(api.downtime.advance, { gameId })
+
+    // Otherwise a player who finished step 1 looks finished for the whole
+    // Downtime — the opposite of what the Mediator needs to know.
+    expect((await a.as.query(api.downtime.state, { gameId })).completedBy).toHaveLength(0)
+  })
+
+  test('marking done twice does not duplicate', async () => {
+    const t = testConvex()
+    const { gm, a, gameId } = await seedTable(t)
+    await gm.as.mutation(api.downtime.begin, { gameId })
+
+    await a.as.mutation(api.downtime.markStepDone, { gameId, done: true })
+    await a.as.mutation(api.downtime.markStepDone, { gameId, done: true })
+
+    expect((await a.as.query(api.downtime.state, { gameId })).completedBy).toHaveLength(1)
+  })
+
+  test('a player can un-mark themselves', async () => {
+    const t = testConvex()
+    const { gm, a, gameId } = await seedTable(t)
+    await gm.as.mutation(api.downtime.begin, { gameId })
+    await a.as.mutation(api.downtime.markStepDone, { gameId, done: true })
+    await a.as.mutation(api.downtime.markStepDone, { gameId, done: false })
+
+    expect((await a.as.query(api.downtime.state, { gameId })).completedBy).toHaveLength(0)
+  })
+})
+
+describe('crawler upkeep is spent once, not per member', () => {
+  test('the second attempt reports already-spent rather than charging again', async () => {
+    const t = testConvex()
+    const { gm, a, b, gameId } = await seedTable(t)
+    await gm.as.mutation(api.downtime.begin, { gameId })
+
+    expect(await a.as.mutation(api.downtime.spendUpkeep, { gameId })).toBe(true)
+    // Six members each paying is the exact double-charging that made
+    // per-player Downtime unworkable.
+    expect(await b.as.mutation(api.downtime.spendUpkeep, { gameId })).toBe(false)
+  })
+
+  test('two players racing is not an error anybody sees', async () => {
+    const t = testConvex()
+    const { gm, a, b, gameId } = await seedTable(t)
+    await gm.as.mutation(api.downtime.begin, { gameId })
+
+    // An ordinary race at a table, not a fault to surface.
+    const results = [
+      await a.as.mutation(api.downtime.spendUpkeep, { gameId }),
+      await b.as.mutation(api.downtime.spendUpkeep, { gameId }),
+    ]
+    expect(results.filter(Boolean)).toHaveLength(1)
+  })
+
+  test('advancing a step does NOT reset it', async () => {
+    const t = testConvex()
+    const { gm, a, gameId } = await seedTable(t)
+    await gm.as.mutation(api.downtime.begin, { gameId })
+    await a.as.mutation(api.downtime.spendUpkeep, { gameId })
+
+    await gm.as.mutation(api.downtime.advance, { gameId })
+
+    // Resetting here would charge the crew again mid-procedure.
+    expect((await a.as.query(api.downtime.state, { gameId })).upkeepSpent).toBe(true)
+    expect(await a.as.mutation(api.downtime.spendUpkeep, { gameId })).toBe(false)
+  })
+
+  test('a NEW downtime does reset it', async () => {
+    const t = testConvex()
+    const { gm, a, gameId } = await seedTable(t)
+    await gm.as.mutation(api.downtime.begin, { gameId })
+    await a.as.mutation(api.downtime.spendUpkeep, { gameId })
+    await gm.as.mutation(api.downtime.end, { gameId })
+
+    await gm.as.mutation(api.downtime.begin, { gameId })
+    // Upkeep is per Downtime, so the next one is payable again.
+    expect(await a.as.mutation(api.downtime.spendUpkeep, { gameId })).toBe(true)
+  })
+})
+
+describe('non-members', () => {
+  test('cannot read or touch a table they are not at', async () => {
+    const t = testConvex()
+    const { gm, gameId } = await seedTable(t)
+    const outsider = await makeUser(t, 'Outsider')
+    await gm.as.mutation(api.downtime.begin, { gameId })
+
+    await expect(outsider.as.query(api.downtime.state, { gameId })).rejects.toThrow(/not a member/i)
+    await expect(
+      outsider.as.mutation(api.downtime.markStepDone, { gameId, done: true })
+    ).rejects.toThrow(/not a member/i)
+  })
+})

--- a/apps/itun/convex/__tests__/entities.test.ts
+++ b/apps/itun/convex/__tests__/entities.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, test } from 'bun:test'
+import { api } from '../_generated/api'
+import type { Id } from '../_generated/dataModel'
+import { testConvex } from './harness'
+
+/**
+ * Entity reads and writes against the server of record.
+ *
+ * Two properties carry the weight here:
+ *
+ *  1. **Every write Zod-parses first.** The schema stores bodies as `v.any()`
+ *     so the Zod schemas stay the single source of truth, which means Convex
+ *     itself cannot reject a malformed body — the mutation must. If that check
+ *     is ever dropped, nothing else in the system will notice until a corrupt
+ *     row reaches a sheet and blanks it.
+ *  2. **Reading is per-Game, writing is per-entity.** Any member sees the whole
+ *     crew (which is what makes vitals and drill-in possible), but nobody
+ *     writes a crewmate's sheet — a Mediator wanting to change one goes through
+ *     a proposal, not a privileged write path.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+/**
+ * A minimal body that satisfies PilotSchema.
+ *
+ * Derived by probing the real schema rather than guessed — the first draft of
+ * this fixture invented fields (`currentHp`, `trainingPoints`, `abilityRefs`)
+ * that do not exist on it and omitted required ones (`classRef`, `motto`,
+ * `keepsake`, `appearance`), so every case failed at the parse step.
+ */
+function pilotBody(over: Record<string, unknown> = {}) {
+  return {
+    id: 'p1',
+    schemaVersion: 1,
+    name: 'Roach-Boy',
+    callsign: 'Roach-Boy',
+    classRef: 'salvager',
+    abilities: [],
+    equipment: [],
+    motto: '',
+    keepsake: '',
+    appearance: '',
+    conditions: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...over,
+  }
+}
+
+/**
+ * A game a player may actually put builds into.
+ *
+ * The crawler is not scene-setting — it is a precondition. `assertMayAddToContainer`
+ * refuses a player's pilot or mech until the Game has one, on the grounds that
+ * a Game with no crawler is not yet set up (the table runner is exempt, since
+ * somebody has to raise the first one). Seeding a game without it produces
+ * "This game has no Union Crawler yet" from every player-side write, which
+ * reads like a permissions failure and is not.
+ */
+async function seedGame(t: Ctx) {
+  const organizer = await makeUser(t, 'Organizer')
+  const player = await makeUser(t, 'Player')
+  const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+  await organizer.as.mutation(api.entities.createCrawler, {
+    gameId,
+    body: {
+      id: 'seed-crawler',
+      schemaVersion: 1,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      name: '#430',
+      techLevel: '1',
+      systems: [],
+    },
+  })
+  const code = await organizer.as.mutation(api.invites.create, { gameId })
+  await player.as.mutation(api.invites.redeem, { code })
+  return { organizer, player, gameId }
+}
+
+describe('every write Zod-parses first', () => {
+  test('a malformed pilot body is rejected, not stored', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    await expect(
+      u.as.mutation(api.entities.create, {
+        table: 'pilots',
+        gameId: null,
+        body: { nonsense: true },
+      })
+    ).rejects.toThrow(/invalid pilots payload/i)
+
+    // Nothing partial left behind.
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(0)
+  })
+
+  test('a well-formed pilot body is stored', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+    await u.as.mutation(api.entities.create, { table: 'pilots', gameId: null, body: pilotBody() })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.gameId).toBeNull()
+    expect(rows[0]?.ownerId).toBe(u.userId)
+  })
+})
+
+describe('reading is per-game, writing is per-entity', () => {
+  test('a member sees the whole crew, including entities they do not own', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    await player.as.mutation(api.entities.create, { table: 'pilots', gameId, body: pilotBody() })
+
+    const seen = await organizer.as.query(api.entities.listForGame, { gameId })
+    // This is what makes crew vitals and read-only drill-in possible.
+    expect(seen.pilots).toHaveLength(1)
+  })
+
+  test('a non-member sees nothing', async () => {
+    const t = testConvex()
+    const { gameId } = await seedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+
+    await expect(outsider.as.query(api.entities.listForGame, { gameId })).rejects.toThrow(
+      /not a member/i
+    )
+  })
+
+  test("a crewmate cannot write another player's pilot", async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    const pilotId = await player.as.mutation(api.entities.create, {
+      table: 'pilots',
+      gameId,
+      body: pilotBody(),
+    })
+
+    await expect(
+      organizer.as.mutation(api.entities.update, {
+        table: 'pilots',
+        entityId: pilotId,
+        body: pilotBody({ name: 'Hijacked' }),
+      })
+    ).rejects.toThrow(/another player/i)
+  })
+
+  test('an unclaimed entity cannot be edited until it is assigned', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const pilotId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('pilots', {
+          gameId,
+          ownerId: null,
+          body: pilotBody(),
+          updatedAt: 1,
+        })
+    )
+
+    // Editing an unclaimed pre-gen would let anyone quietly take it without
+    // going through assignment, which is the act the Change Log records.
+    await expect(
+      organizer.as.mutation(api.entities.update, {
+        table: 'pilots',
+        entityId: pilotId,
+        body: pilotBody({ name: 'Mine now' }),
+      })
+    ).rejects.toThrow(/unclaimed/i)
+  })
+
+  test('the owner can write their own', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedGame(t)
+    const pilotId = await player.as.mutation(api.entities.create, {
+      table: 'pilots',
+      gameId,
+      body: pilotBody(),
+    })
+
+    await player.as.mutation(api.entities.update, {
+      table: 'pilots',
+      entityId: pilotId,
+      body: pilotBody({ name: 'Renamed' }),
+    })
+
+    const row = await t.run(async (ctx) => await ctx.db.get(pilotId as Id<'pilots'>))
+    expect(row).not.toBeNull()
+    expect((row?.body as { name: string } | undefined)?.name).toBe('Renamed')
+  })
+})
+
+describe('the crawler is communal and merges per field', () => {
+  test('two members editing different fields do not clobber each other', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    const crawlerId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('crawlers', {
+          gameId,
+          appId: 'crawler-app-1',
+          // Shape probed against CrawlerSchema, not guessed: techLevel is a
+          // STRING here, there is no `modules` key, and `systems` is required.
+          body: {
+            id: 'c1',
+            schemaVersion: 1,
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            name: '#430',
+            techLevel: '1',
+            systems: [],
+          },
+          updatedAt: 1,
+        })
+    )
+
+    await organizer.as.mutation(api.entities.patchCrawlerByAppId, {
+      appId: 'crawler-app-1',
+      patch: { name: 'Tenacity' },
+    })
+    await player.as.mutation(api.entities.patchCrawlerByAppId, {
+      appId: 'crawler-app-1',
+      patch: { techLevel: '2' },
+    })
+
+    const row = await t.run(async (ctx) => await ctx.db.get(crawlerId))
+    const body = row?.body as { name: string; techLevel: string; id: string }
+
+    // Both survive. A full-body write would have discarded whichever member
+    // lost the race — on exactly the night it matters, during Downtime.
+    expect(body.name).toBe('Tenacity')
+    expect(body.techLevel).toBe('2')
+    expect(body.id).toBe('c1')
+  })
+
+  test('a non-member cannot touch the crawler', async () => {
+    const t = testConvex()
+    const { gameId } = await seedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+    await t.run(
+      async (ctx) =>
+        await ctx.db.insert('crawlers', {
+          gameId,
+          appId: 'crawler-app-2',
+          body: {},
+          updatedAt: 1,
+        })
+    )
+
+    // The member gate is asked BEFORE the body is merged and parsed, which is
+    // why an empty body is enough to make this case: if the gate ever moved
+    // after the parse, this would start failing on a schema error instead and
+    // stop testing what it says it tests.
+    await expect(
+      outsider.as.mutation(api.entities.patchCrawlerByAppId, {
+        appId: 'crawler-app-2',
+        patch: { scrap: 999 },
+      })
+    ).rejects.toThrow(/not a member/i)
+  })
+})
+
+describe('claiming local data on first sign-in', () => {
+  test('everything lands on the shelf, never in a game', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    const result = await u.as.mutation(api.entities.claimLocal, {
+      pilots: [pilotBody(), pilotBody({ id: 'p2' })],
+      mechs: [],
+    })
+
+    expect(result.claimed).toBe(2)
+    const rows = await t.run(async (ctx) => await ctx.db.query('pilots').collect())
+    // Guessing a Game for a build that has no relationship to any crew would be
+    // worse than making the person place it deliberately.
+    expect(rows.every((r) => r.gameId === null)).toBe(true)
+  })
+
+  test('one corrupt record is skipped rather than costing the whole roster', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'A')
+
+    const result = await u.as.mutation(api.entities.claimLocal, {
+      pilots: [pilotBody(), { totally: 'broken' }, pilotBody({ id: 'p3' })],
+      mechs: [],
+    })
+
+    expect(result.claimed).toBe(2)
+    expect(result.skipped).toBe(1)
+  })
+
+  test('an anonymous caller cannot claim', async () => {
+    const t = testConvex()
+    await expect(t.mutation(api.entities.claimLocal, { pilots: [], mechs: [] })).rejects.toThrow(
+      /not signed in/i
+    )
+  })
+})

--- a/apps/itun/convex/__tests__/harness.ts
+++ b/apps/itun/convex/__tests__/harness.ts
@@ -1,0 +1,46 @@
+import { convexTest } from 'convex-test'
+import schema from '../schema'
+
+/**
+ * convex-test harness for Bun.
+ *
+ * convex-test's documented setup passes `import.meta.glob('./**\/*.*s')` so it
+ * can load every Convex module. **Bun's test runner does not implement
+ * `import.meta.glob`** (it is a Vite transform, and `typeof import.meta.glob`
+ * is `undefined` here), so the module map is written out by hand instead.
+ *
+ * The consequence is that this map must be kept in step with `convex/` — a new
+ * function file that is not listed here is simply invisible to the tests, which
+ * fails open rather than loudly. `check-convex-parity.ts` does not cover this
+ * (it compares the repo against the *deployment*), so the only thing keeping
+ * the map honest is remembering. `auth.ts`, `http.ts` and `botHttp.ts` are
+ * deliberately omitted: they pull in the Discord provider, the deployment's
+ * auth env vars and the HTTP router, and nothing under test calls them.
+ * Identity is supplied directly via `withIdentity`, which is what
+ * `getAuthUserId` reads anyway.
+ */
+const modules = {
+  // convex-test locates the modules root by finding a "_generated" path in the
+  // map, so these two are required even though no test imports them directly.
+  './_generated/api.js': () => import('../_generated/api'),
+  './_generated/server.js': () => import('../_generated/server'),
+  './account.ts': () => import('../account'),
+  './botClient.ts': () => import('../botClient'),
+  './crew.ts': () => import('../crew'),
+  './downtime.ts': () => import('../downtime'),
+  './entities.ts': () => import('../entities'),
+  './games.ts': () => import('../games'),
+  './maintenance.ts': () => import('../maintenance'),
+  './mediator.ts': () => import('../mediator'),
+  './invites.ts': () => import('../invites'),
+  './ownership.ts': () => import('../ownership'),
+  './proposals.ts': () => import('../proposals'),
+  './templates.ts': () => import('../templates'),
+  './model/bot.ts': () => import('../model/bot'),
+  './model/entities.ts': () => import('../model/entities'),
+  './model/permissions.ts': () => import('../model/permissions'),
+}
+
+export function testConvex() {
+  return convexTest(schema, modules)
+}

--- a/apps/itun/convex/__tests__/mediator.test.ts
+++ b/apps/itun/convex/__tests__/mediator.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test'
+import { api } from '../_generated/api'
+import { testConvex } from './harness'
+
+/**
+ * The Mediator surface's server layer.
+ *
+ * The NPC tray is the only genuinely secret thing in a Game, so most of these
+ * tests are about it staying that way. A player who can read prepared
+ * opposition can read the encounter before it happens — the one leak that
+ * changes how the game is *played*, rather than merely who can edit what.
+ *
+ * A `presence` block used to sit here, covering `heartbeat` and the
+ * `PRESENCE_WINDOW_MS` staleness cutoff. Both are gone from `mediator.ts`: no
+ * client ever called `heartbeat`, so the table had no writer and the query
+ * always returned nothing, while `botClient.channel` read it and rendered a
+ * permanently-false "0 at the table". The tests were dropped with the feature
+ * rather than left skipped — see the module header in `../mediator.ts`, which
+ * asks that any rebuild land the writer in the same change. Restore them then.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+/** A Game where `organizer` also mediates, plus a plain player. */
+async function seedMediatedGame(t: Ctx) {
+  const organizer = await makeUser(t, 'Mediator')
+  const player = await makeUser(t, 'Player')
+  const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+  const code = await organizer.as.mutation(api.invites.create, { gameId })
+  await player.as.mutation(api.invites.redeem, { code })
+  await organizer.as.mutation(api.games.setMediator, {
+    gameId,
+    userId: organizer.userId,
+    mediator: true,
+  })
+  return { mediator: organizer, player, gameId }
+}
+
+describe('the NPC tray is Mediator-only', () => {
+  test('the Mediator can read it', async () => {
+    const t = testConvex()
+    const { mediator, gameId } = await seedMediatedGame(t)
+    await mediator.as.mutation(api.mediator.addNpc, { gameId, body: { name: 'Wretch' } })
+
+    const rows = await mediator.as.query(api.mediator.npcs, { gameId })
+    expect(rows).toHaveLength(1)
+  })
+
+  test('a player in the same game cannot', async () => {
+    const t = testConvex()
+    const { mediator, player, gameId } = await seedMediatedGame(t)
+    await mediator.as.mutation(api.mediator.addNpc, { gameId, body: { name: 'Wretch' } })
+
+    // Membership is not enough here, unlike everywhere else in the app.
+    await expect(player.as.query(api.mediator.npcs, { gameId })).rejects.toThrow(/mediator/i)
+  })
+
+  test('a player cannot add, edit or remove one', async () => {
+    const t = testConvex()
+    const { mediator, player, gameId } = await seedMediatedGame(t)
+    const npcId = await mediator.as.mutation(api.mediator.addNpc, { gameId, body: { name: 'A' } })
+
+    await expect(
+      player.as.mutation(api.mediator.addNpc, { gameId, body: { name: 'B' } })
+    ).rejects.toThrow(/mediator/i)
+    await expect(
+      player.as.mutation(api.mediator.updateNpc, { npcId, body: { name: 'C' } })
+    ).rejects.toThrow(/mediator/i)
+    await expect(player.as.mutation(api.mediator.removeNpc, { npcId })).rejects.toThrow(/mediator/i)
+  })
+
+  test('an Organizer who does not mediate cannot read it either', async () => {
+    const t = testConvex()
+    const organizer = await makeUser(t, 'Organizer')
+    const gm = await makeUser(t, 'GM')
+    const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    await gm.as.mutation(api.invites.redeem, { code })
+    await organizer.as.mutation(api.games.setMediator, {
+      gameId,
+      userId: gm.userId,
+      mediator: true,
+    })
+
+    // The Organizer flag is administrative and confers no content authority —
+    // reading prepared opposition is very much content.
+    await expect(organizer.as.query(api.mediator.npcs, { gameId })).rejects.toThrow(/mediator/i)
+  })
+})
+
+describe('amMediator', () => {
+  test('true for the Mediator, false for a player', async () => {
+    const t = testConvex()
+    const { mediator, player, gameId } = await seedMediatedGame(t)
+    expect(await mediator.as.query(api.mediator.amMediator, { gameId })).toBe(true)
+    expect(await player.as.query(api.mediator.amMediator, { gameId })).toBe(false)
+  })
+
+  test('false rather than a throw for a non-member', async () => {
+    const t = testConvex()
+    const { gameId } = await seedMediatedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+
+    // "Can I mediate this" is a reasonable question for anyone to ask, and a
+    // surface gating itself on the answer should not have to catch.
+    expect(await outsider.as.query(api.mediator.amMediator, { gameId })).toBe(false)
+  })
+})

--- a/apps/itun/convex/__tests__/permissions.test.ts
+++ b/apps/itun/convex/__tests__/permissions.test.ts
@@ -1,0 +1,517 @@
+import { describe, expect, test } from 'bun:test'
+import { api } from '../_generated/api'
+import type { Id } from '../_generated/dataModel'
+import { testConvex } from './harness'
+
+/**
+ * Authorization tests for Games (ADR-030 §3).
+ *
+ * These exist because the permission layer is the **security boundary for other
+ * people's data**, and a rule enforced only in the UI is not enforced at all.
+ * Every test here calls a real mutation as a specific identity — the same path
+ * a browser takes — rather than unit-testing the helpers in isolation, because
+ * the failure mode worth catching is a mutation that forgets to call them.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+/** Seed a user row and return an identity-bound handle for it. */
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(async (ctx) => {
+    return await ctx.db.insert('users', { name, displayName: name })
+  })
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+/** A Game created by `organizer`, plus a second member who is a plain Player. */
+async function seedGame(t: Ctx) {
+  const organizer = await makeUser(t, 'Organizer')
+  const player = await makeUser(t, 'Player')
+  const gameId = await organizer.as.mutation(api.games.create, { name: 'Tenacity' })
+
+  const code = await organizer.as.mutation(api.invites.create, { gameId })
+  await player.as.mutation(api.invites.redeem, { code })
+
+  return { organizer, player, gameId }
+}
+
+async function seedPilot(t: Ctx, gameId: Id<'games'> | null, ownerId: Id<'users'> | null) {
+  return await t.run(async (ctx) => {
+    return await ctx.db.insert('pilots', {
+      gameId,
+      ownerId,
+      body: { callsign: 'Roach-Boy' },
+      updatedAt: Date.now(),
+    })
+  })
+}
+
+describe('authentication', () => {
+  test('an anonymous caller cannot create a game', async () => {
+    const t = testConvex()
+    await expect(t.mutation(api.games.create, { name: 'Nope' })).rejects.toThrow(/not signed in/i)
+  })
+
+  test('a non-member cannot read a game roster', async () => {
+    const t = testConvex()
+    const { gameId } = await seedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+    await expect(outsider.as.query(api.games.members, { gameId })).rejects.toThrow(/not a member/i)
+  })
+})
+
+describe('roles are a base role plus one modifier', () => {
+  test('the creator is Organizer AND a seated Player, not a third kind of thing', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const roster = await organizer.as.query(api.games.members, { gameId })
+    const me = roster.find((m) => m.userId === organizer.userId)
+
+    expect(me?.organizer).toBe(true)
+    // Mediator starts false: tables usually decide who runs it after the fact.
+    expect(me?.mediator).toBe(false)
+  })
+
+  test('a joiner is a plain Player', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    const roster = await organizer.as.query(api.games.members, { gameId })
+    const them = roster.find((m) => m.userId === player.userId)
+
+    expect(them?.organizer).toBe(false)
+    expect(them?.mediator).toBe(false)
+  })
+
+  test('a Player cannot rename the game', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedGame(t)
+    await expect(player.as.mutation(api.games.rename, { gameId, name: 'Mine' })).rejects.toThrow(
+      /organizer/i
+    )
+  })
+
+  test('a Player cannot appoint a Mediator', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedGame(t)
+    await expect(
+      player.as.mutation(api.games.setMediator, {
+        gameId,
+        userId: player.userId,
+        mediator: true,
+      })
+    ).rejects.toThrow(/organizer/i)
+  })
+})
+
+describe('transferOrganizer keeps exactly one Organizer', () => {
+  test('after transfer there is exactly one, and it is the new holder', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+
+    await organizer.as.mutation(api.games.transferOrganizer, { gameId, userId: player.userId })
+
+    // Read as the NEW organizer — the old one is now a plain Player.
+    const roster = await player.as.query(api.games.members, { gameId })
+    const organizers = roster.filter((m) => m.organizer)
+
+    expect(organizers).toHaveLength(1)
+    expect(organizers[0]?.userId).toBe(player.userId)
+  })
+
+  test('the previous Organizer loses administrative power', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    await organizer.as.mutation(api.games.transferOrganizer, { gameId, userId: player.userId })
+
+    await expect(
+      organizer.as.mutation(api.games.rename, { gameId, name: 'Take-backs' })
+    ).rejects.toThrow(/organizer/i)
+  })
+
+  test('transferring to yourself is a no-op, not a way to end up with none', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    await organizer.as.mutation(api.games.transferOrganizer, { gameId, userId: organizer.userId })
+
+    const roster = await organizer.as.query(api.games.members, { gameId })
+    expect(roster.filter((m) => m.organizer)).toHaveLength(1)
+  })
+})
+
+describe('ownership assignment (ADR-030 §3 — the Organizer fallback)', () => {
+  test('a plain Player cannot assign ownership', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedGame(t)
+    const pilotId = await seedPilot(t, gameId, null)
+
+    await expect(
+      player.as.mutation(api.ownership.assign, {
+        table: 'pilots',
+        entityId: pilotId,
+        toUserId: player.userId,
+      })
+    ).rejects.toThrow(/mediator/i)
+  })
+
+  test('the Organizer CAN assign while the game has no Mediator', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    const pilotId = await seedPilot(t, gameId, null)
+
+    await organizer.as.mutation(api.ownership.assign, {
+      table: 'pilots',
+      entityId: pilotId,
+      toUserId: player.userId,
+    })
+
+    const pilot = await t.run(async (ctx) => await ctx.db.get(pilotId))
+    expect(pilot?.ownerId).toBe(player.userId)
+  })
+
+  test('the Organizer LOSES that power once a Mediator exists', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    const pilotId = await seedPilot(t, gameId, null)
+
+    // The fallback is conditional, and this is the condition ending.
+    await organizer.as.mutation(api.games.setMediator, {
+      gameId,
+      userId: player.userId,
+      mediator: true,
+    })
+
+    await expect(
+      organizer.as.mutation(api.ownership.assign, {
+        table: 'pilots',
+        entityId: pilotId,
+        toUserId: organizer.userId,
+      })
+    ).rejects.toThrow(/mediator/i)
+  })
+
+  test('the Mediator can assign', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    const pilotId = await seedPilot(t, gameId, null)
+
+    await organizer.as.mutation(api.games.setMediator, {
+      gameId,
+      userId: player.userId,
+      mediator: true,
+    })
+    await player.as.mutation(api.ownership.assign, {
+      table: 'pilots',
+      entityId: pilotId,
+      toUserId: organizer.userId,
+    })
+
+    const pilot = await t.run(async (ctx) => await ctx.db.get(pilotId))
+    expect(pilot?.ownerId).toBe(organizer.userId)
+  })
+
+  test('ownership cannot be assigned to a non-member', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+    const pilotId = await seedPilot(t, gameId, null)
+
+    // Otherwise the entity becomes unreachable — owned by someone with no
+    // membership through which to see it.
+    await expect(
+      organizer.as.mutation(api.ownership.assign, {
+        table: 'pilots',
+        entityId: pilotId,
+        toUserId: outsider.userId,
+      })
+    ).rejects.toThrow(/not a member/i)
+  })
+
+  test('every assignment is recorded on the Change Log', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    const pilotId = await seedPilot(t, gameId, null)
+
+    await organizer.as.mutation(api.ownership.assign, {
+      table: 'pilots',
+      entityId: pilotId,
+      toUserId: player.userId,
+    })
+
+    const entries = await t.run(async (ctx) => await ctx.db.query('changeLog').collect())
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.field).toBe('ownerId')
+    expect(entries[0]?.before).toBeNull()
+    expect(entries[0]?.after).toBe(player.userId)
+    expect(entries[0]?.actorId).toBe(organizer.userId)
+    expect(entries[0]?.state).toBe('applied')
+  })
+})
+
+describe('release', () => {
+  test('an owner can release their own entity', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedGame(t)
+    const pilotId = await seedPilot(t, gameId, player.userId)
+
+    await player.as.mutation(api.ownership.release, { table: 'pilots', entityId: pilotId })
+
+    const pilot = await t.run(async (ctx) => await ctx.db.get(pilotId))
+    expect(pilot?.ownerId).toBeNull()
+    // Unclaimed, not destroyed, and still in the game.
+    expect(pilot?.gameId).toBe(gameId)
+  })
+
+  test("a bystander cannot release somebody else's entity", async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    const pilotId = await seedPilot(t, gameId, player.userId)
+
+    // The Organizer is not the owner and (here) not the Mediator either.
+    await expect(
+      organizer.as.mutation(api.ownership.release, { table: 'pilots', entityId: pilotId })
+    ).rejects.toThrow(/owner or the mediator/i)
+  })
+})
+
+describe('leaving a game', () => {
+  test('a departing Player leaves their entities behind, unclaimed', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedGame(t)
+    const pilotId = await seedPilot(t, gameId, player.userId)
+
+    await player.as.mutation(api.ownership.leaveGame, { gameId })
+
+    const pilot = await t.run(async (ctx) => await ctx.db.get(pilotId))
+    // The crew survives a departure; nothing is destroyed.
+    expect(pilot?.gameId).toBe(gameId)
+    expect(pilot?.ownerId).toBeNull()
+  })
+
+  test('the Organizer cannot leave without handing the flag on', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    // A game with no Organizer has nobody who can invite, rename, or delete it.
+    await expect(organizer.as.mutation(api.ownership.leaveGame, { gameId })).rejects.toThrow(
+      /transfer the organizer/i
+    )
+  })
+})
+
+describe('destroying a game preserves owned characters', () => {
+  test('owned entities fall back to their owner shelf; unclaimed ones go', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    const ownedId = await seedPilot(t, gameId, player.userId)
+    const unclaimedId = await seedPilot(t, gameId, null)
+
+    await organizer.as.mutation(api.games.destroy, { gameId })
+
+    const owned = await t.run(async (ctx) => await ctx.db.get(ownedId))
+    const unclaimed = await t.run(async (ctx) => await ctx.db.get(unclaimedId))
+
+    // Deleting a campaign must never delete somebody's character.
+    expect(owned).not.toBeNull()
+    expect(owned?.gameId).toBeNull()
+    expect(owned?.ownerId).toBe(player.userId)
+
+    // An unclaimed entity has no shelf to fall back to. Keeping it would create
+    // the one combination ADR-030 calls invalid: gameId null AND ownerId null.
+    expect(unclaimed).toBeNull()
+  })
+
+  test('a Player cannot destroy the game', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedGame(t)
+    await expect(player.as.mutation(api.games.destroy, { gameId })).rejects.toThrow(/organizer/i)
+  })
+})
+
+describe('listMine', () => {
+  test('returns every game you belong to, with your role and the crew size', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+
+    const mine = await organizer.as.query(api.games.listMine, {})
+    expect(mine).toHaveLength(1)
+    expect(mine[0]?._id).toBe(gameId)
+    expect(mine[0]?.organizer).toBe(true)
+    expect(mine[0]?.memberCount).toBe(2)
+
+    // The same game, seen from the other side, reports the other role.
+    const theirs = await player.as.query(api.games.listMine, {})
+    expect(theirs[0]?.organizer).toBe(false)
+  })
+
+  test('is empty for somebody in no games', async () => {
+    const t = testConvex()
+    await seedGame(t)
+    const outsider = await makeUser(t, 'Outsider')
+    expect(await outsider.as.query(api.games.listMine, {})).toHaveLength(0)
+  })
+
+  test('an anonymous caller cannot list games', async () => {
+    const t = testConvex()
+    await expect(t.query(api.games.listMine, {})).rejects.toThrow(/not signed in/i)
+  })
+})
+
+describe('requireMediator', () => {
+  test('a Mediator passes, a plain Player does not', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    await organizer.as.mutation(api.games.setMediator, {
+      gameId,
+      userId: player.userId,
+      mediator: true,
+    })
+
+    // setMediator is Organizer-gated, so exercise the Mediator gate through a
+    // mutation that actually requires it.
+    const pilotId = await seedPilot(t, gameId, null)
+    await player.as.mutation(api.ownership.assign, {
+      table: 'pilots',
+      entityId: pilotId,
+      toUserId: organizer.userId,
+    })
+
+    const pilot = await t.run(async (ctx) => await ctx.db.get(pilotId))
+    expect(pilot?.ownerId).toBe(organizer.userId)
+  })
+})
+
+describe('invite lifecycle', () => {
+  test('an expired code is refused', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const joiner = await makeUser(t, 'Late')
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+
+    await t.run(async (ctx) => {
+      for (const row of await ctx.db.query('invites').collect()) {
+        await ctx.db.patch(row._id, { expiresAt: Date.now() - 1000 })
+      }
+    })
+
+    await expect(joiner.as.mutation(api.invites.redeem, { code })).rejects.toThrow(/expired/i)
+  })
+
+  test('a used-up code is refused, and uses decrement', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const first = await makeUser(t, 'First')
+    const second = await makeUser(t, 'Second')
+    const code = await organizer.as.mutation(api.invites.create, { gameId, usesRemaining: 1 })
+
+    await first.as.mutation(api.invites.redeem, { code })
+    await expect(second.as.mutation(api.invites.redeem, { code })).rejects.toThrow(/used up/i)
+  })
+
+  test('redeeming twice does not consume a second use', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const joiner = await makeUser(t, 'Joiner')
+    const code = await organizer.as.mutation(api.invites.create, { gameId, usesRemaining: 2 })
+
+    await joiner.as.mutation(api.invites.redeem, { code })
+    await joiner.as.mutation(api.invites.redeem, { code })
+
+    // Tapping a link twice should land you in the game, not cost the table a
+    // seat it did not give away.
+    //
+    // Selected BY CODE: seedGame already minted an invite, so index 0 is a
+    // different row entirely — the first draft of this test asserted against it
+    // and failed for the wrong reason.
+    const invite = await t.run(async (ctx) =>
+      (await ctx.db.query('invites').collect()).find((i) => i.code === code)
+    )
+    expect(invite?.usesRemaining).toBe(1)
+  })
+
+  test('an unknown code is refused', async () => {
+    const t = testConvex()
+    await seedGame(t)
+    const joiner = await makeUser(t, 'Joiner')
+    await expect(joiner.as.mutation(api.invites.redeem, { code: 'NOPENOPE' })).rejects.toThrow(
+      /not valid/i
+    )
+  })
+
+  test('the Organizer can revoke a code before it is used', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const joiner = await makeUser(t, 'Joiner')
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+
+    const invite = await t.run(async (ctx) =>
+      (await ctx.db.query('invites').collect()).find((i) => i.code === code)
+    )
+    await organizer.as.mutation(api.invites.revoke, { inviteId: invite?._id as never })
+
+    await expect(joiner.as.mutation(api.invites.redeem, { code })).rejects.toThrow(/revoked/i)
+  })
+
+  test('a Player cannot revoke', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    const code = await organizer.as.mutation(api.invites.create, { gameId })
+    const invite = await t.run(async (ctx) =>
+      (await ctx.db.query('invites').collect()).find((i) => i.code === code)
+    )
+
+    await expect(
+      player.as.mutation(api.invites.revoke, { inviteId: invite?._id as never })
+    ).rejects.toThrow(/organizer/i)
+  })
+})
+
+describe('a shelved entity is not assignable', () => {
+  test('assigning one is refused, because there is no game to assign within', async () => {
+    const t = testConvex()
+    const { organizer } = await seedGame(t)
+    const shelved = await seedPilot(t, null, organizer.userId)
+
+    // Ownership only means something inside a crew. On a shelf the entity
+    // already belongs to exactly one person and there is nobody to hand it to.
+    await expect(
+      organizer.as.mutation(api.ownership.assign, {
+        table: 'pilots',
+        entityId: shelved,
+        toUserId: organizer.userId,
+      })
+    ).rejects.toThrow(/shelf/i)
+  })
+
+  test('releasing one is refused for the same reason', async () => {
+    const t = testConvex()
+    const { organizer } = await seedGame(t)
+    const shelved = await seedPilot(t, null, organizer.userId)
+
+    // Matched on the load-bearing phrase rather than the full sentence: this
+    // copy is player-facing and gets reworded, and an assertion pinned to the
+    // whole string fails on a comma. It already drifted once ("already
+    // unclaimed" → "already yours") while these tests sat unlanded.
+    await expect(
+      organizer.as.mutation(api.ownership.release, { table: 'pilots', entityId: shelved })
+    ).rejects.toThrow(/already yours/i)
+  })
+})
+
+describe('requireMediator', () => {
+  test('rejects a member who does not mediate', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedGame(t)
+    const { requireMediator } = await import('../model/permissions')
+
+    // Exercised directly: this PR ships the helper ahead of its Phase 3
+    // callers, and an untested gate is the kind that quietly stops gating.
+    await expect(
+      t.run(async (ctx) => {
+        const withIdentity = {
+          ...ctx,
+          auth: { getUserIdentity: async () => ({ subject: player.userId }) },
+        }
+        return await requireMediator(withIdentity as never, gameId)
+      })
+    ).rejects.toThrow(/mediator/i)
+  })
+})

--- a/apps/itun/convex/__tests__/proposals.test.ts
+++ b/apps/itun/convex/__tests__/proposals.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, test } from 'bun:test'
+import { api } from '../_generated/api'
+import type { Id } from '../_generated/dataModel'
+import { testConvex } from './harness'
+
+/**
+ * Propose-and-confirm (D7, D25).
+ *
+ * The thing being protected is that **a Mediator never writes a player's
+ * sheet**. So the tests are less about the happy path and more about the ways
+ * that promise could quietly erode: a force-apply path appearing, a proposal
+ * expiring and dropping damage, or two contradictory pendings against one field.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+async function seedTable(t: Ctx) {
+  const gm = await makeUser(t, 'Mediator')
+  const player = await makeUser(t, 'Player')
+  const gameId = await gm.as.mutation(api.games.create, { name: 'Tenacity' })
+  const code = await gm.as.mutation(api.invites.create, { gameId })
+  await player.as.mutation(api.invites.redeem, { code })
+  await gm.as.mutation(api.games.setMediator, { gameId, userId: gm.userId, mediator: true })
+
+  const mechId = await t.run(
+    async (ctx) =>
+      await ctx.db.insert('mechs', {
+        gameId,
+        ownerId: player.userId,
+        /*
+         * A COMPLETE mech, not a two-field stub. `proposals.apply` re-parses
+         * the merged body against `MechSchema` before writing, so a partial
+         * fixture fails on a missing required field rather than on anything
+         * the test is about — and the failure ("expected string, received
+         * undefined") names neither the field nor the schema.
+         */
+        body: {
+          id: 'mech-1',
+          schemaVersion: 1,
+          name: 'Mule',
+          chassisRef: 'mule',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          systems: [],
+          modules: [],
+          cargoLots: [],
+          conditions: [],
+          currentSP: 10,
+        },
+        updatedAt: 1,
+      })
+  )
+  return { gm, player, gameId, mechId }
+}
+
+describe('the Mediator proposes; the player writes', () => {
+  test('a proposal does not change the entity', async () => {
+    const t = testConvex()
+    const { gm, mechId } = await seedTable(t)
+
+    await gm.as.mutation(api.proposals.propose, {
+      entityId: mechId,
+      entityType: 'mech',
+      field: 'currentSP',
+      before: 10,
+      after: 6,
+    })
+
+    const mech = await t.run(async (ctx) => await ctx.db.get(mechId as Id<'mechs'>))
+    // Still 10. Proposing is not writing.
+    expect((mech?.body as { currentSP: number } | undefined)?.currentSP).toBe(10)
+  })
+
+  test('applying it does, and only the owner may', async () => {
+    const t = testConvex()
+    const { gm, player, gameId, mechId } = await seedTable(t)
+    await gm.as.mutation(api.proposals.propose, {
+      entityId: mechId,
+      entityType: 'mech',
+      field: 'currentSP',
+      before: 10,
+      after: 6,
+    })
+
+    const [pending] = await player.as.query(api.proposals.pending, { gameId })
+    expect(pending).toBeDefined()
+
+    // The Mediator cannot apply on the player's behalf — that would be the
+    // direct write this whole mechanism exists to avoid.
+    await expect(
+      gm.as.mutation(api.proposals.apply, { proposalId: pending?._id as Id<'changeLog'> })
+    ).rejects.toThrow(/only the owner/i)
+
+    await player.as.mutation(api.proposals.apply, {
+      proposalId: pending?._id as Id<'changeLog'>,
+    })
+    const mech = await t.run(async (ctx) => await ctx.db.get(mechId as Id<'mechs'>))
+    expect((mech?.body as { currentSP: number } | undefined)?.currentSP).toBe(6)
+  })
+
+  test("a player cannot propose to their own or a crewmate's entity", async () => {
+    const t = testConvex()
+    const { player, mechId } = await seedTable(t)
+    await expect(
+      player.as.mutation(api.proposals.propose, {
+        entityId: mechId,
+        entityType: 'mech',
+        field: 'currentSP',
+        before: 10,
+        after: 999,
+      })
+    ).rejects.toThrow(/mediator/i)
+  })
+
+  test('an unclaimed entity cannot be proposed to', async () => {
+    const t = testConvex()
+    const { gm, gameId } = await seedTable(t)
+    const orphan = await t.run(
+      async (ctx) => await ctx.db.insert('mechs', { gameId, ownerId: null, body: {}, updatedAt: 1 })
+    )
+
+    // Nobody would ever see it, so it would sit pending forever.
+    await expect(
+      gm.as.mutation(api.proposals.propose, {
+        entityId: orphan,
+        entityType: 'mech',
+        field: 'currentSP',
+        before: 0,
+        after: 1,
+      })
+    ).rejects.toThrow(/unclaimed/i)
+  })
+})
+
+describe('supersession, not expiry', () => {
+  test('a newer proposal on the same field retires the older one', async () => {
+    const t = testConvex()
+    const { gm, player, gameId, mechId } = await seedTable(t)
+
+    const first = await gm.as.mutation(api.proposals.propose, {
+      entityId: mechId,
+      entityType: 'mech',
+      field: 'currentSP',
+      before: 10,
+      after: 6,
+    })
+    await gm.as.mutation(api.proposals.propose, {
+      entityId: mechId,
+      entityType: 'mech',
+      field: 'currentSP',
+      before: 10,
+      after: 4,
+    })
+
+    const pending = await player.as.query(api.proposals.pending, { gameId })
+    // One pending, not two: a player is never asked to choose between
+    // contradictory values for the same field.
+    expect(pending).toHaveLength(1)
+    expect(pending[0]?.after).toBe(4)
+
+    const old = await t.run(async (ctx) => await ctx.db.get(first))
+    expect(old?.state).toBe('superseded')
+    expect(old?.supersededBy).toBeDefined()
+  })
+
+  test('a proposal on a DIFFERENT field is left alone', async () => {
+    const t = testConvex()
+    const { gm, player, gameId, mechId } = await seedTable(t)
+
+    await gm.as.mutation(api.proposals.propose, {
+      entityId: mechId,
+      entityType: 'mech',
+      field: 'currentSP',
+      before: 10,
+      after: 6,
+    })
+    await gm.as.mutation(api.proposals.propose, {
+      entityId: mechId,
+      entityType: 'mech',
+      field: 'currentHeat',
+      before: 0,
+      after: 3,
+    })
+
+    // Supersession is per FIELD. Damage and heat are separate facts.
+    expect(await player.as.query(api.proposals.pending, { gameId })).toHaveLength(2)
+  })
+
+  test('nothing expires — an unanswered proposal stays pending', async () => {
+    const t = testConvex()
+    const { gm, player, gameId, mechId } = await seedTable(t)
+    const id = await gm.as.mutation(api.proposals.propose, {
+      entityId: mechId,
+      entityType: 'mech',
+      field: 'currentSP',
+      before: 10,
+      after: 6,
+    })
+
+    // Backdate it well past any plausible timeout. A timer here would silently
+    // drop damage the player was meant to take.
+    await t.run(async (ctx) => {
+      await ctx.db.patch(id, { ts: Date.now() - 1000 * 60 * 60 * 24 * 30 })
+    })
+
+    expect(await player.as.query(api.proposals.pending, { gameId })).toHaveLength(1)
+  })
+})
+
+describe('declining', () => {
+  test('records rather than deletes, and leaves the entity alone', async () => {
+    const t = testConvex()
+    const { gm, player, gameId, mechId } = await seedTable(t)
+    const id = await gm.as.mutation(api.proposals.propose, {
+      entityId: mechId,
+      entityType: 'mech',
+      field: 'currentSP',
+      before: 10,
+      after: 6,
+    })
+
+    await player.as.mutation(api.proposals.decline, { proposalId: id })
+
+    const row = await t.run(async (ctx) => await ctx.db.get(id))
+    // The log is append-only; a declined proposal is history, not a gap.
+    expect(row?.state).toBe('declined')
+    const mech = await t.run(async (ctx) => await ctx.db.get(mechId as Id<'mechs'>))
+    expect((mech?.body as { currentSP: number } | undefined)?.currentSP).toBe(10)
+    expect(await player.as.query(api.proposals.pending, { gameId })).toHaveLength(0)
+  })
+})
+
+describe('pending is scoped to the asker', () => {
+  test("a player is not shown proposals against a crewmate's entity", async () => {
+    const t = testConvex()
+    const { gm, gameId, mechId } = await seedTable(t)
+    const bystander = await makeUser(t, 'Bystander')
+    const code = await gm.as.mutation(api.invites.create, { gameId })
+    await bystander.as.mutation(api.invites.redeem, { code })
+
+    await gm.as.mutation(api.proposals.propose, {
+      entityId: mechId,
+      entityType: 'mech',
+      field: 'currentSP',
+      before: 10,
+      after: 6,
+    })
+
+    // Showing it would leak an edit in flight against a crewmate.
+    expect(await bystander.as.query(api.proposals.pending, { gameId })).toHaveLength(0)
+  })
+})
+
+describe('alerts share the proposal bus', () => {
+  test('the Mediator broadcasts and every member reads', async () => {
+    const t = testConvex()
+    const { gm, player, gameId } = await seedTable(t)
+    await gm.as.mutation(api.proposals.broadcast, { gameId, message: 'Sandstorm inbound' })
+
+    const seen = await player.as.query(api.proposals.alerts, { gameId })
+    expect(seen[0]?.message).toBe('Sandstorm inbound')
+  })
+
+  test('a player cannot broadcast', async () => {
+    const t = testConvex()
+    const { player, gameId } = await seedTable(t)
+    await expect(
+      player.as.mutation(api.proposals.broadcast, { gameId, message: 'free scrap' })
+    ).rejects.toThrow(/mediator/i)
+  })
+
+  test('an alert does not appear as a pending proposal', async () => {
+    const t = testConvex()
+    const { gm, player, gameId } = await seedTable(t)
+    await gm.as.mutation(api.proposals.broadcast, { gameId, message: 'Sandstorm' })
+
+    // Same table, different shape — an alert has no entity to answer for.
+    expect(await player.as.query(api.proposals.pending, { gameId })).toHaveLength(0)
+  })
+})

--- a/apps/itun/convex/__tests__/templates.test.ts
+++ b/apps/itun/convex/__tests__/templates.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from 'bun:test'
+import { api } from '../_generated/api'
+import { testConvex } from './harness'
+
+/**
+ * Game templates (D34).
+ *
+ * The property under test is the one that makes a template useful rather than
+ * decorative: **its entities arrive unclaimed**, so the person running the
+ * table hands them out. A template that pre-assigned everything to its creator
+ * would just be a private roster with extra steps.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+describe('starter-set template', () => {
+  test('is listed', async () => {
+    const t = testConvex()
+    const templates = await t.query(api.templates.list, {})
+    expect(templates.map((x) => x.id)).toContain('starter-set')
+  })
+
+  test('every pilot and mech arrives unclaimed', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const { pilots, mechs } = await t.run(async (ctx) => ({
+      pilots: await ctx.db.query('pilots').collect(),
+      mechs: await ctx.db.query('mechs').collect(),
+    }))
+
+    expect(pilots.length).toBeGreaterThan(0)
+    expect(mechs.length).toBeGreaterThan(0)
+    // Not owned by the creator — that is the difference between a template and
+    // a private roster.
+    expect(pilots.every((p) => p.ownerId === null)).toBe(true)
+    expect(mechs.every((m) => m.ownerId === null)).toBe(true)
+  })
+
+  test('the creator is Organizer and a seated Player, as with any game', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    const gameId = await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const roster = await u.as.query(api.games.members, { gameId })
+    expect(roster).toHaveLength(1)
+    expect(roster[0]?.organizer).toBe(true)
+    // A template changes what is IN the game, never who runs it.
+    expect(roster[0]?.mediator).toBe(false)
+  })
+
+  test('the crawler is created communally, with no owner column at all', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const crawlers = await t.run(async (ctx) => await ctx.db.query('crawlers').collect())
+    expect(crawlers.length).toBeGreaterThan(0)
+    expect(crawlers[0]).not.toHaveProperty('ownerId')
+  })
+
+  test('soft links come across, so the crew is wired together on arrival', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const links = await t.run(async (ctx) => await ctx.db.query('softLinks').collect())
+    // Without these the pilots and mechs would arrive as unrelated strangers.
+    expect(links.length).toBeGreaterThan(0)
+    expect(links.some((l) => l.type === 'mech-to-pilot')).toBe(true)
+  })
+
+  test('the game records which template it came from', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    const gameId = await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
+
+    const game = await t.run(async (ctx) => await ctx.db.get(gameId))
+    expect(game?.templateOrigin).toBe('starter-set')
+  })
+
+  test('a custom name overrides the template name', async () => {
+    const t = testConvex()
+    const u = await makeUser(t, 'Organizer')
+    const gameId = await u.as.mutation(api.templates.createGame, {
+      templateId: 'starter-set',
+      name: '  Our Tuesday Game  ',
+    })
+
+    const game = await t.run(async (ctx) => await ctx.db.get(gameId))
+    expect(game?.name).toBe('Our Tuesday Game')
+  })
+
+  test('an anonymous caller cannot create one', async () => {
+    const t = testConvex()
+    await expect(
+      t.mutation(api.templates.createGame, { templateId: 'starter-set' })
+    ).rejects.toThrow(/not signed in/i)
+  })
+})

--- a/tools/check-convex-codegen.ts
+++ b/tools/check-convex-codegen.ts
@@ -44,7 +44,19 @@ const NOT_MODULES = new Set(['schema.ts', 'auth.config.ts'])
 function walk(dir: string, out: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry)
-    if (entry === '_generated') continue
+    /*
+     * Convex's own rule, not a special case for `_generated`: any path segment
+     * beginning with `_` is outside the function namespace entirely. That is
+     * what makes `convex/__tests__/` a legal place to put tests — Convex never
+     * tries to register them, so they cannot appear in `api.d.ts` and their
+     * absence from it is not drift.
+     *
+     * Matching only `_generated` here made this check fail on the first test
+     * file added under `convex/`, demanding the impossible: that codegen
+     * register a module Convex refuses to see. Anyone hitting that reasonably
+     * concludes tests do not belong in `convex/` and puts them nowhere.
+     */
+    if (entry.startsWith('_')) continue
     if (statSync(full).isDirectory()) {
       walk(full, out)
       continue


### PR DESCRIPTION
## The gap

`apps/itun/convex/` — the server of record for every pilot, mech and crawler, 18 modules with `entities.ts` alone at 962 lines — had **zero tests in `main`**. Not thin coverage. None:

```
$ git ls-tree -r --name-only origin/main -- apps/itun/convex | grep -i test
$
```

It was not missing because nobody wrote it. It was written, on the `itun-accounts-*` stack, and those PRs were closed when the work landed via #647/#656 — taking ~1,700 lines of tests with them. This restores **109 of them**, reconciled against ten weeks of drift.

## Why this is worth doing, concretely

`appId.test.ts` contains a test named:

> `'a second write updates rather than duplicating'`

That is precisely the invariant that broke in production on 2026-08-09. Duplicate `appId` rows made `byAppId` throw; a player's pilot edits stopped reaching their game while every surface rendered them as saved; 39 mirrored writes failed in one evening and it surfaced as a Discord message rather than a red build. **The test that would have caught it existed the whole time, on a branch.**

Two more of the same shape. `crew.ts` carries a comment explaining that it once read `currentHp` while the Zod schema defines `currentHP`, so every pilot's HP came back null and the crew strip rendered a row of em-dashes — indistinguishable from "nobody has taken damage yet" — and it closes with "nothing but this comment and **the test below** will catch it next time." That test is in this PR. `proposals` had the identical `currentSp` slip.

## Reconciliation

Each of these is a real change since the branch, not a test that was wrong:

- **`patchCrawler` was deleted.** The communal-merge and member-gate tests now go through `patchCrawlerByAppId`.
- **`assertMayAddToContainer` now requires a crawler** before a player may add builds, so `seedGame` raises one. Without it every player-side write fails with "This game has no Union Crawler yet", which reads like a permissions bug and is not.
- **`proposals.apply` re-parses the merged body**, so its mech fixture had to become a complete `MechSchema` record rather than a two-field stub.
- **Two refusal messages were reworded.** Both assertions now match the load-bearing phrase rather than the whole sentence, with a comment saying why — this copy is player-facing and will drift again.
- **`presence` was deliberately removed** from `mediator.ts` (no client ever called `heartbeat`, so the table had no writer and `botClient.channel` rendered a permanently-false "0 at the table"). Those tests are dropped with the feature rather than left skipped, with a note pointing at the module header that asks any rebuild to land the writer in the same change.

## A tooling fix that may explain the gap

`tools/check-convex-codegen.ts` **failed on the first test file placed under `convex/`**. It skipped only `_generated`, while Convex ignores *any* path segment starting with `_` — so `convex/__tests__/` tripped it, and it demanded that codegen register modules Convex refuses to see. There is no way to satisfy that. Anyone who hit it would reasonably conclude tests do not belong in `convex/` at all.

`convex-test@0.0.55` was already a dependency in `main`, unused — the harness needed nothing new.

## Verification

- `bun --filter itun test`: **1830 → 1939 pass, 0 fail.** Picked up by the workspace runner automatically; no bunfig change needed.
- `bun run test` (canonical, all workspaces): green.
- `bun run check:fast`: green — lint, `validate:all` (including the now-passing `validate:convex-codegen`), knip, typecheck across all packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Ms18wRLjK2W62PGUk8XWj
