### PR TITLE
feat(component-lib): migrate the Foundations stories off Tailwind

### DIFF
--- a/packages/component-lib/CLAUDE.md
+++ b/packages/component-lib/CLAUDE.md
@@ -70,15 +70,22 @@ collapsing the type on every heading in the catalog. Ladle is the only surface
 with this problem, because it is the only one that renders both systems at once;
 an app imports `index.css` directly, unlayered, as designed.
 
-**Two rungs the token scale was missing.** `ink15` / `ink10` were added because
-`border-ink/15` and `border-ink/10` are in live use and had nowhere exact to
-land. That is not a one-off: Tailwind's `/NN` opacity modifier is an OPEN
-mechanism and `tokens.ts` is a CLOSED set, and roughly 59 of the ~74 alpha call
-sites in this package still have no matching rung (`ink/70`, `paper/70`,
-`rust/25`, …). Rounding one to a neighbouring rung is a re-tone, and a raw
-`rgb(… / .NN)` at the call site is a `check:tokens` violation — so which rungs
-the system should own is a design decision owed before the Atoms layer, and it
-is tracked on #799 rather than settled by whoever migrates the next file.
+**Two rungs the token scale was missing, and ~17 more it still is.** `ink15` /
+`ink10` were added because `border-ink/15` and `border-ink/10` are in live use
+and had nowhere exact to land. That is not a one-off: Tailwind's `/NN` opacity
+modifier is an OPEN mechanism and `tokens.ts` is a CLOSED set. **34 alpha usages
+across 17 non-story files still have no matching rung**, in 17 distinct
+spellings — `ink/5`, `ink/35`, `ink/55`, `ink/60`, `ink/70`, `paper/10`,
+`paper/15`, `paper/40`, `paper/55`, `paper/70`, `paper/80`, `paper/85`,
+`paper/95`, `rust/25`, `caution/25`, `status-bad/25`, `wk-faint/80`. Rounding one
+to a neighbouring rung is a re-tone, and a raw `rgb(… / .NN)` at the call site is
+a `check:tokens` `raw-color` violation, so adding rungs is the only legal move —
+but which rungs the system should own enlarges the closed colour set and is a
+design call, not a port. Tracked on #799.
+
+**The Atoms layer is blocked on five of them**: `paper/70` (Stat), `ink/55` +
+`ink/70` (VitalGauge), `rust/25` (Toggle), `status-bad/25` (InlineEditField).
+Containers needs seven more, Compositions the rest.
 
 **A catalog-only rule goes in `src/stories/_stories.css`, not `index.css`.** The
 split rule sends anything stateful or responsive to a stylesheet class, but

--- a/packages/component-lib/CLAUDE.md
+++ b/packages/component-lib/CLAUDE.md
@@ -47,12 +47,43 @@ so its style objects were never asked to carry interaction or viewport state.
 Here they would be, and they cannot. That is the one thing that must not be lost
 in translation, and it is why the stylesheet is not optional.)
 
+### Migration status (#799, epic #802)
+
+Migrating by Ladle group, one PR per group: **Foundations ✅ → Atoms → Containers
+→ Compositions.** A group is done when no file in it carries a Tailwind class.
+
 ### While both systems are live
 
 `src/styles/theme.css` is still the source of record and Tailwind still works
 untouched: the token scale is a re-shaping of the values already in that file,
 not a re-design. The `--su-*` namespace exists so the two can coexist in one
 build until Tailwind is dropped.
+
+**`src/styles/ladle.css` must import `index.css` into `layer(su-base)`, and this
+is load-bearing.** `index.css` is written to be loaded alone once Tailwind
+leaves, so its base block is unlayered — and unlayered CSS beats layered CSS
+whatever the source order, while Tailwind v4 puts its utilities in
+`@layer utilities`. A plain `@import` therefore inverts the cascade for every
+rule the two share: measured on the real build, `h1,…,h6 { font-size: inherit }`
+landed past the end of the utilities layer and outranked every `text-*` utility,
+collapsing the type on every heading in the catalog. Ladle is the only surface
+with this problem, because it is the only one that renders both systems at once;
+an app imports `index.css` directly, unlayered, as designed.
+
+**Two rungs the token scale was missing.** `ink15` / `ink10` were added because
+`border-ink/15` and `border-ink/10` are in live use and had nowhere exact to
+land. That is not a one-off: Tailwind's `/NN` opacity modifier is an OPEN
+mechanism and `tokens.ts` is a CLOSED set, and roughly 59 of the ~74 alpha call
+sites in this package still have no matching rung (`ink/70`, `paper/70`,
+`rust/25`, …). Rounding one to a neighbouring rung is a re-tone, and a raw
+`rgb(… / .NN)` at the call site is a `check:tokens` violation — so which rungs
+the system should own is a design decision owed before the Atoms layer, and it
+is tracked on #799 rather than settled by whoever migrates the next file.
+
+**A catalog-only rule goes in `src/stories/_stories.css`, not `index.css`.** The
+split rule sends anything stateful or responsive to a stylesheet class, but
+`index.css` is the one stylesheet a *consumer* loads — story-page layout ships in
+no app. The underscore is the same story-scaffolding marker as `_harness.tsx`.
 
 The scale therefore exists twice — once as TypeScript, once as custom properties
 — because neither form can serve the other's job. `src/design/tokens.parity.test.ts`

--- a/packages/component-lib/src/design/tokens.ts
+++ b/packages/component-lib/src/design/tokens.ts
@@ -253,14 +253,25 @@ const base = {
 
   /** Ink at opacity — hairlines, placeholders, ghosts, disabled fills and
    *  shadows. Warm ink at opacity reads as the same material at distance,
-   *  which a true-neutral grey does not against warm paper. */
+   *  which a true-neutral grey does not against warm paper.
+   *
+   *  `ink15` and `ink10` were added by #799, not invented by it: both are in
+   *  live use (`border-ink/15`, `border-ink/10`) and neither had a rung, so a
+   *  migrating call site had to round to `ink12` — the one thing the note at
+   *  the top of `space` promises never happens. They are the first two of a
+   *  LONGER list the migration turned up; the rest are recorded on #799 rather
+   *  than added speculatively here, because Tailwind's `/NN` modifier is an
+   *  open mechanism and this scale is a closed set, so which rungs the system
+   *  should actually own is a design call and not a port. */
   ink85: 'rgb(40 32 25 / 0.85)',
   ink75: 'rgb(40 32 25 / 0.75)',
   ink50: 'rgb(40 32 25 / 0.5)',
   ink40: 'rgb(40 32 25 / 0.4)',
   ink30: 'rgb(40 32 25 / 0.3)',
   ink20: 'rgb(40 32 25 / 0.2)',
+  ink15: 'rgb(40 32 25 / 0.15)',
   ink12: 'rgb(40 32 25 / 0.12)',
+  ink10: 'rgb(40 32 25 / 0.1)',
   ink8: 'rgb(40 32 25 / 0.08)',
 
   /** The ONE light surface (ruleset §4.1) — a near-white warm paper. Pure

--- a/packages/component-lib/src/stories/Layout.stories.tsx
+++ b/packages/component-lib/src/stories/Layout.stories.tsx
@@ -1,13 +1,31 @@
 import type { Story } from '@ladle/react'
+import type { CSSProperties } from 'react'
 import { SalvageUnionReference } from 'salvageunion-reference'
 import { Badge } from '../components/chrome/Badge'
 import { Card } from '../components/shared/Card'
 import { FilterRow } from '../components/shared/FilterRow'
 import { MasonryColumns } from '../components/shared/MasonryColumns'
+import { color, font, space, weight } from '../design/tokens'
 
 export default {
   title: 'Foundations/Layout',
 }
+
+/**
+ * The stage each layout is demonstrated on. `maxWidth` is the Tailwind rung
+ * ported verbatim — `max-w-4xl` is 56rem, `max-w-2xl` is 42rem.
+ */
+const stage = {
+  backgroundColor: color.paper,
+  padding: space[16],
+} satisfies CSSProperties
+
+const headerTitle = {
+  fontFamily: font.cond,
+  fontWeight: weight.bold,
+  textTransform: 'uppercase',
+  color: color.ink,
+} satisfies CSSProperties
 
 // Real SRD content fills every layout so wrapping/overflow read truthfully.
 const chassis = SalvageUnionReference.Chassis.all().slice(0, 6)
@@ -20,14 +38,14 @@ function ChassisRow({ name }: { name: string }) {
     <Card
       extent="head"
       headerBg="bg-mech"
-      headerContent={<span className="font-cond font-bold uppercase text-ink">{name}</span>}
+      headerContent={<span style={headerTitle}>{name}</span>}
     />
   )
 }
 
 /** MasonryColumns — viewport-driven column count; balances cards across columns. */
 export const Masonry: Story = () => (
-  <div className="max-w-4xl bg-paper p-4">
+  <div style={{ ...stage, maxWidth: '56rem' }}>
     <MasonryColumns>
       {chassis.map((c) => (
         <ChassisRow key={c.name} name={c.name} />
@@ -38,7 +56,15 @@ export const Masonry: Story = () => (
 
 /** FilterRow — a labelled row of controls that wraps under its label on mobile. */
 export const Filters: Story = () => (
-  <div className="flex max-w-2xl flex-col gap-4 bg-paper p-4">
+  <div
+    style={{
+      ...stage,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: space[16],
+      maxWidth: '42rem',
+    }}
+  >
     <FilterRow label="Traits">
       {traits.map((t) => (
         <Badge key={t}>{t}</Badge>

--- a/packages/component-lib/src/stories/RenderingMatrix.stories.tsx
+++ b/packages/component-lib/src/stories/RenderingMatrix.stories.tsx
@@ -1,5 +1,5 @@
 import type { Story } from '@ladle/react'
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import { SalvageUnionReference } from 'salvageunion-reference'
 import { Badge } from '../components/chrome/Badge'
 import { RollTable } from '../components/shared/RollTable'
@@ -8,10 +8,29 @@ import { Stat } from '../components/shared/Stat'
 import { BayStatus } from '../components/stat/BayStatus'
 import { ConditionSwatch } from '../components/stat/ConditionSwatch'
 import { VitalGauge } from '../components/stat/VitalGauge'
+import {
+  borderWidth,
+  color,
+  font,
+  fontSize,
+  radius,
+  space,
+  tracking,
+  weight,
+} from '../design/tokens'
 
 export default {
   title: 'Foundations/Rendering Matrix',
 }
+
+// Migrated off Tailwind in #799 (epic #802). The table chrome is static — no
+// hover, no breakpoint, no pseudo-element — so all of it lands in style
+// objects and this page needs no stylesheet class of its own.
+
+const cellStyle = { padding: space[8] } satisfies CSSProperties
+
+/** `size-4` — 16px square. */
+const swatchSize = { height: space[16], width: space[16] } satisfies CSSProperties
 
 const noop = () => {}
 
@@ -72,7 +91,7 @@ const rows: MatrixRow[] = [
     use: 'VitalGauge',
     rule: 'Segmented current/max; skin sheet|instrument.',
     example: (
-      <div className="w-52">
+      <div style={{ width: '208px' }}>
         <VitalGauge label="Cargo" value={Math.ceil(cargo * 0.6)} max={cargo} onChange={noop} />
       </div>
     ),
@@ -101,10 +120,13 @@ const rows: MatrixRow[] = [
     use: 'ConditionSwatch',
     rule: 'Tri-state; fill-shape primary, no gradient.',
     example: (
-      <div className="flex gap-2">
-        <ConditionSwatch state="intact" className="size-4" />
-        <ConditionSwatch state="damaged" className="size-4" />
-        <ConditionSwatch state="destroyed" className="size-4" />
+      // `size-4` is 16px. ConditionSwatch keeps its `className` sizing override
+      // (that is its API, and it migrates with the Atoms layer); the call site
+      // reaches the same size through `style`, which it already accepts.
+      <div style={{ display: 'flex', gap: space[8] }}>
+        <ConditionSwatch state="intact" style={swatchSize} />
+        <ConditionSwatch state="damaged" style={swatchSize} />
+        <ConditionSwatch state="destroyed" style={swatchSize} />
       </div>
     ),
   },
@@ -128,7 +150,7 @@ const rows: MatrixRow[] = [
     use: 'RollTable',
     rule: 'Banded d20 map; uniform peach/paper.',
     example: rollTable ? (
-      <div className="w-80">
+      <div style={{ width: '320px' }}>
         <RollTable
           table={rollTable}
           tableName={rollTableEntity?.name}
@@ -142,21 +164,53 @@ const rows: MatrixRow[] = [
 ]
 
 export const Default: Story = () => (
-  <div className="bg-paper p-6 font-body text-ink">
+  <div
+    style={{
+      backgroundColor: color.paper,
+      color: color.ink,
+      fontFamily: font.body,
+      padding: space[24],
+    }}
+  >
     <Badge shape="stamp" size="full" as="span">
       Rendering Matrix
     </Badge>
-    <p className="mt-3 max-w-2xl text-sm leading-relaxed text-wk-muted">
-      <span className="font-bold text-ink">What to use, when.</span> Every UI <em>role</em> — the
-      job a piece of data does on screen — maps to exactly one primitive, with a live render of
-      each; the rule tailors it to context. Instances collapse into their role (ruleset §2).
+    <p
+      style={{
+        color: color.wkMuted,
+        fontSize: fontSize.sm,
+        lineHeight: 1.625,
+        marginTop: space[12],
+        maxWidth: '42rem',
+      }}
+    >
+      <span style={{ color: color.ink, fontWeight: weight.bold }}>What to use, when.</span> Every UI{' '}
+      <em>role</em> — the job a piece of data does on screen — maps to exactly one primitive, with a
+      live render of each; the rule tailors it to context. Instances collapse into their role
+      (ruleset §2).
     </p>
-    <div className="mt-5 overflow-x-auto">
-      <table className="w-full min-w-[52rem] border-collapse text-sm">
+    <div style={{ marginTop: space[20], overflowX: 'auto' }}>
+      <table
+        style={{
+          borderCollapse: 'collapse',
+          fontSize: fontSize.sm,
+          minWidth: '52rem',
+          width: '100%',
+        }}
+      >
         <thead>
-          <tr className="border-b-2 border-ink text-left">
+          <tr style={{ borderBottom: `${borderWidth.pill} solid ${color.ink}`, textAlign: 'left' }}>
             {['Role', 'When', 'Use', 'Rule', 'Example'].map((h) => (
-              <th key={h} className="p-2 text-xs font-bold uppercase tracking-caps-tight">
+              <th
+                key={h}
+                style={{
+                  ...cellStyle,
+                  fontSize: fontSize.xs,
+                  fontWeight: weight.bold,
+                  letterSpacing: tracking.capsTight,
+                  textTransform: 'uppercase',
+                }}
+              >
                 {h}
               </th>
             ))}
@@ -164,14 +218,29 @@ export const Default: Story = () => (
         </thead>
         <tbody>
           {rows.map((row) => (
-            <tr key={`${row.role}-${row.when}`} className="border-b border-ink/12 align-top">
-              <td className="p-2 font-bold">{row.role}</td>
-              <td className="p-2 text-wk-muted">{row.when}</td>
-              <td className="p-2">
-                <code className="rounded-badge bg-ink/8 px-1 py-0.5 text-[12px]">{row.use}</code>
+            <tr
+              key={`${row.role}-${row.when}`}
+              style={{
+                borderBottom: `${borderWidth.hairline} solid ${color.ink12}`,
+                verticalAlign: 'top',
+              }}
+            >
+              <td style={{ ...cellStyle, fontWeight: weight.bold }}>{row.role}</td>
+              <td style={{ ...cellStyle, color: color.wkMuted }}>{row.when}</td>
+              <td style={cellStyle}>
+                <code
+                  style={{
+                    backgroundColor: color.ink8,
+                    borderRadius: radius.badge,
+                    fontSize: fontSize.xs,
+                    padding: `${space[2]} ${space[4]}`,
+                  }}
+                >
+                  {row.use}
+                </code>
               </td>
-              <td className="max-w-[14rem] p-2 text-wk-muted">{row.rule}</td>
-              <td className="p-2">{row.example}</td>
+              <td style={{ ...cellStyle, color: color.wkMuted, maxWidth: '14rem' }}>{row.rule}</td>
+              <td style={cellStyle}>{row.example}</td>
             </tr>
           ))}
         </tbody>

--- a/packages/component-lib/src/stories/Sizing.stories.tsx
+++ b/packages/component-lib/src/stories/Sizing.stories.tsx
@@ -1,14 +1,23 @@
 import type { Story } from '@ladle/react'
+import type { CSSProperties } from 'react'
 import { SalvageUnionReference } from 'salvageunion-reference'
 import { Text } from '../components/base/Text'
 import { Badge } from '../components/chrome/Badge'
+import { borderWidth, color, font, fontSize, space, tracking, weight } from '../design/tokens'
 import type { SizeRung } from '../styles/sizing'
-import { DEFAULT_RUNG, RUNG_INLINE_PADDING, RUNG_TYPE } from '../styles/sizing'
+import { DEFAULT_RUNG, RUNG_FONT_SIZE, RUNG_INLINE_PAD } from '../styles/sizing'
 import { Caption } from './_harness'
+import './_stories.css'
 
 export default {
   title: 'Foundations/Sizing',
 }
+
+// Migrated off Tailwind in #799 (epic #802). The specimens now read
+// `RUNG_FONT_SIZE` / `RUNG_INLINE_PAD` from `styles/sizing.ts` — the token-valued
+// half of the same ladder Badge and Button consume — so the page still cannot
+// drift from the code, and the values it PRINTS are the real sizes rather than
+// the names of utility classes that are on their way out of the build.
 
 /** Ladder order, largest first — specimen iteration only (the catalog page). */
 const SIZE_RUNGS: readonly SizeRung[] = ['full', 'compact', 'mini']
@@ -32,15 +41,55 @@ const INTENT: Record<SizeRung, { line: string; use: string }> = {
 /** Real game terms — a specimen must never be lorem. */
 const chassis = SalvageUnionReference.Chassis.all()[0]
 
+const sectionStyle = {
+  borderTop: `${borderWidth.chrome} solid ${color.ink15}`,
+  paddingTop: space[16],
+} satisfies CSSProperties
+
+const headerStyle = {
+  alignItems: 'baseline',
+  columnGap: space[12],
+  display: 'flex',
+  flexWrap: 'wrap',
+  marginBottom: space[12],
+  rowGap: space[4],
+} satisfies CSSProperties
+
+const intentLineStyle = {
+  color: color.ink,
+  fontFamily: font.body,
+  fontSize: fontSize.caption,
+  fontWeight: weight.bold,
+} satisfies CSSProperties
+
+const mutedBodyStyle = {
+  color: color.wkMuted,
+  fontFamily: font.body,
+  fontSize: fontSize.caption,
+} satisfies CSSProperties
+
+const monoNoteStyle = {
+  color: color.wkMuted,
+  fontFamily: 'monospace',
+  fontSize: fontSize.note,
+} satisfies CSSProperties
+
+/** A `space-y-2` column. */
+const columnStyle = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: space[8],
+} satisfies CSSProperties
+
 function Rung({ rung }: { rung: SizeRung }) {
   const intent = INTENT[rung]
   return (
-    <section className="border-chrome border-ink/15 border-t pt-4">
-      <header className="mb-3 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+    <section style={sectionStyle}>
+      <header style={headerStyle}>
         <Badge shape="stamp" size={rung}>
           {rung}
         </Badge>
-        <span className="font-body text-caption font-bold text-ink">{intent.line}</span>
+        <span style={intentLineStyle}>{intent.line}</span>
         {rung === DEFAULT_RUNG && (
           <Badge shape="stamp" size="mini" surface="inverse">
             default
@@ -48,24 +97,25 @@ function Rung({ rung }: { rung: SizeRung }) {
         )}
       </header>
 
-      <p className="mb-4 max-w-prose font-body text-caption text-wk-muted">{intent.use}</p>
+      <p style={{ ...mutedBodyStyle, marginBottom: space[16], maxWidth: '65ch' }}>{intent.use}</p>
 
-      <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-        <div className="space-y-2">
-          <Caption>label · {RUNG_TYPE[rung].label}</Caption>
+      {/* The one responsive rule on this page — a media query, so a class. */}
+      <div className="su-story-split">
+        <div style={columnStyle}>
+          <Caption>label · {RUNG_FONT_SIZE[rung].label}</Caption>
           {/* The stamp reads its geometry from the ladder, so this specimen
               cannot drift from the token the way a hand-set example would. */}
           <Badge shape="stamp" size={rung}>
             {chassis?.name ?? 'Mule'}
           </Badge>
-          <p className="font-body text-note text-wk-muted">
-            {RUNG_INLINE_PADDING[rung]} · {RUNG_TYPE[rung].label}
+          <p style={{ ...mutedBodyStyle, fontSize: fontSize.note }}>
+            {RUNG_INLINE_PAD[rung]} · {RUNG_FONT_SIZE[rung].label}
           </p>
         </div>
 
-        <div className="space-y-2">
-          <Caption>body · {RUNG_TYPE[rung].body}</Caption>
-          <Text variant="body" className={RUNG_TYPE[rung].body}>
+        <div style={columnStyle}>
+          <Caption>body · {RUNG_FONT_SIZE[rung].body}</Caption>
+          <Text variant="body" style={{ fontSize: RUNG_FONT_SIZE[rung].body }}>
             Structure Points are restored during Downtime at the Union Crawler.
           </Text>
         </div>
@@ -87,19 +137,28 @@ function Rung({ rung }: { rung: SizeRung }) {
  * constants the components consume — so the catalog cannot drift from the code.
  */
 export const Default: Story = () => (
-  <div className="max-w-3xl space-y-6">
+  <div style={{ display: 'flex', flexDirection: 'column', gap: space[24], maxWidth: '48rem' }}>
     <div>
-      <h2 className="mb-1 font-cond text-lede font-bold uppercase tracking-caps text-ink">
+      <h2
+        style={{
+          color: color.ink,
+          fontFamily: font.cond,
+          fontSize: fontSize.lede,
+          fontWeight: weight.bold,
+          letterSpacing: tracking.caps,
+          marginBottom: space[4],
+          textTransform: 'uppercase',
+        }}
+      >
         The size ladder
       </h2>
-      <p className="max-w-prose font-body text-caption text-wk-muted">
+      <p style={{ ...mutedBodyStyle, maxWidth: '65ch' }}>
         Three rungs, named for what they are for. A component offers the rungs it genuinely has and
         names them from this list — a two-rung component with{' '}
-        <code className="font-mono text-note">compact</code> and{' '}
-        <code className="font-mono text-note">mini</code> is correct and complete. Scan-past
-        elements rest at <code className="font-mono text-note">compact</code>; a component whose
-        resting anatomy is a destination readout (the poster gauge, the reading callout) rests at{' '}
-        <code className="font-mono text-note">full</code>.
+        <code style={monoNoteStyle}>compact</code> and <code style={monoNoteStyle}>mini</code> is
+        correct and complete. Scan-past elements rest at <code style={monoNoteStyle}>compact</code>
+        {'; '}a component whose resting anatomy is a destination readout (the poster gauge, the
+        reading callout) rests at <code style={monoNoteStyle}>full</code>.
       </p>
     </div>
 
@@ -114,15 +173,24 @@ export const Default: Story = () => (
  * over body-size text, which is why the ladder defines the two separately.
  */
 export const LabelVersusBody: Story = () => (
-  <div className="max-w-3xl space-y-3">
+  <div style={{ display: 'flex', flexDirection: 'column', gap: space[12], maxWidth: '48rem' }}>
     <Caption>each rung's label size beside its body size</Caption>
-    <table className="w-full border-collapse text-left">
+    <table style={{ borderCollapse: 'collapse', textAlign: 'left', width: '100%' }}>
       <thead>
         <tr>
           {['rung', 'label', 'body', 'inline padding'].map((h) => (
             <th
               key={h}
-              className="border-ink/15 border-b px-2 py-1.5 font-cond text-micro font-bold uppercase tracking-caps-wide text-wk-muted"
+              style={{
+                borderBottom: `${borderWidth.hairline} solid ${color.ink15}`,
+                color: color.wkMuted,
+                fontFamily: font.cond,
+                fontSize: fontSize.micro,
+                fontWeight: weight.bold,
+                letterSpacing: tracking.capsWide,
+                padding: `${space[6]} ${space[8]}`,
+                textTransform: 'uppercase',
+              }}
             >
               {h}
             </th>
@@ -132,25 +200,44 @@ export const LabelVersusBody: Story = () => (
       <tbody>
         {SIZE_RUNGS.map((rung) => (
           <tr key={rung}>
-            <td className="border-ink/10 border-b px-2 py-2">
+            <td style={cellStyle}>
               <Badge shape="stamp" size={rung}>
                 {rung}
               </Badge>
             </td>
-            <td className="border-ink/10 border-b px-2 py-2">
-              <span className={`font-cond font-bold uppercase ${RUNG_TYPE[rung].label} text-ink`}>
+            <td style={cellStyle}>
+              <span
+                style={{
+                  color: color.ink,
+                  fontFamily: font.cond,
+                  fontSize: RUNG_FONT_SIZE[rung].label,
+                  fontWeight: weight.bold,
+                  textTransform: 'uppercase',
+                }}
+              >
                 Salvage Union
               </span>
             </td>
-            <td className="border-ink/10 border-b px-2 py-2">
-              <span className={`font-body ${RUNG_TYPE[rung].body} text-ink`}>Salvage Union</span>
+            <td style={cellStyle}>
+              <span
+                style={{
+                  color: color.ink,
+                  fontFamily: font.body,
+                  fontSize: RUNG_FONT_SIZE[rung].body,
+                }}
+              >
+                Salvage Union
+              </span>
             </td>
-            <td className="border-ink/10 border-b px-2 py-2 font-mono text-note text-wk-muted">
-              {RUNG_INLINE_PADDING[rung]}
-            </td>
+            <td style={{ ...cellStyle, ...monoNoteStyle }}>{RUNG_INLINE_PAD[rung]}</td>
           </tr>
         ))}
       </tbody>
     </table>
   </div>
 )
+
+const cellStyle = {
+  borderBottom: `${borderWidth.hairline} solid ${color.ink10}`,
+  padding: `${space[8]} ${space[8]}`,
+} satisfies CSSProperties

--- a/packages/component-lib/src/stories/Styleguide.stories.tsx
+++ b/packages/component-lib/src/stories/Styleguide.stories.tsx
@@ -1,5 +1,6 @@
 import type { Story } from '@ladle/react'
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
+import { color, font, fontSize, radius, space, tracking, weight } from '../design/tokens'
 import { Caption } from './_harness'
 
 export default {
@@ -8,59 +9,128 @@ export default {
 
 // The orientation front-door for the catalog. This page is DOCUMENTATION rendered
 // as a story: it explains how to read the catalog and how to add to it, in the
-// catalog's own voice (paper canvas, font-cond labels, canon tokens). The full
-// contributor reference lives at docs/design-system/ladle-styleguide.md.
+// catalog's own voice (paper canvas, condensed caps labels, canon tokens). The
+// full contributor reference lives at docs/design-system/ladle-styleguide.md.
+//
+// Migrated off Tailwind in #799 (epic #802). Every value is read from
+// `design/tokens.ts`; the `ch`/`rem` measures are the Tailwind rungs ported
+// verbatim, since a line-length measure is not a token on any scale here.
+
+// ── Type roles ──────────────────────────────────────────────────────────────
+
+const titleStyle = {
+  color: color.ink,
+  fontFamily: font.cond,
+  fontSize: fontSize.xl2,
+  letterSpacing: tracking.capsTight,
+  textTransform: 'uppercase',
+} satisfies CSSProperties
+
+const sectionHeadingStyle = {
+  color: color.ink,
+  fontFamily: font.cond,
+  fontSize: fontSize.lg,
+  letterSpacing: tracking.capsTight,
+  textTransform: 'uppercase',
+} satisfies CSSProperties
+
+/** Running documentation copy. `leading-relaxed` is 1.625. */
+const proseStyle = {
+  color: color.wkMuted,
+  fontSize: fontSize.sm,
+  lineHeight: 1.625,
+  maxWidth: '68ch',
+} satisfies CSSProperties
+
+/** An inline term lifted back to primary ink inside muted prose. */
+const inkStyle = { color: color.ink } satisfies CSSProperties
+
+const emphasisStyle = { fontWeight: weight.semibold } satisfies CSSProperties
+
+/** A square ink stamp — the catalog's canonical label chip. */
+const stampStyle = {
+  backgroundColor: color.ink,
+  borderRadius: radius.none,
+  color: color.paper,
+  display: 'inline-block',
+  fontFamily: font.cond,
+  fontSize: fontSize.xs,
+  letterSpacing: tracking.capsTight,
+  padding: `${space[4]} ${space[8]}`,
+  textTransform: 'uppercase',
+} satisfies CSSProperties
+
+// ── Layout ──────────────────────────────────────────────────────────────────
+
+/** The page column. `max-w-[80ch]` ported verbatim. */
+const pageStyle = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: space[24],
+  maxWidth: '80ch',
+  padding: space[8],
+} satisfies CSSProperties
+
+const stack = (gap: string): CSSProperties => ({
+  display: 'flex',
+  flexDirection: 'column',
+  gap,
+})
 
 function Title({ children }: { children: ReactNode }) {
-  return <h1 className="font-cond text-2xl uppercase tracking-caps-tight text-ink">{children}</h1>
+  return <h1 style={titleStyle}>{children}</h1>
 }
 
 function SectionHeading({ children }: { children: ReactNode }) {
-  return <h2 className="font-cond text-lg uppercase tracking-caps-tight text-ink">{children}</h2>
+  return <h2 style={sectionHeadingStyle}>{children}</h2>
 }
 
 function Prose({ children }: { children: ReactNode }) {
-  return <p className="max-w-[68ch] text-sm leading-relaxed text-wk-muted">{children}</p>
+  return <p style={proseStyle}>{children}</p>
 }
 
 function Rule({ children }: { children: ReactNode }) {
   return (
-    <li className="max-w-[68ch] text-sm leading-relaxed text-wk-muted">
-      <span className="text-ink">{children}</span>
+    <li style={proseStyle}>
+      <span style={inkStyle}>{children}</span>
     </li>
   )
 }
 
-/** A square ink stamp — the catalog's canonical label chip. */
 function Stamp({ children }: { children: ReactNode }) {
+  return <span style={stampStyle}>{children}</span>
+}
+
+/** A bulleted rule list. */
+function Rules({ children }: { children: ReactNode }) {
   return (
-    <span className="inline-block rounded-none bg-ink px-2 py-1 font-cond text-xs uppercase tracking-caps-tight text-paper">
+    <ul style={{ ...stack(space[8]), listStyleType: 'disc', paddingLeft: space[24] }}>
       {children}
-    </span>
+    </ul>
   )
 }
 
 // --- Overview: what this catalog is, and how to read it -------------------
 
 export const Overview: Story = () => (
-  <div className="flex max-w-[80ch] flex-col gap-6 p-2">
-    <div className="flex flex-col gap-2">
+  <div style={pageStyle}>
+    <div style={stack(space[8])}>
       <Caption>Salvage Union · component-lib</Caption>
       <Title>The Styleguide</Title>
     </div>
 
     <Prose>
       This is the single, authoritative catalog for the design system. Every UI primitive the apps
-      ship — <span className="text-ink">srd</span> and <span className="text-ink">itun</span> — is
-      rendered here, in its real states, with the real design tokens and real Salvage Union data. If
-      a component is public, it appears here; if it drifts, the catalog shows it. Read the sidebar
+      ship — <span style={inkStyle}>srd</span> and <span style={inkStyle}>itun</span> — is rendered
+      here, in its real states, with the real design tokens and real Salvage Union data. If a
+      component is public, it appears here; if it drifts, the catalog shows it. Read the sidebar
       top-to-bottom: it runs from raw material to finished game components.
     </Prose>
 
-    <div className="flex flex-col gap-3">
+    <div style={stack(space[12])}>
       <SectionHeading>The four groups (+ a Legacy drain)</SectionHeading>
       <Caption>sidebar order, top-to-bottom — composition level rising as you descend</Caption>
-      <div className="flex flex-col gap-3">
+      <div style={stack(space[12])}>
         <GroupRow
           stamp="Foundations"
           body="Design tokens, layout scaffolding, and the QA harness. No product component — Theme, Layout, the Rendering Matrix, and this page."
@@ -84,12 +154,12 @@ export const Overview: Story = () => (
       </div>
     </div>
 
-    <div className="flex flex-col gap-3">
+    <div style={stack(space[12])}>
       <SectionHeading>The one rule that makes it trustworthy</SectionHeading>
       <Prose>
-        Every story renders <span className="text-ink">real SRD data or real game terms</span> —
-        never lorem, placeholder, or invented content. Stories are driven from{' '}
-        <code className="text-ink">SalvageUnionReference.*</code> fixtures and fed through the real
+        Every story renders <span style={inkStyle}>real SRD data or real game terms</span> — never
+        lorem, placeholder, or invented content. Stories are driven from{' '}
+        <code style={inkStyle}>SalvageUnionReference.*</code> fixtures and fed through the real
         components exactly as the apps feed them. A story is a preview of what ships; fake data
         hides the overflow, wrapping, tone, and empty-state bugs a styleguide exists to catch. The
         one exception is a genuinely generic container primitive (e.g. Card), which may show
@@ -101,11 +171,11 @@ export const Overview: Story = () => (
 
 function GroupRow({ stamp, body }: { stamp: string; body: string }) {
   return (
-    <div className="flex items-start gap-3">
-      <div className="w-[120px] shrink-0">
+    <div style={{ display: 'flex', alignItems: 'flex-start', gap: space[12] }}>
+      <div style={{ width: '120px', flexShrink: 0 }}>
         <Stamp>{stamp}</Stamp>
       </div>
-      <p className="max-w-[60ch] text-sm leading-relaxed text-wk-muted">{body}</p>
+      <p style={{ ...proseStyle, maxWidth: '60ch' }}>{body}</p>
     </div>
   )
 }
@@ -113,19 +183,30 @@ function GroupRow({ stamp, body }: { stamp: string; body: string }) {
 // --- Conventions: how a story is written ----------------------------------
 
 export const Conventions: Story = () => (
-  <div className="flex max-w-[80ch] flex-col gap-6 p-2">
-    <div className="flex flex-col gap-2">
+  <div style={pageStyle}>
+    <div style={stack(space[8])}>
       <Caption>writing a story</Caption>
       <Title>Conventions</Title>
     </div>
 
     <Prose>
-      Stories are plain function components typed <code className="text-ink">Story</code>, in a file
+      Stories are plain function components typed <code style={inkStyle}>Story</code>, in a file
       that carries its meta via a static default export. No args, argTypes, controls, decorators, or
-      MSW — interactivity is plain <code className="text-ink">useState</code>. The shape:
+      MSW — interactivity is plain <code style={inkStyle}>useState</code>. The shape:
     </Prose>
 
-    <pre className="max-w-full overflow-x-auto rounded-card bg-ink p-4 text-xs leading-relaxed text-paper">
+    <pre
+      style={{
+        backgroundColor: color.ink,
+        borderRadius: radius.card,
+        color: color.paper,
+        fontSize: fontSize.xs,
+        lineHeight: 1.625,
+        maxWidth: '100%',
+        overflowX: 'auto',
+        padding: space[16],
+      }}
+    >
       {`import type { Story } from '@ladle/react'
 import { SalvageUnionReference } from 'salvageunion-reference'
 import { Stat } from './Stat'
@@ -139,61 +220,59 @@ export const Anatomies: Story = () => (
 )`}
     </pre>
 
-    <ul className="flex list-disc flex-col gap-2 pl-6">
+    <Rules>
       <Rule>
-        <span className="font-semibold">Title is Group/Title Case</span> and matches the component's
+        <span style={emphasisStyle}>Title is Group/Title Case</span> and matches the component's
         display name — <code>Atoms/Stat</code>, <code>Containers/Card</code>. Slashes become sidebar
         nesting.
       </Rule>
       <Rule>
-        <span className="font-semibold">The file keeps the component symbol name</span> —{' '}
+        <span style={emphasisStyle}>The file keeps the component symbol name</span> —{' '}
         <code>Stat.stories.tsx</code> — so a symbol grep finds it, and it is co-located beside the
         component.
       </Rule>
       <Rule>
-        <span className="font-semibold">title, storyName, and meta must be static literals</span> —
-        they are statically analyzed and cannot be built from variables.
+        <span style={emphasisStyle}>title, storyName, and meta must be static literals</span> — they
+        are statically analyzed and cannot be built from variables.
       </Rule>
       <Rule>
-        <span className="font-semibold">
-          A catch-all "show everything" page is exported as Default
-        </span>{' '}
+        <span style={emphasisStyle}>A catch-all "show everything" page is exported as Default</span>{' '}
         — not Variants / Costs / etc.
       </Rule>
       <Rule>
-        <span className="font-semibold">No outer bg-paper wrapper</span> — the global canvas
+        <span style={emphasisStyle}>No outer paper wrapper</span> — the global canvas
         (.ladle/components.tsx) already frames every story on paper with a mono font and the data
         preload gate.
       </Rule>
       <Rule>
-        <span className="font-semibold">Import shared helpers</span> (Caption, frames) from{' '}
+        <span style={emphasisStyle}>Import shared helpers</span> (Caption, frames) from{' '}
         <code>src/stories/_harness.tsx</code> — don't re-declare a local copy. Lead each gallery
         with one line of prose stating the rule it demonstrates.
       </Rule>
-    </ul>
+    </Rules>
   </div>
 )
 
 // --- Contributing: the enforced contract ----------------------------------
 
 export const Contributing: Story = () => (
-  <div className="flex max-w-[80ch] flex-col gap-6 p-2">
-    <div className="flex flex-col gap-2">
+  <div style={pageStyle}>
+    <div style={stack(space[8])}>
       <Caption>adding a component</Caption>
       <Title>The catalog is a contract</Title>
     </div>
 
     <Prose>
-      Coverage is enforced by <code className="text-ink">src/story-coverage.test.ts</code>: every
-      barrel-exported (<code className="text-ink">src/index.ts</code>) visual component must be
-      referenced by at least one <code className="text-ink">*.stories.tsx</code>. Add a public
-      component and you add its story in the same change — CI fails otherwise. That guard is what
-      lets the catalog claim to be complete, not "most things, probably."
+      Coverage is enforced by <code style={inkStyle}>src/story-coverage.test.ts</code>: every
+      barrel-exported (<code style={inkStyle}>src/index.ts</code>) visual component must be
+      referenced by at least one <code style={inkStyle}>*.stories.tsx</code>. Add a public component
+      and you add its story in the same change — CI fails otherwise. That guard is what lets the
+      catalog claim to be complete, not "most things, probably."
     </Prose>
 
-    <div className="flex flex-col gap-2">
+    <div style={stack(space[8])}>
       <SectionHeading>Checklist</SectionHeading>
-      <ul className="flex list-disc flex-col gap-2 pl-6">
+      <Rules>
         <Rule>Component added to the src/index.ts barrel (if public).</Rule>
         <Rule>
           Story co-located beside it, titled with the correct group (not Legacy unless genuinely
@@ -205,18 +284,18 @@ export const Contributing: Story = () => (
           <code>bun run ladle</code> renders it; <code>bun --filter component-lib test</code> passes
           (coverage guard green); <code>ladle:build</code> succeeds.
         </Rule>
-      </ul>
+      </Rules>
     </div>
 
-    <div className="flex flex-wrap items-end gap-6">
-      <div className="flex flex-col gap-1">
+    <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'flex-end', gap: space[24] }}>
+      <div style={stack(space[4])}>
         <Stamp>Reference</Stamp>
         <Caption>full contributor guide</Caption>
       </div>
-      <p className="max-w-[52ch] text-sm leading-relaxed text-wk-muted">
+      <p style={{ ...proseStyle, maxWidth: '52ch' }}>
         The complete reference — config options, the GlobalProvider, addons, visual-regression, and
         the load-bearing version pin — lives at{' '}
-        <code className="text-ink">docs/design-system/ladle-styleguide.md</code>.
+        <code style={inkStyle}>docs/design-system/ladle-styleguide.md</code>.
       </p>
     </div>
   </div>

--- a/packages/component-lib/src/stories/Theme.stories.tsx
+++ b/packages/component-lib/src/stories/Theme.stories.tsx
@@ -1,226 +1,269 @@
 import type { Story } from '@ladle/react'
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import { statBlockRowStarts } from '../components/stat/pipRows'
+import {
+  borderWidth,
+  color,
+  font,
+  fontSize,
+  radius,
+  space,
+  tracking,
+  weight,
+} from '../design/tokens'
 
 export default {
   title: 'Foundations/Theme',
 }
 
+// Migrated off Tailwind in #799 (epic #802). Every specimen on this page now
+// resolves through `design/tokens.ts`, where it previously resolved through a
+// `var(--color-*)` string or a utility class. That is the same guarantee in a
+// stronger form: the maps below used to be the drift risk this page exists to
+// prevent (they once carried hardcoded rgb values that had gone stale against
+// theme.css in TEN places), and `var(--color-*)` fixed that by referencing.
+// Reading the token object goes one further — a name that is not on the scale
+// is now a TYPE ERROR rather than a variable that silently resolves to nothing.
+
 // Shared caption in the catalog's canonical voice (design ruleset §4).
+const captionStyle = {
+  color: color.wkMuted,
+  fontFamily: font.cond,
+  fontSize: fontSize.label,
+  letterSpacing: tracking.caps,
+  textTransform: 'uppercase',
+} satisfies CSSProperties
+
 function Caption({ children }: { children: ReactNode }) {
-  return (
-    <span className="font-cond text-label uppercase tracking-caps text-wk-muted">{children}</span>
-  )
+  return <span style={captionStyle}>{children}</span>
 }
 
+const pageStyle = {
+  display: 'flex',
+  flexDirection: 'column',
+  padding: space[16],
+} satisfies CSSProperties
+
+const h2Style = {
+  color: color.ink,
+  fontFamily: font.cond,
+  fontSize: fontSize.lg,
+  letterSpacing: tracking.capsTight,
+  textTransform: 'uppercase',
+} satisfies CSSProperties
+
+const tokenNameStyle = {
+  color: color.ink,
+  fontFamily: font.cond,
+  fontSize: fontSize.label,
+  letterSpacing: tracking.capsTight,
+} satisfies CSSProperties
+
 // --- §4.1 Colour roles ---------------------------------------------------
-// Every swatch renders a REAL token via its Tailwind utility class (never a
-// raw hex) so the catalog stays ground-truth against theme.css.
+// Every swatch renders a REAL token, never a raw hex, so the catalog stays
+// ground-truth against the scale.
 type ColorRole = {
-  bg: string
+  /** A key on the token scale — mistyping one no longer compiles. */
+  swatch: keyof typeof color
   role: string
-  token: string
 }
 
 const colorRoles: ColorRole[] = [
-  { bg: 'bg-ink', role: 'ink', token: '--color-ink' },
-  { bg: 'bg-paper', role: 'paper · system white', token: '--color-paper' },
-  { bg: 'bg-rust', role: 'rust · action', token: '--color-rust' },
-  { bg: 'bg-pilot', role: 'pilot', token: '--color-pilot' },
-  { bg: 'bg-mech', role: 'mech', token: '--color-mech' },
-  { bg: 'bg-crawler', role: 'crawler', token: '--color-crawler' },
-  { bg: 'bg-cargo', role: 'cargo', token: '--color-cargo' },
-  { bg: 'bg-status-ok', role: 'status · ok', token: '--color-status-ok' },
-  { bg: 'bg-status-warn', role: 'status · warn', token: '--color-status-warn' },
-  { bg: 'bg-status-bad', role: 'status · bad', token: '--color-status-bad' },
+  { swatch: 'ink', role: 'ink' },
+  { swatch: 'paper', role: 'paper · system white' },
+  { swatch: 'rust', role: 'rust · action' },
+  { swatch: 'pilot', role: 'pilot' },
+  { swatch: 'mech', role: 'mech' },
+  { swatch: 'crawler', role: 'crawler' },
+  { swatch: 'cargo', role: 'cargo' },
+  { swatch: 'statusOk', role: 'status · ok' },
+  { swatch: 'statusWarn', role: 'status · warn' },
+  { swatch: 'statusBad', role: 'status · bad' },
 ]
 
-function RoleSwatch({ bg, role, token }: ColorRole) {
+/** `statusOk` → `--su-color-status-ok`, spelled as tokens.parity.test.ts spells it. */
+const colorVarName = (key: string) =>
+  `--su-color-${key
+    .replace(/([A-Z])/g, '-$1')
+    .replace(/(\d+)/g, '-$1')
+    .toLowerCase()}`
+
+function RoleSwatch({ swatch, role }: ColorRole) {
   return (
-    <div className="flex w-[128px] flex-col gap-1">
+    <div style={{ display: 'flex', flexDirection: 'column', gap: space[4], width: '128px' }}>
       <div
-        className={`h-20 w-full rounded-card border-chrome border-ink ${bg}`}
-        style={{ borderColor: 'var(--color-ink)' }}
+        style={{
+          backgroundColor: color[swatch],
+          border: `${borderWidth.chrome} solid ${color.ink}`,
+          borderRadius: radius.card,
+          height: '80px',
+          width: '100%',
+        }}
       />
       <Caption>{role}</Caption>
-      <span className="font-cond text-label tracking-caps-tight text-ink">{token}</span>
+      <span style={tokenNameStyle}>{colorVarName(swatch)}</span>
     </div>
   )
 }
 
-/* Every specimen map below resolves through `var(--color-*)` rather than a
-   literal. This is load-bearing, not stylistic: these maps used to hardcode rgb
+/* Each specimen map is a list of KEYS on the token scale rather than a list of
+   values. This is load-bearing, not stylistic: these maps used to hardcode rgb
    values and had silently drifted from theme.css in TEN places — `paper`,
    `ink-2`, `wk-muted`, `wk-faint`, the old `su-orange-dark`, and all five roll
    tiers, which still showed the stock-Material hues that the warm re-tone
    retired. The page whose entire job is to be the ground truth for the token
-   system was misreporting it. Referencing the tokens makes drift impossible. */
-const coreColors: Record<string, string> = {
-  ink: 'var(--color-ink)',
-  'ink-2': 'var(--color-ink-2)',
-  'ink-deep': 'var(--color-ink-deep)',
-  paper: 'var(--color-paper)',
-  'band-cream': 'var(--color-band-cream)',
-  rust: 'var(--color-rust)',
-  'rust-hi': 'var(--color-rust-hi)',
-}
+   system was misreporting it. A key cannot drift from the value it names. */
+const coreColors = ['ink', 'ink2', 'inkDeep', 'paper', 'bandCream', 'rust', 'rustHi'] as const
 
-const inkRamp: Record<string, string> = {
-  'ink-75': 'var(--color-ink-75)',
-  'ink-50': 'var(--color-ink-50)',
-  'ink-30': 'var(--color-ink-30)',
-  'ink-12': 'var(--color-ink-12)',
-  'ink-8': 'var(--color-ink-8)',
-}
+const inkRamp = ['ink75', 'ink50', 'ink30', 'ink20', 'ink15', 'ink12', 'ink10', 'ink8'] as const
 
-const groundColors: Record<string, string> = {
-  'wk-bg': 'var(--color-wk-bg)',
-  'wk-bg-2': 'var(--color-wk-bg-2)',
-  'wk-muted': 'var(--color-wk-muted)',
-  'wk-faint': 'var(--color-wk-faint)',
-  'wk-line': 'var(--color-wk-line)',
-  'wk-accent': 'var(--color-wk-accent)',
-  caution: 'var(--color-caution)',
-  inert: 'var(--color-inert)',
-}
+const groundColors = [
+  'wkBg',
+  'wkBg2',
+  'wkMuted',
+  'wkFaint',
+  'wkLine',
+  'wkAccent',
+  'caution',
+  'inert',
+] as const
 
-const techLevelColors: Record<string, string> = {
-  '1': 'var(--color-tl-1)',
-  '2': 'var(--color-tl-2)',
-  '3': 'var(--color-tl-3)',
-  '4': 'var(--color-tl-4)',
-  '5': 'var(--color-tl-5)',
-  '6': 'var(--color-tl-6)',
-  b: 'var(--color-tl-b)',
-  n: 'var(--color-tl-n)',
-}
+const techLevelColors = ['tl1', 'tl2', 'tl3', 'tl4', 'tl5', 'tl6', 'tlB', 'tlN'] as const
 
-const semanticColors: Record<string, string> = {
-  pilot: 'var(--color-pilot)',
-  'pilot-light': 'var(--color-pilot-light)',
-  mech: 'var(--color-mech)',
-  'mech-dark': 'var(--color-mech-dark)',
-  crawler: 'var(--color-crawler)',
-  adversary: 'var(--color-adversary)',
-  cargo: 'var(--color-cargo)',
-  'tier-core': 'var(--color-tier-core)',
-  'tier-core-pale': 'var(--color-tier-core-pale)',
-}
+const semanticColors = [
+  'pilot',
+  'pilotLight',
+  'mech',
+  'mechDark',
+  'crawler',
+  'adversary',
+  'cargo',
+  'tierCore',
+  'tierCorePale',
+] as const
 
 /* Bot-only. The web never colours roll outcomes (ruleset §3.4); these are shown
    so the warm ramp is inspectable, not because a web surface may use them. */
-const rollColors: Record<string, string> = {
-  'roll-cascade': 'var(--color-roll-cascade)',
-  'roll-failure': 'var(--color-roll-failure)',
-  'roll-tough': 'var(--color-roll-tough)',
-  'roll-success': 'var(--color-roll-success)',
-  'roll-nailed': 'var(--color-roll-nailed)',
-}
+const rollColors = ['rollCascade', 'rollFailure', 'rollTough', 'rollSuccess', 'rollNailed'] as const
 
-const statusColors: Record<string, string> = {
-  'status-ok': 'var(--color-status-ok)',
-  'status-warn': 'var(--color-status-warn)',
-  'status-bad': 'var(--color-status-bad)',
-}
+const statusColors = ['statusOk', 'statusWarn', 'statusBad'] as const
 
+/* These two are NOT on the `--su-*` scale: they are the ShadCN-compat aliases
+   declared in theme.css's plain `:root`, outside the Tailwind `@theme` block,
+   and `Text` still reads `--foreground`. They are shown as the raw custom
+   properties they are, because that is precisely what this story documents;
+   they retire with theme.css in the Tailwind-removal layer (#801). */
 const cssVarMappings: Record<string, string> = {
   '--background': 'var(--color-paper)',
   '--foreground': 'var(--color-ink)',
 }
 
-function Swatch({ name, color }: { name: string; color: string }) {
+function Swatch({ name, value }: { name: string; value: string }) {
   return (
     <div
       style={{
+        alignItems: 'center',
         display: 'flex',
         flexDirection: 'column',
-        alignItems: 'center',
-        gap: '0.25rem',
+        gap: space[4],
         width: '120px',
       }}
     >
       <div
         style={{
-          width: '80px',
+          backgroundColor: value,
+          border: `${borderWidth.hairline} solid ${color.ink}`,
+          borderRadius: radius.panel,
           height: '80px',
-          backgroundColor: color,
-          borderRadius: '0.375rem',
-          border: '1px solid rgb(40, 32, 25)',
+          width: '80px',
         }}
       />
-      <span style={{ fontSize: '0.75rem', textAlign: 'center', fontFamily: 'monospace' }}>
+      <span style={{ fontFamily: 'monospace', fontSize: fontSize.xs, textAlign: 'center' }}>
         {name}
       </span>
     </div>
   )
 }
 
-function ColorSection({ title, colors }: { title: string; colors: Record<string, string> }) {
+function ColorSection({ title, keys }: { title: string; keys: readonly (keyof typeof color)[] }) {
   return (
-    <div style={{ marginBottom: '1.5rem' }}>
+    <div style={{ marginBottom: space[24] }}>
       <h3
         style={{
           fontFamily: "'Fira Code', monospace",
-          fontSize: '1.25rem',
-          fontWeight: 'bold',
-          marginBottom: '0.75rem',
+          fontSize: fontSize.xl,
+          fontWeight: weight.bold,
+          marginBottom: space[12],
         }}
       >
         {title}
       </h3>
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
-        {Object.entries(colors).map(([name, value]) => (
-          <Swatch key={name} name={name} color={value} />
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: space[16] }}>
+        {keys.map((key) => (
+          <Swatch
+            key={key}
+            name={colorVarName(key).replace('--su-color-', '')}
+            value={color[key]}
+          />
         ))}
       </div>
     </div>
   )
 }
 
+const pageHeadingStyle = {
+  fontSize: fontSize.xl2,
+  fontWeight: weight.bold,
+  marginBottom: space[16],
+} satisfies CSSProperties
+
+const monoPageStyle = {
+  fontFamily: "'Fira Code', monospace",
+  padding: space[16],
+} satisfies CSSProperties
+
 export const ColorPalette: Story = () => (
-  <div style={{ fontFamily: "'Fira Code', monospace", padding: '1rem' }}>
-    <h2 style={{ fontSize: '1.5rem', fontWeight: 'bold', marginBottom: '1rem' }}>
-      The Closed Colour Set
-    </h2>
-    <ColorSection title="Core — ink · paper · action" colors={coreColors} />
-    <ColorSection title="Ink ramp — hairlines, placeholders, ghosts" colors={inkRamp} />
-    <ColorSection title="Ground & attention" colors={groundColors} />
-    <ColorSection title="State overlays" colors={statusColors} />
+  <div style={monoPageStyle}>
+    <h2 style={pageHeadingStyle}>The Closed Colour Set</h2>
+    <ColorSection title="Core — ink · paper · action" keys={coreColors} />
+    <ColorSection title="Ink ramp — hairlines, placeholders, ghosts" keys={inkRamp} />
+    <ColorSection title="Ground & attention" keys={groundColors} />
+    <ColorSection title="State overlays" keys={statusColors} />
   </div>
 )
 
 export const TechLevelColors: Story = () => (
-  <div style={{ fontFamily: "'Fira Code', monospace", padding: '1rem' }}>
-    <h2 style={{ fontSize: '1.5rem', fontWeight: 'bold', marginBottom: '1rem' }}>
-      Tech Level Colors
-    </h2>
-    <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
-      {Object.entries(techLevelColors).map(([level, color]) => (
+  <div style={monoPageStyle}>
+    <h2 style={pageHeadingStyle}>Tech Level Colors</h2>
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: space[8] }}>
+      {techLevelColors.map((key) => (
         <div
-          key={level}
+          key={key}
           style={{
+            alignItems: 'center',
             display: 'flex',
             flexDirection: 'column',
-            alignItems: 'center',
-            gap: '0.25rem',
+            gap: space[4],
           }}
         >
           <div
             style={{
-              width: '100px',
-              height: '60px',
-              backgroundColor: color,
-              borderRadius: '0.375rem',
-              display: 'flex',
               alignItems: 'center',
+              backgroundColor: color[key],
+              borderRadius: radius.panel,
+              display: 'flex',
+              height: '60px',
               justifyContent: 'center',
+              width: '100px',
             }}
           >
-            <span style={{ color: 'white', fontWeight: 'bold', fontSize: '1.25rem' }}>
-              TL {level}
+            <span style={{ color: 'white', fontSize: fontSize.xl, fontWeight: weight.bold }}>
+              TL {key.replace('tl', '').toLowerCase()}
             </span>
           </div>
-          <span style={{ fontSize: '0.625rem' }}>tl-{level}</span>
+          <span style={{ fontSize: fontSize.label }}>
+            {colorVarName(key).replace('--su-color-', '')}
+          </span>
         </div>
       ))}
     </div>
@@ -228,59 +271,55 @@ export const TechLevelColors: Story = () => (
 )
 
 export const SemanticColors: Story = () => (
-  <div style={{ fontFamily: "'Fira Code', monospace", padding: '1rem' }}>
-    <h2 style={{ fontSize: '1.5rem', fontWeight: 'bold', marginBottom: '1rem' }}>
-      Semantic Colors
-    </h2>
+  <div style={monoPageStyle}>
+    <h2 style={pageHeadingStyle}>Semantic Colors</h2>
 
-    <ColorSection title="Entity Types" colors={semanticColors} />
-    <ColorSection title="Roll Results" colors={rollColors} />
+    <ColorSection title="Entity Types" keys={semanticColors} />
+    <ColorSection title="Roll Results" keys={rollColors} />
   </div>
 )
 
 export const CSSVariables: Story = () => (
-  <div style={{ fontFamily: "'Fira Code', monospace", padding: '1rem' }}>
-    <h2 style={{ fontSize: '1.5rem', fontWeight: 'bold', marginBottom: '1rem' }}>
-      ShadCN CSS Variable Mappings
-    </h2>
-    <p style={{ fontSize: '0.875rem', marginBottom: '1rem', color: 'rgb(80, 80, 80)' }}>
+  <div style={monoPageStyle}>
+    <h2 style={pageHeadingStyle}>ShadCN CSS Variable Mappings</h2>
+    <p style={{ color: 'rgb(80, 80, 80)', fontSize: fontSize.sm, marginBottom: space[16] }}>
       These CSS custom properties are set in <code>:root</code> and map to SU brand colors.
     </p>
     <div
       style={{
         display: 'grid',
+        gap: space[12],
         gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))',
-        gap: '0.75rem',
       }}
     >
       {Object.entries(cssVarMappings).map(([varName, value]) => (
         <div
           key={varName}
           style={{
-            display: 'flex',
             alignItems: 'center',
-            gap: '0.75rem',
-            padding: '0.5rem',
             border: '1px solid rgb(199, 199, 199)',
-            borderRadius: '0.375rem',
+            borderRadius: radius.panel,
+            display: 'flex',
+            gap: space[12],
+            padding: space[8],
           }}
         >
           <div
             style={{
-              width: '40px',
-              height: '40px',
               backgroundColor: `var(${varName})`,
-              borderRadius: '0.25rem',
-              border: '1px solid rgb(40, 32, 25)',
+              border: `${borderWidth.hairline} solid ${color.ink}`,
+              borderRadius: radius.badge,
               flexShrink: 0,
+              height: '40px',
+              width: '40px',
             }}
           />
           <div style={{ overflow: 'hidden' }}>
-            <div style={{ fontSize: '0.75rem', fontWeight: 'bold' }}>{varName}</div>
+            <div style={{ fontSize: fontSize.xs, fontWeight: weight.bold }}>{varName}</div>
             <div
               style={{
-                fontSize: '0.625rem',
                 color: 'rgb(80, 80, 80)',
+                fontSize: fontSize.label,
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
                 whiteSpace: 'nowrap',
@@ -298,100 +337,106 @@ export const CSSVariables: Story = () => (
 // === Foundations, mirroring codex §03 =====================================
 
 export const ColorRoles: Story = () => (
-  <div className="flex flex-col gap-3 p-4">
-    <h2 className="font-cond text-lg uppercase tracking-caps-tight text-ink">Colour roles</h2>
+  <div style={{ ...pageStyle, gap: space[12] }}>
+    <h2 style={h2Style}>Colour roles</h2>
     <Caption>
-      the closed set — ink, paper (system white #fbfaf7), rust = action, the three entity tones,
+      the closed set — ink, paper (the one light surface), rust = action, the three entity tones,
       cargo, and status ok/warn/bad. State is a treatment, never a random colour.
     </Caption>
-    <div className="flex flex-wrap gap-4">
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: space[16] }}>
       {colorRoles.map((role) => (
-        <RoleSwatch key={role.token} {...role} />
+        <RoleSwatch key={role.swatch} {...role} />
       ))}
     </div>
   </div>
 )
 
+/**
+ * The caps tracking ladder.
+ *
+ * BEFORE #799 this story captioned two custom properties that do not exist —
+ * `--tracking-label` and `--tracking-display` — and the second specimen set its
+ * 0.01em inline, so the page asserted a token the stylesheet never declared.
+ * (Foundations/Typography carried the same two phantoms in its own table, and
+ * additionally rendered them via `tracking-label` / `tracking-display` utility
+ * classes that resolved to nothing.) The real ladder is the five rungs below,
+ * and iterating the token object is what keeps it honest.
+ */
 export const Tracking: Story = () => (
-  <div className="flex flex-col gap-6 p-4">
-    <h2 className="font-cond text-lg uppercase tracking-caps-tight text-ink">One label tracking</h2>
-    <Caption>15 tracking values today → 3. Shown on real uppercase label text.</Caption>
+  <div style={{ ...pageStyle, gap: space[24] }}>
+    <h2 style={h2Style}>The caps tracking ladder</h2>
+    <Caption>Five rungs, shown on real uppercase label text.</Caption>
 
-    <div className="flex flex-col gap-1">
-      <span className="font-cond text-xl uppercase text-ink tracking-caps-tight">
-        Systems &amp; Modules
-      </span>
-      <Caption>--tracking-label · 0.04em · every stamp / label / tab (tracking-caps-tight)</Caption>
-    </div>
-
-    <div className="flex flex-col gap-1">
-      <span className="font-cond text-2xl uppercase text-ink" style={{ letterSpacing: '0.01em' }}>
-        Iron Mongrel
-      </span>
-      <Caption>--tracking-display · 0.01em · titles ≥22px + buttons</Caption>
-    </div>
-
-    <div className="flex flex-col gap-1">
-      <span className="font-cond text-sm uppercase text-ink tracking-eyebrow">Salvage Union</span>
-      <Caption>--tracking-eyebrow · 0.22em · brand caption only (tracking-eyebrow)</Caption>
-    </div>
+    {(Object.keys(tracking) as (keyof typeof tracking)[]).map((key) => (
+      <div key={key} style={{ display: 'flex', flexDirection: 'column', gap: space[4] }}>
+        <span
+          style={{
+            color: color.ink,
+            fontFamily: font.cond,
+            fontSize: fontSize.xl,
+            letterSpacing: tracking[key],
+            textTransform: 'uppercase',
+          }}
+        >
+          Systems &amp; Modules
+        </span>
+        <Caption>
+          {`--su-tracking-${key.replace(/([A-Z])/g, '-$1').toLowerCase()}`} · {tracking[key]} ·{' '}
+          tracking.{key}
+        </Caption>
+      </div>
+    ))}
   </div>
 )
 
 type BorderWeight = {
-  cssWidth: string
-  token: string
-  label: string
+  token: keyof typeof borderWidth
   applies: string
 }
 
 const borderWeights: BorderWeight[] = [
-  {
-    cssWidth: 'var(--bw-entity)',
-    token: '--bw-entity',
-    label: '3px',
-    applies: 'entity cards + hero header',
-  },
-  {
-    cssWidth: 'var(--bw-rail)',
-    token: '--bw-rail',
-    label: '2.5px',
-    applies: 'rail cards & Hold frames',
-  },
-  {
-    cssWidth: 'var(--bw-pill)',
-    token: '--bw-pill',
-    label: '2px',
-    applies: 'pills / status badges / dividers',
-  },
-  {
-    cssWidth: 'var(--bw-chrome)',
-    token: '--bw-chrome',
-    label: '1.5px',
-    applies: 'buttons, inputs, panels, rows, pips',
-  },
+  { token: 'entity', applies: 'entity cards + hero header' },
+  { token: 'rail', applies: 'rail cards & Hold frames' },
+  { token: 'pill', applies: 'pills / status badges / dividers' },
+  { token: 'chrome', applies: 'buttons, inputs, panels, rows, pips' },
 ]
 
 export const BorderMap: Story = () => (
-  <div className="flex flex-col gap-3 p-4">
-    <h2 className="font-cond text-lg uppercase tracking-caps-tight text-ink">The border map</h2>
-    <Caption>
-      Canon weights, one meaning each — the ONE border vocabulary, never border-[1.5px].
-    </Caption>
-    <div className="flex flex-wrap gap-5">
+  <div style={{ ...pageStyle, gap: space[12] }}>
+    <h2 style={h2Style}>The border map</h2>
+    <Caption>Canon weights, one meaning each — the ONE border vocabulary.</Caption>
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: space[20] }}>
       {borderWeights.map((w) => (
-        <div key={w.token} className="flex w-[160px] flex-col gap-1">
+        <div
+          key={w.token}
+          style={{ display: 'flex', flexDirection: 'column', gap: space[4], width: '160px' }}
+        >
           <div
-            className="flex h-20 w-full items-center justify-center rounded-card bg-paper"
             style={{
+              alignItems: 'center',
+              backgroundColor: color.paper,
+              borderColor: color.ink,
+              borderRadius: radius.card,
               borderStyle: 'solid',
-              borderWidth: w.cssWidth,
-              borderColor: 'var(--color-ink)',
+              borderWidth: borderWidth[w.token],
+              display: 'flex',
+              height: '80px',
+              justifyContent: 'center',
+              width: '100%',
             }}
           >
-            <span className="font-cond text-sm tracking-caps-tight text-ink">{w.label}</span>
+            <span
+              style={{
+                color: color.ink,
+                fontFamily: font.cond,
+                fontSize: fontSize.sm,
+                letterSpacing: tracking.capsTight,
+              }}
+            >
+              {borderWidth[w.token]}
+            </span>
           </div>
-          <span className="font-cond text-label tracking-caps-tight text-ink">{w.token}</span>
+          <span style={tokenNameStyle}>--su-bw-{w.token}</span>
           <Caption>{w.applies}</Caption>
         </div>
       ))}
@@ -400,63 +445,98 @@ export const BorderMap: Story = () => (
 )
 
 export const RadiusSpacing: Story = () => (
-  <div className="flex flex-col gap-6 p-4">
-    <h2 className="font-cond text-lg uppercase tracking-caps-tight text-ink">
-      Radius &amp; spacing
-    </h2>
+  <div style={{ ...pageStyle, gap: space[24] }}>
+    <h2 style={h2Style}>Radius &amp; spacing</h2>
     <Caption>
       3px outer radius (card + Button — the one primitive allowed to round); inner = calc(3px −
       frame). Stamps are square. Spacing spends only {'{2, 4, 6, 8, 12}px'} — 12px = the card
       gutter.
     </Caption>
 
-    <div className="flex flex-wrap items-start gap-6">
-      <div className="flex flex-col gap-1">
+    <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'flex-start', gap: space[24] }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: space[4] }}>
         <div
-          className="h-24 w-40 rounded-card bg-paper"
-          style={{ border: 'var(--bw-entity) solid var(--color-ink)' }}
+          style={{
+            backgroundColor: color.paper,
+            border: `${borderWidth.entity} solid ${color.ink}`,
+            borderRadius: radius.card,
+            height: '96px',
+            width: '160px',
+          }}
         />
-        <Caption>card · rounded-card outer</Caption>
+        <Caption>card · radius.card outer</Caption>
       </div>
 
-      <div className="flex flex-col gap-1">
+      <div style={{ display: 'flex', flexDirection: 'column', gap: space[4] }}>
         <button
           type="button"
-          className="rounded-card bg-rust px-4 py-2 font-cond uppercase tracking-caps-tight text-paper"
-          style={{ letterSpacing: '0.01em' }}
+          style={{
+            backgroundColor: color.rust,
+            borderRadius: radius.card,
+            color: color.paper,
+            fontFamily: font.cond,
+            letterSpacing: tracking.capsTight,
+            padding: `${space[8]} ${space[16]}`,
+            textTransform: 'uppercase',
+          }}
         >
           Commit
         </button>
-        <Caption>Button · rounded-card · rust = action</Caption>
+        <Caption>Button · radius.card · rust = action</Caption>
       </div>
 
-      <div className="flex flex-col gap-1">
-        <span className="inline-block rounded-none bg-ink px-2 py-1 font-cond text-xs uppercase tracking-caps-tight text-paper">
+      <div style={{ display: 'flex', flexDirection: 'column', gap: space[4] }}>
+        <span
+          style={{
+            backgroundColor: color.ink,
+            borderRadius: radius.none,
+            color: color.paper,
+            display: 'inline-block',
+            fontFamily: font.cond,
+            fontSize: fontSize.xs,
+            letterSpacing: tracking.capsTight,
+            padding: `${space[4]} ${space[8]}`,
+            textTransform: 'uppercase',
+          }}
+        >
           Stamp
         </span>
-        <Caption>stamp · square (rounded-none)</Caption>
+        <Caption>stamp · square (radius.none)</Caption>
       </div>
     </div>
   </div>
 )
 
-const PIP = 'h-3 w-3 rounded-badge border-chrome border-ink'
+const pipStyle = {
+  border: `${borderWidth.chrome} solid ${color.ink}`,
+  borderRadius: radius.badge,
+  height: space[12] as string,
+  width: space[12] as string,
+} satisfies CSSProperties
 
 function PipRows({ max, label }: { max: number; label: string }) {
   return (
-    <div className="flex w-40 flex-col gap-2">
-      <div className="flex flex-col items-center gap-1">
+    <div style={{ display: 'flex', flexDirection: 'column', gap: space[8], width: '160px' }}>
+      <div
+        style={{
+          alignItems: 'center',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: space[4],
+        }}
+      >
         {statBlockRowStarts(max).map((row) => (
-          <div key={row.start} className="flex gap-1">
+          <div key={row.start} style={{ display: 'flex', gap: space[4] }}>
             {Array.from({ length: row.count }, (_, i) => (
               // biome-ignore lint/suspicious/noArrayIndexKey: pips are positional — the index IS their identity
-              <span key={row.start + i} className={PIP} />
+              <span key={row.start + i} style={pipStyle} />
             ))}
           </div>
         ))}
       </div>
-      <div className="text-xs font-bold text-ink">
-        max = {max} <span className="font-normal text-wk-muted">({label})</span>
+      <div style={{ color: color.ink, fontSize: fontSize.xs, fontWeight: weight.bold }}>
+        max = {max}{' '}
+        <span style={{ color: color.wkMuted, fontWeight: weight.normal }}>({label})</span>
       </div>
     </div>
   )
@@ -464,13 +544,13 @@ function PipRows({ max, label }: { max: number; label: string }) {
 
 /** Pip-row split — ≤6 per row, bottom-heavy (heavy row on the bottom), centred. */
 export const PipSplit: Story = () => (
-  <div className="flex flex-col gap-6 p-4">
-    <h2 className="font-cond text-lg uppercase tracking-caps-tight text-ink">Pip-row split</h2>
+  <div style={{ ...pageStyle, gap: space[24] }}>
+    <h2 style={h2Style}>Pip-row split</h2>
     <Caption>
       Every pip surface (gauges, statblocks, cargo) splits into balanced rows via the real
       statBlockRowStarts — ≤6 per row, bottom-heavy (the heavier row rides on the bottom).
     </Caption>
-    <div className="flex flex-wrap gap-8">
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: space[32] }}>
       <PipRows max={6} label="6" />
       <PipRows max={11} label="5/6" />
       <PipRows max={12} label="6/6" />

--- a/packages/component-lib/src/stories/Typography.stories.tsx
+++ b/packages/component-lib/src/stories/Typography.stories.tsx
@@ -1,7 +1,8 @@
 import type { Story } from '@ladle/react'
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import { SalvageUnionReference } from 'salvageunion-reference'
 import { Text } from '../components/base/Text'
+import { color, font, fontSize, space, tracking } from '../design/tokens'
 import { Caption } from './_harness'
 
 export default {
@@ -21,97 +22,71 @@ const specimenBody =
     .find((d): d is string => typeof d === 'string' && d.length > 0) ??
   'Salvage what you can carry, break down what you cannot, and keep the Mech running.'
 
-// ── Token tables (kept 1:1 with theme.css + ruleset.md §4.2) ──────────────────
+// ── Token tables ─────────────────────────────────────────────────────────────
+//
+// Migrated off Tailwind in #799 (epic #802). Each table is now DERIVED from
+// `design/tokens.ts` rather than restating a utility class beside a hand-typed
+// pixel value, which is what component-lib/CLAUDE.md means by "specimens are
+// generated from the tokens so they cannot drift". The `--su-*` custom-property
+// name is spelled mechanically from the token key, exactly as
+// `tokens.parity.test.ts` spells it, so this page cannot claim a property the
+// stylesheet does not emit.
 
-/** The ONE font-size ladder (theme.css `--text-*`). Never `text-[Npx]` for these. */
-const SCALE: { cls: string; token: string; px: string; use: string }[] = [
-  {
-    cls: 'text-nano',
-    token: '--text-nano',
-    px: '8px',
-    use: 'smallest markers — TL glyphs, unit suffixes',
-  },
-  {
-    cls: 'text-micro',
-    token: '--text-micro',
-    px: '9px',
-    use: 'dense caps meta labels (NPC insets, encounter cards)',
-  },
-  {
-    cls: 'text-label',
-    token: '--text-label',
-    px: '10px',
-    use: 'standard uppercase font-cond field / section label',
-  },
-  {
-    cls: 'text-label-lg',
-    token: '--text-label-lg',
-    px: '10.5px',
-    use: 'stamp / rail caps label',
-  },
-  {
-    cls: 'text-badge',
-    token: '--text-badge',
-    px: '11px',
-    use: 'badges, pills, compact caps values',
-  },
-  {
-    cls: 'text-note',
-    token: '--text-note',
-    px: '11.5px',
-    use: 'small body copy in rails and insets',
-  },
-  {
-    cls: 'text-caption',
-    token: '--text-caption',
-    px: '13px',
-    use: 'small body copy — hints, empty states, subtitles',
-  },
-  {
-    cls: 'text-lede',
-    token: '--text-lede',
-    px: '15px',
-    use: 'emphasized inline values, inset titles',
-  },
-]
+/** `fontSize.labelLg` → `--su-text-label-lg`. */
+const cssVarName = (group: string, key: string) =>
+  `--su-${group}-${key
+    .replace(/([A-Z])/g, '-$1')
+    .replace(/(\d+)$/, '-$1')
+    .toLowerCase()}`
 
-/** The two faces (theme.css `--font-*`). */
-const FONTS: { cls: string; token: string; name: string; use: string }[] = [
-  {
-    cls: 'font-body',
-    token: '--font-body',
-    name: 'Barlow',
-    use: 'body copy, values, default running text',
-  },
-  {
-    cls: 'font-cond',
-    token: '--font-cond',
-    name: 'Barlow Semi Condensed',
-    use: 'stamps, labels, titles, tabs — all-caps chrome',
-  },
-]
+/**
+ * The semantic rungs this page specimens — nano through lede, the ladder the
+ * chrome actually spends. The display end (readout … hero) is shown on
+ * Foundations/Theme, and the inherited Tailwind rungs are deliberately absent:
+ * `tokens.ts` carries them only so a migrating call site does not re-size, and
+ * a catalog page that specimened them would advertise the debt as a choice.
+ */
+const SCALE_RUNGS = [
+  ['nano', 'smallest markers — TL glyphs, unit suffixes'],
+  ['micro', 'dense caps meta labels (NPC insets, encounter cards)'],
+  ['label', 'standard uppercase condensed field / section label'],
+  ['labelLg', 'stamp / rail caps label'],
+  ['badge', 'badges, pills, compact caps values'],
+  ['note', 'small body copy in rails and insets'],
+  ['caption', 'small body copy — hints, empty states, subtitles'],
+  ['lede', 'emphasized inline values, inset titles'],
+] as const satisfies readonly (readonly [keyof typeof fontSize, string])[]
 
-/** Three tracking values, down from 15 (ruleset §4.2). */
-const TRACKING: { cls: string; token: string; value: string; use: string }[] = [
-  {
-    cls: 'tracking-label',
-    token: '--tracking-label',
-    value: '0.04em',
-    use: 'every stamp / label / tab',
-  },
-  {
-    cls: 'tracking-display',
-    token: '--tracking-display',
-    value: '0.01em',
-    use: 'titles ≥ 22px + buttons',
-  },
-  {
-    cls: 'tracking-eyebrow',
-    token: '--tracking-eyebrow',
-    value: '0.22em',
-    use: 'brand caption only',
-  },
-]
+/** The two faces. TWO, no aliases. */
+const FONTS = [
+  ['body', 'Barlow', 'body copy, values, default running text'],
+  ['cond', 'Barlow Semi Condensed', 'stamps, labels, titles, tabs — all-caps chrome'],
+] as const satisfies readonly (readonly [keyof typeof font, string, string])[]
+
+/**
+ * The caps tracking ladder.
+ *
+ * THIS TABLE WAS WRONG BEFORE #799, and the migration is what surfaced it. It
+ * listed three rows — `--tracking-label` (0.04em), `--tracking-display`
+ * (0.01em) and `--tracking-eyebrow` — of which only the last exists. Neither
+ * `--tracking-label` nor `--tracking-display` is declared in `theme.css` or
+ * anywhere else in the repo, and the `tracking-label` / `tracking-display`
+ * utility classes the specimens rendered with had no definition to resolve, so
+ * two of the three rows rendered at the browser's default tracking while
+ * captioning a value they were not showing. (Foundations/Theme repeats the same
+ * two names; that page is corrected in the same change.)
+ *
+ * The real ladder is five rungs, and it is the one `tokens.ts` and `theme.css`
+ * agree on. Deriving the table from the token object is what stops this
+ * recurring: a rung cannot be listed here unless it exists.
+ */
+const TRACKING_USE: Record<keyof typeof tracking, string> = {
+  capsTight: 'the canonical stamp / label / tab tracking',
+  capsSnug: 'section titles inside a panel',
+  caps: 'captions and column headers',
+  capsWide: 'the widest chrome rung — dense table headers',
+  eyebrow: 'brand caption only',
+}
 
 /** The `Text` component's variant roles (components/base/Text.tsx). */
 const ROLES: {
@@ -135,6 +110,40 @@ const ROLES: {
 
 // ── Layout helpers ────────────────────────────────────────────────────────────
 
+const rowStyle = {
+  alignItems: 'baseline',
+  borderTop: `1px solid ${color.ink12}`,
+  columnGap: space[24],
+  display: 'flex',
+  flexWrap: 'wrap',
+  paddingBottom: space[12],
+  paddingTop: space[12],
+  rowGap: space[4],
+} satisfies CSSProperties
+
+const specimenNameStyle = {
+  color: color.ink,
+  fontFamily: font.cond,
+  fontSize: fontSize.badge,
+  letterSpacing: tracking.capsTight,
+  textTransform: 'uppercase',
+} satisfies CSSProperties
+
+const metaStyle = {
+  color: color.wkMuted,
+  fontFamily: font.body,
+  fontSize: fontSize.nano,
+  letterSpacing: 'normal',
+  marginLeft: space[8],
+  textTransform: 'none',
+} satisfies CSSProperties
+
+const useStyle = {
+  color: color.wkMuted,
+  fontFamily: font.body,
+  fontSize: fontSize.caption,
+} satisfies CSSProperties
+
 /** A specimen row: the live rendering on the left, its spec meta on the right. */
 function Row({
   specimen,
@@ -148,16 +157,16 @@ function Row({
   use: string
 }) {
   return (
-    <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1 border-t border-ink/12 py-3">
-      <div className="min-w-[16rem] flex-1">{specimen}</div>
-      <div className="flex min-w-[18rem] flex-1 flex-col gap-0.5">
-        <span className="font-cond text-badge uppercase tracking-caps-tight text-ink">
+    <div style={rowStyle}>
+      <div style={{ flex: 1, minWidth: '16rem' }}>{specimen}</div>
+      <div
+        style={{ display: 'flex', flex: 1, flexDirection: 'column', gap: '2px', minWidth: '18rem' }}
+      >
+        <span style={specimenNameStyle}>
           {name}
-          <span className="ml-2 font-body text-nano normal-case tracking-normal text-wk-muted">
-            {meta}
-          </span>
+          <span style={metaStyle}>{meta}</span>
         </span>
-        <span className="font-body text-caption text-wk-muted">{use}</span>
+        <span style={useStyle}>{use}</span>
       </div>
     </div>
   )
@@ -173,9 +182,9 @@ function Section({
   children: ReactNode
 }) {
   return (
-    <section className="mt-8">
+    <section style={{ marginTop: space[32] }}>
       <Caption>{title}</Caption>
-      <p className="mb-2 max-w-3xl font-body text-caption text-wk-muted">{blurb}</p>
+      <p style={{ ...useStyle, marginBottom: space[8], maxWidth: '48rem' }}>{blurb}</p>
       {children}
     </section>
   )
@@ -187,19 +196,27 @@ function Section({
 export const Scale: Story = () => (
   <Section
     title="Type scale — the one font-size ladder"
-    blurb="theme.css --text-nano … --text-lede. Use these tokens (text-nano … text-lede); never an arbitrary text-[Npx] for a step on this ladder."
+    blurb="design/tokens.ts fontSize.nano … fontSize.lede, emitted as --su-text-nano … --su-text-lede. Reach for a rung by name; never an arbitrary pixel value for a step on this ladder."
   >
-    {SCALE.map((s) => (
+    {SCALE_RUNGS.map(([key, use]) => (
       <Row
-        key={s.cls}
+        key={key}
         specimen={
-          <span className={`${s.cls} font-cond uppercase tracking-caps-tight text-ink`}>
+          <span
+            style={{
+              color: color.ink,
+              fontFamily: font.cond,
+              fontSize: fontSize[key],
+              letterSpacing: tracking.capsTight,
+              textTransform: 'uppercase',
+            }}
+          >
             {specimenName}
           </span>
         }
-        name={s.cls}
-        meta={`${s.token} · ${s.px}`}
-        use={s.use}
+        name={`fontSize.${key}`}
+        meta={`${cssVarName('text', key)} · ${fontSize[key]}`}
+        use={use}
       />
     ))}
   </Section>
@@ -211,37 +228,47 @@ export const Fonts: Story = () => (
     title="Font families"
     blurb="Two faces, no aliases: Barlow (body/values) and Barlow Semi Condensed (all-caps chrome)."
   >
-    {FONTS.map((f) => (
+    {FONTS.map(([key, name, use]) => (
       <Row
-        key={f.cls}
+        key={key}
         specimen={
-          <span className={`${f.cls} text-lede text-ink`}>
+          <span style={{ color: color.ink, fontFamily: font[key], fontSize: fontSize.lede }}>
             {specimenName} · {specimenName.toLowerCase()}
           </span>
         }
-        name={f.cls}
-        meta={`${f.token} · ${f.name}`}
-        use={f.use}
+        name={`font.${key}`}
+        meta={`${cssVarName('font', key)} · ${name}`}
+        use={use}
       />
     ))}
   </Section>
 )
 
-/** The three tracking tokens. */
+/** The caps tracking ladder — five rungs, every one of them real. */
 export const Tracking: Story = () => (
   <Section
-    title="Tracking — three values, down from fifteen"
-    blurb="ruleset §4.2. The wide instrument-HUD stamps conform down to --tracking-label. (tracking-caps / tracking-caps-tight are the common utility aliases in use across the cards.)"
+    title="Tracking — the caps ladder"
+    blurb="design/tokens.ts tracking.capsTight … tracking.eyebrow. capsTight (0.04em) is the canonical stamp/label rung; eyebrow (0.22em) is the brand caption and nothing else."
   >
-    {TRACKING.map((t) => (
+    {(Object.keys(tracking) as (keyof typeof tracking)[]).map((key) => (
       <Row
-        key={t.cls}
+        key={key}
         specimen={
-          <span className={`${t.cls} font-cond text-lede uppercase text-ink`}>{specimenName}</span>
+          <span
+            style={{
+              color: color.ink,
+              fontFamily: font.cond,
+              fontSize: fontSize.lede,
+              letterSpacing: tracking[key],
+              textTransform: 'uppercase',
+            }}
+          >
+            {specimenName}
+          </span>
         }
-        name={t.cls}
-        meta={`${t.token} · ${t.value}`}
-        use={t.use}
+        name={`tracking.${key}`}
+        meta={`${cssVarName('tracking', key)} · ${tracking[key]}`}
+        use={TRACKING_USE[key]}
       />
     ))}
   </Section>

--- a/packages/component-lib/src/stories/_dashboardStage.tsx
+++ b/packages/component-lib/src/stories/_dashboardStage.tsx
@@ -4,9 +4,16 @@
  * and frames children on the warm-paper cockpit ground — so a single instrument
  * renders exactly as it does inside the live Dashboard, without the full
  * scale-to-fit canvas.
+ *
+ * `pc-root` STAYS a class, and is not a Tailwind holdover: it is the instrument
+ * token scope those three stylesheets key off, so the stage must keep applying
+ * it. Only the frame's own `var(--color-*)` reads move onto `design/tokens.ts`
+ * here (#799) — the ones inside `.pc-root` belong to the dashboard's own
+ * stylesheets and migrate with the Compositions layer.
  */
 
 import type { ReactNode } from 'react'
+import { color, radius, space } from '../design/tokens'
 import '../components/dashboard/DashboardCanvas.css'
 import '../components/dashboard/DashboardGrid.css'
 import '../components/dashboard/instruments.css'
@@ -25,9 +32,9 @@ export function InstrumentStage({
       className="pc-root"
       data-mount={mount}
       style={{
-        background: 'var(--color-paper)',
-        padding: 16,
-        borderRadius: 'var(--radius-panel)',
+        background: color.paper,
+        padding: space[16],
+        borderRadius: radius.panel,
         maxWidth: width,
       }}
     >

--- a/packages/component-lib/src/stories/_harness.tsx
+++ b/packages/component-lib/src/stories/_harness.tsx
@@ -1,19 +1,29 @@
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
+import { color, font, fontSize, space, tracking } from '../design/tokens'
 
 /**
  * Shared Ladle story helpers.
  *
- * Every story renders on a global paper canvas provided by `.ladle/components.tsx`
- * (bg-paper + mono), so a story no longer needs its own outer `bg-paper` wrapper.
- * When a caption/frame helper would otherwise be copy-pasted across story files,
- * put it here and import it instead of re-declaring it per file.
+ * Every story renders on a global paper canvas provided by `.ladle/components.tsx`,
+ * so a story does not need its own outer paper wrapper. When a caption/frame
+ * helper would otherwise be copy-pasted across story files, put it here and
+ * import it instead of re-declaring it per file.
+ *
+ * Migrated off Tailwind in #799 (epic #802): every value below is read from
+ * `design/tokens.ts` rather than spelled as a utility class, so these helpers
+ * cannot drift from the scale they are captioning.
  */
 
 /** A small caps caption above a demo cluster — the workshop-muted label. */
+const captionStyle = {
+  color: color.wkMuted,
+  fontFamily: font.cond,
+  fontSize: fontSize.label,
+  letterSpacing: tracking.caps,
+  marginBottom: space[4],
+  textTransform: 'uppercase',
+} satisfies CSSProperties
+
 export function Caption({ children }: { children: ReactNode }) {
-  return (
-    <div className="mb-1 font-cond text-label uppercase tracking-caps text-wk-muted">
-      {children}
-    </div>
-  )
+  return <div style={captionStyle}>{children}</div>
 }

--- a/packages/component-lib/src/stories/_stories.css
+++ b/packages/component-lib/src/stories/_stories.css
@@ -1,0 +1,32 @@
+/*
+ * Catalog-only stylesheet — the stateful/responsive half of the split rule for
+ * the Foundations specimen pages.
+ *
+ * WHY THIS IS NOT `src/styles/index.css`. That file is the ONE stylesheet a web
+ * consumer loads; these rules lay out a Ladle page and ship in no app, so
+ * putting them there would export catalog scaffolding to every consumer. The
+ * leading underscore is the same marker `_harness.tsx` and `_dashboardStage.tsx`
+ * already use for story scaffolding (component-lib/CLAUDE.md), and co-located
+ * CSS is an existing shape in this package — `DashboardCanvas.css`,
+ * `instruments.css`.
+ *
+ * It is still the SECOND half of the split rule, not a third mechanism: a media
+ * query is precisely what an inline `style={}` cannot express, so it lands in a
+ * stylesheet class. Only the class's ADDRESS differs, because its audience does.
+ */
+
+/*
+ * The two-column specimen split on Foundations/Sizing. Ported verbatim from
+ * `sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]` — Tailwind's `sm` breakpoint is
+ * 40rem, and below it the grid stays the single column a bare `grid` gives.
+ */
+.su-story-split {
+  display: grid;
+  gap: var(--su-space-16);
+}
+
+@media (min-width: 40rem) {
+  .su-story-split {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+}

--- a/packages/component-lib/src/styles/index.css
+++ b/packages/component-lib/src/styles/index.css
@@ -170,14 +170,18 @@
   --su-color-ink-2: rgb(70, 61, 49);
   --su-color-ink-deep: rgb(27, 23, 18);
 
-  /* Ink at opacity — hairlines, placeholders, ghosts, disabled fills, shadows. */
+  /* Ink at opacity — hairlines, placeholders, ghosts, disabled fills, shadows.
+     `ink-15` / `ink-10` are #799 additions covering `border-ink/15` and
+     `border-ink/10`, which had no rung to land on; see the note in tokens.ts. */
   --su-color-ink-85: rgb(40 32 25 / 0.85);
   --su-color-ink-75: rgb(40 32 25 / 0.75);
   --su-color-ink-50: rgb(40 32 25 / 0.5);
   --su-color-ink-40: rgb(40 32 25 / 0.4);
   --su-color-ink-30: rgb(40 32 25 / 0.3);
   --su-color-ink-20: rgb(40 32 25 / 0.2);
+  --su-color-ink-15: rgb(40 32 25 / 0.15);
   --su-color-ink-12: rgb(40 32 25 / 0.12);
+  --su-color-ink-10: rgb(40 32 25 / 0.1);
   --su-color-ink-8: rgb(40 32 25 / 0.08);
 
   /* The ONE light surface (ruleset §4.1). Paper as a background is always flat. */

--- a/packages/component-lib/src/styles/ladle.css
+++ b/packages/component-lib/src/styles/ladle.css
@@ -1,5 +1,32 @@
-@layer reset;
+/*
+ * The Ladle-only stylesheet. Loads Tailwind (still live) AND the package
+ * stylesheet, so a migrated story and an un-migrated one render side by side in
+ * the same catalog.
+ *
+ * THE `layer(su-base)` IS LOAD-BEARING — do not simplify it to a bare @import.
+ *
+ * `index.css` is written to be loaded on its own once Tailwind leaves, so its
+ * base block is UNLAYERED. Tailwind v4 puts its utilities in `@layer utilities`,
+ * and unlayered CSS beats layered CSS whatever the source order — so a plain
+ * `@import './index.css'` inverts the cascade for every rule the two share.
+ * Measured on the real build: index.css landed at byte 85032, past the end of
+ * the utilities layer (80759), which put `h1,…,h6 { font-size: inherit }` above
+ * every `text-*` utility and collapsed the type on every heading in the catalog.
+ *
+ * Importing it into `su-base` — declared below, between `base` and
+ * `components` — restores the intended order: Tailwind preflight, then the
+ * package base, then Tailwind utilities on top. The `--su-*` custom properties
+ * and the `.su-*` classes have no Tailwind counterpart, so they are unaffected
+ * either way; it is only the shared element-level base rules that need this.
+ *
+ * The apps get no equivalent and never need one: an app imports
+ * `component-lib/styles/index.css` directly, which is the unlayered form the
+ * file is designed for. The coexistence problem is Ladle's alone, because Ladle
+ * is the one surface that renders both systems at once.
+ */
+@layer reset, theme, base, su-base, components, utilities;
 @import 'tailwindcss';
 @import './theme.css';
+@import './index.css' layer(su-base);
 
 @source '..';

--- a/packages/component-lib/src/styles/sizing.ts
+++ b/packages/component-lib/src/styles/sizing.ts
@@ -29,6 +29,8 @@
  * `compact` and `mini` is correct and complete.
  */
 
+import { fontSize, space } from '../design/tokens'
+
 export type SizeRung = 'full' | 'compact' | 'mini'
 
 /**
@@ -63,4 +65,32 @@ export const RUNG_INLINE_PADDING: Record<SizeRung, string> = {
   full: 'px-2 py-1',
   compact: 'px-1.5 py-0.5',
   mini: 'px-1 py-0.5',
+}
+
+/**
+ * The two maps above as token VALUES rather than utility classes — the form a
+ * migrated call site can put in a style object (#799, epic #802).
+ *
+ * They are a deliberate, temporary PAIR with the Tailwind maps, on exactly the
+ * terms `tokens.ts` and the `--su-*` block of `index.css` are a pair: these are
+ * read by everything already off Tailwind, `RUNG_TYPE` / `RUNG_INLINE_PADDING`
+ * by everything still on it (Badge and Button, which migrate with the Atoms
+ * layer), and the older maps are deleted in the same change as their last
+ * consumer. Nothing here re-decides a rung.
+ *
+ * `RUNG_TYPE` ports 1:1 — `text-sm` is `fontSize.sm`, `text-lede` is
+ * `fontSize.lede`. `RUNG_INLINE_PADDING` ports through Tailwind's quarter-rem
+ * step: `px-2 py-1` is 8px/4px, `px-1.5 py-0.5` is 6px/2px, `px-1 py-0.5` is
+ * 4px/2px. All six numbers are already rungs on `space`, so nothing rounds.
+ */
+export const RUNG_FONT_SIZE: Record<SizeRung, { label: string; body: string }> = {
+  full: { label: fontSize.sm, body: fontSize.lede },
+  compact: { label: fontSize.xs, body: fontSize.caption },
+  mini: { label: fontSize.badge, body: fontSize.note },
+}
+
+export const RUNG_INLINE_PAD: Record<SizeRung, string> = {
+  full: `${space[4]} ${space[8]}`,
+  compact: `${space[2]} ${space[6]}`,
+  mini: `${space[2]} ${space[4]}`,
 }


### PR DESCRIPTION
Layer 2 of the Tailwind removal — **group 1 of 4, Foundations**. Part of #799 (epic #802), built on #798 / #813.

## Scope

`packages/component-lib/src/stories/` — the six `Foundations/*` catalog pages plus the two story-scaffolding helpers.

| | |
|---|---|
| Files migrated | 8 (6 stories + `_harness.tsx` + `_dashboardStage.tsx`) |
| `className` usages removed | 140 → 2 |
| Variant usages moved to a stylesheet class | 1 of 1 (`sm:grid-cols-…`) |
| `cn()` call sites touched | 0 |
| Component APIs / prop names / barrel changed | none |

The two remaining classes are deliberate: `pc-root` is the dashboard instrument token scope those stylesheets key off (not Tailwind), and `su-story-split` is the new media-query class.

Re-measured against `origin/main`, the package as a whole is **223 files with `className=`, 306 `cn()` call sites, 296 variant usages** — the numbers in the issue came from a stale tree.

## Three things worth reading before the next layer

### 1. Wiring the package stylesheet into Ladle — the obvious way is wrong

`index.css` had no importer (by design — that is what made layer 1 safe). It needs one now, and a plain `@import` breaks the catalog.

`index.css` is written to be loaded **alone** once Tailwind leaves, so its base block is unlayered. Unlayered CSS beats layered CSS whatever the source order, and Tailwind v4 puts its utilities in `@layer utilities`. Measured on the real build:

```
LAYER utilities   spans 20563 -> 80759
index.css rules   at    85032          ← unlayered, therefore higher priority
```

That puts `h1,…,h6 { font-size: inherit }` above every `text-*` utility and collapses the type on every heading in the catalog. Importing into `layer(su-base)` (declared between `base` and `components`) restores the intended order:

```
LAYER base      16756 -> 20458
LAYER su-base   20459 -> 25291
LAYER utilities 25310 -> 84652
```

Verified by rendering `WizShell`'s `<h1 className="text-display">` — the one heading in the package carrying a Tailwind size — at full size, plus unmigrated Button and Card stories unchanged. Ladle is the only surface with this problem, because it is the only one rendering both systems at once; an app imports `index.css` directly, unlayered, as designed.

> **Do not "tidy" that import back to a bare `@import`.** It reads like redundant ceremony and it is the only thing holding the cascade the right way up. The failure is silent — nothing errors, the type just goes flat.

### 2. The token scale is missing 17 alpha rungs — a decision is owed before Atoms

`border-ink/15` and `border-ink/10` are in live use and had **no exact rung**, which contradicts `tokens.ts`'s own stated property ("a migrated call site always has an exact landing spot and never rounds"). Added `ink15` / `ink10` to both halves of the scale; the parity test covers them.

They are the first two of a longer list. Tailwind's `/NN` opacity modifier is an **open** mechanism; `tokens.ts` is a **closed** set. Across the non-story files of this package, **34 alpha usages in 17 files have no rung**, in 17 distinct spellings:

| group | blocked components | rungs needed |
|---|---|---|
| **Atoms** | Stat, VitalGauge, Toggle, InlineEditField | `paper/70`, `ink/55`, `ink/70`, `rust/25`, `status-bad/25` |
| **Containers** | Banner, FilterRow, Inset, MobileSearchDialog, ModalShell, RosterSkeleton, SheetSectionSlab | `caution/25`, `paper/85`, `paper/15`, `paper/80`, `ink/60`, `ink/5`, `ink/35` |
| **Compositions** | RollTable, WizShell, NavDrawer, OffRulesEscape, + 2 internal | `paper/10`, `paper/40`, `paper/55`, `paper/95`, `wk-faint/80` |

Neither escape hatch is legal: rounding to a neighbouring rung is a **re-tone**, and a raw `rgb(40 32 25 / 0.7)` at the call site is a **`check:tokens` `raw-color` violation** (only the token-definition files are exempt). So adding rungs is the only sanctioned move — but *which* rungs the system should own enlarges the closed colour set, and that is a design call, not a port. **Flagging rather than taking it.** **Atoms is blocked on five rungs** — it cannot be completed until they are ruled on.

### 3. Two Foundations pages documented tokens that do not exist

`--tracking-label` and `--tracking-display` are declared **nowhere** in the repo. `Foundations/Typography` listed both in its tracking table *and rendered its specimens with the matching `tracking-label` / `tracking-display` utility classes* — which resolve to nothing, so two of three rows displayed the browser's default tracking while captioning a value they were not showing. `Foundations/Theme` repeated the same two names.

Both pages now iterate the real five-rung ladder (`capsTight` 0.04 · `capsSnug` 0.06 · `caps` 0.08 · `capsWide` 0.12 · `eyebrow` 0.22) straight off `tokens.ts`. A rung cannot be listed unless it exists — which is what "specimens are generated from the tokens so they cannot drift" was supposed to guarantee.

This is the one place the port changes what renders. It could not be avoided: there is no way to port a class that has no definition.

## Deliberately not changed

- **Three raw colours on `Foundations/Theme`** — `rgb(80, 80, 80)` ×2, `rgb(199, 199, 199)`, and one `color: 'white'` — match no token. Ported **verbatim** rather than re-toned; they are pre-existing `raw-color` baseline debt.
- **`headerBg="bg-mech"`** on `Foundations/Layout` stays. It is `Card`'s API, and the `bg-*`-as-a-value pattern is its own problem (below).
- **`RUNG_TYPE` / `RUNG_INLINE_PADDING`** in `styles/sizing.ts` stay Tailwind — Badge and Button still consume them. Added `RUNG_FONT_SIZE` / `RUNG_INLINE_PAD` as the token-valued pair (ported 1:1); the old maps die with their last consumer in the Atoms layer.
- **`cn()`** — untouched, goes with its last consumer in #801.

## A structural problem the later layers will hit

`bg-*` class strings are used as **data**, not just as `className`: computed by `calculateBackgroundColor()` (52 sites), threaded through props (`headerBg`, `catalogBg`, `labelBg`, `hostTone`, `titleClass`), passed in from both apps (9 `headerBg`, 3 `catalogBg`), and converted *back* to CSS by string surgery — `` `var(--color-${headerBg.replace('bg-', '')})` ``. Those class names stop existing when Tailwind leaves, but the props are public API.

The split rule does not address this (it is about static vs stateful, not about where a value comes from). It is resolvable without an API change — resolve the tone string to a token at the point of use, which is what `borderColorFromHeaderBg` already does informally — but it should be decided deliberately. Containers and Compositions are where it lands.

## Verification

- `bun run --filter component-lib test` — **766 pass, 0 fail** (identical to baseline), incl. `story-coverage.test.ts` and `tokens.parity.test.ts`
- `bun --filter component-lib typecheck` — clean
- `bun run check:tokens` — no new violations (24 known, unchanged)
- `bun run check:styling` — no new violations (0 known)
- `bun run lint` — clean; the one new biome warning introduced mid-work was fixed, not left
- `ladle:build` — succeeds; emitted CSS layer order asserted
- **Walked the group in `ladle preview`** and spot-checked unmigrated Atoms / Containers / Compositions stories for regression from the stylesheet import
- `story-coverage.test.ts` `ALLOWLIST` remains `[]`

Refs #799.

