### PR TITLE
fix(itun): unbreak every snapshot Function — sharing has been 502ing since #781

### DIFF
--- a/apps/discord-bot/src/observability.ts
+++ b/apps/discord-bot/src/observability.ts
@@ -10,17 +10,21 @@
  * ever committed — it is supplied via the Render worker's environment.
  */
 
+import * as Sentry from '@sentry/node'
 import { createObservability } from 'observability/node'
 import { config } from './config.js'
 
-const observability = createObservability(() => ({
-  dsn: config.sentryDsn,
-  environment: config.nodeEnv ?? 'production',
-  // Tags events with the deployed commit SHA (Render's RENDER_GIT_COMMIT) so a
-  // Sentry error maps back to the exact deploy that produced it. Undefined when
-  // unset (e.g. local dev) — Sentry simply omits the tag.
-  release: config.releaseSha,
-}))
+const observability = createObservability(
+  () => ({
+    dsn: config.sentryDsn,
+    environment: config.nodeEnv ?? 'production',
+    // Tags events with the deployed commit SHA (Render's RENDER_GIT_COMMIT) so a
+    // Sentry error maps back to the exact deploy that produced it. Undefined when
+    // unset (e.g. local dev) — Sentry simply omits the tag.
+    release: config.releaseSha,
+  }),
+  Sentry
+)
 
 /**
  * Initializes Sentry if SENTRY_DSN is configured. Idempotent and safe to call

--- a/apps/itun/netlify/functions/_observability.ts
+++ b/apps/itun/netlify/functions/_observability.ts
@@ -14,21 +14,29 @@
  * routes (Netlify ignores `_`-prefixed files as endpoints).
  */
 
+import * as Sentry from '@sentry/node'
 import { createObservability } from 'observability/node'
 
-const observability = createObservability(() => ({
-  dsn: process.env.SENTRY_DSN,
-  environment: process.env.NODE_ENV ?? 'production',
-  // Tags events with the deployed commit so an error maps back to a specific
-  // deploy. COMMIT_REF is a Netlify-provided deploy-metadata var — confirmed
-  // present in the *build* shell (netlify.toml's ignore scripts read it
-  // directly); whether it also reaches the Function's *runtime* environment is
-  // unconfirmed. If release tags don't show up on function errors in Sentry,
-  // that's the reason — the fallback is to bake the commit SHA into the bundle
-  // at build time (e.g. via an esbuild define) rather than reading it from
-  // process.env at runtime.
-  release: process.env.COMMIT_REF,
-}))
+// The SDK is imported HERE, not in `observability/node`, so Netlify's bundler
+// resolves it from this app and copies it beside the emitted function. See the
+// header of packages/observability/src/node.ts — with the import in the shared
+// package instead, all three snapshot Functions 502'd at module load.
+const observability = createObservability(
+  () => ({
+    dsn: process.env.SENTRY_DSN,
+    environment: process.env.NODE_ENV ?? 'production',
+    // Tags events with the deployed commit so an error maps back to a specific
+    // deploy. COMMIT_REF is a Netlify-provided deploy-metadata var — confirmed
+    // present in the *build* shell (netlify.toml's ignore scripts read it
+    // directly); whether it also reaches the Function's *runtime* environment is
+    // unconfirmed. If release tags don't show up on function errors in Sentry,
+    // that's the reason — the fallback is to bake the commit SHA into the bundle
+    // at build time (e.g. via an esbuild define) rather than reading it from
+    // process.env at runtime.
+    release: process.env.COMMIT_REF,
+  }),
+  Sentry
+)
 
 /** Initializes Sentry once per cold start, if SENTRY_DSN is configured. */
 export function initObservability(): void {

--- a/apps/itun/package.json
+++ b/apps/itun/package.json
@@ -25,6 +25,7 @@
     "@netlify/blobs": "catalog:",
     "@randsum/roller": "catalog:",
     "@sentry/browser": "catalog:",
+    "@sentry/node": "catalog:",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-router": "^1.170.23",
     "@tanstack/router-plugin": "^1.168.27",

--- a/apps/su-assets/netlify/functions/_observability.ts
+++ b/apps/su-assets/netlify/functions/_observability.ts
@@ -16,14 +16,22 @@
  * in this directory would be an unclaimed endpoint on the artwork host.
  */
 
+import * as Sentry from '@sentry/node'
 import { createObservability } from 'observability/node'
 
-const observability = createObservability(() => ({
-  dsn: process.env.SENTRY_DSN,
-  environment: process.env.NODE_ENV ?? 'production',
-  // See the itun module for the COMMIT_REF-at-runtime caveat and its fallback.
-  release: process.env.COMMIT_REF,
-}))
+// Imported HERE rather than in the shared package so Netlify's bundler resolves
+// it from this app — see packages/observability/src/node.ts. itun is where that
+// broke in production; this site had the identical wiring and had simply not
+// redeployed yet.
+const observability = createObservability(
+  () => ({
+    dsn: process.env.SENTRY_DSN,
+    environment: process.env.NODE_ENV ?? 'production',
+    // See the itun module for the COMMIT_REF-at-runtime caveat and its fallback.
+    release: process.env.COMMIT_REF,
+  }),
+  Sentry
+)
 
 /** Initializes Sentry once per cold start, if SENTRY_DSN is configured. */
 export function initObservability(): void {

--- a/apps/su-assets/package.json
+++ b/apps/su-assets/package.json
@@ -10,9 +10,7 @@
   },
   "dependencies": {
     "@netlify/blobs": "catalog:",
+    "@sentry/node": "catalog:",
     "observability": "workspace:*"
-  },
-  "devDependencies": {
-    "@sentry/node": "catalog:"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,7 @@
         "@netlify/blobs": "catalog:",
         "@randsum/roller": "catalog:",
         "@sentry/browser": "catalog:",
+        "@sentry/node": "catalog:",
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-router": "^1.170.23",
         "@tanstack/router-plugin": "^1.168.27",
@@ -108,10 +109,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@netlify/blobs": "catalog:",
-        "observability": "workspace:*",
-      },
-      "devDependencies": {
         "@sentry/node": "catalog:",
+        "observability": "workspace:*",
       },
     },
     "packages/component-lib": {
@@ -154,7 +153,7 @@
     "packages/observability": {
       "name": "observability",
       "version": "0.0.0",
-      "dependencies": {
+      "devDependencies": {
         "@sentry/node": "catalog:",
       },
     },

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -21,7 +21,7 @@
     "format:check": "biome format .",
     "test": "bun test"
   },
-  "dependencies": {
+  "devDependencies": {
     "@sentry/node": "catalog:"
   }
 }

--- a/packages/observability/src/__tests__/node.test.ts
+++ b/packages/observability/src/__tests__/node.test.ts
@@ -1,4 +1,5 @@
-import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { beforeEach, describe, expect, test } from 'bun:test'
+import type { SentrySdk } from '../node'
 import { createObservability } from '../node'
 
 type Call = { fn: string; args: unknown[] }
@@ -6,27 +7,35 @@ let calls: Call[] = []
 let flushShouldThrow = false
 
 /**
- * `mock.module` is process-global — it rewrites the registry for every file
- * that runs after this one, so the real namespace is captured FIRST (spread at
- * capture time, since a module namespace is a live view) and restored in
- * `afterAll`. See `.claude/rules/testing-patterns.md`.
+ * The SDK is a constructor parameter, so the double is passed in rather than
+ * swapped into the module registry.
+ *
+ * This file used to `mock.module('@sentry/node', …)`, which is process-global —
+ * it rewrote the registry for every test file that ran after it, and needed a
+ * capture-and-restore dance in `afterAll` to stay honest (see
+ * `.claude/rules/testing-patterns.md`). Injection deletes that whole hazard.
+ * The return values are the real ones' shapes, so this stays assignable to
+ * `SentrySdk` with no cast — if the SDK's API moves, this fails typecheck.
  */
-const realSentry = { ...(await import('@sentry/node')) }
-
-mock.module('@sentry/node', () => ({
-  init: (...args: unknown[]) => calls.push({ fn: 'init', args }),
-  captureException: (...args: unknown[]) => calls.push({ fn: 'captureException', args }),
-  captureMessage: (...args: unknown[]) => calls.push({ fn: 'captureMessage', args }),
+const sentry: SentrySdk = {
+  init: (...args: unknown[]) => {
+    calls.push({ fn: 'init', args })
+    return undefined
+  },
+  captureException: (...args: unknown[]) => {
+    calls.push({ fn: 'captureException', args })
+    return 'event-id'
+  },
+  captureMessage: (...args: unknown[]) => {
+    calls.push({ fn: 'captureMessage', args })
+    return 'event-id'
+  },
   flush: async (...args: unknown[]) => {
     calls.push({ fn: 'flush', args })
     if (flushShouldThrow) throw new Error('transport down')
     return true
   },
-}))
-
-afterAll(() => {
-  mock.module('@sentry/node', () => realSentry)
-})
+}
 
 beforeEach(() => {
   calls = []
@@ -37,7 +46,7 @@ const of = (fn: string) => calls.filter((c) => c.fn === fn)
 
 describe('with no DSN', () => {
   test('init does nothing and everything stays a no-op', async () => {
-    const o = createObservability(() => ({ dsn: undefined }))
+    const o = createObservability(() => ({ dsn: undefined }), sentry)
     expect(o.init()).toBe(false)
     expect(o.enabled).toBe(false)
     o.captureException(new Error('boom'))
@@ -50,11 +59,14 @@ describe('with no DSN', () => {
 
 describe('with a DSN', () => {
   test('init passes dsn, environment and release through', () => {
-    const o = createObservability(() => ({
-      dsn: 'https://key@example.ingest.de.sentry.io/1',
-      environment: 'staging',
-      release: 'abc123',
-    }))
+    const o = createObservability(
+      () => ({
+        dsn: 'https://key@example.ingest.de.sentry.io/1',
+        environment: 'staging',
+        release: 'abc123',
+      }),
+      sentry
+    )
     expect(o.init()).toBe(true)
     expect(o.enabled).toBe(true)
     expect(of('init')[0]?.args[0]).toEqual({
@@ -65,21 +77,21 @@ describe('with a DSN', () => {
   })
 
   test('environment defaults to production', () => {
-    const o = createObservability(() => ({ dsn: 'https://k@e.io/1' }))
+    const o = createObservability(() => ({ dsn: 'https://k@e.io/1' }), sentry)
     o.init()
     const options = of('init')[0]?.args[0] as { environment?: string } | undefined
     expect(options?.environment).toBe('production')
   })
 
   test('a second init is a no-op, so startup can call it freely', () => {
-    const o = createObservability(() => ({ dsn: 'https://k@e.io/1' }))
+    const o = createObservability(() => ({ dsn: 'https://k@e.io/1' }), sentry)
     o.init()
     o.init()
     expect(of('init')).toHaveLength(1)
   })
 
   test('context rides as `extra`, and is omitted when absent', () => {
-    const o = createObservability(() => ({ dsn: 'https://k@e.io/1' }))
+    const o = createObservability(() => ({ dsn: 'https://k@e.io/1' }), sentry)
     o.init()
     const err = new Error('boom')
     o.captureException(err, { entityId: 'e1' })
@@ -89,7 +101,7 @@ describe('with a DSN', () => {
   })
 
   test('flush passes the timeout and swallows a transport failure', async () => {
-    const o = createObservability(() => ({ dsn: 'https://k@e.io/1' }))
+    const o = createObservability(() => ({ dsn: 'https://k@e.io/1' }), sentry)
     o.init()
     flushShouldThrow = true
     // Never rejects: the caller is on its way to process.exit().
@@ -107,7 +119,7 @@ describe('the config thunk', () => {
    */
   test('is read at init, not at construction', () => {
     let dsn: string | undefined
-    const o = createObservability(() => ({ dsn }))
+    const o = createObservability(() => ({ dsn }), sentry)
 
     dsn = 'https://k@e.io/1' // set AFTER the instance exists
     expect(o.init()).toBe(true)
@@ -119,7 +131,7 @@ describe('the config thunk', () => {
     createObservability(() => {
       resolved += 1
       return { dsn: undefined }
-    })
+    }, sentry)
     expect(resolved).toBe(0)
   })
 })

--- a/packages/observability/src/node.ts
+++ b/packages/observability/src/node.ts
@@ -36,9 +36,46 @@
  * the SDK to every visitor. The part of them that genuinely duplicated — the
  * capture-hint construction — is shared from `./browser`, which imports no
  * Sentry code at all.
+ *
+ * And THE SDK ITSELF is not here — it is a parameter. This file imports
+ * `@sentry/node` for its types only (`import type`, erased at build), so the
+ * package contributes no runtime import of it.
+ *
+ * That is not style; it is what keeps the Netlify Functions bootable. Netlify's
+ * bundler (zip-it-and-ship-it) cannot inline `@sentry/node` — the OpenTelemetry
+ * layer under it uses dynamic requires — so it externalises the package and
+ * copies it into the zip *next to the file the import was resolved from*. When
+ * the import lived here, that was `packages/observability/node_modules/`, while
+ * the bundled function is emitted at `apps/itun/netlify/functions/*.mjs`. Node
+ * resolves from the emitted file upward and never reaches `packages/`, so every
+ * snapshot Function died at module load with
+ *
+ *     Cannot find package '@sentry/node' imported from
+ *     /var/task/apps/itun/netlify/functions/snapshot-publish.mjs
+ *
+ * — a 502 on publish, retrieve AND delete, i.e. sharing entirely down, for a
+ * package.json edit that nothing in typecheck, tests, lint or knip could see.
+ *
+ * With the SDK injected, each consumer's own `import * as Sentry from
+ * '@sentry/node'` is what the bundler resolves, so the copy lands under that
+ * consumer's `node_modules` and the emitted file can reach it. Consequently
+ * **every consumer must declare `@sentry/node` in its own package.json**;
+ * `tools/check-observability.ts` asserts that, because production is otherwise
+ * the first place you find out.
  */
 
-import * as Sentry from '@sentry/node'
+import type * as SentryNode from '@sentry/node'
+
+/**
+ * The slice of the `@sentry/node` API this wiring uses.
+ *
+ * Derived from the real module type rather than hand-written, so a breaking SDK
+ * change fails typecheck here instead of at runtime in a Function.
+ */
+export type SentrySdk = Pick<
+  typeof SentryNode,
+  'init' | 'captureException' | 'captureMessage' | 'flush'
+>
 
 export type ObservabilityConfig = {
   /** The Sentry DSN. When absent, every method is a no-op and no SDK call is made. */
@@ -82,7 +119,10 @@ export type Observability = {
  * because every test then saw whatever the DSN was when the module first
  * loaded.
  */
-export function createObservability(resolve: () => ObservabilityConfig): Observability {
+export function createObservability(
+  resolve: () => ObservabilityConfig,
+  Sentry: SentrySdk
+): Observability {
   let initialized = false
   let enabled = false
 

--- a/tools/check-observability.ts
+++ b/tools/check-observability.ts
@@ -459,17 +459,136 @@ async function checkLive(app: BrowserApp): Promise<void> {
   console.log(`  [${app.name}] served CSP permits ${dsnHost}`)
 }
 
+/**
+ * The SERVER surfaces, which fail a different way than the browser ones.
+ *
+ * Each of these owns a shim that configures `observability/node`, and each must
+ * import `@sentry/node` ITSELF and pass it in — the shared package takes the SDK
+ * as a parameter and imports it for types only. That is not a style rule, it is
+ * a deploy constraint, so it gets a check rather than a comment.
+ *
+ * Netlify's bundler cannot inline `@sentry/node` (dynamic requires under its
+ * OpenTelemetry layer), so it externalises the package and copies it beside the
+ * file the import RESOLVED FROM. With the import in `packages/observability`,
+ * the copy landed in `packages/observability/node_modules/` while the bundled
+ * function was emitted at `apps/itun/netlify/functions/*.mjs` — and Node
+ * resolves from the emitted file upward, never reaching `packages/`. Every
+ * snapshot Function then died at module load:
+ *
+ *     Cannot find package '@sentry/node' imported from
+ *     /var/task/apps/itun/netlify/functions/snapshot-publish.mjs
+ *
+ * Publish, retrieve and delete all 502'd — sharing entirely down — from a
+ * one-line package.json edit. Typecheck, tests, lint and knip were all green,
+ * because every one of them resolves modules the way the REPO is laid out, not
+ * the way the deployed artifact is. Nothing but a deploy could see it.
+ *
+ * So: the import must live in the app, and the app must declare the dependency.
+ * A missing declaration is the same outage by a different route — it is what
+ * removes the `node_modules` entry the bundler copies from.
+ */
+type ServerSurface = {
+  name: string
+  /** The shim that calls `createObservability`, relative to repo root. */
+  modulePath: string
+  /** The manifest that must declare `@sentry/node`. */
+  manifestPath: string
+}
+
+const SERVER_SURFACES: ServerSurface[] = [
+  {
+    name: 'itun-functions',
+    modulePath: 'apps/itun/netlify/functions/_observability.ts',
+    manifestPath: 'apps/itun/package.json',
+  },
+  {
+    name: 'su-assets-functions',
+    modulePath: 'apps/su-assets/netlify/functions/_observability.ts',
+    manifestPath: 'apps/su-assets/package.json',
+  },
+  {
+    name: 'discord-bot',
+    modulePath: 'apps/discord-bot/src/observability.ts',
+    manifestPath: 'apps/discord-bot/package.json',
+  },
+]
+
+/** A VALUE import of the SDK — `import type` is erased and would not resolve. */
+const SDK_VALUE_IMPORT = /^\s*import \* as Sentry from '@sentry\/node'$/m
+
+function checkServerSurface(surface: ServerSurface): void {
+  const module = read(surface.modulePath)
+  if (module === null) {
+    fail(surface.name, `no observability module at ${surface.modulePath}`)
+    return
+  }
+
+  if (!SDK_VALUE_IMPORT.test(module)) {
+    fail(
+      surface.name,
+      `${surface.modulePath} does not value-import the SDK.\n` +
+        `      Expected: import * as Sentry from '@sentry/node'\n` +
+        '      The shared package takes it as a parameter on purpose; importing it there\n' +
+        '      instead makes the deployed Netlify Function unable to resolve it (502 at\n' +
+        '      module load). See the header of packages/observability/src/node.ts.'
+    )
+  }
+
+  const manifest = read(surface.manifestPath)
+  if (manifest === null) {
+    fail(surface.name, `no manifest at ${surface.manifestPath}`)
+    return
+  }
+
+  const { dependencies } = JSON.parse(manifest) as { dependencies?: Record<string, string> }
+  if (!dependencies?.['@sentry/node']) {
+    fail(
+      surface.name,
+      `${surface.manifestPath} does not list @sentry/node in "dependencies".\n` +
+        "      It is what puts the package under this app's node_modules, which is where\n" +
+        '      the bundler copies it from. devDependencies is not enough: the Netlify\n' +
+        '      build sets NODE_ENV=production, so it must not depend on dev installs.'
+    )
+  }
+}
+
+/**
+ * The shared package must NOT value-import the SDK — that is the exact edit
+ * that took production down, so it is asserted from both ends.
+ */
+function checkSharedPackage(): void {
+  const shared = read('packages/observability/src/node.ts')
+  if (shared === null) {
+    failures.push('  [observability] packages/observability/src/node.ts is missing')
+    return
+  }
+  if (SDK_VALUE_IMPORT.test(shared)) {
+    failures.push(
+      '  [observability] packages/observability/src/node.ts value-imports @sentry/node.\n' +
+        '      It must import it for TYPES only (`import type * as SentryNode`) and take\n' +
+        '      the SDK as a parameter — otherwise the bundler resolves it here and the\n' +
+        '      deployed Netlify Functions 502 at module load.'
+    )
+  }
+}
+
 const live = process.argv.includes('--live')
 
 console.log(
   live
     ? 'Probing production for the Sentry SDK…'
-    : 'Checking observability wiring (module → entry → CSP)…'
+    : 'Checking observability wiring (module → entry → CSP, and the server surfaces)…'
 )
 
 for (const app of BROWSER_APPS) {
   if (live) await checkLive(app)
   else checkStatic(app)
+}
+
+// Static-only: this is repo layout, and the live probe reads deployed bytes.
+if (!live) {
+  checkSharedPackage()
+  for (const surface of SERVER_SURFACES) checkServerSurface(surface)
 }
 
 if (failures.length > 0) {


### PR DESCRIPTION
## Sharing is down in production, and has been since #781

Publish, retrieve and delete all 502. Every previously-minted share link is dead too:

```
$ curl https://intheunionnow.com/api/snapshots/does-not-exist
{"errorType":"Error","errorMessage":"Cannot find package '@sentry/node' imported from
 /var/task/apps/itun/netlify/functions/snapshot-retrieve.mjs"}
```

## Why

#781 moved the Sentry wiring into `packages/observability` — the right call — and took the SDK's **import** with it.

Netlify's bundler cannot inline `@sentry/node` (dynamic requires under its OpenTelemetry layer), so it externalises the package and copies it into the zip **beside the file the import resolved from**. That became `packages/observability/node_modules/`, while the bundled function is emitted at `apps/itun/netlify/functions/*.mjs`. Node resolves from the emitted file upward and never reaches `packages/`, so the module throws before any handler runs.

## The fix

`createObservability` now takes the SDK as a parameter, and each consumer does its own `import * as Sentry from '@sentry/node'`. The wiring stays shared — #781's whole point — while the import sits where the bundler can resolve it. The shared package keeps `import type`, which is erased.

`apps/su-assets` had identical wiring and was saved only by not having redeployed yet. Fixed the same way rather than left as a timed one.

## Verification

Bundled with Netlify's own `zip-it-and-ship-it` and loaded the emitted artifact under Node:

| | before | after |
|---|---|---|
| `apps/itun/node_modules/@sentry/node` in zip | absent | present |
| `import()` the emitted `.mjs` | `ERR_MODULE_NOT_FOUND` | loads |

Full suite green (0 fail), `check:fast` green.

## The guard

`tools/check-observability.ts` now asserts both ends: the shared package must **not** value-import the SDK, and every server surface must import it *and* declare it in its own `dependencies`. Deleting the declaration reproduces #781 exactly, and the check catches it:

```
✗ observability wiring failed:
  [itun-functions] apps/itun/package.json does not list @sentry/node in "dependencies".
```

Nothing else could have. Typecheck, tests, lint and knip all resolve modules the way the **repo** is laid out, not the way the **deployed artifact** is — all four were green for the entire outage.

Also drops `mock.module('@sentry/node')` from the package tests in favour of passing a double in, removing one process-global registry rewrite (per `.claude/rules/testing-patterns.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFX8ZqS44p847zv4VbG9SY
