### PR TITLE
fix(ci): run CI and CodeQL on stacked PRs, not just PRs based on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,21 @@ name: CI
 on:
   push:
     branches: ['main']
+  # NO `branches:` filter here, deliberately. That filter matches the PR's BASE
+  # branch, so `branches: ['main']` silently gave ZERO checks to any PR based on
+  # something other than main — i.e. every layer of a stacked PR above the
+  # bottom one. Since `quality-checks` is a required status on main, those PRs
+  # were not merely unchecked, they were unmergeable, with nothing on the PR
+  # saying why: `gh pr checks` reports "no checks reported" and the required
+  # check simply never arrives.
+  #
+  # Observed on stack #742: #738 (base main) got a full run, while #739 and #740
+  # (bases bun-bot-sourcemaps / bun-install-cooldown) got none at all.
+  #
+  # Stacked PRs are the preferred shape for multi-part work here, so CI has to
+  # run regardless of base. The cost is that a PR targeting any branch now runs
+  # CI, which is the intended behaviour rather than a side effect.
   pull_request:
-    branches: ['main']
   # Run on the merge queue's temporary branches so the required `quality-checks`
   # gate reports on queued PRs; without this the merge queue hangs forever
   # waiting for a check that never fires.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,8 +6,11 @@ name: CodeQL
 on:
   push:
     branches: ['main']
+  # Unfiltered for the same reason as ci.yml: `branches:` matches the PR's BASE
+  # branch, so it gave no run at all to a PR stacked on another PR — and
+  # `Analyze (javascript-typescript)` is its OWN required status on main, so
+  # that left those PRs permanently unmergeable rather than merely unscanned.
   pull_request:
-    branches: ['main']
   # Required before `Analyze (javascript-typescript)` may be made a required
   # status context on `main`, and the order matters: this repo merges through a
   # merge queue, whose temporary `gh-readonly-queue/**` branches fire NEITHER

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,16 @@ on:
     # top of the hour to avoid the scheduling stampede.
     - cron: '30 5 * * 1'
 
+# Cancel superseded runs, mirroring ci.yml. This became load-bearing when the
+# `pull_request` base filter came off above: CodeQL now fires on every layer of
+# a stack, and one `gh stack sync` force-pushes all of them at once. Without
+# this, an N-layer stack starts N analyses per sync and leaves every earlier
+# in-flight analysis running to its `timeout-minutes: 360`, which the old
+# main-only filter had bounded by accident.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
 # CodeQL needs its own permissions block — the ci.yml block does not apply here.
 permissions:
   contents: read


### PR DESCRIPTION

Both workflows filtered `pull_request` with `branches: ['main']`. That filter
matches the pull request's BASE branch, so any PR based on another PR — every
layer of a stacked PR above the bottom one — got no run at all.

Because `quality-checks` and `Analyze (javascript-typescript)` are both required
statuses on main, the effect was worse than "unscanned": those PRs were
permanently unmergeable, and nothing on the PR explained why. `gh pr checks`
reports "no checks reported" and the required status simply never arrives.

Observed directly on stack #742: #738, based on main, got a full run and passed;
#739 and #740, based on bun-bot-sourcemaps and bun-install-cooldown, had zero
checks of any kind.

Stacked PRs are the preferred shape for multi-part work in this repo, so CI has
to run regardless of base. Dropping the filter (rather than enumerating branch
patterns) is what makes that true for stacks that do not exist yet. The `push`
trigger keeps its `branches: ['main']` filter, so branch pushes still do not
double-run.

The cost is that a PR targeting any branch now runs the full suite. That is the
intended behaviour here, not a side effect — the path filters in `changes` still
skip the heavy jobs for changes that cannot affect them.

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_01S7FKAMEU6h1MxzrmRMnkEC

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7FKAMEU6h1MxzrmRMnkEC