### PR TITLE
fix(ci): stop the nightly observability probe hanging, and bound every job

### DIFF
--- a/.github/workflows/catalog-update.yml
+++ b/.github/workflows/catalog-update.yml
@@ -42,6 +42,10 @@ permissions: {}
 jobs:
   update:
     runs-on: ubuntu-latest
+    # Bounded like every job in ci.yml and e2e-nightly.yml — GitHub's default is
+    # 360 minutes, and an unattended weekly job is the least likely place anyone
+    # would notice one hanging.
+    timeout-minutes: 15
     permissions:
       # The minimum the action needs: commit a branch, open a PR against it.
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,18 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# EVERY job below declares `timeout-minutes`. GitHub's default is 360 (six
+# hours), so an unbounded job that hangs does not fail — it sits, burning runner
+# minutes and holding the `quality-checks` gate, and therefore the PR, open for
+# the rest of the day. Until now only the two e2e jobs were bounded and the
+# other thirteen were not, which is the same hole that let the nightly
+# observability probe hang undiagnosed: nothing is red, so nothing is read.
+#
+# 15 minutes is deliberately generous — the slowest job on main measures 2.1m,
+# so this is ~7x headroom and will only ever fire on a genuine hang, never on a
+# slow runner. The e2e jobs keep their own 20: they boot a dev server and drive
+# a browser, so their spread is wider. Raise a specific job's number when its
+# real work grows; do not remove the key.
 jobs:
   # ---------------------------------------------------------------------------
   # Path filter — decide which areas a change touches so we can skip heavy jobs
@@ -45,6 +57,7 @@ jobs:
   # ---------------------------------------------------------------------------
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       itun: ${{ steps.filter.outputs.itun || steps.all.outputs.all }}
       web: ${{ steps.filter.outputs.web || steps.all.outputs.all }}
@@ -154,6 +167,7 @@ jobs:
     # Always runs — format:check covers docs (markdown/yaml) too, and the two
     # static design guards below are unconditional by design.
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -186,6 +200,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -214,6 +229,7 @@ jobs:
     needs: [changes, build-package]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -228,6 +244,7 @@ jobs:
     needs: [changes, build-package]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -242,6 +259,7 @@ jobs:
     needs: [changes, build-package]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -261,6 +279,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -288,6 +307,7 @@ jobs:
     needs: [changes, build-package]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -386,6 +406,7 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -404,6 +425,7 @@ jobs:
     needs: [changes, build-package, lint, typecheck, test, validate, knip, audit]
     if: needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -428,6 +450,7 @@ jobs:
     needs: [changes, build-package, lint, typecheck, test, validate, knip, audit]
     if: needs.changes.outputs.itun == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -458,6 +481,7 @@ jobs:
     needs: [changes, build-package, lint, typecheck, test, validate, knip, audit]
     if: needs.changes.outputs.bot == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -630,6 +654,7 @@ jobs:
       # it would race the other workflow, and a poll that times out or 404s
       # reports green — worse than the advisory state it replaced.
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Verify no job failed
         run: |

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -248,7 +248,15 @@ jobs:
     # goes dark again opens the tracking issue like any other nightly failure.
     if: vars.OBSERVABILITY_PROBE == 'on'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Must EXCEED the probe's own PROBE_BUDGET_MS (120s in
+    # tools/check-observability.ts), so the tool always loses the race and
+    # reports a real reason. It was 5 minutes, and the arithmetic never worked:
+    # the probe crawls ~134 chunks and its retry ladder costs up to 7s each, so
+    # a bad-weather run could spend ~938s — 3x the job timeout. Every nightly
+    # from 2026-08-05 died at exactly 5m having printed NOTHING, which read as
+    # "cancelled" in the run list and told nobody anything. The probe itself was
+    # healthy the whole time (3-21s locally, DSN present on both sites).
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -324,6 +332,11 @@ jobs:
        needs.convex-parity.result == 'failure' ||
        needs.convex-parity.result == 'cancelled')
     runs-on: ubuntu-latest
+    # Bounded like every other job here: this one is two REST calls, so if it is
+    # still running at 5 minutes it is wedged, and a wedged notifier is the
+    # worst one to leave unbounded — it is the thing that tells you the rest
+    # broke.
+    timeout-minutes: 5
     permissions:
       issues: write
     steps:
@@ -333,6 +346,7 @@ jobs:
           ITUN_RESULT: ${{ needs.e2e-itun.result }}
           SRD_RESULT: ${{ needs.e2e-srd.result }}
           PROBE_RESULT: ${{ needs.observability-probe.result }}
+          PARITY_RESULT: ${{ needs.convex-parity.result }}
         with:
           script: |
             const label = 'nightly-e2e-failure'
@@ -347,12 +361,21 @@ jobs:
             // still being filed — an alarm that refuses to say what tripped it.
             // Omitted entirely when skipped (the OBSERVABILITY_PROBE variable is
             // off), so the report never lists a job that did not run.
+            //
+            // convex-parity obeys the same rule for the same reason, and did NOT
+            // when it was added: it sat in `needs:` and in the `if:` above — so it
+            // could open this issue entirely on its own — while having no line
+            // here at all. A parity failure therefore filed an issue reading
+            // "e2e-itun: success, e2e-srd: success" and nothing else, which is
+            // precisely the alarm-that-won't-say-what-tripped-it the paragraph
+            // above describes. Anything in that `if:` MUST appear in this list.
+            const optional = (job, result) =>
+              result && result !== 'skipped' ? [[job, result]] : []
             const results = [
               ['e2e-itun', process.env.ITUN_RESULT],
               ['e2e-srd', process.env.SRD_RESULT],
-              ...(process.env.PROBE_RESULT && process.env.PROBE_RESULT !== 'skipped'
-                ? [['observability-probe', process.env.PROBE_RESULT]]
-                : []),
+              ...optional('observability-probe', process.env.PROBE_RESULT),
+              ...optional('convex-parity', process.env.PARITY_RESULT),
             ]
             const body = [
               `Nightly E2E (\`e2e-nightly.yml\`) did not pass on \`${context.ref}\`.`,
@@ -415,6 +438,8 @@ jobs:
       needs.convex-parity.result != 'failure' &&
       needs.convex-parity.result != 'cancelled'
     runs-on: ubuntu-latest
+    # Bounded for the same reason as notify-failure above.
+    timeout-minutes: 5
     permissions:
       issues: write
     steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,8 @@ concurrency:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    # Bounded like every job in ci.yml and e2e-nightly.yml — see the note there.
+    timeout-minutes: 15
     steps:
       - uses: googleapis/release-please-action@v5
         with:

--- a/tools/check-observability.ts
+++ b/tools/check-observability.ts
@@ -197,12 +197,52 @@ function checkStatic(app: BrowserApp): void {
  *
  * Retries only what is plausibly transient: network errors and 5xx. A 4xx is a
  * real answer from a working server and is returned immediately.
+ *
+ * ## Both bounds below are load-bearing — the retry ladder outgrew its job
+ *
+ * This policy is deliberately patient, and patience without a ceiling is a
+ * hang. `fetch` has NO default timeout, so one stalled socket blocked the probe
+ * forever; and the ladder costs 1+2+4 = 7s per URL, which across the ~43 chunks
+ * the two apps actually serve is 301s of retrying — just past the job's
+ * `timeout-minutes: 5`. So the nightly job died at exactly its timeout having
+ * printed nothing at all, for a week, while the probe itself was healthy and
+ * finishes in 3-21s locally. The runner saw weather the laptop did not, and the
+ * policy had no way to say so.
+ *
+ * Hence two ceilings, and a distinct error type for the second:
+ *
+ *   REQUEST_TIMEOUT_MS  one attempt cannot stall forever
+ *   PROBE_BUDGET_MS     the whole probe cannot outlive its own job timeout
+ *
+ * Budget exhaustion must NOT be reported as "production is dark". It is a
+ * statement about the probe's network, not about the deploy, and this job opens
+ * a tracking issue — mislabelling it is the cry-wolf failure this retry policy
+ * was written to avoid in the first place.
  */
+const REQUEST_TIMEOUT_MS = 15_000
+const PROBE_BUDGET_MS = 120_000
+const probeDeadline = Date.now() + PROBE_BUDGET_MS
+
+/** The probe ran out of wall-clock. Distinct so it never reads as "SDK absent". */
+class ProbeBudgetExhausted extends Error {
+  constructor(url: string, cause: unknown) {
+    super(
+      `probe budget of ${PROBE_BUDGET_MS / 1000}s exhausted while fetching ${url} ` +
+        `(last error: ${String(cause)})`
+    )
+    this.name = 'ProbeBudgetExhausted'
+  }
+}
+
 async function fetchWithRetry(url: string, attempts = 4): Promise<Response> {
   let lastError: unknown = new Error('no attempt made')
   for (let attempt = 0; attempt < attempts; attempt++) {
+    if (Date.now() > probeDeadline) throw new ProbeBudgetExhausted(url, lastError)
     try {
-      const res = await fetch(url, { redirect: 'follow' })
+      const res = await fetch(url, {
+        redirect: 'follow',
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      })
       if (res.status < 500) return res
       lastError = new Error(`HTTP ${res.status}`)
     } catch (error) {
@@ -264,7 +304,11 @@ async function reachableChunks(seeds: string[], origin: string): Promise<Map<str
     let body: string
     try {
       body = await (await fetchWithRetry(url)).text()
-    } catch {
+    } catch (error) {
+      // Running out of budget is NOT "this chunk is missing" — swallowing it
+      // would walk the rest of the queue finding nothing and report the deploy
+      // as dark. Abort and let the caller say what actually happened.
+      if (error instanceof ProbeBudgetExhausted) throw error
       // A single unreachable chunk is not proof of absence; keep looking.
       continue
     }
@@ -295,6 +339,9 @@ async function checkLive(app: BrowserApp): Promise<void> {
   // and a CSP can lag a merge, be overridden in the Netlify UI, or come from a
   // _headers file this repo never sees.
   let servedCsp: string | null = null
+  // Announced BEFORE the first network call, so a stall names the app it stalled
+  // on. Previously the whole job could be killed having printed nothing.
+  console.log(`  [${app.name}] fetching ${app.productionUrl}…`)
   try {
     const res = await fetchWithRetry(app.productionUrl)
     if (!res.ok) {
@@ -304,6 +351,13 @@ async function checkLive(app: BrowserApp): Promise<void> {
     servedCsp = res.headers.get('content-security-policy')
     html = await res.text()
   } catch (error) {
+    // Same distinction the chunk crawl makes: out of budget is a statement
+    // about the probe's own network, and "production unreachable" would point
+    // the resulting tracking issue squarely at an innocent deploy.
+    if (error instanceof ProbeBudgetExhausted) {
+      fail(app.name, `${error.message} — this is a PROBE failure, not evidence the deploy is dark`)
+      return
+    }
     fail(app.name, `production unreachable (${app.productionUrl}): ${String(error)}`)
     return
   }
@@ -316,7 +370,17 @@ async function checkLive(app: BrowserApp): Promise<void> {
 
   // Follow the module graph — the SDK and the inlined DSN routinely land in a
   // chunk the HTML never names (see reachableChunks).
-  const chunks = await reachableChunks(urls, app.productionUrl)
+  let chunks: Map<string, string>
+  try {
+    chunks = await reachableChunks(urls, app.productionUrl)
+  } catch (error) {
+    if (error instanceof ProbeBudgetExhausted) {
+      fail(app.name, `${error.message} — this is a PROBE failure, not evidence the deploy is dark`)
+      return
+    }
+    throw error
+  }
+  console.log(`  [${app.name}] scanned ${chunks.size} chunk(s) from ${urls.length} entry point(s)`)
   let sdkFoundIn: string | null = null
   let dsnHost: string | null = null
   let dsnFoundIn: string | null = null


### PR DESCRIPTION
Follow-up to #750, which fixed the `e2e-itun` half of #616. This fixes the other nightly job and makes timeout policy consistent across every workflow.

Three findings, all the same shape: **a failure that produces no signal.**

## 1. The observability probe has hung silently since 2026-08-05

`observability-probe` is `cancelled` on every nightly, having printed **nothing at all**. That reads as "cancelled" in the run list, which looks like someone stopped it — so nobody looked.

The probe itself is healthy. It runs in **3–21s locally** and reports the DSN inlined and the CSP permitting on both sites. Two defects made a working check unrunnable:

| | |
|---|---|
| `fetch` has no default timeout | one stalled socket blocks forever |
| retry ladder is 1+2+4 = **7s per URL** | × ~134 chunks (srd 49, itun 85) = up to **938s** |

Against `timeout-minutes: 5`, the job could *only* die at its timeout — and did, at 315s. No output, because the tool printed only at the end: no way to tell which app, which URL, or even which phase.

**Fixed by bounding both axes without weakening the retry policy** (which exists so the probe doesn't cry wolf):

- 15s per-attempt `AbortSignal.timeout`
- 120s whole-probe budget
- progress lines naming each app before its first request, and the chunk count after its crawl
- job timeout → 10m, so it always **loses the race** to the probe's own budget; the tool reports the reason instead of the runner killing it mute

Budget exhaustion raises a distinct `ProbeBudgetExhausted`, reported as *"this is a PROBE failure, not evidence the deploy is dark"*. Without that it surfaces as "SDK absent" / "production unreachable" and opens a tracking issue against an innocent deploy — the exact cry-wolf outcome the retry policy was written to prevent. Verified by forcing the budget to 1ms.

New output:

```
  [srd] fetching https://salvageunion.io…
  [srd] scanned 49 chunk(s) from 3 entry point(s)
  [srd] DSN inlined in …/islands-C4xH-Zp7.js (ingest o…de.sentry.io)
  [itun] fetching https://intheunionnow.com…
  [itun] scanned 85 chunk(s) from 34 entry point(s)
✓ observability probe OK
```

## 2. `convex-parity` could open the tracking issue but never named itself

It sat in `needs:` and in the notify `if:` — so it can file the issue on its own — while having **no line in the issue body**. A parity-only failure therefore filed an issue reading "e2e-itun: **success**, e2e-srd: **success**" and nothing else.

That is verbatim the defect the comment directly above it warns about for `observability-probe`; the lesson just wasn't applied when this job was added. Verified by running the real extracted script against stubbed GitHub APIs:

```
- `e2e-itun`: **success**
- `e2e-srd`: **success**
- `convex-parity`: **failure**
```

## 3. 13 of 15 `ci.yml` jobs had no timeout at all

GitHub's default is **360 minutes**. A hung job doesn't fail — it holds the `quality-checks` gate, and therefore the PR, open for six hours. Only the two e2e jobs were bounded.

Every job in every workflow is now bounded — **25 jobs across 5 workflows**; CodeQL keeps its deliberate 360. 15m is ~7× the slowest measured job on main (2.1m), so it fires only on a genuine hang, never on a slow runner. `convex-parity` keeps its 5m: measured at 42s, 7× headroom.

## Verification

- Probe passes live (6.6s) and its budget-exhaustion path was exercised directly.
- Static `validate:observability` unchanged and still green.
- Both `github-script` bodies extracted and `node --check`ed, then behaviourally tested.
- All five workflows re-parsed; a script asserts every job is bounded.
- `check:fast` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Ms18wRLjK2W62PGUk8XWj
