### PR TITLE
feat(component-lib): stand up tokens, style objects and the package stylesheet

### DIFF
--- a/packages/component-lib/CLAUDE.md
+++ b/packages/component-lib/CLAUDE.md
@@ -7,7 +7,56 @@ Shared React component library consumed by both `srd` and `itun`.
 - **No build step** - exports TypeScript source directly via `src/index.ts` barrel ([ADR-011](../../docs/adrs/ADR-011-component-lib-source-no-build.md))
 - **Data-source agnostic** - no backend/persistence dependency; consumers inject behavior via slot props, and choice components are persistence-agnostic ([ADR-010](../../docs/adrs/ADR-010-srd-choices-ephemeral-vs-persisted.md))
 - Vite in consuming apps handles `.ts/.tsx` compilation
-- Uses Tailwind + `cn()` utility for styling
+- Uses Tailwind + `cn()` utility for styling — **being removed** in favour of tokens + style objects + one stylesheet (see [Styling](#styling) below, and epic #802)
+
+## Styling
+
+Tailwind is on its way out of this repo (#802). The pattern replacing it is three
+files, and every component migrated from here on lands on them:
+
+| File | Role |
+| --- | --- |
+| [`src/design/tokens.ts`](src/design/tokens.ts) | The typed token scale — colour, space, font size, weight, tracking, radius, border width. Plain `as const` objects, no dependency. |
+| [`src/design/styles.ts`](src/design/styles.ts) | Exported `React.CSSProperties` objects for **static** styling, each `satisfies` the type. |
+| [`src/styles/index.css`](src/styles/index.css) | The **one** stylesheet a web consumer loads. Emits the scale as `--su-*` custom properties, binds the page ground and body face, and carries every rule a style object cannot express. |
+
+Both halves of the pattern are load-bearing. The token scale and the style objects
+are the visible half; the stylesheet is the half that is easy to miss, and
+dropping it would be a functional regression rather than a styling change.
+
+### The split rule
+
+- **Style object** — static values that never vary by interaction or viewport:
+  colour, padding, font, border, layout.
+- **Stylesheet class** — anything stateful or conditional: `:hover`,
+  `:focus-visible`, `:disabled`, `@media`, pseudo-elements, sibling/child
+  selectors.
+- A component may use both. The object goes on `style=`, the class on
+  `className=`.
+
+This is a capability boundary, not a preference: an inline `style={}` object has
+no way to express a single item on the second list. That matters here more than
+it looks. Measured across the three UI workspaces, the codebase depends on ~403
+Tailwind variant usages — 215 responsive (`sm:`/`md:`/`lg:`/`xl:`), 120 `hover:`,
+15 `focus-visible:`, 12 `disabled:`, 9 `focus:`, 5 structural. A migration to
+style objects alone would silently drop every one of them.
+
+(The pattern is ported from `binfinite-app`, whose component library has zero
+`:hover` and zero `@media` because it is React-Native-first and RN has neither —
+so its style objects were never asked to carry interaction or viewport state.
+Here they would be, and they cannot. That is the one thing that must not be lost
+in translation, and it is why the stylesheet is not optional.)
+
+### While both systems are live
+
+`src/styles/theme.css` is still the source of record and Tailwind still works
+untouched: the token scale is a re-shaping of the values already in that file,
+not a re-design. The `--su-*` namespace exists so the two can coexist in one
+build until Tailwind is dropped.
+
+The scale therefore exists twice — once as TypeScript, once as custom properties
+— because neither form can serve the other's job. `src/design/tokens.parity.test.ts`
+fails if they disagree, so **edit both or neither**.
 
 ## Contents
 
@@ -67,6 +116,6 @@ Component stories live beside their components (`*.stories.tsx`) and are served 
 ## Conventions
 
 - Named exports only (via `src/index.ts` barrel)
-- Use `cn()` for conditional Tailwind class merging
+- Use `cn()` for conditional Tailwind class merging — on surfaces still on Tailwind. New and migrated styling follows the [split rule](#the-split-rule) instead.
 - Keep components data-source agnostic
 - Use `type` over `interface` for props

--- a/packages/component-lib/package.json
+++ b/packages/component-lib/package.json
@@ -6,6 +6,7 @@
   "license": "Salvage Union Open Game Licence 1.0b",
   "exports": {
     ".": "./src/index.ts",
+    "./styles/index.css": "./src/styles/index.css",
     "./styles/theme.css": "./src/styles/theme.css"
   },
   "scripts": {

--- a/packages/component-lib/src/design/styles.ts
+++ b/packages/component-lib/src/design/styles.ts
@@ -1,0 +1,241 @@
+import type { CSSProperties } from 'react'
+import { borderWidth, color, font, fontSize, radius, space, tracking, weight } from './tokens'
+
+/**
+ * The shared chrome, as `CSSProperties` objects.
+ *
+ * Layer 1 of the Tailwind removal (#798, epic #802). These are the STATIC half
+ * of the split rule — read this package's CLAUDE.md for the rule itself, and
+ * `src/styles/index.css` for the other half. In one line:
+ *
+ *   style object  → static values: colour, padding, font, border, layout
+ *   stylesheet class → anything stateful or conditional: `:hover`,
+ *                      `:focus-visible`, `:disabled`, `@media`, pseudo-elements
+ *
+ * The boundary is not a preference, it is a capability: an inline `style={}`
+ * object has no way to express any of the second list. A component uses both —
+ * the object on `style=`, the class on `className=`.
+ *
+ * Every object is `satisfies CSSProperties`, so it keeps its literal type (a
+ * caller can read `panel.borderRadius`) while still being checked as a real
+ * style object. `as CSSProperties` would have thrown that away, and an
+ * annotation would have widened every value to `string`.
+ *
+ * This is the STARTING set, not the finished one. It covers the surfaces,
+ * type roles and layout primitives that recur across the package; the
+ * migration layers (#799, #800) add to it as call sites move, and anything
+ * that turns out to belong to exactly one component belongs in that component,
+ * not here.
+ */
+
+// ── Surfaces ────────────────────────────────────────────────────────────────
+
+/** The page ground. Paired with the `body` binding in `styles/index.css`. */
+export const page = {
+  backgroundColor: color.paper,
+  color: color.ink,
+  fontFamily: font.body,
+} satisfies CSSProperties
+
+/** App-chrome panel — the outer frame of a section of the app. */
+export const panel = {
+  backgroundColor: color.paper,
+  border: `${borderWidth.chrome} solid ${color.ink}`,
+  borderRadius: radius.panel,
+  padding: space[12],
+} satisfies CSSProperties
+
+/** A card, input or button's shell: the 3px outer radius, chrome weight. */
+export const card = {
+  backgroundColor: color.paper,
+  border: `${borderWidth.chrome} solid ${color.ink}`,
+  borderRadius: radius.card,
+  padding: space[8],
+} satisfies CSSProperties
+
+/** An entity card — the 3px frame that says "this is the thing the page is
+ *  about" (design-spec §1.3). */
+export const entityCard = {
+  backgroundColor: color.paper,
+  border: `${borderWidth.entity} solid ${color.ink}`,
+  borderRadius: radius.card,
+} satisfies CSSProperties
+
+/** The step off-paper that makes a card read as a panel. */
+export const workshopGround = {
+  backgroundColor: color.wkBg,
+  color: color.ink,
+} satisfies CSSProperties
+
+/** A 1px rule. `wkFaint` is non-text only, which is exactly what a divider is. */
+export const hairline = {
+  border: 'none',
+  borderTop: `${borderWidth.hairline} solid ${color.wkFaint}`,
+  margin: 0,
+} satisfies CSSProperties
+
+// ── Type roles ──────────────────────────────────────────────────────────────
+
+/** Body copy. */
+export const body = {
+  color: color.ink,
+  fontFamily: font.body,
+  fontSize: fontSize.caption,
+  fontWeight: weight.normal,
+} satisfies CSSProperties
+
+/** Small supporting copy — hints, empty states, subtitles. */
+export const caption = {
+  color: color.wkMuted,
+  fontFamily: font.body,
+  fontSize: fontSize.caption,
+  fontWeight: weight.normal,
+} satisfies CSSProperties
+
+/** The condensed all-caps label — the workhorse of the chrome. */
+export const capsLabel = {
+  color: color.ink,
+  fontFamily: font.cond,
+  fontSize: fontSize.label,
+  fontWeight: weight.bold,
+  letterSpacing: tracking.capsTight,
+  textTransform: 'uppercase',
+} satisfies CSSProperties
+
+/** The stamp's caps label — one rung up from `capsLabel`. */
+export const stampLabel = {
+  color: color.ink,
+  fontFamily: font.cond,
+  fontSize: fontSize.labelLg,
+  fontWeight: weight.bold,
+  letterSpacing: tracking.capsTight,
+  textTransform: 'uppercase',
+} satisfies CSSProperties
+
+/** The brand eyebrow — the ONE place the 0.22em ladder rung is used. */
+export const eyebrow = {
+  color: color.wkMuted,
+  fontFamily: font.cond,
+  fontSize: fontSize.micro,
+  fontWeight: weight.semibold,
+  letterSpacing: tracking.eyebrow,
+  textTransform: 'uppercase',
+} satisfies CSSProperties
+
+/** A section heading inside a panel. */
+export const sectionTitle = {
+  color: color.ink,
+  fontFamily: font.cond,
+  fontSize: fontSize.lede,
+  fontWeight: weight.bold,
+  letterSpacing: tracking.capsSnug,
+  textTransform: 'uppercase',
+} satisfies CSSProperties
+
+/** A readout meant to be read across a table, not a label. */
+export const readout = {
+  color: color.ink,
+  fontFamily: font.body,
+  fontSize: fontSize.readout,
+  fontWeight: weight.bold,
+  lineHeight: 1,
+} satisfies CSSProperties
+
+// ── Layout ──────────────────────────────────────────────────────────────────
+
+/** Horizontal run, vertically centred, on the 8px rhythm. */
+export const row = {
+  alignItems: 'center',
+  display: 'flex',
+  flexDirection: 'row',
+  gap: space[8],
+} satisfies CSSProperties
+
+/** Vertical stack on the 8px rhythm. */
+export const stack = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: space[8],
+} satisfies CSSProperties
+
+/** Label on the left, value hard right — the KV row shape. */
+export const spread = {
+  alignItems: 'center',
+  display: 'flex',
+  flexDirection: 'row',
+  gap: space[8],
+  justifyContent: 'space-between',
+} satisfies CSSProperties
+
+// ── Controls ────────────────────────────────────────────────────────────────
+
+/**
+ * The static half of a button. Its `:hover`, `:focus-visible` and `:disabled`
+ * treatments live in `styles/index.css` as `.su-button`, because none of the
+ * three can be written here — that is the split rule in one object.
+ */
+export const buttonBase = {
+  alignItems: 'center',
+  border: `${borderWidth.chrome} solid ${color.ink}`,
+  borderRadius: radius.card,
+  cursor: 'pointer',
+  display: 'inline-flex',
+  fontFamily: font.cond,
+  fontSize: fontSize.label,
+  fontWeight: weight.bold,
+  gap: space[6],
+  justifyContent: 'center',
+  letterSpacing: tracking.capsTight,
+  padding: `${space[6]} ${space[12]}`,
+  textTransform: 'uppercase',
+} satisfies CSSProperties
+
+/** The primary action. Rust is the ONE action colour (ruleset §3.1). */
+export const buttonPrimary = {
+  ...buttonBase,
+  backgroundColor: color.rust,
+  borderColor: color.rust,
+  color: color.paper,
+} satisfies CSSProperties
+
+/** The secondary action — the same shape, on paper. */
+export const buttonSecondary = {
+  ...buttonBase,
+  backgroundColor: color.paper,
+  color: color.ink,
+} satisfies CSSProperties
+
+/**
+ * The static half of a text input. Its `:focus` ring is `.su-input` in
+ * `styles/index.css` — an editable control shows the ring on every focus, not
+ * only on keyboard focus, which is why it is not the `:focus-visible` rung.
+ */
+export const inputBase = {
+  backgroundColor: color.paper,
+  border: `${borderWidth.chrome} solid ${color.ink}`,
+  borderRadius: radius.card,
+  color: color.ink,
+  fontFamily: font.body,
+  fontSize: fontSize.sm,
+  padding: `${space[6]} ${space[8]}`,
+  width: '100%',
+} satisfies CSSProperties
+
+// ── Utility ─────────────────────────────────────────────────────────────────
+
+/**
+ * Present to a screen reader, absent to the eye. The clip-rect idiom rather
+ * than `display: none` or `visibility: hidden`, both of which remove the
+ * element from the accessibility tree as well.
+ */
+export const visuallyHidden = {
+  border: 0,
+  clip: 'rect(0 0 0 0)',
+  clipPath: 'inset(50%)',
+  height: '1px',
+  overflow: 'hidden',
+  padding: 0,
+  position: 'absolute',
+  whiteSpace: 'nowrap',
+  width: '1px',
+} satisfies CSSProperties

--- a/packages/component-lib/src/design/tokens.parity.test.ts
+++ b/packages/component-lib/src/design/tokens.parity.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { borderWidth, color, font, fontSize, radius, space, tracking, weight } from './tokens'
+
+/**
+ * Token-parity guard — the thing that makes it safe for the scale to exist
+ * twice.
+ *
+ * `design/tokens.ts` holds the values as TypeScript, `styles/index.css` emits
+ * the same values as `--su-*` custom properties, and each half is there for a
+ * reason the other cannot serve: a style object cannot reach a CSS variable's
+ * value, and a stylesheet cannot be read by a canvas renderer or a Node script.
+ * So the duplication is deliberate — but two hand-maintained copies of one set
+ * of numbers is precisely the drift shape the design-token guard exists to
+ * catch, and nothing else in the build would notice them diverging. A missing
+ * property renders unstyled; a stale one renders the wrong colour. Neither
+ * fails typecheck.
+ *
+ * The mapping is mechanical rather than a hand-written table, because a table
+ * is a third copy that can drift too: a camelCase key maps to its kebab-case
+ * property (`inkDeep` → `--su-color-ink-deep`, `wkBg2` → `--su-color-wk-bg-2`,
+ * `tl1` → `--su-color-tl-1`), and an all-digit key is used verbatim
+ * (`space[8]` → `--su-space-8`).
+ *
+ * Both directions are asserted. A one-way check would let an orphan custom
+ * property — a token deleted from TypeScript but left in the CSS — survive
+ * indefinitely.
+ */
+
+const CSS_PATH = join(import.meta.dir, '../styles/index.css')
+
+/** TS group name → the `--su-<prefix>-` the CSS emits it under. */
+const GROUPS = {
+  bw: borderWidth,
+  color,
+  font,
+  radius,
+  space,
+  text: fontSize,
+  tracking,
+  weight,
+} as const satisfies Record<string, Record<string, string | number>>
+
+const PREFIXES = Object.keys(GROUPS) as (keyof typeof GROUPS)[]
+
+/**
+ * `inkDeep` → `ink-deep`, `wkBg2` → `wk-bg-2`, `tl1` → `tl-1`, `8` → `8`.
+ * An all-digit key is a spacing rung and is used as-is; anything else gets a
+ * separator before each capital and before each digit run.
+ */
+function kebab(key: string): string {
+  if (/^\d+$/.test(key)) return key
+  return key
+    .replace(/([A-Z])/g, '-$1')
+    .replace(/(\d+)/g, '-$1')
+    .toLowerCase()
+}
+
+/** The declarations inside the single top-level `:root` block, comments stripped. */
+function readRootDeclarations(): Map<string, string> {
+  const css = readFileSync(CSS_PATH, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '')
+  const open = css.indexOf(':root {')
+  if (open === -1) throw new Error(`no :root block in ${CSS_PATH}`)
+  const close = css.indexOf('}', open)
+  if (close === -1) throw new Error(`unterminated :root block in ${CSS_PATH}`)
+  const block = css.slice(open, close)
+
+  const out = new Map<string, string>()
+  for (const m of block.matchAll(/--su-([a-z0-9-]+)\s*:\s*([^;]+);/g)) {
+    const [, name, value] = m
+    if (name && value) out.set(name, value.trim())
+  }
+  return out
+}
+
+/** Follow `var(--su-x)` aliases to the literal they point at. */
+function resolve(value: string, declarations: Map<string, string>, depth = 0): string {
+  const alias = value.match(/^var\(--su-([a-z0-9-]+)\)$/)
+  if (!alias?.[1]) return value
+  if (depth > 8) throw new Error(`custom-property alias cycle at --su-${alias[1]}`)
+  const target = declarations.get(alias[1])
+  if (target === undefined) throw new Error(`--su-${alias[1]} referenced but never defined`)
+  return resolve(target, declarations, depth + 1)
+}
+
+const declarations = readRootDeclarations()
+
+/** Every token, flattened to the custom-property name it must be emitted as. */
+const expected = new Map<string, string>()
+for (const prefix of PREFIXES) {
+  for (const [key, value] of Object.entries(GROUPS[prefix])) {
+    expected.set(`${prefix}-${kebab(key)}`, String(value))
+  }
+}
+
+describe('design token parity', () => {
+  test('the guard actually parsed the stylesheet', () => {
+    // A moved file or a reshaped :root block would otherwise make every
+    // assertion below pass vacuously.
+    expect(declarations.size).toBeGreaterThan(80)
+    expect(expected.size).toBeGreaterThan(80)
+  })
+
+  test('every token is emitted as a --su-* custom property with the same value', () => {
+    const mismatches: string[] = []
+    for (const [name, value] of expected) {
+      const declared = declarations.get(name)
+      if (declared === undefined) {
+        mismatches.push(`--su-${name} is missing from styles/index.css`)
+        continue
+      }
+      const resolved = resolve(declared, declarations)
+      if (resolved !== value) {
+        mismatches.push(`--su-${name}: css has "${resolved}", tokens.ts has "${value}"`)
+      }
+    }
+    expect(
+      mismatches,
+      'design/tokens.ts and styles/index.css have drifted — edit both, never one'
+    ).toEqual([])
+  })
+
+  test('no --su-* custom property outlives the token it came from', () => {
+    const orphans = [...declarations.keys()]
+      .filter((name) => !expected.has(name))
+      .map((name) => `--su-${name} is declared in styles/index.css but is not a token`)
+    expect(orphans, 'delete the property, or add the token it belongs to').toEqual([])
+  })
+})

--- a/packages/component-lib/src/design/tokens.ts
+++ b/packages/component-lib/src/design/tokens.ts
@@ -1,0 +1,333 @@
+/**
+ * The typed token scale — the TypeScript half of the design system's source of
+ * record.
+ *
+ * Layer 1 of the Tailwind removal (#798, epic #802). Every value here is
+ * **ported verbatim** from `src/styles/theme.css`, which is still the live
+ * source while Tailwind is in the build. Nothing is re-designed, re-toned or
+ * rounded: this file is a re-shaping of what already ships, so the migration
+ * layers that follow can move a call site off a utility class without also
+ * changing what it looks like.
+ *
+ * Three properties are deliberate:
+ *
+ *   - **Plain `as const` objects, no dependency.** Not a theme provider, not a
+ *     context, not a function. A token is a value, and a value can be read from
+ *     a style object, a test, a canvas, a PDF generator, or a Node script that
+ *     has no DOM at all. Reaching for `var(--su-*)` here would have made the
+ *     scale depend on the stylesheet being loaded, which is the one thing a
+ *     token scale must not require.
+ *   - **Literals, not aliases of each other's CSS variables.** The same values
+ *     are emitted as `--su-*` custom properties by `src/styles/index.css`, for
+ *     the half of the system a style object cannot express (see that file, and
+ *     the split rule in this package's CLAUDE.md). Two files holding one set of
+ *     numbers is a drift risk, so `tokens.parity.test.ts` asserts they agree —
+ *     that test is what makes the duplication safe.
+ *   - **Names match theme.css.** `--color-ink-75` is `color.ink75`, `--text-label-lg`
+ *     is `fontSize.labelLg`, `--bw-chrome` is `borderWidth.chrome`. A camelCase
+ *     key maps to its kebab-case custom property mechanically (`inkDeep` →
+ *     `ink-deep`, `wkBg2` → `wk-bg-2`, `tl1` → `tl-1`), which is what lets the
+ *     parity test compare the two files without a hand-maintained mapping.
+ */
+
+/**
+ * Type faces. TWO, no aliases: Barlow for body and values, Barlow Semi
+ * Condensed for the all-caps chrome (stamps, labels, eyebrows).
+ */
+export const font = {
+  body: "'Barlow', system-ui, -apple-system, sans-serif",
+  cond: "'Barlow Semi Condensed', 'Barlow', system-ui, -apple-system, sans-serif",
+} as const
+
+/**
+ * The spacing rhythm, keyed by its own pixel value.
+ *
+ * Keyed by pixels rather than by an invented `xs`/`sm`/`lg` vocabulary on
+ * purpose: the repo has no such vocabulary today (spacing came from Tailwind's
+ * numeric scale, where the rung number is a quarter of the pixel value), and
+ * inventing one in a port would mean every migrated call site had to be
+ * re-judged rather than translated. `space[8]` is 8px, and `p-2` — Tailwind's
+ * name for 8px — translates to it without a lookup table.
+ *
+ * The rungs are the ones actually in use across the three UI workspaces, so a
+ * migrated call site always has an exact landing spot and never rounds.
+ */
+export const space = {
+  0: '0px',
+  2: '2px',
+  4: '4px',
+  6: '6px',
+  8: '8px',
+  10: '10px',
+  12: '12px',
+  14: '14px',
+  16: '16px',
+  20: '20px',
+  24: '24px',
+  28: '28px',
+  32: '32px',
+  40: '40px',
+  48: '48px',
+  64: '64px',
+  96: '96px',
+} as const
+
+/**
+ * The type ladder.
+ *
+ * The first block is the SEMANTIC ladder (ruleset §4.2) — the one to reach for,
+ * named by role rather than by size, and shared by every surface:
+ *
+ *   nano      8px      smallest markers — TL glyphs, unit suffixes
+ *   micro     9px      dense caps meta labels
+ *   label     10px     standard uppercase font-cond field/section label
+ *   labelLg   10.5px   stamp / rail caps label
+ *   badge     11px     badges, pills, compact caps values
+ *   note      11.5px   small body copy in rails and insets
+ *   caption   13px     hints, empty states, subtitles
+ *   lede      15px     emphasized inline values, inset titles
+ *   readout   17px     …then the display end, at a ~1.2 ratio:
+ *   title     22px
+ *   display   26px
+ *   displayLg 31px
+ *   hero      38px
+ *
+ * The second block is the INHERITED rungs, and they are here for an honest
+ * reason rather than a tidy one. They are Tailwind's built-in `text-xs` …
+ * `text-3xl`, which ~340 call sites across the three workspaces use today.
+ * They vanish the moment Tailwind leaves the build, so a scale that omitted
+ * them would silently re-size a third of the app's type during migration —
+ * exactly the class of regression the epic exists to avoid.
+ *
+ * They overlap the semantic ladder (14 sits between caption and lede; 24 and 30
+ * sit either side of title and displayLg), and that overlap is real debt: two
+ * spellings for one intent is the drift this system's own ruleset is written to
+ * prevent. Reconciling them is a DESIGN pass with visible consequences at every
+ * one of those call sites, not a mechanical port, so it is flagged here rather
+ * than smuggled into a foundation layer. **Prefer the semantic rung; reach for
+ * an inherited one only when migrating a call site that already used it.**
+ */
+export const fontSize = {
+  // — semantic ladder (ruleset §4.2) —
+  nano: '8px',
+  micro: '9px',
+  label: '10px',
+  labelLg: '10.5px',
+  badge: '11px',
+  note: '11.5px',
+  caption: '13px',
+  lede: '15px',
+  readout: '17px',
+  title: '22px',
+  display: '26px',
+  displayLg: '31px',
+  hero: '38px',
+  // — inherited rungs (Tailwind built-ins in live use; see the note above) —
+  xs: '12px',
+  sm: '14px',
+  base: '16px',
+  lg: '18px',
+  xl: '20px',
+  xl2: '24px',
+  xl3: '30px',
+} as const
+
+/** Font weights in use. Barlow ships the whole range; these are the rungs used. */
+export const weight = {
+  normal: 400,
+  medium: 500,
+  semibold: 600,
+  bold: 700,
+  extrabold: 800,
+} as const
+
+/**
+ * The caps tracking ladder (ruleset §4.2). `capsTight` (0.04em) is the
+ * canonical stamp/label tracking; `eyebrow` (0.22em) is the brand caption only.
+ */
+export const tracking = {
+  capsTight: '0.04em',
+  capsSnug: '0.06em',
+  caps: '0.08em',
+  capsWide: '0.12em',
+  eyebrow: '0.22em',
+} as const
+
+/**
+ * The ONE radius vocabulary (ruleset §4.4). Pick by ROLE, not by which number
+ * is nearest:
+ *
+ *   pip    tracker pips
+ *   badge  the stamp-chip family
+ *   card   cards, inputs, buttons
+ *   panel  app-chrome panels & pick cards
+ *   none   stamps are square
+ *   full   pills and circles
+ *
+ * Tailwind's own `rounded` / `rounded-md` / `rounded-xl` rungs are deliberately
+ * NOT carried across, unlike the inherited type rungs above. The radius ladder
+ * is a *closed* role vocabulary with a guard behind it (`check:tokens`,
+ * `arbitrary-radius`), so their ~40 call sites are drift the ladder already
+ * has a word for — 4px is `card`, 6px is exactly `panel`. Migrating them means
+ * naming the role, which is the point of the ladder.
+ */
+export const radius = {
+  pip: '1px',
+  badge: '2px',
+  card: '3px',
+  panel: '6px',
+  none: '0px',
+  full: '9999px',
+} as const
+
+/**
+ * Border weights, one meaning each (design-spec §1.3 / ruleset §4.3):
+ *
+ *   hairline  1px    plain rules
+ *   chrome    1.5px  buttons, inputs, panels, rows, pips
+ *   pill      2px    pills / status badges / dividers
+ *   rail      2.5px  rail cards & Hold frames
+ *   entity    3px    entity cards + hero header
+ */
+export const borderWidth = {
+  hairline: '1px',
+  chrome: '1.5px',
+  pill: '2px',
+  rail: '2.5px',
+  entity: '3px',
+} as const
+
+/**
+ * The base colour values. Not exported directly — `color` below re-exports
+ * these alongside the semantic aliases that point at them, so an alias stays an
+ * alias (retone `rollSuccess` and `statusOk` follows) instead of being a second
+ * literal of the same number. That aliasing is why the shadow `su-*` family had
+ * to be deleted from theme.css, and it is preserved here rather than flattened.
+ */
+const base = {
+  // — Tech Level blues —
+  tl1: 'rgb(115, 201, 230)',
+  tl2: 'rgb(87, 169, 200)',
+  tl3: 'rgb(68, 135, 162)',
+  tl4: 'rgb(48, 107, 128)',
+  tl5: 'rgb(30, 83, 100)',
+  tl6: 'rgb(6, 52, 65)',
+  // Non-numeric equipment tiers (Core Book p.3): Bio + Nanite.
+  tlB: 'rgb(86, 156, 104)',
+  tlN: 'rgb(146, 109, 184)',
+
+  // — Entity colours: hue encodes ontology (ruleset §3/§4.1) —
+  pilot: 'rgb(239, 137, 79)',
+  pilotLight: 'rgb(245, 193, 163)',
+  mech: 'rgb(122, 151, 138)',
+  mechDark: 'rgb(92, 121, 108)',
+  crawler: 'rgb(206, 88, 152)',
+  /** The world/opposition schemas — creatures, bio-titans, factions, npcs,
+   *  meld, squads. NOT the action rust, despite the tone. */
+  adversary: 'rgb(140, 75, 56)',
+
+  // — Guide tones that are not one of the five ontology domains. A guide's band
+  //   colour is authored per-guide; most reuse an ontology hue, and these two
+  //   cover the guides that are about none of them — the salvage/condition
+  //   procedures, and the hazard-stripe band. —
+  guideSalvage: 'rgb(90, 157, 181)',
+  guideHazard: 'rgb(184, 76, 76)',
+
+  // — Class ability-tier ramp. Advanced and Legendary reuse pilot/crawler, so
+  //   only Core needs its own token. —
+  tierCore: 'rgb(168, 89, 71)',
+  tierCorePale: 'rgb(210, 160, 140)',
+
+  // — Roll result tiers: the canonical warm state ramp, shared with the bot —
+  rollCascade: 'rgb(176, 67, 43)',
+  rollFailure: 'rgb(192, 122, 47)',
+  rollTough: 'rgb(193, 154, 62)',
+  rollSuccess: 'rgb(111, 138, 74)',
+  rollNailed: 'rgb(75, 134, 160)',
+
+  // — Ink / paper / action —
+  ink: 'rgb(40, 32, 25)',
+  ink2: 'rgb(70, 61, 49)',
+  /** The dark header ground. */
+  inkDeep: 'rgb(27, 23, 18)',
+
+  /** Ink at opacity — hairlines, placeholders, ghosts, disabled fills and
+   *  shadows. Warm ink at opacity reads as the same material at distance,
+   *  which a true-neutral grey does not against warm paper. */
+  ink85: 'rgb(40 32 25 / 0.85)',
+  ink75: 'rgb(40 32 25 / 0.75)',
+  ink50: 'rgb(40 32 25 / 0.5)',
+  ink40: 'rgb(40 32 25 / 0.4)',
+  ink30: 'rgb(40 32 25 / 0.3)',
+  ink20: 'rgb(40 32 25 / 0.2)',
+  ink12: 'rgb(40 32 25 / 0.12)',
+  ink8: 'rgb(40 32 25 / 0.08)',
+
+  /** The ONE light surface (ruleset §4.1) — a near-white warm paper. Pure
+   *  white is retired from the UI; the only survivor is the print sheet. */
+  paper: 'rgb(251, 250, 247)',
+  /** Paper as a FOREGROUND — text and hairlines printed onto a tone or a dark
+   *  ground. Paper as a background is always the flat `paper`. */
+  paper60: 'rgb(251 250 247 / 0.6)',
+  paper30: 'rgb(251 250 247 / 0.3)',
+
+  /** THE single action colour. */
+  rust: 'rgb(168, 82, 34)',
+  rustHi: 'rgb(138, 64, 25)',
+  /** The one sanctioned cream — RollTable banding, and nowhere else. */
+  bandCream: 'rgb(243, 237, 226)',
+
+  // — Workshop (light) ground: the step off-paper that makes a card read as a
+  //   panel —
+  wkBg: 'rgb(230, 240, 245)',
+  wkBg2: 'rgb(215, 230, 238)',
+  /** The muted secondary-text tone, toned to clear WCAG AA on all three
+   *  grounds it lands on (paper 5.78:1 · wkBg 5.22:1 · wkBg2 4.73:1). */
+  wkMuted: 'rgb(90, 100, 109)',
+  /** NON-TEXT ONLY — 2.03:1 on paper. A hairline/divider tone. */
+  wkFaint: 'rgb(167, 180, 189)',
+  /** Advisory/info rule. */
+  wkLine: 'rgb(143, 195, 216)',
+  /** Game-state accent. */
+  wkAccent: 'rgb(125, 206, 235)',
+
+  // — Attention fills that are neither an ontology hue nor a status overlay —
+  caution: 'rgb(215, 195, 125)',
+  inert: 'rgb(192, 192, 192)',
+
+  // — Cargo (storage) accent triplet —
+  cargo: 'rgb(156, 122, 62)',
+  cargoDeep: 'rgb(111, 85, 39)',
+  cargoPale: 'rgb(239, 230, 212)',
+
+  // — Sheet "deep" tones that are literals rather than aliases —
+  sheetMechDeep: 'rgb(47, 67, 56)',
+  sheetCrawlerDeep: 'rgb(126, 42, 91)',
+  /** A LITERAL, not an alias of `tl5`, which holds the same value but means
+   *  TECH LEVEL — aliasing it would tie the Game ontology to tech-level
+   *  semantics. */
+  sheetGameDeep: 'rgb(30, 83, 100)',
+} as const
+
+/**
+ * The closed colour set (ruleset §0/§4.1). One name per colour: there is no
+ * second spelling of any value here, which is what makes a law like "rust =
+ * action, only action" auditable by search.
+ */
+export const color = {
+  ...base,
+
+  // — Status (Intact / Damaged / Destroyed): aliases of the roll tiers —
+  statusOk: base.rollSuccess,
+  statusWarn: base.rollFailure,
+  statusBad: base.rollCascade,
+
+  // — Sheet tones (Header C live sheets): base + deep pairs —
+  sheetPilot: base.pilot,
+  sheetPilotDeep: base.rust,
+  sheetMech: base.mech,
+  sheetCrawler: base.crawler,
+  /** The shared-table ontology (ADR-030). Blue, so a Game row never reads as
+   *  the crawler row next to it. */
+  sheetGame: base.wkAccent,
+} as const

--- a/packages/component-lib/src/index.ts
+++ b/packages/component-lib/src/index.ts
@@ -230,6 +230,20 @@ export type { RollTableDeps } from './components/wizard/rollTableHelpers'
 // Wizard roll-table + class-option helpers (moved with their components).
 export { rollForPilotField } from './components/wizard/rollTableHelpers'
 export { SystemsList } from './components/wizard/SystemsList'
+/**
+ * The styling foundation (#798, epic #802) — the target pattern Tailwind is
+ * being removed in favour of. Namespaced rather than spread flat into this
+ * barrel, because the token names are deliberately generic (`color`, `space`,
+ * `radius`) and read correctly only when qualified: `tokens.color.rust`,
+ * `style={styles.card}`.
+ *
+ * `styles` is the STATIC half. The stateful half — `:hover`, `:focus-visible`,
+ * `:disabled`, `@media` — cannot live in a style object at all and ships as
+ * the stylesheet `component-lib/styles/index.css`. The split rule between them
+ * is in this package's CLAUDE.md; read it before migrating a component.
+ */
+export * as styles from './design/styles'
+export * as tokens from './design/tokens'
 // Utilities — the ONE cn(): its tailwind-merge config knows the custom
 // text/tracking/border-width utilities (consumers must not re-wrap twMerge
 // with the default config, which drops them as unknown "colors").

--- a/packages/component-lib/src/styles/index.css
+++ b/packages/component-lib/src/styles/index.css
@@ -1,0 +1,417 @@
+/*
+ * The package stylesheet — the ONE stylesheet a web consumer loads.
+ *
+ * Layer 1 of the Tailwind removal (#798, epic #802). This is the other half of
+ * the pattern whose TypeScript half is `src/design/tokens.ts` +
+ * `src/design/styles.ts`, and it is the half that is easy to miss.
+ *
+ * WHY IT IS NOT OPTIONAL
+ *
+ * An inline `style={}` object cannot express `:hover`, `@media`,
+ * `:focus-visible`, `:disabled`, or a pseudo-element. Measured across the three
+ * UI workspaces, this codebase depends on all of them — ~403 Tailwind variant
+ * usages: 215 responsive, 120 hover, 15 focus-visible, 12 disabled, 9 focus, 5
+ * structural. A migration to style objects ALONE would drop every one of them,
+ * which is a straight functional regression, not a styling change. Everything
+ * in that list lands here.
+ *
+ * (The pattern is ported from `binfinite-app`, whose component library has zero
+ * `:hover` and zero `@media` because it is React-Native-first and RN has
+ * neither. Its style objects were therefore never asked to carry interaction or
+ * viewport state. Here they would be, and they cannot, so both halves are
+ * ported deliberately rather than just the visible one.)
+ *
+ * THE SPLIT RULE
+ *
+ *   Style object     static values that never vary by interaction or viewport:
+ *                    colour, padding, font, border, layout.
+ *   Stylesheet class anything stateful or conditional: `:hover`,
+ *                    `:focus-visible`, `:disabled`, `@media`,
+ *                    pseudo-elements, sibling/child selectors.
+ *
+ * A component may use both — the object on `style=`, the class on `className=`.
+ * The full statement lives in this package's CLAUDE.md.
+ *
+ * RELATIONSHIP TO theme.css, WHILE BOTH EXIST
+ *
+ * `theme.css` is still the live source: Tailwind is in the build and every
+ * component still renders through it, untouched by this layer. This file is a
+ * re-shaping of the same values into a form that does not need Tailwind, so the
+ * two overlap on purpose until #801 deletes the Tailwind side. Nothing imports
+ * this file yet — it has no runtime effect until the migration layers wire it
+ * up, which is what makes a foundation layer safe to land.
+ *
+ * The custom-property values below are the same numbers as `src/design/
+ * tokens.ts`, and `src/design/tokens.parity.test.ts` fails if the two ever
+ * disagree. Do not edit one without the other.
+ */
+
+/* ══ The token scale, as custom properties ══════════════════════════════════
+ *
+ * Namespaced `--su-*` so this scale can coexist with Tailwind's `@theme`
+ * output (`--color-*`, `--text-*`, …) for as long as both are in the build.
+ * The names are `--su-<group>-<token>`, where the token is the kebab-case
+ * spelling of its `tokens.ts` key: `color.inkDeep` is `--su-color-ink-deep`.
+ */
+:root {
+  /* ── Type faces ── */
+  --su-font-body: 'Barlow', system-ui, -apple-system, sans-serif;
+  --su-font-cond: 'Barlow Semi Condensed', 'Barlow', system-ui, -apple-system, sans-serif;
+
+  /* ── Spacing rhythm, keyed by its own pixel value ── */
+  --su-space-0: 0px;
+  --su-space-2: 2px;
+  --su-space-4: 4px;
+  --su-space-6: 6px;
+  --su-space-8: 8px;
+  --su-space-10: 10px;
+  --su-space-12: 12px;
+  --su-space-14: 14px;
+  --su-space-16: 16px;
+  --su-space-20: 20px;
+  --su-space-24: 24px;
+  --su-space-28: 28px;
+  --su-space-32: 32px;
+  --su-space-40: 40px;
+  --su-space-48: 48px;
+  --su-space-64: 64px;
+  --su-space-96: 96px;
+
+  /* ── Type ladder: the semantic rungs (ruleset §4.2) ── */
+  --su-text-nano: 8px;
+  --su-text-micro: 9px;
+  --su-text-label: 10px;
+  --su-text-label-lg: 10.5px;
+  --su-text-badge: 11px;
+  --su-text-note: 11.5px;
+  --su-text-caption: 13px;
+  --su-text-lede: 15px;
+  --su-text-readout: 17px;
+  --su-text-title: 22px;
+  --su-text-display: 26px;
+  --su-text-display-lg: 31px;
+  --su-text-hero: 38px;
+  /* ── …and the inherited rungs. These are Tailwind's built-ins, carried
+     because ~340 call sites use them and they vanish with Tailwind. They
+     overlap the ladder above, which is real debt; see the note in tokens.ts.
+     Prefer a semantic rung. ── */
+  --su-text-xs: 12px;
+  --su-text-sm: 14px;
+  --su-text-base: 16px;
+  --su-text-lg: 18px;
+  --su-text-xl: 20px;
+  --su-text-xl-2: 24px;
+  --su-text-xl-3: 30px;
+
+  /* ── Weights ── */
+  --su-weight-normal: 400;
+  --su-weight-medium: 500;
+  --su-weight-semibold: 600;
+  --su-weight-bold: 700;
+  --su-weight-extrabold: 800;
+
+  /* ── Caps tracking ladder ── */
+  --su-tracking-caps-tight: 0.04em;
+  --su-tracking-caps-snug: 0.06em;
+  --su-tracking-caps: 0.08em;
+  --su-tracking-caps-wide: 0.12em;
+  --su-tracking-eyebrow: 0.22em;
+
+  /* ── The ONE radius vocabulary (ruleset §4.4) — pick by role ── */
+  --su-radius-pip: 1px;
+  --su-radius-badge: 2px;
+  --su-radius-card: 3px;
+  --su-radius-panel: 6px;
+  --su-radius-none: 0px;
+  --su-radius-full: 9999px;
+
+  /* ── Border weights, one meaning each (design-spec §1.3) ── */
+  --su-bw-hairline: 1px;
+  --su-bw-chrome: 1.5px;
+  --su-bw-pill: 2px;
+  --su-bw-rail: 2.5px;
+  --su-bw-entity: 3px;
+
+  /* ── Tech Level blues ── */
+  --su-color-tl-1: rgb(115, 201, 230);
+  --su-color-tl-2: rgb(87, 169, 200);
+  --su-color-tl-3: rgb(68, 135, 162);
+  --su-color-tl-4: rgb(48, 107, 128);
+  --su-color-tl-5: rgb(30, 83, 100);
+  --su-color-tl-6: rgb(6, 52, 65);
+  --su-color-tl-b: rgb(86, 156, 104);
+  --su-color-tl-n: rgb(146, 109, 184);
+
+  /* ── Entity colours: hue encodes ontology (ruleset §3/§4.1) ── */
+  --su-color-pilot: rgb(239, 137, 79);
+  --su-color-pilot-light: rgb(245, 193, 163);
+  --su-color-mech: rgb(122, 151, 138);
+  --su-color-mech-dark: rgb(92, 121, 108);
+  --su-color-crawler: rgb(206, 88, 152);
+  --su-color-adversary: rgb(140, 75, 56);
+
+  /* ── Guide tones that are not one of the five ontology domains ── */
+  --su-color-guide-salvage: rgb(90, 157, 181);
+  --su-color-guide-hazard: rgb(184, 76, 76);
+
+  /* ── Class ability-tier ramp ── */
+  --su-color-tier-core: rgb(168, 89, 71);
+  --su-color-tier-core-pale: rgb(210, 160, 140);
+
+  /* ── Roll result tiers — the canonical warm state ramp ── */
+  --su-color-roll-cascade: rgb(176, 67, 43);
+  --su-color-roll-failure: rgb(192, 122, 47);
+  --su-color-roll-tough: rgb(193, 154, 62);
+  --su-color-roll-success: rgb(111, 138, 74);
+  --su-color-roll-nailed: rgb(75, 134, 160);
+
+  /* ── Ink / paper / action ── */
+  --su-color-ink: rgb(40, 32, 25);
+  --su-color-ink-2: rgb(70, 61, 49);
+  --su-color-ink-deep: rgb(27, 23, 18);
+
+  /* Ink at opacity — hairlines, placeholders, ghosts, disabled fills, shadows. */
+  --su-color-ink-85: rgb(40 32 25 / 0.85);
+  --su-color-ink-75: rgb(40 32 25 / 0.75);
+  --su-color-ink-50: rgb(40 32 25 / 0.5);
+  --su-color-ink-40: rgb(40 32 25 / 0.4);
+  --su-color-ink-30: rgb(40 32 25 / 0.3);
+  --su-color-ink-20: rgb(40 32 25 / 0.2);
+  --su-color-ink-12: rgb(40 32 25 / 0.12);
+  --su-color-ink-8: rgb(40 32 25 / 0.08);
+
+  /* The ONE light surface (ruleset §4.1). Paper as a background is always flat. */
+  --su-color-paper: rgb(251, 250, 247);
+  /* Paper as a FOREGROUND — printed onto a tone or a dark ground. */
+  --su-color-paper-60: rgb(251 250 247 / 0.6);
+  --su-color-paper-30: rgb(251 250 247 / 0.3);
+
+  /* THE single action colour. */
+  --su-color-rust: rgb(168, 82, 34);
+  --su-color-rust-hi: rgb(138, 64, 25);
+  /* The one sanctioned cream — RollTable banding, and nowhere else. */
+  --su-color-band-cream: rgb(243, 237, 226);
+
+  /* ── Workshop (light) ground ── */
+  --su-color-wk-bg: rgb(230, 240, 245);
+  --su-color-wk-bg-2: rgb(215, 230, 238);
+  --su-color-wk-muted: rgb(90, 100, 109);
+  /* NON-TEXT ONLY — 2.03:1 on paper. A hairline/divider tone. */
+  --su-color-wk-faint: rgb(167, 180, 189);
+  --su-color-wk-line: rgb(143, 195, 216);
+  --su-color-wk-accent: rgb(125, 206, 235);
+
+  /* ── Attention fills ── */
+  --su-color-caution: rgb(215, 195, 125);
+  --su-color-inert: rgb(192, 192, 192);
+
+  /* ── Cargo (storage) accent triplet ── */
+  --su-color-cargo: rgb(156, 122, 62);
+  --su-color-cargo-deep: rgb(111, 85, 39);
+  --su-color-cargo-pale: rgb(239, 230, 212);
+
+  /* ── Sheet "deep" tones that are literals rather than aliases ── */
+  --su-color-sheet-mech-deep: rgb(47, 67, 56);
+  --su-color-sheet-crawler-deep: rgb(126, 42, 91);
+  /* A LITERAL, not `var(--su-color-tl-5)`, which holds the same value but means
+     TECH LEVEL — aliasing it would tie the Game ontology to tech-level semantics. */
+  --su-color-sheet-game-deep: rgb(30, 83, 100);
+
+  /* ── Aliases. These stay aliases so a retone propagates. ── */
+  --su-color-status-ok: var(--su-color-roll-success);
+  --su-color-status-warn: var(--su-color-roll-failure);
+  --su-color-status-bad: var(--su-color-roll-cascade);
+  --su-color-sheet-pilot: var(--su-color-pilot);
+  --su-color-sheet-pilot-deep: var(--su-color-rust);
+  --su-color-sheet-mech: var(--su-color-mech);
+  --su-color-sheet-crawler: var(--su-color-crawler);
+  --su-color-sheet-game: var(--su-color-wk-accent);
+}
+
+/* ══ Base ═══════════════════════════════════════════════════════════════════
+ *
+ * Tailwind's preflight supplies these today and takes them away when it leaves,
+ * so the package stylesheet has to carry them or every migrated component's box
+ * maths changes underneath it. Deliberately minimal: only the rules the app
+ * visibly depends on, not a general-purpose reset.
+ */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+figure,
+blockquote,
+dl,
+dd {
+  margin: 0;
+}
+
+/* Headings inherit until a style object or class says otherwise, so a semantic
+   <h2> is a landmark rather than a size. */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+img,
+picture,
+video,
+canvas,
+svg {
+  display: block;
+  max-width: 100%;
+}
+
+/* Form controls do not inherit type by default; every design system wants them to. */
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  margin: 0;
+}
+
+button {
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+/* ══ The page ground and body face ══════════════════════════════════════════ */
+body {
+  background-color: var(--su-color-paper);
+  color: var(--su-color-ink);
+  font-family: var(--su-font-body);
+  font-size: var(--su-text-sm);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ══ The stateful half ══════════════════════════════════════════════════════
+ *
+ * Everything below is here because a style object could not hold it. Each class
+ * is the interactive complement of an object in `src/design/styles.ts`: the
+ * object paints the resting state, the class paints every other state.
+ */
+
+/**
+ * The canonical rust focus ring (design-spec §2.4), on `:focus-visible` — a
+ * button shows it to the keyboard, not to the mouse.
+ */
+.su-focus-ring:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--su-color-ink-20);
+}
+
+/**
+ * The ON-TONE rung: an ink ring with a paper offset, for a focusable surface
+ * whose own background is a caller-supplied ENTITY TONE. The soft ring above
+ * simply disappears against the dark end of the tech-level ramp, and a ring
+ * that vanishes on a legal background is not an accessibility affordance.
+ */
+.su-focus-ring-on-tone:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--su-color-paper),
+    0 0 0 4px var(--su-color-ink);
+}
+
+/** The interactive complement of `styles.buttonBase`. */
+.su-button:hover:not(:disabled) {
+  filter: brightness(0.94);
+}
+
+.su-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--su-color-ink-20);
+}
+
+.su-button:disabled {
+  cursor: default;
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+/**
+ * The interactive complement of `styles.inputBase`. Plain `:focus`, not
+ * `:focus-visible`: an editable control shows the ring on every focus.
+ */
+.su-input:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--su-color-ink-20);
+}
+
+.su-input:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+
+.su-input::placeholder {
+  color: var(--su-color-wk-muted);
+}
+
+/**
+ * The search-shell rung: the bordered shell is the thing that should look
+ * focused, but the <input> inside is what actually takes focus. Ring-only —
+ * there is no outline on the shell to suppress, and pretending otherwise would
+ * imply the shell is focusable when it is not.
+ */
+.su-focus-within:focus-within {
+  box-shadow: 0 0 0 3px var(--su-color-ink-20);
+}
+
+/* ══ Mobile-first touch targets ═════════════════════════════════════════════ */
+@media (pointer: coarse) {
+  button,
+  [role='button'],
+  input,
+  select,
+  textarea {
+    min-height: 44px;
+    min-width: 44px;
+  }
+}
+
+/* ══ Reduced-motion backstop ════════════════════════════════════════════════
+ *
+ * The single place the "no loops for a prefers-reduced-motion user" guarantee is
+ * made true. A per-call-site convention that nothing enforces will drift; this
+ * is the floor under it, and it holds for a call site nobody remembered to mark.
+ *
+ * `animation-duration: 0.01ms` + `animation-iteration-count: 1` does NOT strip
+ * the animation — it runs it once, instantly, so the element lands on the
+ * keyframes' END state rather than being left mid-transform. Simply disabling
+ * the animation would strand an exit animation mounted forever.
+ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    /* biome-ignore lint/complexity/noImportantStyles: an accessibility backstop must out-rank every inline style and class it covers, whatever their specificity or layer */
+    animation-duration: 0.01ms !important;
+    /* biome-ignore lint/complexity/noImportantStyles: same — a loop must not survive because one call site set iteration-count inline */
+    animation-iteration-count: 1 !important;
+    /* biome-ignore lint/complexity/noImportantStyles: same — transitions are motion too */
+    transition-duration: 0.01ms !important;
+    /* biome-ignore lint/complexity/noImportantStyles: same — smooth scrolling is vestibular motion */
+    scroll-behavior: auto !important;
+  }
+}

--- a/tools/check-design-tokens.ts
+++ b/tools/check-design-tokens.ts
@@ -189,6 +189,18 @@ const EXEMPTIONS: { file: string; rules: string[]; reason: string }[] = [
       'The token definitions themselves — this file is where colour is allowed to be a literal. arbitrary-border-width and arbitrary-radius are exempt for a different reason: the file authors no borders and no radii at all, it DEFINES the --bw-* and --radius-* ladders. Their only matches are the prose in each ladder doc-comment ("never `border-[1.5px]`", "never rounded-[Npx]") — the rule text quoting the form it forbids. Rewording those comments to dodge the regex would make the canon harder to read to satisfy a lint.',
   },
   {
+    file: 'packages/component-lib/src/design/tokens.ts',
+    rules: ['raw-color'],
+    reason:
+      'The same standing as theme.css above, in the language the design system is moving TO (#798, epic #802): this is a token-definition file, so it is where colour is allowed to be a literal. Every value is ported verbatim from theme.css — nothing here is a new colour, and `src/design/tokens.parity.test.ts` fails if these literals and the `--su-*` custom properties in styles/index.css ever disagree. The exemption is scoped to `raw-color` alone: an arbitrary radius, tracking or border width written here would still be a violation, because those ladders are token NAMES rather than literals even inside the file that defines them.',
+  },
+  {
+    file: 'packages/component-lib/src/styles/index.css',
+    rules: ['raw-color'],
+    reason:
+      'The CSS half of the same definition — the package stylesheet emits the token scale as `--su-*` custom properties, so its literals are the identical set tokens.ts holds, kept honest by the same parity test. Note what is NOT exempt: this file is also where every `:hover` / `@media` / `:focus-visible` rule migrated off a Tailwind variant will land, and a colour written into one of THOSE rules is ordinary drift that this rule should catch. It cannot distinguish the two blocks, which is the accepted cost of a file-level exemption — recorded here rather than silently absorbed. Every stateful rule in the file today references a `var(--su-color-*)`, and the next one should too.',
+  },
+  {
     file: 'packages/component-lib/src/components/chrome/Slab.tsx',
     rules: ['gradient'],
     reason:


### PR DESCRIPTION
Closes #798.

Layer 1 of the Tailwind removal (epic #802). **Foundation only** — no component
files change, nothing imports the new stylesheet, and Tailwind keeps working
untouched. This layer exists so every later layer has somewhere to land.

## What landed

| File | Role |
| --- | --- |
| `packages/component-lib/src/design/tokens.ts` | The typed scale as plain `as const` objects — colour, space, font size, weight, tracking, radius, border width, type faces. No dependency, so a token is readable from a test, a canvas or a Node script with no DOM. |
| `packages/component-lib/src/design/styles.ts` | The **static** half: `CSSProperties` objects that each `satisfies` the type — surfaces, type roles, layout, controls. |
| `packages/component-lib/src/styles/index.css` | The **one** stylesheet a web consumer loads. Emits the scale as `--su-*` custom properties, carries the preflight rules Tailwind takes with it, binds the page ground and body face, and holds the stateful half. |

Plus: `tokens.parity.test.ts`, the split rule in `packages/component-lib/CLAUDE.md`,
a barrel export (`tokens` / `styles`, namespaced), the `./styles/index.css`
package export, and two `check:tokens` exemptions.

Every value is ported **verbatim** from `theme.css` — including the two
`--color-guide-*` tones added in #769. Nothing is re-designed, re-toned or
rounded.

## Why the stylesheet is not optional

An inline `style={}` object cannot express `:hover`, `@media`,
`:focus-visible`, `:disabled` or a pseudo-element, and this codebase depends on
~403 such usages (215 responsive, 120 hover, 15 focus-visible, 12 disabled, 9
focus, 5 structural). `binfinite-app`'s library never had to carry them because
it is React-Native-first; here they would be, and they cannot. Both halves of
the pattern are ported deliberately.

## The scale exists twice, on purpose — and a guard makes that safe

Neither form can do the other's job: a style object cannot read a CSS
variable's value, and a stylesheet cannot be read by a renderer with no DOM.
But two hand-maintained copies of one set of numbers is exactly the drift shape
nothing else in the build would notice — a missing property renders unstyled, a
stale one renders the wrong colour, and neither fails typecheck.

`src/design/tokens.parity.test.ts` asserts both directions (every token is
emitted; no custom property outlives its token), derives the name mapping
mechanically rather than from a third hand-written table, and resolves
`var(--su-*)` so an alias stays an alias. Mutation-checked: flipping one
channel of `--su-color-rust` fails it, and drags `--su-color-sheet-pilot-deep`
along with it.

## Judgment calls worth a reviewer's eye

1. **Two token groups beyond the six the issue names.** `font` and
   `borderWidth` are ladders `theme.css` genuinely ships and L2 has no way to
   migrate `border-chrome` without them. Read as part of "the full scale".
2. **Inherited type rungs.** `fontSize` carries Tailwind's built-in
   `xs`…`3xl` alongside the semantic ladder, because ~340 call sites use them
   and they vanish with Tailwind — a scale that omitted them would silently
   re-size a third of the app's type during migration. They overlap the
   semantic ladder, and that overlap is real debt: it is flagged in the file
   rather than smuggled in, and reconciling it is a design pass, not a port.
3. **Radius is NOT given the same treatment.** Tailwind's `rounded` /
   `rounded-md` / `rounded-xl` rungs are deliberately left out: that ladder is
   a closed role vocabulary with a guard behind it, and 4px is `card` while 6px
   is exactly `panel`. Migrating those ~40 sites means naming the role.
4. **A base reset in `index.css`.** Tailwind's preflight supplies box-sizing,
   margin and form-control inheritance today and takes them away when it goes.
   "The one stylesheet a consumer loads" is not true without them.
5. **No ADR in this PR.** #802 says the ADR should be written as part of L1,
   but #798's own acceptance list does not include it, and an ADR also drags
   edits to the root `CLAUDE.md` ADR count and `docs/README.md`'s table along
   with it. Say the word and it is a follow-up commit on this branch.

## Checks

`bun run check:all` — exit 0. Design-token and styling-ownership ratchets both
still at their baselines; knip clean; 766 component-lib tests pass, including
the 3 new parity assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134EvKDdA1167vAeBoPpuf1
