### PR TITLE
fix(itun): stop printed sheets losing the pilot class, mech chassis and crawler type

### DIFF
--- a/apps/itun/src/components/sheet/__tests__/print.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/print.test.tsx
@@ -145,6 +145,36 @@ describe('Print markup — PilotSheet', () => {
     const backLink = container.querySelector('header a[aria-label="Back to roster"]')
     expect(backLink).toBeTruthy()
   })
+
+  /**
+   * Regression (#616). A picker `Field` renders its VALUE *inside* the button
+   * rather than beside it, so the print rule `button:not([data-print='keep'])`
+   * hid the pilot's class on paper — the one field saying what the pilot IS.
+   * The sibling fields printed fine because `InlineEditField` renders a
+   * `<span role="button">`, which that element selector never matched, so the
+   * loss looked like a quirk of one field instead of a rule hitting a whole
+   * variant. Same shape on the mech (chassis) and crawler (type) sheets.
+   *
+   * jsdom applies no `@media print` rules, so assert the opt-in attribute and
+   * the containment that makes it necessary — not a computed style.
+   */
+  test('class picker opts into print, so its value survives the button-hide rule', () => {
+    const { container } = render(
+      <Sheet
+        kind="pilot"
+        id="print-pilot-1"
+        entityStore={makeEntityStore([fakePilot])}
+        softLinkStore={makeEmptySoftLinkStore()}
+      />
+    )
+    const picker = container.querySelector('button[aria-label="Change class"]')
+    expect(picker).toBeTruthy()
+    // The value is inside the button — this containment is why the hatch is
+    // required, so assert it too; if it ever moves out, this test should be
+    // revisited rather than silently passing on the attribute alone.
+    expect(picker?.textContent).toContain('Engineer')
+    expect(picker?.getAttribute('data-print')).toBe('keep')
+  })
 })
 
 describe('Print markup — MechSheet', () => {

--- a/packages/component-lib/src/components/chrome/Field.tsx
+++ b/packages/component-lib/src/components/chrome/Field.tsx
@@ -151,6 +151,18 @@ export function Field(props: FieldProps) {
             type="button"
             aria-label={`Change ${labelText.toLowerCase()}`}
             onClick={onEditClick}
+            // The VALUE lives inside this button, not beside it, so the print
+            // stylesheets' `button:not([data-print='keep'])` rule took the
+            // field's content along with its affordance: a printed sheet lost
+            // the pilot's class, the mech's chassis and the crawler's type —
+            // each surface's single most identifying field — while every other
+            // field printed, because `InlineEditField` renders a
+            // `<span role="button">` that the element selector never matched.
+            // This is the case the hatch was written for; it is shared verbatim
+            // by both apps' print CSS, so the opt-in belongs on the markup.
+            // Only the editable branch needs it: a read-only Field renders the
+            // `<div>` below and was never hidden.
+            data-print="keep"
             className={cn(
               FIELD_BOX,
               'cursor-pointer text-left hover:bg-ink-8',


### PR DESCRIPTION
Fixes #616 — the nightly `e2e-itun` failure.

## The bug

A picker `Field` renders its **value inside the `<button>`** rather than beside it, so both apps' print rule `button:not([data-print='keep'])` took the field's *content* along with its affordance.

On paper, each sheet lost its single most identifying field:

| Sheet | Field | Renders as |
|---|---|---|
| Pilot | **Class** | `PilotIdentity.tsx:200` picker |
| Mech | **Chassis** | `MechIdentity.tsx:105` picker |
| Crawler | **Type** | `CrawlerIdentity.tsx:134` picker |

Every *sibling* field printed fine, which is what made this read as a quirk of one field rather than a rule hitting a whole variant: `InlineEditField` renders a `<span role="button">`, which the element selector never matched. Only the editable branch was affected — a read-only `Field` already rendered a plain `<div>`.

## The fix

`data-print="keep"` on the picker button — the escape hatch `print.css` documents for exactly this case ("a control that carries printed STATE… opts back in"), shared verbatim with `apps/srd/src/styles/global.css`, and until now unused. The value box prints as a bordered box, which is what a printed form field should look like.

## Verification

- **Causal, not correlational**: both print-preview specs (A4 + US Letter) **fail with the fix reverted** and **pass with it applied**.
- Added a unit-level guard so this doesn't rely solely on the nightly. jsdom applies no `@media` rules, so it asserts the opt-in attribute *and* the containment that makes it necessary.
- `check:fast` (lint + validate:all + knip + typecheck, 6 workspaces) — clean.
- Full suite `bun run test` — green.
- `bun --filter srd gate` — **SNAPSHOT OK, zero unexpected differences** (srd renders these fields read-only, so its output is untouched).

## Notes

Pips were checked and are **not** affected — they render as `span[data-pip]`, so the print stylesheet's pip rules were always live. The "filled pip button" in that file's comment was hypothetical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Ms18wRLjK2W62PGUk8XWj
