### PR TITLE
fix(itun): round field-repair cost down, per the book

### DIFF
--- a/apps/itun/src/components/sheet/__tests__/mechItemRules.test.ts
+++ b/apps/itun/src/components/sheet/__tests__/mechItemRules.test.ts
@@ -2,13 +2,14 @@
  * mechItemRules — pure helper tests (plan 4.5, S12).
  *
  * itemEconomy mines EP cost / Hot heat / Uses from real reference data;
- * repairScrapCost is half SV rounded up (min 1); repairPoolTl finds the
+ * repairScrapCost is half SV rounded DOWN (min 1, Core Book p.233); repairPoolTl finds the
  * lowest qualifying TL bucket (Scrap TL ≥ item TL, higher allowed);
  * mechConditionsPatch maps unified-list edits back onto conditions[] + the
  * boolean flags (removing a flag label clears the flag — the manual clear).
  */
 
 import { describe, expect, test } from 'bun:test'
+import { halfSalvageScrap } from '../../../lib/rules/salvage'
 import { must } from '../../__tests__/must'
 import {
   cycleCondition,
@@ -72,9 +73,21 @@ describe('resolveSystem / resolveModule ref forms', () => {
 })
 
 describe('repairScrapCost', () => {
-  test('half SV rounded up', () => {
-    expect(repairScrapCost(5)).toBe(3)
+  // Core Book p.233: "always round down unless stated otherwise". Neither
+  // repair rule (p.221, p.248) states otherwise, so an odd Salvage Value
+  // rounds down — SV 5 costs 2, not 3.
+  test('half SV rounded down', () => {
+    expect(repairScrapCost(5)).toBe(2)
     expect(repairScrapCost(4)).toBe(2)
+    expect(repairScrapCost(7)).toBe(3)
+  })
+
+  test('agrees with halfSalvageScrap — one rule, not two', () => {
+    // The salvage side of the same phrase lives in src/lib/rules/salvage.ts and
+    // has always floored. These disagreed for every odd Salvage Value.
+    for (const sv of [1, 2, 3, 4, 5, 6, 7, 16]) {
+      expect(repairScrapCost(sv)).toBe(halfSalvageScrap(sv))
+    }
   })
 
   test('minimum 1, even for SV 0/undefined', () => {

--- a/apps/itun/src/components/sheet/mechItemRules.ts
+++ b/apps/itun/src/components/sheet/mechItemRules.ts
@@ -71,9 +71,24 @@ export function itemEconomy(entity: MechItem): MechItemEconomy {
   return { epCost, heat, maxUses }
 }
 
-/** Field-repair cost: half Salvage Value in Scrap, rounded up, min 1. */
+/**
+ * Field-repair cost: half Salvage Value in Scrap, rounded DOWN, minimum 1.
+ *
+ * The book states the cost with no rounding of its own — "an amount of Scrap
+ * equal to half its Salvage Value" (Core Book p.221, Union Crawler Mech Bay)
+ * and "half its Salvage Value to a minimum of 1" (p.248, the Repair ability).
+ * Neither says round up, so the general rule governs: "In any situation where
+ * you need to round a number, always round down unless stated otherwise"
+ * (p.233), immediately followed by "Specific beats general".
+ *
+ * This used to round UP, which made an SV-3 item cost 2 Scrap to repair while
+ * `halfSalvageScrap` (src/lib/rules/salvage.ts) — the same "half Salvage Value,
+ * min 1" phrase from the same book — yielded 1 when salvaged. The asymmetry
+ * read as deliberate (both directions disadvantage the player) and was not:
+ * neither site cited a page, and the book has one rule for both.
+ */
 export function repairScrapCost(salvageValue: number | undefined): number {
-  return Math.max(1, Math.ceil((salvageValue ?? 1) / 2))
+  return Math.max(1, Math.floor((salvageValue ?? 1) / 2))
 }
 
 /**


### PR DESCRIPTION
"Half Salvage Value" was implemented twice with opposite rounding:

    repairScrapCost   (sheet/mechItemRules.ts)  Math.ceil   — repair COST
    halfSalvageScrap  (lib/rules/salvage.ts)    Math.floor  — salvage YIELD

so an SV-3 item cost 2 Scrap to repair but yielded 1 when salvaged. Neither
site cited a page. The asymmetry read as deliberate — both directions
disadvantage the player — and it is not.

The book has one rule for both:

  p.233  "In any situation where you need to round a number, always round down
          unless stated otherwise", immediately followed by "Specific beats
          general".
  p.221  Union Crawler Mech Bay: "an amount of Scrap equal to half its Salvage
          Value of its Tech Level or higher" — no rounding stated.
  p.248  the Repair ability: "half its Salvage Value to a minimum of 1" — no
          rounding stated.

No specific rule states otherwise, so the general rule governs and the repair
cost rounds DOWN. `halfSalvageScrap` was already correct.

Player-visible: repairing an odd-Salvage-Value item gets cheaper (SV 5: 3 → 2
Scrap). The minimum of 1 is unchanged, and is in the book for both.

A new test asserts the two functions agree across a range of Salvage Values, so
the next edit to either cannot silently re-open the gap. Both call sites and
the test-file header now cite the pages rather than restating the maths in
prose.

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_013Kko69Tg9VVf5LETsQ1TAR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>