### PR TITLE
fix(tools): check the docs a contributor actually reads first

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,7 @@ The project-scoped [`.mcp.json`](.mcp.json) is committed (Claude Code prompts ea
 - **Sentry** — browser + server error tracking for all three code apps (`@sentry/browser` in `srd` and `itun`, `@sentry/node` in `itun` and `discord-bot`, `@sentry/vite-plugin` for `itun` release artifacts). MCP server: remote HTTP at `https://mcp.sentry.dev/mcp`.
 - **Render** — hosts `apps/discord-bot` as a worker (see `render.yaml`). MCP server: hosted HTTP at `https://mcp.render.com/mcp`.
 - **GitHub** — repo host + Actions CI + PR workflow. MCP server: remote HTTP at `https://api.githubcopilot.com/mcp/`. **This one does not work unconfigured** — the endpoint does not support dynamic client registration, so it needs a machine-local PAT header; see the registry doc. Until then, use the `gh` CLI.
-- **Convex** — the **server of record** for accounts and Games ([ADR-030](docs/adrs/ADR-030-accounts-games-server-of-record.md)); the backend lives in `apps/itun/convex/` (17 modules — `auth.ts`, `games.ts`, `invites.ts`, `proposals.ts`, `mediator.ts`, `http.ts`, …) and the phased delivery plan is [`docs/architecture/accounts-and-games.md`](docs/architecture/accounts-and-games.md). MCP server: stdio via `bunx convex mcp start --project-dir apps/itun`, authenticating with the Convex CLI's own device credentials. It targets the **dev** deployment resolved from `CONVEX_DEPLOYMENT`, so run `bunx convex dev` once or every tool call fails; production access is gated behind flags that are deliberately **not** set.
+- **Convex** — the **server of record** for accounts and Games ([ADR-030](docs/adrs/ADR-030-accounts-games-server-of-record.md)); the backend lives in `apps/itun/convex/` (`auth.ts`, `games.ts`, `invites.ts`, `proposals.ts`, `mediator.ts`, `http.ts`, … — `tools/check-convex-codegen.ts` prints the true module count on every run, so it is not restated here) and the phased delivery plan is [`docs/architecture/accounts-and-games.md`](docs/architecture/accounts-and-games.md). MCP server: stdio via `bunx convex mcp start --project-dir apps/itun`, authenticating with the Convex CLI's own device credentials. It targets the **dev** deployment resolved from `CONVEX_DEPLOYMENT`, so run `bunx convex dev` once or every tool call fails; production access is gated behind flags that are deliberately **not** set.
 
 - **Context7** — version-pinned library documentation, remote HTTP at `https://mcp.context7.com/mcp`. Keyless on the free tier, so it adds no credential. It is here because this repo pins hard and runs ahead of model training data (TypeScript 7 + the `typescript-classic` 6 alias, Vite 8, Tailwind 4.3, Convex 1.43, TanStack Router 1.170) — "what is the API in **this** version" is the recurring failure. Two tools, the smallest context cost of any server here. Treat what it returns as advisory: the docs are condensed, not authoritative.
 
@@ -303,7 +303,7 @@ bun --filter srd gate             # build, then diff the output against the comm
 - `apps/srd/` - Static SRD reference site (in-house SSG at `apps/srd/ssg`, React 19 islands, Tailwind v4, Vite). No auth, no backend, no user data. **Not Astro** — Astro was removed; see the "srd App" section below.
 - `apps/itun/` - Character builder & game manager (React 19, TanStack Router/Query, ShadCN + Tailwind v4, Vite). Has roster, wizards, dashboard, live sheets, snapshot sharing. **Two storage modes** ([ADR-030](docs/adrs/ADR-030-accounts-games-server-of-record.md), which supersedes ADR-001): **Solo** — not signed in, IndexedDB is the source of truth, nothing is gated, and this must keep working forever (a build with no `VITE_CONVEX_URL` is permanently Solo); **Connected / Disconnected** — signed in, Convex (`apps/itun/convex/`) is the source of truth and IndexedDB becomes a cache, with offline meaning read-only rather than a write queue. Resolve the mode through `src/lib/connection/`, never by reading `navigator.onLine` or an auth flag directly. Read [`apps/itun/CLAUDE.md`](apps/itun/CLAUDE.md) before touching data.
 - `apps/discord-bot/` - Discord.js bot for rolling on Salvage Union tables
-- `apps/su-assets/` - Dedicated Netlify site (`assets.salvageunion.io`) serving licensed entity artwork from a Netlify Blobs store via one function. Image bytes live in Blobs, never in git. `packages/salvageunion-reference` points at it at runtime (`ASSET_BASE_URL` in `lib/utilities.ts`), so entity-card artwork in both `srd` and `itun` depends on it.
+- `apps/su-assets/` - Dedicated Netlify site (`assets.salvageunion.io`) serving licensed entity artwork from a Netlify Blobs store via one function. Image bytes live in Blobs, never in git. `packages/salvageunion-reference` points at it at runtime (`ASSET_BASE_URL` in `lib/assets.ts`, re-exported from `lib/utilities.ts`), so entity-card artwork in both `srd` and `itun` depends on it.
 - `packages/component-lib/` - Shared React component library (ShadCN + Tailwind, entity display system, base typography, UI primitives). No build step, exports TypeScript source.
 - `packages/observability/` - Sentry wiring shared by the Node surfaces (`/node`: the two Netlify Functions + the Discord bot) plus the capture-hint helper the two browser shims share (`/browser`, imports no Sentry code).
 - `packages/salvageunion-reference/` - TypeScript ORM + schema-validated JSON dataset for game data
@@ -329,15 +329,16 @@ Detailed cross-cutting architecture docs live in `docs/architecture/`:
 - **[seo-accessibility.md](docs/architecture/seo-accessibility.md)** — SEO strategy (srd) and WCAG 2.1 AA compliance patterns
 - **[package-contracts.md](docs/architecture/package-contracts.md)** — Package APIs, dependency rules, cross-package change checklist
 
-### Code Conventions (from `.claude/rules/`)
+### Code Conventions
 
-- **Always use relative imports** (never `@/` path aliases)
-- **Use `type` over `interface`** for object types (unless extending)
-- **Avoid `any`** - use `unknown` if type is truly unknown
-- **Use `import type`** syntax for type-only imports
-- **Named exports** everywhere except route components (which may use default exports for TanStack Router)
-- **Bun** for all package management (not npm/yarn)
-- **Biome** for formatting/linting — the **only** formatter. Prettier has been removed entirely (it is not a dependency, and `lefthook.yml` has no Markdown/YAML step). Biome still cannot parse Markdown or YAML, so `.md`/`.yml` are formatted by **nothing** — keep them tidy by hand. Pre-commit hooks via Lefthook
+Relative imports only, `type` over `interface`, no `any`, `import type`, named
+exports outside route components — **all five are Biome rules**, so `bun run
+lint` is the authority, not this list. See [`biome.jsonc`](biome.jsonc) and
+[`.claude/rules/typescript-style.md`](.claude/rules/typescript-style.md).
+
+Not enforced, so stated here: **Bun** for package management (never npm/yarn),
+and Biome cannot parse Markdown or YAML — `.md`/`.yml` are formatted by
+**nothing**, so keep them tidy by hand.
 
 ### salvageunion-reference Package
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ bot, and two shared packages.
 # Install all workspace dependencies
 bun install
 
-# Build the reference package (required before apps can resolve types)
+# Regenerate the reference package's committed artifacts (JSON Schemas, the
+# registry codegen, the schema catalog and the API report). NOT required before
+# the apps can resolve types — the package ships TypeScript source.
 bun run build:package
 
 # Start the reference site dev server (builds package, then serves srd)
@@ -29,21 +31,26 @@ Other dev servers: `bun run dev:itun` (character builder), `bun run dev:bot`
 ```
 .
 ├── apps/
-│   ├── srd/              # Static SRD reference site (in-house SSG in srd/ssg + React islands)
-│   ├── itun/       # Character builder & game manager (React 19, local-first)
-│   └── discord-bot/            # Discord.js bot for rolling on SU tables
+│   ├── srd/                    # Static SRD reference site (in-house SSG in srd/ssg + React islands)
+│   ├── itun/                   # Character builder & game manager (React 19)
+│   ├── discord-bot/            # Discord.js bot for rolling on SU tables
+│   └── su-assets/              # Netlify site serving entity artwork from Blobs
 ├── packages/
-│   ├── salvageunion-reference/ # Game-data ORM + schema-validated JSON dataset (built)
-│   └── component-lib/            # Shared React component library (no build step)
+│   ├── salvageunion-reference/ # Game-data ORM + schema-validated JSON dataset
+│   ├── component-lib/          # Shared React component library
+│   └── observability/          # Sentry wiring shared by the Node surfaces
 ├── docs/                       # Architecture docs + ADRs (see docs/README.md)
 ├── package.json                # Root workspace configuration
 ├── biome.jsonc                 # Shared Biome (lint + format) config
 └── tsconfig.json               # Shared TypeScript base config
 ```
 
-**Dependency graph:** `salvageunion-reference → component-lib → {srd,
-itun}`; `discord-bot` is standalone. The reference package must be
-built (`bun run build:package`) before the apps can resolve its types.
+**Dependency graph:** `salvageunion-reference → component-lib → {srd, itun}`;
+`discord-bot` depends on the reference package directly. **No package has a
+build step** — both ship TypeScript source, which the consuming apps' bundlers
+compile. `bun run build:package` regenerates committed artifacts (JSON Schemas,
+registry codegen, the schema catalog, the API report) and CI fails on drift; it
+is not a prerequisite for typechecking or running anything.
 
 ## Common Commands
 

--- a/apps/itun/CLAUDE.md
+++ b/apps/itun/CLAUDE.md
@@ -38,7 +38,7 @@ consumers, one renderer. Don't add a fourth read-only sheet renderer.
 - **TanStack Query** — only for async/derived/server-touching data (snapshots).
   **Not** the persistence cache — see below.
 - **Zustand** stores for persistent client state (`src/stores/`).
-- **ShadCN + Tailwind v4** — UI primitives in `src/components/ui/`; SU brand
+- **Base UI + Tailwind v4** — UI primitives come from `component-lib` (`ui/`, `chrome/`, `base/`), NOT from an app-local `src/components/ui/`; there is no such directory. SU brand
   theme in `src/index.css` (`@theme` block) + `component-lib` theme.
 - **PWA** (`vite-plugin-pwa`, **`registerType: 'prompt'`**) — installable,
   offline-capable. It is `prompt` and must stay that way: `autoUpdate` force-sets

--- a/packages/salvageunion-reference/README.md
+++ b/packages/salvageunion-reference/README.md
@@ -171,7 +171,7 @@ const heavyEquipment: SURefEquipment[] = Equipment.findAll((e) => (e.techLevel ?
 
 ```bash
 # Validate all data against JSON schemas
-bun run validate
+bun run validate:all
 
 # Validate all IDs are unique UUIDs (including nested objects)
 bun run validate:ids
@@ -202,7 +202,7 @@ Contributions are welcome! Please:
 
 1. Ensure all data includes page references
 2. Ensure all items have unique UUIDs (run `bun run validate:ids`)
-3. Validate changes with `bun run validate`
+3. Validate changes with `bun run validate:all`
 4. Run type checking with `bun run typecheck`
 5. Follow existing data structure patterns
 

--- a/tools/check-doc-drift.ts
+++ b/tools/check-doc-drift.ts
@@ -210,10 +210,39 @@ const HISTORICAL_DOCS = new Set([
   'docs/architecture/game-invites-and-membership-plan.md',
 ])
 
+/**
+ * Per-workspace instruction docs and the two files a new contributor opens
+ * first.
+ *
+ * These were outside the live set, and it showed. `README.md` twice stated the
+ * reference package "must be built before the apps can resolve its types" —
+ * there has been no such step since the package started shipping TypeScript
+ * source — and `packages/salvageunion-reference/README.md` instructed
+ * `bun run validate`, which is not a script in that manifest. Check 7 exists to
+ * stop docs naming dead commands and was running green while three did.
+ *
+ * The per-app `CLAUDE.md` files matter more than their size suggests: each is
+ * loaded into every agent session scoped to that app, so a false claim there is
+ * FOLLOWED rather than read. `apps/itun/CLAUDE.md` still named a
+ * `src/components/ui/` directory that does not exist.
+ */
 function liveInstructionDocs(root: string): string[] {
-  return ['CLAUDE.md', ...LIVE_INSTRUCTION_DOC_DIRS.flatMap((dir) => markdownIn(root, dir))].filter(
-    (doc) => !HISTORICAL_DOCS.has(doc) && existsSync(join(root, doc))
-  )
+  const perWorkspace = ['apps', 'packages'].flatMap((dir) => {
+    // A test fixture root has neither directory; the filter below drops any
+    // path that does not exist, but `readdirSync` on a missing dir throws.
+    const base = join(root, dir)
+    if (!existsSync(base)) return []
+    return readdirSync(base, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .flatMap((entry) => [`${dir}/${entry.name}/CLAUDE.md`, `${dir}/${entry.name}/README.md`])
+  })
+  return [
+    'CLAUDE.md',
+    'README.md',
+    'CONTRIBUTING.md',
+    ...perWorkspace,
+    ...LIVE_INSTRUCTION_DOC_DIRS.flatMap((dir) => markdownIn(root, dir)),
+  ].filter((doc) => !HISTORICAL_DOCS.has(doc) && existsSync(join(root, doc)))
 }
 
 /**
@@ -884,21 +913,49 @@ function scriptsOf(root: string, manifest: string): Set<string> {
   return new Set(Object.keys(pkg.scripts ?? {}))
 }
 
-/** Workspace directory by package name, for `bun --filter <name> <script>`. */
-const WORKSPACE_MANIFESTS: Record<string, string> = {
-  srd: 'apps/srd/package.json',
-  itun: 'apps/itun/package.json',
-  'discord-bot': 'apps/discord-bot/package.json',
-  'su-assets': 'apps/su-assets/package.json',
-  'component-lib': 'packages/component-lib/package.json',
-  'salvageunion-reference': 'packages/salvageunion-reference/package.json',
+/**
+ * Workspace directory by package name, for `bun --filter <name> <script>`.
+ * Discovered rather than listed, so a new workspace is covered on the day it
+ * lands instead of silently escaping the check.
+ */
+function workspaceManifests(root: string): Record<string, string> {
+  return Object.fromEntries(
+    ['apps', 'packages'].flatMap((dir) => {
+      const base = join(root, dir)
+      if (!existsSync(base)) return []
+      return readdirSync(base, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .filter((entry) => existsSync(join(base, entry.name, 'package.json')))
+        .map((entry) => {
+          const manifest = `${dir}/${entry.name}/package.json`
+          const pkg = JSON.parse(readFileSync(join(root, manifest), 'utf-8')) as { name?: string }
+          return [pkg.name ?? entry.name, manifest] as const
+        })
+    })
+  )
+}
+
+/**
+ * The workspace a doc belongs to, if any — `apps/srd/CLAUDE.md` → `apps/srd`.
+ *
+ * A per-workspace doc may reference that workspace's OWN scripts without
+ * `--filter`, because that is how you run them from inside the directory:
+ * `apps/srd/CLAUDE.md` documents `bun run gate`, which is a script in
+ * `apps/srd/package.json` and deliberately not in the root's. Resolving those
+ * against the root manifest alone reported four false failures the moment these
+ * files entered scope.
+ */
+function owningManifest(doc: string): string | undefined {
+  const m = doc.match(/^((?:apps|packages)\/[^/]+)\//)
+  return m ? `${m[1]}/package.json` : undefined
 }
 
 function checkReferencedScripts(root: string): { ok: string; failures: string[] } {
   const failures: string[] = []
   const rootScripts = scriptsOf(root, 'package.json')
+  const manifests = workspaceManifests(root)
   const workspaceScripts = new Map<string, Set<string>>()
-  for (const [name, manifest] of Object.entries(WORKSPACE_MANIFESTS)) {
+  for (const [name, manifest] of Object.entries(manifests)) {
     workspaceScripts.set(name, scriptsOf(root, manifest))
   }
 
@@ -906,13 +963,19 @@ function checkReferencedScripts(root: string): { ok: string; failures: string[] 
   for (const doc of liveInstructionDocs(root)) {
     const text = readFileSync(join(root, doc), 'utf-8')
 
+    const localScripts = (() => {
+      const manifest = owningManifest(doc)
+      return manifest ? scriptsOf(root, manifest) : new Set<string>()
+    })()
+
     for (const m of text.matchAll(/\bbun run ([a-z][\w:-]*)/g)) {
       const script = m[1]
       if (script === undefined) continue
       checked++
-      if (!rootScripts.has(script)) {
+      if (!rootScripts.has(script) && !localScripts.has(script)) {
         failures.push(
-          `${doc} references \`bun run ${script}\`, which is not a script in the root package.json.\n` +
+          `${doc} references \`bun run ${script}\`, which is not a script in the root package.json` +
+            `${owningManifest(doc) ? ` or in ${owningManifest(doc)}` : ''}.\n` +
             `  → rename the reference to the surviving script, or drop it.`
         )
       }
@@ -928,7 +991,7 @@ function checkReferencedScripts(root: string): { ok: string; failures: string[] 
       if (!known.has(script)) {
         failures.push(
           `${doc} references \`bun --filter ${workspace} ${script}\`, which is not a script in ` +
-            `${WORKSPACE_MANIFESTS[workspace]}.\n  → rename the reference to the surviving script, or drop it.`
+            `${manifests[workspace]}.\n  → rename the reference to the surviving script, or drop it.`
         )
       }
     }


### PR DESCRIPTION
`check-doc-drift` read four directories plus the root CLAUDE.md — 5 of the
repo's instruction docs. Everything else was unchecked, and it showed. With the
scope widened to per-workspace CLAUDE.md and README files, three real errors
surfaced immediately:

  README.md          twice claimed the reference package "must be built before
                     the apps can resolve its types". There has been no such
                     step since it started shipping TypeScript source; the
                     build only regenerates committed artifacts. It also
                     labelled the package "(built)" and listed 5 of 7
                     workspaces.
  salvageunion-      instructed `bun run validate` — not a script in that
  reference/README   manifest. Check 7 exists precisely to stop docs naming
                     dead commands, and was green while this one did.
  apps/itun/CLAUDE.md named `src/components/ui/` as the primitive home. That
                     directory does not exist; primitives live in
                     component-lib's `chrome/`.

The per-app files matter more than their size suggests: each is loaded into
every agent session scoped to that app, so a false claim there is FOLLOWED
rather than read.

Widening needed one real fix to the checker, not just a bigger list. Resolving
`bun run <script>` against the ROOT manifest alone reported four FALSE failures
the moment these files entered scope — `apps/srd/CLAUDE.md` documents
`bun run gate`, which is a script in `apps/srd/package.json` and deliberately
not in the root's. Script references now resolve against the owning workspace
too. Coverage went from 79 to 181 references checked.

`workspaceManifests` is also now discovered rather than hardcoded (it had
listed six workspaces by hand, and there are seven), and both directory scans
guard a missing `apps/`/`packages/` so the checker still runs against the test
fixtures' roots.

Root CLAUDE.md, in the same pass:
  - `ASSET_BASE_URL` corrected to `lib/assets.ts` (it is only re-exported from
    `lib/utilities.ts`);
  - the "17 modules" Convex count removed rather than corrected — it was wrong,
    and `check-convex-codegen` prints the true number on every run;
  - the Code Conventions list replaced with a pointer to `biome.jsonc`, since
    all five are Biome rules and a copy here can disagree with the linter.

I did NOT chase the ~33% cut the audit suggested. Re-reading the file, most of
its length is reasoning that exists nowhere else — the audit-gate suppressions,
the install cooldown, the profiling recipes — and cutting those would delete
context rather than de-duplicate it. The blocks with a genuine owner elsewhere
are handled above.

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_013Kko69Tg9VVf5LETsQ1TAR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>