### PR TITLE
fix(reference): delete the corrupt .tool-versions that breaks mise

### DIFF
--- a/packages/salvageunion-reference/.tool-versions
+++ b/packages/salvageunion-reference/.tool-versions
@@ -1,1 +1,0 @@
-python 3.14.0t --home


### PR DESCRIPTION
`packages/salvageunion-reference/.tool-versions` contains a single line:

    python 3.14.0t --home

That is a shell fragment, not a version. It pins python — a runtime this Bun
monorepo does not use anywhere — and mise refuses to parse it, so EVERY
command run with that package as the working directory fails before it starts:

    mise ERROR error parsing config file: .../.tool-versions
    mise ERROR invalid tool version "--home": must not start with '-'

That includes `bun --filter salvageunion-reference validate:all`, which is why
the package's own validators have to be invoked from the repo root to work.

The repo's real runtime pin is the root `.tool-versions` plus `.bun-version`,
which `tools/check-bun-version.ts` already reconciles across CI, three
netlify.toml files, render.yaml and bun-types. Nothing reads this file.

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_013Kko69Tg9VVf5LETsQ1TAR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>