### PR TITLE
fix: give the SRD route grammar one owner

### DIFF
--- a/apps/itun/src/lib/srd-deep-link.ts
+++ b/apps/itun/src/lib/srd-deep-link.ts
@@ -9,7 +9,7 @@
  * See: apps/srd/src/pages/schema/[schemaId]/item/[itemId].astro
  */
 
-import { getEntitySchemas, SRD_SITE_URL, srdEntityUrl } from 'salvageunion-reference'
+import { getEntitySchemas, srdEntityUrl, srdSchemaUrl } from 'salvageunion-reference'
 
 type EntityRef = {
   schemaName: string
@@ -52,5 +52,5 @@ export function deepLinkTo({ schemaName, slug }: EntityRef): string {
  * ITUN has no in-app schema list routes.
  */
 export function deepLinkToSchema(schemaName: string): string {
-  return `${SRD_SITE_URL}/schema/${schemaName}`
+  return srdSchemaUrl(schemaName)
 }

--- a/apps/srd/src/lib/entityHref.ts
+++ b/apps/srd/src/lib/entityHref.ts
@@ -1,25 +1,36 @@
 import type { EntityHrefBuilder } from 'component-lib'
-import { getEntitySlug } from 'salvageunion-reference'
+import { getEntitySlug, srdEntityPath, srdSchemaPath } from 'salvageunion-reference'
 
 /**
- * THE srd route grammar. Every internal link to a schema listing, an entity show
- * page or a pattern page is built here and nowhere else.
+ * srd's TRAILING-SLASH policy over the shared route grammar.
  *
- * It used to be hand-built at eight call sites (islands, static-link resolution,
- * pattern hrefs, og-card tiles, Astro pages) — eight copies of one string, each
- * free to drift on the trailing slash or the segment order. `trailingSlash:
- * 'ignore'` (astro.config.mjs) means such drift 404s nothing, so it would have
- * gone unnoticed while quietly splitting canonical URLs in two.
+ * The grammar itself — which segments in which order — lives in
+ * `salvageunion-reference/lib/assets.ts` (`srdSchemaPath` / `srdEntityPath`),
+ * because the Discord bot and ITUN link into this site and must build the same
+ * paths. This module adds the one thing that is genuinely srd's own: the
+ * trailing slash its directory-style output wants.
+ *
+ * It used to re-author the grammar instead of composing it, and the two copies
+ * had already diverged — the package emitted `/schema/x/item/y`, this file
+ * `/schema/x/item/y/`. Nothing failed, because directory-style output redirects
+ * the un-slashed form, so the cost was a redirect hop on every inbound deep
+ * link plus two spellings of the canonical URL. The structural cost was worse:
+ * changing the route pattern here would have left the package emitting the old
+ * path, silently 404ing every external link.
+ *
+ * (The previous version of this note justified itself with `trailingSlash:
+ * 'ignore'` in `astro.config.mjs` — a file deleted when srd moved off Astro,
+ * ADR-031.)
  *
  * The path segment is always a SLUG, never a uuid — see `getEntitySlug`.
  */
 export function schemaHref(schemaName: string): string {
-  return `/schema/${schemaName}/`
+  return `${srdSchemaPath(schemaName)}/`
 }
 
 /** An entity's show page: `/schema/<schema>/item/<slug>/`. */
 export function itemHref(schemaName: string, slug: string): string {
-  return `${schemaHref(schemaName)}item/${slug}/`
+  return `${srdEntityPath(schemaName, slug)}/`
 }
 
 /**

--- a/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
+++ b/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
@@ -391,6 +391,34 @@ export declare const SRD_SITE_URL = "https://salvageunion.io";
  */
 export declare function srdEntityPath(schemaName: string, slug: string): string;
 /**
+ * The reference site's ROOT-RELATIVE path for one schema's LISTING page.
+ *
+ * The other half of the route grammar, and it exists for the same reason
+ * {@link srdEntityPath} does. Both are written WITHOUT a trailing slash; srd
+ * emits directory-style output and appends the slash itself in exactly one
+ * place (`apps/srd/src/lib/entityHref.ts`), so the slash is a rendering
+ * decision of that app rather than part of the grammar.
+ *
+ * Keep this the only place either shape is spelled. Two modules previously each
+ * claimed to be the single source of the route grammar and disagreed on the
+ * trailing slash — the package emitted `/schema/x/item/y` while srd emitted
+ * `/schema/x/item/y/`. Directory-style output meant the un-slashed form
+ * redirected rather than 404ing, so the divergence cost a hop on every bot and
+ * ITUN deep link and split the canonical URL in two, without ever failing.
+ *
+ * @param schemaName - The entity's schema id (e.g. `'chassis'`)
+ * @returns The root-relative listing path
+ */
+export declare function srdSchemaPath(schemaName: string): string;
+/**
+ * The reference site's ABSOLUTE URL for one schema's listing page —
+ * {@link SRD_SITE_URL} + {@link srdSchemaPath}.
+ *
+ * @param schemaName - The entity's schema id (e.g. `'chassis'`)
+ * @returns The absolute listing URL
+ */
+export declare function srdSchemaUrl(schemaName: string): string;
+/**
  * The reference site's ABSOLUTE URL for one entity's page —
  * {@link SRD_SITE_URL} + {@link srdEntityPath}.
  *

--- a/packages/salvageunion-reference/lib/assets.ts
+++ b/packages/salvageunion-reference/lib/assets.ts
@@ -74,7 +74,41 @@ export const SRD_SITE_URL = 'https://salvageunion.io'
  */
 
 export function srdEntityPath(schemaName: string, slug: string): string {
-  return `/schema/${schemaName}/item/${slug}`
+  return `${srdSchemaPath(schemaName)}/item/${slug}`
+}
+
+/**
+ * The reference site's ROOT-RELATIVE path for one schema's LISTING page.
+ *
+ * The other half of the route grammar, and it exists for the same reason
+ * {@link srdEntityPath} does. Both are written WITHOUT a trailing slash; srd
+ * emits directory-style output and appends the slash itself in exactly one
+ * place (`apps/srd/src/lib/entityHref.ts`), so the slash is a rendering
+ * decision of that app rather than part of the grammar.
+ *
+ * Keep this the only place either shape is spelled. Two modules previously each
+ * claimed to be the single source of the route grammar and disagreed on the
+ * trailing slash — the package emitted `/schema/x/item/y` while srd emitted
+ * `/schema/x/item/y/`. Directory-style output meant the un-slashed form
+ * redirected rather than 404ing, so the divergence cost a hop on every bot and
+ * ITUN deep link and split the canonical URL in two, without ever failing.
+ *
+ * @param schemaName - The entity's schema id (e.g. `'chassis'`)
+ * @returns The root-relative listing path
+ */
+export function srdSchemaPath(schemaName: string): string {
+  return `/schema/${schemaName}`
+}
+
+/**
+ * The reference site's ABSOLUTE URL for one schema's listing page —
+ * {@link SRD_SITE_URL} + {@link srdSchemaPath}.
+ *
+ * @param schemaName - The entity's schema id (e.g. `'chassis'`)
+ * @returns The absolute listing URL
+ */
+export function srdSchemaUrl(schemaName: string): string {
+  return `${SRD_SITE_URL}${srdSchemaPath(schemaName)}`
 }
 
 /**


### PR DESCRIPTION
Two modules each declared themselves the single source of the site's route
grammar, and they disagreed:

  packages/salvageunion-reference/lib/assets.ts:76  ->  /schema/x/item/y
    "This is the site's route grammar ... expressed once."
  apps/srd/src/lib/entityHref.ts:17                 ->  /schema/x/item/y/
    "THE srd route grammar. Every internal link ... built here and nowhere else."

srd never imported the package's version; the Discord bot and ITUN never
imported srd's. A third spelling sat in ITUN's `deepLinkToSchema`.

Bounded today, unbounded tomorrow. srd emits directory-style output, so the
un-slashed form resolves via redirect rather than 404 — the live cost is a
redirect hop on every bot/ITUN deep link plus two spellings of the canonical
URL. The structural cost is the real one: change srd's route pattern and
NOTHING fails, because the package keeps emitting the old path and every
external deep link silently 404s.

The split now follows what each layer actually owns:
  - the package owns the GRAMMAR (which segments, in which order), because
    three consumers build these paths — adds `srdSchemaPath` / `srdSchemaUrl`
    beside the existing entity pair, so the listing route is single-sourced too;
  - srd owns its TRAILING SLASH, applied in exactly one place, because that is
    a property of its directory-style output rather than of the grammar.

Output is unchanged — `bun --filter srd gate` is clean, so every emitted href
is byte-identical.

Also drops a stale justification: `entityHref.ts` cited `trailingSlash:
'ignore'` in `astro.config.mjs`, a file deleted when srd moved off Astro
(ADR-031).

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_013Kko69Tg9VVf5LETsQ1TAR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>