### PR TITLE
fix: break two import cycles and ratchet the card's size

### DIFF
--- a/apps/itun/src/lib/db/migrations/10-workspace-default-backfill.ts
+++ b/apps/itun/src/lib/db/migrations/10-workspace-default-backfill.ts
@@ -37,7 +37,7 @@ const DEFAULT_WORKSPACE = {
 } as const
 
 import { STORE_NAMES } from '../stores'
-import type { UpgradeTransaction } from './index'
+import type { UpgradeTransaction } from './types'
 
 /** Object stores whose records get the Default-workspace backfill. */
 const BACKFILL_STORES: readonly string[] = [

--- a/apps/itun/src/lib/db/migrations/11-equipment-loadouts-to-partners.ts
+++ b/apps/itun/src/lib/db/migrations/11-equipment-loadouts-to-partners.ts
@@ -32,7 +32,7 @@
 
 import { isRecord } from '../../isRecord'
 import { STORE_NAMES } from '../stores'
-import type { UpgradeTransaction } from './index'
+import type { UpgradeTransaction } from './types'
 
 /**
  * Choice names carrying a partner's identity, as they appear in

--- a/apps/itun/src/lib/db/migrations/12-companion-mechs-to-partners.ts
+++ b/apps/itun/src/lib/db/migrations/12-companion-mechs-to-partners.ts
@@ -50,7 +50,7 @@
 
 import { isRecord } from '../../isRecord'
 import { STORE_NAMES } from '../stores'
-import type { UpgradeTransaction } from './index'
+import type { UpgradeTransaction } from './types'
 
 /**
  * The `equipment` records that carry a mech-shaped stat block, i.e. the only

--- a/apps/itun/src/lib/db/migrations/13-workspace-to-game-or-shelf.ts
+++ b/apps/itun/src/lib/db/migrations/13-workspace-to-game-or-shelf.ts
@@ -1,4 +1,4 @@
-import type { UpgradeTransaction } from './index'
+import type { UpgradeTransaction } from './types'
 
 /**
  * v12 → v13: give every entity an explicit container (ADR-030 §2).

--- a/apps/itun/src/lib/db/migrations/14-starter-set-seed-ref.ts
+++ b/apps/itun/src/lib/db/migrations/14-starter-set-seed-ref.ts
@@ -1,4 +1,4 @@
-import type { UpgradeTransaction } from './index'
+import type { UpgradeTransaction } from './types'
 
 /**
  * v13 → v14: record Starter Set provenance as `seedRef`.

--- a/apps/itun/src/lib/db/migrations/15-partner-equipment-backfill.ts
+++ b/apps/itun/src/lib/db/migrations/15-partner-equipment-backfill.ts
@@ -46,7 +46,7 @@
 
 import { isRecord } from '../../isRecord'
 import { STORE_NAMES } from '../stores'
-import type { UpgradeTransaction } from './index'
+import type { UpgradeTransaction } from './types'
 
 /**
  * The `equipment` records carrying a mech-shaped stat block — the only slugs a

--- a/apps/itun/src/lib/db/migrations/3-cargo-to-cargo-lots.ts
+++ b/apps/itun/src/lib/db/migrations/3-cargo-to-cargo-lots.ts
@@ -13,7 +13,7 @@
 import { isRecord } from '../../isRecord'
 import { normalizeLegacyCargoRecord } from '../../schemas/cargoLot'
 import { STORE_NAMES } from '../stores'
-import type { UpgradeTransaction } from './index'
+import type { UpgradeTransaction } from './types'
 
 export async function migrate(tx: UpgradeTransaction): Promise<void> {
   for (const storeName of [STORE_NAMES.mechs, STORE_NAMES.mechPatterns]) {

--- a/apps/itun/src/lib/db/migrations/4-remove-pilot-roll-results.ts
+++ b/apps/itun/src/lib/db/migrations/4-remove-pilot-roll-results.ts
@@ -13,7 +13,7 @@
 import { isRecord } from '../../isRecord'
 import { normalizeLegacyPilotRecord } from '../../schemas/pilot'
 import { STORE_NAMES } from '../stores'
-import type { UpgradeTransaction } from './index'
+import type { UpgradeTransaction } from './types'
 
 export async function migrate(tx: UpgradeTransaction): Promise<void> {
   if (!tx.db.objectStoreNames.contains(STORE_NAMES.pilots)) return

--- a/apps/itun/src/lib/db/migrations/6-mech-refs-to-slugs.ts
+++ b/apps/itun/src/lib/db/migrations/6-mech-refs-to-slugs.ts
@@ -28,7 +28,7 @@
 import { nameToSlug } from 'salvageunion-reference'
 import { isRecord } from '../../isRecord'
 import { STORE_NAMES } from '../stores'
-import type { UpgradeTransaction } from './index'
+import type { UpgradeTransaction } from './types'
 
 /** Slugify one ref; leaves empty strings untouched. */
 function slugifyRef(ref: unknown): unknown {

--- a/apps/itun/src/lib/db/migrations/8-crawler-battle-sp-to-derived.ts
+++ b/apps/itun/src/lib/db/migrations/8-crawler-battle-sp-to-derived.ts
@@ -35,7 +35,7 @@
 
 import { isRecord } from '../../isRecord'
 import { STORE_NAMES } from '../stores'
-import type { UpgradeTransaction } from './index'
+import type { UpgradeTransaction } from './types'
 
 /** The Battle crawler type's SRD id + name at ship time (frozen snapshot). */
 const BATTLE_TYPE_REFS: readonly string[] = ['3d1d9f79-9c56-43fa-a4c9-6dfe10b9aac9', 'Battle']

--- a/apps/itun/src/lib/db/migrations/README.md
+++ b/apps/itun/src/lib/db/migrations/README.md
@@ -19,7 +19,7 @@ Example: `3-cargo-to-cargo-lots.ts`
    performs the record rewrites for that version:
 
    ```typescript
-   import type { UpgradeTransaction } from './index'
+   import type { UpgradeTransaction } from './types'
 
    export async function migrate(tx: UpgradeTransaction): Promise<void> {
      let cursor = await tx.objectStore('mechs').openCursor()

--- a/apps/itun/src/lib/db/migrations/index.ts
+++ b/apps/itun/src/lib/db/migrations/index.ts
@@ -17,7 +17,7 @@
  *   - Never edit a shipped migration — add a new version.
  */
 
-import type { IDBPDatabase, IDBPTransaction, StoreNames } from 'idb'
+import type { IDBPDatabase } from 'idb'
 import { migrate as migrate3CargoToCargoLots } from './3-cargo-to-cargo-lots'
 import { migrate as migrate4RemovePilotRollResults } from './4-remove-pilot-roll-results'
 import { migrate as migrate6MechRefsToSlugs } from './6-mech-refs-to-slugs'
@@ -28,13 +28,12 @@ import { migrate as migrate12CompanionMechsToPartners } from './12-companion-mec
 import { migrate as migrate13WorkspaceToGameOrShelf } from './13-workspace-to-game-or-shelf'
 import { migrate as migrate14StarterSetSeedRef } from './14-starter-set-seed-ref'
 import { migrate as migrate15PartnerEquipmentBackfill } from './15-partner-equipment-backfill'
+// Declared in the leaf `./types` so the migrations can import it without
+// importing this barrel (which imports all of them). Re-exported here so
+// existing import paths keep working.
+import type { UpgradeTransaction } from './types'
 
-/** The untyped versionchange transaction handed to the idb upgrade callback. */
-export type UpgradeTransaction = IDBPTransaction<
-  unknown,
-  ArrayLike<StoreNames<unknown>>,
-  'versionchange'
->
+export type { UpgradeTransaction } from './types'
 
 type MigrationFn = (
   tx: UpgradeTransaction,

--- a/apps/itun/src/lib/db/migrations/types.ts
+++ b/apps/itun/src/lib/db/migrations/types.ts
@@ -1,0 +1,17 @@
+import type { IDBPTransaction, StoreNames } from 'idb'
+
+/**
+ * The untyped versionchange transaction handed to the idb upgrade callback.
+ *
+ * This type lives in a LEAF module rather than in `./index`, which imports every
+ * migration. Each migration needs the type, so importing it from `./index` made
+ * an 11-node import cycle — harmless at runtime (every edge is `import type`, so
+ * all of it erases), but a cycle to every tool that reads the module graph, and
+ * the kind of thing that stops being type-only the first time someone needs a
+ * value from the barrel.
+ */
+export type UpgradeTransaction = IDBPTransaction<
+  unknown,
+  ArrayLike<StoreNames<unknown>>,
+  'versionchange'
+>

--- a/packages/component-lib/src/components/chrome/Field.tsx
+++ b/packages/component-lib/src/components/chrome/Field.tsx
@@ -209,54 +209,14 @@ export function Field(props: FieldProps) {
   )
 }
 
-type InputProps = ComponentPropsWithoutRef<'input'>
-
-/**
- * Text input (design-spec §2.5 `.input`): paper bg, 1.5px ink border, 3px
- * radius, rust focus ring (no outline).
- */
-export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  { className, ...props },
-  ref
-) {
-  return (
-    <input
-      ref={ref}
-      className={cn(
-        'w-full rounded-card border-chrome border-ink bg-paper px-3 py-2.5 font-body text-sm text-ink placeholder:text-wk-muted',
-        INPUT_FOCUS,
-        className
-      )}
-      {...props}
-    />
-  )
-})
-
-type TextareaProps = ComponentPropsWithoutRef<'textarea'>
-
-/**
- * Multiline text input (design-spec §2.5): the `Input` sibling — identical
- * paper / 1.5px-ink / 3px-radius / rust-ring skin, with vertical resize.
- * `Field`-wrappable exactly like `Input`. Distinct from `InlineEditField`'s
- * internal textarea (that one is a click-to-edit control, this is a plain field).
- */
-export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
-  { className, rows = 3, ...props },
-  ref
-) {
-  return (
-    <textarea
-      ref={ref}
-      rows={rows}
-      className={cn(
-        'w-full resize-y rounded-card border-chrome border-ink bg-paper px-3 py-2.5 font-body text-sm text-ink placeholder:text-wk-muted',
-        INPUT_FOCUS,
-        className
-      )}
-      {...props}
-    />
-  )
-})
+// `Input` and `Textarea` now live in the leaf module `./inputs`, and are
+// re-exported here so every existing import path still resolves.
+//
+// They moved to break a two-node runtime import cycle: this file imports
+// `InlineEditField`, which imported `Input`/`Textarea` back from here. srd's SSR
+// pass evaluates this source under Bun with no bundler, where a cycle is
+// TDZ-sensitive and evaluation-order dependent.
+export { Input, Textarea } from './inputs'
 
 type SelectProps = ComponentPropsWithoutRef<'select'> & {
   /**

--- a/packages/component-lib/src/components/chrome/InlineEditField.tsx
+++ b/packages/component-lib/src/components/chrome/InlineEditField.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react'
 import { cn } from '../../utils/cn'
-import { Input, Textarea } from './Field'
 import { FieldError } from './FieldError'
+import { Input, Textarea } from './inputs'
 import { INPUT_FOCUS } from './interaction'
 
 // ---------------------------------------------------------------------------

--- a/packages/component-lib/src/components/chrome/inputs.tsx
+++ b/packages/component-lib/src/components/chrome/inputs.tsx
@@ -1,0 +1,66 @@
+/**
+ * The two bare text-entry primitives, in a LEAF module.
+ *
+ * They lived in `Field.tsx`, which imports `InlineEditField`, which imports
+ * them back — a two-node runtime import cycle (both edges are value imports,
+ * not types). Cycles are worse here than in most codebases: srd's SSR pass
+ * evaluates this TypeScript under Bun with no bundler in the loop, where cyclic
+ * module initialisation is TDZ-sensitive and depends on evaluation order.
+ *
+ * Nothing else changes — `Field.tsx` re-exports both, so every existing import
+ * still resolves and no rendered markup moves.
+ */
+
+import type { ComponentPropsWithoutRef } from 'react'
+import { forwardRef } from 'react'
+import { cn } from '../../utils/cn'
+import { INPUT_FOCUS } from './interaction'
+
+type InputProps = ComponentPropsWithoutRef<'input'>
+
+/**
+ * Text input (design-spec §2.5 `.input`): paper bg, 1.5px ink border, 3px
+ * radius, rust focus ring (no outline).
+ */
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { className, ...props },
+  ref
+) {
+  return (
+    <input
+      ref={ref}
+      className={cn(
+        'w-full rounded-card border-chrome border-ink bg-paper px-3 py-2.5 font-body text-sm text-ink placeholder:text-wk-muted',
+        INPUT_FOCUS,
+        className
+      )}
+      {...props}
+    />
+  )
+})
+
+type TextareaProps = ComponentPropsWithoutRef<'textarea'>
+
+/**
+ * Multiline text input (design-spec §2.5): the `Input` sibling — identical
+ * paper / 1.5px-ink / 3px-radius / rust-ring skin, with vertical resize.
+ * `Field`-wrappable exactly like `Input`. Distinct from `InlineEditField`'s
+ * internal textarea (that one is a click-to-edit control, this is a plain field).
+ */
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { className, rows = 3, ...props },
+  ref
+) {
+  return (
+    <textarea
+      ref={ref}
+      rows={rows}
+      className={cn(
+        'w-full resize-y rounded-card border-chrome border-ink bg-paper px-3 py-2.5 font-body text-sm text-ink placeholder:text-wk-muted',
+        INPUT_FOCUS,
+        className
+      )}
+      {...props}
+    />
+  )
+})

--- a/tools/check-architecture.ts
+++ b/tools/check-architecture.ts
@@ -101,7 +101,7 @@ const LIFECYCLE_EXEMPT = new Set(['preload', 'isLoaded'])
 
 type Violation = { file: string; line: number; snippet: string; rule: RuleId }
 
-type RuleId = 'module-scope-orm' | 'inline-pool-default'
+type RuleId = 'module-scope-orm' | 'inline-pool-default' | 'oversized-function'
 
 /**
  * "An unset pool means FULL" — the rule `resolvePool` / `resolveGauge` own
@@ -123,6 +123,30 @@ type RuleId = 'module-scope-orm' | 'inline-pool-default'
  * walks every file's AST, so the rule lives here instead.
  */
 const POOL_FIELD = /^current[A-Z]/
+
+/**
+ * Function-body ratchet for `packages/component-lib`.
+ *
+ * `ReferenceEntityCard.tsx` is 2,479 lines and the most-churned source file in
+ * the repo — 24 commits in three months — because ONE function inside it is
+ * ~1,870 lines with 45 props and four exits. Six independent workstreams edit
+ * that single body, so every change has blast radius across all six render
+ * regions and parallel work conflicts on one file.
+ *
+ * This does NOT decompose it. It stops it growing, which is the part a tool can
+ * do: the cap is seeded at today's largest body, so the file can only get
+ * smaller. Decomposition wants a human and a visual review — the srd snapshot
+ * gate digests `<main>` TEXT, not markup, and says so explicitly, so a
+ * class-level regression in this renderer would pass every gate in the repo.
+ *
+ * Seeded at 1,823 — the exact size of `ReferenceEntityCardInner` today, so ONE
+ * more line in it fails CI. The next largest body in the package is 364 lines,
+ * so this constrains exactly the one function that needs constraining and
+ * nothing else.
+ *
+ * Lower the number when a seam lands. Never raise it.
+ */
+const COMPONENT_LIB_FUNCTION_CAP = 1823
 
 function isFunctionLike(node: ts.Node): boolean {
   return (
@@ -183,6 +207,31 @@ function checkFile(filePath: string): Violation[] {
       }
     }
 
+    // An oversized function body in component-lib.
+    if (RATCHET_SCOPE.test(relative(root, filePath))) {
+      const fn = node as ts.FunctionLikeDeclaration
+      const isFn =
+        ts.isFunctionDeclaration(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isArrowFunction(node) ||
+        ts.isMethodDeclaration(node)
+      if (isFn && fn.body) {
+        const startLine = sourceFile.getLineAndCharacterOfPosition(
+          fn.body.getStart(sourceFile)
+        ).line
+        const endLine = sourceFile.getLineAndCharacterOfPosition(fn.body.getEnd()).line
+        const length = endLine - startLine + 1
+        if (length > COMPONENT_LIB_FUNCTION_CAP) {
+          violations.push({
+            file: relative(root, filePath),
+            line: startLine + 1,
+            snippet: `${(node as ts.FunctionDeclaration).name?.getText(sourceFile) ?? '<anonymous>'} — ${length} lines (cap ${COMPONENT_LIB_FUNCTION_CAP})`,
+            rule: 'oversized-function',
+          })
+        }
+      }
+    }
+
     // `<something>.currentX ?? <fallback>` — the inlined pool rule.
     if (
       ts.isBinaryExpression(node) &&
@@ -232,12 +281,20 @@ async function collectFiles(): Promise<string[]> {
  */
 const SCAN_FLOOR = 400
 
+/** Only the shared component library is ratcheted; apps are not (yet). */
+const RATCHET_SCOPE = /^packages\/component-lib\//
+
 const RULE_EXPLANATION: Record<RuleId, string> = {
   'module-scope-orm':
     'These execute at import time, before preload() has run, and will throw\n' +
     '  "Schema not loaded" the instant the module is imported.\n' +
     "  Move the call inside a function, hook, or effect that runs after the app's\n" +
     '  preload bootstrap — see docs/architecture/package-contracts.md, "Module-Scope ORM Call Risk".',
+  'oversized-function':
+    'This function body is over the component-lib ratchet.\n' +
+    '  The cap is seeded at the largest body that existed when it was added, so it\n' +
+    '  only ever goes DOWN. Extract a seam rather than raising it — and lower the\n' +
+    '  constant in tools/check-architecture.ts in the same commit.',
   'inline-pool-default':
     'This inlines the "an unset pool means FULL" rule instead of using it.\n' +
     "  Use resolvePool(entity.currentX, maxX) from 'salvageunion-reference/rules' —\n" +
@@ -251,6 +308,7 @@ const RULE_EXPLANATION: Record<RuleId, string> = {
 const RULE_HEADLINE: Record<RuleId, string> = {
   'module-scope-orm': 'module-scope SalvageUnionReference call(s)',
   'inline-pool-default': 'inlined pool/gauge default(s)',
+  'oversized-function': 'function(s) over the component-lib size ratchet',
 }
 
 async function main() {


### PR DESCRIPTION
Two cycles, removed by moving a leaf out from under its own consumer. Neither
changes a line of rendered output.

  chrome/Field.tsx ↔ chrome/InlineEditField.tsx — a RUNTIME cycle (both edges
  are value imports). `Input`/`Textarea` move to `chrome/inputs.tsx`; `Field`
  re-exports them, so every existing import path still resolves. This matters
  more here than in most codebases: srd's SSR pass evaluates this TypeScript
  under Bun with no bundler, where cyclic initialisation is TDZ-sensitive and
  evaluation-order dependent.

  db/migrations/index.ts ↔ its 11 migrations — a TYPE-ONLY cycle (harmless at
  runtime, since every edge erases, but a cycle to every tool that reads the
  module graph, and one bad day from needing a value). `UpgradeTransaction`
  moves to a leaf `migrations/types.ts`; the barrel re-exports it.

AND A RATCHET, NOT A DECOMPOSITION. `ReferenceEntityCard.tsx` is 2,479 lines
and the most-churned file in the repo because ONE function inside it is 1,823
lines with 45 props and four exits — six workstreams editing one body.
`check-architecture.ts` now caps function-body length in component-lib, seeded
at exactly 1,823, so ONE more line in that function fails CI. The next largest
body in the package is 364 lines, so it constrains the one function that needs
constraining and nothing else. Proved: a single added line reports
"ReferenceEntityCardInner — 1824 lines (cap 1823)".

I did NOT attempt the S1–S3 seam extraction (~850 lines) in this stack, and the
reason is the gate coverage rather than the effort. The srd snapshot gate
digests `<main>` TEXT, not markup or attributes — `apps/srd/CLAUDE.md` says so
outright, citing the CardImage regression that hid every piece of entity artwork
behind `style="opacity:0"` and passed. So a class-level regression in the
renderer for 82% of SRD pages would clear every gate in this repo. That
refactor wants a human looking at the pages; the ratchet is what stops the
problem growing until then, and it is a forcing function for doing it with
review.

One correction while in there: the audit that prompted this reported the header
stat cluster at line 745 as "built TWICE — pure waste on the hottest render
path". It is not waste. Line 790 reuses the first list when the card is compact
and builds a second ONLY for non-compact, where the abbreviated labels are
genuinely different and feed `narrowStats` for the header's self-measuring
narrow fallback. The comment above it already explains this. Left alone.

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_013Kko69Tg9VVf5LETsQ1TAR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>