### PR TITLE
feat(install): refuse dependency versions published in the last 3 days

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,30 @@ The companion fix in the same change was real, not suppressed: `nanoid` is
 pinned to `^3.3.18` in `overrides` (from `3.3.16`, via `vite → postcss`),
 clearing `GHSA-2v37-7h3g-55p8`.
 
+### Install cooldown (`minimumReleaseAge`)
+
+`bunfig.toml` refuses dependency versions **published less than 3 days ago**.
+Dependabot opens *grouped* minor/patch PRs weekly, so reviewing one realistically
+means glancing at a list of version numbers — three days is about how long a
+hijacked npm release lasts before it is noticed and unpublished, and this makes
+such a version unresolvable rather than trusting that glance to catch it.
+
+Two behaviours, measured on Bun 1.3.14 — know which one you are hitting:
+
+- an **exact pin** the gate cannot satisfy is a hard, self-describing error
+  (`... (blocked by minimum-release-age: N seconds)`). Most deps here are exact
+  pins, so this is the usual case.
+- a **caret range silently resolves *down*** to the newest version old enough.
+  No warning. So `bun update <pkg>` to clear a *fresh* advisory can look like it
+  did nothing — check the publish date before concluding the fix is broken. The
+  `overrides` floors still hold (resolving below a floor errors instead).
+
+`bun install --frozen-lockfile` does no resolution and is **unaffected** —
+verified; CI and all four deploy targets never see this gate.
+
+The escape hatch is `minimumReleaseAgeExcludes` (currently `bun-types`, which
+must track `.bun-version` exactly), **not** lowering the number.
+
 ### Dead-code gate (knip)
 
 `bun run knip` runs with **`includeEntryExports: true`**, so it also reports unused

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -2,6 +2,51 @@
 # Use isolated linker for better dependency isolation and security
 linker = 'isolated'
 
+# Supply-chain cooldown: refuse versions published less than 3 days ago.
+#
+# The window this closes is specific. Dependabot runs weekly and deliberately
+# GROUPS minor/patch bumps into one PR to keep churn manageable, which means the
+# realistic review of that PR is a glance at a list of version numbers — nobody
+# is reading tarballs. Three days is roughly how long a hijacked npm release
+# survives before it is noticed and unpublished, so this makes the compromised
+# version unresolvable here rather than relying on that glance to catch it.
+#
+# (There is NO dependabot auto-merge workflow in this repo — .github/workflows
+# holds ci, codeql, e2e-nightly and release-please only. A human or an agent
+# merges these. Do not "restore" an auto-merge rationale here without checking;
+# an earlier draft of this comment asserted that workflow existed.)
+#
+# TWO BEHAVIOURS, and the difference matters when this bites (both measured
+# against 1.3.14, not inferred):
+#
+#   - An EXACT pin the gate cannot satisfy is a hard error, and it says so:
+#       error: No version matching "typescript" found for specifier "7.0.2"
+#              (blocked by minimum-release-age: N seconds)
+#     Most of this repo's deps are exact pins, so this is the common case.
+#
+#   - A RANGE (caret) silently resolves DOWN to the newest version old enough.
+#     No warning. That is the footgun: the `overrides` block in package.json is
+#     a set of security FLOORS, and a caret floor whose fix shipped in the last
+#     three days resolves to something below what you think you pinned. It can
+#     never resolve below the floor itself (that would error, per above), so the
+#     floors still hold — but `bun update <pkg>` to clear a FRESH advisory will
+#     appear to do nothing until the cooldown elapses.
+#
+# `bun install --frozen-lockfile` is unaffected: it installs what bun.lock
+# already resolved and does no resolution, so CI and every deploy target never
+# see this gate. It only applies where a version is being chosen.
+#
+# WHEN IT BLOCKS SOMETHING YOU ACTUALLY WANT, the escape hatch is
+# `minimumReleaseAgeExcludes` below — not lowering this number.
+minimumReleaseAge = 259200 # 3 days, in seconds
+
+# `bun-types` must match .bun-version EXACTLY — tools/check-bun-version.ts fails
+# `validate:all` when they disagree, and it is an exact pin, so the gate turns a
+# routine Bun upgrade into a hard install error for three days. It carries no
+# install scripts and no runtime code (type declarations only), so the cooldown
+# buys nothing here that it does not already cost.
+minimumReleaseAgeExcludes = ["bun-types"]
+
 [test]
 # Preloads for a ROOT-level `bun test` run. Paths are relative to the repo root.
 #

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -11,10 +11,11 @@ linker = 'isolated'
 # survives before it is noticed and unpublished, so this makes the compromised
 # version unresolvable here rather than relying on that glance to catch it.
 #
-# (There is NO dependabot auto-merge workflow in this repo — .github/workflows
-# holds ci, codeql, e2e-nightly and release-please only. A human or an agent
-# merges these. Do not "restore" an auto-merge rationale here without checking;
-# an earlier draft of this comment asserted that workflow existed.)
+# (There is NO dependabot auto-merge workflow in this repo — a human or an agent
+# merges these. Do not "restore" an auto-merge rationale here without checking
+# `ls .github/workflows`; an earlier draft of this comment asserted that
+# workflow existed. Deliberately not listing the workflows by name: a hardcoded
+# inventory in a comment is stale the next time one is added.)
 #
 # TWO BEHAVIOURS, and the difference matters when this bites (both measured
 # against 1.3.14, not inferred):


### PR DESCRIPTION
Adds `minimumReleaseAge = 259200` to the root bunfig, with `bun-types`
excluded.

Dependabot runs weekly and deliberately GROUPS minor/patch bumps into a single
PR to keep churn manageable, which means reviewing one realistically means
glancing at a list of version numbers — nobody is reading tarballs. Three days
is roughly how long a hijacked npm release survives before it is noticed and
unpublished, so this makes such a version unresolvable here instead of relying
on that glance.

Two behaviours, both measured against 1.3.14 rather than inferred, because they
fail very differently:

  - an EXACT pin the gate cannot satisfy is a hard, self-describing error:
      No version matching "typescript" found for specifier "7.0.2"
      (blocked by minimum-release-age: N seconds)
    Most deps here are exact pins, so this is the common case.

  - a CARET range silently resolves DOWN to the newest version old enough, with
    no warning. That is the footgun worth knowing about: `bun update <pkg>` to
    clear a *fresh* advisory can look like a no-op. The `overrides` security
    floors still hold — resolving below a floor errors rather than downgrading.

`bun install --frozen-lockfile` does no resolution and is unaffected (verified:
"Checked 953 installs ... (no changes)", lockfile byte-identical), so CI and all
four deploy targets never encounter the gate.

`bun-types` is excluded because tools/check-bun-version.ts requires it to match
.bun-version exactly, so the gate would turn a routine Bun upgrade into a hard
install error for three days. It ships type declarations only — no install
scripts, no runtime code — so the cooldown buys nothing there.

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_01S7FKAMEU6h1MxzrmRMnkEC

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>