### PR TITLE
chore(deps): cut the overrides block from eight entries to one

### DIFF
--- a/.catalog-updaterc.json
+++ b/.catalog-updaterc.json
@@ -13,6 +13,6 @@
     { "name": "fontsource", "patterns": ["@fontsource/*"] },
     { "name": "all-patch-updates", "patterns": ["*"], "updateTypes": ["patch"] }
   ],
-  "ignore": [{ "pattern": "@vitejs/plugin-react-swc", "updateTypes": ["major"] }],
+  "ignore": [],
   "audit": { "enabled": false }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,22 +278,43 @@ jobs:
       # high/critical advisories so a vulnerable dependency blocks merge; lower
       # severities are reported by `bun audit` locally but do not gate CI.
       #
-      # THE BLOCK IS NOW `{ "undici": "^6.28.0" }`. It held eight entries until
-      # #787; seven were removed after measuring, one at a time, what each was
-      # actually holding back. The method is the point, so that it can be redone:
-      # empty the block, `bun install`, then `bun run check:audit`. Anything that
-      # reappears earned its floor; anything that does not, did not.
+      # THE BLOCK IS NOW `{ "@discordjs/rest": "^2.6.3" }` — ONE entry. It held
+      # eight until #787; seven were removed after measuring, one at a time, what
+      # each was actually holding back, and the eighth was REPLACED by a better
+      # fix. The method is the point, so that it can be redone: empty the block,
+      # `bun install`, then `bun run check:audit`. Anything that reappears earned
+      # its floor; anything that does not, did not.
       #
-      #   undici: ^6.28.0 — KEPT, and the only genuine security floor here.
-      #     `@discordjs/rest@2.6.1` requires undici at EXACTLY 6.24.1, and
-      #     GHSA-vxpw-j846-p89q is HIGH over `< 6.27.0` — so without this entry a
-      #     high advisory is back in the tree via discord.js. Floored at ^6.28.0
-      #     rather than ^6.27.0 because three further MODERATE advisories
-      #     (GHSA-m8rv-5g2x-5cg5, GHSA-v3r7-h72x-cjcm, GHSA-8xcm-r25x-g524) run
-      #     to `< 6.28.0`. Verify with:
+      #   @discordjs/rest: ^2.6.3 — a DEDUPE pin that removes the need for a
+      #     security floor, rather than a security floor itself.
+      #
+      #     The problem it solves: `discord.js@14.27.0` -> `@discordjs/ws@1.2.3`
+      #     -> `@discordjs/rest@2.6.1`, and 2.6.1 requires undici at EXACTLY
+      #     6.24.1. GHSA-vxpw-j846-p89q is HIGH over `< 6.27.0`, so that one
+      #     stale edge put a high advisory in the tree via discord.js.
+      #
+      #     This block used to answer that with `undici: ^6.28.0` — floor the
+      #     symptom. The better lever is one level up: `@discordjs/rest@2.6.3`
+      #     asks undici for `^6.27.0`, and `@discordjs/ws@1.2.3` already accepts
+      #     `^2.5.1`, so 2.6.3 is INSIDE its declared range. Pinning it there is a
+      #     dedupe, not a forced upgrade — the tree drops a duplicate
+      #     `@discordjs/rest` (2.6.1 alongside 2.6.3) and undici then floats to
+      #     6.28.0 on its own, with no undici entry at all. One fewer package
+      #     installed, and the lockfile diff is a pure deletion.
+      #
+      #     REMOVAL CONDITION: `discord.js` is ALREADY at the latest release
+      #     (14.27.0 — there is no upgrade to take, checked with `bun pm view
+      #     discord.js version`), and it requires `@discordjs/ws ^1.2.3`, so the
+      #     fixed `@discordjs/ws@2.0.4` is unreachable across that major. When a
+      #     discord.js release ships a `ws` that pulls `rest >= 2.6.3` itself,
+      #     delete this entry and the block goes to ZERO. Re-check with
+      #     `bun why undici` — if it resolves >= 6.27.0 unaided, the entry is dead.
+      #
+      #     Verify the advisory ranges with:
       #       gh api graphql -f query='{securityVulnerabilities(package:"undici",
       #         ecosystem:NPM,first:60){nodes{severity vulnerableVersionRange
       #         advisory{ghsaId}}}}'
+      #     Verified here with `bun run build:bot` and the bot's 225 tests.
       #
       # WHAT THE SEVEN REMOVALS ACTUALLY DID (from the #787 bun.lock diff — the
       # resolved versions, not the ranges, because only the former can be audited):
@@ -374,7 +395,11 @@ jobs:
       #   - It then claimed deleting the block brought back two high advisories,
       #     `sharp` AND `undici` — while also, three paragraphs down, correcting
       #     that `sharp` is not in the block at all. Only the undici half was ever
-      #     true, and #787 measured it: seven entries out, audit unchanged.
+      #     true, and #787 measured it: seven entries out, audit unchanged. The
+      #     undici half was true but was being answered at the wrong level — see
+      #     the `@discordjs/rest` entry above. A floor on the vulnerable package
+      #     is the LAST resort; first look for a parent whose own range already
+      #     admits a fixed version, because that is a dedupe rather than a pin.
       #
       # No dependency is in BOTH `overrides` and `workspaces.catalog` any more, so
       # the catalog-becomes-fiction hazard described in CLAUDE.md is dormant.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,10 +383,23 @@ jobs:
       #     newest version old enough (CLAUDE.md, "Install cooldown") — so a
       #     re-resolve while a fresh fix is still inside the 3-day window lands the
       #     older, in-advisory version with no warning at all, where resolving
-      #     below an override would have errored. `check:audit` still gates the
-      #     resolved lockfile, so this is a hardening regression, not a hole.
-      #     If any of the five above goes red, restore that package's floor rather
-      #     than hunting for a new consumer.
+      #     below an override would have errored.
+      #
+      #     AND THE WATCH LIST IS MANUAL BELOW `high` — know this before trusting
+      #     it. `check:audit` is `bun audit --audit-level=high`, so a MODERATE
+      #     advisory landing on any of those five fails nothing: not this job, not
+      #     `check:all`, not a pre-push hook. That is precisely the class these
+      #     packages draw (ReDoS), and the class the dropped `nanoid` floor was
+      #     originally added for (GHSA-2v37-7h3g-55p8). Nothing anywhere runs a
+      #     bare `bun audit`, so a silent caret step-down onto a moderate-advisory
+      #     version is caught only by someone running it by hand.
+      #
+      #     So the honest summary is: the `high` gate still holds (that severity
+      #     policy predates this change and is deliberate), and below it these
+      #     five are watched by convention rather than by CI. Restoring a floor is
+      #     the fix; a periodic bare-`bun audit` over just these five would be the
+      #     automation if it is ever wanted. If any of them goes red, restore that
+      #     package's floor rather than hunting for a new consumer.
       #   - `@vitejs/plugin-react-swc` was a DEDUPE floor, not a security floor.
       #     Removing it costs one duplicate copy (a nested @ladle/react 3.11.0)
       #     and no advisory — install weight only, in a dev-only tool.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,63 +268,94 @@ jobs:
         run: bun run validate:all
 
       # ---------------------------------------------------------------
-      # The dependency audit, and WHY the `overrides` block exists.
+      # The dependency audit, and WHY the `overrides` block is now ONE entry.
       #
-      # This block was nearly lost when six jobs merged into one: CLAUDE.md
-      # points here twice ("the CI comment in .github/workflows/ci.yml") for
-      # which security floors bind and via what, and package.json cannot
-      # carry comments. Deleting it would have left an 8-entry `overrides`
-      # block with no surviving record of its reasoning.
+      # CLAUDE.md points here twice ("the CI comment in .github/workflows/ci.yml")
+      # for which security floors bind and via what, because package.json cannot
+      # carry comments. This is that record. Keep it in step with the block.
       # ---------------------------------------------------------------
       # Dependency vulnerability scan against the resolved lockfile. Fails on
       # high/critical advisories so a vulnerable dependency blocks merge; lower
       # severities are reported by `bun audit` locally but do not gate CI.
       #
-      # HOW ADVISORIES GET CLEARED HERE. Most resolve on their own when the
-      # lockfile moves. The rest are held above the vulnerable range by the
-      # `overrides` block in the root package.json — those entries are SECURITY
-      # FLOORS, and the block is load-bearing: delete it, re-resolve, and two high
-      # advisories come straight back — `sharp` (GHSA-f88m-g3jw-g9cj; it reached
-      # the graph via workspace:srd -> astro until srd left Astro, and is now a
-      # direct srd devDependency for the OG-screenshot pass) and `undici`
-      # (GHSA-vxpw-j846-p89q, via discord.js).
-      # The other floors do not bind on a fresh resolve today; they are kept as
-      # cheap insurance against a parent range drifting back down.
+      # THE BLOCK IS NOW `{ "undici": "^6.28.0" }`. It held eight entries until
+      # #787; seven were removed after measuring, one at a time, what each was
+      # actually holding back. The method is the point, so that it can be redone:
+      # empty the block, `bun install`, then `bun run check:audit`. Anything that
+      # reappears earned its floor; anything that does not, did not.
       #
-      # TWO ADVISORIES ARE NOW SUPPRESSED, and this comment used to say the
-      # opposite ("No `--ignore` is needed"). `check:audit` passes
+      #   undici: ^6.28.0 — KEPT, and the only genuine security floor here.
+      #     `@discordjs/rest@2.6.1` requires undici at EXACTLY 6.24.1, and
+      #     GHSA-vxpw-j846-p89q is HIGH over `< 6.27.0` — so without this entry a
+      #     high advisory is back in the tree via discord.js. Floored at ^6.28.0
+      #     rather than ^6.27.0 because three further MODERATE advisories
+      #     (GHSA-m8rv-5g2x-5cg5, GHSA-v3r7-h72x-cjcm, GHSA-8xcm-r25x-g524) run
+      #     to `< 6.28.0`. Verify with:
+      #       gh api graphql -f query='{securityVulnerabilities(package:"undici",
+      #         ecosystem:NPM,first:60){nodes{severity vulnerableVersionRange
+      #         advisory{ghsaId}}}}'
+      #
+      # WHAT THE SEVEN REMOVALS ACTUALLY DID (from the #787 bun.lock diff — the
+      # resolved versions, not the ranges, because only the former can be audited):
+      #   shell-quote  ^1.10.0 -> resolves 1.9.0   (worst advisory is `<= 1.8.4`)
+      #   fast-uri     ^4.1.2  -> resolves 3.1.5   (`< 3.1.5`; newest of the 3.x line)
+      #   filelist     ^2.0.2  -> resolves 1.0.6, dragging minimatch@5.1.9 and
+      #                           brace-expansion@2.1.4 (`< 2.1.4`) with it
+      #   brace-expansion ^5.0.9 -> top level unchanged at 5.0.9 (minimatch@10 asks ^5.0.5)
+      #   nanoid       ^3.3.18 -> NOT ONE LOCKFILE LINE CHANGED; a pure no-op
+      #   @opentelemetry/core ^2.8.0 -> adds a nested @netlify/otel copy at 2.8.0
+      #   @vitejs/plugin-react-swc ^4.3.3 -> adds a nested @ladle/react copy at 3.11.0
+      # Post-removal `bun run check:audit` is EMPTY, and full `bun audit` reports
+      # only the two suppressed image-size ids below — i.e. no new advisory at any
+      # severity. `check:all`, `bun --filter component-lib ladle:build` and
+      # `bun install --frozen-lockfile` were all green on that lockfile.
+      #
+      # KNOW WHAT THIS TRADED AWAY, because it is a real cost and not zero.
+      # The last three of those seven are the ones to watch:
+      #   - fast-uri 3.1.5 and brace-expansion 2.1.4 each sit at EXACTLY the last
+      #     patch of an older line. Today that is clean. If a new advisory lands on
+      #     3.x / 2.x and the fix ships only on the newer major, the parent caret
+      #     (`ajv` asks fast-uri ^3.0.1) cannot reach it and the floor must come
+      #     back. That is the restore condition — do not treat a red audit on
+      #     either package as a mystery.
+      #   - the last two entries were DEDUPE floors, not security floors, and
+      #     removing them costs one duplicate copy each. That is install weight
+      #     only; neither duplicate carries an advisory.
+      #
+      # TWO ADVISORIES ARE SUPPRESSED. `check:audit` passes
       # `--ignore=GHSA-w3rx-r6r6-pgpr --ignore=GHSA-5p2g-fcmc-qvqq`, both
       # `image-size <=2.0.2` via `@netlify/blobs -> @netlify/dev-utils`. There is
       # no fixed version to float a floor to — 2.0.2 IS latest — so the usual
       # `bun update` / raise-the-floor remedy below cannot apply. Full reasoning
       # and the removal condition are in CLAUDE.md, "Audit gate". The ignores are
       # scoped to those two ids, so everything else still gates.
-      # Getting there took DEDUPE floors, which are a different kind of entry from
-      # the rest of the block and should not be confused with them:
       #
-      #   (An `astro: ^7.1.4` dedupe floor used to sit here. `@vite-pwa/astro@1.2.0`
+      # TWO DEAD DEDUPE FLOORS, kept as lessons rather than as config:
+      #
+      #   (An `astro: ^7.1.4` floor used to sit here. `@vite-pwa/astro@1.2.0`
       #   peer-required `astro ^1 || … || ^5`, so bun installed a SECOND, complete
       #   astro@6.4.6 tree beside the real one — in-advisory, and it dragged in a
       #   vulnerable esbuild. Both the floor and the problem are gone: srd left
       #   Astro for the in-house SSG (ADR-031), and @vite-pwa/astro went with it.
-      #   Do not restore the override; nothing depends on astro any more.)
+      #   Do not restore it; nothing depends on astro any more.)
       #
-      #   @vitejs/plugin-react-swc: ^4.3.3
-      #     A `@ladle/react@5.1.1` dependency, pinned there at ^3.7.2 whose vite
-      #     peer stops at ^7 — so bun resolved vite@7.3.5 for it, which pulled
-      #     esbuild@0.27.7, the one genuinely vulnerable esbuild in the tree.
-      #     4.3.x widened the peer to include ^8, so it dedupes onto the vite 8
-      #     already present. Verified with `bun --filter component-lib ladle:build`.
+      #   (`@vitejs/plugin-react-swc: ^4.3.3` was the same shape. `@ladle/react`
+      #   asks ^3.7.2, whose vite peer stopped at ^7, so bun once resolved
+      #   vite@7.3.5 for it and pulled esbuild@0.27.7 — the one genuinely
+      #   vulnerable esbuild in the tree. THAT NO LONGER REPRODUCES: removing the
+      #   floor in #787 restores a nested plugin-react-swc@3.11.0 whose vite peer
+      #   is satisfied by the vite@6.4.3 Ladle already carries, so no second vite
+      #   and no vulnerable esbuild appear. Re-measure before restoring it.
       #
-      #     NOTE the road not taken: a blanket `esbuild` floor would ALSO have
-      #     cleared this, but `convex` pins esbuild to exactly 0.27.0 — which is
-      #     BELOW the advisory range and therefore not vulnerable — so a global
-      #     floor would have forced Convex's bundler off a deliberate pin to fix
-      #     a Windows-dev-server issue in Ladle's tooling. Move the offending
-      #     subtree, not every consumer of the package it happens to contain.
+      #   The road not taken is still the transferable part: a blanket `esbuild`
+      #   floor would ALSO have cleared that, but `convex` pins esbuild to exactly
+      #   0.27.0 — BELOW the advisory range, so not vulnerable — and a global floor
+      #   would have forced Convex's bundler off a deliberate pin to fix a
+      #   Windows-dev-server issue in Ladle's tooling. Move the offending subtree,
+      #   not every consumer of the package it happens to contain.)
       #
       # WHEN THIS JOB FAILS ON A TRANSITIVE DEP, the fix is `bun update <pkg>`
-      # plus the regenerated bun.lock. The floors are caret ranges so that works.
+      # plus the regenerated bun.lock. Floors are caret ranges so that works.
       # Do NOT pin a floor to an exact version: an exact override pins the package
       # *down* as well as up, so when the next advisory is fixed one patch above
       # it, the override itself becomes the thing holding the vulnerable version
@@ -333,20 +364,23 @@ jobs:
       # (#673) — each time after the exact pin had blocked every open PR.
       # Raise the floor, never freeze it.
       #
-      # CORRECTION (this comment was wrong for months): it claimed `sharp` was "the
-      # one deliberate exception", carrying an EXACT override kept in lockstep with
-      # its root and apps/srd pins. There is no `sharp` entry in `overrides` at all
-      # — verify with `bun why sharp` and by reading the block itself. `sharp` is a
-      # plain pinned devDependency, now expressed once in `workspaces.catalog`, and
-      # is bumped like any other. The claim was load-bearing in the wrong
-      # direction: it was copied into CLAUDE.md and used to justify excluding
-      # `sharp` from automated catalog updates, protecting a constraint that did
-      # not exist.
+      # CORRECTION (this comment was wrong for months, in two directions):
+      #   - It claimed `sharp` was "the one deliberate exception", carrying an EXACT
+      #     override kept in lockstep with its root and apps/srd pins. There has
+      #     never been a `sharp` entry in `overrides` — verify with `bun why sharp`.
+      #     That claim was copied into CLAUDE.md and used to justify excluding
+      #     `sharp` from automated catalog updates, protecting a constraint that did
+      #     not exist.
+      #   - It then claimed deleting the block brought back two high advisories,
+      #     `sharp` AND `undici` — while also, three paragraphs down, correcting
+      #     that `sharp` is not in the block at all. Only the undici half was ever
+      #     true, and #787 measured it: seven entries out, audit unchanged.
       #
-      # The dependency that IS in both `overrides` and the catalog is
-      # `@vitejs/plugin-react-swc` (`^4.3.3`). Raising the catalog past that caret
-      # would leave the catalog stating a version the override prevents resolving,
-      # so `.catalog-updaterc.json` ignores its MAJOR updates only.
+      # No dependency is in BOTH `overrides` and `workspaces.catalog` any more, so
+      # the catalog-becomes-fiction hazard described in CLAUDE.md is dormant.
+      # `@vitejs/plugin-react-swc` was the only one, which is why
+      # `.catalog-updaterc.json` ignored its majors; that ignore went with it.
+      # Re-add both together or neither.
       - name: Audit dependencies
         # `bun run check:audit`, NOT a bare `bun audit` — the script carries the
         # `--ignore` flags, and this ran the bare command for long enough that a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,17 @@ jobs:
       #     (`ajv` asks fast-uri ^3.0.1) cannot reach it and the floor must come
       #     back. That is the restore condition — do not treat a red audit on
       #     either package as a mystery.
+      #
+      #     THE SHARPER EDGE, and the reason a floor is not merely redundant here:
+      #     a floor fails LOUDLY and a caret fails SILENTLY. `bunfig.toml` sets
+      #     `minimumReleaseAge`, and a caret range under it resolves *down* to the
+      #     newest version old enough (CLAUDE.md, "Install cooldown") — so a
+      #     re-resolve while a fresh fix is still inside the 3-day window lands the
+      #     older, in-advisory version with no warning at all, where resolving
+      #     below an override would have errored. `check:audit` still gates the
+      #     resolved lockfile, so this is a hardening regression, not a hole.
+      #     If any of these three go red, restore that package's floor rather than
+      #     hunting for a new consumer.
       #   - the last two entries were DEDUPE floors, not security floors, and
       #     removing them costs one duplicate copy each. That is install weight
       #     only; neither duplicate carries an advisory.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
         run: bun run validate:all
 
       # ---------------------------------------------------------------
-      # The dependency audit, and WHY the `overrides` block is now ONE entry.
+      # The dependency audit, and WHY the `overrides` block is now TWO entries.
       #
       # CLAUDE.md points here twice ("the CI comment in .github/workflows/ci.yml")
       # for which security floors bind and via what, because package.json cannot
@@ -315,6 +315,13 @@ jobs:
       #     delete THIS entry — and only this one; `@opentelemetry/core` below is
       #     kept for an unrelated reason and must survive. Re-check with
       #     `bun why undici`: if it resolves >= 6.27.0 unaided, this entry is dead.
+      #
+      #     ALSO delete it if `discord.js` ever moves to a `@discordjs/rest`
+      #     MAJOR. A bun `overrides` entry is tree-wide and unconditional, so a
+      #     future `rest@^3` would be silently CLAMPED back to 2.6.x instead of
+      #     failing loudly — the "freeze, not floor" hazard this block warns about
+      #     below, applied across a major boundary rather than a patch one. The
+      #     `undici: ^6.28.0` this replaced had the identical property.
       #
       #     Note this pin is not a floor, but it IS security-load-bearing: it is
       #     the only thing keeping GHSA-vxpw-j846-p89q out of the tree. Do not

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,8 +312,13 @@ jobs:
       #     discord.js version`), and it requires `@discordjs/ws ^1.2.3`, so the
       #     fixed `@discordjs/ws@2.0.4` is unreachable across that major. When a
       #     discord.js release ships a `ws` that pulls `rest >= 2.6.3` itself,
-      #     delete this entry and the block goes to ZERO. Re-check with
-      #     `bun why undici` — if it resolves >= 6.27.0 unaided, the entry is dead.
+      #     delete THIS entry — and only this one; `@opentelemetry/core` below is
+      #     kept for an unrelated reason and must survive. Re-check with
+      #     `bun why undici`: if it resolves >= 6.27.0 unaided, this entry is dead.
+      #
+      #     Note this pin is not a floor, but it IS security-load-bearing: it is
+      #     the only thing keeping GHSA-vxpw-j846-p89q out of the tree. Do not
+      #     drop it as "just a dedupe".
       #
       #     Verify the advisory ranges with:
       #       gh api graphql -f query='{securityVulnerabilities(package:"undici",
@@ -438,11 +443,14 @@ jobs:
       #   - It then claimed deleting the block brought back two high advisories,
       #     `sharp` AND `undici` — while also, three paragraphs down, correcting
       #     that `sharp` is not in the block at all. Only the undici half was ever
-      #     true, and #787 measured it: seven entries out, audit unchanged. The
-      #     undici half was true but was being answered at the wrong level — see
-      #     the `@discordjs/rest` entry above. A floor on the vulnerable package
-      #     is the LAST resort; first look for a parent whose own range already
-      #     admits a fixed version, because that is a dedupe rather than a pin.
+      #     true. #787 measured it: six entries out and the audit is unchanged —
+      #     but ONLY because `@discordjs/rest: ^2.6.3` went in as part of the same
+      #     change. Take all eight out and add nothing, and GHSA-vxpw-j846-p89q
+      #     really does come back through the nested `@discordjs/rest@2.6.1` ->
+      #     `undici@6.24.1`. So the undici half was true; it was just being
+      #     answered at the wrong level. A floor on the vulnerable package is the
+      #     LAST resort — first look for a parent whose own range already admits a
+      #     fixed version, because that is a dedupe rather than a pin.
       #
       # No dependency is in BOTH `overrides` and `workspaces.catalog` any more, so
       # the catalog-becomes-fiction hazard described in CLAUDE.md is dormant.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,8 +351,24 @@ jobs:
       #     If any of these three go red, restore that package's floor rather than
       #     hunting for a new consumer.
       #   - the last two entries were DEDUPE floors, not security floors, and
-      #     removing them costs one duplicate copy each. That is install weight
-      #     only; neither duplicate carries an advisory.
+      #     removing them costs one duplicate copy each. Neither duplicate carries
+      #     an advisory — but "install weight" is the wrong ceiling for one of
+      #     them, so do not record it that way:
+      #
+      #     @opentelemetry/core is the one to understand. `@netlify/otel@6.0.5`
+      #     pins core at exactly 2.8.0 while its own
+      #     `@opentelemetry/sdk-trace-node@2.9.0` depends on core 2.9.0 — so
+      #     without the override there are TWO core instances inside a single
+      #     package's subtree (`bun.lock` has both a nested
+      #     `@netlify/otel/@opentelemetry/core@2.8.0` and the top-level 2.9.0).
+      #     OTel's context keys are non-registered `Symbol`s, which do not compare
+      #     equal across copies, so a duplicated core can silently DESYNC context
+      #     and suppression between the two rather than merely costing disk.
+      #     Kept out anyway because the blast radius is `@netlify/blobs`' own
+      #     internal tracing, which nothing here consumes — this repo's
+      #     observability is Sentry (see packages/observability). RESTORE
+      #     `"@opentelemetry/core": "^2.8.0"` the moment anything starts reading
+      #     Netlify's traces, or if blobs behaviour ever looks context-dependent.
       #
       # TWO ADVISORIES ARE SUPPRESSED. `check:audit` passes
       # `--ignore=GHSA-w3rx-r6r6-pgpr --ignore=GHSA-5p2g-fcmc-qvqq`, both

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,12 +278,17 @@ jobs:
       # high/critical advisories so a vulnerable dependency blocks merge; lower
       # severities are reported by `bun audit` locally but do not gate CI.
       #
-      # THE BLOCK IS NOW `{ "@discordjs/rest": "^2.6.3" }` — ONE entry. It held
-      # eight until #787; seven were removed after measuring, one at a time, what
-      # each was actually holding back, and the eighth was REPLACED by a better
-      # fix. The method is the point, so that it can be redone: empty the block,
-      # `bun install`, then `bun run check:audit`. Anything that reappears earned
-      # its floor; anything that does not, did not.
+      # THE BLOCK IS NOW TWO ENTRIES — `@discordjs/rest` and
+      # `@opentelemetry/core`, and NEITHER is a security floor; both are dedupe
+      # pins. It held eight until #787: six were removed after measuring, one at a
+      # time, what each was actually holding back, one was REPLACED by a better
+      # fix a level up, and one was removed and then put back when review showed
+      # the removal was not inert. The method is the point, so that it can be
+      # redone: empty the block, `bun install`, then `bun run check:audit`.
+      # Anything that reappears earned its floor; anything that does not, did not.
+      # Note what that method does NOT catch — `@opentelemetry/core` below is the
+      # worked example, and it is why "audit is clean" is a necessary rather than
+      # a sufficient answer.
       #
       #   @discordjs/rest: ^2.6.3 — a DEDUPE pin that removes the need for a
       #     security floor, rather than a security floor itself.
@@ -316,7 +321,28 @@ jobs:
       #         advisory{ghsaId}}}}'
       #     Verified here with `bun run build:bot` and the bot's 225 tests.
       #
-      # WHAT THE SEVEN REMOVALS ACTUALLY DID (from the #787 bun.lock diff — the
+      #   @opentelemetry/core: ^2.8.0 — KEPT, and the cautionary tale of this whole
+      #     change. It was removed with the other six on the grounds that the audit
+      #     stayed clean, which it did. That was the wrong test.
+      #
+      #     `@netlify/otel@6.0.5` pins core at EXACTLY 2.8.0 while its own
+      #     `@opentelemetry/sdk-trace-node@2.9.0` depends on core 2.9.0 — so with
+      #     no override the lockfile carries a nested
+      #     `@netlify/otel/@opentelemetry/core@2.8.0` AND a top-level 2.9.0: two
+      #     copies inside one package's subtree. OTel's context keys are
+      #     non-registered `Symbol`s, which never compare equal across copies, so
+      #     the two disagree about what is in context and what is suppressed.
+      #
+      #     That is not confined to Netlify's own tracing, which is what the first
+      #     draft of this comment claimed. `@sentry/node@10.69.0` IS an OTel SDK
+      #     (it requires `@opentelemetry/sdk-trace-base ^2.9.0`), and it shares a
+      #     process with `@netlify/blobs`: `apps/su-assets/netlify/functions/
+      #     asset.ts` imports `getStore` and `initObservability` together, as do
+      #     the ITUN snapshot functions. So the desync can mis-parent or
+      #     un-suppress SENTRY's spans — silently, with no crash and no advisory.
+      #     Keep this entry. `grep -c 'opentelemetry/core@2' bun.lock` must be 1.
+      #
+      # WHAT THE SIX REMOVALS ACTUALLY DID (from the #787 bun.lock diff — the
       # resolved versions, not the ranges, because only the former can be audited):
       #   shell-quote  ^1.10.0 -> resolves 1.9.0   (worst advisory is `<= 1.8.4`)
       #   fast-uri     ^4.1.2  -> resolves 3.1.5   (`< 3.1.5`; newest of the 3.x line)
@@ -324,21 +350,27 @@ jobs:
       #                           brace-expansion@2.1.4 (`< 2.1.4`) with it
       #   brace-expansion ^5.0.9 -> top level unchanged at 5.0.9 (minimatch@10 asks ^5.0.5)
       #   nanoid       ^3.3.18 -> NOT ONE LOCKFILE LINE CHANGED; a pure no-op
-      #   @opentelemetry/core ^2.8.0 -> adds a nested @netlify/otel copy at 2.8.0
       #   @vitejs/plugin-react-swc ^4.3.3 -> adds a nested @ladle/react copy at 3.11.0
       # Post-removal `bun run check:audit` is EMPTY, and full `bun audit` reports
       # only the two suppressed image-size ids below — i.e. no new advisory at any
-      # severity. `check:all`, `bun --filter component-lib ladle:build` and
-      # `bun install --frozen-lockfile` were all green on that lockfile.
+      # severity. `check:all`, `bun --filter component-lib ladle:build`,
+      # `bun run build:bot` and `bun install --frozen-lockfile` were all green.
       #
       # KNOW WHAT THIS TRADED AWAY, because it is a real cost and not zero.
-      # The last three of those seven are the ones to watch:
-      #   - fast-uri 3.1.5 and brace-expansion 2.1.4 each sit at EXACTLY the last
-      #     patch of an older line. Today that is clean. If a new advisory lands on
-      #     3.x / 2.x and the fix ships only on the newer major, the parent caret
-      #     (`ajv` asks fast-uri ^3.0.1) cannot reach it and the floor must come
-      #     back. That is the restore condition — do not treat a red audit on
-      #     either package as a mystery.
+      # FIVE of the six are downgrades onto an older line, and all five are on the
+      # watch list — do not shorten it, and do not treat a red audit on any of
+      # them as a mystery:
+      #
+      #     fast-uri 3.1.5, brace-expansion 2.1.4 (nested, via filelist),
+      #     shell-quote 1.9.0, filelist 1.0.6, nanoid 3.3.18
+      #
+      #   - The first four sit at or near the LAST patch of an older line, and
+      #     nanoid sits at exactly the fixed version with a caret above it. Today
+      #     all of that is clean. If a new advisory lands on one of those lines and
+      #     the fix ships only on a newer major, the parent caret (`ajv` asks
+      #     fast-uri ^3.0.1; `jake` asks filelist ^1.0.4; `concurrently` pins
+      #     shell-quote at exactly 1.9.0) cannot reach it and the floor must come
+      #     back. Restoring one is a one-line edit plus `bun install`.
       #
       #     THE SHARPER EDGE, and the reason a floor is not merely redundant here:
       #     a floor fails LOUDLY and a caret fails SILENTLY. `bunfig.toml` sets
@@ -348,27 +380,11 @@ jobs:
       #     older, in-advisory version with no warning at all, where resolving
       #     below an override would have errored. `check:audit` still gates the
       #     resolved lockfile, so this is a hardening regression, not a hole.
-      #     If any of these three go red, restore that package's floor rather than
-      #     hunting for a new consumer.
-      #   - the last two entries were DEDUPE floors, not security floors, and
-      #     removing them costs one duplicate copy each. Neither duplicate carries
-      #     an advisory — but "install weight" is the wrong ceiling for one of
-      #     them, so do not record it that way:
-      #
-      #     @opentelemetry/core is the one to understand. `@netlify/otel@6.0.5`
-      #     pins core at exactly 2.8.0 while its own
-      #     `@opentelemetry/sdk-trace-node@2.9.0` depends on core 2.9.0 — so
-      #     without the override there are TWO core instances inside a single
-      #     package's subtree (`bun.lock` has both a nested
-      #     `@netlify/otel/@opentelemetry/core@2.8.0` and the top-level 2.9.0).
-      #     OTel's context keys are non-registered `Symbol`s, which do not compare
-      #     equal across copies, so a duplicated core can silently DESYNC context
-      #     and suppression between the two rather than merely costing disk.
-      #     Kept out anyway because the blast radius is `@netlify/blobs`' own
-      #     internal tracing, which nothing here consumes — this repo's
-      #     observability is Sentry (see packages/observability). RESTORE
-      #     `"@opentelemetry/core": "^2.8.0"` the moment anything starts reading
-      #     Netlify's traces, or if blobs behaviour ever looks context-dependent.
+      #     If any of the five above goes red, restore that package's floor rather
+      #     than hunting for a new consumer.
+      #   - `@vitejs/plugin-react-swc` was a DEDUPE floor, not a security floor.
+      #     Removing it costs one duplicate copy (a nested @ladle/react 3.11.0)
+      #     and no advisory — install weight only, in a dev-only tool.
       #
       # TWO ADVISORIES ARE SUPPRESSED. `check:audit` passes
       # `--ignore=GHSA-w3rx-r6r6-pgpr --ignore=GHSA-5p2g-fcmc-qvqq`, both

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,8 +78,11 @@ Use it before editing an `overrides` entry too — the CI comment in
 and that comment can go stale while `bun why` cannot.
 
 **`overrides` is now two entries, and NEITHER is a security floor** — both are
-dedupe pins. `@discordjs/rest` lifts one stale `discord.js` edge onto a version
-its own range already allows, so `undici` clears `GHSA-vxpw-j846-p89q` unaided;
+dedupe pins. **Neither is optional, though: do not drop either as install
+weight.** `@discordjs/rest` lifts one stale `discord.js` edge onto a version its
+own range already allows, so `undici` clears `GHSA-vxpw-j846-p89q` unaided —
+which makes that pin the only thing keeping a **HIGH** advisory out of the tree,
+dedupe or not;
 `@opentelemetry/core` collapses two OTel cores that would otherwise coexist in
 one subtree and silently desync `@sentry/node`'s span context. The other six
 entries were removed in #787 after measuring what each held back; `ci.yml`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,9 +73,9 @@ image-size@2.0.2
         └─ su-assets@workspace (requires ^10.7.11)
 ```
 
-Use it before editing an `overrides` floor too — the CI comment in
-`.github/workflows/ci.yml` documents which floors bind and via what, and that
-comment can go stale while `bun why` cannot.
+Use it before editing an `overrides` entry too — the CI comment in
+`.github/workflows/ci.yml` documents what each entry holds back and via what,
+and that comment can go stale while `bun why` cannot.
 
 **`overrides` is now two entries, and NEITHER is a security floor** — both are
 dedupe pins. `@discordjs/rest` lifts one stale `discord.js` edge onto a version
@@ -96,6 +96,12 @@ resolve silently *down*** to the newest version old enough (see "Install
 cooldown"), where a floor would have errored. So if `bun audit` ever reports
 `nanoid`, `fast-uri`, `brace-expansion`, `shell-quote` or `filelist`, the fix is
 to restore that package's floor — not to hunt for a new consumer.
+
+**That watch list is manual below `high`.** `check:audit` gates at
+`--audit-level=high`, and nothing in `check:all`, CI or the pre-push hook runs a
+bare `bun audit` — so a *moderate* advisory on any of those five (the ReDoS
+class they actually draw) fails nothing and is caught only by running
+`bun audit` by hand. The `high` gate is unaffected.
 
 ### Shared versions live in the catalog
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,19 +77,25 @@ Use it before editing an `overrides` floor too — the CI comment in
 `.github/workflows/ci.yml` documents which floors bind and via what, and that
 comment can go stale while `bun why` cannot.
 
-**`overrides` is now a single entry** (`@discordjs/rest`), and it is a *dedupe
-pin*, not a security floor — it lifts one stale `discord.js` edge onto a
-`@discordjs/rest` its own range already allows, so `undici` clears
-`GHSA-vxpw-j846-p89q` unaided. The seven other entries were removed in #787
-after measuring what each held back; `ci.yml` records the per-entry evidence
-and the removal condition. `nanoid` was among them — it is no longer pinned
-anywhere, and `3.3.18` now holds only because `postcss`'s `^3.3.16` caret
-happens to resolve there. That is a caret, not a guarantee: **`bunfig.toml`'s
-`minimumReleaseAge` makes a caret resolve silently *down*** to the newest
-version old enough (CLAUDE.md, "Install cooldown"), where a floor would have
-errored. So if `bun audit` ever reports `nanoid`, `fast-uri` or
-`brace-expansion`, the fix is to restore that package's floor — not to hunt for
-a new consumer.
+**`overrides` is now two entries, and NEITHER is a security floor** — both are
+dedupe pins. `@discordjs/rest` lifts one stale `discord.js` edge onto a version
+its own range already allows, so `undici` clears `GHSA-vxpw-j846-p89q` unaided;
+`@opentelemetry/core` collapses two OTel cores that would otherwise coexist in
+one subtree and silently desync `@sentry/node`'s span context. The other six
+entries were removed in #787 after measuring what each held back; `ci.yml`
+records the per-entry evidence, the watch list and the restore conditions.
+
+**Read that comment before removing an entry here**, because "the audit is still
+clean" is necessary but *not sufficient* — `@opentelemetry/core` is the worked
+example of a removal that audits clean and still degrades behaviour.
+
+`nanoid` was among the six: it is no longer pinned anywhere, and `3.3.18` holds
+only because `postcss`'s `^3.3.16` caret happens to resolve there. That is a
+caret, not a guarantee — **`bunfig.toml`'s `minimumReleaseAge` makes a caret
+resolve silently *down*** to the newest version old enough (see "Install
+cooldown"), where a floor would have errored. So if `bun audit` ever reports
+`nanoid`, `fast-uri`, `brace-expansion`, `shell-quote` or `filelist`, the fix is
+to restore that package's floor — not to hunt for a new consumer.
 
 ### Shared versions live in the catalog
 
@@ -129,7 +135,7 @@ Two things this interacts with, both of which have bitten:
 takes no comments, so the reason lives here. That feature defaults to **on** at
 `moderate` severity and writes `overrides` entries automatically; this repo
 curates `overrides` by hand — every entry documented in `ci.yml`, and as of
-#787 that is a single dedupe pin with zero security floors — and gates at
+#787 that is two dedupe pins with zero security floors — and gates at
 `--audit-level=high`. Leaving it on would open PRs editing that block for
 advisories `check:audit` deliberately ignores.
 
@@ -152,13 +158,14 @@ Two behaviours, measured on Bun 1.3.14 — know which one you are hitting:
   pins, so this is the usual case.
 - a **caret range silently resolves *down*** to the newest version old enough.
   No warning. So `bun update <pkg>` to clear a *fresh* advisory can look like it
-  did nothing — check the publish date before concluding the fix is broken. The
-  An `overrides` floor is the loud alternative — resolving below one errors
-  instead of silently stepping down. **There is currently only one `overrides`
-  entry and it is not a floor** (see "Audit gate"), so nothing in this repo is
-  protected that way today. That is the accepted cost of #787, not an oversight:
-  the packages it applies to (`nanoid`, `fast-uri`, `brace-expansion`) are named
-  there with the instruction to restore a floor if any of them goes red.
+  did nothing — check the publish date before concluding the fix is broken.
+  An `overrides` floor is the loud alternative: resolving below one errors
+  instead of silently stepping down. **Both current `overrides` entries are
+  dedupe pins, not floors** (see "Audit gate"), so nothing here is protected that
+  way today. That is the accepted cost of #787, not an oversight — the five
+  packages it applies to (`nanoid`, `fast-uri`, `brace-expansion`, `shell-quote`,
+  `filelist`) are listed there with the instruction to restore a floor if any of
+  them goes red.
 
 `bun install --frozen-lockfile` does no resolution and is **unaffected** —
 verified; CI and all four deploy targets never see this gate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,14 +98,16 @@ Two things this interacts with, both of which have bitten:
 - **`overrides` beats the catalog.** An `overrides` entry forces a version
   tree-wide, so raising a catalogued dep past the range its override allows
   leaves the catalog stating a version that is not what resolves — the catalog
-  becomes fiction, silently. Exactly one dependency is in both places:
-  **`@vitejs/plugin-react-swc`** (catalogued, and overridden at `^4.3.3`). A
-  major bump is therefore ignored in `.catalog-updaterc.json`; minor and patch
-  updates stay automated because the caret absorbs them. To take a major, bump
-  the catalog entry **and** the override together, by hand.
-  (`sharp` is *not* an example of this — it has no override at all. Check
-  `overrides` before assuming; the comment in `ci.yml`'s audit job asserted a
-  `sharp` override that has never existed and is corrected in this change.)
+  becomes fiction, silently. **No dependency is currently in both places**, so
+  this hazard is dormant, not active — check before assuming it applies.
+  `@vitejs/plugin-react-swc` used to be the one example (catalogued *and*
+  overridden at `^4.3.3`), which is why `.catalog-updaterc.json` ignored its
+  major updates. That override is gone, so the ignore is gone with it and its
+  majors are automated like everything else. If you ever add an override for a
+  catalogued dep, restore the ignore in the same change.
+  (`sharp` is *not* an example of this — it has never had an override. Check
+  `overrides` before assuming; `ci.yml`'s audit job asserted a `sharp` override
+  that never existed.)
 - **Dependabot cannot read `catalog:`.** It will not update catalogued deps
   (dependabot-core #14320) and may strip the `catalog` field from a manifest it
   rewrites (#12522) — both still open.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,19 @@ Use it before editing an `overrides` floor too — the CI comment in
 `.github/workflows/ci.yml` documents which floors bind and via what, and that
 comment can go stale while `bun why` cannot.
 
-The companion fix in the same change was real, not suppressed: `nanoid` is
-pinned to `^3.3.18` in `overrides` (from `3.3.16`, via `vite → postcss`),
-clearing `GHSA-2v37-7h3g-55p8`.
+**`overrides` is now a single entry** (`@discordjs/rest`), and it is a *dedupe
+pin*, not a security floor — it lifts one stale `discord.js` edge onto a
+`@discordjs/rest` its own range already allows, so `undici` clears
+`GHSA-vxpw-j846-p89q` unaided. The seven other entries were removed in #787
+after measuring what each held back; `ci.yml` records the per-entry evidence
+and the removal condition. `nanoid` was among them — it is no longer pinned
+anywhere, and `3.3.18` now holds only because `postcss`'s `^3.3.16` caret
+happens to resolve there. That is a caret, not a guarantee: **`bunfig.toml`'s
+`minimumReleaseAge` makes a caret resolve silently *down*** to the newest
+version old enough (CLAUDE.md, "Install cooldown"), where a floor would have
+errored. So if `bun audit` ever reports `nanoid`, `fast-uri` or
+`brace-expansion`, the fix is to restore that package's floor — not to hunt for
+a new consumer.
 
 ### Shared versions live in the catalog
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,8 @@ Two things this interacts with, both of which have bitten:
 `.catalog-updaterc.json` sets `"audit": {"enabled": false}` deliberately — JSON
 takes no comments, so the reason lives here. That feature defaults to **on** at
 `moderate` severity and writes `overrides` entries automatically; this repo
-curates `overrides` by hand as documented security floors, and gates at
+curates `overrides` by hand — every entry documented in `ci.yml`, and as of
+#787 that is a single dedupe pin with zero security floors — and gates at
 `--audit-level=high`. Leaving it on would open PRs editing that block for
 advisories `check:audit` deliberately ignores.
 
@@ -152,7 +153,12 @@ Two behaviours, measured on Bun 1.3.14 — know which one you are hitting:
 - a **caret range silently resolves *down*** to the newest version old enough.
   No warning. So `bun update <pkg>` to clear a *fresh* advisory can look like it
   did nothing — check the publish date before concluding the fix is broken. The
-  `overrides` floors still hold (resolving below a floor errors instead).
+  An `overrides` floor is the loud alternative — resolving below one errors
+  instead of silently stepping down. **There is currently only one `overrides`
+  entry and it is not a floor** (see "Audit gate"), so nothing in this repo is
+  protected that way today. That is the accepted cost of #787, not an oversight:
+  the packages it applies to (`nanoid`, `fast-uri`, `brace-expansion`) are named
+  there with the instruction to restore a floor if any of them goes red.
 
 `bun install --frozen-lockfile` does no resolution and is **unaffected** —
 verified; CI and all four deploy targets never see this gate.

--- a/bun.lock
+++ b/bun.lock
@@ -171,13 +171,6 @@
     "@ladle/react@5.1.1": "patches/@ladle%2Freact@5.1.1.patch",
   },
   "overrides": {
-    "@opentelemetry/core": "^2.8.0",
-    "@vitejs/plugin-react-swc": "^4.3.3",
-    "brace-expansion": "^5.0.9",
-    "fast-uri": "^4.1.2",
-    "filelist": "^2.0.2",
-    "nanoid": "^3.3.18",
-    "shell-quote": "^1.10.0",
     "undici": "^6.28.0",
   },
   "catalog": {
@@ -1385,7 +1378,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@4.1.2", "", {}, "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw=="],
+    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
@@ -1395,7 +1388,7 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
-    "filelist": ["filelist@2.0.2", "", { "dependencies": { "minimatch": "^10.2.1" } }, "sha512-qiTS+zFS40hGcaPnunc1VBkcaiEBdMSughI6Jfm5ojSNUnn28vpfftIm/q7SIjLf6Ws+l8DMWlnzlZV/f8GKAA=="],
+    "filelist": ["filelist@1.0.6", "", { "dependencies": { "minimatch": "^5.0.1" } }, "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
@@ -2093,7 +2086,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "shell-quote": ["shell-quote@1.10.0", "", {}, "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA=="],
+    "shell-quote": ["shell-quote@1.9.0", "", {}, "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA=="],
 
     "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
 
@@ -2409,11 +2402,15 @@
 
     "@happy-dom/global-registrator/@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
 
+    "@ladle/react/@vitejs/plugin-react-swc": ["@vitejs/plugin-react-swc@3.11.0", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-beta.27", "@swc/core": "^1.12.11" }, "peerDependencies": { "vite": "^4 || ^5 || ^6 || ^7" } }, "sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w=="],
+
     "@ladle/react/axe-core": ["axe-core@4.12.1", "", {}, "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA=="],
 
     "@ladle/react/vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
 
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
+
+    "@netlify/otel/@opentelemetry/core": ["@opentelemetry/core@2.8.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
@@ -2462,6 +2459,8 @@
     "buffer-image-size/@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
 
     "bun-types/@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
+
+    "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
     "happy-dom/@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
 
@@ -2517,6 +2516,8 @@
 
     "@apm-js-collab/tracing-hooks/@apm-js-collab/code-transformer/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
+    "@ladle/react/@vitejs/plugin-react-swc/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
+
     "@ladle/react/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "@ladle/react/vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -2570,6 +2571,8 @@
     "buffer-image-size/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "filelist/minimatch/brace-expansion": ["brace-expansion@2.1.4", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg=="],
 
     "msw/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
@@ -2694,6 +2697,8 @@
     "@vitejs/plugin-react/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "@vitejs/plugin-react/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "filelist/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "msw/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -172,6 +172,7 @@
   },
   "overrides": {
     "@discordjs/rest": "^2.6.3",
+    "@opentelemetry/core": "^2.8.0",
   },
   "catalog": {
     "@base-ui/react": "1.6.0",
@@ -2407,8 +2408,6 @@
     "@ladle/react/vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
 
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
-
-    "@netlify/otel/@opentelemetry/core": ["@opentelemetry/core@2.8.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -171,7 +171,7 @@
     "@ladle/react@5.1.1": "patches/@ladle%2Freact@5.1.1.patch",
   },
   "overrides": {
-    "undici": "^6.28.0",
+    "@discordjs/rest": "^2.6.3",
   },
   "catalog": {
     "@base-ui/react": "1.6.0",
@@ -2395,8 +2395,6 @@
     "@discordjs/util/discord-api-types": ["discord-api-types@0.38.48", "", {}, "sha512-WFUE/2o0lBlLeCQonQ+Pu2RqHAqbytBJ2RlXR91gzk05InSS6k9ShzzLYoymrA4c2oRgRKGE7/VqQJNNdGWSxQ=="],
 
     "@discordjs/ws/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
-
-    "@discordjs/ws/@discordjs/rest": ["@discordjs/rest@2.6.1", "", { "dependencies": { "@discordjs/collection": "^2.1.1", "@discordjs/util": "^1.2.0", "@sapphire/async-queue": "^1.5.3", "@sapphire/snowflake": "^3.5.5", "@vladfrangu/async_event_emitter": "^2.4.6", "discord-api-types": "^0.38.40", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "6.24.1" } }, "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg=="],
 
     "@discordjs/ws/discord-api-types": ["discord-api-types@0.38.48", "", {}, "sha512-WFUE/2o0lBlLeCQonQ+Pu2RqHAqbytBJ2RlXR91gzk05InSS6k9ShzzLYoymrA4c2oRgRKGE7/VqQJNNdGWSxQ=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -26,12 +26,19 @@ linker = 'isolated'
 #     Most of this repo's deps are exact pins, so this is the common case.
 #
 #   - A RANGE (caret) silently resolves DOWN to the newest version old enough.
-#     No warning. That is the footgun: the `overrides` block in package.json is
-#     a set of security FLOORS, and a caret floor whose fix shipped in the last
-#     three days resolves to something below what you think you pinned. It can
-#     never resolve below the floor itself (that would error, per above), so the
-#     floors still hold — but `bun update <pkg>` to clear a FRESH advisory will
-#     appear to do nothing until the cooldown elapses.
+#     No warning. `bun update <pkg>` to clear a FRESH advisory therefore appears
+#     to do nothing until the cooldown elapses — check the publish date before
+#     concluding the fix is broken.
+#
+#     This comment used to add that "the `overrides` block in package.json is a
+#     set of security FLOORS ... so the floors still hold". THAT IS NO LONGER
+#     TRUE and it was the reassuring half. As of #787 `overrides` holds two
+#     DEDUPE pins and zero security floors, so nothing in this repo is protected
+#     from the silent step-down described above. An override would still fail
+#     loudly (resolving below one errors), which is exactly why the five
+#     packages whose floors were dropped — nanoid, fast-uri, brace-expansion,
+#     shell-quote, filelist — are on a watch list in .github/workflows/ci.yml
+#     with the instruction to restore a floor if any of them goes red.
 #
 # `bun install --frozen-lockfile` is unaffected: it installs what bun.lock
 # already resolved and does no resolution, so CI and every deploy target never

--- a/package.json
+++ b/package.json
@@ -35,14 +35,7 @@
     }
   },
   "overrides": {
-    "undici": "^6.28.0",
-    "shell-quote": "^1.10.0",
-    "filelist": "^2.0.2",
-    "brace-expansion": "^5.0.9",
-    "fast-uri": "^4.1.2",
-    "@opentelemetry/core": "^2.8.0",
-    "@vitejs/plugin-react-swc": "^4.3.3",
-    "nanoid": "^3.3.18"
+    "undici": "^6.28.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.7",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     }
   },
   "overrides": {
-    "@discordjs/rest": "^2.6.3"
+    "@discordjs/rest": "^2.6.3",
+    "@opentelemetry/core": "^2.8.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.7",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     }
   },
   "overrides": {
-    "undici": "^6.28.0"
+    "@discordjs/rest": "^2.6.3"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.7",

--- a/tools/check-catalog.ts
+++ b/tools/check-catalog.ts
@@ -26,10 +26,12 @@
  *      and an entry nothing shares is a claim that has stopped being true.
  *
  * Deliberately NOT checked here: `overrides` (a separate mechanism that BEATS
- * the catalog — see CLAUDE.md on `@vitejs/plugin-react-swc`, the one package in
- * both), and runtime version pins like `.bun-version`, which
- * `tools/check-bun-version.ts` already reconciles across CI and every deploy
- * target.
+ * the catalog, so a package in both can leave the catalog stating a version that
+ * never resolves). No package is in both today — `@vitejs/plugin-react-swc` was
+ * the last one and its override was removed in #787 — so that hazard is dormant
+ * rather than absent. Also not checked: runtime version pins like
+ * `.bun-version`, which `tools/check-bun-version.ts` already reconciles across
+ * CI and every deploy target.
  */
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs'


### PR DESCRIPTION
`overrides` goes from **eight entries to two**, and **neither survivor is a security floor** — both are dedupe pins.

I removed them by **measuring**, not reasoning: empty the block, `bun install`, `bun run check:audit`. That method is written into `ci.yml` so it can be redone — along with the case where it is *not enough*, which this PR found the hard way.

## The two that remain

**`@discordjs/rest: ^2.6.3`** — replaces the old `undici: ^6.28.0` floor with a fix one level up.

`discord.js@14.27.0` → `@discordjs/ws@1.2.3` → `@discordjs/rest@2.6.1`, and **2.6.1 requires undici at exactly 6.24.1**, while GHSA-vxpw-j846-p89q is **HIGH** over `< 6.27.0`. Flooring undici treats the symptom. `@discordjs/rest@2.6.3` asks undici for `^6.27.0`, and `@discordjs/ws@1.2.3` already accepts `^2.5.1` — **2.6.3 is inside its declared range**, so pinning it is a dedupe, not a forced upgrade. The duplicate `@discordjs/rest` collapses, undici floats to 6.28.0 unaided, one fewer package installed, lockfile diff a pure deletion.

There is no discord.js upgrade to take instead: **14.27.0 is already the latest**, and it requires `@discordjs/ws ^1.2.3`, so the fixed `ws@2.0.4` is unreachable across that major.

**`@opentelemetry/core: ^2.8.0`** — removed, then **put back** when review disproved my justification. This is the cautionary tale of the change.

It was dropped because the audit stayed clean, which it did. Wrong test. `@netlify/otel@6.0.5` pins core at exactly 2.8.0 while its own `sdk-trace-node@2.9.0` needs core 2.9.0 — so without the override the lockfile carries **two cores in one subtree**. OTel context keys are non-registered `Symbol`s and never compare equal across copies, so the two disagree about what is in context and what is suppressed.

I then defended keeping it out on the grounds that the blast radius was Netlify's own tracing that nothing reads. **That was false.** `@sentry/node@10.69.0` *is* an OTel SDK (`sdk-trace-base ^2.9.0`) and shares a process with `@netlify/blobs` — `apps/su-assets/netlify/functions/asset.ts` imports `getStore` and `initObservability` together, as do the ITUN snapshot functions. The desync can mis-parent or un-suppress **Sentry's own spans**, silently, with no advisory to catch it.

## What the six removals actually did

Resolved versions from the `bun.lock` diff — only those can be audited:

| entry | resolves to without it | worst advisory |
|---|---|---|
| `shell-quote ^1.10.0` | 1.9.0 | `<= 1.8.4` |
| `fast-uri ^4.1.2` | 3.1.5 | `< 3.1.5` (newest of 3.x) |
| `filelist ^2.0.2` | 1.0.6 → minimatch@5.1.9 → brace-expansion@2.1.4 | `< 2.1.4` |
| `brace-expansion ^5.0.9` | unchanged at 5.0.9 | `< 5.0.9` |
| `nanoid ^3.3.18` | **not one lockfile line changed** | `< 3.3.18` |
| `@vitejs/plugin-react-swc ^4.3.3` | adds nested `@ladle/react` copy at 3.11.0 | — (dev-only dedupe) |

Three of these **end semver violations** the overrides were forcing (filelist major, fast-uri major, shell-quote exact pin), so those resolves are more correct than before, not less.

## Verification

`check:audit` **empty** · full `bun audit` only the two suppressed `image-size` ids · `check:all` exit 0 · `ladle:build` · `build:bot` + the bot's **225 tests** · `bun install --frozen-lockfile` clean · `grep -c 'opentelemetry/core@2' bun.lock` = **1**

## The trade, stated rather than hidden

Five of the six removals are downgrades onto an older line, and all five are now on a watch list in `ci.yml` **and** `CLAUDE.md`: `nanoid`, `fast-uri`, `brace-expansion`, `shell-quote`, `filelist`.

The sharper edge: **a floor fails loudly, a caret fails silently.** `bunfig.toml` sets `minimumReleaseAge`, under which a caret resolves *down* to the newest version old enough — so a re-resolve while a fresh fix is inside the 3-day window lands the older in-advisory version with no warning, where resolving below an override would have errored. `check:audit` still gates the resolved lockfile, so this is a hardening regression, not a hole. If any of the five goes red, restore that package's floor.

## Documentation corrected

`ci.yml`'s rationale (which CLAUDE.md points at **twice**), `CLAUDE.md` in four places, `bunfig.toml`, `.catalog-updaterc.json` and `tools/check-catalog.ts` all described the old block. Notable fixes:

- `ci.yml` claimed deleting the block brought back **`sharp` and `undici`**, while separately correcting three paragraphs down that `sharp` has never been in the block. Only the undici half was ever true.
- `bunfig.toml` still asserted the block "is a set of security FLOORS" and "the floors still hold" — the reassuring half, and now false.
- A draft leftover read "delete this entry and the block goes to ZERO", which would have taken `@opentelemetry/core` with it.
- The swc entry was the only package in **both** `overrides` and `workspaces.catalog` — the entire reason `.catalog-updaterc.json` ignored its majors. That ignore goes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Kko69Tg9VVf5LETsQ1TAR
