### PR TITLE
fix(component-lib): drop the card fold chevron's width-keyed tap floor

### DIFF
--- a/packages/component-lib/src/components/shared/ControlButtons.tsx
+++ b/packages/component-lib/src/components/shared/ControlButtons.tsx
@@ -103,39 +103,32 @@ function ControlButton({
   // replaces, so an icon button and a worded one are interchangeable in the
   // row.
   //
-  // The coarse-pointer tap target is an invisible ::before, NOT a bigger box.
-  // This used to be `min-h-11 min-w-11 sm:min-h-0 sm:min-w-0` — the repo-wide
-  // 44px touch floor, which is correct everywhere it sits in normal flow
-  // (SmallButtons, the Stat steppers, Field). Here it is not: this button
-  // renders inside `CardControlRail`, an ABSOLUTE row centred on the card's top
-  // frame line, so growing the box grows the rail with it. Measured at 390px
-  // the rail went 22px → 44px tall and the button 24×20 → 44×44, which (a) hung
-  // 22px down into the header band, covering the TL/SV stat cells the rail is
-  // z-30 over, and (b) put a 44px square next to a 22px status badge in a row
-  // whose whole premise is that every cell is the same stamp height.
-  // Expanding the HIT AREA instead keeps the rail one uniform stamp row at
-  // every width while still giving a finger 44px of vertical reach.
+  // It carries NO tap-target floor of its own. It used to:
+  // `min-h-11 min-w-11 sm:min-h-0 sm:min-w-0`, which was a WIDTH-keyed
+  // duplicate of the POINTER-keyed floor `theme.css` already applies to every
+  // `button` under `@media (pointer: coarse)`. Two consequences, and the second
+  // is the bug:
   //
-  // Its size is bounded by the rail's own gaps, in BOTH axes — an invisible
-  // target that reaches past a neighbour steals that neighbour's taps, and one
-  // of the neighbours here is the `danger` remove:
+  //  - Where there IS a touch pointer, the utility was redundant. That rule is
+  //    unlayered, so it beats any Tailwind utility (those are in
+  //    `@layer utilities`) — the 44px box survives with or without this class,
+  //    at every viewport width.
+  //  - Where there is NOT — a narrow desktop window, a responsive-mode preview,
+  //    a small laptop — the utility applied a touch floor to a mouse. That is
+  //    the one case the pointer rule deliberately skips, and the only case this
+  //    class could actually change.
   //
-  // - width: siblings in this group sit 4px away (`flex gap-1`) and the rail's
-  //   other groups 6px (`gap-1.5`), so `w-7` — 28px on a 24px button — spends
-  //   2px per side and stops 2px short of the nearest edge.
-  // - height: the rail is `flex-wrap`, and its documented crowded case (status
-  //   seal + selection seal + count seal + three controls) wraps at exactly the
-  //   widths this pseudo is live at. Wrapped lines are 6px apart, and the line
-  //   is ~22px tall around a 20px button, so anything over 34px overhangs into
-  //   the line above and below. `h-8` (32px) stops ~1px short of the gap.
-  //   The former `min-h-11` had no such ceiling only because it grew the line
-  //   itself — the very thing that broke the geometry.
+  // So all it ever did was distort the geometry for pointers that never needed
+  // it. This button renders inside `CardControlRail`, an ABSOLUTE row centred
+  // on a card's top frame line, so a 44px box grew the rail with it: measured
+  // at 390px, rail 22px → 44px and button 24×20 → 44×44, which hung 22px down
+  // into the header band over the TL/SV stat cells the rail is z-30 above, and
+  // put a 44px square beside a 22px status badge in a row whose whole premise
+  // is that every cell is the same stamp height.
   //
-  // So the reach is 28×32, not the 44px of the repo-wide floor. That is the
-  // most this rail's geometry actually affords, and it still clears the 24×24
-  // minimum in WCAG 2.2 §2.5.8, which measures the target, not the ink. On a
-  // FOLDED card the whole surface is an expand target as well (`cardClick`), so
-  // the chevron is never the only way in.
+  // Measure this with touch emulation, not just a narrow viewport — the two
+  // disagree here, and a fine-pointer run alone will tell you a coarse-pointer
+  // change worked when it did nothing.
   //
   // A `danger` icon (the ✕ remove) is a RED stamp — filled, not outlined —
   // because it is the one control in the rail that destroys something, and as
@@ -148,8 +141,7 @@ function ControlButton({
       <button
         type="button"
         className={cn(
-          'relative inline-flex shrink-0 items-center justify-center border-2 transition-colors',
-          "before:absolute before:left-1/2 before:top-1/2 before:h-8 before:w-7 before:-translate-x-1/2 before:-translate-y-1/2 before:content-[''] sm:before:hidden",
+          'inline-flex shrink-0 items-center justify-center border-2 transition-colors',
           RUNG_INLINE_PADDING.mini,
           RUNG_TYPE.mini.label,
           isDisabled

--- a/packages/component-lib/src/components/shared/ControlButtons.tsx
+++ b/packages/component-lib/src/components/shared/ControlButtons.tsx
@@ -101,8 +101,27 @@ function ControlButton({
   // remove/swap/fold cluster. It is a STAMP like every other control in the
   // rail: same padding, same height, the glyph sized to the label line it
   // replaces, so an icon button and a worded one are interchangeable in the
-  // row. `min-h-11`/`min-w-11` still holds the 44px coarse-pointer tap target
-  // without changing the desktop size.
+  // row.
+  //
+  // The coarse-pointer tap target is an invisible ::before, NOT a bigger box.
+  // This used to be `min-h-11 min-w-11 sm:min-h-0 sm:min-w-0` — the repo-wide
+  // 44px touch floor, which is correct everywhere it sits in normal flow
+  // (SmallButtons, the Stat steppers, Field). Here it is not: this button
+  // renders inside `CardControlRail`, an ABSOLUTE row centred on the card's top
+  // frame line, so growing the box grows the rail with it. Measured at 390px
+  // the rail went 22px → 44px tall and the button 24×20 → 44×44, which (a) hung
+  // 22px down into the header band, covering the TL/SV stat cells the rail is
+  // z-30 over, and (b) put a 44px square next to a 22px status badge in a row
+  // whose whole premise is that every cell is the same stamp height.
+  // Expanding the HIT AREA instead keeps the rail one uniform stamp row at
+  // every width while still giving a finger 44px of vertical reach.
+  //
+  // The pseudo-element is deliberately NOT 44px wide: siblings in this row are
+  // only 4px away (`flex gap-1`) and the rail's other groups 6px
+  // (`gap-1.5`), so a 44px-wide invisible box would swallow taps meant for the
+  // status badge beside it. `w-7` (28px on a 24px button) leaves 2px of
+  // clearance and still clears the 24×24 floor in WCAG 2.2 §2.5.8, which
+  // measures the target, not the ink.
   //
   // A `danger` icon (the ✕ remove) is a RED stamp — filled, not outlined —
   // because it is the one control in the rail that destroys something, and as
@@ -115,8 +134,8 @@ function ControlButton({
       <button
         type="button"
         className={cn(
-          'inline-flex shrink-0 items-center justify-center border-2 transition-colors',
-          'min-h-11 min-w-11 sm:min-h-0 sm:min-w-0',
+          'relative inline-flex shrink-0 items-center justify-center border-2 transition-colors',
+          "before:absolute before:left-1/2 before:top-1/2 before:h-11 before:w-7 before:-translate-x-1/2 before:-translate-y-1/2 before:content-[''] sm:before:hidden",
           RUNG_INLINE_PADDING.mini,
           RUNG_TYPE.mini.label,
           isDisabled

--- a/packages/component-lib/src/components/shared/ControlButtons.tsx
+++ b/packages/component-lib/src/components/shared/ControlButtons.tsx
@@ -116,12 +116,26 @@ function ControlButton({
   // Expanding the HIT AREA instead keeps the rail one uniform stamp row at
   // every width while still giving a finger 44px of vertical reach.
   //
-  // The pseudo-element is deliberately NOT 44px wide: siblings in this row are
-  // only 4px away (`flex gap-1`) and the rail's other groups 6px
-  // (`gap-1.5`), so a 44px-wide invisible box would swallow taps meant for the
-  // status badge beside it. `w-7` (28px on a 24px button) leaves 2px of
-  // clearance and still clears the 24×24 floor in WCAG 2.2 §2.5.8, which
-  // measures the target, not the ink.
+  // Its size is bounded by the rail's own gaps, in BOTH axes — an invisible
+  // target that reaches past a neighbour steals that neighbour's taps, and one
+  // of the neighbours here is the `danger` remove:
+  //
+  // - width: siblings in this group sit 4px away (`flex gap-1`) and the rail's
+  //   other groups 6px (`gap-1.5`), so `w-7` — 28px on a 24px button — spends
+  //   2px per side and stops 2px short of the nearest edge.
+  // - height: the rail is `flex-wrap`, and its documented crowded case (status
+  //   seal + selection seal + count seal + three controls) wraps at exactly the
+  //   widths this pseudo is live at. Wrapped lines are 6px apart, and the line
+  //   is ~22px tall around a 20px button, so anything over 34px overhangs into
+  //   the line above and below. `h-8` (32px) stops ~1px short of the gap.
+  //   The former `min-h-11` had no such ceiling only because it grew the line
+  //   itself — the very thing that broke the geometry.
+  //
+  // So the reach is 28×32, not the 44px of the repo-wide floor. That is the
+  // most this rail's geometry actually affords, and it still clears the 24×24
+  // minimum in WCAG 2.2 §2.5.8, which measures the target, not the ink. On a
+  // FOLDED card the whole surface is an expand target as well (`cardClick`), so
+  // the chevron is never the only way in.
   //
   // A `danger` icon (the ✕ remove) is a RED stamp — filled, not outlined —
   // because it is the one control in the rail that destroys something, and as
@@ -135,7 +149,7 @@ function ControlButton({
         type="button"
         className={cn(
           'relative inline-flex shrink-0 items-center justify-center border-2 transition-colors',
-          "before:absolute before:left-1/2 before:top-1/2 before:h-11 before:w-7 before:-translate-x-1/2 before:-translate-y-1/2 before:content-[''] sm:before:hidden",
+          "before:absolute before:left-1/2 before:top-1/2 before:h-8 before:w-7 before:-translate-x-1/2 before:-translate-y-1/2 before:content-[''] sm:before:hidden",
           RUNG_INLINE_PADDING.mini,
           RUNG_TYPE.mini.label,
           isDisabled

--- a/packages/component-lib/src/components/shared/__tests__/ControlButtons.test.tsx
+++ b/packages/component-lib/src/components/shared/__tests__/ControlButtons.test.tsx
@@ -195,15 +195,24 @@ describe('ControlButtons', () => {
     expect(button.className).not.toContain('bg-paper')
   })
 
-  test('icon-only control keeps the 44px coarse-pointer tap floor', () => {
+  test('icon-only control takes its coarse-pointer tap floor from a ::before, not its box', () => {
     render(
       <ControlButtons
         controls={[makeControl({ label: undefined, ariaLabel: 'Remove', icon: RemoveGlyph })]}
       />
     )
     const button = screen.getByLabelText('Remove')
-    expect(button.className).toContain('min-h-11')
-    expect(button.className).toContain('sm:min-h-0')
+    // The 44px reach is an invisible pseudo-element. Growing the BOX instead
+    // (the former `min-h-11 min-w-11`) doubled the height of `CardControlRail`,
+    // an absolute row centred on the card's top frame line, pushing the button
+    // down over the header's TL/SV stats at mobile widths.
+    expect(button.className).toContain('before:h-11')
+    expect(button.className).toContain('sm:before:hidden')
+    expect(button.className).toContain('relative')
+    expect(button.className).not.toContain('min-h-11')
+    // Narrower than it is tall on purpose: siblings in the rail sit 4–6px away
+    // and a 44px-wide hit box would swallow taps meant for the status badge.
+    expect(button.className).toContain('before:w-7')
   })
 
   test('icon-only control fires onClick', () => {

--- a/packages/component-lib/src/components/shared/__tests__/ControlButtons.test.tsx
+++ b/packages/component-lib/src/components/shared/__tests__/ControlButtons.test.tsx
@@ -169,10 +169,11 @@ describe('ControlButtons', () => {
     // square), so an icon button and a worded one are interchangeable in a row.
     expect(button.className).toContain('px-1')
     expect(button.className).toContain('py-0.5')
-    // No fixed 28/32px square ON THE BOX. Checked per class TOKEN, not as a
-    // substring: the coarse-pointer hit area is a `before:h-8` pseudo-element,
-    // which sizes generated content rather than the button, and a substring
-    // check reads that as the fixed height it exists to forbid.
+    // No fixed 28/32px square. Checked per class TOKEN rather than as a
+    // substring, because a substring match also fires on any variant-prefixed
+    // or pseudo-element utility that merely CONTAINS a size (`before:h-8`,
+    // `sm:w-8`) — which sizes something other than this box, and is not what
+    // this assertion is about.
     const sized = button.className.split(/\s+/).filter((c) => /^[hw]-\d/.test(c))
     expect(sized).toEqual([])
     // The provided icon renders inside.

--- a/packages/component-lib/src/components/shared/__tests__/ControlButtons.test.tsx
+++ b/packages/component-lib/src/components/shared/__tests__/ControlButtons.test.tsx
@@ -169,7 +169,12 @@ describe('ControlButtons', () => {
     // square), so an icon button and a worded one are interchangeable in a row.
     expect(button.className).toContain('px-1')
     expect(button.className).toContain('py-0.5')
-    expect(button.className).not.toContain('h-8')
+    // No fixed 28/32px square ON THE BOX. Checked per class TOKEN, not as a
+    // substring: the coarse-pointer hit area is a `before:h-8` pseudo-element,
+    // which sizes generated content rather than the button, and a substring
+    // check reads that as the fixed height it exists to forbid.
+    const sized = button.className.split(/\s+/).filter((c) => /^[hw]-\d/.test(c))
+    expect(sized).toEqual([])
     // The provided icon renders inside.
     expect(screen.getByTestId('remove-glyph')).toBeTruthy()
   })
@@ -206,12 +211,14 @@ describe('ControlButtons', () => {
     // (the former `min-h-11 min-w-11`) doubled the height of `CardControlRail`,
     // an absolute row centred on the card's top frame line, pushing the button
     // down over the header's TL/SV stats at mobile widths.
-    expect(button.className).toContain('before:h-11')
+    expect(button.className).toContain('before:h-8')
     expect(button.className).toContain('sm:before:hidden')
     expect(button.className).toContain('relative')
     expect(button.className).not.toContain('min-h-11')
-    // Narrower than it is tall on purpose: siblings in the rail sit 4–6px away
-    // and a 44px-wide hit box would swallow taps meant for the status badge.
+    // Bounded in BOTH axes by the rail's gaps — an invisible target that reached
+    // past a neighbour would steal that neighbour's taps, and one neighbour is
+    // the destructive remove. `w-7` clears the 4px in-group gap; `h-8` stays
+    // inside the 6px gap between wrapped lines.
     expect(button.className).toContain('before:w-7')
   })
 

--- a/packages/component-lib/src/components/shared/__tests__/ControlButtons.test.tsx
+++ b/packages/component-lib/src/components/shared/__tests__/ControlButtons.test.tsx
@@ -200,26 +200,22 @@ describe('ControlButtons', () => {
     expect(button.className).not.toContain('bg-paper')
   })
 
-  test('icon-only control takes its coarse-pointer tap floor from a ::before, not its box', () => {
+  test('icon-only control carries no width-keyed tap floor of its own', () => {
     render(
       <ControlButtons
         controls={[makeControl({ label: undefined, ariaLabel: 'Remove', icon: RemoveGlyph })]}
       />
     )
     const button = screen.getByLabelText('Remove')
-    // The 44px reach is an invisible pseudo-element. Growing the BOX instead
-    // (the former `min-h-11 min-w-11`) doubled the height of `CardControlRail`,
-    // an absolute row centred on the card's top frame line, pushing the button
-    // down over the header's TL/SV stats at mobile widths.
-    expect(button.className).toContain('before:h-8')
-    expect(button.className).toContain('sm:before:hidden')
-    expect(button.className).toContain('relative')
+    // The touch floor is `theme.css`'s `@media (pointer: coarse)` rule, which
+    // applies to every button and cannot be overridden from here anyway (it is
+    // unlayered, so it beats `@layer utilities`). A `min-h-11 sm:min-h-0` on
+    // this element was therefore redundant wherever there IS a touch pointer,
+    // and active harm wherever there is not: it grew `CardControlRail` — an
+    // absolute row centred on the card's top frame line — from 22px to 44px,
+    // pushing it down over the header's TL/SV stats at narrow desktop widths.
     expect(button.className).not.toContain('min-h-11')
-    // Bounded in BOTH axes by the rail's gaps — an invisible target that reached
-    // past a neighbour would steal that neighbour's taps, and one neighbour is
-    // the destructive remove. `w-7` clears the 4px in-group gap; `h-8` stays
-    // inside the 6px gap between wrapped lines.
-    expect(button.className).toContain('before:w-7')
+    expect(button.className).not.toContain('min-w-11')
   })
 
   test('icon-only control fires onClick', () => {


### PR DESCRIPTION
## The bug

On narrow screens the fold ("enlarge") chevron on entity cards in the live sheets rendered as an oversized white square that hung down into the card header and covered the TL/SV stat cells.

## Cause

The icon-only rail control carried `min-h-11 min-w-11 sm:min-h-0 sm:min-w-0` — a **width**-keyed duplicate of the **pointer**-keyed touch floor `theme.css` already applies to every `button` under `@media (pointer: coarse)`.

That rule is unlayered, so it beats any Tailwind utility (those live in `@layer utilities`). Two consequences, and the second is the bug:

- Where there **is** a touch pointer, the utility was redundant — the 44px box survives with or without it, at every width.
- Where there is **not** — a narrow desktop window, a responsive-mode preview, a small laptop — it applied a touch floor to a mouse. That is the one case the pointer rule deliberately skips, and the only case the class could actually change.

So all it ever did was distort geometry for pointers that never needed it. This button renders inside `CardControlRail`, an **absolute** row centred on the card's top frame line, so a 44px box grew the rail with it.

## Measured (Playwright, real Ladle render, 390px)

| | chevron | rail | status badge |
|---|---|---|---|
| `hasTouch=false` **before** | 44×44 | 44 | 22 |
| `hasTouch=false` **after** | **24×20** | **22** | 22 |
| `hasTouch=true` before / after | 44×44 | 44 | 44 |

The rail's premise is that every cell is the same stamp height, so a 44px square beside a 22px status badge read as broken. After the fix the rail is a uniform 22px and the TL/SV cells are clear.

Coarse-pointer output is **byte-identical to `main`** — `theme.css` governs there either way, so there is no tap-target regression.

## Note on the earlier revisions of this PR

The first two commits added a `::before` hit area and a `data-tap-floor` opt-out in `theme.css`. The automated review's blocking finding was correct and invalidated the measurement they rested on: I had measured by viewport width only, which never matches `pointer: coarse`.

Both are reverted. The opt-out was also verified to achieve nothing on touch: `ControlButtons` renders a `flex gap-1` row whose default `align-items: stretch` stretches children to the rail's line height, and that height is set by the status badge — itself still floored at 44px. Exempting one button while its neighbour sets the line is a no-op, and would have shipped a global stylesheet change for it.

## Known, not addressed here

On a **real touch device** the whole rail is 44px tall and still overlaps the TL/SV stats. That is pre-existing and unchanged by this PR. Fixing it means exempting every rail cell from the global floor and giving each its own hit area — trading tap-target size for rail geometry across `StatusBadge`, `CountStepper` and the worded controls. That is a design call, not a bug in this diff.

Same root cause, also unchanged: the section chevron (`SheetSectionSlab`, declared `size-7`) measures 28×28 on a fine pointer but **44×44** on a coarse one, contradicting its own documented size contract.

## Checks

`bun run check:all` exits 0 — 5,064 tests pass / 0 fail, plus lint, knip, format, styling, audit and the srd output snapshot gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016YGBUwi4LZ4bs3FzzgRr2c
