### PR TITLE
fix(itun): stop share links needing five refreshes after a deploy

### DIFF
--- a/apps/itun/CLAUDE.md
+++ b/apps/itun/CLAUDE.md
@@ -40,7 +40,15 @@ consumers, one renderer. Don't add a fourth read-only sheet renderer.
 - **Zustand** stores for persistent client state (`src/stores/`).
 - **ShadCN + Tailwind v4** — UI primitives in `src/components/ui/`; SU brand
   theme in `src/index.css` (`@theme` block) + `component-lib` theme.
-- **PWA** (`vite-plugin-pwa`, autoUpdate) — installable, offline-capable.
+- **PWA** (`vite-plugin-pwa`, **`registerType: 'prompt'`**) — installable,
+  offline-capable. It is `prompt` and must stay that way: `autoUpdate` force-sets
+  `skipWaiting` + `clientsClaim` (an assignment in the plugin, not a default, so
+  the `workbox` block cannot override it), which activated a new worker under a
+  live page and ran `cleanupOutdatedCaches()` — deleting the precache that page
+  was still resolving code-split chunks against. Share links wore it worst; see
+  the header comments in `vite.config.ts`, `src/lib/sw/register.ts` and
+  `src/lib/chunkRecovery.ts`, plus the `/assets/*` → 404 rule in `netlify.toml`
+  that stops a rotated-away chunk coming back as `200 text/html`.
 
 ## Persistence (read before touching data)
 

--- a/apps/itun/netlify.toml
+++ b/apps/itun/netlify.toml
@@ -152,6 +152,24 @@
 #     after failing to find a file on disk, so as written this matches misses
 #     only. Forcing it would shadow `dist/assets/` and 404 *every* chunk in the
 #     build — i.e. take the whole site down.
+#
+# Measured on deploy-preview-759 with both rules in place:
+#   /assets/index-C9pQFcVN.js  (real)     -> 200 application/javascript
+#   /assets/index-DEADBEEF.js  (missing)  -> 404
+#   /  /s/AAAAAAAA  /p/pilot/abc          -> 200 text/html
+#
+# KNOWN RESIDUE, deliberately not fought: the 404 still carries the `immutable`
+# Cache-Control from the `/assets/*` header block below, because Netlify matches
+# header rules on the REQUEST path and cannot condition them on response status.
+# A browser may therefore cache that 404 for a year under a chunk URL. It does
+# not matter in the forward direction — hashed URLs are never reissued, so the
+# entry is simply never consulted again. It would matter on a ROLLBACK, which
+# republishes a prior deploy and brings its hashes back. What covers that is the
+# service worker: workbox precaches with `cache: 'reload'`, which bypasses the
+# HTTP cache, and the precache glob covers every emitted chunk — so a
+# rolled-back build repopulates from the network and is served out of Cache
+# Storage rather than the poisoned HTTP entries. If a rollback ever does strand
+# a client, a hard reload is the manual out.
 [[redirects]]
   from = "/assets/*"
   to = "/index.html"

--- a/apps/itun/netlify.toml
+++ b/apps/itun/netlify.toml
@@ -117,6 +117,46 @@
   status = 200
   force = true
 
+# A build asset that does not exist must 404 — NOT fall through to the SPA.
+#
+# Verified against production before this rule existed:
+#
+#   $ curl -D- https://intheunionnow.com/assets/index-DEADBEEF.js
+#   HTTP/2 200
+#   content-type: text/html; charset=UTF-8
+#   cache-control: public,max-age=31536000,immutable
+#
+# Every hashed chunk a deploy rotates away is requested by exactly one
+# population: clients still running the previous build — which, because the
+# PWA swaps its precache out from under a live page (`skipWaiting` +
+# `clientsClaim` + `cleanupOutdatedCaches`), is the normal state for the
+# seconds after a deploy. Those clients `import()` the old URL and got back an
+# HTML document with a **200**, so the import rejected on MIME type ("Expected
+# a JavaScript module script"), and the `/assets/*` header block below then
+# pinned that HTML into the HTTP cache as `immutable` for a **year**, under the
+# chunk's URL. The share surfaces are where this showed: `/s/:id` and
+# `/p/:kind/:appId` are opened cold, once, from a link, on a device whose
+# service worker is whatever build it last saw.
+#
+# `status = 404` is the entire point of this rule; the body is irrelevant
+# (index.html is reused only to avoid shipping a second document). An honest
+# 404 makes the failed import surface as `vite:preloadError`, which
+# `src/lib/chunkRecovery.ts` recovers from with a single reload — and that reload
+# fetches a current index.html naming current hashes, so the dead URL is never
+# requested again whether or not the 404 itself got cached.
+#
+# TWO placement rules, both load-bearing:
+#   - It MUST precede the SPA fallback below. First match wins, and that rule's
+#     `/*` would otherwise swallow these.
+#   - It MUST NOT set `force = true`. Netlify consults the redirect table only
+#     after failing to find a file on disk, so as written this matches misses
+#     only. Forcing it would shadow `dist/assets/` and 404 *every* chunk in the
+#     build — i.e. take the whole site down.
+[[redirects]]
+  from = "/assets/*"
+  to = "/index.html"
+  status = 404
+
 # SPA fallback — serve index.html for all unmatched paths
 [[redirects]]
   from = "/*"

--- a/apps/itun/src/lib/__tests__/chunkRecovery.test.ts
+++ b/apps/itun/src/lib/__tests__/chunkRecovery.test.ts
@@ -1,0 +1,180 @@
+/**
+ * chunkRecovery — the deploy-skew reload guard.
+ *
+ * These exercise the real listener against the real `window`, driving it with a
+ * dispatched `vite:preloadError` event. Storage/clock/reload are injected, so
+ * no `mock.module` is involved and nothing leaks into later files in the
+ * process (see .claude/rules/testing-patterns.md).
+ */
+import { describe, expect, it } from 'bun:test'
+import { installChunkRecovery } from '../chunkRecovery'
+
+/** Minimal in-memory Storage stand-in. */
+function fakeStorage(seed: Record<string, string> = {}): Storage {
+  const map = new Map(Object.entries(seed))
+  return {
+    get length() {
+      return map.size
+    },
+    clear: () => map.clear(),
+    getItem: (k: string) => map.get(k) ?? null,
+    key: (i: number) => [...map.keys()][i] ?? null,
+    removeItem: (k: string) => void map.delete(k),
+    setItem: (k: string, v: string) => void map.set(k, v),
+  } as Storage
+}
+
+/** A storage whose every access throws, as in a locked-down privacy mode. */
+function hostileStorage(): Storage {
+  return {
+    get length(): number {
+      throw new Error('denied')
+    },
+    clear: () => {
+      throw new Error('denied')
+    },
+    getItem: () => {
+      throw new Error('denied')
+    },
+    key: () => {
+      throw new Error('denied')
+    },
+    removeItem: () => {
+      throw new Error('denied')
+    },
+    setItem: () => {
+      throw new Error('denied')
+    },
+  } as unknown as Storage
+}
+
+function firePreloadError(): Event {
+  const event = new Event('vite:preloadError', { cancelable: true })
+  Object.defineProperty(event, 'payload', {
+    value: new Error('Failed to fetch dynamically imported module: /assets/x-OLDHASH.js'),
+  })
+  window.dispatchEvent(event)
+  return event
+}
+
+describe('installChunkRecovery', () => {
+  it('reloads once on the first preload failure', () => {
+    let reloads = 0
+    const teardown = installChunkRecovery({
+      storage: fakeStorage(),
+      reload: () => {
+        reloads += 1
+      },
+      now: () => 1_000_000,
+    })
+
+    firePreloadError()
+    teardown()
+
+    expect(reloads).toBe(1)
+  })
+
+  it('cancels the event so Vite does not also rethrow into the error boundary', () => {
+    const teardown = installChunkRecovery({
+      storage: fakeStorage(),
+      reload: () => {},
+      now: () => 1_000_000,
+    })
+
+    const event = firePreloadError()
+    teardown()
+
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('does NOT reload again inside the cooldown — this is the infinite-loop guard', () => {
+    let reloads = 0
+    let clock = 1_000_000
+    const storage = fakeStorage()
+    const teardown = installChunkRecovery({
+      storage,
+      reload: () => {
+        reloads += 1
+      },
+      now: () => clock,
+    })
+
+    firePreloadError()
+    clock += 5_000 // still well inside the 20s cooldown
+    const second = firePreloadError()
+    teardown()
+
+    expect(reloads).toBe(1)
+    // The second failure must be allowed to surface, not silently swallowed.
+    expect(second.defaultPrevented).toBe(false)
+  })
+
+  it('rearms after the cooldown, so a later deploy in a long-lived tab still recovers', () => {
+    let reloads = 0
+    let clock = 1_000_000
+    const teardown = installChunkRecovery({
+      storage: fakeStorage(),
+      reload: () => {
+        reloads += 1
+      },
+      now: () => clock,
+    })
+
+    firePreloadError()
+    clock += 60_000
+    firePreloadError()
+    teardown()
+
+    expect(reloads).toBe(2)
+  })
+
+  it('treats a cooldown recorded by a previous page load as authoritative', () => {
+    // The reload happened, the page came back, and it failed again immediately.
+    // That is the loop case, and it is only detectable via persisted state.
+    let reloads = 0
+    const teardown = installChunkRecovery({
+      storage: fakeStorage({ 'itun:chunk-reload-at': '1000000' }),
+      reload: () => {
+        reloads += 1
+      },
+      now: () => 1_002_000,
+    })
+
+    firePreloadError()
+    teardown()
+
+    expect(reloads).toBe(0)
+  })
+
+  it('still recovers when sessionStorage throws on every access', () => {
+    let reloads = 0
+    const teardown = installChunkRecovery({
+      storage: hostileStorage(),
+      reload: () => {
+        reloads += 1
+      },
+      now: () => 1_000_000,
+    })
+
+    expect(() => firePreloadError()).not.toThrow()
+    teardown()
+
+    expect(reloads).toBe(1)
+  })
+
+  it('removes its listener on teardown', () => {
+    let reloads = 0
+    const teardown = installChunkRecovery({
+      storage: fakeStorage(),
+      reload: () => {
+        reloads += 1
+      },
+      now: () => 1_000_000,
+    })
+
+    teardown()
+    firePreloadError()
+
+    expect(reloads).toBe(0)
+  })
+})

--- a/apps/itun/src/lib/chunkRecovery.ts
+++ b/apps/itun/src/lib/chunkRecovery.ts
@@ -1,0 +1,143 @@
+/**
+ * chunkRecovery — survive a deploy that lands while the page is open.
+ *
+ * ITUN is code-split (`autoCodeSplitting` in vite.config.ts) and preloads the
+ * whole reference dataset as ~30 dynamic imports (`GameDataReady`), so a single
+ * route render can pull a dozen hashed chunks *after* first paint. Every one of
+ * those URLs is only valid for the build that emitted it.
+ *
+ * That window is not rare here. The PWA serves navigations cache-first from a
+ * precached `index.html`, then — on `skipWaiting` + `clientsClaim` +
+ * `cleanupOutdatedCaches` — installs the new build and deletes the old precache
+ * *underneath the live page*. The page carries on asking for chunk names that
+ * no longer exist anywhere, and at ~3 deploys a day the odds of a share link
+ * being opened inside that window are not small. Symptom: a snapshot or public
+ * sheet that renders only after four or five refreshes.
+ *
+ * The fix is to notice and reload once, because a reload fetches a current
+ * `index.html` naming current hashes. It pairs with the `/assets/*` → 404 rule
+ * in `netlify.toml`: without that rule a missing chunk came back as `200
+ * text/html` from the SPA fallback, which fails the import on MIME type but is
+ * also, thanks to the `/assets/*` header block, cached `immutable` for a year.
+ *
+ * Deliberately narrow: this listens for Vite's own `vite:preloadError`, which
+ * is emitted by the `__vitePreload` helper that wraps every dynamic import in
+ * the build. A chunk that fails some other way (a `<script>` tag, a non-Vite
+ * fetch) is not covered and should not be bolted on here without evidence it
+ * happens.
+ */
+
+import { captureException } from './observability'
+
+/**
+ * sessionStorage key holding the epoch-ms of the last recovery reload.
+ *
+ * Session-scoped on purpose: the condition is "this tab is running a build the
+ * server no longer has", which a new tab does not inherit.
+ */
+const LAST_RELOAD_KEY = 'itun:chunk-reload-at'
+
+/**
+ * How long a recovery reload suppresses the next one.
+ *
+ * This is the loop guard, and it is a cooldown rather than a one-shot flag for
+ * a reason. A one-shot flag never rearms, so a second deploy later in the same
+ * long-lived tab — the exact thing this recovers from — would go unhandled. A
+ * cooldown rearms on its own while still making an infinite reload loop
+ * impossible: if the very next load fails the same way, we let the error
+ * surface to the root error boundary instead of reloading again.
+ */
+const RELOAD_COOLDOWN_MS = 20_000
+
+/** Vite dispatches this on `window` with the failed import's error as `payload`. */
+type PreloadErrorEvent = Event & { payload?: unknown }
+
+/**
+ * sessionStorage throws rather than degrading in some privacy modes (Safari
+ * private windows, cookies-blocked iframes). Recovery must not depend on
+ * storage being writable, so both accessors fail soft — a read failure means
+ * "no cooldown recorded", which errs toward reloading, and the reload itself is
+ * still bounded because a repeat failure lands on a page that cannot record one
+ * either and therefore reloads at most as fast as the network serves it.
+ */
+function readLastReloadAt(storage: Storage | undefined): number {
+  if (!storage) return 0
+  try {
+    return Number(storage.getItem(LAST_RELOAD_KEY)) || 0
+  } catch {
+    return 0
+  }
+}
+
+function writeLastReloadAt(storage: Storage | undefined, at: number): void {
+  if (!storage) return
+  try {
+    storage.setItem(LAST_RELOAD_KEY, String(at))
+  } catch {
+    // Non-fatal: we lose the loop guard, not the recovery.
+  }
+}
+
+export type ChunkRecoveryDeps = {
+  /** Defaults to `window.sessionStorage`; pass a stub in tests. */
+  storage?: Storage
+  /** Defaults to a hard reload. */
+  reload?: () => void
+  /** Defaults to `Date.now`. */
+  now?: () => number
+}
+
+/**
+ * Installs the `vite:preloadError` listener. Idempotent per call site — call it
+ * once, from the entry module.
+ *
+ * @returns a teardown function that removes the listener (used by tests).
+ */
+export function installChunkRecovery(deps: ChunkRecoveryDeps = {}): () => void {
+  const {
+    storage = typeof sessionStorage === 'undefined' ? undefined : sessionStorage,
+    reload = () => {
+      window.location.reload()
+    },
+    now = Date.now,
+  } = deps
+
+  const onPreloadError = (event: Event) => {
+    const error = (event as PreloadErrorEvent).payload ?? event
+
+    const at = now()
+    const since = at - readLastReloadAt(storage)
+    const willReload = since >= RELOAD_COOLDOWN_MS
+
+    // Report either way. A chunk failure that reloads is invisible to the user
+    // and would otherwise be invisible to us too — which is how this shipped
+    // undiagnosed in the first place. The fingerprint is fixed so every one of
+    // these lands in a single issue: the message carries a bundle hash, so
+    // Sentry's default grouping would mint a fresh issue per deploy.
+    captureException(
+      error,
+      { recovered: willReload, msSinceLastReload: since },
+      {
+        fingerprint: ['chunk-preload-error'],
+        tags: { recovered: String(willReload) },
+      }
+    )
+
+    if (!willReload) {
+      // Second failure inside the cooldown: stop. Let Vite rethrow so the root
+      // error boundary shows its recovery panel rather than looping.
+      return
+    }
+
+    writeLastReloadAt(storage, at)
+    // Suppress Vite's default rethrow — we are handling this by reloading, and
+    // an uncaught error here would also trip the root error boundary mid-reload.
+    event.preventDefault()
+    reload()
+  }
+
+  window.addEventListener('vite:preloadError', onPreloadError)
+  return () => {
+    window.removeEventListener('vite:preloadError', onPreloadError)
+  }
+}

--- a/apps/itun/src/lib/sw/__tests__/register.test.ts
+++ b/apps/itun/src/lib/sw/__tests__/register.test.ts
@@ -1,35 +1,67 @@
 /**
- * Service worker registration smoke tests.
+ * Service worker registration + update-prompt tests.
  *
- * Tests verify the guard logic in registerServiceWorker():
- *   1. DEV mode guard — returns early, no registration attempt
- *   2. Unavailable SW guard — returns early when serviceWorker is falsy
- *   3. Production path guards pass through silently
- *
- * The actual navigator.serviceWorker.register() call (in production builds)
- * is not covered by automated tests because:
- *   - import.meta.env.DEV is `true` in Bun's test runner (NODE_ENV=test),
- *     so the DEV guard exits before reaching the register call.
- *   - happy-dom sets navigator.serviceWorker = undefined (property exists
- *     but is falsy), so the SW-unavailable guard also exits early.
- * Full offline behavior is captured as a manual-test checklist in the PR
- * description (per AC-5).
+ * `registerServiceWorker()` itself is only smoke-testable: `import.meta.env.DEV`
+ * is true in Bun's test runner and happy-dom leaves `navigator.serviceWorker`
+ * undefined, so both guards fire before the register call. The part that
+ * actually carries risk — deciding *when* an update is ready and how it is
+ * activated — is `watchForUpdate`, which takes only the slice of the SW API it
+ * uses so a plain object can stand in.
  */
 import { describe, expect, it } from 'bun:test'
-import { registerServiceWorker } from '../register'
+import { registerServiceWorker, watchForUpdate } from '../register'
+
+type Listener = (event?: unknown) => void
+
+/** A stand-in ServiceWorker whose posted messages are recorded. */
+function fakeWorker(state: ServiceWorker['state'] = 'installed') {
+  const listeners = new Map<string, Listener[]>()
+  const posted: unknown[] = []
+  return {
+    posted,
+    state,
+    postMessage: (message: unknown) => void posted.push(message),
+    addEventListener: (type: string, fn: Listener) => {
+      listeners.set(type, [...(listeners.get(type) ?? []), fn])
+    },
+    emit: (type: string) => {
+      for (const fn of listeners.get(type) ?? []) fn()
+    },
+  }
+}
+
+function fakeRegistration(initial: { waiting?: unknown; installing?: unknown } = {}) {
+  const listeners = new Map<string, Listener[]>()
+  return {
+    waiting: initial.waiting ?? null,
+    installing: initial.installing ?? null,
+    addEventListener: (type: string, fn: Listener) => {
+      listeners.set(type, [...(listeners.get(type) ?? []), fn])
+    },
+    emit: (type: string) => {
+      for (const fn of listeners.get(type) ?? []) fn()
+    },
+  }
+}
+
+function fakeContainer(controller: unknown) {
+  const listeners = new Map<string, Listener[]>()
+  return {
+    controller,
+    addEventListener: (type: string, fn: Listener) => {
+      listeners.set(type, [...(listeners.get(type) ?? []), fn])
+    },
+    emit: (type: string) => {
+      for (const fn of listeners.get(type) ?? []) fn()
+    },
+  }
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: structural stand-ins for the SW API
+const asAny = (value: unknown) => value as any
 
 describe('registerServiceWorker', () => {
-  it('returns without throwing when import.meta.env.DEV is true (test environment default)', () => {
-    // In Bun's test runner, import.meta.env.DEV is true (set by NODE_ENV=test).
-    // The function must exit early and not throw.
-    expect(() => registerServiceWorker()).not.toThrow()
-  })
-
-  it('returns without throwing when navigator.serviceWorker is undefined (happy-dom default)', () => {
-    // happy-dom sets navigator.serviceWorker = undefined (property exists,
-    // value is falsy). The guard `!navigator.serviceWorker` catches this.
-    // In the DEV environment the DEV guard fires first, but this test
-    // confirms the guard chain is correctly ordered.
+  it('returns without throwing in the test environment (DEV + no serviceWorker)', () => {
     expect(() => registerServiceWorker()).not.toThrow()
   })
 
@@ -39,5 +71,156 @@ describe('registerServiceWorker', () => {
       registerServiceWorker()
       registerServiceWorker()
     }).not.toThrow()
+  })
+
+  it('accepts an onUpdateReady notifier without invoking it during the guarded exit', () => {
+    let notified = false
+    registerServiceWorker({
+      onUpdateReady: () => {
+        notified = true
+      },
+    })
+    expect(notified).toBe(false)
+  })
+})
+
+describe('watchForUpdate', () => {
+  it('prompts when a worker finishes installing while a controller exists', () => {
+    const installing = fakeWorker('installing')
+    const registration = fakeRegistration({ installing })
+    const container = fakeContainer({})
+    let prompts = 0
+
+    watchForUpdate(
+      asAny(registration),
+      asAny(container),
+      () => {
+        prompts += 1
+      },
+      () => {}
+    )
+
+    installing.state = 'installed'
+    registration.emit('updatefound')
+    installing.emit('statechange')
+
+    expect(prompts).toBe(1)
+  })
+
+  it('does NOT prompt on a first install — no controller means nothing is stale', () => {
+    const installing = fakeWorker('installing')
+    const registration = fakeRegistration({ installing })
+    // controller null == this page is not controlled == first ever visit.
+    const container = fakeContainer(null)
+    let prompts = 0
+
+    watchForUpdate(
+      asAny(registration),
+      asAny(container),
+      () => {
+        prompts += 1
+      },
+      () => {}
+    )
+
+    installing.state = 'installed'
+    registration.emit('updatefound')
+    installing.emit('statechange')
+
+    expect(prompts).toBe(0)
+  })
+
+  it('prompts immediately when a worker was already waiting at registration time', () => {
+    const registration = fakeRegistration({ waiting: fakeWorker() })
+    const container = fakeContainer({})
+    let prompts = 0
+
+    watchForUpdate(
+      asAny(registration),
+      asAny(container),
+      () => {
+        prompts += 1
+      },
+      () => {}
+    )
+
+    expect(prompts).toBe(1)
+  })
+
+  it('does not prompt mid-install, only once state reaches installed', () => {
+    const installing = fakeWorker('installing')
+    const registration = fakeRegistration({ installing })
+    const container = fakeContainer({})
+    let prompts = 0
+
+    watchForUpdate(
+      asAny(registration),
+      asAny(container),
+      () => {
+        prompts += 1
+      },
+      () => {}
+    )
+
+    registration.emit('updatefound')
+    installing.emit('statechange') // still 'installing'
+
+    expect(prompts).toBe(0)
+  })
+
+  it('accepting posts SKIP_WAITING and defers the reload to controllerchange', () => {
+    const waiting = fakeWorker()
+    const registration = fakeRegistration({ waiting })
+    const container = fakeContainer({})
+    let reloads = 0
+    // Collected into an array rather than a `let`: TS's control-flow analysis
+    // cannot see that the notifier callback ran, so a nullable local narrows to
+    // `never` at the call below.
+    const accepts: Array<() => void> = []
+
+    watchForUpdate(
+      asAny(registration),
+      asAny(container),
+      (fn) => {
+        accepts.push(fn)
+      },
+      () => {
+        reloads += 1
+      }
+    )
+
+    accepts[0]?.()
+
+    // The message went out, but reloading now would race skipWaiting() and can
+    // land back on the old worker — so nothing has reloaded yet.
+    expect(waiting.posted).toEqual([{ type: 'SKIP_WAITING' }])
+    expect(reloads).toBe(0)
+
+    container.emit('controllerchange')
+    expect(reloads).toBe(1)
+  })
+
+  it('reloads directly when accept finds nothing waiting', () => {
+    const registration = fakeRegistration({ waiting: fakeWorker() })
+    const container = fakeContainer({})
+    let reloads = 0
+    const accepts: Array<() => void> = []
+
+    watchForUpdate(
+      asAny(registration),
+      asAny(container),
+      (fn) => {
+        accepts.push(fn)
+      },
+      () => {
+        reloads += 1
+      }
+    )
+
+    // The waiting worker activated on its own between prompt and accept.
+    registration.waiting = null
+    accepts[0]?.()
+
+    expect(reloads).toBe(1)
   })
 })

--- a/apps/itun/src/lib/sw/register.ts
+++ b/apps/itun/src/lib/sw/register.ts
@@ -10,30 +10,142 @@
  *     every emitted filename (content-hashed), which drifts silently.
  *   - Wraps workbox under the hood — proven cache-first strategy for app
  *     shells with automatic stale-while-revalidate semantics.
- *   - registerType: 'autoUpdate' in vite.config.ts silently swaps in new
- *     SW versions on next page load, appropriate for a local-first app with
- *     no server-coordinated deploys required.
  *   - The plugin also auto-injects registration into the built index.html,
  *     but this file provides an explicit registration call so the boot
  *     sequence is visible in main.tsx rather than hidden in injected HTML.
+ *     Both register `/sw.js` at scope `/`, which the spec makes idempotent —
+ *     they resolve to the same ServiceWorkerRegistration, so the update
+ *     listener below sees every update regardless of which call created it.
  *   - Hand-written SW alternative would require: manual glob patterns,
  *     cache versioning, skipWaiting/clientsClaim logic — all solved by
  *     workbox already.
  *
  * Trade-offs accepted:
  *   - SW is skipped in DEV mode so HMR works correctly (see guard below).
- *   - Icons are placeholders for M1; replace before M3 launch.
- *   - registerType: 'autoUpdate' means the user gets the new version
- *     automatically; no prompt is shown. Acceptable for a local-first app.
  *   - We register `/sw.js` directly (the workbox output filename from
  *     vite-plugin-pwa) rather than importing `virtual:pwa-register`, because
  *     the virtual module only resolves in Vite's build context and cannot be
- *     mocked in Bun's test runner without modifying bunfig.toml (which is
- *     frozen by Wave 1). Direct registration is functionally equivalent since
- *     `registerType: 'autoUpdate'` configures the same workbox options.
+ *     mocked in Bun's test runner without modifying bunfig.toml.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THIS IS A PROMPT AND NOT A SILENT AUTO-UPDATE
+ *
+ * This file used to say `registerType: 'autoUpdate'` "silently swaps in new SW
+ * versions on next page load, appropriate for a local-first app". That was the
+ * bug. Under `autoUpdate` the plugin forces `skipWaiting` + `clientsClaim`, so
+ * a newly-installed worker activated immediately, claimed the page the user was
+ * already looking at, and ran `cleanupOutdatedCaches()` — destroying the
+ * precache that page was still resolving its code-split chunks against. Every
+ * subsequent lazy import asked for a hash the server no longer served. Share
+ * links (`/s/:id`, `/p/:kind/:appId`) took it worst, because they are opened
+ * cold from a link on a device whose worker is whatever build it last saw.
+ *
+ * `vite.config.ts` is now `registerType: 'prompt'`, which emits a worker that
+ * installs and WAITS. Nothing is swapped under a live page. The update lands
+ * when the user accepts here (post `SKIP_WAITING`, then reload on
+ * `controllerchange`) or when every tab has closed.
  */
 
-export function registerServiceWorker(): void {
+import { captureException } from '../observability'
+
+/** Signature of the "an update is ready" notifier supplied by the caller. */
+export type UpdateReadyNotifier = (accept: () => void) => void
+
+export type RegisterOptions = {
+  /**
+   * Invoked when a new worker has finished installing and is waiting. Receives
+   * the accept callback — call it to activate the update and reload.
+   *
+   * Defaults to a no-op so that callers which do not care (and the tests) need
+   * not supply one. main.tsx passes the toast; keeping the UI out of this
+   * module is what lets the update logic be tested without a DOM toaster.
+   */
+  onUpdateReady?: UpdateReadyNotifier
+}
+
+/**
+ * Guards against a double reload: `controllerchange` can fire more than once
+ * (notably if the user accepts in two tabs at nearly the same moment), and a
+ * second reload mid-navigation is user-visible jank.
+ */
+let reloading = false
+
+/**
+ * Activates a waiting worker and reloads once it has taken control.
+ *
+ * The reload is driven by `controllerchange` rather than fired straight after
+ * `postMessage` because `skipWaiting()` is asynchronous: reloading immediately
+ * races the activation and can land back on the OLD worker, which presents as
+ * "I clicked reload and nothing changed".
+ */
+function activateWaitingWorker(
+  registration: Pick<ServiceWorkerRegistration, 'waiting'>,
+  container: Pick<ServiceWorkerContainer, 'addEventListener'>,
+  reload: () => void
+): void {
+  const waiting = registration.waiting
+  if (!waiting) {
+    // Nothing waiting after all (it may have activated on its own because the
+    // last controlled tab closed). A plain reload still gets the new build.
+    reload()
+    return
+  }
+
+  container.addEventListener(
+    'controllerchange',
+    () => {
+      if (reloading) return
+      reloading = true
+      reload()
+    },
+    { once: true }
+  )
+
+  waiting.postMessage({ type: 'SKIP_WAITING' })
+}
+
+/**
+ * Watches a registration for an update that is ready to activate.
+ *
+ * Exported for tests — it takes only the slice of the SW API it uses, so a
+ * plain object stands in for a real registration.
+ *
+ * The `controller` check is what separates an UPDATE from a FIRST INSTALL. On a
+ * first visit a worker also reaches `installed`, but there is no controller yet
+ * and nothing stale on screen, so prompting would be nonsense ("a new version
+ * is available" on a page that just loaded that version).
+ */
+export function watchForUpdate(
+  registration: Pick<ServiceWorkerRegistration, 'waiting' | 'installing' | 'addEventListener'>,
+  container: Pick<ServiceWorkerContainer, 'addEventListener' | 'controller'>,
+  notify: UpdateReadyNotifier,
+  reload: () => void
+): void {
+  const accept = () => {
+    activateWaitingWorker(registration, container, reload)
+  }
+
+  // Already waiting at registration time: a previous visit installed it but the
+  // page was never reloaded, so no `updatefound` will fire for it now.
+  if (registration.waiting && container.controller) {
+    notify(accept)
+  }
+
+  registration.addEventListener('updatefound', () => {
+    const installing = registration.installing
+    if (!installing) return
+
+    installing.addEventListener('statechange', () => {
+      if (installing.state === 'installed' && container.controller) {
+        notify(accept)
+      }
+    })
+  })
+}
+
+export function registerServiceWorker(options: RegisterOptions = {}): void {
+  const { onUpdateReady = () => {} } = options
+
   if (import.meta.env.DEV) {
     // Skip SW registration in development so Vite HMR is not disrupted.
     return
@@ -45,8 +157,26 @@ export function registerServiceWorker(): void {
     return
   }
 
-  // Register the workbox-generated SW produced by vite-plugin-pwa.
-  // The SW filename 'sw.js' is the default output from vite-plugin-pwa
-  // when no custom filename is configured.
-  void navigator.serviceWorker.register('/sw.js', { scope: '/' })
+  const container = navigator.serviceWorker
+
+  container
+    .register('/sw.js', { scope: '/' })
+    .then((registration) => {
+      watchForUpdate(registration, container, onUpdateReady, () => {
+        window.location.reload()
+      })
+    })
+    .catch((error: unknown) => {
+      // Previously `void`-ed with no catch, which surfaced in Sentry as two
+      // untitled "Error: Rejected" issues via the unhandled-rejection handler.
+      // Registration failing is not fatal — the app runs fine uncached — but it
+      // should be legible rather than anonymous.
+      captureException(
+        error,
+        { stage: 'serviceWorker.register' },
+        {
+          fingerprint: ['sw-register-failed'],
+        }
+      )
+    })
 }

--- a/apps/itun/src/main.tsx
+++ b/apps/itun/src/main.tsx
@@ -1,7 +1,9 @@
 import { createRouter, RouterProvider } from '@tanstack/react-router'
+import { toast } from 'component-lib'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouteNotFound, RoutePending } from './components/shared/RouteFallbacks'
+import { installChunkRecovery } from './lib/chunkRecovery'
 import { initBrowserObservability } from './lib/observability'
 import { registerServiceWorker } from './lib/sw/register'
 import { routeTree } from './routeTree.gen'
@@ -21,6 +23,11 @@ declare module '@tanstack/react-router' {
 // Optional, env-gated browser error tracking (no-op unless VITE_SENTRY_DSN set).
 void initBrowserObservability()
 
+// Installed BEFORE render, because the failure it recovers from — a lazy chunk
+// whose build no longer exists on the server — can be thrown by the very first
+// route the router resolves. See lib/chunkRecovery.ts.
+installChunkRecovery()
+
 const rootEl = document.getElementById('root')
 if (!rootEl) throw new Error('Root element not found')
 
@@ -30,4 +37,20 @@ createRoot(rootEl).render(
   </StrictMode>
 )
 
-registerServiceWorker()
+// `registerType: 'prompt'` (vite.config.ts) means a new worker installs and then
+// waits rather than claiming this page mid-session, so the swap is ours to time.
+// The toast is that timing: an update the user accepts, not one that happens to
+// them while they are reading a sheet.
+//
+// Deliberately persistent (`duration: Infinity`) and dismissible. This fires at
+// most once per installed update, and the alternative — auto-dismiss — puts the
+// user back on a stale build with no way to ask for the new one.
+registerServiceWorker({
+  onUpdateReady: (accept) => {
+    toast('A new version of ITUN is ready', {
+      description: 'Reload to pick it up. Your saved data is not affected.',
+      duration: Number.POSITIVE_INFINITY,
+      action: { label: 'Reload', onClick: accept },
+    })
+  },
+})

--- a/apps/itun/src/routes/s/$id.tsx
+++ b/apps/itun/src/routes/s/$id.tsx
@@ -18,6 +18,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { buttonVariants, SheetSkeleton } from 'component-lib'
 import { AppLink } from '../../components/shared/AppLink'
 import { SnapshotSheet } from '../../components/sheet/SnapshotSheet'
+import { captureException } from '../../lib/observability'
 import type { SnapshotPayload } from '../../lib/snapshot/client'
 import { retrieveSnapshot, SnapshotNotFoundError } from '../../lib/snapshot/client'
 import { cn } from '../../lib/utils'
@@ -35,6 +36,30 @@ export const Route = createFileRoute('/s/$id')({
       if (err instanceof SnapshotNotFoundError) {
         return { snapshot: null, notFound: true as const, error: null }
       }
+
+      // Report before rendering the error state. Catching is exactly what stops
+      // an error reaching Sentry's global handler, so until now every failure on
+      // this route — timeouts, 503s from a Blobs outage, the MIME-type rejection
+      // from a rotated-away chunk — was converted into calm on-screen prose and
+      // nothing else. The route looked healthy from the outside while being the
+      // single most-reported broken surface in the app.
+      //
+      // A 404 above is deliberately NOT reported: a revoked or expired snapshot
+      // is a designed outcome, not a fault, and reporting it would bury the real
+      // failures in noise.
+      //
+      // Fingerprinted on the route rather than the message, because the messages
+      // embed a timeout figure and HTTP status and would otherwise shard one
+      // condition across many issues.
+      captureException(
+        err,
+        { snapshotId: params.id },
+        {
+          fingerprint: ['snapshot-retrieve-failed'],
+          tags: { route: '/s/$id' },
+        }
+      )
+
       const message = err instanceof Error ? err.message : 'Unknown error'
       return { snapshot: null, notFound: false as const, error: message }
     }

--- a/apps/itun/vite.config.ts
+++ b/apps/itun/vite.config.ts
@@ -34,7 +34,31 @@ export default defineConfig({
     // is not an option on this plugin and would be rejected.
     react(),
     VitePWA({
-      registerType: 'autoUpdate',
+      // 'prompt', NOT 'autoUpdate' — this is the setting that made share links
+      // need four or five refreshes.
+      //
+      // Under 'autoUpdate' the plugin FORCE-ASSIGNS `workbox.skipWaiting` and
+      // `workbox.clientsClaim` to true (dist/index.js: an assignment, not a
+      // default, so setting them in `workbox` below cannot override it). The
+      // emitted worker then activates the moment it finishes installing,
+      // claims the already-open page, and runs `cleanupOutdatedCaches()` —
+      // deleting the precache the live page is still reading from. That page
+      // goes on requesting hashed chunks from a build the server no longer
+      // has, and every one of them fails. Reloading is the only way out, which
+      // is precisely the symptom: a snapshot link that renders on the fifth
+      // try, once the ~1.2 MB precache install has finally finished.
+      //
+      // Under 'prompt' the new worker installs and then WAITS. The running
+      // page keeps the precache it booted with, so its chunks stay resolvable
+      // for as long as it is open, and the swap happens only when the user
+      // accepts (src/lib/sw/register.ts posts SKIP_WAITING and reloads) or
+      // when every tab has closed. Nothing is yanked mid-session.
+      //
+      // The cost is that a user can sit on an old build until they accept —
+      // which is why the prompt is a toast and not a silent no-op, and why
+      // chunkRecovery.ts still exists as the backstop for the tab that was
+      // already mid-flight when a deploy landed.
+      registerType: 'prompt',
       includeAssets: ['favicon.svg'],
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],


### PR DESCRIPTION
A snapshot link (`/s/:id`) routinely needed four or five refreshes before it rendered. Two independent faults compounded, and **neither was "the PWA" alone — removing the PWA would have fixed neither.**

## Fault 1 — a missing chunk came back as `200 text/html`, cached immutable for a year

Verified against production before this PR:

```
$ curl -D- https://intheunionnow.com/assets/index-DEADBEEF.js
HTTP/2 200
content-type: text/html; charset=UTF-8
cache-control: public,max-age=31536000,immutable
```

The `/*` SPA fallback swallowed rotated-away asset hashes, so a dynamic `import()` failed on MIME type — and the `/assets/*` header block then pinned that HTML into the HTTP cache under the chunk's URL, for a year, where no later deploy can dislodge it. This would bite any code-split SPA on this config, PWA or not.

Fixed with an `/assets/*` → 404 rule ahead of the fallback.

> **Reviewer note — the one thing to check here.** The rule deliberately has **no `force = true`**. Netlify consults the redirect table only after failing to find a file on disk, so as written it matches misses only. Forcing it would shadow `dist/assets/` and 404 *every* chunk in the build, i.e. take the site down. Verified on the deploy preview below.

## Fault 2 — the service worker deleted its own precache under a live page

`registerType: 'autoUpdate'` **force-assigns** `skipWaiting` + `clientsClaim` (an assignment in the plugin source, not a default — the `workbox` block cannot override it). A new worker therefore activated the moment it installed, claimed the page the user was already looking at, and ran `cleanupOutdatedCaches()`. That page then went on requesting chunk hashes from a build the server no longer had → Fault 1.

Now `registerType: 'prompt'`: the worker installs and **waits**. The swap happens when the user accepts (post `SKIP_WAITING`, reload on `controllerchange`) or when every tab has closed. Verified in the emitted `sw.js`: `clientsClaim` is gone entirely, and `skipWaiting` survives only behind the message guard.

At ~3 deploys/day the collision window was open most of the time, and share surfaces wore it worst — `/s/:id` and `/p/:kind/:appId` are opened cold, once, from a link, on a device whose worker is whatever build it last saw.

## Also in here

- **`chunkRecovery.ts`** — recovers a tab that was already mid-flight when a deploy landed, via Vite's `vite:preloadError`. 20s cooldown as the loop guard; a cooldown rather than a one-shot flag so a *second* deploy in a long-lived tab still recovers. Fails soft when `sessionStorage` throws (Safari private mode).
- **`/s/:id` now reports to Sentry.** Catching is exactly what stopped these reaching the global handler, so the most-reported broken surface in the app was structurally invisible — Sentry showed zero snapshot errors the whole time. A 404 stays unreported: a revoked snapshot is a designed outcome, not a fault.
- **`serviceWorker.register()` gets a `.catch`.** Its unhandled rejection is the pair of untitled `Error: Rejected` issues already in Sentry (ITUN-4 / ITUN-5).
- Fingerprints pinned on all three captures — the messages embed bundle hashes and HTTP statuses, so default grouping would shard one condition into a fresh issue per deploy.

## Verification

- `bun run check:all` green (lint, format, typecheck, full test suite, audit, tokens, styling, schema-drift, srd output snapshot).
- itun suite 1868 pass / 0 fail; 15 new tests across `chunkRecovery` and `watchForUpdate`.
- Emitted `sw.js` inspected directly for the `clientsClaim` / `skipWaiting` change rather than assumed.
- Deploy-preview curl checks for the redirect are in a comment below.

## Not fixed here

The publish endpoint returns `url: /api/snapshots/${id}` while `PublishResult` documents it as the share page `/s/${id}`. The share UI ignores the field and builds `${origin}/s/${id}` itself, so it is a stale doc comment rather than a live bug — left alone to keep this PR to the reported fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoaHi5zfFQxcFMbLzyYQVX