### PR TITLE
fix(component-lib): state the split rule per-property, correct the focus-ring colour, add three alpha rungs

### DIFF
--- a/packages/component-lib/CLAUDE.md
+++ b/packages/component-lib/CLAUDE.md
@@ -92,6 +92,42 @@ Nothing consumes the two objects yet, so they are left in place rather than
 churned — but **they are not the pattern to copy.** A button's colours belong in
 a `.su-btn--*` class, resting value included.
 
+### The one exemption: class-string exports are stylesheet-only
+
+The split rule governs **components** — things this library renders. A handful of
+exports are not components but **class strings**, and for those there is no
+element for a style object to attach to, so *all* of their styling lives in
+`src/styles/index.css`. Geometry and type included, not just the stateful half.
+
+The members, and anything built on them:
+
+| export | shape |
+| --- | --- |
+| `buttonVariants` | `(opts) => string` — the `.btn` recipe |
+| `capsLabel` | `(opts) => string` — the condensed-caps label recipe |
+| `FOCUS_RING`, `FOCUS_RING_ON_TONE`, `FOCUS_WITHIN`, `INPUT_FOCUS` | the focus vocabulary |
+| `DISABLED` | the disabled treatment |
+| `SELECTION_RING`, `SELECTION_RING_INK_DOUBLE` | the selection rings |
+
+This is the rule's **boundary, not an escape from it.** These exports exist
+precisely so a consuming app can style an element the library never renders —
+`buttonVariants`' own doc comment puts it as *"a design system the consuming apps
+cannot import is one they will re-invent"*, and both apps use it on `<a>`
+elements. A function that returns a string cannot return a style object without
+changing its signature, and its signature is public API. So they were always
+going to be stylesheet-only the moment Tailwind left: a class name is the only
+thing they can carry.
+
+Two consequences to hold onto:
+
+- **The `.su-*` names are public API.** Apps compose them with `cn()`, so they
+  end up in app-side code and cannot be churned cheaply. Name a new one
+  deliberately the first time.
+- **Do not let the exemption leak.** A component this library *renders* still
+  follows the per-property split, even when it is convenient to move everything
+  into a class. The exemption is for exports whose contract is literally a class
+  string — nothing else.
+
 (The pattern is ported from `binfinite-app`, whose component library has zero
 `:hover` and zero `@media` because it is React-Native-first and RN has neither —
 so its style objects were never asked to carry interaction or viewport state.

--- a/packages/component-lib/CLAUDE.md
+++ b/packages/component-lib/CLAUDE.md
@@ -17,7 +17,7 @@ files, and every component migrated from here on lands on them:
 | File | Role |
 | --- | --- |
 | [`src/design/tokens.ts`](src/design/tokens.ts) | The typed token scale — colour, space, font size, weight, tracking, radius, border width. Plain `as const` objects, no dependency. |
-| [`src/design/styles.ts`](src/design/styles.ts) | Exported `React.CSSProperties` objects for **static** styling, each `satisfies` the type. |
+| [`src/design/styles.ts`](src/design/styles.ts) | Exported `React.CSSProperties` objects for **static** styling, each `satisfies` the type. **`buttonPrimary` / `buttonSecondary` are a known defect — see below; do not copy them.** |
 | [`src/styles/index.css`](src/styles/index.css) | The **one** stylesheet a web consumer loads. Emits the scale as `--su-*` custom properties, binds the page ground and body face, and carries every rule a style object cannot express. |
 
 Both halves of the pattern are load-bearing. The token scale and the style objects
@@ -26,20 +26,71 @@ dropping it would be a functional regression rather than a styling change.
 
 ### The split rule
 
-- **Style object** — static values that never vary by interaction or viewport:
-  colour, padding, font, border, layout.
-- **Stylesheet class** — anything stateful or conditional: `:hover`,
-  `:focus-visible`, `:disabled`, `@media`, pseudo-elements, sibling/child
-  selectors.
-- A component may use both. The object goes on `style=`, the class on
-  `className=`.
+**The split is per-PROPERTY, not per-component.** Decide it one CSS property at
+a time, never one component at a time:
 
-This is a capability boundary, not a preference: an inline `style={}` object has
-no way to express a single item on the second list. That matters here more than
-it looks. Measured across the three UI workspaces, the codebase depends on ~403
-Tailwind variant usages — 215 responsive (`sm:`/`md:`/`lg:`/`xl:`), 120 `hover:`,
-15 `focus-visible:`, 12 `disabled:`, 9 `focus:`, 5 structural. A migration to
-style objects alone would silently drop every one of them.
+- **Style object** — a property with **no** stateful or responsive variant
+  anywhere on that element: padding, border-radius, font, most layout.
+- **Stylesheet class** — a property that has **any** stateful or conditional
+  variant (`:hover`, `:focus`, `:focus-visible`, `:disabled`, `@media`,
+  pseudo-elements, sibling/child selectors) — **including its resting value.**
+- A component routinely uses both, splitting down the middle of its own style:
+  a Button's `padding` is an object, its `background-color` a class, because
+  only the second one changes on hover.
+
+#### Why the resting value has to come along
+
+Not a preference — a cascade fact, and the reason is what stops someone
+"simplifying" this back. **An inline `style=` declaration outranks any author
+stylesheet rule regardless of selector specificity or state**, because it sits
+higher in the cascade origin order. `:hover` cannot beat it and no amount of
+selector weight fixes that. So splitting one property across the two mechanisms
+is not merely inelegant, it is **silently broken**: the resting value wins
+forever, the stateful one never fires, nothing errors, and the only symptom is a
+hover that does nothing.
+
+Measured on a real page rather than argued from specificity — two identical
+elements, one hovered at a time:
+
+| resting `background-color` | computed value while hovered |
+| --- | --- |
+| inline `style=` | `rgb(0, 128, 0)` — the hover **did not apply** |
+| in the class | `rgb(255, 0, 0)` — the hover applied |
+
+Specificity intuition is exactly where this goes wrong, which is why the check is
+a measurement and not an argument.
+
+#### The capability half
+
+The other half of the rule is a plain capability boundary: an inline `style={}`
+object has no way to express a single item on the stateful list. Measured across
+the three UI workspaces, the codebase depends on ~403 Tailwind variant usages —
+215 responsive (`sm:`/`md:`/`lg:`/`xl:`), 120 `hover:`, 15 `focus-visible:`, 12
+`disabled:`, 9 `focus:`, 5 structural. A migration to style objects alone would
+silently drop every one of them.
+
+#### Consequence: the stylesheet is bigger than it looks
+
+Because a stateful property brings its resting value with it, `src/styles/index.css`
+carries considerably more than "the bits an object cannot express". Within
+component-lib alone there are ~127 stateful usages (81 `hover:`, 14 `disabled:`,
+12 `focus:`, 11 `active:`, 9 `focus-visible:`), and each one drags its resting
+`background-color` / `border-color` / `color` into the stylesheet with it. That
+growth is the rule working, not scope creep.
+
+#### `styles.buttonPrimary` / `buttonSecondary` are a known defect (#813)
+
+They put `backgroundColor` inline, and `index.css` pairs them with
+`.su-button:hover { filter: brightness(0.94) }`. That renders — but only because
+`filter` is a **different property** from `background-color`, so it sidesteps the
+collision above instead of resolving it. It does not generalise: the real
+`Button` swaps to a NAMED colour per variant (`hover:bg-ink-8`,
+`hover:bg-rust-hi`, `hover:border-rust-hi`), and approximating those with a
+brightness filter would be a re-tone, not a port.
+
+Nothing consumes the two objects yet, so they are left in place rather than
+churned — but **they are not the pattern to copy.** A button's colours belong in
+a `.su-btn--*` class, resting value included.
 
 (The pattern is ported from `binfinite-app`, whose component library has zero
 `:hover` and zero `@media` because it is React-Native-first and RN has neither —

--- a/packages/component-lib/src/design/tokens.ts
+++ b/packages/component-lib/src/design/tokens.ts
@@ -280,11 +280,21 @@ const base = {
   /** Paper as a FOREGROUND — text and hairlines printed onto a tone or a dark
    *  ground. Paper as a background is always the flat `paper`. */
   paper60: 'rgb(251 250 247 / 0.6)',
+  /** The de-emphasised rung ON a tone or dark ground — the inverse counterpart
+   *  of `wkMuted`, which only clears AA on the light grounds. Added by the
+   *  Atoms layer of #799 for `Stat`'s `inverse` skin (`text-paper/70`). */
+  paper70: 'rgb(251 250 247 / 0.7)',
   paper30: 'rgb(251 250 247 / 0.3)',
 
   /** THE single action colour. */
   rust: 'rgb(168, 82, 34)',
   rustHi: 'rgb(138, 64, 25)',
+  /** The focus-ring wash. Added by the Atoms layer of #799: this is the tone
+   *  of the canonical rust focus ring (`ring-rust/25`, design-spec §2.4), so
+   *  it is shared infrastructure rather than one component's colour — Button,
+   *  StepButton, Sel, Toggle and all three input rungs in
+   *  `components/chrome/interaction.ts` resolve to it. */
+  rust25: 'rgb(168 82 34 / 0.25)',
   /** The one sanctioned cream — RollTable banding, and nowhere else. */
   bandCream: 'rgb(243, 237, 226)',
 
@@ -332,6 +342,21 @@ export const color = {
   statusOk: base.rollSuccess,
   statusWarn: base.rollFailure,
   statusBad: base.rollCascade,
+  /**
+   * The error focus-ring wash — `statusBad` at 25%, the destructive
+   * counterpart of `rust25`, used by `InlineEditField`'s error skin
+   * (`focus:ring-status-bad/25`). Added by the Atoms layer of #799.
+   *
+   * A LITERAL rather than an alias, and unavoidably so: the three rungs above
+   * stay aliases because a retone of `rollCascade` should follow, but CSS has
+   * no way to spell "that custom property, at 25%" that the parity test can
+   * resolve — `color-mix()` produces a computed value, not the literal the
+   * test compares against. So this one must be re-toned BY HAND alongside
+   * `rollCascade`, which is exactly the drift the aliases exist to prevent.
+   * Recorded here rather than hidden, because it is the first place the
+   * aliasing discipline could not be honoured.
+   */
+  statusBad25: 'rgb(176 67 43 / 0.25)',
 
   // — Sheet tones (Header C live sheets): base + deep pairs —
   sheetPilot: base.pilot,

--- a/packages/component-lib/src/styles/index.css
+++ b/packages/component-lib/src/styles/index.css
@@ -188,11 +188,16 @@
   --su-color-paper: rgb(251, 250, 247);
   /* Paper as a FOREGROUND — printed onto a tone or a dark ground. */
   --su-color-paper-60: rgb(251 250 247 / 0.6);
+  /* The de-emphasised rung ON a tone — `wk-muted`'s inverse counterpart. */
+  --su-color-paper-70: rgb(251 250 247 / 0.7);
   --su-color-paper-30: rgb(251 250 247 / 0.3);
 
   /* THE single action colour. */
   --su-color-rust: rgb(168, 82, 34);
   --su-color-rust-hi: rgb(138, 64, 25);
+  /* The canonical focus-ring wash (design-spec §2.4) — shared infrastructure,
+     not one component's colour. See the note in tokens.ts. */
+  --su-color-rust-25: rgb(168 82 34 / 0.25);
   /* The one sanctioned cream — RollTable banding, and nowhere else. */
   --su-color-band-cream: rgb(243, 237, 226);
 
@@ -225,6 +230,10 @@
   --su-color-status-ok: var(--su-color-roll-success);
   --su-color-status-warn: var(--su-color-roll-failure);
   --su-color-status-bad: var(--su-color-roll-cascade);
+  /* NOT an alias, and unavoidably so: CSS has no spelling of "that property at
+     25%" the parity test can resolve back to a literal. Re-tone this BY HAND
+     whenever --su-color-roll-cascade moves. See the note in tokens.ts. */
+  --su-color-status-bad-25: rgb(176 67 43 / 0.25);
   --su-color-sheet-pilot: var(--su-color-pilot);
   --su-color-sheet-pilot-deep: var(--su-color-rust);
   --su-color-sheet-mech: var(--su-color-mech);
@@ -311,18 +320,41 @@ body {
 
 /* ══ The stateful half ══════════════════════════════════════════════════════
  *
- * Everything below is here because a style object could not hold it. Each class
- * is the interactive complement of an object in `src/design/styles.ts`: the
- * object paints the resting state, the class paints every other state.
+ * Everything below is here because a style object could not hold it.
+ *
+ * THE SPLIT IS PER-PROPERTY, NOT PER-COMPONENT — and this is the part that is
+ * easy to get wrong. An earlier framing of this section said the object paints
+ * the resting state and the class paints every other state. That does not work,
+ * and it fails SILENTLY: an inline declaration outranks an author rule whatever
+ * its selector, so a resting `background-color` on `style=` beats the same
+ * property in a `:hover` rule and the hover never renders at all. Measured on a
+ * real page — resting colour inline, hovered computed value unchanged; resting
+ * colour in the class, hover applied.
+ *
+ * So a property that VARIES by state is not static, and its resting value
+ * belongs here too, beside the state that overrides it. A component splits down
+ * the middle of its own style: `padding`, `border-radius` and `font` on the
+ * object; `background-color`, `border-color` and `color` in the class whenever
+ * a `:hover` / `:focus` / `:disabled` rule touches them.
+ *
+ * (`.su-button` below is the shape that hid this — `filter: brightness()`
+ * dodges the collision by being a different property from the one the object
+ * sets. That is a workaround, not the rule; see the note on it.)
  */
 
 /**
  * The canonical rust focus ring (design-spec §2.4), on `:focus-visible` — a
  * button shows it to the keyboard, not to the mouse.
+ *
+ * The wash is `rust/25`. These four ring rules shipped against
+ * `--su-color-ink-20` in #798 while their own comments named the rust ring; the
+ * live value every one of them mirrors is `ring-[3px] ring-rust/25`
+ * (`components/chrome/interaction.ts`), so #799 corrected the value rather than
+ * the comment. The on-tone rung below was already right.
  */
 .su-focus-ring:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 3px var(--su-color-ink-20);
+  box-shadow: 0 0 0 3px var(--su-color-rust-25);
 }
 
 /**
@@ -338,14 +370,25 @@ body {
     0 0 0 4px var(--su-color-ink);
 }
 
-/** The interactive complement of `styles.buttonBase`. */
+/**
+ * The interactive complement of `styles.buttonBase`.
+ *
+ * NOT the pattern to copy. `filter: brightness()` is a generic darkening that
+ * happens to survive `styles.buttonPrimary` setting `background-color` inline,
+ * because the two are different properties — which is why this rule works and
+ * masks the precedence trap described at the top of this section. The real
+ * `Button` (`components/chrome/buttonVariants.ts`) does not darken generically:
+ * it swaps to a NAMED colour per variant (`hover:bg-ink-8`, `hover:bg-rust-hi`,
+ * `hover:border-rust-hi`), and no brightness filter reproduces those without
+ * re-toning them. Those live in `.su-btn--*` below, resting colour included.
+ */
 .su-button:hover:not(:disabled) {
   filter: brightness(0.94);
 }
 
 .su-button:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 3px var(--su-color-ink-20);
+  box-shadow: 0 0 0 3px var(--su-color-rust-25);
 }
 
 .su-button:disabled {
@@ -360,7 +403,7 @@ body {
  */
 .su-input:focus {
   outline: none;
-  box-shadow: 0 0 0 3px var(--su-color-ink-20);
+  box-shadow: 0 0 0 3px var(--su-color-rust-25);
 }
 
 .su-input:disabled {
@@ -379,7 +422,7 @@ body {
  * imply the shell is focusable when it is not.
  */
 .su-focus-within:focus-within {
-  box-shadow: 0 0 0 3px var(--su-color-ink-20);
+  box-shadow: 0 0 0 3px var(--su-color-rust-25);
 }
 
 /* ══ Mobile-first touch targets ═════════════════════════════════════════════ */


### PR DESCRIPTION
Groundwork for the Atoms layer of #799 (epic #802), stacked on #814.

**The Atoms components are NOT in this PR.** Two reasons, both worth reading: the split rule needed a correction first (below), and the group itself is blocked on a ruling about class-string exports. Everything here is correct regardless of how that ruling goes.

## 1. The split rule was ambiguous in the direction that produces invisible bugs

**An inline `style=` declaration outranks any author stylesheet rule regardless of selector specificity or state** — it sits higher in the cascade origin order, so `:hover` cannot beat it and no amount of selector weight fixes it. Splitting one CSS *property* across the two mechanisms is therefore not merely inelegant, it is **silently broken**: the resting value wins forever, the stateful one never fires, nothing errors, and the only symptom is a hover that does nothing.

Measured on a real page rather than argued from specificity — two identical elements, one hovered at a time:

| resting `background-color` | computed value while hovered |
| --- | --- |
| inline `style=` | `rgb(0, 128, 0)` — the hover **did not apply** |
| in the class | `rgb(255, 0, 0)` — the hover applied |

**So the split is per-PROPERTY, not per-component.** A property with any stateful variant goes wholly to the stylesheet, *resting value included*; a property with none stays inline. One component routinely splits down the middle of its own style — a Button's `padding` is an object, its `background-color` a class. That was always the rule ("static values that never vary by interaction"); the #813 examples just read as per-component at a glance.

`packages/component-lib/CLAUDE.md` now states it that way, with the cascade reason and this measurement. The reason is included deliberately: it is what stops the next person simplifying it back.

### `index.css` will be substantially larger than #813 implied — this is not scope creep

Because a stateful property drags its resting colour in with it, the stylesheet carries far more than "the bits an object cannot express". Within component-lib alone there are **~127 stateful usages** — 81 `hover:`, 14 `disabled:`, 12 `focus:`, 11 `active:`, 9 `focus-visible:` — and each one moves its resting `background-color` / `border-color` / `color` into the stylesheet alongside the state that overrides it. A reviewer expecting a thin stateful appendix should expect roughly the opposite.

### `styles.buttonPrimary` / `buttonSecondary` are a known defect in #813

They put `backgroundColor` inline and are paired with `.su-button:hover { filter: brightness(0.94) }`. That renders — but **only because `filter` is a different property from `background-color`**, so it sidesteps the collision above rather than resolving it. It cannot generalise: the real Button swaps to a *named* colour per variant (`hover:bg-ink-8`, `hover:bg-rust-hi`, `hover:border-rust-hi`), and approximating those with a brightness filter would be a re-tone, not a port.

Nothing consumes the two objects yet, so this PR leaves them in place rather than churning them — but they are **not the pattern to copy**, and both `index.css` and the package CLAUDE.md now say so at the point someone would reach for them.

## 2. The four focus rings were pointing at the wrong colour

#798 wrote them as `var(--su-color-ink-20)` while their own doc comments named *"the canonical rust focus ring (design-spec §2.4)"*. The live value every one mirrors is `focus-visible:ring-[3px] focus-visible:ring-rust/25` (`components/chrome/interaction.ts`) — a different hue **and** a different alpha. Corrected the value rather than the comment, across `.su-focus-ring`, `.su-button:focus-visible`, `.su-input:focus` and `.su-focus-within`. The on-tone rung was already correct.

## 3. Three alpha rungs, each justified by a live usage

No speculative rungs; `tokens.parity.test.ts` covers all three.

| rung | justifying usage |
|---|---|
| `rust25` | **The canonical focus ring** (`ring-rust/25`, design-spec §2.4). Shared infrastructure rather than one component's colour: `FOCUS_RING`, `INPUT_FOCUS` and `FOCUS_WITHIN` in `interaction.ts` all resolve to it, reaching Button, StepButton, Sel and every input rung — plus Toggle directly. |
| `statusBad25` | `focus:ring-status-bad/25` — InlineEditField's error skin. |
| `paper70` | `text-paper/70` — Stat's inverse skin, where `wkMuted` only clears AA on the light grounds. |

**The rendered palette is unchanged; the named palette grew by three.** Tailwind computes all three from opacity modifiers today, so those pixels already ship — what grows is only the set of values that have a name.

One wart recorded rather than hidden: `statusBad25` is a **literal, not an alias**. `statusOk/Warn/Bad` stay aliases so a retone propagates, but CSS has no spelling of "that custom property at 25%" the parity test can resolve back to a literal (`color-mix()` yields a computed value). So it must be re-toned by hand alongside `rollCascade` — the first place the aliasing discipline could not be honoured.

**`ink55` and `ink70` are NOT added.** They appeared in an earlier count of mine; that scan was wrong. Their only occurrences are prose inside a VitalGauge comment recording that both were *removed* for failing WCAG AA. VitalGauge is not blocked. The corrected per-group table is in #814.

## 4. The blocker: class strings are public API

`buttonVariants` is a **barrel export** (`src/index.ts:40`) whose entire contract is *"returns a Tailwind class string"*. Its doc comment says it exists so consumers can style non-button elements without re-inlining it — and that is how it is used:

| consumer | call sites |
|---|---|
| **`apps/itun` + `apps/srd`** | **30** — e.g. `` className={cn(buttonVariants({ variant: 'ghost', size: 'compact' }), 'no-underline')} `` on `<a>` elements |
| `component-lib` internals | 34 — EntityDetailDialog, MobileSearchDialog, NavDrawer, EntityRow, sheetChrome, RailBar |

The barrel exports the focus vocabulary the same way, and says why: *"Exported because the APPS need it, not only the lib… A design system the consuming apps cannot import is one they will re-invent."* — `FOCUS_RING` (4 app / 37 lib), `INPUT_FOCUS` (2/17), `DISABLED` (1/7), plus internal-only `capsLabel` (37) and `SELECTION_RING` (10).

Both obvious routes break a stated constraint:

- **Change what `buttonVariants` returns** → 30 app call sites change. Violates *"Do NOT change… the barrel"* and *"a consumer should not need editing."*
- **Leave it on Tailwind** → Button stays on Tailwind, and so do the six lib components composing it.

This is a different shape from the two blockers already ruled on. Alpha rungs were solvable by adding tokens; `bg-*`-as-data was solvable at the point of use *inside* the library. Here the exported **value itself** is the Tailwind string and the point of use is **in the apps**, so there is no in-library seam.

### The option I did not take

`buttonVariants` could keep returning a class string and return `.su-*` names instead — `buttonVariants({ variant: 'ghost' })` → `"su-btn su-btn--ghost su-btn--compact"`. Signature identical, `cn()` still composes, `<a>` still works, **zero app edits**. The cost is that Button becomes **stylesheet-only**: geometry and type move into `index.css` too, because a caller putting the string on an `<a>` never receives a style object. That makes the style-object half of the split rule unusable for anything whose classes are public API — Button, the focus vocabulary, `capsLabel`, and everything composing them.

That is a call about the shape of the design system, not a port, so I have not made it. **Awaiting a ruling.**

Note the scope of the blocker is narrow within Atoms: only **Button** is affected. The other 33 Atoms components can migrate without it, and will follow in separate PRs — Atoms is 68 files / 513 `className` / 111 `cn()`, four times Foundations, and too large for one reviewable PR.

## Verification

- `bun run --filter component-lib test` — 766 pass, 0 fail (unchanged), incl. `tokens.parity.test.ts` covering the three new rungs
- `bun --filter component-lib typecheck` — clean
- `bun run check:tokens` — no new violations (24 known)
- `bun run check:styling` — no new violations (0 known)
- Biome clean

No component, prop, barrel export or app file is touched by this PR.

Refs #799. Stacked on #814 — review that first.
