### PR TITLE
fix(tools): close three blind spots in the design-token scanner

### DIFF
--- a/packages/component-lib/src/styles/theme.css
+++ b/packages/component-lib/src/styles/theme.css
@@ -31,8 +31,9 @@
   --radius-card: 3px;
   --radius-panel: 6px;
 
-  /* Semantic type scale (ruleset §4.2 — the ONE font-size ladder; never
-     text-[Npx] for these steps). Shared by every surface (was ITUN-local):
+  /* Semantic type scale (ruleset §4.2 — the ONE font-size ladder; never an
+     arbitrary bracket size for these steps). Shared by every surface (was
+     ITUN-local):
        nano     8px    smallest markers — TL glyphs, unit suffixes
        micro    9px    dense caps meta labels (NPC insets, encounter cards)
        label    10px   standard uppercase font-cond field/section label

--- a/tools/check-design-tokens.ts
+++ b/tools/check-design-tokens.ts
@@ -27,15 +27,27 @@ const ROOT = join(import.meta.dir, '..')
 const SCAN_DIRS = [
   'packages/component-lib/src',
   'packages/salvageunion-reference/lib',
+  // The DATASET, not just the code that reads it. `data/guides.json` carried
+  // five raw hexes in a `guideColor` field — one byte-identical to
+  // `--color-mech`, two near-misses of `--color-pilot`/`--color-crawler` — and
+  // `entityCardTone.ts` gave them precedence over the domain tone, so they
+  // shipped on 15 entity cards. Two blind spots hid it: this list stopped at
+  // `lib`, and SCAN_EXTENSIONS excluded `.json`. The field now names a theme
+  // tone and this directory is clean; scanning it is what keeps it that way.
+  'packages/salvageunion-reference/data',
   'apps/srd/src',
   'apps/itun/src',
+  // An entire APP the guard could not see. It restates the palette as hex ints
+  // (see the `0x` arm of raw-color) — 12 of them, tracked in the baseline and
+  // burning down.
+  'apps/discord-bot/src',
 ]
 
 // `.astro` was here until apps/srd moved off Astro. Nothing in the repo emits
 // that extension any more, and the pages it used to cover are now .tsx — which
 // is how greembeem's deliberate Wikipedia palette became visible to this check
 // for the first time (see EXEMPTIONS).
-const SCAN_EXTENSIONS = ['.ts', '.tsx', '.css']
+const SCAN_EXTENSIONS = ['.ts', '.tsx', '.css', '.json']
 
 type Rule = {
   /** Stable id, used by the exemption list. */
@@ -96,7 +108,7 @@ const RULES: Rule[] = [
     //    identifier ending in it (`srgb(`) is not a false positive, while `_`,
     //    `(`, space and line-start all correctly count as a boundary.
     pattern:
-      /(?<!&)#(?!\d{1,3}\b)(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})\b|(?<![a-zA-Z0-9])rgba?\([^)]*\)/g,
+      /(?<!&)#(?!\d{1,3}\b)(?:[0-9a-fA-F]{8}|[0-9a-fA-F]{6}|[0-9a-fA-F]{4}|[0-9a-fA-F]{3})\b|(?<![a-zA-Z0-9])rgba?\([^)]*\)|(?<![a-zA-Z0-9_])0x[0-9a-fA-F]{6}\b/g,
   },
   {
     id: 'gradient',
@@ -149,7 +161,7 @@ const RULES: Rule[] = [
     id: 'arbitrary-font-size',
     rule: 'ruleset §4.2 — one type scale',
     fix: 'Use the semantic ladder: text-nano / micro / label / label-lg / badge / note / caption / lede, then the display end — readout (17) / title (22) / display (26) / display-lg (31) / hero (38).',
-    pattern: /text-\[\d*\.?\d+(?:px|rem)\]/g,
+    pattern: /text-\[(?!var\(|color:|--)[^\]]+\]/g,
   },
   {
     id: 'pure-white',
@@ -314,7 +326,8 @@ type Violation = { file: string; line: number; text: string; match: string; rule
 const violations: Violation[] = []
 
 /**
- * Catastrophe floor for SCAN_DIRS. 998 files today; see tools/lib/scanFloor.ts
+ * Catastrophe floor for SCAN_DIRS. 1,069 files today (was 998 before the
+ * dataset and discord-bot were added); see tools/lib/scanFloor.ts
  * for why this is deliberately far below the real count.
  */
 const SCAN_FLOOR = 650

--- a/tools/design-tokens-baseline.json
+++ b/tools/design-tokens-baseline.json
@@ -1,9 +1,10 @@
 {
   "shadow-tokens": 0,
-  "raw-color": 0,
+  "raw-color": 22,
   "gradient": 0,
   "arbitrary-tracking": 0,
   "arbitrary-border-width": 0,
-  "arbitrary-font-size": 0,
+  "arbitrary-radius": 0,
+  "arbitrary-font-size": 2,
   "pure-white": 0
 }


### PR DESCRIPTION
The gate reported zero violations while three whole classes of off-token colour
and size were invisible to it. Each was a scope gap, not a rule gap.

1. THE DATASET was never scanned. `SCAN_DIRS` stopped at
   `salvageunion-reference/lib` and `SCAN_EXTENSIONS` excluded `.json`, so
   `data/guides.json`'s five raw hexes — one byte-identical to `--color-mech`,
   two near-misses of `--color-pilot`/`--color-crawler` — were unreachable,
   while `entityCardTone.ts` gave them precedence over the domain tone and
   shipped them on 15 entity cards. That data is now clean (guides name a
   theme tone), so this arm lands at ZERO and keeps it there.

2. `apps/discord-bot` was scanned by nothing at all, and TWO gaps stacked: the
   directory was absent from SCAN_DIRS, and `raw-color` matched `#rrggbb` but
   never `0xrrggbb` — the form a Discord embed colour actually takes. Adding
   the directory alone would still have found nothing.

3. `arbitrary-font-size` matched only `text-[<number>px|rem]`, so a size
   wrapped in a function walked straight through. Two `text-[clamp(...)]` sizes
   ship today; any future `calc()`/`min()` size would have too.

Baselines move 0 → 22 (raw-color) and 0 → 2 (arbitrary-font-size). These are
not new violations — they are violations that were always there and could not
be seen, now enforced from their current count downward like every other rule
in this file. NEW ones fail immediately: verified with a probe `0xabcdef` in
the bot, which the gate rejects by file and line.

The burn-down for the 22 is the bot's palette: `format.ts` and `gameEmbed.ts`
restate `--color-roll-*` and the pilot/mech/crawler hues as ints, and
`NEUTRAL = 0xb7410e` is defined three times while matching no token at all
(the theme's rust is #a85222). Fixing it needs a shared source the bot can
reach — it depends on `salvageunion-reference`, not `component-lib`, so
`theme.css` is out of reach today. Tracked, not silently frozen.

One self-citation in theme.css was reworded rather than exempted: its comment
named the banned bracket form in order to ban it, and the widened pattern
correctly matched the prose.

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_013Kko69Tg9VVf5LETsQ1TAR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>