### PR TITLE
fix(discord-bot): map Sentry stack traces back to TypeScript source

### DIFF
--- a/apps/discord-bot/CLAUDE.md
+++ b/apps/discord-bot/CLAUDE.md
@@ -11,6 +11,17 @@ at startup ([ADR-005](../../docs/adrs/ADR-005-reference-data-orm.md)).
 - **Library:** Discord.js v14
 - **Data:** `salvageunion-reference` workspace package (standalone, no component-lib)
 
+## Sourcemaps are half of Sentry here
+
+`build` bundles with `--sourcemap=linked` and `start` runs
+`node --enable-source-maps`. **Both halves are required and neither is a debug
+nicety.** The bot ships a 2 MB bundle, so without them every Sentry issue points
+at an offset in `dist/index.js` and names no real file; with them Node maps the
+frames in-process *before* `@sentry/node` builds the event, which is also why the
+bot needs no sourcemap upload step. Verified: `dist/index.js:58721` resolves to
+`src/config.ts:4:11`. `render.yaml`'s `startCommand` carries the runtime half and
+the full reasoning — change the two together or not at all.
+
 ## Structure
 
 - `src/index.ts` - Bot entry point

--- a/apps/discord-bot/package.json
+++ b/apps/discord-bot/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "dev": "bun run src/index.ts",
     "dev:watch": "bun --watch run src/index.ts",
-    "build": "bun build src/index.ts src/deploy-commands.ts --outdir dist --target node --external discord.js --external @sentry/node --external @randsum/roller",
-    "start": "node dist/index.js",
+    "build": "bun build src/index.ts src/deploy-commands.ts --outdir dist --target node --sourcemap=linked --external discord.js --external @sentry/node --external @randsum/roller",
+    "start": "node --enable-source-maps dist/index.js",
     "deploy-commands": "bun run src/deploy-commands.ts",
     "deploy-commands:global": "DEPLOY_GLOBAL=true bun run src/deploy-commands.ts",
     "typecheck": "tsc --noEmit",

--- a/render.yaml
+++ b/render.yaml
@@ -8,7 +8,15 @@ services:
     # Global slash commands are registered manually (an explicit step) only
     # when the command shape changes — see apps/discord-bot/README.md.
     buildCommand: 'bun install --ignore-scripts && bun run build:bot'
-    startCommand: 'node apps/discord-bot/dist/index.js'
+    # `--enable-source-maps` is load-bearing for Sentry, not a debug nicety.
+    # `build:bot` bundles with `--sourcemap=linked`, which emits dist/index.js.map;
+    # this flag is what makes Node apply it, so the stack frames @sentry/node
+    # captures are already mapped back to src/*.ts. Without it every bot issue in
+    # Sentry points at a bundled offset in dist/index.js and names no real file.
+    # Sentry needs no sourcemap upload for the bot precisely because the mapping
+    # happens in-process before the event is built. Keep the two halves together:
+    # dropping either the build flag or this one silently restores bundled frames.
+    startCommand: 'node --enable-source-maps apps/discord-bot/dist/index.js'
     # Without this, every commit to main rebuilds and redeploys the bot —
     # including srd/itun/component-lib work and release-please chores that it
     # cannot possibly depend on. Measured over the 71 commits between


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>