### PR TITLE
fix(su-assets): send the same security headers as the other two sites

### DIFF
--- a/apps/su-assets/netlify.toml
+++ b/apps/su-assets/netlify.toml
@@ -20,8 +20,29 @@
 
 # Long-lived immutable caching for served artwork (the asset function also sets
 # these per-response; this covers anything served statically from public/).
+#
+# The security headers below are the SAME SET apps/srd and apps/itun send, and
+# they were missing here. That gap was invisible for the obvious reason: the two
+# netlify.toml files anyone opens are the two that have them, and
+# tools/check-observability.ts parses only `connect-src`, so nothing compared
+# the rest across the three sites.
+#
+# Being a pure CDN behind `Access-Control-Allow-Origin: *` is not a reason to
+# skip them. HSTS still matters on a host that serves over TLS, and
+# X-Frame-Options still matters because an image origin is a fine thing to frame
+# for a clickjacking overlay. None of them costs anything here.
+#
+# No Content-Security-Policy: this origin serves image bytes and a JSON error
+# body, never HTML or script, so a CSP would govern nothing. That is also why
+# the Sentry `connect-src` clause the other two sites carry has no counterpart
+# here.
 [[headers]]
   for = "/*"
   [headers.values]
+    X-Frame-Options = "DENY"
     X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "geolocation=(), microphone=(), camera=()"
+    Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
+    X-DNS-Prefetch-Control = "on"
     Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
`apps/srd` and `apps/itun` both set X-Frame-Options, X-Content-Type-Options,
Referrer-Policy, Permissions-Policy, Strict-Transport-Security and
X-DNS-Prefetch-Control, byte-identically. `apps/su-assets` set two of them, so
assets.salvageunion.io served no HSTS and was framable.

The gap was invisible for a structural reason rather than an oversight in
review: the two netlify.toml files anyone opens are the two that HAVE the
headers, and `tools/check-observability.ts` parses only `connect-src` — nothing
compared the remaining values across the three sites.

Being a pure CDN behind `Access-Control-Allow-Origin: *` is not a reason to
skip them. HSTS matters on any host served over TLS, and an image origin is a
perfectly good thing to frame under a clickjacking overlay. None of them costs
anything here.

Deliberately still absent: a Content-Security-Policy. This origin serves image
bytes and a JSON error body, never HTML or script, so a CSP would govern
nothing — and that is also why the Sentry `connect-src` clause the other two
sites carry has no counterpart here. Recorded in the file so the next reader
does not "fix" it.

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_013Kko69Tg9VVf5LETsQ1TAR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>