### PR TITLE
PROBE: pin node_bundler (do not merge)

### DIFF
--- a/apps/itun/netlify.toml
+++ b/apps/itun/netlify.toml
@@ -81,6 +81,11 @@
   BUN_VERSION = "1.3.14" # keep in sync with .bun-version (checked by tools/check-bun-version.ts)
   NODE_ENV = "production"
 
+# PROBE (not for merge): pin the function bundler to see whether the
+# "D.handler is not a function" bootstrap failure follows the default (nft).
+[functions]
+  node_bundler = "esbuild"
+
 # ---------------------------------------------------------------------------
 # Snapshot API routing
 # ---------------------------------------------------------------------------

--- a/apps/itun/netlify/functions/snapshot-delete.ts
+++ b/apps/itun/netlify/functions/snapshot-delete.ts
@@ -20,7 +20,7 @@ import { isValidSnapshotId } from '../../src/lib/snapshot/id'
 import { getClientIp, RateLimiter } from '../../src/lib/snapshot/rateLimit'
 import type { SnapshotStorage } from '../../src/lib/snapshot/storage'
 import { createNetlifyBlobsStorage } from '../../src/lib/snapshot/storage'
-import { captureException, initObservability } from './_observability'
+import { captureException, initObservability } from '../lib/observability'
 
 // ---------------------------------------------------------------------------
 // Module-level rate limiter — persists across invocations within one instance

--- a/apps/itun/netlify/functions/snapshot-publish.ts
+++ b/apps/itun/netlify/functions/snapshot-publish.ts
@@ -15,7 +15,7 @@ import { generateUniqueId } from '../../src/lib/snapshot/id'
 import { getClientIp, RateLimiter } from '../../src/lib/snapshot/rateLimit'
 import type { SnapshotStorage } from '../../src/lib/snapshot/storage'
 import { createNetlifyBlobsStorage } from '../../src/lib/snapshot/storage'
-import { captureException, initObservability } from './_observability'
+import { captureException, initObservability } from '../lib/observability'
 
 // ---------------------------------------------------------------------------
 // Module-level rate limiter — persists across invocations within one instance

--- a/apps/itun/netlify/functions/snapshot-retrieve.ts
+++ b/apps/itun/netlify/functions/snapshot-retrieve.ts
@@ -13,7 +13,7 @@
 import { isValidSnapshotId } from '../../src/lib/snapshot/id'
 import type { SnapshotStorage } from '../../src/lib/snapshot/storage'
 import { createNetlifyBlobsStorage } from '../../src/lib/snapshot/storage'
-import { captureException, initObservability } from './_observability'
+import { captureException, initObservability } from '../lib/observability'
 
 // ---------------------------------------------------------------------------
 // Handler factory — accepts injected storage for testability

--- a/apps/itun/netlify/functions/zzprobe.ts
+++ b/apps/itun/netlify/functions/zzprobe.ts
@@ -1,0 +1,6 @@
+/** Diagnostic probe — NOT for merge.
+ * @public Netlify Functions handler: invoked by the platform, never imported.
+ */
+export default async function (): Promise<Response> {
+  return new Response('hello from a v2 function')
+}

--- a/apps/itun/netlify/functions/zzprobe2.ts
+++ b/apps/itun/netlify/functions/zzprobe2.ts
@@ -1,0 +1,8 @@
+import { getStore } from '@netlify/blobs'
+
+/** Diagnostic probe — NOT for merge. Isolates the `@netlify/blobs` import.
+ * @public Netlify Functions handler: invoked by the platform, never imported.
+ */
+export default async function (): Promise<Response> {
+  return new Response(`blobs import ok: ${typeof getStore}`)
+}

--- a/apps/itun/netlify/functions/zzprobe3.ts
+++ b/apps/itun/netlify/functions/zzprobe3.ts
@@ -1,0 +1,9 @@
+import { initObservability } from '../lib/observability'
+
+/** Diagnostic probe — NOT for merge. Isolates the observability import, i.e.
+ * the `observability` workspace package plus the externalized `@sentry/node`.
+ * @public Netlify Functions handler: invoked by the platform, never imported.
+ */
+export default async function (): Promise<Response> {
+  return new Response(`observability import ok: ${typeof initObservability}`)
+}

--- a/apps/itun/netlify/functions/zzprobe4.ts
+++ b/apps/itun/netlify/functions/zzprobe4.ts
@@ -1,0 +1,12 @@
+/** Diagnostic probe — NOT for merge. Isolates having a NAMED export alongside
+ * the default, which is the shape every snapshot function has.
+ * @public Netlify Functions handler: invoked by the platform, never imported.
+ */
+export function makeSomeHandler(x: string): string {
+  return x
+}
+
+/** @public */
+export default async function (req: Request): Promise<Response> {
+  return new Response(`named+default ok: ${makeSomeHandler(req.method)}`)
+}

--- a/apps/itun/netlify/functions/zzprobe5.ts
+++ b/apps/itun/netlify/functions/zzprobe5.ts
@@ -1,0 +1,9 @@
+import { createNetlifyBlobsStorage } from '../../src/lib/snapshot/storage'
+
+/** Diagnostic probe — NOT for merge. Isolates importing app source from
+ * `../../src/lib/`, which every snapshot function does and no other probe does.
+ * @public Netlify Functions handler: invoked by the platform, never imported.
+ */
+export default async function (): Promise<Response> {
+  return new Response(`src import ok: ${typeof createNetlifyBlobsStorage}`)
+}

--- a/apps/itun/netlify/lib/observability.ts
+++ b/apps/itun/netlify/lib/observability.ts
@@ -1,17 +1,38 @@
 /**
- * _observability — optional Sentry error tracking for the snapshot Netlify
+ * observability — optional Sentry error tracking for the snapshot Netlify
  * Functions.
  *
  * The wiring lives in `observability/node`; this file is the ITUN site's
- * configuration of it. It used to be a byte-identical copy of
- * `apps/su-assets/netlify/functions/_observability.ts`, whose own comment said
- * "there is no reason for the two to drift" — and they had, this one carrying a
- * COMMIT_REF caveat the other lacked.
+ * configuration of it. It used to be a byte-identical copy of su-assets',
+ * whose own comment said "there is no reason for the two to drift" — and they
+ * had, this one carrying a COMMIT_REF caveat the other lacked.
  *
  * Env-gated: with `SENTRY_DSN` unset, every export is a no-op and no Sentry
  * network call is made. No DSN is committed — it comes from the Netlify site
- * environment. The leading underscore keeps this out of the deployed function
- * routes (Netlify ignores `_`-prefixed files as endpoints).
+ * environment.
+ *
+ * ## It lives in `lib/`, not `functions/`, and that is not tidying
+ *
+ * It sat beside the handlers as `functions/_observability.ts` on the belief —
+ * written into this header — that "the leading underscore keeps this out of the
+ * deployed function routes (Netlify ignores `_`-prefixed files as endpoints)".
+ *
+ * Netlify does not ignore them. The deploy manifest listed `_observability`
+ * among the site's deployed functions, and hitting it confirmed what that meant:
+ *
+ *     $ curl https://intheunionnow.com/.netlify/functions/_observability
+ *     {"errorType":"Runtime.HandlerNotFound",
+ *      "errorMessage":"_observability.handler is undefined or not exported"}
+ *
+ * A public endpoint that 502s and prints an internal path, for a file that is
+ * not a handler and never claimed to be. `functions = "apps/itun/netlify/
+ * functions"` in netlify.toml is what makes a file a function — a naming
+ * convention is not, and cannot be.
+ *
+ * So the rule is positional: only handlers go in `functions/`. What they import
+ * lives here, where esbuild still inlines it into each bundle and the platform
+ * never sees it as an endpoint. `tools/check-observability.ts` asserts the
+ * location.
  */
 
 import * as Sentry from '@sentry/node'

--- a/apps/su-assets/netlify/functions/asset.ts
+++ b/apps/su-assets/netlify/functions/asset.ts
@@ -14,7 +14,7 @@
  * mutated in place (a new image gets a new name).
  */
 import { getStore } from '@netlify/blobs'
-import { captureException, initObservability } from './_observability'
+import { captureException, initObservability } from '../lib/observability'
 
 const CONTENT_TYPES: Record<string, string> = {
   png: 'image/png',

--- a/apps/su-assets/netlify/lib/observability.test.ts
+++ b/apps/su-assets/netlify/lib/observability.test.ts
@@ -26,10 +26,10 @@ mock.module('@sentry/node', () => ({
   captureException: (...args: unknown[]) => sentryCalls.push({ fn: 'captureException', args }),
 }))
 
-let obs: typeof import('../_observability')
+let obs: typeof import('./observability')
 
 beforeAll(async () => {
-  obs = await import('../_observability')
+  obs = await import('./observability')
 })
 
 afterAll(() => {
@@ -79,15 +79,15 @@ describe('with no DSN configured', () => {
  * declaration for a cache-busted one; a non-literal specifier is untyped, so
  * the cast restores the real shape.
  */
-const FRESH_SPECIFIER = '../_observability?fresh'
+const FRESH_SPECIFIER = './observability?fresh'
 
 describe('once a DSN is configured before the first init', () => {
-  let fresh: typeof import('../_observability')
+  let fresh: typeof import('./observability')
 
   beforeAll(async () => {
     process.env.SENTRY_DSN = 'https://key@example.ingest.sentry.io/1'
     process.env.COMMIT_REF = 'abc123'
-    fresh = (await import(FRESH_SPECIFIER)) as typeof import('../_observability')
+    fresh = (await import(FRESH_SPECIFIER)) as typeof import('./observability')
   })
 
   test('init passes the DSN, environment and release through', () => {

--- a/apps/su-assets/netlify/lib/observability.ts
+++ b/apps/su-assets/netlify/lib/observability.ts
@@ -1,5 +1,5 @@
 /**
- * _observability — optional Sentry error tracking for the artwork function.
+ * observability — optional Sentry error tracking for the artwork function.
  *
  * The wiring lives in `observability/node`; this file is the su-assets site's
  * configuration of it. It used to be a byte-identical copy of ITUN's, kept in
@@ -10,10 +10,17 @@
  * export is a no-op and no Sentry network call is made. No DSN is ever
  * committed — it comes from the `su-assets` Netlify site environment.
  *
- * The leading underscore keeps this out of the deployed function routes
- * (Netlify ignores `_`-prefixed files as endpoints), which matters more here
- * than on itun: `asset.ts` claims `path: '/*'`, so a second routable function
- * in this directory would be an unclaimed endpoint on the artwork host.
+ * ## It lives in `lib/`, not `functions/` — see ITUN's copy for the receipts
+ *
+ * The old header claimed the leading underscore kept it out of the deployed
+ * function routes. It did not: Netlify deployed `_observability` as a function
+ * on both sites, where it answered `Runtime.HandlerNotFound`.
+ *
+ * That claim mattered more here than on ITUN, and the reason it gave was sound
+ * even though its premise was false: `asset.ts` claims `path: '/*'`, so a second
+ * routable function on the artwork host is an unclaimed endpoint sitting beside
+ * a catch-all. Moving the file out is what actually delivers what the comment
+ * promised.
  */
 
 import * as Sentry from '@sentry/node'

--- a/tools/check-observability.ts
+++ b/tools/check-observability.ts
@@ -40,7 +40,7 @@
  *   bun tools/check-observability.ts --live    # production probe (nightly)
  */
 
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 /**
@@ -498,12 +498,12 @@ type ServerSurface = {
 const SERVER_SURFACES: ServerSurface[] = [
   {
     name: 'itun-functions',
-    modulePath: 'apps/itun/netlify/functions/_observability.ts',
+    modulePath: 'apps/itun/netlify/lib/observability.ts',
     manifestPath: 'apps/itun/package.json',
   },
   {
     name: 'su-assets-functions',
-    modulePath: 'apps/su-assets/netlify/functions/_observability.ts',
+    modulePath: 'apps/su-assets/netlify/lib/observability.ts',
     manifestPath: 'apps/su-assets/package.json',
   },
   {
@@ -512,6 +512,53 @@ const SERVER_SURFACES: ServerSurface[] = [
     manifestPath: 'apps/discord-bot/package.json',
   },
 ]
+
+/**
+ * Every Netlify functions directory in the repo.
+ *
+ * A file sitting here IS an endpoint. That is positional and absolute: the
+ * `functions = …` key in netlify.toml is what makes a file a function, and no
+ * naming convention overrides it. `_observability.ts` lived in both of these on
+ * the belief that a leading underscore excluded it; Netlify deployed it anyway,
+ * on both sites, where it answered
+ *
+ *     Runtime.HandlerNotFound: _observability.handler is undefined or not exported
+ *
+ * — a public 502 printing an internal path, for a module that was never a
+ * handler. Nothing was watching, because the belief was in a comment.
+ */
+const FUNCTION_DIRS = ['apps/itun/netlify/functions', 'apps/su-assets/netlify/functions']
+
+/** What the Netlify runtime looks for: v2 `export default`, or v1 `handler`. */
+const EXPORTS_A_HANDLER =
+  /^\s*export\s+(default\b|(async\s+)?function\s+handler\b|const\s+handler\b)/m
+
+/**
+ * Nothing may sit in a functions directory unless it is a function.
+ *
+ * Subdirectories are skipped — zisi only treats top-level files as entries, so
+ * `__tests__/` is not an endpoint.
+ */
+function checkFunctionDirs(): void {
+  for (const dir of FUNCTION_DIRS) {
+    const full = join(process.cwd(), dir)
+    if (!existsSync(full)) {
+      failures.push(`  [functions] missing directory ${dir}`)
+      continue
+    }
+    for (const entry of readdirSync(full, { withFileTypes: true })) {
+      if (!entry.isFile() || !/\.(ts|js|mjs)$/.test(entry.name)) continue
+      const source = read(join(dir, entry.name))
+      if (source !== null && EXPORTS_A_HANDLER.test(source)) continue
+      failures.push(
+        `  [functions] ${dir}/${entry.name} exports no handler, but everything in a\n` +
+          '      functions directory is deployed as a public endpoint — this one would\n' +
+          '      answer Runtime.HandlerNotFound. A leading underscore does NOT exclude it.\n' +
+          '      Shared modules belong in ../lib/, which the bundler still inlines.'
+      )
+    }
+  }
+}
 
 /** A VALUE import of the SDK — `import type` is erased and would not resolve. */
 const SDK_VALUE_IMPORT = /^\s*import \* as Sentry from '@sentry\/node'$/m
@@ -587,6 +634,7 @@ for (const app of BROWSER_APPS) {
 
 // Static-only: this is repo layout, and the live probe reads deployed bytes.
 if (!live) {
+  checkFunctionDirs()
   checkSharedPackage()
   for (const surface of SERVER_SURFACES) checkServerSurface(surface)
 }


### PR DESCRIPTION
Diagnostic only — testing whether the `D.handler is not a function` bootstrap failure follows the default nft bundler. Will be closed.