### PR TITLE
refactor(itun): name the share options live vs frozen, not public vs snapshot

### DIFF
--- a/apps/itun/src/components/sheet/PublicSheetPanel.tsx
+++ b/apps/itun/src/components/sheet/PublicSheetPanel.tsx
@@ -2,10 +2,16 @@
  * PublicSheetPanel — turn one sheet into a public, always-current page
  * ([ADR-032](../../../../../docs/adrs/ADR-032-public-read-only-sheets.md)).
  *
- * Sits below the snapshot section in `ShareStatusDialog` because the two answer
- * different questions and a player choosing between them should see both:
- * a snapshot is a **frozen** copy of this build, and this is a **live** view
- * that follows the sheet as it changes.
+ * Sits ABOVE the snapshot section in `ShareStatusDialog`, because for a
+ * signed-in player it is the better default: a link that stays current is what
+ * "share my sheet" usually means, and a frozen copy is the deliberate exception.
+ *
+ * It is headed **"Live public sheet"**, and the first word is the load-bearing
+ * one. Read-only is not what distinguishes these two — BOTH shared surfaces
+ * render through `frozenSheet.ts` + `<Sheet readOnly />`, so read-only is the
+ * constant. Heading this "Public sheet" beside "Snapshot" named the wrong axis
+ * and invited the guess that the public one was somehow writable by whoever
+ * held the link. Live-versus-frozen is the only choice actually on offer.
  *
  * Connected-only, and the gate lives in the PARENT rather than here. That is
  * not a style choice: this component calls `useQuery`/`useMutation`, which
@@ -80,19 +86,19 @@ export function PublicSheetPanel({ kind, appId, entityName, headingClass }: Publ
     // border inside a border. It kept the Panel while it sat on the share
     // screen's bare grid, where the frame was the only thing separating it.
     <section>
-      <h2 className={headingClass}>Public sheet</h2>
+      <h2 className={headingClass}>Live public sheet</h2>
 
       <p className="text-wk-muted mb-3 font-body text-caption leading-relaxed">
         {isPublic === true ? (
           <>
-            Anyone with this link can read {entityName}, with no account. It stays current as you
-            play. Turning it off takes effect immediately, everywhere.
+            On. Anyone with this link reads {entityName} as it stands right now, and it follows
+            every edit you make. Switching it off revokes the link immediately, everywhere.
           </>
         ) : (
           <>
-            Publish {entityName} to a page anyone can read without an account. Unlike a snapshot it
-            stays current as you play — and everything on the sheet, including bio and appearance
-            text, becomes readable by anyone with the link.
+            Off. Publishing gives {entityName} one page that follows the sheet as you play — no
+            account needed to read it, and no new link to send when something changes. Everything on
+            the sheet goes with it, including bio and appearance text.
           </>
         )}
       </p>
@@ -114,7 +120,13 @@ export function PublicSheetPanel({ kind, appId, entityName, headingClass }: Publ
         disabled={busy || isPublic === null}
         onClick={() => void toggle(isPublic !== true)}
       >
-        {isPublic === null ? 'Checking…' : isPublic ? 'Stop sharing' : 'Publish public sheet'}
+        {/*
+          "Stop sharing" was the off-label while this was the only thing on the
+          screen called sharing. It is now one of two, and the snapshot links
+          below survive this switch untouched — so it has to name what it turns
+          off rather than claim to end sharing outright.
+        */}
+        {isPublic === null ? 'Checking…' : isPublic ? 'Turn off' : 'Publish live sheet'}
       </Button>
 
       {error !== null && <FieldError className="mt-2">{error}</FieldError>}

--- a/apps/itun/src/components/sheet/ShareStatusDialog.tsx
+++ b/apps/itun/src/components/sheet/ShareStatusDialog.tsx
@@ -18,15 +18,27 @@
  * over the live sheet, and one less route, one less screen and one less
  * duplicate of the derived-stat math.
  *
- * ## The two share models are deliberately both here
+ * ## The two share models are deliberately both here, and named on the right axis
  *
  * They answer different questions and a player choosing between them should see
  * both (ADR-004, ADR-032):
  *
- *   Snapshot      frozen at publish time; the id IS the capability, including
- *                 for revocation; no account.
- *   Public sheet  live, follows the sheet as it changes; opt-in per entity;
- *                 revoked by switching it off, everywhere at once.
+ *   Live public sheet  follows the sheet as it changes; opt-in per entity;
+ *                      revoked by switching it off, everywhere at once.
+ *   Frozen snapshot    fixed at publish time; the id IS the capability,
+ *                      including for revocation; no account.
+ *
+ * They used to be headed "Public sheet" and "Snapshot link", which named the
+ * wrong axis. **Read-only is the constant** — every shared surface in the app
+ * renders through `frozenSheet.ts` + `<Sheet readOnly />`, the public one
+ * included — so "public" opposite "snapshot" reads as public-versus-private and
+ * invites the guess that the public page is somehow writable by whoever holds
+ * the link. Live-versus-frozen is the only thing actually being chosen, so it is
+ * what the headings say, and one line above them frames it.
+ *
+ * The live one goes FIRST when it is present: for a signed-in player a link that
+ * stays current is what "share my sheet" usually means, and a frozen copy is the
+ * deliberate exception.
  *
  * ## Two gates that are not the same gate
  *
@@ -146,6 +158,16 @@ export function ShareStatusDialog({
 
   const shareUrl = publishState.status === 'published' ? publishState.shareUrl : null
 
+  /**
+   * Whether the live half is on offer at all — which decides both the framing
+   * line's wording and whether `PublicSheetPanel` MOUNTS.
+   *
+   * The mount half is not a style choice: that component calls Convex hooks,
+   * which cannot be called conditionally and throw outright with no provider —
+   * precisely the Solo case. Gating on render is what keeps Solo working.
+   */
+  const showLive = isConvexConfigured && connectionMode === 'connected'
+
   async function handlePublish(): Promise<void> {
     setPublishState({ status: 'publishing' })
     setCopied(false)
@@ -233,22 +255,69 @@ export function ShareStatusDialog({
       */}
       {/* The padding was the Panel's; ModalShell's Card body supplies none. */}
       <div className="flex flex-col gap-5 divide-y-2 divide-ink/10 p-4 sm:p-5 [&>*+*]:pt-5">
+        {/*
+          The one sentence that makes the two sections legible as a pair.
+
+          Both were named for the wrong axis: "Public sheet" versus "Snapshot"
+          reads as public-versus-private, and invites the guess that the public
+          one is somehow editable by whoever holds the link. It is not — every
+          shared surface renders through `frozenSheet.ts` + `<Sheet readOnly />`.
+          Read-only is the CONSTANT. Live-versus-frozen is the only thing a
+          player is actually choosing between, so that is what the headings say
+          and what this line frames.
+        */}
+        <p className="text-wk-muted mb-0 mt-0 font-body text-caption leading-relaxed">
+          {showLive ? (
+            <>
+              Both give whoever has the link a read-only view of {entity.name}. The choice is
+              whether it keeps up with you.
+            </>
+          ) : (
+            /* Solo has one option, so "both" would be a lie — but the read-only
+               promise is the half that must survive either way. */
+            <>Whoever has the link gets a read-only view of {entity.name}.</>
+          )}
+        </p>
+
+        {/*
+          First when present, because for a signed-in player it is the better
+          default: a link that stays current is what "share my sheet" usually
+          means, and the frozen one is the deliberate exception below it.
+        */}
+        {showLive && (
+          <PublicSheetPanel
+            kind={kind}
+            appId={id}
+            entityName={entity.name}
+            headingClass={PANEL_HEADING_CLASS}
+          />
+        )}
+
         <section>
-          <h2 className={PANEL_HEADING_CLASS}>Snapshot link</h2>
+          <h2 className={PANEL_HEADING_CLASS}>Frozen snapshot</h2>
 
           {/*
             The status line, and the reason this dialog is called "Share status"
             rather than "Share": the first thing a player wants is not a control,
             it is an answer to "is this already out there?".
           */}
+          {/*
+            "Active", not "live". `links.length` counts snapshots that have not
+            been revoked — but one section up, "live" now means the sheet that
+            keeps current, which is the exact opposite of what a snapshot does.
+            One word, two meanings, three inches apart.
+          */}
           <p className="text-wk-muted mb-3 mt-0 font-body text-caption leading-relaxed">
             {links.length === 0 ? (
-              <>Not shared. Publishing mints a frozen copy of this build at a link.</>
+              <>
+                Not shared. Publishing mints a copy of {entity.name} as it is right now, at a link
+                that never changes again.
+              </>
             ) : (
               <>
-                Shared — {links.length} live {links.length === 1 ? 'link' : 'links'}. Each is frozen
-                at the moment it was published, so later edits to {entity.name} won&rsquo;t change
-                what it shows.
+                Shared — {links.length} active {links.length === 1 ? 'link' : 'links'}. Each shows{' '}
+                {entity.name} as it was the moment that link was published; later edits never reach
+                it.
               </>
             )}
           </p>
@@ -342,21 +411,6 @@ export function ShareStatusDialog({
             No account needed. The snapshot stores no personal data — just the build.
           </p>
         </section>
-
-        {/*
-          Mounted only when connected, and the check belongs HERE rather than
-          inside the panel: it calls Convex hooks, which cannot be called
-          conditionally and throw with no provider — precisely the Solo case.
-          Gating on render is what keeps Solo working.
-        */}
-        {isConvexConfigured && connectionMode === 'connected' && (
-          <PublicSheetPanel
-            kind={kind}
-            appId={id}
-            entityName={entity.name}
-            headingClass={PANEL_HEADING_CLASS}
-          />
-        )}
       </div>
     </ModalShell>
   )

--- a/apps/itun/src/components/sheet/__tests__/ShareStatusDialog.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/ShareStatusDialog.test.tsx
@@ -98,6 +98,28 @@ describe('ShareStatusDialog — status', () => {
     expect(screen.getByText(/not shared/i)).toBeTruthy()
   })
 
+  /**
+   * The naming axis, locked.
+   *
+   * Read-only is the CONSTANT — both shared surfaces render through
+   * `frozenSheet.ts` + `<Sheet readOnly />` — so heading these "Public sheet"
+   * and "Snapshot link" named public-versus-private, an axis on which they do
+   * not differ, and invited the guess that the public page was writable by
+   * whoever held the link. Live-versus-frozen is the real choice.
+   *
+   * Only the frozen half is assertable here: the live half calls Convex hooks
+   * and cannot mount without a provider (which is the Solo case, and this).
+   */
+  test('names the section for what it is — frozen, not "a snapshot link"', async () => {
+    await act(async () => {
+      renderDialog()
+    })
+    expect(screen.getByRole('heading', { name: /frozen snapshot/i })).toBeTruthy()
+    expect(screen.queryByRole('heading', { name: /snapshot link/i })).toBeNull()
+    // And the line that frames the pair: read-only is a given, not a choice.
+    expect(screen.getByText(/read-only view of Mara Vex/i)).toBeTruthy()
+  })
+
   test('counts existing links for this entity, and offers to revoke each', async () => {
     recordPublishedSnapshot({
       id: 'PRIOR001',
@@ -109,7 +131,10 @@ describe('ShareStatusDialog — status', () => {
     await act(async () => {
       renderDialog()
     })
-    expect(screen.getByText(/shared — 1 live link/i)).toBeTruthy()
+    // "active", not "live" — the section above is the LIVE public sheet, and
+    // one word meaning both "not revoked" and "keeps current" is the confusion
+    // this naming pass exists to remove.
+    expect(screen.getByText(/shared — 1 active link/i)).toBeTruthy()
     expect(screen.getByRole('button', { name: /remove shared link PRIOR001/i })).toBeTruthy()
   })
 })


### PR DESCRIPTION
## The headings named the wrong axis

"Public sheet" beside "Snapshot link" implies the two differ on *public vs private*. They don't. **Read-only is the constant** — every shared surface in the app renders through `frozenSheet.ts` + `<Sheet readOnly />`, the public page included — so calling one "public" invites the guess that whoever holds that link can edit the sheet.

The only thing a player is actually choosing is whether the link keeps up with them:

| | |
|---|---|
| **Live public sheet** | follows the sheet as you play |
| **Frozen snapshot** | fixed at the moment you published it |

...with one line above the pair making the shared half explicit: both give the holder a read-only view; the choice is whether it stays current.

The live one goes **first** when present. For a signed-in player, a link that stays current is what "share my sheet" usually means; a frozen copy is the deliberate exception.

## Three consequences, none cosmetic

- **"N live links" → "N active links".** `links.length` counts snapshots that haven't been revoked — but one section up, "live" now means *keeps current*, the exact opposite of what a snapshot does. One word, two meanings, three inches apart.
- **"Stop sharing" → "Turn off".** It was the off-label while this was the only thing on screen called sharing. It's now one of two, and the snapshot links below survive that switch untouched, so it has to name what it turns off rather than claim to end sharing.
- **The framing line adapts.** Solo has no live option, so "Both give…" would have been a lie there. Caught by looking at the rendered dialog, not the diff.

## Verified

Driven through the running app in Solo, published and unpublished. `check:all` green, full suite 0 fail. A test locks the headings and the read-only framing line.

The connected two-section case is not visually verified here — it needs a signed-in Convex session — but the live half is unchanged except for its heading, copy and button label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFX8ZqS44p847zv4VbG9SY
