### PR TITLE
docs(itun): Convex exception reporting is delivering — verified, not assumed

### DIFF
--- a/apps/itun/CLAUDE.md
+++ b/apps/itun/CLAUDE.md
@@ -111,12 +111,16 @@ and remains the account-free way to share a build.
   (`src/lib/observability.ts`) and the Netlify Functions
   (`netlify/functions/_observability.ts`) each own one; Convex instead uses its
   first-party Exception Reporting integration, enabled in the Convex dashboard
-  with no application code. **It was configured on 2026-08-05 and is not
-  delivering** — the `itun-convex` Sentry project has had zero events in 30 days
-  (measured 2026-08-10, over a window containing 39 real mutation failures), so
-  a quiet project is not evidence of a healthy backend. Read Convex errors with
-  `bunx convex logs --deployment alex-jarvis:suref-itun:prod`; the Pro-plan gate
-  is the first suspect. Queries and
+  with no application code. **Delivering since 2026-08-12**, verified end to end
+  rather than assumed: a forced error appeared in `convex logs` and then in
+  Sentry as `ITUN-CONVEX-1`, the first event that project had ever received.
+  It also forwards `ArgumentValidationError`, not only handler throws.
+  Before that it had been recorded as "enabled" on 2026-08-05 while the DSN
+  had never actually been pasted into the dashboard, and it sat silent for a
+  week — through 39 real mutation failures. **A quiet Sentry project is not
+  evidence of a healthy backend**; re-verify by forcing an error and comparing
+  against `bunx convex logs --deployment alex-jarvis:suref-itun:prod`, which
+  remains the ground truth. Queries and
   mutations run in a deterministic runtime with no `fetch`, so an in-function SDK
   could not report from them at all — rationale and the enable-it runbook are in
   [docs/architecture/accounts-and-games.md](../../docs/architecture/accounts-and-games.md)

--- a/docs/architecture/accounts-and-games.md
+++ b/docs/architecture/accounts-and-games.md
@@ -322,25 +322,44 @@ repo):
   Convex errors will not carry a commit SHA the way the Netlify and Render
   surfaces do.
 
-**Status: configured 2026-08-05, and NOT delivering.** Measured 2026-08-10: the
-`itun-convex` Sentry project has received **zero events in 30 days** — over a
-window that contains 39 failed `entities:upsertByAppId` mutations in a single
-evening, every one of which should have landed there.
+**Status: DELIVERING since 2026-08-12**, confirmed end to end — a forced error
+was seen in `convex logs` and then in Sentry as `ITUN-CONVEX-1`, the first event
+that project had ever received. Step 2 above (pasting the DSN) is what had been
+missing; the Pro-plan caveat turned out not to apply.
 
-That number is the whole point of writing this down. "Enabled" was recorded here
-as a status and then believed for five days, and a reporting integration that
-reports nothing is indistinguishable from a healthy one with no errors — the
-same trap `tools/check-observability.ts` exists to close for the browser SDKs.
-The **Pro-plan gate above is the first thing to check**; until it is resolved,
-the honest description of this repo is *Convex errors are visible in the
-deployment's function logs only*, and the way you read them is:
+It forwards `ArgumentValidationError` as well as handler throws, which was an
+open question until the probe answered it.
+
+**How it was wrong for a week, because the shape recurs.** This section said
+"enabled" from 2026-08-05, recorded as a status the moment the *Sentry project*
+was created — step 1 of two. Nobody clicked step 2, and nothing about the result
+looked different: a reporting integration that reports nothing is
+indistinguishable from a healthy one with no errors. It stayed that way through
+39 failed `entities:upsertByAppId` mutations in a single evening, every one of
+which should have landed there, and the incident surfaced instead as a Discord
+message from a player. `tools/check-observability.ts` exists to close exactly
+this trap for the browser SDKs; there is no equivalent here, because "zero
+events" is also what a healthy quiet week looks like, so it cannot be asserted.
+
+**So verify by probe, never by status line.** Force an error, then check both
+channels — the deployment log is the ground truth and Sentry is the thing being
+tested:
 
 ```bash
-timeout 120 bunx convex logs --deployment alex-jarvis:suref-itun:prod \
-  --history 4000 --jsonl > logs.jsonl   # streams; wrap in timeout, read the file
+cd apps/itun
+CONVEX_DEPLOYMENT=dev:perfect-donkey-72 bunx convex run --prod \
+  maintenance:dedupeAppIds '{"apply":"not-a-boolean"}'      # forces one error
+bunx convex logs --deployment alex-jarvis:suref-itun:prod --history 6 --jsonl
 ```
 
+then <https://susrd.sentry.io/issues/?project=itun-convex>. In the log but not
+in Sentry means it has stopped delivering again.
+
 Do not treat a quiet `itun-convex` as evidence that the backend is healthy.
+
+**Events arriving is not the same as anyone reading them.** There is no alert
+rule on this project yet, and Sentry's default is to collect silently — which
+is how an evening of 39 backend errors reached a player before it reached us.
 
 #### What reaches Sentry, and what reaches the player
 


### PR DESCRIPTION
## It works now

Both `apps/itun/CLAUDE.md` and `docs/architecture/accounts-and-games.md` asserted this integration was configured on 2026-08-05 and **not delivering**. The DSN is now in the Convex dashboard and events are arriving.

**Confirmed end to end, not by the save button:**

1. Forced an error against production — `maintenance:dedupeAppIds '{"apply":"not-a-boolean"}'`
2. Saw it in `convex logs` at `20:36:51Z`
3. Saw it in Sentry as **`ITUN-CONVEX-1`** — the first event that project has *ever* received, after **zero in 90 days**

The Pro-plan caveat the docs flagged as the prime suspect turned out not to apply. Step 1 of the runbook (create the Sentry project) had been done; step 2 (paste the DSN) never had.

It also settles a question the docs left open: Convex forwards **`ArgumentValidationError`**, not only handler throws.

## Why the wording changed shape

The old text failed in a specific way worth not repeating. "Enabled" was recorded the moment the *Sentry project* existed — one of two steps — and nothing about the result looked different afterwards, because a reporting integration that reports nothing is indistinguishable from a healthy one with no errors. It stayed wrong for a week, through 39 failed `entities:upsertByAppId` mutations in one evening, and that incident reached a player on Discord before it reached us.

So both files now carry **the probe** instead of a status line:

```bash
cd apps/itun
CONVEX_DEPLOYMENT=dev:perfect-donkey-72 bunx convex run --prod \
  maintenance:dedupeAppIds '{"apply":"not-a-boolean"}'
bunx convex logs --deployment alex-jarvis:suref-itun:prod --history 6 --jsonl
```

In the log but not in Sentry ⇒ it has stopped delivering again.

## No automated check, deliberately

`tools/check-observability.ts` can assert the browser SDK is present in the shipped bundle. There is no equivalent here: **"zero events" is also what a healthy quiet week looks like**, so it cannot be asserted without producing a false alarm on every quiet day. Saying so in the doc is the honest alternative to a check that would get muted.

## Flagged, not fixed

There is **no alert rule** on the `itun-convex` project, and Sentry collects silently by default. Events arriving is not the same as anyone reading them — which is the actual failure mode from 8/9. Worth a rule before the next incident.

Also: `ITUN-CONVEX-1` is my synthetic probe. Resolve it whenever — it's evidence, not a real defect.

## Verification

`bun run validate:doc-drift` green (ADR supersession markers, component-lib symbols, framework majors, and all 79 documented bun-script references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Ms18wRLjK2W62PGUk8XWj
