### PR TITLE
feat(ci): fail when a job is missing from the quality-checks gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,20 @@ jobs:
       - name: Styling ownership check
         run: bun run check:styling
 
+      # Proves `quality-checks` below still `needs:` every job in this file. A
+      # job missing from that list runs, can go red, and cannot block a merge —
+      # the gate does not break, it silently stops gating, and every PR keeps
+      # showing green.
+      #
+      # Unconditional, deliberately. `.github/workflows/**` is in the `shared`
+      # filter today, so a code gate would in fact fire on a ci.yml edit — but
+      # the whole point of this guard is that the gate must not depend on a
+      # hand-maintained list staying correct, and a path filter is another such
+      # list. It is a sub-0.1 s parse of one file, so running it always costs
+      # nothing.
+      - name: CI aggregator gate check
+        run: bun run check:ci-aggregator
+
       # The package ships TypeScript source (no dist) — this step guards the
       # committed generated artifacts: the JSON schemas, the schema catalog, the
       # generated docs, the registry codegen (lib/generated/*.generated.ts) and

--- a/package.json
+++ b/package.json
@@ -101,10 +101,11 @@
     "check:audit": "bun audit --audit-level=high --ignore=GHSA-w3rx-r6r6-pgpr --ignore=GHSA-5p2g-fcmc-qvqq",
     "check:tokens": "bun tools/check-design-tokens.ts",
     "check:styling": "bun tools/check-styling-ownership.ts",
+    "check:ci-aggregator": "bun tools/check-ci-aggregator.ts",
     "check:printed-names": "bun tools/check-printed-names.ts",
     "check:fast": "concurrently -g 'bun run lint' 'bun run validate:all' 'bun run knip' && bun run typecheck",
     "check:srd-output": "bun --filter srd gate",
-    "check:all": "bun run check:schemas && concurrently -g 'bun run lint' 'bun run format:check' && bun run typecheck && concurrently -g 'bun run test' 'bun run validate:all' 'bun run knip' 'bun run check:audit' 'bun run check:tokens' 'bun run check:styling' 'bun run check:srd-output'",
+    "check:all": "bun run check:schemas && concurrently -g 'bun run lint' 'bun run format:check' && bun run typecheck && concurrently -g 'bun run test' 'bun run validate:all' 'bun run knip' 'bun run check:audit' 'bun run check:tokens' 'bun run check:styling' 'bun run check:ci-aggregator' 'bun run check:srd-output'",
     "ladle": "bun --filter component-lib ladle",
     "check:catalog": "bun tools/check-catalog.ts"
   },

--- a/tools/__tests__/check-ci-aggregator.test.ts
+++ b/tools/__tests__/check-ci-aggregator.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for the ci-aggregator guard.
+ *
+ * The parse is hand-rolled (no YAML dependency in this repo), and a guard whose
+ * parse quietly stops seeing jobs reports success while checking nothing —
+ * exactly the failure mode it was written to prevent. So the cases below pin
+ * the parse itself and the two traps in the diff: the aggregate is never
+ * reported as un-gating itself, and a path-filtered job is still required to be
+ * in `needs:`.
+ *
+ * Every case runs against a synthetic workflow. The repo's own ci.yml is what
+ * `bun run check:ci-aggregator` asserts.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { checkAggregator, jobNeeds, WorkflowShapeError, workflowJobs } from '../check-ci-aggregator'
+
+/** A minimal well-formed workflow: two jobs, both gated. */
+const GATED = `name: CI
+
+on:
+  pull_request:
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+  test:
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test
+        run: bun run test
+
+  quality-checks:
+    if: always()
+    needs:
+      - changes
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify no job failed
+        run: |
+          echo "checking"
+`
+
+describe('workflowJobs', () => {
+  it('reads every top-level job key, in file order', () => {
+    expect(workflowJobs(GATED)).toEqual(['changes', 'test', 'quality-checks'])
+  })
+
+  it('does not read block-scalar bodies as YAML', () => {
+    // A `run: |` body is arbitrary text, and a `filters: |` body is a nested
+    // document — both are full of colon-terminated, dash-prefixed lines that
+    // are not jobs.
+    const source = `jobs:
+  changes:
+    steps:
+      - name: Filters
+        with:
+          filters: |
+            itun:
+              - 'apps/itun/**'
+            web:
+              - 'apps/srd/**'
+      - name: Force-all on merge queue
+        run: |
+          case "$ref" in
+            gh-readonly-queue/*)
+              echo "all=true" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+  quality-checks:
+    needs:
+      - changes
+`
+    expect(workflowJobs(source)).toEqual(['changes', 'quality-checks'])
+  })
+
+  it('stops at the next top-level key', () => {
+    const source = `jobs:
+  changes:
+    runs-on: ubuntu-latest
+
+defaults:
+  run:
+    shell: bash
+`
+    expect(workflowJobs(source)).toEqual(['changes'])
+  })
+
+  it('rejects a workflow with no `jobs:` mapping', () => {
+    expect(() => workflowJobs('name: CI\non:\n  pull_request:\n')).toThrow(WorkflowShapeError)
+  })
+
+  it('rejects a `jobs:` mapping it parsed nothing out of', () => {
+    expect(() => workflowJobs('jobs:\n')).toThrow(/parsed zero jobs/)
+  })
+})
+
+describe('jobNeeds', () => {
+  it('reads the block-sequence form', () => {
+    expect([...jobNeeds(GATED, 'quality-checks')]).toEqual(['changes', 'test'])
+  })
+
+  it('reads the inline flow form', () => {
+    expect([...jobNeeds(GATED, 'test')]).toEqual(['changes'])
+  })
+
+  it('reads a quoted, multi-entry inline flow form', () => {
+    const source = `jobs:
+  a:
+    runs-on: ubuntu-latest
+  b:
+    runs-on: ubuntu-latest
+  quality-checks:
+    needs: ['a', "b"]
+    runs-on: ubuntu-latest
+`
+    expect([...jobNeeds(source, 'quality-checks')]).toEqual(['a', 'b'])
+  })
+
+  it('stops at the next job property, not the next job', () => {
+    // `runs-on:`/`steps:` end the list; the sequence items under `steps:` must
+    // not be swallowed as needs entries.
+    expect([...jobNeeds(GATED, 'quality-checks')]).not.toContain('name')
+  })
+
+  it('lets a block-scalar introducer terminate the list', () => {
+    // Regression: the body of `env: |` is stripped, and stripping its
+    // INTRODUCER too left `needs:` still open, so the next six-space sequence
+    // item — a `steps:` entry, in the real file — was read as a dependency.
+    const source = `jobs:
+  a:
+    runs-on: ubuntu-latest
+  quality-checks:
+    needs:
+      - a
+    env: |
+      NOTE=whatever
+    steps:
+      - uses: actions/checkout@v7
+`
+    expect([...jobNeeds(source, 'quality-checks')]).toEqual(['a'])
+  })
+
+  it('rejects a job that is not in the workflow', () => {
+    expect(() => jobNeeds(GATED, 'nope')).toThrow(WorkflowShapeError)
+  })
+})
+
+describe('checkAggregator', () => {
+  it('passes when every job is in `needs:`', () => {
+    const report = checkAggregator(GATED)
+    expect(report.missing).toEqual([])
+    expect(report.stale).toEqual([])
+    expect(report.gated).toEqual(['changes', 'test'])
+  })
+
+  it('never reports the aggregate as missing from its own `needs:`', () => {
+    // A job cannot `needs:` itself, so a naive key-set diff reports the gate
+    // ungated forever — the check fails on its own repo on day one and gets
+    // deleted.
+    expect(checkAggregator(GATED).missing).not.toContain('quality-checks')
+    expect(checkAggregator(GATED).gated).not.toContain('quality-checks')
+  })
+
+  it('fails on a job that was added without being added to `needs:`', () => {
+    const source = GATED.replace(
+      '  quality-checks:',
+      `  coverage:
+    needs: [changes]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coverage
+        run: bun run test:coverage
+
+  quality-checks:`
+    )
+    expect(checkAggregator(source).missing).toEqual(['coverage'])
+  })
+
+  it('requires a path-filtered job to be in `needs:` too', () => {
+    // Presence, not reachability: being skipped is a runtime outcome the
+    // aggregate handles (it passes on `skipped`), so an `if:` is no excuse for
+    // being absent from the list.
+    const source = GATED.replace('      - test\n', '')
+    expect(checkAggregator(source).missing).toEqual(['test'])
+  })
+
+  it('reports a `needs:` entry that is not a job', () => {
+    const source = GATED.replace('      - test\n', '      - test\n      - deleted-job\n')
+    expect(checkAggregator(source).stale).toEqual(['deleted-job'])
+  })
+
+  it('rejects a workflow with no aggregate job', () => {
+    expect(() => checkAggregator(GATED, 'ci-success')).toThrow(/no `ci-success` job/)
+  })
+
+  it('rejects an aggregate with an unparseable `needs:` list', () => {
+    // An empty needs list gates nothing at all, which reads as a clean pass to
+    // every other tool in the chain.
+    const source = GATED.replace('    needs:\n      - changes\n      - test\n', '')
+    expect(() => checkAggregator(source)).toThrow(/gates NOTHING/)
+  })
+
+  it('honours an explicit exemption, and flags one that has gone stale', () => {
+    const ungated = GATED.replace('      - test\n', '')
+    expect(checkAggregator(ungated, 'quality-checks', { test: 'reason' }).missing).toEqual([])
+    expect(
+      checkAggregator(GATED, 'quality-checks', { test: 'reason' }).redundantExemptions
+    ).toEqual(['test'])
+  })
+})

--- a/tools/check-ci-aggregator.ts
+++ b/tools/check-ci-aggregator.ts
@@ -1,0 +1,329 @@
+#!/usr/bin/env bun
+
+/**
+ * ci-aggregator guard — proves the ONE required status check actually gates
+ * every job in the CI workflow.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Branch protection on `main` requires `quality-checks`, the `if: always()`
+ * aggregate job at the bottom of .github/workflows/ci.yml. Its verdict is a
+ * loop over `join(needs.*.result, ' ')`, so it covers precisely the jobs named
+ * in its hand-maintained `needs:` array, and NOTHING else. A job missing from
+ * that list still runs, still goes red, and still cannot block the merge: it is
+ * invisible to the only check anyone requires.
+ *
+ * That is the worst failure mode a gate can have — it does not break, it stops
+ * gating, silently, and every PR keeps showing green. Nothing in GitHub Actions
+ * warns about it, because a `needs:` list that omits a job is perfectly valid
+ * YAML and a perfectly valid workflow. The omission is only visible to someone
+ * diffing two lists by eye, which is exactly the review step that gets skipped
+ * when a job is added under time pressure. So: diff the two lists mechanically,
+ * on every `bun run check:all` and in CI.
+ *
+ * PRESENCE, NOT REACHABILITY. Most jobs here are path-filtered
+ * (`if: needs.changes.outputs.code == 'true'`), and a filtered-out job is
+ * perfectly fine — the aggregate's own step passes on `skipped` and fails only
+ * on `failure`/`cancelled`. Being skipped is a runtime outcome the gate already
+ * handles correctly; being absent from `needs:` is a structural hole. This
+ * check therefore asserts membership and never reads a job's `if:`.
+ *
+ * SCOPE: ONE FILE. `needs:` cannot reach across workflows, so neither can this
+ * check. Other workflows that are required status contexts in their own right
+ * are listed in SEPARATELY_REQUIRED and reported on every run — a pass here is
+ * "ci.yml is fully gated", never "main is fully gated".
+ *
+ * HARDCODES NOTHING ABOUT WHICH JOBS EXIST. Both sides of the diff are derived
+ * from the workflow at runtime: the set of top-level `jobs:` keys, and the set
+ * of `needs:` entries on the aggregate. Jobs get added, renamed and
+ * consolidated; a guard carrying its own copy of the job list would just be a
+ * third list to drift. The only fixed name is AGGREGATOR, which is the identity
+ * of the required status check rather than a fact about the job graph.
+ *
+ * WHY A HAND-ROLLED PARSE AND NOT A YAML LIBRARY. There is no YAML parser in
+ * this repo's dependencies, and adding one to read two lists out of one file
+ * whose shape we control is not a trade worth making. The parse below is
+ * deliberately narrow and hard-errors rather than guessing if ci.yml stops
+ * looking the way it expects — a guard that silently parses zero jobs would
+ * report success while checking nothing, which is the very failure it exists to
+ * prevent.
+ *
+ * Exit codes: 0 — every job is gated; 1 — a job is un-gated, `needs:` carries a
+ * stale entry, or the workflow could not be read in the shape this check
+ * requires.
+ *
+ * Usage: bun run check:ci-aggregator
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+const LABEL = 'check:ci-aggregator'
+
+const WORKFLOW = '.github/workflows/ci.yml'
+
+/**
+ * The aggregate job's key. This is the required-status-check identity, not an
+ * assumption about the job graph — if it is renamed, the branch ruleset for
+ * `main` has to be updated in the same breath, and this check failing loudly is
+ * the reminder to do it.
+ */
+const AGGREGATOR = 'quality-checks'
+
+/**
+ * Required status contexts that live in OTHER workflows and therefore cannot be
+ * reached by `quality-checks.needs`. Reported on every run so a pass is never
+ * mistaken for full coverage of `main`. Confirm context strings with:
+ *   gh api repos/{owner}/{repo}/commits/main/check-runs --jq '.check_runs[].name'
+ */
+const SEPARATELY_REQUIRED = [
+  {
+    context: 'Analyze (javascript-typescript)',
+    workflow: '.github/workflows/codeql.yml',
+  },
+] as const
+
+/**
+ * Jobs deliberately left out of the gate, each with the one-line reason it is
+ * exempt. Empty today, and the bar for an entry is high: anything listed here
+ * can go red without blocking a merge. An entry is a *documented* hole rather
+ * than a silent one — which is the whole point of it being a list and not an
+ * omission.
+ */
+const UNGATED_BY_DESIGN: Record<string, string> = {}
+
+/** Job keys sit at exactly two spaces under the top-level `jobs:` mapping. */
+const JOB_KEY = /^ {2}([A-Za-z0-9_-]+):[ \t]*(#.*)?$/
+
+/** `    needs:` — a job property, so exactly four spaces. */
+const NEEDS_KEY = /^ {4}needs:[ \t]*(.*)$/
+
+/** `      - job-name` — a sequence item under `needs:`, six spaces. */
+const NEEDS_ITEM = /^ {6}-[ \t]+([A-Za-z0-9_-]+)[ \t]*(#.*)?$/
+
+/** Any other four-space job property (`runs-on:`, `steps:`, …) ends `needs:`. */
+const NEEDS_END = /^ {4}[A-Za-z0-9_-]+:/
+
+/** A block-scalar indicator (`run: |`, `filters: |`, `foo: >-`) opens literal content. */
+const BLOCK_SCALAR = /^\s*[^#\s].*[|>][-+]?\d*[ \t]*$/
+
+/** The workflow did not parse in the shape this check requires. */
+export class WorkflowShapeError extends Error {}
+
+/**
+ * The `jobs:` block as plain lines, with comments, blanks and every
+ * block-scalar BODY removed. The introducer (`run: |`, `if: >`) is kept — it is
+ * a real key line, and dropping it silently un-terminates whatever list it
+ * follows.
+ *
+ * Stripping the bodies is the whole reason this is a state machine and not a
+ * grep: a `run: |` body is arbitrary text, and nothing stops a shell line
+ * inside one from being shaped exactly like the YAML this parse is looking for.
+ */
+function jobsBlockLines(source: string): string[] {
+  const lines = source.split('\n')
+
+  const jobsAt = lines.findIndex((line) => /^jobs:[ \t]*(#.*)?$/.test(line))
+  if (jobsAt === -1) {
+    throw new WorkflowShapeError(`no top-level \`jobs:\` mapping found in ${WORKFLOW}.`)
+  }
+
+  const out: string[] = []
+  let blockIndent: number | null = null
+
+  for (let i = jobsAt + 1; i < lines.length; i++) {
+    const line = lines[i] ?? ''
+    const blank = line.trim() === ''
+    const indent = line.length - line.trimStart().length
+
+    // Inside a block scalar: everything more-indented than its introducer, and
+    // every blank line, is opaque content.
+    if (blockIndent !== null) {
+      if (blank || indent > blockIndent) continue
+      blockIndent = null
+    }
+
+    if (blank) continue
+    if (line.trimStart().startsWith('#')) continue
+
+    // A column-0 key ends the `jobs:` block — another top-level mapping is not
+    // part of it.
+    if (indent === 0) break
+
+    if (BLOCK_SCALAR.test(line)) blockIndent = indent
+
+    out.push(line)
+  }
+
+  return out
+}
+
+/** Every top-level job key in `jobs:`, in file order. */
+export function workflowJobs(source: string): string[] {
+  const jobs = jobsBlockLines(source).flatMap((line) => line.match(JOB_KEY)?.[1] ?? [])
+  if (jobs.length === 0) {
+    throw new WorkflowShapeError(
+      `parsed zero jobs from ${WORKFLOW} — the parse is wrong, not the workflow.`
+    )
+  }
+  return jobs
+}
+
+/**
+ * One job's `needs:` entries. Handles both the inline flow form
+ * (`needs: [changes]`) and the block sequence the aggregate uses.
+ */
+export function jobNeeds(source: string, job: string): Set<string> {
+  const block = jobsBlockLines(source)
+  const startAt = block.findIndex((line) => line.match(JOB_KEY)?.[1] === job)
+  if (startAt === -1) throw new WorkflowShapeError(`no \`${job}\` job in ${WORKFLOW}.`)
+
+  const needs = new Set<string>()
+  let inNeeds = false
+
+  for (const line of block.slice(startAt + 1)) {
+    if (JOB_KEY.test(line)) break // next job — done with this one.
+
+    const key = line.match(NEEDS_KEY)
+    if (key) {
+      inNeeds = true
+      // Inline flow form: `needs: [a, b]`.
+      const inline = (key[1] ?? '').trim()
+      if (inline.startsWith('[')) {
+        for (const raw of inline.replace(/^\[|][ \t]*$/g, '').split(',')) {
+          const name = raw.trim().replace(/^['"]|['"]$/g, '')
+          if (name) needs.add(name)
+        }
+        inNeeds = false
+      }
+      continue
+    }
+
+    if (!inNeeds) continue
+
+    const item = line.match(NEEDS_ITEM)
+    if (item?.[1]) needs.add(item[1])
+    else if (NEEDS_END.test(line)) inNeeds = false
+  }
+
+  return needs
+}
+
+export type AggregatorReport = {
+  /** Jobs that must be in `needs:` and are not — the gate has a hole. */
+  missing: string[]
+  /** `needs:` entries that are not jobs — a typo, or a job that was deleted. */
+  stale: string[]
+  /** Allowlisted jobs that turn out to be gated after all — the exemption is dead. */
+  redundantExemptions: string[]
+  /** Jobs actually covered by the gate. */
+  gated: string[]
+}
+
+export function checkAggregator(
+  source: string,
+  aggregator = AGGREGATOR,
+  exempt: Record<string, string> = UNGATED_BY_DESIGN
+): AggregatorReport {
+  const jobs = workflowJobs(source)
+  if (!jobs.includes(aggregator)) {
+    throw new WorkflowShapeError(
+      `no \`${aggregator}\` job in ${WORKFLOW}.\n` +
+        `  If the aggregate gate was renamed, update AGGREGATOR in this script AND the\n` +
+        '  branch-protection ruleset for `main` — they are the same fact in two places.'
+    )
+  }
+
+  const needs = jobNeeds(source, aggregator)
+  if (needs.size === 0) {
+    throw new WorkflowShapeError(
+      `\`${aggregator}\` has no parseable \`needs:\` list.\n` +
+        '  With an empty needs list the required check gates NOTHING at all.'
+    )
+  }
+
+  // The aggregate is excluded from its own diff: a job cannot `needs:` itself,
+  // so a naive key-set comparison would report the gate as ungated forever.
+  const expected = jobs.filter((job) => job !== aggregator)
+
+  return {
+    missing: expected.filter((job) => !needs.has(job) && !(job in exempt)),
+    stale: [...needs].filter((name) => !jobs.includes(name)),
+    redundantExemptions: Object.keys(exempt).filter((job) => needs.has(job)),
+    gated: expected.filter((job) => needs.has(job)),
+  }
+}
+
+function scopeNote(): string[] {
+  const lines = [
+    `  Scope: ${WORKFLOW} only. \`needs:\` cannot reach across workflows, so neither can`,
+    '  this check. Required contexts owned by other workflows are NOT covered:',
+  ]
+  for (const { context, workflow } of SEPARATELY_REQUIRED) {
+    const missing = existsSync(join(repoRoot, workflow)) ? '' : '  ← FILE MISSING'
+    lines.push(`    • ${context} (${workflow})${missing}`)
+  }
+  lines.push(
+    '  Those are required as their own status contexts in the `main` ruleset. A pass',
+    `  here means ${WORKFLOW} is fully gated, not that \`main\` is.`
+  )
+  return lines
+}
+
+function main(): void {
+  let source: string
+  try {
+    source = readFileSync(join(repoRoot, WORKFLOW), 'utf8')
+  } catch {
+    console.error(`[${LABEL}] ERROR: cannot read ${WORKFLOW}.`)
+    process.exit(1)
+  }
+
+  let report: AggregatorReport
+  try {
+    report = checkAggregator(source)
+  } catch (error) {
+    if (!(error instanceof WorkflowShapeError)) throw error
+    console.error(`[${LABEL}] ERROR: ${error.message}`)
+    process.exit(1)
+  }
+
+  const { missing, stale, redundantExemptions, gated } = report
+
+  if (missing.length === 0 && stale.length === 0 && redundantExemptions.length === 0) {
+    console.log(`[${LABEL}] ✓ \`${AGGREGATOR}\` gates all ${gated.length} jobs in ${WORKFLOW}.`)
+    for (const [job, reason] of Object.entries(UNGATED_BY_DESIGN)) {
+      console.log(`  ! \`${job}\` is exempt by design — ${reason}`)
+    }
+    for (const line of scopeNote()) console.log(line)
+    return
+  }
+
+  console.error(`[${LABEL}] FAIL — ${WORKFLOW}`)
+  for (const job of missing) {
+    console.error(
+      `  • job \`${job}\` is NOT in \`${AGGREGATOR}.needs\` — it can never fail the required check.`
+    )
+  }
+  for (const name of stale) {
+    console.error(
+      `  • \`${AGGREGATOR}.needs\` lists \`${name}\`, which is not a job — stale entry.`
+    )
+  }
+  for (const job of redundantExemptions) {
+    console.error(
+      `  • \`${job}\` is in UNGATED_BY_DESIGN but IS gated — drop the dead exemption from this script.`
+    )
+  }
+  console.error(
+    `\n\`${AGGREGATOR}\` is the required status check for \`main\`, and it can only fail on a\n` +
+      'job it `needs:`. Add every job to that list (or remove the stale entry):\n' +
+      `  ${WORKFLOW} → ${AGGREGATOR}: → needs:`
+  )
+  process.exit(1)
+}
+
+if (import.meta.main) main()


### PR DESCRIPTION
Closes #804

## The hole

`quality-checks` is the required status check on `main`. It is `if: always()` and decides pass/fail by looping over `join(needs.*.result, ' ')` — so its verdict covers precisely the jobs in its hand-maintained `needs:` array, and nothing else.

A job left out of that list still runs and still goes red, but **cannot block a merge**. The gate does not break; it silently stops gating, and every PR keeps showing green. Nothing in GitHub Actions warns about it, because a `needs:` list that omits a job is perfectly valid YAML and a perfectly valid workflow. The omission is only ever visible to someone diffing two lists by eye — exactly the review step that gets skipped when a job is added under time pressure.

## The check

`tools/check-ci-aggregator.ts` (ported from `BinfiniteLLC/binfinite-app`) diffs the two lists mechanically: every top-level `jobs:` key in `ci.yml` against `quality-checks.needs`. Both sides are derived from the workflow at runtime, so the guard carries no copy of the job list to drift. It also reports the reverse — a `needs:` entry naming a job that no longer exists.

Two things it deliberately does **not** do, both of which would make it fail on this repo and get deleted:

- **It never reports the aggregate as missing from its own `needs:`.** A job cannot depend on itself, so a naive key-set comparison reports the gate as ungated forever.
- **It never reads a job's `if:`.** Most jobs here are path-filtered, and a filtered-out job is fine — the aggregate's own step passes on `skipped` and fails only on `failure`/`cancelled`. Being skipped is a runtime outcome the gate already handles; being absent from `needs:` is a structural hole. So the check asserts *presence*, not reachability. (This preserves the distinction the issue asked for: `if: always()` semantics, not job presence at runtime.)

### Scope, stated rather than implied

`needs:` reaches only inside one workflow file, so neither can this check. CodeQL's `Analyze (javascript-typescript)` is required as its **own** status context from `codeql.yml`, and is invisible here. Every run — including a passing one — says so:

```
[check:ci-aggregator] ✓ `quality-checks` gates all 7 jobs in .github/workflows/ci.yml.
  Scope: .github/workflows/ci.yml only. `needs:` cannot reach across workflows, so neither can
  this check. Required contexts owned by other workflows are NOT covered:
    • Analyze (javascript-typescript) (.github/workflows/codeql.yml)
  Those are required as their own status contexts in the `main` ruleset. A pass
  here means .github/workflows/ci.yml is fully gated, not that `main` is.
```

A pass means ci.yml is fully gated, never that `main` is. If `codeql.yml` ever disappears, the note flags `← FILE MISSING` rather than quietly continuing to cite it.

There is also an `UNGATED_BY_DESIGN` allowlist — **empty today** — so any future exemption is a documented hole with a one-line reason, not a silent omission. An entry that turns out to be gated after all is reported as a dead exemption.

## Wiring

- `check:ci-aggregator` script, and into `check:all` so it runs locally.
- A `CI aggregator gate check` step in `static-checks`, which is itself in `quality-checks.needs` — so the check cannot be bypassed.
- The CI step is **unconditional**, for the same reason the design-token and styling-ownership guards are. `.github/workflows/**` is in the `shared` filter today so a code gate would in fact fire on a ci.yml edit, but the whole point is that the gate must not depend on a hand-maintained list staying correct — and a path filter is another such list. It is a sub-0.1 s parse of one file.

## Failure-mode demo (required by the issue)

Temporarily added a `demo-ungated` job to `ci.yml` without adding it to `needs:`:

```
[check:ci-aggregator] FAIL — .github/workflows/ci.yml
  • job `demo-ungated` is NOT in `quality-checks.needs` — it can never fail the required check.

`quality-checks` is the required status check for `main`, and it can only fail on a
job it `needs:`. Add every job to that list (or remove the stale entry):
  .github/workflows/ci.yml → quality-checks: → needs:
```

Exit code 1. **Reverted** — the diff in this PR adds no job to `ci.yml`, only the one step.

## On the hand-rolled parse

There is no YAML parser in this repo's dependencies, and this reads two lists out of one file whose shape we control. The parse is deliberately narrow and hard-errors rather than guessing if `ci.yml` stops looking the way it expects — a guard that silently parsed zero jobs would report success while checking nothing, which is the very failure it exists to prevent. Zero jobs, a missing aggregate, and an empty `needs:` are all hard errors.

19 tests (`tools/__tests__/check-ci-aggregator.test.ts`) pin the parse and both traps, against synthetic workflows. They earned their keep immediately: they caught a real bug where stripping a block-scalar **introducer** (`env: |`) along with its body left `needs:` un-terminated, so the next six-space sequence item — a `steps:` entry, in the real file — was read as a dependency. Fixed, with a regression case.

## Checks

- `bun run check:all` — passes (exit 0), with `check:ci-aggregator` running inside it.
- `bun test tools/__tests__/check-ci-aggregator.test.ts` — 19 pass, 0 fail.
