### PR TITLE
fix(itun): repair the nightly E2E locator and name the rail's View links

### DIFF
--- a/apps/itun/e2e/_helpers.ts
+++ b/apps/itun/e2e/_helpers.ts
@@ -408,26 +408,26 @@ export async function openSheetFor(page: Page, name: string): Promise<void> {
 
 /**
  * Wire a pilot onto the mech sheet currently open, via the rail's
- * 'Assign Pilot' dialog. Resolves when the pilot's RailChip renders.
+ * 'Assign Pilot' dialog. Resolves when the pilot's rail row renders.
  */
 export async function assignPilotOnMechSheet(page: Page, pilotName: string): Promise<void> {
   await page.getByRole('button', { name: /assign pilot to mech/i }).click()
   await page.getByRole('dialog').getByText(pilotName).click()
   await page.getByRole('button', { name: /confirm pilot assignment/i }).click()
-  await expect(
-    page.getByRole('link', { name: new RegExp(`Assigned Pilot: ${pilotName}`, 'i') })
-  ).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByRole('link', { name: new RegExp(`View ${pilotName}`, 'i') })).toBeVisible({
+    timeout: 10_000,
+  })
 }
 
 /**
  * Wire a crawler onto the pilot sheet currently open, via the rail's
- * 'Assign Crawler' dialog. Resolves when the crawler's RailChip renders.
+ * 'Assign Crawler' dialog. Resolves when the crawler's rail row renders.
  */
 export async function assignCrawlerOnPilotSheet(page: Page, crawlerName: string): Promise<void> {
   await page.getByRole('button', { name: /assign crawler to pilot/i }).click()
   await page.getByRole('dialog').getByText(crawlerName).click()
   await page.getByRole('button', { name: /confirm crawler assignment/i }).click()
   await expect(
-    page.getByRole('link', { name: new RegExp(`Home Crawler: ${crawlerName}`, 'i') })
+    page.getByRole('link', { name: new RegExp(`View ${crawlerName}`, 'i') })
   ).toBeVisible({ timeout: 10_000 })
 }

--- a/apps/itun/e2e/segment-switch.e2e.ts
+++ b/apps/itun/e2e/segment-switch.e2e.ts
@@ -44,7 +44,7 @@ test.describe('wired sheet segment switch', () => {
 
     await expect(page.getByRole('navigation', { name: /wired sheets/i })).toBeHidden()
     // The rail chip remains the desktop navigation affordance.
-    await expect(page.getByRole('link', { name: /Assigned Pilot: Mara Vex/i })).toBeVisible()
+    await expect(page.getByRole('link', { name: /View Mara Vex/i })).toBeVisible()
   })
 
   test('absent on unwired sheets at 390', async ({ page }) => {

--- a/apps/itun/e2e/wired-build-and-snapshot.e2e.ts
+++ b/apps/itun/e2e/wired-build-and-snapshot.e2e.ts
@@ -66,10 +66,10 @@ test('wire pilot + mech + crawler on the live sheets', async ({ page }) => {
   // Wiring flips the composition mode: the assigned-pilot rail chip now links
   // to the wired pilot's sheet (the mobile segment switch is asserted at 390
   // in the segment spec).
-  await expect(page.getByRole('link', { name: /Assigned Pilot: Mira Voss/i })).toBeVisible()
+  await expect(page.getByRole('link', { name: /View Mira Voss/i })).toBeVisible()
 
-  // --- RailChip navigates (TanStack Link, client-side) to the pilot sheet ---
-  await page.getByRole('link', { name: /Assigned Pilot: Mira Voss/i }).click()
+  // --- the rail row View link navigates (TanStack Link, client-side) to the pilot sheet ---
+  await page.getByRole('link', { name: /View Mira Voss/i }).click()
   await page.waitForURL(/\/sheet\/pilot\//, { timeout: 10_000 })
 
   // There is deliberately no top-bar "edit this pilot" link any more: the edit

--- a/apps/itun/src/components/games/__tests__/GameRoster.connected.test.tsx
+++ b/apps/itun/src/components/games/__tests__/GameRoster.connected.test.tsx
@@ -111,7 +111,7 @@ describe('what a row offers', () => {
     expect(screen.getByText('Mediator')).toBeTruthy()
     // Readable: a shared table whose crew you cannot look at is not shared.
     // The link goes to the frozen crew sheet, addressed by the SERVER id.
-    const view = screen.getByRole('link', { name: 'View' })
+    const view = screen.getByRole('link', { name: /^View / })
     expect(view.getAttribute('href')).toBe('/games/g1/view/pilot/s-theirs')
     // But not editable — that would hand over an editor the server refuses.
     expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull()

--- a/apps/itun/src/components/roster/__tests__/Roster.test.tsx
+++ b/apps/itun/src/components/roster/__tests__/Roster.test.tsx
@@ -287,7 +287,9 @@ describe('Roster — entity listing', () => {
 
     await renderRoster()
 
-    const sheetLinks = screen.getAllByRole('link', { name: 'View' })
+    // The link's accessible name now carries the entity (`View <name>`) so a rail
+    // of rows is distinguishable to a screen reader; the visible text is still 'View'.
+    const sheetLinks = screen.getAllByRole('link', { name: /^View / })
     expect(sheetLinks.length).toBe(1)
     expect((sheetLinks[0] as HTMLAnchorElement).href).toContain(`/sheet/pilot/${pilot.id}`)
   })

--- a/apps/itun/src/components/sheet/CrawlerSheet.tsx
+++ b/apps/itun/src/components/sheet/CrawlerSheet.tsx
@@ -114,7 +114,7 @@ type CrawlerSheetProps = {
    */
   economy?: ReactNode
   /**
-   * The Linked Units rail content (docked mech + lead pilot RailChip/
+   * The Linked Units rail content (docked mech + lead pilot rail row/
    * RailEmpty), built by SheetCrawler from `composition` — CrawlerSheet has
    * no composition access of its own, so this is passed straight through
    * into the content column's bottom section.

--- a/apps/itun/src/components/sheet/MechSheet.tsx
+++ b/apps/itun/src/components/sheet/MechSheet.tsx
@@ -103,7 +103,7 @@ type MechSheetProps = {
    */
   crawler?: Crawler | null
   /**
-   * The Linked Units rail content (pilot + crawler RailChip/RailEmpty), built
+   * The Linked Units rail content (pilot + crawler rail row/RailEmpty), built
    * by SheetMech from `composition` — MechSheet has no composition access of
    * its own, so this is passed straight through into the R4 section.
    */

--- a/apps/itun/src/components/sheet/PilotSheet.tsx
+++ b/apps/itun/src/components/sheet/PilotSheet.tsx
@@ -132,7 +132,7 @@ type PilotSheetProps = {
   /** When true, every edit affordance is suppressed (published snapshots). */
   readOnly?: boolean
   /**
-   * The Linked Units rail content (mech + crawler RailChip/RailEmpty), built
+   * The Linked Units rail content (mech + crawler rail row/RailEmpty), built
    * by SheetPilot from `composition` — PilotSheet has no composition access
    * of its own, so this is passed straight through into the R3 section.
    */

--- a/packages/component-lib/src/components/shared/EntityRow.tsx
+++ b/packages/component-lib/src/components/shared/EntityRow.tsx
@@ -464,6 +464,13 @@ export function EntityRow(props: EntityRowProps) {
               {sheetHref !== undefined && (
                 <Link
                   href={sheetHref}
+                  // The visible label is "View" on every row, so without this
+                  // every link in a rail has the same accessible name and a
+                  // screen-reader user hears "View, View, View" with no way to
+                  // tell which unit each one opens (WCAG 2.4.4, link purpose
+                  // from its name). The visible text stays "View" — the rail is
+                  // tight and the name already has its own band above.
+                  aria-label={`View ${name}`}
                   className={cn(
                     buttonVariants({ variant: 'default', size: 'mini' }),
                     'no-underline'


### PR DESCRIPTION
The nightly E2E suite has been red every night since 2026-07-25 — 23 failures
and 19 timeout-cancelled runs — with an identical file:line failure set each
time. It is test rot, not flake.

`assignPilotOnMechSheet` waited on

    getByRole('link', { name: /Assigned Pilot: <name>/i })

and its docstring said it resolved "when the pilot's RailChip renders".
`RailChip` has not existed in app source for months; the rail now renders
`EntityRow`, which never produced an accessible name of that shape. All six
failing specs cascaded from that one helper and the pickers it drives. The app
was fine — the locator described a contract that had been deleted.

The fix is in the app as well as the tests, because the underlying problem was
a real accessibility defect: `EntityRow`'s link is labelled "View" on every
row, so a rail of linked units gave a screen-reader user "View, View, View"
with no way to tell which unit each one opened (WCAG 2.4.4). It now carries
`aria-label={`View ${name}`}`; the visible text stays "View", since the rail is
tight and the name already has its own band above.

The specs then assert on a name that means something, rather than on a string
no element had.

Also removes the last four `RailChip` mentions (three sheet comments, one e2e
comment), so nothing points at a component that isn't there.

NOT changed, having checked: the failure notifier. The audit that prompted this
recorded it as firing once per outage and going quiet — it does not. Issue #616
carries 17 comments across its 16 open days, i.e. one per nightly failure, and
`notify-failure` calls `createComment` on the open tracking issue by design.
The signal was being sent every night; #616 was closed on 2026-08-13 without a
fix and #756 opened five hours later. There is nothing to fix in the notifier.

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_013Kko69Tg9VVf5LETsQ1TAR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>