### PR TITLE
chore(ci): name the aggregate gate "CI Success"

### DIFF
--- a/.github/workflows/catalog-update.yml
+++ b/.github/workflows/catalog-update.yml
@@ -72,7 +72,7 @@ jobs:
           # NOT trigger ci.yml — GitHub suppresses workflow runs for events
           # raised by GITHUB_TOKEN, to prevent recursion.
           #
-          # That fails CLOSED here rather than open: `quality-checks` is a
+          # That fails CLOSED here rather than open: `CI Success` is a
           # required status on main, so a catalog PR with no CI run simply
           # cannot be merged. To get checks running, either close and reopen the
           # PR, or give the action a GitHub App token (see the action's README)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   # NO `branches:` filter here, deliberately. That filter matches the PR's BASE
   # branch, so `branches: ['main']` silently gave ZERO checks to any PR based on
   # something other than main — i.e. every layer of a stacked PR above the
-  # bottom one. Since `quality-checks` is a required status on main, those PRs
+  # bottom one. Since `CI Success` is a required status on main, those PRs
   # were not merely unchecked, they were unmergeable, with nothing on the PR
   # saying why: `gh pr checks` reports "no checks reported" and the required
   # check simply never arrives.
@@ -707,11 +707,17 @@ jobs:
   # ---------------------------------------------------------------------------
   # Single aggregate gate. Always runs; fails if any job actually failed (a
   # path-filtered "skipped" job is fine). Branch protection should require just
-  # this one check (`quality-checks`) so the per-area gating above never leaves
+  # this one check (`CI Success`) so the per-area gating above never leaves
   # a required check stuck pending.
+  #
+  # The job KEY stays `quality-checks` — it is what `needs:` and the comments
+  # throughout this file refer to. The `name:` is what branch protection
+  # matches on, and it is `CI Success` across all four monorepos so one
+  # ruleset checklist applies everywhere.
   # ---------------------------------------------------------------------------
 
   quality-checks:
+    name: CI Success
     if: always()
     needs:
       - changes
@@ -736,7 +742,7 @@ jobs:
       # .github/workflows/codeql.yml. CodeQL is therefore required as its OWN
       # status context rather than through this aggregate — the branch ruleset
       # for `main` lists `Analyze (javascript-typescript)` alongside
-      # `quality-checks`, so a SAST finding blocks a merge.
+      # `CI Success`, so a SAST finding blocks a merge.
       #
       # That requires codeql.yml to carry a `merge_group:` trigger, and the
       # ORDER is load-bearing: the queue's temporary `gh-readonly-queue/**`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ bun run check:all
 
 This runs, in order: schema-drift check (`build:package` + `git diff`), lint,
 format check, typecheck, tests, data validation, knip, and `bun audit`. If
-`check:all` is green, CI's `quality-checks` gate should be too. The app builds
+`check:all` is green, CI's `CI Success` gate should be too. The app builds
 (`build:web`, `build:itun`, `build:bot`) run only in CI/deploy; run them locally
 if you touched build config.
 

--- a/docs/adrs/ADR-024-derived-release-changelogs.md
+++ b/docs/adrs/ADR-024-derived-release-changelogs.md
@@ -20,7 +20,7 @@ The two user-facing sites announce changes very differently today:
 
 The repo already squash-merges with **conventional-commit PR titles**
 (`feat:`, `fix:`, …) and gates every PR behind a single aggregate
-`quality-checks` status check. That is exactly the structured input release
+`CI Success` status check. That is exactly the structured input release
 tooling consumes.
 
 The stated goal is **formal releases + on-site release history at the least
@@ -86,7 +86,7 @@ config.
 
 - **CI / merge interplay.** release-please runs as a workflow on push to `main`.
   It must authenticate with a **PAT**, not the default `GITHUB_TOKEN`, so its
-  release PRs trigger `ci.yml` and the required `quality-checks` check reports
+  release PRs trigger `ci.yml` and the required `CI Success` check reports
   (a `GITHUB_TOKEN`-opened PR triggers no workflows and would be unmergeable).
   This is a one-time repo-secret setup step, documented at rollout. Release PRs
   touch only `CHANGELOG.md` / `package.json` version / the manifest, so they
@@ -124,7 +124,7 @@ config.
   two — and `main`'s `CHANGELOG.md` fell behind by exactly that much. The
   release-please workflow now re-arms auto-merge on every open
   `release-please--*` PR on each run, so a release lands as soon as
-  `quality-checks` is green with no human step. It is re-asserted every run
+  `CI Success` is green with no human step. It is re-asserted every run
   rather than only on creation, because a PR ejected from the merge queue (both
   release PRs edit `.release-please-manifest.json`, so one always rebases) loses
   auto-merge silently; a daily `schedule:` covers the case where no push follows.


### PR DESCRIPTION
Closes #803

Cross-repo standardization. **Purely a rename — nothing about what CI checks changes.**

Four monorepos independently landed on the same CI topology (a `changes` paths-filter job, parallel per-concern jobs, and one `if: always()` aggregate that `needs:` every other job and is the sole required status check) but named that final job four different ways. Since branch protection matches on the check **name**, that made the ruleset setup bespoke per repo and blocked `agent-friendly-repo` from applying one checklist across them.

`CI Success` is the standard, matching `binfinite-app` — already wired into that repo's `deploy-prod.yml` gating and branch protection, so it has the most to lose from moving.

---

## ⚠️ MERGE WARNING — the ruleset must be updated by a human, in this order

The required status check for `main` is **not** changed by this PR (deliberately — see scope note below). If the ruleset is not updated after this merges, **every PR in this repo will block forever** waiting for a check named `quality-checks` that can no longer arrive.

Do these three steps, in this order:

1. **Merge this PR first**, so a run reporting under the name `CI Success` exists on `main`. (A required check that has never reported on the default branch cannot be selected.)
2. **Add `CI Success`** to the branch ruleset for `main` as a required status check.
3. **Remove `quality-checks`** from that ruleset.

Do not reorder. Removing the old name before the new one is live leaves a window with no aggregate gate at all; adding the new name before a run exists leaves PRs pending on a check GitHub has never seen.

### The CodeQL requirement must stay

This repo **also** requires `Analyze (javascript-typescript)`, from `codeql.yml`, as its **own separate status context**. That is not redundancy — `needs:` cannot reach across workflows, so the aggregate gate in `ci.yml` structurally cannot cover CodeQL. **Leave that requirement in place.** After step 3 the ruleset should require exactly two contexts:

- `CI Success`
- `Analyze (javascript-typescript)`

Confirm the exact context strings against a real run before editing the ruleset:

```
gh api repos/SalvageUnion-io/SU-SRD/commits/main/check-runs --jq '.check_runs[].name'
```

---

## What changed

**`.github/workflows/ci.yml`** — added `name: CI Success` to the aggregate job.

The job **key stays `quality-checks`**. It is referenced by `needs:` and by comments throughout the file, so adding a display name is the lower-risk form of the rename — nothing in the `needs:` graph moves.

```yaml
  quality-checks:
    name: CI Success      # <- added
    if: always()
    needs: [ ... ]        # <- unchanged
```

**Comments and docs that asserted the old required-check name** — updated to `CI Success`, since it is the name branch protection matches on:

- `.github/workflows/ci.yml` — the stacked-PR note, the aggregate-gate header, and the CodeQL note
- `.github/workflows/catalog-update.yml` — the `GITHUB_TOKEN` fails-closed note
- `CONTRIBUTING.md` — the `check:all` / CI parity note
- `docs/adrs/ADR-024-derived-release-changelogs.md` — three references to the required check

References to `quality-checks` **as a job key** (the `needs:` graph, the "input to `quality-checks`" note) are deliberately left alone — the key did not change.

## Scope

This PR changes **workflow and doc files only**. No branch protection, no ruleset, and no repo setting was read or modified — no `gh api` call was made against either. Steps 1–3 above are the human's to run.

## Verification

- `ci.yml` parses; the aggregate job is the only one carrying a `name:`, so there is no context-name collision
- all 7 sibling jobs are still present in its `needs:` list — nothing dropped
- full pre-push suite green (lint, typecheck, schemas, knip, validate, design-tokens, styling-ownership, 763 tests)

## Acceptance

- [x] Aggregate job displays as `CI Success`
- [ ] Branch ruleset for `main` requires `CI Success` — **human, step 2**
- [ ] The CodeQL context requirement is still present — **human, verify after step 3**
- [ ] A PR blocks correctly when a downstream job fails — verifiable once the ruleset is updated
