### PR TITLE
test: assert hard-coded dataset names actually resolve

### DIFF
--- a/packages/component-lib/src/components/__tests__/datasetNameResolution.test.ts
+++ b/packages/component-lib/src/components/__tests__/datasetNameResolution.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test'
+import { SalvageUnionReference } from 'salvageunion-reference'
+import { TABLE_CATEGORY_LABEL, TABLE_CATEGORY_ORDER } from '../dashboard/tableCategories'
+import { MECH_ROLL_TABLE_NAMES } from '../wizard/mechRollTables'
+import { PILOT_ROLL_TABLE_NAMES } from '../wizard/rollTableHelpers'
+
+/**
+ * Registries in this package bind code to a dataset entity's `name` — the most
+ * editable field in the data, and the one the repo's own convention says links
+ * should never use ("entity links must use slugs, never UUIDs" exists for the
+ * same reason).
+ *
+ * Nothing checked that any of them resolved. A rename in `data/roll-tables.json`
+ * passes every existing validator — ids stay unique, references still resolve,
+ * schemas still match — and then silently empties a wizard's Roll button. No
+ * error is thrown anywhere: the lookup returns `undefined` and the surface
+ * renders without the control.
+ *
+ * These tests assert the one property that matters: every name a registry
+ * hard-codes still resolves to a real entity. They are deliberately NOT
+ * assertions about the literal strings — comparing a map to its own literal
+ * (which is what the Mediator table test used to do on its own) passes for any
+ * pair of strings and never touches the dataset.
+ */
+describe('hard-coded dataset names resolve', () => {
+  test('the dataset is actually loaded (guards a vacuous pass)', () => {
+    // Without this, every case below would "pass" against an empty ORM.
+    expect(SalvageUnionReference.RollTables.all().length).toBeGreaterThan(0)
+  })
+
+  test('pilot wizard roll tables', () => {
+    for (const [field, name] of Object.entries(PILOT_ROLL_TABLE_NAMES)) {
+      expect(
+        SalvageUnionReference.RollTables.getByName(name),
+        `PILOT_ROLL_TABLE_NAMES.${field} = "${name}" resolves no roll table — the ` +
+          "pilot wizard's Roll button for this field would render dead"
+      ).toBeDefined()
+    }
+  })
+
+  test('mech wizard roll tables', () => {
+    for (const [field, name] of Object.entries(MECH_ROLL_TABLE_NAMES)) {
+      expect(
+        SalvageUnionReference.RollTables.getByName(name),
+        `MECH_ROLL_TABLE_NAMES.${field} = "${name}" resolves no roll table — the ` +
+          "mech wizard's Roll button for this field would render dead"
+      ).toBeDefined()
+    }
+  })
+
+  test('every table category has a label', () => {
+    // Not a dataset lookup, but the same class of silent gap: a category in the
+    // order list with no label renders an unnamed section.
+    for (const category of TABLE_CATEGORY_ORDER) {
+      expect(TABLE_CATEGORY_LABEL[category], `no label for category "${category}"`).toBeTruthy()
+    }
+  })
+})

--- a/packages/salvageunion-reference/lib/rules/mediatorTables.test.ts
+++ b/packages/salvageunion-reference/lib/rules/mediatorTables.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, expect, test } from 'bun:test'
+import { SalvageUnionReference } from '../index.js'
 import type { FindRollTable } from './mediatorTables.js'
 import {
   describeMediatorRoll,
@@ -139,6 +140,22 @@ describe('table-name mapping', () => {
       morale: 'Morale',
       retreat: 'Retreat',
     })
+  })
+
+  /**
+   * The assertion above compares the map to its own literal, so it passes for
+   * any pair of strings and never touches the dataset. This one does.
+   *
+   * These names bind code to a roll table's `name` — the most editable field
+   * in the data. A rename passes every existing validator and then silently
+   * empties whatever surface rolls on it, with no error anywhere. Resolution
+   * is the only thing worth asserting.
+   */
+  test('every mapped name resolves to a real roll table', () => {
+    for (const [id, name] of Object.entries(MEDIATOR_TABLE_NAMES)) {
+      const table = SalvageUnionReference.RollTables.getByName(name)
+      expect(table, `MEDIATOR_TABLE_NAMES.${id} = "${name}" resolves no roll table`).toBeDefined()
+    }
   })
 })
 


### PR DESCRIPTION
Registries across component-lib and the reference package bind code to an
entity's `name` — the most editable field in the data, and the one the repo's
own convention says links must never use.

Nothing checked that any of them resolved. A rename in `data/roll-tables.json`
passes every existing validator (ids unique, references resolve, schemas
match) and then silently empties a wizard's Roll button: the lookup returns
`undefined` and the surface renders without the control. No error anywhere.

The one existing test in this area was a tautology — it compared
`MEDIATOR_TABLE_NAMES` to its own literal, which passes for any pair of strings
and never touches the dataset. It is kept (it does guard the id→name shape) and
joined by one that resolves each name against the ORM.

Covers: PILOT_ROLL_TABLE_NAMES (5 names), MECH_ROLL_TABLE_NAMES (3),
MEDIATOR_TABLE_NAMES (3), and the table-category order/label pair.

Each was PROVED to fire: renaming `Morale` and `Quirks` in their registries
produces a named failure pointing at the field and saying what the player would
see. Both restored.

The component-lib file also asserts the ORM is non-empty first — without it
every case would pass vacuously against an unloaded dataset, which is the same
shape as the scan-floor problem elsewhere in this stack.

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_013Kko69Tg9VVf5LETsQ1TAR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>