### PR TITLE
feat(apps): load the package stylesheet, layered below Tailwind's utilities

### DIFF
--- a/apps/itun/src/index.css
+++ b/apps/itun/src/index.css
@@ -1,5 +1,24 @@
+/*
+ * The `@layer` order below and the `layer(su-base)` on the package stylesheet
+ * are LOAD-BEARING — do not simplify either to a bare `@import` (#799, #802).
+ *
+ * `component-lib/styles/index.css` carries the `--su-*` token scale and every
+ * rule a style object cannot express, so a component migrated off Tailwind
+ * renders unstyled without it. It is written to be loaded ALONE once Tailwind
+ * leaves, so its base block is unlayered — and unlayered CSS beats layered CSS
+ * whatever the source order, while Tailwind v4 puts its utilities in
+ * `@layer utilities`. Imported plainly it inverts the cascade for every rule the
+ * two share: measured on the real build, `h1,…,h6 { font-size: inherit }` landed
+ * past the end of the utilities layer and outranked every `text-*` utility,
+ * flattening the type on every heading. Declaring the order up front and
+ * importing into `su-base` puts the package base between Tailwind's preflight
+ * and Tailwind's utilities, which is where it belongs while both are live.
+ * When Tailwind goes this collapses back to a plain import.
+ */
+@layer theme, base, su-base, components, utilities;
 @import 'tailwindcss';
 @import 'component-lib/styles/theme.css';
+@import 'component-lib/styles/index.css' layer(su-base);
 /* The app's ONE print stylesheet. index.css declares no print rules of its own
    — a second block here is what let six rules duplicate and one contradict. */
 @import './styles/print.css';

--- a/apps/srd/src/styles/global.css
+++ b/apps/srd/src/styles/global.css
@@ -1,5 +1,24 @@
+/*
+ * The `@layer` order below and the `layer(su-base)` on the package stylesheet
+ * are LOAD-BEARING — do not simplify either to a bare `@import` (#799, #802).
+ *
+ * `component-lib/styles/index.css` carries the `--su-*` token scale and every
+ * rule a style object cannot express, so a component migrated off Tailwind
+ * renders unstyled without it. It is written to be loaded ALONE once Tailwind
+ * leaves, so its base block is unlayered — and unlayered CSS beats layered CSS
+ * whatever the source order, while Tailwind v4 puts its utilities in
+ * `@layer utilities`. Imported plainly it inverts the cascade for every rule the
+ * two share: measured on the real build, `h1,…,h6 { font-size: inherit }` landed
+ * past the end of the utilities layer and outranked every `text-*` utility,
+ * flattening the type on every heading. Declaring the order up front and
+ * importing into `su-base` puts the package base between Tailwind's preflight
+ * and Tailwind's utilities, which is where it belongs while both are live.
+ * When Tailwind goes this collapses back to a plain import.
+ */
+@layer theme, base, su-base, components, utilities;
 @import 'tailwindcss';
 @import 'component-lib/styles/theme.css';
+@import 'component-lib/styles/index.css' layer(su-base);
 
 @source '../../../../packages/component-lib/src';
 

--- a/tools/check-styling-ownership.ts
+++ b/tools/check-styling-ownership.ts
@@ -383,6 +383,92 @@ function scanUnboundComponents(): Violation[] {
 
 // ── rule table ────────────────────────────────────────────────────────────────
 
+/**
+ * The app entry stylesheets — the two files that compose the whole cascade for
+ * a shipped app. Named explicitly rather than discovered, because the property
+ * being checked is about these files SPECIFICALLY: a partial like `print.css`
+ * neither should nor could carry the import.
+ */
+const APP_ENTRY_CSS = ['apps/itun/src/index.css', 'apps/srd/src/styles/global.css'] as const
+
+/**
+ * Both halves of the package-stylesheet wiring, in the two files that own it.
+ *
+ * WHY A GUARD. This is the highest-consequence silent failure in the Tailwind
+ * migration, and it fails in two different directions:
+ *
+ *   MISSING IMPORT — every component already migrated off Tailwind renders
+ *   unstyled in production. The library still compiles, every test still
+ *   passes, and Ladle looks perfect because Ladle loads the stylesheet through
+ *   its own `ladle.css`. Nothing but a human eye on the real app would notice.
+ *
+ *   UNLAYERED IMPORT — worse, because it looks like the tidier spelling.
+ *   `index.css` is written to be loaded ALONE once Tailwind leaves, so its base
+ *   block is unlayered; unlayered CSS beats layered CSS whatever the source
+ *   order, and Tailwind v4 puts utilities in `@layer utilities`. Measured on the
+ *   real build, a bare `@import` landed `h1,…,h6 { font-size: inherit }` past
+ *   the end of the utilities layer, outranking every `text-*` utility and
+ *   flattening the type on every heading in the app.
+ *
+ * Both are invisible to typecheck, lint and the test suite, which is exactly the
+ * standard the sibling rules in this file are held to. The layer NAME is not
+ * asserted — only that the import carries some `layer(...)` and that the
+ * declared order puts it before `utilities` — so renaming `su-base` stays cheap
+ * while removing the layering does not.
+ */
+function scanPackageStylesheetImport(): Violation[] {
+  const out: Violation[] = []
+  for (const rel of APP_ENTRY_CSS) {
+    const css = stripCssComments(read(join(ROOT, rel)))
+    const lines = css.split('\n')
+
+    const importLine = lines.findIndex((l) =>
+      /@import\s+['"]component-lib\/styles\/index\.css['"]/.test(l)
+    )
+    if (importLine === -1) {
+      out.push({
+        file: rel,
+        line: 1,
+        detail:
+          "does not import 'component-lib/styles/index.css' — every component migrated off Tailwind renders unstyled in this app",
+      })
+      continue
+    }
+
+    const line = lines[importLine] ?? ''
+    const layerMatch = line.match(/layer\(([a-z0-9-]+)\)/i)
+    if (!layerMatch) {
+      out.push({
+        file: rel,
+        line: importLine + 1,
+        detail:
+          'imports the package stylesheet WITHOUT a cascade layer — unlayered CSS outranks Tailwind utilities, which flattens every heading',
+      })
+      continue
+    }
+
+    const layerName = layerMatch[1] as string
+    const orderDecl = css.match(/@layer\s+([a-z0-9,\s-]+);/i)
+    const order = orderDecl?.[1]?.split(',').map((n) => n.trim()) ?? []
+    if (!order.includes(layerName)) {
+      out.push({
+        file: rel,
+        line: importLine + 1,
+        detail: `imports into layer(${layerName}) but no @layer declaration names it — layer order then depends on emission order`,
+      })
+      continue
+    }
+    if (order.includes('utilities') && order.indexOf(layerName) > order.indexOf('utilities')) {
+      out.push({
+        file: rel,
+        line: importLine + 1,
+        detail: `layer(${layerName}) is declared AFTER 'utilities' — the package base then outranks every Tailwind utility`,
+      })
+    }
+  }
+  return out
+}
+
 const RULES: Rule[] = [
   {
     id: 'app-theme',
@@ -401,6 +487,12 @@ const RULES: Rule[] = [
     rule: 'source-of-truth §the dashboard class contract is closed and bidirectional',
     fix: 'used-but-undefined: define the class in dashboard/{DashboardCanvas,DashboardGrid,instruments}.css (or fix the className typo in the .tsx). defined-but-unused: delete the dead rule, or reference it. Match the EXACT class name — pc-crawler-focus and pc-crawler-focus-note are different classes.',
     scan: scanPcContract,
+  },
+  {
+    id: 'package-stylesheet-import',
+    rule: 'ruleset §the package stylesheet is the ONE stylesheet a consumer loads, and it must not outrank Tailwind while both are live (#799, epic #802)',
+    fix: "Each app entry stylesheet must (a) import 'component-lib/styles/index.css' and (b) import it into a cascade layer declared BEFORE Tailwind's `utilities` — the shape is `@layer theme, base, su-base, components, utilities;` at the top and `@import 'component-lib/styles/index.css' layer(su-base);` beside the theme.css import.",
+    scan: scanPackageStylesheetImport,
   },
 ]
 


### PR DESCRIPTION
A prerequisite the migration plan did not account for. Part of #799 (epic #802), stacked on #815.

## Neither app was loading the package stylesheet

Both app entry sheets import `component-lib/styles/theme.css` and Tailwind — **neither imports `component-lib/styles/index.css`**. That is the file carrying the `--su-*` token scale and every `.su-*` rule, so as things stood:

- Every component migrated off Tailwind from the Atoms layer onwards would render **unstyled in production**.
- Ladle would look perfect, because it loads the stylesheet through its own `ladle.css` (wired in #814).
- Typecheck, lint and all 766 tests would stay green.

Nothing but a human eye on the real app would have caught it. **This has to land before the first component migration, not alongside it** — which is why it is its own PR rather than the head of the Atoms one.

## The `layer(su-base)` is load-bearing

`index.css` is written to be loaded **alone** once Tailwind leaves, so its base block is unlayered. Unlayered CSS beats layered CSS whatever the source order, and Tailwind v4 puts its utilities in `@layer utilities` — so a plain `@import` inverts the cascade for every rule the two share. Measured on the real Ladle build in #814: `h1,…,h6 { font-size: inherit }` landed at byte 85032, past the end of the utilities layer at 80759, outranking every `text-*` utility and flattening the type on every heading.

Declaring the order up front and importing into `su-base` puts the package base between Tailwind's preflight and Tailwind's utilities:

```css
@layer theme, base, su-base, components, utilities;
@import 'tailwindcss';
@import 'component-lib/styles/theme.css';
@import 'component-lib/styles/index.css' layer(su-base);
```

When Tailwind goes, both lines collapse back to a plain import.

## Verified on the real production bundles

Not reasoned about — measured, on the actual emitted CSS:

| app | `base` | `su-base` | `utilities` | `--su-*` emitted |
|---|---|---|---|---|
| srd | 13746→17434 | **17435→22368** | 22387→84020 | 127 |
| itun | 13858→17546 | **17547→22480** | 22499→89663 | 127 |

`su-base` precedes `utilities` in both, and the heading reset sits *inside* `su-base` rather than loose at the end.

Then spot-checked the built srd in a browser. The page renders identically — masthead, catalog tiles, entity tones, section headers — and the visible headings still compute to **13px / 700** from their Tailwind utilities rather than being flattened to `inherit`. (The one `h1` that does report `14px/400` is the `sr-only` SEO heading — 1×1, `position: absolute` — which is unchanged behaviour, since Tailwind's own preflight resets headings the same way.)

## Guarded, because both failure modes are silent

`check:styling` gains a `package-stylesheet-import` rule. Two distinct failures, neither of which fails typecheck, lint or any test, and both of which Ladle hides:

| failure | consequence |
|---|---|
| **missing import** | every migrated component renders unstyled in that app |
| **unlayered import** | the package base outranks Tailwind utilities — flattens the type on every heading. *This is the more dangerous one, because it looks like the tidier spelling.* |

Both were **probed against the real checker before shipping**, not just asserted:

1. correct state → `✓ no new violations`
2. strip `layer(su-base)` → `✗ imports the package stylesheet WITHOUT a cascade layer — unlayered CSS outranks Tailwind utilities, which flattens every heading`
3. remove the import → `✗ does not import 'component-lib/styles/index.css' — every component migrated off Tailwind renders unstyled in this app`
4. restore → `✓ no new violations`

The layer **name** is deliberately not asserted — only that the import carries *some* `layer(...)` and that the declared order puts it before `utilities`. Renaming `su-base` stays cheap; removing the layering does not.

## On touching app files

This edits two app files, which brushes against *"a consumer should not need editing"*. It is not an API change — no component, prop, or barrel export moves, and no app call site changes. It is the one-time wiring the design always implied: `index.css` is described in #798 as *"the ONE stylesheet a web consumer loads"*, and until now no consumer loaded it. Flagging it explicitly rather than slipping it in.

## Verification

- `bun run --filter component-lib test` — 766 pass, 0 fail (unchanged)
- `bun run typecheck` — clean across all workspaces
- `bun run lint` — clean
- `bun run check:tokens` — no new violations (24 known)
- `bun run check:styling` — no new violations (0 known), now including the new rule
- `bun --filter srd build` and `bun --filter itun build` — both succeed; layer order asserted on the output
- Built srd rendered and inspected in a browser

Refs #799. Stacked on #815 → #814.
