### PR TITLE
feat(component-lib): move the interaction vocabulary onto .su-* class names

### DIFF
--- a/packages/component-lib/CLAUDE.md
+++ b/packages/component-lib/CLAUDE.md
@@ -134,6 +134,29 @@ so its style objects were never asked to carry interaction or viewport state.
 Here they would be, and they cannot. That is the one thing that must not be lost
 in translation, and it is why the stylesheet is not optional.)
 
+### Checking a focus style: `.focus()` will lie to you
+
+**`:focus-visible` does not match programmatic focus.** Calling `el.focus()` — or
+`.focus()` from a devtools console, or `userEvent`/`fireEvent.focus` in a test —
+moves focus without satisfying the browser's keyboard heuristic, so
+`:focus-visible` stays unmatched and `getComputedStyle(el).boxShadow` reports
+`none`. Every focus ring in this package is on `:focus-visible` (that is the
+point — a button shows its ring to the keyboard, not to the mouse), so **a
+working ring reads as a missing one** under that check.
+
+That is the dangerous direction: it makes a correct feature look broken, which
+invites someone to "fix" it until it really is. Verified on the real thing —
+`el.focus()` gave `boxShadow: none` on a Button whose ring was fine, while a real
+**Tab** press gave `matchesFocusVisible: true` and
+`rgba(168, 82, 34, 0.25) 0 0 0 3px`.
+
+So to check a focus style: send a real key press (a browser driver's Tab key), or
+assert `el.matches(':focus-visible')` alongside the computed value so a false
+negative is distinguishable from a real one. `:focus` rungs — `.su-input-focus`,
+`.su-focus-within` — are exempt from this and do respond to `.focus()`, which is
+its own trap, since it makes the two rungs behave differently under the same
+check for reasons that have nothing to do with either being correct.
+
 ### Migration status (#799, epic #802)
 
 Migrating by Ladle group, one PR per group: **Foundations ✅ → Atoms → Containers

--- a/packages/component-lib/CLAUDE.md
+++ b/packages/component-lib/CLAUDE.md
@@ -157,6 +157,41 @@ negative is distinguishable from a real one. `:focus` rungs — `.su-input-focus
 its own trap, since it makes the two rungs behave differently under the same
 check for reasons that have nothing to do with either being correct.
 
+### Checking cascade layers: assert on the DECLARATION, never on block position
+
+**Layer order is set by the first `@layer` declaration, not by where the blocks
+land in the file.** So checking a cascade by finding the `@layer name { … }`
+blocks and comparing their byte offsets measures the wrong thing — and it does
+not fail honestly, because it is right in one environment and wrong in another.
+
+Measured both ways on this repo's own wiring, which imports the package
+stylesheet into `su-base` (see `apps/*/src/**.css`):
+
+| | block order | actual cascade |
+| --- | --- | --- |
+| production build | `base` → `su-base` → `utilities` | correct |
+| Vite dev | `base` → `utilities` → … → `su-base` | **also correct** |
+
+Dev emits `su-base`'s block ~86 KB after the utilities block, so an
+offset-comparing script reports the cascade inverted. It is not: both outputs
+carry `@layer theme, base, su-base, components, utilities;` ahead of Tailwind's
+own declaration, and that line decides. Confirmed by injecting an
+`<h2 class="text-2xl">` into the running dev app and reading **24px** rather than
+the inherited 14px — Tailwind's utility still outranks the `su-base` heading
+reset, exactly as in the build.
+
+So verify a layer question one of two ways, and never by block position:
+
+- **the declaration** — find the bare `@layer a, b, c;` and read the order off
+  it. This is what `check:styling`'s `package-stylesheet-import` rule asserts.
+- **a computed value** — render the real thing and read
+  `getComputedStyle(el)`, which cannot be fooled by emission order at all.
+
+The reason this one is worth writing down: the offset method was *decisive* on
+the production bundle and *false* in dev, which makes it far harder to distrust
+than a method that is simply wrong. A scratch tool that agrees with you once
+earns credibility it has not got.
+
 ### Migration status (#799, epic #802)
 
 Migrating by Ladle group, one PR per group: **Foundations ✅ → Atoms → Containers

--- a/packages/component-lib/src/components/chrome/__tests__/Btn.test.tsx
+++ b/packages/component-lib/src/components/chrome/__tests__/Btn.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from 'bun:test'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { Button } from '../Button'
+import { DISABLED } from '../interaction'
 
 describe('Button', () => {
   test('defaults to a paper/ink md button of type="button"', () => {
@@ -47,7 +48,10 @@ describe('Button', () => {
     )
     const btn = screen.getByRole('button')
     expect(btn.hasAttribute('disabled')).toBe(true)
-    expect(btn.className).toContain('disabled:opacity-40')
+    // Asserted against the exported constant rather than its spelling: the
+    // vocabulary moved from Tailwind classes to `.su-*` names in #799, and a
+    // test pinned to the spelling breaks on a rename that changes nothing.
+    expect(btn.className).toContain(DISABLED)
     fireEvent.click(btn)
     expect(onClick).not.toHaveBeenCalled()
   })

--- a/packages/component-lib/src/components/chrome/__tests__/chrome.test.tsx
+++ b/packages/component-lib/src/components/chrome/__tests__/chrome.test.tsx
@@ -6,6 +6,7 @@ import { ConditionChip, Conditions } from '../Conditions'
 import { EmptyState } from '../EmptyState'
 import { Field, Input, Select, Textarea } from '../Field'
 import { Glyph } from '../glyphs'
+import { INPUT_FOCUS } from '../interaction'
 import { KvRow } from '../KvRow'
 import { ModeDoor } from '../ModeDoor'
 import { Panel, Row } from '../Panel'
@@ -33,7 +34,7 @@ describe('Field / Input', () => {
 
   test('input carries the rust focus ring classes', () => {
     render(<Input aria-label="callsign" />)
-    expect(screen.getByLabelText('callsign').className).toContain('focus:ring-')
+    expect(screen.getByLabelText('callsign').className).toContain(INPUT_FOCUS)
   })
 
   test('Textarea and Select share the Input skin (paper/ink border, rust ring)', () => {
@@ -42,7 +43,7 @@ describe('Field / Input', () => {
     for (const label of ['motto', 'class']) {
       const el = screen.getByLabelText(label)
       expect(el.className).toContain('border-ink')
-      expect(el.className).toContain('focus:ring-')
+      expect(el.className).toContain(INPUT_FOCUS)
     }
   })
 })

--- a/packages/component-lib/src/components/chrome/__tests__/selection.test.tsx
+++ b/packages/component-lib/src/components/chrome/__tests__/selection.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test'
 import { fireEvent, render, screen } from '@testing-library/react'
+import { SELECTION_RING } from '../interaction'
 import { Sel } from '../Sel'
 
 describe('Sel', () => {
@@ -9,13 +10,13 @@ describe('Sel', () => {
         <div>card</div>
       </Sel>
     )
-    expect(container.firstElementChild?.className).not.toContain('shadow-[0_0_0_3px')
+    expect(container.firstElementChild?.className).not.toContain(SELECTION_RING)
     rerender(
       <Sel selected>
         <div>card</div>
       </Sel>
     )
-    expect(container.firstElementChild?.className).toContain('shadow-[0_0_0_3px')
+    expect(container.firstElementChild?.className).toContain(SELECTION_RING)
   })
 
   test('onToggle makes the wrapper keyboard-operable', () => {

--- a/packages/component-lib/src/components/chrome/interaction.ts
+++ b/packages/component-lib/src/components/chrome/interaction.ts
@@ -4,17 +4,36 @@ import type { KeyboardEvent } from 'react'
  * Shared interaction primitives for the chrome atoms — one source of truth for
  * the focus ring, disabled treatment, selection ring, and keyboard activation
  * that Button / StepButton / Sel would otherwise each re-inline.
+ *
+ * ## These are `.su-*` class NAMES now, not Tailwind class strings (#799, #802)
+ *
+ * The SHAPE is unchanged — each is still a string you drop into `className`,
+ * still composes through `cn()`, still works on any element — so no call site
+ * moves, in this package or in either app. What changed is where the rules
+ * live: `src/styles/index.css`, rather than Tailwind's generated utilities.
+ *
+ * **Why these do not get the split rule's style-object half.** That half
+ * assumes the library owns the element being styled. These deliberately do not:
+ * they exist so a consuming app can put the treatment on an element the library
+ * never renders, which is the whole reason they are exported. A constant
+ * holding a string cannot carry a style object without changing its type, and
+ * its type is public API. So they were always going to be stylesheet-only the
+ * moment Tailwind left — a class name is the only thing they can carry. The
+ * category is written up in this package's CLAUDE.md as the split rule's
+ * BOUNDARY, not an exception to it.
+ *
+ * **The names are public API.** Apps compose them with `cn()`, so they land in
+ * app-side code and cannot be renamed cheaply. Treat a new one as a commitment.
  */
 
 /** The canonical rust focus ring (design-spec §2.4). */
-export const FOCUS_RING =
-  'focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-rust/25'
+export const FOCUS_RING = 'su-focus-ring'
 
 /**
  * The same rust ring for text inputs (design-spec §2.5), on plain `focus:` —
  * an editable control shows the ring on every focus, not just keyboard focus.
  */
-export const INPUT_FOCUS = 'focus:outline-none focus:ring-[3px] focus:ring-rust/25'
+export const INPUT_FOCUS = 'su-input-focus'
 
 /**
  * The same rust ring again, raised by a focusable DESCENDANT — the search-field
@@ -29,7 +48,7 @@ export const INPUT_FOCUS = 'focus:outline-none focus:ring-[3px] focus:ring-rust/
  * signal that the vocabulary was missing a word, not that the surfaces were
  * special.
  */
-export const FOCUS_WITHIN = 'focus-within:ring-[3px] focus-within:ring-rust/25'
+export const FOCUS_WITHIN = 'su-focus-within'
 
 /**
  * The ON-TONE rung: an ink ring with a paper offset, for a focusable surface
@@ -42,22 +61,20 @@ export const FOCUS_WITHIN = 'focus-within:ring-[3px] focus-within:ring-rust/25'
  * background is not one. Reach for it ONLY when the background is caller-supplied
  * tone; everything sitting on paper uses `FOCUS_RING`.
  */
-export const FOCUS_RING_ON_TONE =
-  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink focus-visible:ring-offset-2 focus-visible:ring-offset-paper'
+export const FOCUS_RING_ON_TONE = 'su-focus-ring-on-tone'
 
 /** The canonical disabled treatment (opacity + no pointer events). */
-export const DISABLED = 'disabled:pointer-events-none disabled:opacity-40'
+export const DISABLED = 'su-disabled'
 
 /** Non-layout-shifting 3px rust selection ring (design-spec §2.8). */
-export const SELECTION_RING = 'shadow-[0_0_0_3px_var(--color-rust)]'
+export const SELECTION_RING = 'su-selection-ring'
 
 /**
  * Double-ink "halo" selection ring — a ground gap then a 3px ink ring, the
  * emphasis the onboarding doors / custom-build door use instead of the rust
  * ring. Opt in via `Sel`'s `ring="ink-double"`.
  */
-export const SELECTION_RING_INK_DOUBLE =
-  'shadow-[0_0_0_3px_var(--ground),0_0_0_6px_var(--color-ink)]'
+export const SELECTION_RING_INK_DOUBLE = 'su-selection-ring-ink-double'
 
 /**
  * Enter/Space → activate, matching native button semantics on a `div` wrapper

--- a/packages/component-lib/src/components/shared/__tests__/Card.test.tsx
+++ b/packages/component-lib/src/components/shared/__tests__/Card.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { fireEvent, render, screen } from '@testing-library/react'
 import { renderToStaticMarkup } from 'react-dom/server'
+import { FOCUS_RING_ON_TONE } from '../../chrome/interaction'
 import type { ReferenceEntityControl } from '../../referenceEntity/referenceEntityControlTypes'
 import { Card } from '../Card'
 
@@ -372,12 +373,17 @@ describe('Card', () => {
     // Wrapper should be keyboard-focusable when clickable
     expect(wrapper.getAttribute('tabIndex')).toBe('0')
     expect(wrapper.getAttribute('role')).toBe('button')
-    // Ring-based focus indicator with a contrasting offset color so the outline
-    // remains visible on both light and dark tech-level backgrounds.
-    expect(wrapper.className).toContain('focus-visible:ring-2')
-    expect(wrapper.className).toContain('focus-visible:ring-ink')
-    expect(wrapper.className).toContain('focus-visible:ring-offset-2')
-    expect(wrapper.className).toContain('focus-visible:ring-offset-paper')
+    // Ring-based focus indicator with a contrasting offset colour so the ring
+    // stays visible on both the light and the dark end of the tech-level ramp.
+    //
+    // One assertion, on the exported constant, where there were four on the
+    // pieces of its Tailwind spelling (`ring-ink`, `ring-offset-2`,
+    // `ring-offset-paper`). The vocabulary moved to `.su-*` names in #799, and
+    // the ring's composition is the STYLESHEET's business now — what this test
+    // is actually about is that a clickable Card reaches for the on-tone rung
+    // rather than the soft one. Re-spelling the four would just re-pin the test
+    // to an implementation detail a rename can move.
+    expect(wrapper.className).toContain(FOCUS_RING_ON_TONE)
   })
 
   test('non-button (non-clickable) card does not render focus ring classes', () => {

--- a/packages/component-lib/src/components/shared/__tests__/Stat.test.tsx
+++ b/packages/component-lib/src/components/shared/__tests__/Stat.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import { render, screen } from '@testing-library/react'
+import { FOCUS_RING } from '../../chrome/interaction'
 import { Stat } from '../Stat'
 
 describe('Stat', () => {
@@ -29,6 +30,6 @@ describe('Stat', () => {
   test('interactive stat has focus-visible outline for keyboard users', () => {
     const { getByRole } = render(<Stat label="HP" value={10} onClick={() => {}} />)
     const button = getByRole('button')
-    expect(button.className).toContain('focus-visible:outline')
+    expect(button.className).toContain(FOCUS_RING)
   })
 })

--- a/packages/component-lib/src/styles/index.css
+++ b/packages/component-lib/src/styles/index.css
@@ -425,6 +425,53 @@ body {
   box-shadow: 0 0 0 3px var(--su-color-rust-25);
 }
 
+/*
+ * The INPUT focus rung, as a standalone class.
+ *
+ * Distinct from `.su-input` above, which also paints an input's resting shell.
+ * This one is ring-only, so a control that already owns its frame takes the
+ * canonical ring without inheriting a second border. Plain `:focus`, not
+ * `:focus-visible` — an editable control shows the ring on every focus.
+ */
+.su-input-focus:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--su-color-rust-25);
+}
+
+/** The canonical disabled treatment. */
+.su-disabled:disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+/*
+ * The SELECTION rings — a box-shadow rather than a border, so a selected card
+ * does not nudge its neighbours (design-spec §2.8).
+ *
+ * Unlike the focus rings these are NOT stateful: selection is application
+ * state, not a CSS pseudo-class, so the class is applied conditionally from
+ * TypeScript and the rule itself is unconditional. They live here because they
+ * are class-string exports (see the class-string exemption in this package's
+ * CLAUDE.md), not because a style object could not hold them.
+ */
+.su-selection-ring {
+  box-shadow: 0 0 0 3px var(--su-color-rust);
+}
+
+/*
+ * The double-ink "halo" — a ground-coloured gap, then a 3px ink ring. The
+ * emphasis the onboarding doors use instead of the rust ring.
+ *
+ * `--ground` is supplied by the CALLER, which is the whole point: the gap has
+ * to match whatever surface the door is sitting on, so it is a bare custom
+ * property rather than a token.
+ */
+.su-selection-ring-ink-double {
+  box-shadow:
+    0 0 0 3px var(--ground),
+    0 0 0 6px var(--su-color-ink);
+}
+
 /* ══ Mobile-first touch targets ═════════════════════════════════════════════ */
 @media (pointer: coarse) {
   button,


### PR DESCRIPTION
Atoms layer, **part 1 of 3** (#799, epic #802). The class-string exports, authorized on #799. Stacked on #816 → #815 → #814.

## What changed

`FOCUS_RING`, `INPUT_FOCUS`, `FOCUS_WITHIN`, `FOCUS_RING_ON_TONE`, `DISABLED`, `SELECTION_RING`, `SELECTION_RING_INK_DOUBLE` now hold `.su-*` class names instead of Tailwind class strings.

**The shape is identical.** Each is still a string dropped into `className`, still composes through `cn()`, still works on any element. **No call site moves** — not in this package, not in either app. What changed is where the rules live.

| export | before | after |
|---|---|---|
| `FOCUS_RING` | `focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-rust/25` | `su-focus-ring` |
| `INPUT_FOCUS` | `focus:outline-none focus:ring-[3px] focus:ring-rust/25` | `su-input-focus` |
| `FOCUS_WITHIN` | `focus-within:ring-[3px] focus-within:ring-rust/25` | `su-focus-within` |
| `FOCUS_RING_ON_TONE` | `focus-visible:outline-none focus-visible:ring-2 …` | `su-focus-ring-on-tone` |
| `DISABLED` | `disabled:pointer-events-none disabled:opacity-40` | `su-disabled` |
| `SELECTION_RING` | `shadow-[0_0_0_3px_var(--color-rust)]` | `su-selection-ring` |
| `SELECTION_RING_INK_DOUBLE` | `shadow-[0_0_0_3px_var(--ground),…]` | `su-selection-ring-ink-double` |

Four of the rules already existed in `index.css` from #798; three are new (`.su-input-focus`, `.su-disabled`, and the two selection rings).

## Why these skip the style-object half

This is the split rule's **boundary**, not an exception to it. That half assumes the library owns the element it is styling — and these deliberately do not. They exist so a consuming app can put the treatment on an element the library never renders, which is the documented reason they are exported at all:

> *"Exported because the APPS need it, not only the lib… A design system the consuming apps cannot import is one they will re-invent."*

A constant holding a string cannot carry a style object without changing its type, and its type is public API. So these were always going to be stylesheet-only the moment Tailwind left — a class name is the only thing they can carry. The category is written up in `packages/component-lib/CLAUDE.md` (landed in #815) so the next reader sees this as the rule's edge rather than a violation of it.

**The `.su-*` names are public API from this commit on.** Apps compose them with `cn()`, so they will end up in app-side code and cannot be renamed cheaply.

One thing worth noticing: the **selection rings are not stateful**. Selection is application state, not a CSS pseudo-class, so the class is applied conditionally from TypeScript and the rule itself is unconditional. They live in the stylesheet because they are class-string exports, not because a style object could not hold them — the two reasons are different and only the first applies here.

## Eight test assertions re-pointed from spellings to constants

These asserted on `'disabled:opacity-40'`, `'focus:ring-'`, `'shadow-[0_0_0_3px'`, `'focus-visible:outline'` — the Tailwind *spelling* of the thing rather than the thing. They now assert `toContain(DISABLED)`, `toContain(INPUT_FOCUS)` and so on, so a future rename moves them for free instead of breaking them.

Card's on-tone test is the one judgement call: it had **four** assertions on the pieces of the ring's spelling (`ring-ink`, `ring-offset-2`, `ring-offset-paper`, plus the base). That collapsed to one on `FOCUS_RING_ON_TONE`. The ring's composition is the stylesheet's business now, and what the test is actually about is that a clickable Card reaches for the **on-tone** rung rather than the soft one — re-spelling the four would just re-pin it to an implementation detail.

## Verified in a browser, not by inspection

A real **Tab** press onto a Button:

```
matchesFocusVisible: true
boxShadow:           rgba(168, 82, 34, 0.25) 0px 0px 0px 3px
outline:             none
```

That is the canonical rust ring at 3px, resolved from `index.css` — and it also confirms #815's finding, since #798's rules would have painted `ink/20` here. A disabled Button computes `opacity: 0.4` / `pointer-events: none`.

Worth recording for whoever checks this next: **programmatic `.focus()` does not reproduce it.** `:focus-visible` depends on the keyboard heuristic, so `el.focus()` reports `boxShadow: none` and looks like a regression. The check has to be a real key press.

## Verification

- `bun run --filter component-lib test` — 766 pass, 0 fail (same count as baseline)
- `bun --filter component-lib typecheck` — clean
- `bun run check:tokens` — no new violations (24 known)
- `bun run check:styling` — no new violations (0 known)
- Biome clean
- `ladle:build` succeeds; the three new rules confirmed present in the emitted CSS

## Still to come in Atoms

- **Part 2** — `capsLabel` (internal-only: 37 lib usages, 0 app) plus the leaf atoms.
- **Part 3** — `buttonVariants` + Button, on the same `.su-*` basis.

Refs #799.
