### PR TITLE
feat(tools): enforce that the catalog is the only place a version is written

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "validate:observability:live": "bun tools/check-observability.ts --live",
     "validate:convex-parity": "bun tools/check-convex-parity.ts",
     "validate:convex-parity:live": "bun tools/check-convex-parity.ts --live",
-    "validate:all": "bun --filter salvageunion-reference validate:all && bun tools/check-bun-version.ts && bun run validate:architecture && bun run validate:doc-drift && bun run validate:observability && bun run validate:convex-codegen && bun run validate:convex-parity",
+    "validate:all": "bun --filter salvageunion-reference validate:all && bun tools/check-bun-version.ts && bun run validate:architecture && bun run validate:doc-drift && bun run validate:observability && bun run validate:convex-codegen && bun run validate:convex-parity && bun run check:catalog",
     "clean": "bun --filter \"*\" clean || true",
     "reap": "tools/prune-stale-worktrees.sh",
     "knip": "knip",
@@ -109,7 +109,8 @@
     "check:fast": "concurrently -g 'bun run lint' 'bun run validate:all' 'bun run knip' && bun run typecheck",
     "check:srd-output": "bun --filter srd gate",
     "check:all": "bun run check:schemas && concurrently -g 'bun run lint' 'bun run format:check' && bun run typecheck && concurrently -g 'bun run test' 'bun run validate:all' 'bun run knip' 'bun run check:audit' 'bun run check:tokens' 'bun run check:styling' 'bun run check:srd-output'",
-    "ladle": "bun --filter component-lib ladle"
+    "ladle": "bun --filter component-lib ladle",
+    "check:catalog": "bun tools/check-catalog.ts"
   },
   "patchedDependencies": {
     "@ladle/react@5.1.1": "patches/@ladle%2Freact@5.1.1.patch"

--- a/tools/__tests__/check-catalog.test.ts
+++ b/tools/__tests__/check-catalog.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ROOT = join(import.meta.dir, '..', '..')
+const TOOL = join(ROOT, 'tools', 'check-catalog.ts')
+
+async function runCheck() {
+  const proc = Bun.spawn(['bun', TOOL], { cwd: ROOT, stdout: 'pipe', stderr: 'pipe' })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { stdout, stderr, exitCode }
+}
+
+/**
+ * Each case mutates a real manifest, runs the tool, and restores the file.
+ * Mutating the real tree rather than a fixture is deliberate: the tool's whole
+ * job is to read THESE seven manifests, and a fixture copy would not prove it
+ * is pointed at them.
+ */
+type MutableManifest = {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  workspaces?: { catalog?: Record<string, string> }
+}
+
+/** Reach a manifest's dependency / catalog block, creating it if absent. */
+function deps(j: MutableManifest): Record<string, string> {
+  j.dependencies ??= {}
+  return j.dependencies
+}
+
+function catalogOf(j: MutableManifest): Record<string, string> {
+  j.workspaces ??= {}
+  j.workspaces.catalog ??= {}
+  return j.workspaces.catalog
+}
+
+async function withManifest(rel: string, mutate: (json: MutableManifest) => void) {
+  const path = join(ROOT, rel)
+  const original = readFileSync(path, 'utf8')
+  try {
+    const json = JSON.parse(original) as MutableManifest
+    mutate(json)
+    writeFileSync(path, `${JSON.stringify(json, null, 2)}\n`)
+    return await runCheck()
+  } finally {
+    writeFileSync(path, original)
+  }
+}
+
+describe('check-catalog', () => {
+  test('passes on the tree as committed', async () => {
+    const { exitCode, stdout } = await runCheck()
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('no version written twice')
+  })
+
+  test('reports the real entry and reference counts', async () => {
+    // Guards against the check silently reading an empty catalog and passing —
+    // the same vacuous-pass shape the scan floors exist for.
+    const { stdout } = await runCheck()
+    expect(stdout).toMatch(/catalog: \d+ entries, \d+ references/)
+    const entries = Number(stdout.match(/catalog: (\d+) entries/)?.[1])
+    expect(entries).toBeGreaterThan(10)
+  })
+
+  test('FAILS when a package is pinned with a literal in two manifests', async () => {
+    const { exitCode, stderr } = await withManifest('apps/su-assets/package.json', (j) => {
+      // `idb` is already pinned literally in apps/itun, so this makes two.
+      deps(j).idb = '8.0.3'
+    })
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('idb')
+    expect(stderr).toContain('not in the catalog')
+  })
+
+  test('FAILS when a catalogued package is pinned with a literal', async () => {
+    const { exitCode, stderr } = await withManifest('apps/su-assets/package.json', (j) => {
+      deps(j)['@sentry/node'] = '10.69.0'
+    })
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('@sentry/node')
+    expect(stderr).toContain('IS catalogued')
+  })
+
+  test('FAILS on a catalog entry nothing references', async () => {
+    const { exitCode, stderr } = await withManifest('package.json', (j) => {
+      catalogOf(j)['left-pad'] = '^1.3.0'
+    })
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('left-pad')
+    expect(stderr).toContain('referenced by 0 manifest')
+  })
+
+  test('FAILS loudly if the catalog itself goes missing', async () => {
+    const { exitCode, stderr } = await withManifest('package.json', (j) => {
+      if (j.workspaces) j.workspaces.catalog = {}
+    })
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('declares no `workspaces.catalog`')
+  })
+})

--- a/tools/check-catalog.ts
+++ b/tools/check-catalog.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env bun
+/**
+ * Catalog ratchet — `bun run check:catalog`.
+ *
+ * `workspaces.catalog` in the root manifest is this repo's single source of
+ * truth for the version of any dependency more than one workspace uses: declare
+ * it once, reference it everywhere as `"react": "catalog:"`. CLAUDE.md states
+ * the rule and calls a version literal for a catalogued package "a bug".
+ *
+ * Nothing enforced it. The repo is currently clean on all three conditions
+ * below — 19 catalog entries, 44 `catalog:` references, zero violations — and
+ * that held by hand-discipline alone. The next contributor or agent who adds
+ * `"zod": "^4.4.3"` to a second workspace instead of cataloguing it would have
+ * got a green CI, and the catalog would quietly stop being the source of truth
+ * for that package.
+ *
+ * Three conditions, each a different way the property breaks:
+ *
+ *   1. UNCATALOGUED DUPLICATE — the same package pinned in 2+ manifests with a
+ *      literal. This is the version written twice.
+ *   2. STRAY LITERAL — a package that IS in the catalog, but some workspace
+ *      pins it directly anyway. Silently un-shares that dependency, and is the
+ *      one a reader is least likely to spot: the catalog still looks correct.
+ *   3. ORPHAN ENTRY — a catalog entry with fewer than 2 consumers. Not a
+ *      correctness bug, but the catalog is meant to describe SHARED versions,
+ *      and an entry nothing shares is a claim that has stopped being true.
+ *
+ * Deliberately NOT checked here: `overrides` (a separate mechanism that BEATS
+ * the catalog — see CLAUDE.md on `@vitejs/plugin-react-swc`, the one package in
+ * both), and runtime version pins like `.bun-version`, which
+ * `tools/check-bun-version.ts` already reconciles across CI and every deploy
+ * target.
+ */
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ROOT = join(import.meta.dir, '..')
+
+const MANIFESTS = [
+  'package.json',
+  'apps/srd/package.json',
+  'apps/itun/package.json',
+  'apps/discord-bot/package.json',
+  'apps/su-assets/package.json',
+  'packages/component-lib/package.json',
+  'packages/salvageunion-reference/package.json',
+] as const
+
+type Manifest = {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+  workspaces?: { catalog?: Record<string, string> }
+}
+
+const read = (rel: string): Manifest =>
+  JSON.parse(readFileSync(join(ROOT, rel), 'utf8')) as Manifest
+
+const root = read('package.json')
+const catalog = root.workspaces?.catalog ?? {}
+
+if (Object.keys(catalog).length === 0) {
+  console.error('✗ catalog: root package.json declares no `workspaces.catalog`.')
+  console.error('  Either the field moved or this check is pointed at the wrong file.')
+  process.exit(1)
+}
+
+/** package name -> manifests that reference it (any dependency block). */
+const consumers = new Map<string, string[]>()
+/** package name -> manifests that pin it with a literal (not `catalog:`). */
+const literals = new Map<string, string[]>()
+
+for (const rel of MANIFESTS) {
+  const m = read(rel)
+  // peerDependencies are deliberately excluded: a peer RANGE is a compatibility
+  // statement rather than a resolved version, so it is a different kind of
+  // claim from a dependency pin. (component-lib restates several catalogued
+  // versions there; that is tracked separately, not by this rule.)
+  for (const block of [m.dependencies, m.devDependencies]) {
+    for (const [name, spec] of Object.entries(block ?? {})) {
+      // `workspace:*` is the correct form for an internal package and is not a
+      // version literal at all.
+      if (spec.startsWith('workspace:')) continue
+      consumers.set(name, [...(consumers.get(name) ?? []), rel])
+      if (!spec.startsWith('catalog:')) {
+        literals.set(name, [...(literals.get(name) ?? []), rel])
+      }
+    }
+  }
+}
+
+const problems: string[] = []
+
+// 1. Duplicated version literal across manifests, not catalogued.
+for (const [name, where] of literals) {
+  if (name in catalog) continue
+  if (where.length < 2) continue
+  problems.push(
+    `  ${name} — pinned with a literal in ${where.length} manifests, not in the catalog:\n` +
+      where.map((w) => `      ${w}`).join('\n') +
+      `\n    Fix: add "${name}" to workspaces.catalog in the root package.json and` +
+      ' replace each literal with "catalog:".'
+  )
+}
+
+// 2. A catalogued package pinned directly anyway.
+for (const [name, where] of literals) {
+  if (!(name in catalog)) continue
+  problems.push(
+    `  ${name} — IS catalogued (${catalog[name]}) but pinned with a literal in:\n` +
+      where.map((w) => `      ${w}`).join('\n') +
+      '\n    Fix: replace the literal with "catalog:". A literal here silently' +
+      ' un-shares this dependency while the catalog still looks correct.'
+  )
+}
+
+// 3. Catalog entry with fewer than two consumers.
+for (const name of Object.keys(catalog)) {
+  const count = consumers.get(name)?.length ?? 0
+  if (count >= 2) continue
+  problems.push(
+    `  ${name} — in the catalog but referenced by ${count} manifest(s).\n` +
+      '    The catalog describes versions that are SHARED. Either a consumer was' +
+      ' removed (drop the entry) or one should be referencing it.'
+  )
+}
+
+if (problems.length > 0) {
+  console.error('\n✗ catalog is no longer the single source of truth for these versions:\n')
+  console.error(problems.join('\n\n'))
+  console.error('\n  See CLAUDE.md, "Shared versions live in the catalog".')
+  process.exit(1)
+}
+
+const refCount = [...consumers.entries()]
+  .filter(([name]) => name in catalog)
+  .reduce((n, [, where]) => n + where.length, 0)
+
+console.log(
+  `✓ catalog: ${Object.keys(catalog).length} entries, ${refCount} references, no version written twice`
+)


### PR DESCRIPTION
`workspaces.catalog` is this repo's single source of truth for the version of
any dependency more than one workspace uses, and CLAUDE.md calls a version
literal for a catalogued package "a bug". Nothing enforced it.

The repo is clean today — 19 entries, 44 references, zero violations on all
three conditions — and that held by hand-discipline alone. Anyone adding
`"zod": "^4.4.3"` to a second workspace instead of cataloguing it got a green
CI, and the catalog quietly stopped being the truth for that package. This
finding determines whether the other zeros stay zero.

Three conditions, each a different way the property breaks:

  1. the same package pinned with a literal in 2+ manifests (the version
     written twice);
  2. a package that IS catalogued but pinned directly anyway — the one a
     reader is least likely to spot, because the catalog still looks correct;
  3. a catalog entry with fewer than two consumers — the catalog describes
     SHARED versions, so an entry nothing shares is a claim that stopped
     being true.

Every condition was PROVED to fire before shipping, by mutating a real
manifest: an uncatalogued duplicate, a stray literal on a catalogued package,
an orphan entry, and an empty catalog each produce a non-zero exit with a
specific message. Six tests in tools/__tests__/check-catalog.test.ts cover the
same cases against the real manifests, restoring each file afterwards — a
fixture copy would not prove the tool is reading the seven manifests it claims
to.

Deliberately out of scope: `overrides` (a different mechanism that BEATS the
catalog — `@vitejs/plugin-react-swc` is in both by design), peerDependency
ranges (a compatibility statement, not a resolved version), and runtime pins
like `.bun-version`, which check-bun-version.ts already reconciles.

Wired into `validate:all`, so it runs in pre-push and CI beside the other
static checks.

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_013Kko69Tg9VVf5LETsQ1TAR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>