### PR TITLE
docs(component-lib): promote the :focus vs :focus-visible split out of a footnote

### DIFF
--- a/packages/component-lib/CLAUDE.md
+++ b/packages/component-lib/CLAUDE.md
@@ -151,11 +151,35 @@ invites someone to "fix" it until it really is. Verified on the real thing —
 `rgba(168, 82, 34, 0.25) 0 0 0 3px`.
 
 So to check a focus style: send a real key press (a browser driver's Tab key), or
-assert `el.matches(':focus-visible')` alongside the computed value so a false
-negative is distinguishable from a real one. `:focus` rungs — `.su-input-focus`,
-`.su-focus-within` — are exempt from this and do respond to `.focus()`, which is
-its own trap, since it makes the two rungs behave differently under the same
-check for reasons that have nothing to do with either being correct.
+assert `el.matches(':focus-visible')` alongside the computed value, so a false
+negative is distinguishable from a real one.
+
+#### The worse half: the two rungs disagree under the same check
+
+**Only the `:focus-visible` rungs are affected. The `:focus` rungs respond to
+`.focus()` perfectly well.**
+
+| rung | selector | responds to `el.focus()`? |
+| --- | --- | --- |
+| `.su-focus-ring` | `:focus-visible` | **no** |
+| `.su-focus-ring-on-tone` | `:focus-visible` | **no** |
+| `.su-button` | `:focus-visible` | **no** |
+| `.su-input-focus` | `:focus` | yes |
+| `.su-input` | `:focus` | yes |
+| `.su-focus-within` | `:focus-within` | yes |
+
+That split is worse than the original trap, and it is the reason this is a
+section rather than a footnote. Spot-check a handful of components with
+`.focus()` and the results are *internally inconsistent*: inputs light up,
+buttons do not. The natural reading is "the focus treatment is applied
+unevenly — some components got it, some were missed", and someone then goes
+looking for the components that were "missed". Every one of them is correct;
+the check is the variable.
+
+The failure mode is not "I could not verify this". It is **"I verified it and
+concluded something false"**, which is the one that produces work. If two focus
+rungs ever appear to disagree, confirm the selector each one uses before
+concluding anything about the components.
 
 ### Checking cascade layers: assert on the DECLARATION, never on block position
 


### PR DESCRIPTION
A follow-up to #817, which merged while this commit was still local. Docs only — one file, no code.

#817 landed the `:focus-visible` verification gotcha as a section with the divergence noted in a trailing sentence. This promotes that divergence to its own sub-section with a per-rung table, because it is the more dangerous half.

## Why it needed promoting

**Only the `:focus-visible` rungs ignore programmatic focus.** The `:focus` and `:focus-within` rungs respond to `el.focus()` perfectly well:

| rung | selector | responds to `el.focus()`? |
| --- | --- | --- |
| `.su-focus-ring` | `:focus-visible` | **no** |
| `.su-focus-ring-on-tone` | `:focus-visible` | **no** |
| `.su-button` | `:focus-visible` | **no** |
| `.su-input-focus` | `:focus` | yes |
| `.su-input` | `:focus` | yes |
| `.su-focus-within` | `:focus-within` | yes |

Spot-check a handful of components with `.focus()` and the results are *internally inconsistent* — inputs light up, buttons do not. The natural reading is "the focus treatment was applied unevenly; some components got it and some were missed", and someone then goes hunting for the ones that were missed. Every one of them is correct. The check is the variable.

The failure mode is not *"I could not verify this"* — that one is self-announcing and cheap. It is **"I verified it and concluded something false"**, which is the one that produces work: a hunt for a bug that does not exist, and possibly a "fix" to a component that was right.

That is a different shape from the trap in #817 (a working ring reading as missing), and a trailing sentence was not enough to carry it.

## Accuracy note

The table lists only selectors that exist in `index.css` today — verified against the file rather than written from memory. `.su-button` is #798's; Button's own rung joins the list when Button migrates in Atoms part 3.

## Verification

`bun run check:all` — exit 0.

Refs #799.
