### PR TITLE
docs: delete five knip tags whose reason no longer exists

### DIFF
--- a/apps/srd/ssg/types.ts
+++ b/apps/srd/ssg/types.ts
@@ -89,10 +89,10 @@ export type PageModule<Params = Record<string, string>, Props = unknown> = {
 /**
  * A non-HTML build output.
  *
- * @public — part of the SSG contract in `ssg/DESIGN.md`. Its consumer,
- * `ssg/endpoints.ts` (llms.txt, search-index.json, schema/[schemaId].json),
- * lands in a later phase of the migration; the type ships with the contract,
- * not with the first implementation of it.
+ * Part of the SSG contract in `ssg/DESIGN.md`. The tag that used to sit here
+ * said its consumer "lands in a later phase of the migration" — it landed:
+ * `src/endpoints/{itemJson,llmsTxt,schemaDefinitionJson,schemaJson,searchIndexJson}.ts`
+ * all implement this type today.
  */
 export type EndpointModule<Params = Record<string, string>, Props = unknown> = {
   /** Concrete output path relative to dist, may contain [params]. */

--- a/knip.json
+++ b/knip.json
@@ -4,6 +4,21 @@
   "ignoreDependencies": ["tailwindcss"],
   "ignoreExportsUsedInFile": true,
   "includeEntryExports": true,
+  // Exports tagged `@public` or `@knipignore` are excluded from analysis. The
+  // decision procedure for reaching for either is in `.claude/skills/knip-triage`
+  // — delete by default; these two are the only exemptions.
+  //
+  // `--treat-tag-hints-as-errors` does NOT catch a tag that has outlived its
+  // reason, despite reading like it would. Measured against knip 6.32 with this
+  // config: it exits 0 even with a deliberately redundant `@public` on an
+  // already-imported export. It was going to be added to the `knip` script
+  // until that probe ran — recorded here so the next reader does not add it
+  // believing it guards something.
+  //
+  // So a stale tag is found by a human, and its cost is misleading PROSE rather
+  // than a hidden finding: five `@public` tags were pruned in 2026-08, every one
+  // justified by a fork that had already been deleted, each telling a reader to
+  // go de-duplicate files that no longer existed.
   "tags": ["-public", "-knipignore"],
   "workspaces": {
     ".": {

--- a/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
+++ b/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
@@ -17830,9 +17830,10 @@ import type { SURefEntity, SURefEnumSchemaName } from './types/index.js';
  * `ability-tree-requirements`). Narrowing on the catalog rather than the enum is
  * what makes this usable as an untrusted-input guard.
  *
- * @public — the canonical implementation. `apps/discord-bot/src/schemaName.ts`
- * and `packages/component-lib/src/catalog/schemaName.ts` each carry a
- * byte-equivalent fork of it; they exist only because it was not exported.
+ * The canonical implementation, and now the ONLY one. Two byte-equivalent
+ * forks used to exist — `apps/discord-bot/src/schemaName.ts` and
+ * `packages/component-lib/src/catalog/schemaName.ts` — created only because
+ * this was not exported. Both files are gone; every consumer imports this.
  *
  * `getSchemaCatalog()` reads the static schema index and needs no `preload()`,
  * so this is safe from any build-time or test context.
@@ -17860,29 +17861,28 @@ export type SearchResult = {
 /**
  * Extract all text from content blocks recursively.
  *
- * @public — the canonical implementation of "flatten a ContentBlock tree to
- * searchable text". `apps/srd/src/lib/searchIndexBuild.ts` carries a verbatim
- * fork (its own comment says so); it exists only because this was not exported.
+ * The canonical implementation of "flatten a ContentBlock tree to searchable
+ * text". `apps/srd/src/lib/searchIndexBuild.ts` used to carry a verbatim fork;
+ * it now imports this one.
  */
 export declare function extractContentText(content: unknown): string;
 /**
  * True when `token` is within edit distance 1 of `word` (insert, delete, or
  * substitute one character). Two-pointer scan — no DP table, O(len) time.
  *
- * @public — the canonical typo-tolerance primitive. `apps/srd`'s
- * `searchCompactIndex.ts` carries a verbatim port (its own comment says
- * "ported verbatim from search.ts"); it exists only because this was not
- * exported. Ranking parity between the ORM-backed search and the compact
- * client index depends on the two behaving identically, which is exactly the
- * thing a fork cannot guarantee.
+ * The canonical typo-tolerance primitive. `apps/srd`'s
+ * `searchCompactIndex.ts` used to carry a verbatim port and now imports this.
+ * Ranking parity between the ORM-backed search and the compact client index
+ * depends on the two behaving identically, which is exactly the thing a fork
+ * cannot guarantee — so keep it that way.
  */
 export declare function withinEditDistance1(token: string, word: string): boolean;
 /**
  * Minimum token length before typo (edit-distance-1) matching applies.
  *
- * @public — paired with {@link withinEditDistance1}; `apps/srd`'s
- * `searchCompactIndex.ts` re-declares it, and a fork that drifts changes
- * ranking silently.
+ * Paired with {@link withinEditDistance1}. `apps/srd`'s
+ * `searchCompactIndex.ts` used to re-declare it and now imports it; a fork
+ * that drifts changes ranking silently.
  */
 export declare const TYPO_MIN_TOKEN_LENGTH = 4;
 /**

--- a/packages/salvageunion-reference/lib/search.ts
+++ b/packages/salvageunion-reference/lib/search.ts
@@ -18,9 +18,10 @@ let indexableSchemaNames: ReadonlySet<string> | null = null
  * `ability-tree-requirements`). Narrowing on the catalog rather than the enum is
  * what makes this usable as an untrusted-input guard.
  *
- * @public — the canonical implementation. `apps/discord-bot/src/schemaName.ts`
- * and `packages/component-lib/src/catalog/schemaName.ts` each carry a
- * byte-equivalent fork of it; they exist only because it was not exported.
+ * The canonical implementation, and now the ONLY one. Two byte-equivalent
+ * forks used to exist — `apps/discord-bot/src/schemaName.ts` and
+ * `packages/component-lib/src/catalog/schemaName.ts` — created only because
+ * this was not exported. Both files are gone; every consumer imports this.
  *
  * `getSchemaCatalog()` reads the static schema index and needs no `preload()`,
  * so this is safe from any build-time or test context.
@@ -209,9 +210,9 @@ export type SearchResult = {
 /**
  * Extract all text from content blocks recursively.
  *
- * @public — the canonical implementation of "flatten a ContentBlock tree to
- * searchable text". `apps/srd/src/lib/searchIndexBuild.ts` carries a verbatim
- * fork (its own comment says so); it exists only because this was not exported.
+ * The canonical implementation of "flatten a ContentBlock tree to searchable
+ * text". `apps/srd/src/lib/searchIndexBuild.ts` used to carry a verbatim fork;
+ * it now imports this one.
  */
 export function extractContentText(content: unknown): string {
   if (!content) return ''
@@ -248,12 +249,11 @@ export function extractContentText(content: unknown): string {
  * True when `token` is within edit distance 1 of `word` (insert, delete, or
  * substitute one character). Two-pointer scan — no DP table, O(len) time.
  *
- * @public — the canonical typo-tolerance primitive. `apps/srd`'s
- * `searchCompactIndex.ts` carries a verbatim port (its own comment says
- * "ported verbatim from search.ts"); it exists only because this was not
- * exported. Ranking parity between the ORM-backed search and the compact
- * client index depends on the two behaving identically, which is exactly the
- * thing a fork cannot guarantee.
+ * The canonical typo-tolerance primitive. `apps/srd`'s
+ * `searchCompactIndex.ts` used to carry a verbatim port and now imports this.
+ * Ranking parity between the ORM-backed search and the compact client index
+ * depends on the two behaving identically, which is exactly the thing a fork
+ * cannot guarantee — so keep it that way.
  */
 export function withinEditDistance1(token: string, word: string): boolean {
   const lenDiff = token.length - word.length
@@ -271,9 +271,9 @@ export function withinEditDistance1(token: string, word: string): boolean {
 /**
  * Minimum token length before typo (edit-distance-1) matching applies.
  *
- * @public — paired with {@link withinEditDistance1}; `apps/srd`'s
- * `searchCompactIndex.ts` re-declares it, and a fork that drifts changes
- * ranking silently.
+ * Paired with {@link withinEditDistance1}. `apps/srd`'s
+ * `searchCompactIndex.ts` used to re-declare it and now imports it; a fork
+ * that drifts changes ranking silently.
  */
 export const TYPO_MIN_TOKEN_LENGTH = 4
 


### PR DESCRIPTION
Five `@public` tags each cited a fork that had already been deleted, so the
prose told a reader to go de-duplicate files that are not there:

  lib/search.ts:21   named `apps/discord-bot/src/schemaName.ts` and
                     `packages/component-lib/src/catalog/schemaName.ts` as
                     carrying byte-equivalent forks. Both files are GONE.
  lib/search.ts:212  said `apps/srd/src/lib/searchIndexBuild.ts` "carries a
                     verbatim fork". It imports this one (searchIndexBuild.ts:23).
  lib/search.ts:251  said `searchCompactIndex.ts` "carries a verbatim port".
  lib/search.ts:274  said it "re-declares" TYPO_MIN_TOKEN_LENGTH.
                     Both are imported (searchCompactIndex.ts:28); that file's
                     own comment already says "were forked" in the past tense.
  ssg/types.ts:92    said EndpointModule's consumer "lands in a later phase of
                     the migration". It landed: five modules under
                     src/endpoints/ implement the type today.

The tags are inert — verified, not assumed: knip is green with all five
removed. What they cost was not a hidden finding but a wrong map, and stale
prose in a shared package is followed rather than checked. The comments are
rewritten to say what is true now, keeping the reason each symbol is worth
having in one place.

NOT added: `--treat-tag-hints-as-errors`. The audit that prompted this called
it "the single highest-leverage config change" and it does not work here —
measured against knip 6.32 with this config it exits 0 even with a deliberately
redundant `@public` on an already-imported export. A gate that cannot fail is
what the rest of this stack is removing, so it is documented in knip.json
instead of shipped.

Also not shipped: a suppression-count ratchet built for this commit. It could
not be made to fail on a manufactured suppression, so it went the same way, by
the same rule.

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_013Kko69Tg9VVf5LETsQ1TAR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>