### PR TITLE
fix(itun): drop redundant "View in SRD" link and Slots figure from sheet card footers

### DIFF
--- a/apps/itun/src/components/sheet/LiveSheet.tsx
+++ b/apps/itun/src/components/sheet/LiveSheet.tsx
@@ -27,7 +27,13 @@
  */
 
 import type { StatTone } from 'component-lib'
-import { Badge, buttonVariants, SHEET_ICONBTN_CLASS, Stat } from 'component-lib'
+import {
+  Badge,
+  buttonVariants,
+  EntityExternalLinkProvider,
+  SHEET_ICONBTN_CLASS,
+  Stat,
+} from 'component-lib'
 import { ArrowLeft } from 'lucide-react'
 import type { ReactNode, RefObject } from 'react'
 import { useEffect, useRef, useState } from 'react'
@@ -324,7 +330,16 @@ export function LiveSheet({
           </span>
         </span>
         <div className="px-4 pb-[34px] pt-4 sm:px-[30px] sm:pb-[60px] sm:pt-[22px] xl:pl-[84px]">
-          {renderBody()}
+          {/* No "View in SRD →" on a sheet. The app-wide builder is provided at
+              the root (GameDataReady), and every full entity card renders it in
+              its foot band — which on a sheet is EVERY installed system, module
+              and piece of equipment. A sheet is a play surface you read down,
+              not an index you navigate out of, so the link was a per-card exit
+              hatch repeated dozens of times. Overriding the context to
+              `undefined` for the sheet BODY turns it off for the whole subtree
+              (including card detail modals, which are descendants) while the
+              roster, Dashboard and wizards keep it. */}
+          <EntityExternalLinkProvider value={undefined}>{renderBody()}</EntityExternalLinkProvider>
         </div>
       </div>
     </div>

--- a/apps/itun/src/components/sheet/MechItemCard.tsx
+++ b/apps/itun/src/components/sheet/MechItemCard.tsx
@@ -3,7 +3,7 @@
  * (design §4.3, plan 4.5; redesign phase 2: compact listing cards, max 2-up).
  *
  * Every affordance rides the card's controls overlay (no footer actions);
- * `footMeta` still carries the read-only EP/Heat/Slots figures:
+ * `footMeta` still carries the read-only EP/Heat figures:
  *   - Use: spends the primary action's EP cost / adds its Hot heat /
  *     decrements the uses counter. DISABLED while Damaged/Destroyed —
  *     "wire the disabled state, not just the pill" (§4.3).
@@ -124,10 +124,15 @@ export function MechItemCard({
   // wired — the Dashboard passes one; the Free-Edit Live Sheet does not (ADR-021).
   const showUse = onUse !== undefined && (epCost > 0 || heat > 0 || maxUses > 0)
 
+  // Slots deliberately absent: ReferenceEntityCard ALREADY renders
+  // `slotsRequired` as a "Slots" stat in its own header cluster, so this footer
+  // pair was the same number printed twice on the same card. A sheet card is the
+  // SRD card plus interaction affordances — not the SRD card plus a second copy
+  // of its stats. (The sheet also states slot usage against capacity, once, in
+  // the System/Module gauges.)
   const footMeta: CardFootMeta[] = [
     ...(epCost > 0 ? [{ label: 'EP Cost', value: epCost }] : []),
     ...(heat > 0 ? [{ label: 'Heat', value: `+${heat}` }] : []),
-    { label: 'Slots', value: entity.slotsRequired },
   ]
 
   const deductDisabledReason =

--- a/apps/itun/src/components/sheet/PilotSheetItems.tsx
+++ b/apps/itun/src/components/sheet/PilotSheetItems.tsx
@@ -22,12 +22,7 @@ import type { ItemCondition } from '../../lib/schemas/mech'
 import type { GenericInventoryEntry } from '../../lib/schemas/pilot'
 import type { useEntityStore } from '../../stores/entityStore'
 import { useEntityChoices } from '../shared/useEntityChoices'
-import {
-  equipmentMaxUses,
-  equipmentSlotCost,
-  genericEntrySlots,
-  resolveEquipment,
-} from './pilotInventory'
+import { equipmentMaxUses, genericEntrySlots, resolveEquipment } from './pilotInventory'
 
 const HIDE_CHOICES = { choices: true } as const
 
@@ -197,12 +192,17 @@ export function PilotEquipmentItem({
     )
   }
 
-  const slotCost = equipmentSlotCost(equipment)
   const maxUses = equipmentMaxUses(equipment)
   const uses = maxUses !== null ? (usesLeft ?? maxUses) : null
 
+  // Slots deliberately absent. Unlike a mech system (whose `slotsRequired`
+  // ReferenceEntityCard renders as its own "Slots" stat), an equipment's slot
+  // cost is DERIVED — `getInventorySlots`, 1 unless a Heavy/Portable trait makes
+  // it 2 — so this was the sheet bolting an extra figure onto the card rather
+  // than duplicating one. Either way it is not part of the SRD card, and the
+  // inventory band already states slot usage against capacity, once. `Uses`
+  // stays: that is live sheet state, not a restatement of reference data.
   const footMeta: CardFootMeta[] = [
-    { label: 'Slots', value: slotCost },
     ...(maxUses !== null ? [{ label: 'Uses', value: `${uses}/${maxUses}` }] : []),
   ]
   // Use / Restock ride the controls bar (no footer actions); the per-card


### PR DESCRIPTION
A sheet's reference cards should be the SRD reference card **plus the sheet's own interaction affordances** — not the SRD card plus a second copy of its data. Two footer additions failed that test.

## `Slots`

- **Mech systems/modules** — literally the same number twice on the same card: `ReferenceEntityCard` already renders `slotsRequired` as a "Slots" stat in its header cluster (`ReferenceEntityCard.tsx:785`). Verified: `MechSheet-system-cards.test.tsx` asserts `getAllByText('Slots')` and still passes after removal, off the card's own stat.
- **Pilot equipment** — here the figure is *derived* (`getInventorySlots`: 1, or 2 with a Heavy/Portable trait) rather than duplicated, since equipment carries no `slotsRequired`. Still not part of the SRD card, and both sheets already state slot usage against capacity once, in their gauges.

`Uses` on pilot equipment stays — that is live sheet state, not a restatement of reference data.

## `View in SRD →`

The builder is provided app-wide at the root (`GameDataReady`) and every **full** entity card renders it in its foot band — which on a sheet is every installed system, module and piece of equipment, so it read as a per-card exit hatch repeated dozens of times down a surface you scroll rather than navigate out of.

Suppressed by overriding `EntityExternalLinkProvider` to `undefined` around the `LiveSheet` body. That is the tightest node covering the rendered sheet: all three variants (`SheetPilot`/`SheetMech`/`SheetCrawler`) render through it, as do the snapshot, public `/p/:kind/:appId` and Game crew views (all of which go `Sheet` → per-kind view → `LiveSheet`). Card detail modals are React descendants, so they are covered too. **The roster, Dashboard and wizards keep the link** — the change is scoped to sheets.

## Verification

- `bun run check:fast` — green (lint, `validate:all`, knip, typecheck across all six workspaces)
- `bun run test` — full canonical suite, **0 fail** in every workspace (itun 1868 pass)
- No test needed changing; the one assertion that named "Slots" now proves what its comment always claimed — that the *card* rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjUZejFfDogR9LMCdoxsUZ