### PR TITLE
feat(lint): guard the three ungated package-boundary edges

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -222,6 +222,26 @@
               {
                 "group": ["@/*"],
                 "message": "Use relative imports instead of @/ path aliases."
+              },
+              // A workspace package's PUBLIC SURFACE is its entry point, and
+              // nothing enforced that. knip's `includeEntryExports` gate only
+              // sees the barrel, so a deep import both bypasses the one gate
+              // that would notice an export rotting and couples the importer to
+              // the package's internal file layout. There are ZERO deep imports
+              // in the tree today — this keeps it that way rather than cleaning
+              // it up later.
+              //
+              // `salvageunion-reference/data/*` and `/schemas/*` are NOT listed:
+              // both are declared subpath exports in that package's manifest, as
+              // are `/rules`, `/zod` and `/schema-definitions`. Only `lib/**` is
+              // internal.
+              {
+                "group": ["salvageunion-reference/lib/**"],
+                "message": "Import from 'salvageunion-reference' or a declared subpath export ('/rules', '/zod', '/schema-definitions', '/data/*', '/schemas/*') — never a path inside the package."
+              },
+              {
+                "group": ["component-lib/src/**"],
+                "message": "Import from 'component-lib'. Its barrel (src/index.ts) is the public API and the only surface knip's includeEntryExports gate covers."
               }
             ]
           }
@@ -364,6 +384,81 @@
                 "allow": ["warn", "error"]
               }
             }
+          },
+          "style": {
+            // The two apps must never import each other. They share through
+            // `component-lib` and `salvageunion-reference`; a direct edge would
+            // make one app's build depend on the other's internals and give the
+            // shared layer a way to be bypassed.
+            //
+            // There is no such edge today (verified: zero srd↔itun imports in
+            // either direction). This is the guard, not a cleanup.
+            //
+            // The root rule's paths/patterns are RESTATED here because Biome
+            // overrides REPLACE a rule's options for matched files rather than
+            // merging — see the note at the root declaration.
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "zod": "Import `z` from 'salvageunion-reference/zod' instead of importing 'zod' directly (ADR-013: the shared module runs z.config({ jitless: true }) before any schema is constructed, which a direct zod import bypasses)."
+                },
+                "patterns": [
+                  {
+                    "group": ["@/*"],
+                    "message": "Use relative imports instead of @/ path aliases."
+                  },
+                  {
+                    "group": ["salvageunion-reference/lib/**"],
+                    "message": "Import from 'salvageunion-reference' or a declared subpath export — never a path inside the package."
+                  },
+                  {
+                    "group": ["component-lib/src/**"],
+                    "message": "Import from 'component-lib'. Its barrel is the public API."
+                  },
+                  {
+                    "group": ["**/apps/itun/**", "**/itun/**", "itun/**"],
+                    "message": "apps/srd must never import from apps/itun. The two apps share only through component-lib and salvageunion-reference."
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "includes": ["apps/itun/**"],
+      "linter": {
+        "rules": {
+          "style": {
+            // The mirror of the rule on apps/srd — see that block for why.
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "zod": "Import `z` from 'salvageunion-reference/zod' instead of importing 'zod' directly (ADR-013: the shared module runs z.config({ jitless: true }) before any schema is constructed, which a direct zod import bypasses)."
+                },
+                "patterns": [
+                  {
+                    "group": ["@/*"],
+                    "message": "Use relative imports instead of @/ path aliases."
+                  },
+                  {
+                    "group": ["salvageunion-reference/lib/**"],
+                    "message": "Import from 'salvageunion-reference' or a declared subpath export — never a path inside the package."
+                  },
+                  {
+                    "group": ["component-lib/src/**"],
+                    "message": "Import from 'component-lib'. Its barrel is the public API."
+                  },
+                  {
+                    "group": ["**/apps/srd/**", "**/srd/**", "srd/**"],
+                    "message": "apps/itun must never import from apps/srd. The two apps share only through component-lib and salvageunion-reference."
+                  }
+                ]
+              }
+            }
           }
         }
       }
@@ -464,6 +559,19 @@
                   {
                     "group": ["@/*"],
                     "message": "Use relative imports instead of @/ path aliases."
+                  },
+                  // The fourth boundary edge. `salvageunion-reference` already
+                  // banned this for itself; component-lib sits at the same
+                  // level in the graph and had no equivalent guard, so the
+                  // shared library could have taken a dependency on one of its
+                  // own consumers. Zero such imports today.
+                  {
+                    "group": ["**/apps/**", "itun/**", "srd/**"],
+                    "message": "component-lib must never import from an app — the dependency flows one way (apps depend on the library). Inject app-specific behaviour through slot props instead (docs/architecture/package-contracts.md)."
+                  },
+                  {
+                    "group": ["salvageunion-reference/lib/**"],
+                    "message": "Import from 'salvageunion-reference' or a declared subpath export — never a path inside the package."
                   }
                 ]
               }


### PR DESCRIPTION
`tools/check-architecture.ts` enforces exactly one rule despite its name — "no
module-scope SalvageUnionReference accessor calls". It has no import rules at
all. The only import guard in the repo was one pattern banning
`salvageunion-reference` from importing `**/apps/**`.

So three of the four boundary edges were unenforced:

  1. component-lib importing an app
  2. apps/srd ↔ apps/itun
  3. deep imports bypassing a package's public entry

All three are CLEAN today — verified across every workspace, zero violations in
either direction. This is the guard, not a cleanup, and it is the cheapest
permanent guarantee available: Biome already runs in `check:fast`, `check:all`
and pre-push, so it costs no new CI plumbing.

Deep imports matter beyond tidiness: knip's `includeEntryExports` gate only
sees a package's barrel, so a deep import bypasses the one check that would
notice an export rotting, and couples the importer to internal file layout.
`salvageunion-reference/data/*` and `/schemas/*` are deliberately NOT banned —
both are declared subpath exports, as are `/rules`, `/zod` and
`/schema-definitions`. Only `lib/**` is internal.

Each rule was PROVED to fire, not assumed: a probe file importing all three
forbidden shapes produced three `noRestrictedImports` errors, and the first
draft of the cross-app pattern silently did NOT — `**/apps/itun/**` never
matches the relative form (`../../itun/src/…`) a real cross-app import would
actually take, which is the only form that can resolve here. Widened to match a
bare `itun`/`srd` path segment and re-probed.

Note the root rule's paths/patterns are restated in each override: Biome
REPLACES a rule's options for matched files rather than merging, which the root
declaration's own comment warns about.

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_013Kko69Tg9VVf5LETsQ1TAR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>