### PR TITLE
fix(itun): redirect the retired /sheet/:kind/:id/share URL to the live sheet

### DIFF
--- a/apps/itun/netlify.toml
+++ b/apps/itun/netlify.toml
@@ -175,6 +175,33 @@
   to = "/index.html"
   status = 404
 
+# ---------------------------------------------------------------------------
+# Retired URLs
+# ---------------------------------------------------------------------------
+
+# /sheet/:kind/:id/share → the sheet itself.
+#
+# The Share Snapshot screen was removed in #793 — sharing is now a dialog over
+# the live sheet — so this is where a bookmark or a pasted builder link would
+# otherwise dead-end on the SPA's not-found page.
+#
+# MUST precede the SPA fallback below: first match wins, and that rule has no
+# method or path condition, so it would swallow this and answer 200 index.html.
+#
+# This rule is NOT sufficient on its own, and the app carries a matching
+# client-side redirect route. The service worker registers a `NavigationRoute`
+# bound to a precached `index.html`, so for anyone with the app installed or
+# cached a navigation is answered from Cache Storage and never reaches Netlify.
+# This covers first-time loads, crawlers and non-SW clients; the route covers
+# everyone else. See apps/itun/src/routes/sheet/$kind/$id_.share.tsx.
+#
+# 301 rather than 302: the screen is not coming back.
+[[redirects]]
+  from = "/sheet/:kind/:id/share"
+  to = "/sheet/:kind/:id"
+  status = 301
+  force = true
+
 # SPA fallback — serve index.html for all unmatched paths
 [[redirects]]
   from = "/*"

--- a/apps/itun/src/routeTree.gen.ts
+++ b/apps/itun/src/routeTree.gen.ts
@@ -28,6 +28,7 @@ import { Route as SIdRouteImport } from './routes/s/$id'
 import { Route as MechsPatternsIndexRouteImport } from './routes/mechs/patterns/index'
 import { Route as PKindAppIdRouteImport } from './routes/p.$kind.$appId'
 import { Route as SheetKindIdRouteImport } from './routes/sheet/$kind/$id'
+import { Route as SheetKindIdShareRouteImport } from './routes/sheet/$kind/$id_.share'
 import { Route as GamesGameIdViewKindEntityIdRouteImport } from './routes/games_.$gameId_.view.$kind.$entityId'
 
 const IndexRoute = IndexRouteImport.update({
@@ -125,6 +126,11 @@ const SheetKindIdRoute = SheetKindIdRouteImport.update({
   path: '/sheet/$kind/$id',
   getParentRoute: () => rootRouteImport,
 } as any)
+const SheetKindIdShareRoute = SheetKindIdShareRouteImport.update({
+  id: '/sheet/$kind/$id_/share',
+  path: '/sheet/$kind/$id/share',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const GamesGameIdViewKindEntityIdRoute =
   GamesGameIdViewKindEntityIdRouteImport.update({
     id: '/games_/$gameId_/view/$kind/$entityId',
@@ -152,6 +158,7 @@ export interface FileRoutesByFullPath {
   '/p/$kind/$appId': typeof PKindAppIdRoute
   '/sheet/$kind/$id': typeof SheetKindIdRoute
   '/mechs/patterns/': typeof MechsPatternsIndexRoute
+  '/sheet/$kind/$id/share': typeof SheetKindIdShareRoute
   '/games/$gameId/view/$kind/$entityId': typeof GamesGameIdViewKindEntityIdRoute
 }
 export interface FileRoutesByTo {
@@ -174,6 +181,7 @@ export interface FileRoutesByTo {
   '/p/$kind/$appId': typeof PKindAppIdRoute
   '/sheet/$kind/$id': typeof SheetKindIdRoute
   '/mechs/patterns': typeof MechsPatternsIndexRoute
+  '/sheet/$kind/$id/share': typeof SheetKindIdShareRoute
   '/games/$gameId/view/$kind/$entityId': typeof GamesGameIdViewKindEntityIdRoute
 }
 export interface FileRoutesById {
@@ -197,6 +205,7 @@ export interface FileRoutesById {
   '/p/$kind/$appId': typeof PKindAppIdRoute
   '/sheet/$kind/$id': typeof SheetKindIdRoute
   '/mechs/patterns/': typeof MechsPatternsIndexRoute
+  '/sheet/$kind/$id_/share': typeof SheetKindIdShareRoute
   '/games_/$gameId_/view/$kind/$entityId': typeof GamesGameIdViewKindEntityIdRoute
 }
 export interface FileRouteTypes {
@@ -221,6 +230,7 @@ export interface FileRouteTypes {
     | '/p/$kind/$appId'
     | '/sheet/$kind/$id'
     | '/mechs/patterns/'
+    | '/sheet/$kind/$id/share'
     | '/games/$gameId/view/$kind/$entityId'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -243,6 +253,7 @@ export interface FileRouteTypes {
     | '/p/$kind/$appId'
     | '/sheet/$kind/$id'
     | '/mechs/patterns'
+    | '/sheet/$kind/$id/share'
     | '/games/$gameId/view/$kind/$entityId'
   id:
     | '__root__'
@@ -265,6 +276,7 @@ export interface FileRouteTypes {
     | '/p/$kind/$appId'
     | '/sheet/$kind/$id'
     | '/mechs/patterns/'
+    | '/sheet/$kind/$id_/share'
     | '/games_/$gameId_/view/$kind/$entityId'
   fileRoutesById: FileRoutesById
 }
@@ -288,6 +300,7 @@ export interface RootRouteChildren {
   PKindAppIdRoute: typeof PKindAppIdRoute
   SheetKindIdRoute: typeof SheetKindIdRoute
   MechsPatternsIndexRoute: typeof MechsPatternsIndexRoute
+  SheetKindIdShareRoute: typeof SheetKindIdShareRoute
   GamesGameIdViewKindEntityIdRoute: typeof GamesGameIdViewKindEntityIdRoute
 }
 
@@ -426,6 +439,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SheetKindIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/sheet/$kind/$id_/share': {
+      id: '/sheet/$kind/$id_/share'
+      path: '/sheet/$kind/$id/share'
+      fullPath: '/sheet/$kind/$id/share'
+      preLoaderRoute: typeof SheetKindIdShareRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/games_/$gameId_/view/$kind/$entityId': {
       id: '/games_/$gameId_/view/$kind/$entityId'
       path: '/games/$gameId/view/$kind/$entityId'
@@ -456,6 +476,7 @@ const rootRouteChildren: RootRouteChildren = {
   PKindAppIdRoute: PKindAppIdRoute,
   SheetKindIdRoute: SheetKindIdRoute,
   MechsPatternsIndexRoute: MechsPatternsIndexRoute,
+  SheetKindIdShareRoute: SheetKindIdShareRoute,
   GamesGameIdViewKindEntityIdRoute: GamesGameIdViewKindEntityIdRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/itun/src/routes/__tests__/retiredShareRoute.test.tsx
+++ b/apps/itun/src/routes/__tests__/retiredShareRoute.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * The retired `/sheet/:kind/:id/share` URL must land on that entity's live
+ * sheet, not on the not-found page.
+ *
+ * The Share Snapshot screen was removed in #793. Anyone who bookmarked the URL,
+ * or pasted it to themselves, still has it — and the builder is exactly the kind
+ * of app where people keep a tab pinned for a season.
+ *
+ * `beforeLoad` is called directly rather than through a router: the assertion is
+ * about where this route sends you and with which params, which is the whole of
+ * its behaviour.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { Route } from '../sheet/$kind/$id_.share'
+
+/**
+ * What `redirect()` actually throws: the options are NESTED under `.options`,
+ * not spread onto the thrown object. Asserting the flat shape passes `toBe`
+ * nothing and fails confusingly, so it is spelled out here.
+ */
+type RedirectThrow = {
+  options: {
+    to: string
+    params: { kind: string; id: string }
+    replace?: boolean
+  }
+}
+
+function redirectFor(kind: string, id: string): RedirectThrow {
+  const beforeLoad = Route.options.beforeLoad
+  if (typeof beforeLoad !== 'function') throw new Error('route has no beforeLoad')
+  try {
+    // biome-ignore lint/suspicious/noExplicitAny: exercising one field of the router's ctx
+    beforeLoad({ params: { kind, id } } as any)
+  } catch (thrown) {
+    return thrown as RedirectThrow
+  }
+  throw new Error('beforeLoad did not redirect')
+}
+
+describe('retired /sheet/:kind/:id/share', () => {
+  test.each([
+    ['pilot', 'pilot-1'],
+    ['mech', '0246f9a3-84db-4968-b295-4cc8b6b2c2f5'],
+    ['crawler', 'crawler-9'],
+  ])('redirects a %s to its live sheet', (kind, id) => {
+    const { options } = redirectFor(kind, id)
+    expect(options.to).toBe('/sheet/$kind/$id')
+    expect(options.params).toEqual({ kind, id })
+  })
+
+  /**
+   * Without `replace`, Back would return to the retired URL and bounce forward
+   * again — the reader would be unable to leave by the obvious route.
+   */
+  test('replaces rather than pushes, so Back still works', () => {
+    expect(redirectFor('mech', 'mech-1').options.replace).toBe(true)
+  })
+})

--- a/apps/itun/src/routes/sheet/$kind/$id_.share.tsx
+++ b/apps/itun/src/routes/sheet/$kind/$id_.share.tsx
@@ -1,0 +1,38 @@
+/**
+ * /sheet/$kind/$id/share — retired Share Snapshot screen, now a redirect.
+ *
+ * Sharing stopped being a place you go (#793): the screen's whole left half
+ * previewed the sheet you were one click away from, so it became
+ * `ShareStatusDialog` over the live sheet itself. This route is what stops a
+ * bookmark or a pasted builder link from dead-ending on the not-found page.
+ *
+ * It redirects to the sheet rather than opening the dialog. The URL never
+ * carried publish state — it was only ever a way to reach the controls — and
+ * landing on the sheet puts the reader exactly where the controls now live, one
+ * click from Share.
+ *
+ * `replace: true` keeps the retired URL out of history, so Back goes where the
+ * reader came from instead of bouncing off this redirect.
+ *
+ * ## This is the belt; netlify.toml has the braces
+ *
+ * A 301 in netlify.toml alone would NOT be enough, and that is worth stating
+ * because it looks like it should be. The app is a PWA whose service worker
+ * registers a `NavigationRoute` bound to a precached `index.html`
+ * (`createHandlerBoundToURL("index.html")` in the deployed sw.js), so for anyone
+ * who has the app installed or cached, a navigation is answered from the cache
+ * and never reaches Netlify. The edge redirect covers first-time loads, crawlers
+ * and non-SW clients; this route covers everyone else. Both are needed.
+ */
+
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/sheet/$kind/$id_/share')({
+  beforeLoad: ({ params }) => {
+    throw redirect({
+      to: '/sheet/$kind/$id',
+      params: { kind: params.kind, id: params.id },
+      replace: true,
+    })
+  },
+})


### PR DESCRIPTION
#793 removed the Share Snapshot screen — and its route with it. Anyone holding that URL (a bookmark, a tab pinned for a season, a link pasted to themselves) has been landing on the **not-found page**. The builder is exactly the kind of app where people keep that tab open.

It now goes to the entity's live sheet, which is where the share controls moved — one click from the Share button.

Redirecting to the sheet rather than auto-opening the dialog is deliberate: the URL never carried publish state, it was only ever a way to reach the controls.

## Two mechanisms, and both are needed

| | covers |
|---|---|
| `routes/sheet/$kind/$id_.share.tsx` — `beforeLoad` redirect | anyone with the app installed or cached |
| 301 in `netlify.toml`, before the SPA fallback | first loads, crawlers, non-SW clients |

**The edge redirect alone would not do it**, which is worth stating because it looks like it should. This is a PWA whose service worker registers a `NavigationRoute` bound to a precached `index.html` — confirmed in the deployed worker:

```
$ curl -s https://intheunionnow.com/sw.js | grep -o 'createHandlerBoundToURL("index.html")'
createHandlerBoundToURL("index.html")
```

So for a returning user the navigation is answered from Cache Storage and never reaches Netlify.

The `netlify.toml` rule is ordered **before** the SPA fallback on purpose — that rule has no condition, so it would otherwise swallow this and answer `200 index.html`.

The route follows the shape already used by the `/pilots/:id`, `/mechs/:id` and `/crawlers/:id` legacy routes. `replace: true` so Back returns where the reader came from instead of bouncing off the redirect.

## Verified

Drove the real app: entering the retired URL lands on the sheet, Share button present, no not-found. Unit tests cover all three kinds plus the `replace` flag — the thrown redirect nests its options under `.options`, which the test spells out because asserting the flat shape fails confusingly.

`check:all` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFX8ZqS44p847zv4VbG9SY
