### PR TITLE
fix(srd): stop four unactionable browser errors filling Sentry

### DIFF
--- a/apps/srd/src/lib/__tests__/observability.test.ts
+++ b/apps/srd/src/lib/__tests__/observability.test.ts
@@ -39,7 +39,9 @@ mock.module('@sentry/browser', () => ({
   },
 }))
 
-const { captureException, initBrowserObservability } = await import('../observability')
+const { captureException, initBrowserObservability, isNetlifyRumFailure } = await import(
+  '../observability'
+)
 
 afterAll(() => {
   mock.module('@sentry/browser', () => realSentry)
@@ -50,6 +52,33 @@ afterAll(() => {
 beforeEach(() => {
   sentryCalls.length = 0
 })
+
+/**
+ * The frames of a real SRD-4 event, trimmed to what the filter reads.
+ *
+ * The ordering is the point: Netlify's RUM script is at the BOTTOM of the
+ * stack and this site's own bundle is on top, because Sentry's `fetch`
+ * instrumentation wraps the call. That is why `denyUrls` — which tests the last
+ * usable frame — cannot catch these, and why the filter scans every frame.
+ */
+const rumEvent = {
+  exception: {
+    values: [
+      {
+        stacktrace: {
+          frames: [{ filename: '/.netlify/scripts/rum' }, { filename: '/assets/prod-oZptZeYY.js' }],
+        },
+      },
+    ],
+  },
+}
+
+/** A first-party fetch failure — same error class, must still be reported. */
+const firstPartyEvent = {
+  exception: {
+    values: [{ stacktrace: { frames: [{ filename: '/assets/prod-oZptZeYY.js' }] } }],
+  },
+}
 
 describe('observability', () => {
   // Order matters: these walk one module's state machine, unconfigured first.
@@ -82,15 +111,30 @@ describe('observability', () => {
     // `tools/check-observability.ts` asserts against both netlify.tomls.
     expect(options.tracesSampleRate).toBe(0)
 
-    // Cross-document view transitions reject their `finished` promise with an
-    // AbortError whenever a navigation supersedes an in-flight one. It is not
-    // ours to catch (the promise is the browser's) and it means nothing went
-    // wrong, so it must never reach Sentry. Asserted on the substring Sentry
-    // actually matches against `${type}: ${value}`, so the real event shape
-    // "AbortError: Transition was skipped" is covered.
+    // Cross-document view transitions reject a promise the browser owns
+    // whenever it abandons a transition — superseded by a second navigation, or
+    // made ineligible by the document being hidden. It is not ours to catch and
+    // it means nothing went wrong, so it must never reach Sentry.
+    //
+    // Asserted by matching each entry the way Sentry does, as a substring of
+    // `${type}: ${value}`, against the real titles of the three issues these
+    // were added for. Asserting `toContain(entry)` alone would pass on a
+    // typo'd entry that matches nothing.
     const ignored = options.ignoreErrors as string[]
-    expect(ignored).toContain('Transition was skipped')
-    expect('AbortError: Transition was skipped').toContain(ignored[0] as string)
+    const realEventTitles = [
+      'AbortError: Transition was skipped', // SRD-A
+      'AbortError: Skipping view transition because skipTransition() was called.', // SRD-B
+      'InvalidStateError: Transition was aborted because of invalid state', // SRD-D
+    ]
+    for (const title of realEventTitles) {
+      expect(ignored.some((pattern) => title.includes(pattern))).toBe(true)
+    }
+
+    // The RUM filter has to be wired in, not merely exported — a correct
+    // predicate that `init` never installs drops nothing.
+    const beforeSend = options.beforeSend as (event: unknown) => unknown
+    expect(beforeSend(rumEvent)).toBeNull()
+    expect(beforeSend(firstPartyEvent)).toBe(firstPartyEvent)
 
     const boom = new Error('boom')
     captureException(boom, { where: 'island' })
@@ -104,6 +148,16 @@ describe('observability', () => {
     await initBrowserObservability()
 
     expect(sentryCalls.filter((c) => c.fn === 'init')).toHaveLength(0)
+  })
+
+  test('isNetlifyRumFailure keys on the RUM frame, not on the error message', () => {
+    expect(isNetlifyRumFailure(rumEvent)).toBe(true)
+    // `TypeError: Failed to fetch` is far too common a message to filter on, so
+    // an identically-shaped first-party failure must survive.
+    expect(isNetlifyRumFailure(firstPartyEvent)).toBe(false)
+    // Events with no exception at all (a `captureMessage`) must not throw.
+    expect(isNetlifyRumFailure({})).toBe(false)
+    expect(isNetlifyRumFailure({ exception: { values: [{}] } })).toBe(false)
   })
 
   test('captureException still forwards after init, with no context', () => {

--- a/apps/srd/src/lib/observability.ts
+++ b/apps/srd/src/lib/observability.ts
@@ -33,17 +33,83 @@ let sentryModule: typeof import('@sentry/browser') | null = null
  * act on even if we wanted to. Each entry names the mechanism, not just the
  * string.
  *
- * - **`Transition was skipped`** — srd opts into *cross-document* view
- *   transitions declaratively, with `@view-transition { navigation: auto }` in
- *   `src/styles/global.css`. When a second navigation supersedes an in-flight
- *   transition (a fast click, or a click during page load) the browser rejects
- *   the transition's `finished` promise with an `AbortError`. That promise
- *   belongs to the user agent — there is no JS handle of ours to `.catch()`, so
- *   the SDK is the only place it can be dropped. The navigation itself
- *   completes normally; the "error" is the feature working as specified
+ * All three entries below are the same mechanism wearing three different
+ * messages. srd opts into *cross-document* view transitions declaratively, with
+ * `@view-transition { navigation: auto }` in `src/styles/global.css`. The
+ * promises that transition exposes belong to the **user agent** — there is no JS
+ * handle of ours to `.catch()` — so when the browser abandons a transition it
+ * rejects one of them and Sentry's `onunhandledrejection` handler reports it. In
+ * every case the navigation itself completes normally, which is why the SDK is
+ * the only place these can be dropped.
+ *
+ * - **`Transition was skipped`** — a second navigation supersedes an in-flight
+ *   transition (a fast click, or a click during page load). Chrome's wording
  *   (issue SRD-A).
+ * - **`Skipping view transition`** — the same abandonment, worded
+ *   `Skipping view transition because skipTransition() was called.`, which is
+ *   what WebKit and the iOS in-app browsers emit. The `skipTransition()` call
+ *   is the browser's own, not ours: nothing in this app has a
+ *   `ViewTransition` handle to call it on (issue SRD-B, and by event count the
+ *   loudest of the three).
+ * - **`Transition was aborted because of invalid state`** — the document was
+ *   made ineligible mid-transition, typically by being backgrounded or hidden.
+ *   Reported as an `InvalidStateError` rather than an `AbortError`, so the
+ *   error *type* is no help in grouping these; the message is (issue SRD-D).
+ *
+ * Matched as substrings of Sentry's `${type}: ${value}`, so each entry covers
+ * the DOMException name prefix the events actually carry.
  */
-const IGNORED_ERRORS = ['Transition was skipped']
+const IGNORED_ERRORS = [
+  'Transition was skipped',
+  'Skipping view transition',
+  'Transition was aborted because of invalid state',
+]
+
+/**
+ * Netlify's Real User Metrics beacon, injected into every page by the platform.
+ *
+ * It is enabled per-site in the Netlify UI, not in this repo, and it is not
+ * loaded, wrapped or called by any code here.
+ */
+const NETLIFY_RUM_SCRIPT = '/.netlify/scripts/rum'
+
+/** The slice of a Sentry event this filter reads — see `buildCaptureHint` for why it is spelled out. */
+type EventWithFrames = {
+  exception?: {
+    values?: Array<{ stacktrace?: { frames?: Array<{ filename?: string }> } }>
+  }
+}
+
+/**
+ * True when the event is Netlify's RUM beacon failing to reach its collector.
+ *
+ * The beacon POSTs to `ingesteer.services-prod.nsvcs.net/rum_collection` on
+ * `pagehide`/`visibilitychange` and does not catch the rejection. That is a
+ * `TypeError: Failed to fetch` in Chrome and `TypeError: Load failed` in Safari
+ * (issues SRD-4 and SRD-E, together the second-largest source of events in this
+ * project), fired whenever a content blocker, a captive portal, or simply a
+ * page being closed mid-flight stops the request. It is unactionable here: we
+ * neither call it nor can we make it stop.
+ *
+ * This is a `beforeSend` rather than an `ignoreErrors` entry, and rather than
+ * `denyUrls`, for two separate reasons:
+ *
+ * - `ignoreErrors: ['Failed to fetch']` would also silence every genuine fetch
+ *   failure in this app — far too blunt for a message that generic.
+ * - `denyUrls` matches the *last* usable frame, and Sentry's own `fetch`
+ *   instrumentation sits on top of the RUM frames, so the frame it tests is
+ *   this site's bundle. It would not match.
+ *
+ * Keying on any frame naming the RUM script is precise: no first-party stack can
+ * contain it.
+ */
+export function isNetlifyRumFailure(event: EventWithFrames): boolean {
+  return (
+    event.exception?.values?.some((value) =>
+      value.stacktrace?.frames?.some((frame) => frame.filename?.includes(NETLIFY_RUM_SCRIPT))
+    ) ?? false
+  )
+}
 
 /**
  * Initializes browser Sentry when `PUBLIC_SENTRY_DSN` is configured.
@@ -73,6 +139,7 @@ export async function initBrowserObservability(): Promise<void> {
     // chatter minimal and avoids additional CSP surface.
     tracesSampleRate: 0,
     ignoreErrors: IGNORED_ERRORS,
+    beforeSend: (event) => (isNetlifyRumFailure(event) ? null : event),
   })
 }
 


### PR DESCRIPTION
Four of the six open issues in the srd project are noise this site cannot act
on, and between them they are ~85% of its event volume.

Three are one mechanism wearing three messages. srd opts into cross-document
view transitions declaratively; when the browser abandons one it rejects a
promise the *user agent* owns, so there is no JS handle here to `.catch()` and
the SDK is the only place they can be dropped. `Transition was skipped` (SRD-A)
was already filtered — this adds the WebKit/in-app-browser wording
`Skipping view transition because skipTransition() was called.` (SRD-B, the
loudest issue in the project at 42 events) and the backgrounded-document
`InvalidStateError: Transition was aborted because of invalid state` (SRD-D).

The fourth is Netlify's RUM beacon (SRD-4, SRD-E), which POSTs to its collector
on pagehide and does not catch the rejection — a `TypeError: Failed to fetch` /
`Load failed` whenever a content blocker or a closing page stops the request.
Filtered with a `beforeSend` keyed on a `/.netlify/scripts/rum` stack frame,
because the alternatives both fail: `ignoreErrors: ['Failed to fetch']` would
silence every genuine fetch failure in the app, and `denyUrls` tests the last
usable frame, which here is this site's own bundle (Sentry's fetch
instrumentation sits on top of the RUM frames).

Tests match each `ignoreErrors` entry the way Sentry does — as a substring of
`${type}: ${value}` — against the real event titles, so a typo'd entry that
matches nothing fails; and assert `beforeSend` is actually installed, since a
correct predicate `init` never wires in drops nothing.

Fixes SRD-B
Fixes SRD-D
Fixes SRD-4
Fixes SRD-E

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_01BKzRbinXMSKEf1opoAX2uR

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>