### PR TITLE
fix(itun): drop redundant EP/Heat/AP cost figures from sheet card footers

### DIFF
--- a/apps/itun/src/components/sheet/MechItemCard.tsx
+++ b/apps/itun/src/components/sheet/MechItemCard.tsx
@@ -2,8 +2,15 @@
  * MechItemCard — ONE installed system/module as an EntityGridRow'd COMPACT entity card
  * (design §4.3, plan 4.5; redesign phase 2: compact listing cards, max 2-up).
  *
- * Every affordance rides the card's controls overlay (no footer actions);
- * `footMeta` still carries the read-only EP/Heat figures:
+ * Every affordance rides the card's controls overlay (no footer actions), and
+ * the card carries NO `footMeta`: a sheet card is the SRD reference card plus
+ * this sheet's interactions, never plus a second copy of the card's own data.
+ * ReferenceEntityCard already renders `slotsRequired` as a "Slots" stat, each
+ * action's activation cost as its own `2 EP` box, and Hot as a `Hot (2)` trait
+ * badge — so the EP/Heat/Slots footer figures restated all three. The EP one
+ * also flattened a multi-action item to its PRIMARY action's cost, printing
+ * "EP Cost 2" beside a card openly listing 2 EP / 2 EP / 4 EP.
+ *
  *   - Use: spends the primary action's EP cost / adds its Hot heat /
  *     decrements the uses counter. DISABLED while Damaged/Destroyed —
  *     "wire the disabled state, not just the pill" (§4.3).
@@ -23,7 +30,7 @@
  * readOnly suppresses every affordance: no foot actions, no status cycle.
  */
 
-import type { CardFootMeta, ReferenceEntityControl } from 'component-lib'
+import type { ReferenceEntityControl } from 'component-lib'
 import {
   Button,
   CardRemoveButton,
@@ -123,17 +130,6 @@ export function MechItemCard({
   // "Use" (the EP/heat-spending activation) is offered only when a handler is
   // wired — the Dashboard passes one; the Free-Edit Live Sheet does not (ADR-021).
   const showUse = onUse !== undefined && (epCost > 0 || heat > 0 || maxUses > 0)
-
-  // Slots deliberately absent: ReferenceEntityCard ALREADY renders
-  // `slotsRequired` as a "Slots" stat in its own header cluster, so this footer
-  // pair was the same number printed twice on the same card. A sheet card is the
-  // SRD card plus interaction affordances — not the SRD card plus a second copy
-  // of its stats. (The sheet also states slot usage against capacity, once, in
-  // the System/Module gauges.)
-  const footMeta: CardFootMeta[] = [
-    ...(epCost > 0 ? [{ label: 'EP Cost', value: epCost }] : []),
-    ...(heat > 0 ? [{ label: 'Heat', value: `+${heat}` }] : []),
-  ]
 
   const deductDisabledReason =
     deductTl !== null
@@ -247,7 +243,6 @@ export function MechItemCard({
         hide={HIDE_CHOICES}
         status={condition}
         onStatusClick={readOnly ? undefined : onStatusCycle}
-        footMeta={footMeta}
         controls={controls.length ? controls : undefined}
       />
       {repairModal}

--- a/apps/itun/src/components/sheet/MechSheet.tsx
+++ b/apps/itun/src/components/sheet/MechSheet.tsx
@@ -250,16 +250,15 @@ export function MechSheet({
                     {model.chassisAbilities.map((ability, i) => {
                       // Activating an ability (spending its EP) is a Guided-Play
                       // transaction — it lives on the Dashboard, not the
-                      // Free-Edit Live Sheet (ADR-021). The sheet shows the
-                      // ability + its EP cost; EP is spent by hand-editing the
-                      // EP gauge (free state).
-                      const epCost =
-                        typeof ability.activationCost === 'number' ? ability.activationCost : 0
+                      // Free-Edit Live Sheet (ADR-021). EP is spent here by
+                      // hand-editing the EP gauge (free state).
+                      //
+                      // No `footMeta`: the ability's EP cost is the CARD's to
+                      // render and it already does, as its own "2 EP" box, so an
+                      // "EP Cost 2" pair in the footer was the same number twice
+                      // on one card.
                       return (
-                        <EntityGridRow
-                          key={ability.id}
-                          footMeta={epCost > 0 ? [{ label: 'EP Cost', value: epCost }] : undefined}
-                        >
+                        <EntityGridRow key={ability.id}>
                           <ReferenceEntityCard
                             data={ability}
                             size="large"

--- a/apps/itun/src/components/sheet/PilotSheetItems.tsx
+++ b/apps/itun/src/components/sheet/PilotSheetItems.tsx
@@ -65,8 +65,14 @@ export function PilotAbilityItem({
   const apCost = resolveAbilityApCost(ability)
   const canSpend = apCost !== null && currentAP >= apCost
 
-  const footMeta: CardFootMeta[] = [{ label: 'AP Cost', value: apCost ?? '—' }]
-
+  // No `footMeta` here. ReferenceEntityCard already renders the ability's
+  // activation cost from its own action — "1 AP" for a fixed cost, "X AP" for a
+  // variable one — so an "AP Cost" pair restated it. On the variable abilities
+  // it was worse than redundant: `apCost` is null there, so the footer printed
+  // "AP Cost —" beside a card plainly saying "X AP", replacing the one useful
+  // fact (the cost scales with what you spend) with an em-dash. The cost still
+  // reaches the player as an affordance — the Spend AP control names it.
+  //
   // All interactivity rides the controls bar (no footer actions). Read-only
   // shows a static Used stamp; editable shows Spend AP + the used toggle, with
   // the per-card remove (✕) last, in the card HEADER (G4).
@@ -102,7 +108,6 @@ export function PilotAbilityItem({
       size="medium"
       collapsible
       hide={HIDE_CHOICES}
-      footMeta={footMeta}
       controls={controls.length > 0 ? controls : undefined}
     />
   )

--- a/apps/itun/src/components/sheet/__tests__/PilotSheet-abilities.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/PilotSheet-abilities.test.tsx
@@ -66,15 +66,16 @@ function makeStubStore(pilot: Pilot, updateSpy?: ReturnType<typeof mock>): typeo
 }
 
 describe('PilotSheet — ability AP cost (Slice D)', () => {
-  test('displays the ability AP cost in the card foot', () => {
+  test('displays the ability AP cost on the card', () => {
     render(<PilotSheet pilot={makePilot()} store={makeStubStore(makePilot())} />)
     expandCards()
-    // footMeta renders the label and value as adjacent spans in the card foot.
-    // The intrinsic Generic tree puts its own "AP Cost" feet on the page, so
-    // this asserts over ALL of them rather than assuming a single match.
-    const labels = screen.getAllByText('AP Cost')
-    expect(labels.length).toBeGreaterThan(0)
-    expect(labels.some((l) => l.parentElement?.textContent?.includes('3'))).toBe(true)
+    // The cost comes from the CARD's own activation-cost box ("3 AP"), not from
+    // a sheet-added "AP Cost" footMeta pair — that footer restated what the card
+    // already rendered, and printed a bare em-dash for variable-cost abilities
+    // where the card says "X AP". Asserting on the card's rendering keeps this
+    // test pointed at what the player reads.
+    expect(screen.getAllByText('3 AP').length).toBeGreaterThan(0)
+    expect(screen.queryByText('AP Cost')).toBeNull()
   })
 })
 
@@ -177,8 +178,9 @@ describe('PilotSheet — abilities readOnly (Slice D)', () => {
     expect(screen.queryByRole('button', { name: /spend/i })).toBeNull()
     expect(screen.queryByRole('button', { name: /mark .* used/i })).toBeNull()
     expect(screen.queryByRole('button', { name: /recharge/i })).toBeNull()
-    // AP cost still shown read-only, plus a static Used stamp
-    expect(screen.getAllByText('AP Cost').length).toBeGreaterThan(0)
+    // AP cost still shown read-only (from the card's own cost box), plus a
+    // static Used stamp.
+    expect(screen.getAllByText('3 AP').length).toBeGreaterThan(0)
     expect(screen.getByText('Used')).toBeTruthy()
   })
 })


### PR DESCRIPTION
Follow-up to #761, same rule: a sheet's reference card is the SRD reference card **plus this sheet's interactions**, never plus a second copy of the card's own data.

## Verified by rendering, not by reading

Rather than assume, I rendered the real cards and dumped their text. An expanded **Welding Laser** system card already reads:

```
Welding Laser | TL2 | Slots 3 | SV3 | Hot (2) | …
Patch 2 EP … | System Repair 2 EP … | Chassis Repair 4 EP …
```

Every figure the sheet's footer added was already on the card — including the `Slots 3` that #761 removed, which this confirms after the fact.

## Removed

| Site | Footer said | Card already says |
| --- | --- | --- |
| `MechItemCard` | `EP Cost 2`, `Heat +2` | each action's own `2 EP` box; a `Hot (2)` trait badge |
| `PilotAbilityItem` | `AP Cost 1` / `AP Cost —` | `1 AP` / `X AP` |
| `MechSheet` chassis ability | `EP Cost 2` | `2 EP` |

Two of these were **worse than redundant**:

- **`EP Cost` flattened a multi-action item to its primary action's cost** — printing "EP Cost 2" beside a card openly listing 2 EP / 2 EP / 4 EP. It also labelled nothing actionable: no caller passes `onUse` (`MechItemCard`'s only consumers are `MechSheet` and `PartnerCard`, neither of which does), so the Use button never renders on a sheet.
- **`AP Cost` printed a bare em-dash on variable-cost abilities.** `resolveAbilityApCost` returns null for an `X` cost, so the footer showed "AP Cost —" next to a card plainly saying "X AP" — replacing the one useful fact (the cost scales with what you spend) with nothing. The cost still reaches the player through the Spend AP control, which names it in its label.

## Kept

`Uses` on pilot equipment, and the crawler bay `Lead` / `Repair` pairs — those are **live sheet state**, not reference data restated.

## Tests

`PilotSheet-abilities.test.tsx` asserted on the removed `AP Cost` footMeta in two places. Both assert a real behaviour worth keeping — "the ability's AP cost is visible" — so they now assert it against the card's own `3 AP` box, with a `queryByText('AP Cost')` null check pinning the removal.

## Verification

- `bun run check:fast` — exit 0 (lint, `validate:all`, knip, typecheck ×6 workspaces)
- `bun run test` — full canonical suite, **exit 0**, no failing workspace
- pre-push `--changed` gate passes (it is what caught the two test failures above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjUZejFfDogR9LMCdoxsUZ
