### PR TITLE
fix: define "an unset pool means full" once, and enforce it

### DIFF
--- a/apps/discord-bot/src/gameEmbed.ts
+++ b/apps/discord-bot/src/gameEmbed.ts
@@ -1,6 +1,13 @@
 import type { SURefEnumSchemaName } from 'salvageunion-reference'
 import { findEntityBySlug, getAssetUrl, getEntitySlug, srdEntityUrl } from 'salvageunion-reference'
-import { mechMaxHeat, mechMaxSP, pilotMaxAP, pilotMaxHP } from 'salvageunion-reference/rules'
+import {
+  mechMaxHeat,
+  mechMaxSP,
+  pilotMaxAP,
+  pilotMaxHP,
+  resolveGauge,
+  resolvePool,
+} from 'salvageunion-reference/rules'
 import { EMBED_LIMIT, ROLL_COLORS, truncate } from './format.js'
 import type {
   ChannelResult,
@@ -161,13 +168,13 @@ function pilotStats(body: EntityBody): {
   const maxAp = pilotMaxAP(input)
   return {
     // Canonical spellings come from apps/itun/src/lib/schemas/{pilot,mech}.ts.
-    // ABSENT MEANS FULL, not zero — the field is only written once something
-    // has changed it, and all 35 call sites in the app read it as `?? max`.
+    // The absent-means-FULL rule is `resolvePool` in the reference package —
+    // this used to spell it out here, as ~40 sites in the app also did.
     // Defaulting to 0 instead would render a fresh, undamaged crew as wiped
     // out, which is precisely backwards on the one surface built to show it.
-    hp: num(body, 'currentHP', 'currentHp') ?? maxHp,
+    hp: resolvePool(num(body, 'currentHP', 'currentHp') ?? undefined, maxHp),
     maxHp,
-    ap: num(body, 'currentAP', 'currentAp') ?? maxAp,
+    ap: resolvePool(num(body, 'currentAP', 'currentAp') ?? undefined, maxAp),
     maxAp,
   }
 }
@@ -191,12 +198,14 @@ function mechStats(body: EntityBody): {
   const maxSp = mechMaxSP(input)
   return {
     // Absent SP means full, as above.
-    sp: num(body, 'currentSP', 'currentSp') ?? maxSp,
+    sp: resolvePool(num(body, 'currentSP', 'currentSp') ?? undefined, maxSp),
     maxSp,
     // Heat is the exception and reads the other way: absent means COLD, which
     // is 0. A mech starts at no heat and gains it, where SP starts full and is
     // lost — so the same "field not written yet" state means opposite numbers.
-    heat: num(body, 'currentHeat') ?? 0,
+    // That inversion is `resolveGauge`, named beside `resolvePool` so the two
+    // cannot be confused for each other.
+    heat: resolveGauge(num(body, 'currentHeat') ?? undefined, mechMaxHeat(input)),
     maxHeat: mechMaxHeat(input),
   }
 }

--- a/apps/itun/src/components/dashboard/ActionsDeck.tsx
+++ b/apps/itun/src/components/dashboard/ActionsDeck.tsx
@@ -21,7 +21,12 @@
 import type { ActionsDeckView as ActionsDeckViewModel, DeckRow } from 'component-lib'
 import { ActionsDeck as ActionsDeckView } from 'component-lib'
 import { useState } from 'react'
-import { canActivateAction, resolveChassisRef } from 'salvageunion-reference/rules'
+import {
+  canActivateAction,
+  resolveChassisRef,
+  resolveGauge,
+  resolvePoolStart,
+} from 'salvageunion-reference/rules'
 import type { CoreRollResult } from '../../lib/rules/coreMechanic'
 import { CORE_ROLL_BANDS, describePushOutcome, performCoreRoll } from '../../lib/rules/coreMechanic'
 import { mechMaxEP, mechMaxHeat, mechMaxSP, pilotMaxAP } from '../../lib/rules/derivedStats'
@@ -85,7 +90,7 @@ export function ActionsDeck({ mech, pilot, mount = 'mech', store }: ActionsDeckP
     if (onFoot) return { currentHeat: 0, heatCap: HUGE_HEAT_CAP }
     const fresh = s.get('mech', mech.id) ?? mech
     const chassis = resolveChassisRef(mech.chassisRef)
-    return { currentHeat: fresh.currentHeat ?? 0, heatCap: mechMaxHeat(fresh, chassis) }
+    return { currentHeat: resolveGauge(fresh.currentHeat), heatCap: mechMaxHeat(fresh, chassis) }
   })()
 
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
@@ -140,7 +145,7 @@ export function ActionsDeck({ mech, pilot, mount = 'mech', store }: ActionsDeckP
       // never clamp it here, since an unresolved ref makes the max 0.
       const patch = pilotActivationPatch({
         apCost: economy.epCost,
-        currentAP: fresh.currentAP ?? pilotMaxAP(fresh),
+        currentAP: resolvePoolStart(fresh.currentAP, pilotMaxAP(fresh)),
       })
       if (Object.keys(patch).length > 0) {
         runWrite(() => s.update('pilot', pilot.id, patch, DASHBOARD_TXN))
@@ -155,8 +160,8 @@ export function ActionsDeck({ mech, pilot, mount = 'mech', store }: ActionsDeckP
       slug: action.slug,
       economy,
       // Unrecorded EP means a mech that has never spent any — full, not empty.
-      currentEP: fresh.currentEP ?? mechMaxEP(fresh, chassis),
-      currentHeat: fresh.currentHeat ?? 0,
+      currentEP: resolvePoolStart(fresh.currentEP, mechMaxEP(fresh, chassis)),
+      currentHeat: resolveGauge(fresh.currentHeat),
       heatCap,
       prevUses: fresh.itemUses,
     })
@@ -192,11 +197,11 @@ export function ActionsDeck({ mech, pilot, mount = 'mech', store }: ActionsDeckP
     const fresh = s.get('mech', mech.id) ?? mech
     const cap = mechMaxHeat(fresh, chassis)
     const { patch, effect, nextHeat } = pushPatch({
-      heat: Math.min(fresh.currentHeat ?? 0, cap),
+      heat: resolveGauge(fresh.currentHeat, cap),
       heatCap: cap,
       // Unrecorded SP means undamaged. At 0 an Overheat wrote the mech straight
       // to SP 0 — one hit from destroyed — without it ever having taken damage.
-      currentSP: fresh.currentSP ?? mechMaxSP(fresh, chassis),
+      currentSP: resolvePoolStart(fresh.currentSP, mechMaxSP(fresh, chassis)),
       roll: defaultRoll,
     })
     runWrite(() => s.update('mech', mech.id, patch, DASHBOARD_TXN))

--- a/apps/itun/src/components/dashboard/ActiveItemBand.tsx
+++ b/apps/itun/src/components/dashboard/ActiveItemBand.tsx
@@ -25,7 +25,12 @@ import {
 } from 'component-lib'
 import { useEffect, useState } from 'react'
 import { SalvageUnionReference } from 'salvageunion-reference'
-import { resolveChassisRef } from 'salvageunion-reference/rules'
+import {
+  resolveChassisRef,
+  resolveGauge,
+  resolvePool,
+  resolvePoolStart,
+} from 'salvageunion-reference/rules'
 import { describePushOutcome } from '../../lib/rules/coreMechanic'
 import {
   crawlerMaxSPParts,
@@ -198,7 +203,7 @@ function CrawlerBand({
 }) {
   const spParts = crawlerMaxSPParts(crawler)
   const maxSP = spParts.total
-  const sp = Math.min(crawler.currentSP ?? maxSP, maxSP)
+  const sp = resolvePool(crawler.currentSP, maxSP)
   const [prompt, setPrompt] = useState<EconPrompt>(null)
   const crawlerTl = crawlerTechLevelOf(crawler)
 
@@ -374,9 +379,9 @@ function MechBand({
   const maxEP = mechMaxEP(mech, chassis)
   const maxHeat = mechMaxHeat(mech, chassis)
   const maxCargo = mechMaxCargo(mech, chassis, piloting)
-  const sp = Math.min(mech.currentSP ?? maxSP, maxSP)
-  const ep = Math.min(mech.currentEP ?? maxEP, maxEP)
-  const heat = Math.min(mech.currentHeat ?? 0, maxHeat)
+  const sp = resolvePool(mech.currentSP, maxSP)
+  const ep = resolvePool(mech.currentEP, maxEP)
+  const heat = resolveGauge(mech.currentHeat, maxHeat)
   const cargo = totalLotUnits(mech.cargoLots)
 
   const [prompt, setPrompt] = useState<MechPrompt>(null)
@@ -406,9 +411,9 @@ function MechBand({
     const cap = mechMaxHeat(m, chassis)
     const spMax = mechMaxSP(m, chassis, piloting)
     const { patch, effect, nextHeat, meltdown } = pushPatch({
-      heat: Math.min(m.currentHeat ?? 0, cap),
+      heat: resolveGauge(m.currentHeat, cap),
       heatCap: cap,
-      currentSP: Math.min(m.currentSP ?? spMax, spMax),
+      currentSP: resolvePoolStart(m.currentSP, spMax),
       roll: defaultRoll,
     })
     runWrite(
@@ -422,8 +427,8 @@ function MechBand({
     const cap = mechMaxHeat(m, chassis)
     const spMax = mechMaxSP(m, chassis, piloting)
     const { patch, effect, meltdown } = heatCheckOncePatch({
-      heat: Math.min(m.currentHeat ?? 0, cap),
-      currentSP: Math.min(m.currentSP ?? spMax, spMax),
+      heat: resolveGauge(m.currentHeat, cap),
+      currentSP: resolvePoolStart(m.currentSP, spMax),
       roll: defaultRoll,
     })
     runWrite(
@@ -454,7 +459,7 @@ function MechBand({
     // Damage operates on the stored SP (authoritative); default to max only
     // when it was never set. The gauge, not this write, clamps for display.
     const { patch, effect } = mechDamagePatch({
-      currentSP: m.currentSP ?? mechMaxSP(m, chassis, piloting),
+      currentSP: resolvePoolStart(m.currentSP, mechMaxSP(m, chassis, piloting)),
       amount: dmg,
       vulnerable: m.vulnerable ?? false,
     })
@@ -723,8 +728,8 @@ function PilotBand({
 }) {
   const maxHP = Math.max(0, pilotMaxHP(pilot))
   const maxAP = Math.max(0, pilotMaxAP(pilot))
-  const hp = Math.min(pilot.currentHP ?? maxHP, maxHP)
-  const ap = Math.min(pilot.currentAP ?? maxAP, maxAP)
+  const hp = resolvePool(pilot.currentHP, maxHP)
+  const ap = resolvePool(pilot.currentAP, maxAP)
 
   const [prompt, setPrompt] = useState<PilotPrompt>(null)
   const [dmg, setDmg] = useState(1)
@@ -745,7 +750,7 @@ function PilotBand({
   function applyDamage() {
     const p = fresh()
     const { patch, effect } = pilotDamagePatch({
-      currentHP: p.currentHP ?? Math.max(0, pilotMaxHP(p)),
+      currentHP: resolvePoolStart(p.currentHP, Math.max(0, pilotMaxHP(p))),
       amount: dmg,
       vulnerable: false,
     })

--- a/apps/itun/src/components/dashboard/dialItems.ts
+++ b/apps/itun/src/components/dashboard/dialItems.ts
@@ -12,7 +12,7 @@
 
 import type { DialItem as DialCellItem } from 'component-lib'
 import { linesFromBreakdown } from 'component-lib'
-import { resolveChassisRef } from 'salvageunion-reference/rules'
+import { resolveChassisRef, resolveGauge, resolvePool } from 'salvageunion-reference/rules'
 import {
   crawlerMaxSPParts,
   mechMaxHeatParts,
@@ -56,7 +56,7 @@ function pilotItem(pilot: Pilot): DialItem {
     gauges: [
       {
         label: 'HP',
-        value: Math.min(pilot.currentHP ?? maxHP, maxHP),
+        value: resolvePool(pilot.currentHP, maxHP),
         max: maxHP,
         tone: 'pilot',
         provenance: linesFromBreakdown(hpParts, {
@@ -69,7 +69,7 @@ function pilotItem(pilot: Pilot): DialItem {
       },
       {
         label: 'AP',
-        value: Math.min(pilot.currentAP ?? maxAP, maxAP),
+        value: resolvePool(pilot.currentAP, maxAP),
         max: maxAP,
         tone: 'pilot',
         provenance: linesFromBreakdown(apParts, { base: 'Pilot', baseDetail: 'base' }),
@@ -100,7 +100,7 @@ function mechItem(mech: Mech, pilot: Pilot | null): DialItem {
     gauges: [
       {
         label: 'SP',
-        value: Math.min(mech.currentSP ?? maxSP, maxSP),
+        value: resolvePool(mech.currentSP, maxSP),
         max: maxSP,
         tone: 'mech',
         provenance: linesFromBreakdown(spParts, {
@@ -112,7 +112,7 @@ function mechItem(mech: Mech, pilot: Pilot | null): DialItem {
       },
       {
         label: 'Heat',
-        value: Math.min(mech.currentHeat ?? 0, maxHeat),
+        value: resolveGauge(mech.currentHeat, maxHeat),
         max: maxHeat,
         tone: 'mech',
         danger: Math.max(0, maxHeat - 2),
@@ -139,7 +139,7 @@ function crawlerItem(crawler: Crawler): DialItem {
     gauges: [
       {
         label: 'SP',
-        value: Math.min(crawler.currentSP ?? maxSP, maxSP),
+        value: resolvePool(crawler.currentSP, maxSP),
         max: maxSP,
         tone: 'crawler',
         provenance: linesFromBreakdown(spParts, {

--- a/apps/itun/src/components/mech/MechWizard.tsx
+++ b/apps/itun/src/components/mech/MechWizard.tsx
@@ -18,6 +18,7 @@ import {
   matchesRef,
   resolveChassisRef,
   resolveModuleRef,
+  resolvePool,
   resolveSystemRef,
 } from 'salvageunion-reference/rules'
 import { useMech } from '../../hooks/queries'
@@ -365,7 +366,7 @@ export function MechWizard({
     },
     chassis
   )
-  const energyValue = Math.min(existingMech?.currentEP ?? energyMax, energyMax)
+  const energyValue = resolvePool(existingMech?.currentEP, energyMax)
   const loadoutName = form.name.trim() || chassis?.name || form.chassisName || 'Mech'
 
   const editWarnings = useMemo<SoftWarning[]>(() => {

--- a/apps/itun/src/components/sheet/CrawlerEconomyControl.tsx
+++ b/apps/itun/src/components/sheet/CrawlerEconomyControl.tsx
@@ -37,6 +37,7 @@
 
 import { Button, FieldError, ModalShell, Select, Slab, Stat } from 'component-lib'
 import { useState } from 'react'
+import { resolvePool } from 'salvageunion-reference/rules'
 import { scrapPoolBucket } from '../../lib/cargo/cargoTransfer'
 import { parseCrawlerTechLevel } from '../../lib/crawlerLevel'
 import { resolveCrawlerBay } from '../../lib/crawlerRefs'
@@ -182,7 +183,7 @@ function UpkeepDialog({ crawler, store, roll, onClose }: DialogProps & { roll: R
     const fresh = freshEntity(storeState, 'crawler', crawler)
     const bays = fresh.crawlerBays ?? []
     const maxSP = crawlerMaxSP(fresh)
-    const currentSP = Math.min(fresh.currentSP ?? maxSP, maxSP)
+    const currentSP = resolvePool(fresh.currentSP, maxSP)
     const effect = performDeterioration({ currentSP, bayCount: bays.length, roll })
 
     if (effect.spLoss > 0) {

--- a/apps/itun/src/components/sheet/PartnerCard.tsx
+++ b/apps/itun/src/components/sheet/PartnerCard.tsx
@@ -30,6 +30,7 @@
 
 import type { ReferenceEntityControl, StatItem } from 'component-lib'
 import { Field, MasonryColumns, ReferenceEntityCard, summarizeBreakdown } from 'component-lib'
+import { resolveGauge, resolvePool } from 'salvageunion-reference/rules'
 import { usePartnerCargo } from '../../lib/cargo/usePartnerCargo'
 import type { PartnerWithHost } from '../../lib/partnerLookup'
 import { replacePartner } from '../../lib/partnerLookup'
@@ -115,9 +116,9 @@ export function PartnerCard({
     readOnly,
   })
 
-  const sp = Math.min(partner.currentSP ?? max.structurePoints, max.structurePoints)
-  const ep = Math.min(partner.currentEP ?? max.energyPoints, max.energyPoints)
-  const heat = Math.min(partner.currentHeat ?? 0, max.heatCapacity)
+  const sp = resolvePool(partner.currentSP, max.structurePoints)
+  const ep = resolvePool(partner.currentEP, max.energyPoints)
+  const heat = resolveGauge(partner.currentHeat, max.heatCapacity)
 
   /** Write through the HOST — a partner has no store row of its own. */
   const patch = (fields: Partial<PartnerInstance>): void => {

--- a/apps/itun/src/components/sheet/PilotSheet.tsx
+++ b/apps/itun/src/components/sheet/PilotSheet.tsx
@@ -64,6 +64,7 @@ import {
 import type { ReactNode } from 'react'
 import { useState } from 'react'
 import type { SURefAbility } from 'salvageunion-reference'
+import { resolvePool } from 'salvageunion-reference/rules'
 import { pilotMaxAP } from '../../lib/rules/derivedStats'
 import type { Pilot } from '../../lib/schemas/pilot'
 import { useEntityStore } from '../../stores/entityStore'
@@ -162,7 +163,7 @@ export function PilotSheet({
     return (
       <PilotAbilityItem
         ability={ability}
-        currentAP={pilot.currentAP ?? pilotMaxAP(pilot)}
+        currentAP={resolvePool(pilot.currentAP, pilotMaxAP(pilot))}
         used={pilot.usedAbilities?.includes(slug) ?? false}
         onSpend={(cost) => {
           void actions.handleSpendAP(cost)

--- a/apps/itun/src/components/sheet/ShareSnapshotScreen.tsx
+++ b/apps/itun/src/components/sheet/ShareSnapshotScreen.tsx
@@ -40,7 +40,12 @@ import {
   VitalGauge,
 } from 'component-lib'
 import { useEffect, useState } from 'react'
-import { computeMechCapacity, resolveChassisRef } from 'salvageunion-reference/rules'
+import {
+  computeMechCapacity,
+  resolveChassisRef,
+  resolveGauge,
+  resolvePool,
+} from 'salvageunion-reference/rules'
 import { useEntity } from '../../hooks/queries'
 import { resolveClassName } from '../../lib/classRef'
 import { useConnection } from '../../lib/connection/connectionContext'
@@ -525,7 +530,7 @@ function SnapshotPreviewCard({ entity }: SnapshotPreviewCardProps) {
             <VitalGauge
               label="HP"
               max={maxHP}
-              value={Math.min(pilot.currentHP ?? maxHP, maxHP)}
+              value={resolvePool(pilot.currentHP, maxHP)}
               provenance={linesFromBreakdown(hpParts, {
                 base: 'Pilot',
                 baseDetail: 'base',
@@ -537,7 +542,7 @@ function SnapshotPreviewCard({ entity }: SnapshotPreviewCardProps) {
             <VitalGauge
               label="AP"
               max={maxAP}
-              value={Math.min(pilot.currentAP ?? maxAP, maxAP)}
+              value={resolvePool(pilot.currentAP, maxAP)}
               provenance={linesFromBreakdown(apParts, { base: 'Pilot', baseDetail: 'base' })}
               readOnly
             />
@@ -605,7 +610,7 @@ function SnapshotPreviewCard({ entity }: SnapshotPreviewCardProps) {
               label="SP"
               subLabel="Structure"
               max={maxSP}
-              value={Math.min(mech.currentSP ?? maxSP, maxSP)}
+              value={resolvePool(mech.currentSP, maxSP)}
               provenance={linesFromBreakdown(spParts, mechLabels)}
               readOnly
             />
@@ -613,14 +618,14 @@ function SnapshotPreviewCard({ entity }: SnapshotPreviewCardProps) {
               label="EP"
               subLabel="Energy"
               max={maxEP}
-              value={Math.min(mech.currentEP ?? maxEP, maxEP)}
+              value={resolvePool(mech.currentEP, maxEP)}
               provenance={linesFromBreakdown(epParts, mechLabels)}
               readOnly
             />
             <VitalGauge
               label="Heat"
               max={maxHeat}
-              value={Math.min(mech.currentHeat ?? 0, maxHeat)}
+              value={resolveGauge(mech.currentHeat, maxHeat)}
               danger={maxHeat > 0 ? heatDangerFrom(maxHeat) : undefined}
               provenance={linesFromBreakdown(heatParts, mechLabels)}
               readOnly
@@ -656,7 +661,7 @@ function SnapshotPreviewCard({ entity }: SnapshotPreviewCardProps) {
           <VitalGauge
             label="SP"
             max={maxSP}
-            value={Math.min(crawler.currentSP ?? maxSP, maxSP)}
+            value={resolvePool(crawler.currentSP, maxSP)}
             caption={['Structure', 'Max']}
             provenance={linesFromBreakdown(spParts, {
               base: `Tech ${crawler.techLevel?.replace(/\D/g, '') || '?'} Crawler`,

--- a/apps/itun/src/components/sheet/SheetCrawler.tsx
+++ b/apps/itun/src/components/sheet/SheetCrawler.tsx
@@ -16,6 +16,7 @@
 import type { EconLozItem } from 'component-lib'
 import { CrawlerEconFrame, EntityRow, linesFromBreakdown, VitalGauge } from 'component-lib'
 import { useState } from 'react'
+import { resolvePool } from 'salvageunion-reference/rules'
 import { parseCrawlerTechLevel } from '../../lib/crawlerLevel'
 import { bayGate, tradingSourceTl } from '../../lib/rules/crawlerEconomy'
 import { crawlerMaxSPParts } from '../../lib/rules/derivedStats'
@@ -61,7 +62,7 @@ export function SheetCrawler({
     baseDetail: 'base',
     installed: 'Crawler type bonus',
   })
-  const sp = Math.min(crawler.currentSP ?? maxSP, maxSP)
+  const sp = resolvePool(crawler.currentSP, maxSP)
   // Cap override (ADR-022, Free Edit): pin Max SP via a signed maxSpModifier
   // delta; the gauge shows "overridden from N" + a revert. Tagged `override`.
   const overrideCrawlerMax = (fields: Partial<Crawler>) => {

--- a/apps/itun/src/components/sheet/SheetMech.tsx
+++ b/apps/itun/src/components/sheet/SheetMech.tsx
@@ -11,7 +11,7 @@
  */
 
 import { EntityRow } from 'component-lib'
-import { resolveChassisRef } from 'salvageunion-reference/rules'
+import { resolveChassisRef, resolveGauge, resolvePool } from 'salvageunion-reference/rules'
 import { containerOf } from '../../lib/container'
 import { mechMaxCargo, mechMaxEP, mechMaxHeat, mechMaxSP } from '../../lib/rules/derivedStats'
 import { pilotingContext } from '../../lib/rules/pilotingContext'
@@ -58,9 +58,9 @@ export function SheetMech({
   const maxHeat = mechMaxHeat(mech, chassis)
   const maxCargo = mechMaxCargo(mech, chassis, piloting)
   const cargoUsed = totalLotUnits(mech.cargoLots)
-  const sp = Math.min(mech.currentSP ?? maxSP, maxSP)
-  const ep = Math.min(mech.currentEP ?? maxEP, maxEP)
-  const heat = Math.min(mech.currentHeat ?? 0, maxHeat)
+  const sp = resolvePool(mech.currentSP, maxSP)
+  const ep = resolvePool(mech.currentEP, maxEP)
+  const heat = resolveGauge(mech.currentHeat, maxHeat)
 
   // U-5: on phones the condensed bar leads with Heat + SP; EP/Hold fold
   // until the sm breakpoint.

--- a/apps/itun/src/components/sheet/SheetPilot.tsx
+++ b/apps/itun/src/components/sheet/SheetPilot.tsx
@@ -9,6 +9,7 @@
  */
 
 import { EntityRow, Stat } from 'component-lib'
+import { resolvePool } from 'salvageunion-reference/rules'
 import { containerOf } from '../../lib/container'
 import { pilotMaxAP, pilotMaxHP } from '../../lib/rules/derivedStats'
 import { pilotingContext } from '../../lib/rules/pilotingContext'
@@ -52,8 +53,8 @@ export function SheetPilot({
     editable && linkId ? () => runWrite(() => storeState.delete('softLink', linkId)) : undefined
   const maxHP = Math.max(0, pilotMaxHP(pilot))
   const maxAP = Math.max(0, pilotMaxAP(pilot))
-  const hp = Math.min(pilot.currentHP ?? maxHP, maxHP)
-  const ap = Math.min(pilot.currentAP ?? maxAP, maxAP)
+  const hp = resolvePool(pilot.currentHP, maxHP)
+  const ap = resolvePool(pilot.currentAP, maxAP)
 
   const strip: LiveSheetStripItem[] = [
     { key: 'hp', label: 'HP', stat: 'hp', value: hp, max: maxHP },

--- a/apps/itun/src/components/sheet/mechSheetModel.ts
+++ b/apps/itun/src/components/sheet/mechSheetModel.ts
@@ -14,7 +14,12 @@
 import type { ChassisStatItem, ProvenanceLine } from 'component-lib'
 import { linesFromBreakdown } from 'component-lib'
 import { SalvageUnionReference } from 'salvageunion-reference'
-import { computeMechCapacity, resolveChassisRef } from 'salvageunion-reference/rules'
+import {
+  computeMechCapacity,
+  resolveChassisRef,
+  resolveGauge,
+  resolvePool,
+} from 'salvageunion-reference/rules'
 import { useCargo } from '../../lib/cargo/useCargo'
 import { mechMaxEPParts, mechMaxHeatParts, mechMaxSPParts } from '../../lib/rules/derivedStats'
 import { pilotingContext } from '../../lib/rules/pilotingContext'
@@ -94,9 +99,9 @@ export function useMechSheetModel({
   const maxSP = spParts.total
   const maxEP = epParts.total
   const heatCap = heatParts.total
-  const currentSP = mech.currentSP ?? maxSP
-  const currentEP = mech.currentEP ?? maxEP
-  const currentHeat = Math.min(mech.currentHeat ?? 0, heatCap)
+  const currentSP = resolvePool(mech.currentSP, maxSP)
+  const currentEP = resolvePool(mech.currentEP, maxEP)
+  const currentHeat = resolveGauge(mech.currentHeat, heatCap)
 
   // Slot budgets for the picker's loadout panel (soft — never blocks).
   const capacity = computeMechCapacity({

--- a/apps/itun/src/components/sheet/pilotSheetActions.ts
+++ b/apps/itun/src/components/sheet/pilotSheetActions.ts
@@ -28,7 +28,7 @@
  */
 
 import { useState } from 'react'
-import { enrichPilotSnapshot } from 'salvageunion-reference/rules'
+import { enrichPilotSnapshot, resolvePool } from 'salvageunion-reference/rules'
 import { pilotMaxAP } from '../../lib/rules/derivedStats'
 import { isPartnerEquipment, pilotPartnerSeeds, syncPartners } from '../../lib/rules/partnerGrants'
 import type { SoftWarning } from '../../lib/rules/types'
@@ -238,7 +238,7 @@ export function usePilotSheetActions({
 
   async function handleSpendAP(cost: number) {
     const p = freshPilot()
-    const current = p.currentAP ?? pilotMaxAP(p)
+    const current = resolvePool(p.currentAP, pilotMaxAP(p))
     const next = Math.max(0, current - cost)
     if (next === current) return
     await writeAwait({ currentAP: next })

--- a/apps/itun/src/components/sheet/pilotSheetModel.ts
+++ b/apps/itun/src/components/sheet/pilotSheetModel.ts
@@ -17,6 +17,7 @@ import { linesFromBreakdown } from 'component-lib'
 import { useMemo } from 'react'
 import type { SURefAbility } from 'salvageunion-reference'
 import { SalvageUnionReference } from 'salvageunion-reference'
+import { resolvePool } from 'salvageunion-reference/rules'
 import { resolveEffectiveCrawlerLevel } from '../../lib/crawlerLevel'
 import { isPilotDead, pilotMaxAPParts, pilotMaxHPParts } from '../../lib/rules/derivedStats'
 import type { Crawler } from '../../lib/schemas/crawler'
@@ -210,8 +211,8 @@ export function usePilotSheetModel({
   const apLines = linesFromBreakdown(apParts, { base: 'Pilot', baseDetail: 'base' })
   const maxHP = Math.max(0, hpParts.total)
   const maxAP = Math.max(0, apParts.total)
-  const hp = Math.min(pilot.currentHP ?? maxHP, maxHP)
-  const ap = Math.min(pilot.currentAP ?? maxAP, maxAP)
+  const hp = resolvePool(pilot.currentHP, maxHP)
+  const ap = resolvePool(pilot.currentAP, maxAP)
   const tp = pilot.trainingPoints ?? 0
 
   return {

--- a/apps/itun/src/components/sheet/railStats.ts
+++ b/apps/itun/src/components/sheet/railStats.ts
@@ -7,6 +7,7 @@
  */
 
 import type { BadgeTone, StatState } from 'component-lib'
+import { resolveGauge, resolvePool } from 'salvageunion-reference/rules'
 import {
   crawlerMaxSP,
   mechMaxEP,
@@ -68,9 +69,9 @@ export function mechRailItems(mech: Mech, piloting?: Piloting): RailStat[] {
   const maxEP = mechMaxEP(mech, undefined, piloting)
   const maxHeat = mechMaxHeat(mech, undefined, piloting)
   return [
-    { label: 'SP', value: mech.currentSP ?? maxSP, max: maxSP },
-    { label: 'EP', value: mech.currentEP ?? maxEP, max: maxEP },
-    { label: 'Heat', value: Math.min(mech.currentHeat ?? 0, maxHeat), max: maxHeat },
+    { label: 'SP', value: resolvePool(mech.currentSP, maxSP), max: maxSP },
+    { label: 'EP', value: resolvePool(mech.currentEP, maxEP), max: maxEP },
+    { label: 'Heat', value: resolveGauge(mech.currentHeat, maxHeat), max: maxHeat },
   ]
 }
 
@@ -79,8 +80,8 @@ export function pilotRailItems(pilot: Pilot): RailStat[] {
   const maxHP = Math.max(0, pilotMaxHP(pilot))
   const maxAP = Math.max(0, pilotMaxAP(pilot))
   return [
-    { label: 'HP', value: pilot.currentHP ?? maxHP, max: maxHP },
-    { label: 'AP', value: pilot.currentAP ?? maxAP, max: maxAP },
+    { label: 'HP', value: resolvePool(pilot.currentHP, maxHP), max: maxHP },
+    { label: 'AP', value: resolvePool(pilot.currentAP, maxAP), max: maxAP },
   ]
 }
 
@@ -90,7 +91,7 @@ export function crawlerRailItems(crawler: Crawler): RailStat[] {
   const states = bayStates(crawler)
   const intact = states.filter((s) => s === 'intact').length
   return [
-    { label: 'SP', value: crawler.currentSP ?? maxSP, max: maxSP },
+    { label: 'SP', value: resolvePool(crawler.currentSP, maxSP), max: maxSP },
     // Bays only appear once the crawler HAS bays — an empty "Bays 0/0" line was
     // never rendered before and must not start now.
     ...(states.length > 0

--- a/apps/itun/src/lib/rules/downtime.ts
+++ b/apps/itun/src/lib/rules/downtime.ts
@@ -34,7 +34,12 @@
  */
 
 import { SalvageUnionReference } from 'salvageunion-reference'
-import { matchesRef, resolveChassisRef, resolveInstalledRef } from 'salvageunion-reference/rules'
+import {
+  matchesRef,
+  resolveChassisRef,
+  resolveGauge,
+  resolveInstalledRef,
+} from 'salvageunion-reference/rules'
 import { parseCrawlerTechLevel } from '../crawlerLevel'
 import { resolveCrawlerBay } from '../crawlerRefs'
 import type { Crawler } from '../schemas/crawler'
@@ -303,7 +308,7 @@ export function downtimeMechPatch(
     const maxEP = mechMaxEP(mech)
     if (mech.currentSP !== undefined && mech.currentSP !== maxSP) patch.currentSP = maxSP
     if (mech.currentEP !== undefined && mech.currentEP !== maxEP) patch.currentEP = maxEP
-    if ((mech.currentHeat ?? 0) !== 0) patch.currentHeat = 0
+    if (resolveGauge(mech.currentHeat) !== 0) patch.currentHeat = 0
   }
 
   if (steps.repairItems && bayOperational) {

--- a/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
+++ b/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
@@ -2284,6 +2284,72 @@ import type { ActiveEffects, ResolvedContribution } from './contributions.js';
 export declare const PILOT_BASE_HP = 10;
 export declare const PILOT_BASE_AP = 5;
 export declare const PILOT_BASE_INVENTORY_SLOTS = 6;
+/**
+ * Resolve a stored POOL value — HP, SP, AP, EP — to what should be displayed
+ * or acted on.
+ *
+ * The rule, stated once: **an unset pool means FULL**, and a stored value is
+ * clamped to the current maximum. A fresh pilot has no `currentHP` because
+ * nothing has damaged them yet, not because they are at zero; and a max that
+ * has since dropped (an injury, a lost system) must not leave a stored value
+ * above it.
+ *
+ * This existed as `Math.min(x.currentHP ?? maxHP, maxHP)` written out at ~40
+ * call sites across the app and once more in the Discord bot, with no shared
+ * definition anywhere. It is one keystroke wide: drop the `?? maxHP` and a
+ * healthy pilot renders at 0 HP; the bot's own comment records the same worry
+ * ("would render a fresh, undamaged crew as wiped out").
+ *
+ * It is NOT `clampPilotCurrentStats` / `clampMechCurrentStats`, which are
+ * write-time clamps that lower an over-max stored value and deliberately leave
+ * `undefined` alone. This is the read-time resolution.
+ *
+ * @param current - The stored value, or `undefined` if never set
+ * @param max - The current derived maximum
+ * @returns The value to show, in `[0, max]`
+ */
+export declare function resolvePool(current: number | undefined, max: number): number;
+/**
+ * The same "unset means FULL" default, WITHOUT the clamp — for the starting
+ * value of a WRITE.
+ *
+ * Reach for this when the number is about to be spent from or damaged, rather
+ * than shown. {@link resolvePool} clamps to `max`, which is right for display
+ * and wrong here for one specific reason: `max` is derived, and a derivation
+ * can legitimately come back 0 when its inputs do not resolve — an unresolvable
+ * `chassisRef` makes `mechMaxEP` 0, and `MechSheet-unresolved-chassis` exists
+ * because that state is real. Clamping at that moment would write the player's
+ * EP or SP to zero as a side effect of a lookup failure.
+ *
+ * Displaying a stale over-max number is recoverable. Writing one away is not.
+ *
+ * @param current - The stored value, or `undefined` if never set
+ * @param max - The current derived maximum, used only as the default
+ * @returns The stored value, or `max` if it was never set
+ */
+export declare function resolvePoolStart(current: number | undefined, max: number): number;
+/**
+ * Resolve a stored GAUGE value — Heat — to what should be displayed or acted on.
+ *
+ * The mirror of {@link resolvePool}, and the reason both exist: Heat inverts
+ * the default. **An unset gauge means EMPTY**, because a mech that has done
+ * nothing is cold, not overheating. Getting this backwards puts a fresh mech at
+ * its Heat Capacity, one roll from a Reactor Overload.
+ *
+ * That inversion was also hand-carried at every call site (`?? 0` rather than
+ * `?? max`), which is exactly why it is worth naming: the two rules look alike
+ * and mean opposite things.
+ *
+ * `max` is optional because a gauge is often read as the STARTING POINT for
+ * arithmetic ("current heat, plus what this action costs") rather than for
+ * display, and clamping before the addition would be wrong. Omit it to get the
+ * default without a ceiling; pass it wherever the value is shown.
+ *
+ * @param current - The stored value, or `undefined` if never set
+ * @param max - The current derived capacity, if the value is being displayed
+ * @returns The value, in `[0, max]` when a max is given
+ */
+export declare function resolveGauge(current: number | undefined, max?: number): number;
 /** A single pilot injury (rules A11): minor −1 max HP, major −2. */
 type Injury = {
     severity: 'minor' | 'major';
@@ -2643,7 +2709,7 @@ export { isWeaponSystem } from './crawlerSystems.js';
 export type { CrawlerMutationInput, CreationAbilityInput, CreationCoreTrees, CreationEquipmentInput, CreationPatternInput, MechCreationBudget, MechCreationBudgetInput, MechCreationLoadoutEntry, } from './creation.js';
 export { CRAWLER_CREATION_MIN_WEAPONS, CRAWLER_CREATION_TECH_LEVEL, crawlerMaxSpBonus, crawlerWeaponSlots, isCrawlerWeaponPickComplete, isLegalCreationAbility, isLegalCreationChassis, isLegalCreationClass, isLegalCreationCrawlerWeapon, isLegalCreationEquipment, isLegalCreationModule, isLegalCreationSystem, isLegalStartingPattern, isPilotAbilityPickComplete, isPilotEquipmentPickComplete, legalCreationAbilities, legalStartingPatterns, MECH_CREATION_SCRAP_CAP, mechCreationBudget, PILOT_CREATION_ABILITY_PICKS, PILOT_CREATION_EQUIPMENT_PICKS, pilotEquipmentPicksRemaining, } from './creation.js';
 export type { ChassisStats, CrawlerMaxSPParts, StatBreakdown } from './derivedStats.js';
-export { clampCrawlerCurrentStats, clampMechCurrentStats, clampPilotCurrentStats, crawlerMaxSP, crawlerMaxSPParts, injuryMaxHpPenalty, isPilotDead, mechMaxCargo, mechMaxCargoParts, mechMaxEP, mechMaxEPParts, mechMaxHeat, mechMaxHeatParts, mechMaxSP, mechMaxSPParts, PILOT_BASE_AP, PILOT_BASE_HP, PILOT_BASE_INVENTORY_SLOTS, pilotMaxAP, pilotMaxAPParts, pilotMaxHP, pilotMaxHPParts, pilotMaxInventorySlots, pilotMaxInventorySlotsParts, unifiedMechConditions, } from './derivedStats.js';
+export { clampCrawlerCurrentStats, clampMechCurrentStats, clampPilotCurrentStats, crawlerMaxSP, crawlerMaxSPParts, injuryMaxHpPenalty, isPilotDead, mechMaxCargo, mechMaxCargoParts, mechMaxEP, mechMaxEPParts, mechMaxHeat, mechMaxHeatParts, mechMaxSP, mechMaxSPParts, PILOT_BASE_AP, PILOT_BASE_HP, PILOT_BASE_INVENTORY_SLOTS, pilotMaxAP, pilotMaxAPParts, pilotMaxHP, pilotMaxHPParts, pilotMaxInventorySlots, pilotMaxInventorySlotsParts, resolveGauge, resolvePool, resolvePoolStart, unifiedMechConditions, } from './derivedStats.js';
 export { canActivateAction, clampHeat, performHeatCheck, performPush, reactorOverloadOutcome, } from './heatCheck.js';
 export type { FindRollTable } from './mediatorTables.js';
 export { describeMediatorRoll, MEDIATOR_TABLE_LABEL, MEDIATOR_TABLE_NAMES, performMediatorRoll, } from './mediatorTables.js';

--- a/packages/salvageunion-reference/lib/rules/derivedStats.ts
+++ b/packages/salvageunion-reference/lib/rules/derivedStats.ts
@@ -38,6 +38,82 @@ export const PILOT_BASE_HP = 10
 export const PILOT_BASE_AP = 5
 export const PILOT_BASE_INVENTORY_SLOTS = 6
 
+/**
+ * Resolve a stored POOL value — HP, SP, AP, EP — to what should be displayed
+ * or acted on.
+ *
+ * The rule, stated once: **an unset pool means FULL**, and a stored value is
+ * clamped to the current maximum. A fresh pilot has no `currentHP` because
+ * nothing has damaged them yet, not because they are at zero; and a max that
+ * has since dropped (an injury, a lost system) must not leave a stored value
+ * above it.
+ *
+ * This existed as `Math.min(x.currentHP ?? maxHP, maxHP)` written out at ~40
+ * call sites across the app and once more in the Discord bot, with no shared
+ * definition anywhere. It is one keystroke wide: drop the `?? maxHP` and a
+ * healthy pilot renders at 0 HP; the bot's own comment records the same worry
+ * ("would render a fresh, undamaged crew as wiped out").
+ *
+ * It is NOT `clampPilotCurrentStats` / `clampMechCurrentStats`, which are
+ * write-time clamps that lower an over-max stored value and deliberately leave
+ * `undefined` alone. This is the read-time resolution.
+ *
+ * @param current - The stored value, or `undefined` if never set
+ * @param max - The current derived maximum
+ * @returns The value to show, in `[0, max]`
+ */
+export function resolvePool(current: number | undefined, max: number): number {
+  return Math.min(current ?? max, max)
+}
+
+/**
+ * The same "unset means FULL" default, WITHOUT the clamp — for the starting
+ * value of a WRITE.
+ *
+ * Reach for this when the number is about to be spent from or damaged, rather
+ * than shown. {@link resolvePool} clamps to `max`, which is right for display
+ * and wrong here for one specific reason: `max` is derived, and a derivation
+ * can legitimately come back 0 when its inputs do not resolve — an unresolvable
+ * `chassisRef` makes `mechMaxEP` 0, and `MechSheet-unresolved-chassis` exists
+ * because that state is real. Clamping at that moment would write the player's
+ * EP or SP to zero as a side effect of a lookup failure.
+ *
+ * Displaying a stale over-max number is recoverable. Writing one away is not.
+ *
+ * @param current - The stored value, or `undefined` if never set
+ * @param max - The current derived maximum, used only as the default
+ * @returns The stored value, or `max` if it was never set
+ */
+export function resolvePoolStart(current: number | undefined, max: number): number {
+  return current ?? max
+}
+
+/**
+ * Resolve a stored GAUGE value — Heat — to what should be displayed or acted on.
+ *
+ * The mirror of {@link resolvePool}, and the reason both exist: Heat inverts
+ * the default. **An unset gauge means EMPTY**, because a mech that has done
+ * nothing is cold, not overheating. Getting this backwards puts a fresh mech at
+ * its Heat Capacity, one roll from a Reactor Overload.
+ *
+ * That inversion was also hand-carried at every call site (`?? 0` rather than
+ * `?? max`), which is exactly why it is worth naming: the two rules look alike
+ * and mean opposite things.
+ *
+ * `max` is optional because a gauge is often read as the STARTING POINT for
+ * arithmetic ("current heat, plus what this action costs") rather than for
+ * display, and clamping before the addition would be wrong. Omit it to get the
+ * default without a ceiling; pass it wherever the value is shown.
+ *
+ * @param current - The stored value, or `undefined` if never set
+ * @param max - The current derived capacity, if the value is being displayed
+ * @returns The value, in `[0, max]` when a max is given
+ */
+export function resolveGauge(current: number | undefined, max?: number): number {
+  const value = current ?? 0
+  return max === undefined ? value : Math.min(value, max)
+}
+
 /** A single pilot injury (rules A11): minor −1 max HP, major −2. */
 type Injury = { severity: 'minor' | 'major'; note: string }
 

--- a/packages/salvageunion-reference/lib/rules/index.ts
+++ b/packages/salvageunion-reference/lib/rules/index.ts
@@ -128,6 +128,9 @@ export {
   pilotMaxHPParts,
   pilotMaxInventorySlots,
   pilotMaxInventorySlotsParts,
+  resolveGauge,
+  resolvePool,
+  resolvePoolStart,
   unifiedMechConditions,
 } from './derivedStats.js'
 export {

--- a/packages/salvageunion-reference/lib/rules/resolvePool.test.ts
+++ b/packages/salvageunion-reference/lib/rules/resolvePool.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test'
+import { resolveGauge, resolvePool } from './derivedStats.js'
+
+/**
+ * The two rules these encode look alike and mean opposite things, which is why
+ * they are worth one definition each rather than ~40 hand-written copies.
+ */
+describe('resolvePool — an unset pool means FULL', () => {
+  test('undefined resolves to the maximum', () => {
+    // The case that matters: a fresh pilot has no stored HP because nothing has
+    // damaged them, not because they are at zero.
+    expect(resolvePool(undefined, 10)).toBe(10)
+    expect(resolvePool(undefined, 0)).toBe(0)
+  })
+
+  test('a stored value passes through', () => {
+    expect(resolvePool(7, 10)).toBe(7)
+    expect(resolvePool(0, 10)).toBe(0)
+  })
+
+  test('zero is NOT treated as unset', () => {
+    // `?? ` rather than `||` — a downed pilot is at 0, and must stay there.
+    expect(resolvePool(0, 10)).toBe(0)
+  })
+
+  test('a stored value above the max is clamped down', () => {
+    // The max can fall after the value was stored: an injury lowers max HP, a
+    // lost system lowers max EP.
+    expect(resolvePool(12, 10)).toBe(10)
+  })
+})
+
+describe('resolveGauge — an unset gauge means EMPTY', () => {
+  test('undefined resolves to zero', () => {
+    // Heat inverts the default. A mech that has done nothing is cold; defaulting
+    // it to capacity would put a fresh mech one roll from Reactor Overload.
+    expect(resolveGauge(undefined, 6)).toBe(0)
+  })
+
+  test('a stored value passes through and clamps to capacity', () => {
+    expect(resolveGauge(3, 6)).toBe(3)
+    expect(resolveGauge(9, 6)).toBe(6)
+  })
+
+  test('with no max, it defaults without clamping', () => {
+    // Reading heat as the starting point for arithmetic — "current heat, plus
+    // what this action costs" — must not clamp before the addition.
+    expect(resolveGauge(undefined)).toBe(0)
+    expect(resolveGauge(9)).toBe(9)
+  })
+})
+
+describe('the two are opposites', () => {
+  test('an unset value differs by the whole range', () => {
+    // Stated as an assertion so a refactor that unified them would fail here
+    // rather than silently in a sheet.
+    expect(resolvePool(undefined, 8)).toBe(8)
+    expect(resolveGauge(undefined, 8)).toBe(0)
+  })
+})

--- a/tools/check-architecture.ts
+++ b/tools/check-architecture.ts
@@ -99,7 +99,30 @@ const EXCLUDE_PATTERNS: RegExp[] = [
 // anti-pattern this check guards against.
 const LIFECYCLE_EXEMPT = new Set(['preload', 'isLoaded'])
 
-type Violation = { file: string; line: number; snippet: string }
+type Violation = { file: string; line: number; snippet: string; rule: RuleId }
+
+type RuleId = 'module-scope-orm' | 'inline-pool-default'
+
+/**
+ * "An unset pool means FULL" — the rule `resolvePool` / `resolveGauge` own
+ * (salvageunion-reference/lib/rules/derivedStats.ts).
+ *
+ * It was written out at ~36 sites in ITUN and once more in the Discord bot,
+ * with no shared definition anywhere: `Math.min(pilot.currentHP ?? maxHP, maxHP)`
+ * for a pool, `?? 0` for Heat, which inverts. One missed `?? max` renders a
+ * healthy pilot at 0 HP; one wrong default puts a cold mech at its Heat
+ * Capacity. Nothing failed when they disagreed.
+ *
+ * The tell is `?? ` applied directly to a `current*` property: the resolvers
+ * take the raw value, so a correct call site has no `??` at all. Detected on
+ * the AST rather than by regex so a line break or a comment cannot hide it.
+ *
+ * Biome would be the natural home, but `noRestrictedSyntax` does not exist in
+ * the pinned version (2.5.x) — checked, not assumed: it rejects the key
+ * outright and `biome explain` reports "Unrecognized option". This tool already
+ * walks every file's AST, so the rule lives here instead.
+ */
+const POOL_FIELD = /^current[A-Z]/
 
 function isFunctionLike(node: ts.Node): boolean {
   return (
@@ -155,8 +178,31 @@ function checkFile(filePath: string): Violation[] {
           file: relative(root, filePath),
           line: line + 1,
           snippet: node.getText(sourceFile).replace(/\s+/g, ' ').slice(0, 100),
+          rule: 'module-scope-orm',
         })
       }
+    }
+
+    // `<something>.currentX ?? <fallback>` — the inlined pool rule.
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken &&
+      ts.isPropertyAccessExpression(node.left) &&
+      POOL_FIELD.test(node.left.name.text) &&
+      // A STRING fallback is a display decision, not the pool rule: `?? '—'`
+      // deliberately renders "unknown" rather than resolving to a number, which
+      // is a legitimate thing for a projection-fed readout to do. Only a
+      // numeric/computed fallback is the rule being inlined.
+      !ts.isStringLiteral(node.right) &&
+      !ts.isNoSubstitutionTemplateLiteral(node.right)
+    ) {
+      const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile))
+      violations.push({
+        file: relative(root, filePath),
+        line: line + 1,
+        snippet: node.getText(sourceFile).replace(/\s+/g, ' ').slice(0, 100),
+        rule: 'inline-pool-default',
+      })
     }
 
     const nextInsideFunction = insideFunction || isFunctionLike(node)
@@ -186,28 +232,48 @@ async function collectFiles(): Promise<string[]> {
  */
 const SCAN_FLOOR = 400
 
+const RULE_EXPLANATION: Record<RuleId, string> = {
+  'module-scope-orm':
+    'These execute at import time, before preload() has run, and will throw\n' +
+    '  "Schema not loaded" the instant the module is imported.\n' +
+    "  Move the call inside a function, hook, or effect that runs after the app's\n" +
+    '  preload bootstrap — see docs/architecture/package-contracts.md, "Module-Scope ORM Call Risk".',
+  'inline-pool-default':
+    'This inlines the "an unset pool means FULL" rule instead of using it.\n' +
+    "  Use resolvePool(entity.currentX, maxX) from 'salvageunion-reference/rules' —\n" +
+    '  or resolveGauge for Heat, which defaults to EMPTY, not full. Both take the raw\n' +
+    '  `current*` value, so a correct call site has no `??` at all.\n\n' +
+    '  Written out per-site, this is one keystroke from rendering an undamaged pilot\n' +
+    '  at 0 HP, or a cold mech at its Heat Capacity — and nothing fails when two\n' +
+    '  surfaces disagree about which.',
+}
+
+const RULE_HEADLINE: Record<RuleId, string> = {
+  'module-scope-orm': 'module-scope SalvageUnionReference call(s)',
+  'inline-pool-default': 'inlined pool/gauge default(s)',
+}
+
 async function main() {
   const files = await collectFiles()
   assertScanFloor('architecture', files.length, SCAN_FLOOR)
   const violations = files.flatMap(checkFile)
 
   if (violations.length > 0) {
-    console.error(`✗ Found ${violations.length} module-scope SalvageUnionReference call(s):\n`)
-    for (const v of violations) {
-      console.error(`  ${v.file}:${v.line}`)
-      console.error(`    ${v.snippet}`)
+    for (const rule of Object.keys(RULE_HEADLINE) as RuleId[]) {
+      const hits = violations.filter((v) => v.rule === rule)
+      if (hits.length === 0) continue
+      console.error(`✗ Found ${hits.length} ${RULE_HEADLINE[rule]}:\n`)
+      for (const v of hits) {
+        console.error(`  ${v.file}:${v.line}`)
+        console.error(`    ${v.snippet}`)
+      }
+      console.error(`\n  ${RULE_EXPLANATION[rule]}\n`)
     }
-    console.error(
-      '\n  These execute at import time, before preload() has run, and will throw ' +
-        '"Schema not loaded" the instant the module is imported.\n' +
-        "  Move the call inside a function, hook, or effect that runs after the app's " +
-        'preload bootstrap — see docs/architecture/package-contracts.md, "Module-Scope ORM Call Risk".'
-    )
     process.exit(1)
   }
 
   console.log(
-    `✓ No module-scope SalvageUnionReference accessor calls (${files.length} files checked).`
+    `✓ No module-scope ORM calls, no inlined pool defaults (${files.length} files checked).`
   )
 }
 


### PR DESCRIPTION
The rule was written out at ~54 sites across ITUN and once more in the Discord
bot, with no shared definition anywhere:

    Math.min(pilot.currentHP ?? maxHP, maxHP)   // pool: unset means FULL
    mech.currentHeat ?? 0                       // gauge: unset means EMPTY

It is one keystroke wide. Drop the `?? maxHP` and a healthy pilot renders at 0
HP; get the inversion backwards and a cold mech sits at its Heat Capacity, one
roll from a Reactor Overload. Nothing failed when two surfaces disagreed — the
bot's own comment records the same worry ("would render a fresh, undamaged crew
as wiped out") while spelling the rule out a third time.

Three functions now own it, in `salvageunion-reference/lib/rules/derivedStats.ts`:

  resolvePool(current, max)       display — default to full, clamp to max
  resolveGauge(current, max?)     the inversion — default to empty; `max` is
                                  optional because heat is often read as the
                                  start of arithmetic, where clamping first
                                  would be wrong
  resolvePoolStart(current, max)  WRITE paths — default to full, do NOT clamp

The third one is not a convenience. Converting the write paths to the clamping
form broke two tests, and they were right to break: `max` is DERIVED, and a
derivation returns 0 when its inputs do not resolve — an unresolvable
`chassisRef` makes `mechMaxEP` 0, which is a real state
(`MechSheet-unresolved-chassis.test.tsx` exists for it). Clamping at that
moment would write a player's EP to zero as a side effect of a lookup failure.
Showing a stale over-max number is recoverable; writing one away is not.

Enforcement, so it cannot be re-inlined: `tools/check-architecture.ts` gains an
AST rule flagging `?? ` applied to any `current*` property. The resolvers take
the raw value, so a correct call site has no `??` at all. It found 18 sites my
mechanical pass had missed — the UNCLAMPED `?? max` form, the same rule written
differently — which is the argument for an AST rule over a regex.

Two exclusions, both deliberate:
  - a STRING fallback (`?? '—'`) is a display decision, not this rule: the
    Mediator crew strip renders "unknown" for a projection that has not
    arrived, which is legitimate;
  - Biome would be the natural home, but `noRestrictedSyntax` does not exist in
    the pinned 2.5.x — verified, not assumed: it rejects the key and
    `biome explain` reports "Unrecognized option". Recorded in the tool.

Verified: full suite (5,095 tests), typecheck, lint, and the srd snapshot gate
at 1,039 pages with zero differences.

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_013Kko69Tg9VVf5LETsQ1TAR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>