### PR TITLE
docs: record bun why, markdown profiling, and the --parallel/--isolate result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,13 @@ coverage-output.txt
 # (the committed snapshot lives at packages/salvageunion-reference/etc/)
 packages/salvageunion-reference/.api-dts/
 
+# Profiling artifacts (bun --cpu-prof / --heap-prof, bun build --metafile-md).
+# These default to the cwd, so without this they land beside the source they
+# profiled and get swept into the next `git add -A`.
+/.profiles/
+*.cpuprofile
+*.heapsnapshot
+
 # Vite
 .vite
 apps/srd/.vite

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,18 +387,29 @@ profiles as grep-friendly markdown, which is readable in a terminal and in a
 transcript — a binary profile that needs a flamegraph UI is close to useless to
 an agent, and most of the work in this repo is done by one:
 
+Write the artifacts to `.profiles/`, which is gitignored — the profilers and
+`--metafile-md` otherwise drop files in the cwd, and the next `git add -A`
+sweeps them into a commit.
+
 ```bash
-# where the time went (any bun-run script; --cpu-prof-dir to place the output)
-bun --cpu-prof --cpu-prof-md tools/check-doc-drift.ts
+# where the time went (any bun-run script)
+bun --cpu-prof --cpu-prof-md --cpu-prof-dir=.profiles tools/check-doc-drift.ts
 # what was retained — from apps/srd, since ssg/build.ts resolves relative to it
-bun --heap-prof --heap-prof-md ssg/build.ts
+bun --heap-prof --heap-prof-md --heap-prof-dir=../../.profiles ssg/build.ts
 # module graph + a "Raw Data for Searching" section, for bundle-size questions
-bun build --metafile-md=graph.md --target node apps/discord-bot/src/index.ts
+bun build --metafile-md=.profiles/graph.md --outdir=.profiles/build \
+  --target node apps/discord-bot/src/index.ts
 ```
 
+**`--outdir` is not optional there.** `bun build` with no `--outdir` writes the
+bundle to *stdout*, so omitting it dumps the whole 2 MB Discord bot into your
+terminal and the transcript — the exact thing this section exists to avoid.
+
 `--cpu-prof-interval` tightens the 1000µs default sampling when a hot path is
-too short to sample. These are diagnostics — nothing in `check:all` or CI runs
-them, and they should not be wired in.
+too short to sample. (It is real but undocumented — it appears in `bun --help`
+for 1.3.14, not in the bundled markdown docs, so don't "correct" it away.) These
+are diagnostics: nothing in `check:all` or CI runs them, and they should not be
+wired in.
 
 ### Pre-commit Hooks (Lefthook)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,23 @@ This is a TypeScript monorepo with shared packages (component-lib, etc.). After 
 `bun run check:audit`. If it passes, delete this section — a suppression that
 outlives its cause is how a real advisory gets hidden.
 
+**Re-derive the chain, don't trust this prose.** `bun why <pkg>` prints the real
+path from the lockfile, so a suppression's justification can be checked in one
+command instead of read:
+
+```
+$ bun why image-size
+image-size@2.0.2
+  └─ @netlify/dev-utils@4.4.7 (requires ^2.0.2)
+     └─ @netlify/blobs@10.7.12 (requires 4.4.7)
+        ├─ itun@workspace (requires ^10.7.11)
+        └─ su-assets@workspace (requires ^10.7.11)
+```
+
+Use it before editing an `overrides` floor too — the CI comment in
+`.github/workflows/ci.yml` documents which floors bind and via what, and that
+comment can go stale while `bun why` cannot.
+
 The companion fix in the same change was real, not suppressed: `nanoid` is
 pinned to `^3.3.18` in `overrides` (from `3.3.16`, via `vite → postcss`),
 clearing `GHSA-2v37-7h3g-55p8`.
@@ -158,10 +175,26 @@ bun run test             # Canonical FULL suite: each workspace with its own
                          # Pre-push does NOT run this; it runs the --changed
                          # subset (see "Pre-commit Hooks" below), so run this by
                          # hand when you want the whole sweep locally.
-bun test                 # Also works now. The root bunfig.toml preloads the
-                         # UNION of the workspace preloads, so a bare root run
-                         # is green (4712 pass). It used to fail by the hundreds
-                         # (639) purely from missing preloads; that is fixed.
+bun test                 # Also works. The root bunfig.toml preloads the UNION
+                         # of the workspace preloads, so a bare root run is
+                         # viable; it used to fail by the hundreds (639) purely
+                         # from missing preloads. NOT byte-identical to the
+                         # per-workspace run though — measured 2026-08-11 it is
+                         # 4990 pass / 1 fail, the failure being
+                         # component-lib CardImage.ssr.test.tsx, which passes in
+                         # its own workspace. That is a PRELOAD-SET difference
+                         # (the root bunfig adds fake-indexeddb + the bot env
+                         # shim), not cross-file leakage — it fails the same way
+                         # under --isolate. Prefer `bun run test`.
+
+# DO NOT reach for --parallel or --isolate to speed the suite up. Both are large
+# regressions here and this is measured, not assumed (1.3.14, this machine):
+#   bun test              34.4s   4991 tests / 365 files
+#   bun test --parallel   65.1s   + 2 spurious 5s-timeout failures
+#   bun test --isolate   234.1s   6.8x slower
+# The preloads (happy-dom, testing-library, a full ORM schema load,
+# fake-indexeddb) are expensive and both flags re-pay them per isolated file.
+# --changed is the flag that actually makes the suite cheaper; see pre-push.
 bun --filter salvageunion-reference test   # Test package only
 bun --filter component-lib test              # Test shared components only
 bun --filter srd test                # Test reference site only
@@ -348,6 +381,24 @@ When adding a prop that must reach nested cards, pass it explicitly and run type
 ### Debugging
 
 For styling bugs, check Tailwind configuration (@source paths, plugin setup) early before diving into component/data logic. Many visual bugs trace back to Tailwind config rather than application code.
+
+**Profile in markdown, not in `.cpuprofile`.** Bun can emit its CPU and heap
+profiles as grep-friendly markdown, which is readable in a terminal and in a
+transcript — a binary profile that needs a flamegraph UI is close to useless to
+an agent, and most of the work in this repo is done by one:
+
+```bash
+# where the time went (any bun-run script; --cpu-prof-dir to place the output)
+bun --cpu-prof --cpu-prof-md tools/check-doc-drift.ts
+# what was retained — from apps/srd, since ssg/build.ts resolves relative to it
+bun --heap-prof --heap-prof-md ssg/build.ts
+# module graph + a "Raw Data for Searching" section, for bundle-size questions
+bun build --metafile-md=graph.md --target node apps/discord-bot/src/index.ts
+```
+
+`--cpu-prof-interval` tightens the 1000µs default sampling when a hot path is
+too short to sample. These are diagnostics — nothing in `check:all` or CI runs
+them, and they should not be wired in.
 
 ### Pre-commit Hooks (Lefthook)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,9 +57,12 @@ bun --filter srd test          # test one workspace
 bun run typecheck:itun               # typecheck one workspace
 ```
 
-> **Never run a bare `bun test` at the repo root** — it skips each workspace's
-> `bunfig.toml` preloads (fake-indexeddb, happy-dom, reference preload) and fails
-> by the hundreds. Always use `bun run test` or `bun --filter <pkg> test`.
+> **Prefer `bun run test` or `bun --filter <pkg> test`.** A bare `bun test` at
+> the repo root used to fail by the hundreds because it skipped each workspace's
+> `bunfig.toml` preloads; the root `bunfig.toml` now preloads the union of them,
+> so it runs. It is still not identical to the per-workspace run — the preload
+> *sets* differ, and one component-lib SSR test fails only from the root. Use
+> `bun run test` as the source of truth; it is what CI runs.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ bun run build:package    # Reference package only
 bun run lint
 bun run format        # bun run format:check to verify only
 bun run typecheck
-bun run test          # never bare `bun test` at the root — it skips the
-                      # per-workspace bunfig preloads and fails by the hundreds
+bun run test          # prefer this — each workspace with its own bunfig.
+                      # A bare root `bun test` is viable (the root bunfig
+                      # preloads the union) but is not identical; see CLAUDE.md
 bun run validate:all  # Data integrity: IDs, cross-refs, action refs
 bun run check:all     # Full CI suite (lint, format, typecheck, test, validate, knip)
 ```


### PR DESCRIPTION
Three additions to CLAUDE.md, all of them things a session currently gets wrong
by guessing.

`bun why` in the audit-gate section. That section and the long comment in
ci.yml carry hand-written dependency archaeology ("it reached the graph via
workspace:srd -> astro"), which is exactly the kind of prose that goes stale
while reading as authoritative. `bun why image-size` prints the real chain from
the lockfile in one command, so a suppression's justification can be CHECKED
rather than believed.

Markdown profiling in the Debugging section. `--cpu-prof-md`, `--heap-prof-md`
and `--metafile-md` emit grep-friendly markdown instead of a binary
`.cpuprofile` that needs a flamegraph UI — which matters because most of the
work here is done by an agent reading a terminal. Verified: the CPU profile
renders a "Hot Functions (Self Time)" table, and the metafile report includes a
"Raw Data for Searching" section. Explicitly noted as diagnostics that must not
be wired into check:all or CI.

The measured cost of --parallel and --isolate, recorded next to the test
commands so nobody "optimizes" into them:

  bun test              34.4s   4991 tests / 365 files
  bun test --parallel   65.1s   + 2 spurious 5s-timeout failures
  bun test --isolate   234.1s   6.8x slower

Both flags look like the obvious way to speed a 4991-test suite up and are large
regressions here, because the preloads (happy-dom, testing-library, a full ORM
schema load, fake-indexeddb) get re-paid per isolated file.

Also corrects a claim that had gone stale: the bare-root `bun test` line
asserted "green (4712 pass)". Measured today it is 4990 pass / 1 fail —
component-lib's CardImage.ssr.test.tsx, which passes in its own workspace. It
fails identically under --isolate, so it is a preload-set difference (the root
bunfig adds fake-indexeddb and the bot env shim), NOT cross-file leakage. The
failure itself is left alone; this only stops the doc from asserting green.

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_01S7FKAMEU6h1MxzrmRMnkEC

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>