### PR TITLE
fix(itun): bound the Downtime step index, per the book

### DIFF
--- a/apps/itun/convex/downtime.ts
+++ b/apps/itun/convex/downtime.ts
@@ -101,6 +101,23 @@ export const begin = mutation({
   },
 })
 
+/**
+ * How many steps the Crawler Downtime procedure has.
+ *
+ * The book is the source: Core Book p.227-228 walks ten named steps, "Tally
+ * Salvage" through "Prepare for the next Salvage Run", and says explicitly that
+ * you "may go back to any of these steps". The dataset carries them as the
+ * Crawler Downtime guide, which is what `DowntimeWizard` renders and what the
+ * SRD publishes.
+ *
+ * Convex deliberately has no access to `salvageunion-reference` (ADR-006 — the
+ * dataset and its rules math live in the package, and Convex "does not have and
+ * should not grow" them), so this is a MIRROR, and a mirror needs a gate:
+ * `apps/itun/test/convex/downtimeSteps.test.ts` asserts this constant equals
+ * the guide's real step count, so the two cannot drift silently.
+ */
+const DOWNTIME_STEP_COUNT = 10
+
 /** Move the whole table to the next step. */
 export const advance = mutation({
   args: { gameId: v.id('games') },
@@ -111,8 +128,15 @@ export const advance = mutation({
       throw new NotAuthorized('Downtime is not running')
     }
 
+    // Clamp at the last step rather than running past the end. `stepIndex` was
+    // unbounded, so `advance` could be called indefinitely and the Mediator's
+    // panel would render "Step 14 / 10" while the solo wizard — which clamps
+    // client-side — showed step 10. Same procedure, two surfaces, two answers.
+    const next = Math.min(row.stepIndex + 1, DOWNTIME_STEP_COUNT - 1)
+    if (next === row.stepIndex) return
+
     await ctx.db.patch(row._id, {
-      stepIndex: row.stepIndex + 1,
+      stepIndex: next,
       // Per step, not cumulative — see the module header.
       completedBy: [],
     })

--- a/apps/itun/test/convex/downtimeSteps.test.ts
+++ b/apps/itun/test/convex/downtimeSteps.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { SalvageUnionReference } from 'salvageunion-reference'
+
+/**
+ * `apps/itun/convex/downtime.ts` hard-codes how many steps the Crawler Downtime
+ * procedure has, because Convex deliberately has no access to
+ * `salvageunion-reference` (ADR-006). A hard-coded mirror of a dataset fact is
+ * exactly the kind of thing that drifts silently, so this is its gate.
+ *
+ * The book is the source: Core Book p.227-228 walks ten named steps, "Tally
+ * Salvage" through "Prepare for the next Salvage Run".
+ */
+const CONVEX_MODULE = join(import.meta.dir, '..', '..', 'convex', 'downtime.ts')
+
+function convexStepCount(): number {
+  const src = readFileSync(CONVEX_MODULE, 'utf8')
+  const m = src.match(/const DOWNTIME_STEP_COUNT = (\d+)/)
+  if (!m?.[1]) throw new Error('DOWNTIME_STEP_COUNT not found in convex/downtime.ts')
+  return Number(m[1])
+}
+
+function downtimeGuideSteps() {
+  const guide = SalvageUnionReference.Guides.find((g) => g.guideType === 'downtime')
+  return guide?.steps ?? []
+}
+
+describe('Convex Downtime step bound mirrors the dataset', () => {
+  test('the guide is actually there (guards a vacuous pass)', () => {
+    expect(downtimeGuideSteps().length).toBeGreaterThan(0)
+  })
+
+  test('the hard-coded count equals the guide’s real step count', () => {
+    expect(convexStepCount()).toBe(downtimeGuideSteps().length)
+  })
+
+  test('the guide still starts and ends where the book does', () => {
+    // Named rather than counted, so a step being renamed or reordered fails
+    // here instead of silently changing what "step 10" means to the Mediator.
+    const steps = downtimeGuideSteps()
+    expect(steps[0]?.name).toBe('Tally Salvage')
+    expect(steps[steps.length - 1]?.name).toBe('Prepare for the next Salvage Run')
+  })
+})


### PR DESCRIPTION
`convex/downtime.ts`'s `advance` incremented `stepIndex` with no ceiling, so a
Mediator could run the table past the end of the procedure. The Mediator's crew
panel renders `Step {n+1}` straight from that value, while the solo
`DowntimeWizard` clamps client-side — so the same Downtime could read "Step 14"
on one surface and "Step 10" on the other.

The book settles how many steps there are. Core Book p.227-228 walks ten named
steps, "Tally Salvage" through "Prepare for the next Salvage Run", and says
explicitly that you "may go back to any of these steps if you forget anything" —
so the steps are ordered and revisitable, but bounded. The dataset carries them
as the Crawler Downtime guide, which is what `DowntimeWizard` renders and what
the SRD publishes; that guide is the canonical list, and the 7 write-keys in
`lib/rules/downtime.ts` are the subset that transacts, not a second model.

Convex deliberately has no access to `salvageunion-reference` (ADR-006 — the
dataset and its rules math live in the package and Convex "does not have and
should not grow" them), so the count is a MIRROR here. A mirror needs a gate:
`test/convex/downtimeSteps.test.ts` asserts the constant equals the guide's real
step count, and that the guide still begins and ends where the book does — named
rather than counted, so a rename or reorder fails there instead of quietly
changing what "step 10" means to a Mediator. Proved by setting the constant to 7
and watching it fail.

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_013Kko69Tg9VVf5LETsQ1TAR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>