### PR TITLE
fix(itun): retry a transient 502 on the idempotent snapshot calls

### DIFF
--- a/apps/itun/src/lib/snapshot/__tests__/client.test.ts
+++ b/apps/itun/src/lib/snapshot/__tests__/client.test.ts
@@ -13,13 +13,14 @@
  *   - Error paths: non-OK publish, 404 retrieve, non-OK retrieve.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, setSystemTime, test } from 'bun:test'
 import type { PublishResult, SnapshotPayload } from '../client'
 import {
   deleteSnapshot,
   probeSnapshotService,
   publishSnapshot,
   retrieveSnapshot,
+  SNAPSHOT_TIMING,
   SnapshotNotFoundError,
 } from '../client'
 
@@ -318,5 +319,211 @@ describe('probeSnapshotService', () => {
       throw new TypeError('Failed to fetch')
     })
     expect(await probeSnapshotService()).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Transient-platform retry (ITUN-7 / ITUN-8)
+// ---------------------------------------------------------------------------
+
+/**
+ * A stub that answers each call with the next status in `statuses`, repeating
+ * the last one once the list runs out. Lets a test assert on the *sequence* —
+ * "a 502 then a 200" — which is the whole behaviour under test here.
+ *
+ * It records the `init` alongside the URL, not just the URL. Without that a
+ * retry which dropped `init` would turn `probeSnapshotService`'s HEAD into a
+ * GET on the second attempt and every case here would still pass — the probe
+ * only reads `.status`, and a GET to the publish endpoint answers 405 too.
+ */
+function makeSequencedFetchStub(statuses: number[], body: unknown = { ok: true }) {
+  const calls: Array<[string, RequestInit | undefined]> = []
+  const fn = asFetch(async (url, init) => {
+    const status = statuses[calls.length] ?? statuses[statuses.length - 1] ?? 200
+    calls.push([String(url), init])
+    return Response.json(body, { status })
+  })
+  return { fn, calls, urls: () => calls.map(([url]) => url) }
+}
+
+/**
+ * Collapses the client's retry pause to nothing, and records every deadline it
+ * arms on the way through.
+ *
+ * `.claude/rules/testing-patterns.md` bans waiting out a real timer in a test —
+ * dead wall clock on every run, buying no assertion. The seam is the same one
+ * this file already uses for the network: the client reaches both its pause and
+ * its `AbortController` deadlines through the global `setTimeout`, so stubbing
+ * that global is enough, with none of the fake-timer interleaving that an
+ * in-flight promise makes fragile.
+ *
+ * Only the retry *pause* is collapsed; a request budget is passed through to the
+ * real timer untouched. That is load-bearing, not fastidiousness — collapsing a
+ * request budget would abort every request on the next tick and every test here
+ * would fail as a timeout.
+ *
+ * Both buckets are recorded because both are asserted. The pauses catch a
+ * regression that dropped the wait and hammered a cold-starting function twice
+ * in one millisecond; the budgets are the only thing that pins
+ * `retryTimeoutMs`, which the client's docblock calls load-bearing to its ≤10s
+ * ceiling and which nothing else would notice being raised to a minute.
+ */
+function stubRetryDelay(): { pauses: number[]; budgets: number[]; restore: () => void } {
+  const pauses: number[] = []
+  const budgets: number[] = []
+  const real = globalThis.setTimeout
+  globalThis.setTimeout = ((cb: () => void, ms?: number, ...rest: unknown[]) => {
+    if (ms !== SNAPSHOT_TIMING.retryDelayMs) {
+      if (ms !== undefined) budgets.push(ms)
+      return real(cb, ms, ...rest)
+    }
+    pauses.push(ms)
+    return real(cb, 0)
+  }) as typeof globalThis.setTimeout
+  return {
+    pauses,
+    budgets,
+    restore: () => {
+      globalThis.setTimeout = real
+    },
+  }
+}
+
+describe('transient platform failures are retried once', () => {
+  let retryDelay: ReturnType<typeof stubRetryDelay>
+
+  beforeEach(() => {
+    retryDelay = stubRetryDelay()
+  })
+
+  afterEach(() => {
+    retryDelay.restore()
+  })
+
+  test('retrieveSnapshot survives a 502 and returns the retried payload', async () => {
+    const payload = { kind: 'mech', entity: { id: 'm-1' } }
+    const { fn, urls } = makeSequencedFetchStub([502, 200], payload)
+    global.fetch = fn
+
+    expect(await retrieveSnapshot('SZPPXCM3')).toEqual(payload)
+    // Two attempts, both at the same URL — a retry, not a fallback endpoint.
+    expect(urls()).toEqual(['/api/snapshots/SZPPXCM3', '/api/snapshots/SZPPXCM3'])
+    // …separated by a real pause, not fired back-to-back at a cold start.
+    expect(retryDelay.pauses).toEqual([SNAPSHOT_TIMING.retryDelayMs])
+    // The retry runs on its own, shorter budget. Asserting the deadline actually
+    // armed — rather than merely that a signal exists, which is true of any
+    // request — is what stops `retryTimeoutMs` from being silently raised.
+    //
+    // `toContain`, not `toEqual`: the stub classifies timers by duration and so
+    // sees every `setTimeout` in the process during this window, including any
+    // happy-dom or React arms. Exact equality would make that a flake.
+    expect(retryDelay.budgets).toContain(SNAPSHOT_TIMING.requestTimeoutMs)
+    expect(retryDelay.budgets).toContain(SNAPSHOT_TIMING.retryTimeoutMs)
+  })
+
+  test('the timings keep their invariant: a retry cannot outlast one attempt', () => {
+    // The client's docblock argues that retrying never pushes time-to-first-byte
+    // past what a single attempt was already allowed. That argument is only as
+    // good as the four numbers behind it, so it is arithmetic here rather than
+    // prose there — change any of them and this is what says so.
+    const worstCase =
+      SNAPSHOT_TIMING.retryIfAnsweredWithinMs +
+      SNAPSHOT_TIMING.retryDelayMs +
+      SNAPSHOT_TIMING.retryTimeoutMs
+
+    expect(worstCase).toBeLessThanOrEqual(SNAPSHOT_TIMING.requestTimeoutMs)
+    // And the retry's budget must be the shorter of the two, or the sum above
+    // could only hold by shrinking the first attempt — a different trade.
+    expect(SNAPSHOT_TIMING.retryTimeoutMs).toBeLessThan(SNAPSHOT_TIMING.requestTimeoutMs)
+  })
+
+  test('the retry re-sends the same method — a HEAD probe stays a HEAD', async () => {
+    const { fn, calls } = makeSequencedFetchStub([502, 405])
+    global.fetch = fn
+
+    await probeSnapshotService()
+
+    expect(calls.map(([, init]) => init?.method)).toEqual(['HEAD', 'HEAD'])
+  })
+
+  test('deleteSnapshot retries — revoke is idempotent, and a false failure is the costly one', async () => {
+    const { fn, calls } = makeSequencedFetchStub([502, 200])
+    global.fetch = fn
+
+    await deleteSnapshot('SZPPXCM3')
+
+    expect(calls.map(([, init]) => init?.method)).toEqual(['DELETE', 'DELETE'])
+  })
+
+  test('retrieveSnapshot gives up after the second attempt also fails', async () => {
+    const { fn, calls } = makeSequencedFetchStub([502, 502])
+    global.fetch = fn
+
+    // The error still names the real status, so Sentry keeps grouping it as a
+    // 502 rather than as some synthesised "retries exhausted".
+    await expect(retrieveSnapshot('SZPPXCM3')).rejects.toThrow('retrieve failed: 502')
+    expect(calls.length).toBe(2)
+  })
+
+  test('a 404 is not retried — it is an answer, not an outage', async () => {
+    const { fn, calls } = makeSequencedFetchStub([404, 200])
+    global.fetch = fn
+
+    await expect(retrieveSnapshot('SZPPXCM3')).rejects.toThrow(SnapshotNotFoundError)
+    expect(calls.length).toBe(1)
+    expect(retryDelay.pauses).toEqual([])
+  })
+
+  test('a 503 is not retried — the handler chose it about the Blobs store', async () => {
+    // `snapshot-retrieve.ts` answers 503 when `storage.get` throws. That is a
+    // considered answer about a dependency, so asking the same store again
+    // 400ms later buys nothing; only platform-level 502/504 are transient.
+    const { fn, calls } = makeSequencedFetchStub([503, 200])
+    global.fetch = fn
+
+    await expect(retrieveSnapshot('SZPPXCM3')).rejects.toThrow('retrieve failed: 503')
+    expect(calls.length).toBe(1)
+    expect(retryDelay.pauses).toEqual([])
+  })
+
+  test('probeSnapshotService reports available when the retry succeeds', async () => {
+    const { fn, calls } = makeSequencedFetchStub([502, 405])
+    global.fetch = fn
+
+    // Without the retry this returned false, which both hid the share
+    // affordance and reported `snapshot service unavailable` to Sentry.
+    expect(await probeSnapshotService()).toBe(true)
+    expect(calls.length).toBe(2)
+  })
+
+  test('publishSnapshot is never retried — a POST mints a new id per call', async () => {
+    const { fn, calls } = makeSequencedFetchStub([502, 200], { id: 'x', url: '/s/x' })
+    global.fetch = fn
+
+    await expect(publishSnapshot({ data: 'x' })).rejects.toThrow('publish failed: 502')
+    expect(calls.length).toBe(1)
+  })
+
+  test('a SLOW 502 is not retried — the function ran and blew its execution limit', async () => {
+    // Netlify emits 502 both when it declines to start a function (fast, worth
+    // one more try) and when a running function exceeds its limit (slow, and
+    // asking again only makes a person wait for the same answer twice). The
+    // clock is what tells them apart, so it is driven rather than waited on.
+    const start = Date.now()
+    setSystemTime(new Date(start))
+    const calls: string[] = []
+    global.fetch = asFetch(async (url) => {
+      calls.push(String(url))
+      setSystemTime(new Date(start + 8_000))
+      return Response.json(null, { status: 502 })
+    })
+
+    try {
+      await expect(retrieveSnapshot('SZPPXCM3')).rejects.toThrow('retrieve failed: 502')
+      expect(calls.length).toBe(1)
+      expect(retryDelay.pauses).toEqual([])
+    } finally {
+      setSystemTime()
+    }
   })
 })

--- a/apps/itun/src/lib/snapshot/client.ts
+++ b/apps/itun/src/lib/snapshot/client.ts
@@ -26,22 +26,44 @@ export class SnapshotNotFoundError extends Error {
   }
 }
 
-/** Default per-request timeout for snapshot fetches (ms). */
-const REQUEST_TIMEOUT_MS = 10_000
+/**
+ * Every deadline in this module, in one place, because they are only correct
+ * *relative to each other* — see `fetchIdempotentWithRetry`. Exported so the
+ * invariant they encode is asserted by a test rather than only by this comment.
+ */
+export const SNAPSHOT_TIMING = {
+  /** Default per-request timeout for snapshot fetches (ms). */
+  requestTimeoutMs: 10_000,
+  /** A retry is only attempted when the first answer arrived inside this window. */
+  retryIfAnsweredWithinMs: 3_000,
+  /** Pause before the single retry. */
+  retryDelayMs: 400,
+  /** Budget for the retry attempt — shorter than a first attempt, deliberately. */
+  retryTimeoutMs: 6_000,
+} as const
 
 /**
  * fetch with an AbortController timeout so the share UI can never hang on a
  * stalled connection. Throws an Error tagged `SnapshotTimeoutError` on timeout;
  * other network failures propagate as-is.
+ *
+ * The timer covers the **response headers** — it is cleared as soon as `fetch`
+ * resolves — so reading the body afterwards is not bounded by it. That is
+ * unchanged behaviour and fine for payloads this size, but it is why the
+ * guarantees below are stated about time-to-first-byte and not about wall clock.
  */
-async function fetchWithTimeout(input: string, init?: RequestInit): Promise<Response> {
+async function fetchWithTimeout(
+  input: string,
+  init?: RequestInit,
+  timeoutMs: number = SNAPSHOT_TIMING.requestTimeoutMs
+): Promise<Response> {
   const controller = new AbortController()
-  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
   try {
     return await fetch(input, { ...init, signal: controller.signal })
   } catch (err) {
     if (err instanceof DOMException && err.name === 'AbortError') {
-      const timeout = new Error(`snapshot request timed out after ${REQUEST_TIMEOUT_MS}ms`)
+      const timeout = new Error(`snapshot request timed out after ${timeoutMs}ms`)
       timeout.name = 'SnapshotTimeoutError'
       throw timeout
     }
@@ -49,6 +71,85 @@ async function fetchWithTimeout(input: string, init?: RequestInit): Promise<Resp
   } finally {
     clearTimeout(timer)
   }
+}
+
+/**
+ * Statuses that mean the *platform* failed, not the handler.
+ *
+ * Every snapshot function chooses its own statuses — a Blobs outage is a 503 it
+ * returns, an unknown id a 404, a wrong method a 405 — so a 502/504 did not come
+ * from handler code that ran. It is Netlify failing to run or reach the
+ * function. The statuses the handlers *do* choose are therefore absent here:
+ *
+ * - **500** — a real throw the handler caught and reported to Sentry.
+ * - **503** — `snapshot-{retrieve,publish,delete}.ts` return this when the
+ *   Blobs store itself failed. It is a considered answer about a dependency,
+ *   not a blip, so retrying 400ms later just asks a store that has already said
+ *   it is unavailable the same question twice.
+ *
+ * **A 502 is not automatically self-clearing, and this retry is not a substitute
+ * for looking at one.** Sharing was down for about 24 hours across #788 and
+ * #795, from two *stacked* bugs — a misplaced SDK import, then a duplicate zip
+ * entry replacing the handler — and both were deterministic module-load
+ * failures that no number of retries would have touched. Fixing the first only
+ * revealed the second.
+ *
+ * What a retry does buy is the genuinely transient half — a cold start that
+ * missed its window — at a bounded cost. Treat a run of 502s in Sentry as an
+ * outage to diagnose, not as noise this smooths over; and note that every local
+ * signal stayed green through both of those, because nothing in `check:all`
+ * runs the Functions bundler.
+ *
+ * A network-level failure is likewise not retried: this wrapper only inspects
+ * `.status` and lets a throw propagate. That keeps a genuinely offline client
+ * failing fast, which is the common case behind a `TypeError` here — an actual
+ * server that is up but unreachable answers with a status, not a throw.
+ */
+const TRANSIENT_STATUSES = new Set([502, 504])
+
+/**
+ * `fetchWithTimeout`, retried once when the platform answers with a transient
+ * status.
+ *
+ * **Only ever call this for an idempotent request.** `publishSnapshot` is a
+ * POST that mints a new id per call, so a retry there would leave a second
+ * orphaned snapshot behind on every blip; it deliberately does not use this.
+ *
+ * A single retry, not a backoff loop: every caller is in front of a waiting
+ * person — a route loader, a panel that renders "sharing is unavailable", a
+ * revoke button — so the honest ceiling is one extra round trip.
+ *
+ * **The invariant worth keeping is that retrying can never push time-to-first-
+ * byte past what a single attempt was already allowed.** A retry only happens
+ * when the first answer arrived within `retryIfAnsweredWithinMs`, so the worst
+ * case is 3000 + 400 + 6000 = 9.4s against a 10s single-attempt budget, and no
+ * surface gains a longer ceiling from this change. All four values in
+ * `SNAPSHOT_TIMING` are load-bearing to that sum — which is why a test asserts
+ * it rather than leaving this paragraph as the only check.
+ *
+ * It is a bound on headers, not on wall clock: `fetchWithTimeout` clears its
+ * timer once `fetch` resolves, so reading the body is outside it on both the
+ * retried and un-retried paths alike.
+ *
+ * If the second attempt fails too, the failure is real and the caller reports
+ * it, which is what keeps `snapshot service unavailable` meaningful in Sentry.
+ */
+async function fetchIdempotentWithRetry(input: string, init?: RequestInit): Promise<Response> {
+  const startedAt = Date.now()
+  const first = await fetchWithTimeout(input, init)
+  if (!TRANSIENT_STATUSES.has(first.status)) return first
+  if (Date.now() - startedAt > SNAPSHOT_TIMING.retryIfAnsweredWithinMs) return first
+
+  // Release the failed attempt's stream rather than leaving it open until GC.
+  // Deliberately NOT awaited: `fetchWithTimeout` has already cleared its abort
+  // timer by the time it returns, so awaiting here would be the one unbounded
+  // wait in this module — and it would sit on the path that only runs when the
+  // platform is already misbehaving, undoing the "the share UI can never hang"
+  // property the timeout exists for.
+  void first.body?.cancel().catch(() => {})
+
+  await new Promise((resolve) => setTimeout(resolve, SNAPSHOT_TIMING.retryDelayMs))
+  return fetchWithTimeout(input, init, SNAPSHOT_TIMING.retryTimeoutMs)
 }
 
 /**
@@ -77,11 +178,20 @@ export async function publishSnapshot(payload: SnapshotPayload): Promise<Publish
  * else — 404 (no function deployed), a 200 SPA-fallback HTML page, a dev-proxy
  * 5xx, or a network error — means publishing is unavailable.
  *
+ * A transient 502/504 is retried once before that verdict, because this probe's
+ * verdict is load-bearing twice over: it hides the share affordance, and it
+ * reports `snapshot service unavailable` to Sentry. One cold start should do
+ * neither.
+ *
+ * It also now carries the same timeout as every other call here — a bare
+ * `fetch` could leave the panel in `checking` forever, which is the one outcome
+ * a feature-detect must never produce.
+ *
  * Never throws; resolves false on any failure.
  */
 export async function probeSnapshotService(): Promise<boolean> {
   try {
-    const res = await fetch('/api/snapshots', { method: 'HEAD' })
+    const res = await fetchIdempotentWithRetry('/api/snapshots', { method: 'HEAD' })
     return res.status === 405 || res.status === 204
   } catch {
     return false
@@ -91,11 +201,15 @@ export async function probeSnapshotService(): Promise<boolean> {
 /**
  * Retrieves a snapshot payload from the backend by ID.
  *
+ * A shared link is the one surface here with no second chance — the viewer has
+ * no account, no local copy and no reason to suspect a reload would help — so a
+ * transient 502/504 is retried once before it becomes a broken link.
+ *
  * @throws SnapshotNotFoundError if the server returns 404.
  * @throws Error for other non-OK statuses.
  */
 export async function retrieveSnapshot(id: string): Promise<SnapshotPayload> {
-  const res = await fetchWithTimeout(`/api/snapshots/${id}`)
+  const res = await fetchIdempotentWithRetry(`/api/snapshots/${id}`)
   if (res.status === 404) {
     throw new SnapshotNotFoundError(id)
   }
@@ -109,12 +223,15 @@ export async function retrieveSnapshot(id: string): Promise<SnapshotPayload> {
  * Deletes (un-publishes / revokes) a snapshot by ID.
  *
  * The delete is idempotent server-side, so a 404 is treated as success — the
- * snapshot is gone either way, which is all the caller wanted.
+ * snapshot is gone either way, which is all the caller wanted. That same
+ * idempotence is why it is safe to retry a transient 502/504, and revoke is the
+ * operation where a false failure costs the most: the person is told their
+ * share link is still live when it may well be gone.
  *
  * @throws Error for non-OK statuses other than 404.
  */
 export async function deleteSnapshot(id: string): Promise<void> {
-  const res = await fetchWithTimeout(`/api/snapshots/${id}`, { method: 'DELETE' })
+  const res = await fetchIdempotentWithRetry(`/api/snapshots/${id}`, { method: 'DELETE' })
   if (res.ok || res.status === 404) {
     return
   }


### PR DESCRIPTION
Hardening for the snapshot Functions, from a sweep of every open Sentry issue.

## Not the fix for ITUN-7 / ITUN-8 — #795 was

`ITUN-7` ("snapshot service unavailable") and `ITUN-8` ("retrieve failed: 502")
led here, but sharing was down for ~24h from **two stacked bugs**, and this PR
fixed neither:

1. `Cannot find package '@sentry/node'` — fixed in **#788**.
2. `TypeError: D.handler is not a function`, a duplicate zip entry replacing the
   handler — fixed in **#795**.

Both Sentry issues are now resolved against #795, verified against production
(`GET /api/snapshots/AAAAAAAA` answers `404 Not found` again, not 502). This
branch therefore carries **no `Fixes` trailer** — auto-closing them here would
have credited the wrong change, and while the outage was live it would have
hidden it.

Worth stating plainly, because it is the argument for the shape of what follows:
**a retry would not have helped either bug.** Both were deterministic module-load
failures. That is now written into the code, so the next reader does not mistake
this for an outage-suppressor.

## What this PR does

Netlify emits 502/504 when it fails to run or reach a Function. The handlers
choose every other status themselves — 503 for a Blobs outage, 404 for an unknown
id, 405 for a wrong method, 500 for a caught throw — so only the platform-level
pair is retried, once, on the three **idempotent** calls: `retrieveSnapshot`, the
publish-panel probe, and `deleteSnapshot` (revoke, where a false failure is the
costly one — the person is told their link is still live).

`publishSnapshot` is excluded and tested for it: a POST mints a new id per call,
so a retry would strand an orphaned snapshot on every blip.

**Retrying can never push time-to-first-byte past what a single attempt was
already allowed.** It only fires when the first answer arrived within 3s — a fast
502 is the platform declining to start the function, a slow one is the function
having run and blown its execution limit — and the retry gets a 6s budget of its
own. `3000 + 400 + 6000 = 9.4s`, under the pre-existing 10s ceiling. All four
values live in one exported `SNAPSHOT_TIMING` object and **a test asserts the
arithmetic**, so the invariant is checked rather than merely claimed.

The probe also gains the timeout the other calls already had; a bare `fetch`
could leave the share panel in `checking` forever.

## Review

Four rounds of the recorded reviewer's findings are applied — the 503
contradiction (503 is a considered answer about Blobs, not a blip), doubled
worst-case latency, the un-retried `deleteSnapshot`, a fetch stub that discarded
`init` (a retry dropping it would have turned the probe's HEAD into a GET with
every test still green), an unbounded `await` on `body.cancel()`, and a
duration-keyed timer assertion that was a latent flake. Its first finding is what
turned up #788 and reframed this whole PR.

Tests collapse the retry pause through a `setTimeout` stub rather than waiting it
out, per `.claude/rules/testing-patterns.md`, and assert the recorded delays and
budgets so a regression that dropped the pause — or quietly raised
`retryTimeoutMs` — still fails.
