### PR TITLE
feat(component-lib): move the capsLabel recipe onto .su-caps class names

### DIFF
--- a/.claude/rules/stacked-prs.md
+++ b/.claude/rules/stacked-prs.md
@@ -1,0 +1,97 @@
+# Stacked PRs on a squash-merge repo
+
+This repo is **squash-only** with `delete_branch_on_merge`. Both settings are
+deliberate, and together they make stacked PRs behave in two ways that surprise
+people. Neither is a bug; both cost real time when met cold.
+
+Written from the #799 Tailwind-removal work, which ran a four-deep stack through
+four merges.
+
+## 1. A squash merge orphans every layer above it
+
+When the bottom PR squash-merges, `main` gains **one new commit** and none of
+that branch's original SHAs. Every layer above it still carries those SHAs, so
+GitHub retargets the next PR to `main` and it reports **its own work plus
+everything below it** — a 3-file PR shows as 14.
+
+`gh pr update-branch --rebase` cannot fix it: it fails with
+`rebase conflict between base and head`, because the duplicated commit collides
+with its own squashed self.
+
+The fix is `--onto`, which replays only the commits *after* the old branch point
+and drops the duplicate rather than re-applying it:
+
+```sh
+git fetch origin
+git rebase --onto origin/main <old-parent-branch-tip> <this-branch>
+git push --force-with-lease
+```
+
+Record the parent's tip SHA **before** rebasing — the branch ref moves, and
+after that the range is unrecoverable without the reflog.
+
+**A conflict here should be the duplicate and nothing else.** All four rebases on
+#799 were conflict-free, precisely because the only overlap was the squash
+artefact. If `--onto` raises a conflict that is genuinely about *your* changes,
+stop: that means two layers edited the same lines, which is a real merge problem
+and not this one.
+
+**Verify before pushing**, every time — the PR should show only that layer's own
+files and commits. That check is the whole point; a rebase that looks clean and
+leaves a duplicate is the failure mode.
+
+## 2. `--force-with-lease`, never `--force`
+
+Not the textbook reason. The usual argument for the lease is "someone else
+pushed to your branch". On this repo the more likely case is that the **branch no
+longer exists**: the merge deleted it, and the lease refuses to push to a ref
+that is gone.
+
+A bare `--force` there would **recreate a deleted branch and reopen the head of
+an already-merged PR** — which looks like live work, invites a second merge of
+something already landed, and takes a while to diagnose from the other end.
+
+This happened on #799: a doc commit was in flight when the PR merged, and the
+lease rejected the push as `stale info`. The right recovery is to cherry-pick the
+orphaned commit onto fresh `main` as a new branch, not to force the old one back
+into existence.
+
+**On a squash-merge repo with `delete_branch_on_merge`, `--force` can resurrect
+state the merge deliberately destroyed. The lease is what stops it.**
+
+## 3. Prefer `gh stack` for anything more than two layers
+
+The official `github/gh-stack` extension owns the cascading rebase, which is the
+part that gets expensive as layers multiply. Use it once a change wants three or
+more reviewable layers; below that the ceremony is not worth it.
+
+- `gh stack init <branch>` — **the branch argument is required.** The bare form
+  fails with `interactive input required; provide branch names as arguments`,
+  which will stop an unattended agent that assumes otherwise.
+- `gh stack submit --auto --open` — `--auto` takes an auto-generated title, so
+  set the real title and body with `gh pr edit` afterwards.
+- `gh stack sync` after **every** merge beneath you. Do not hand-rebase inside a
+  gh-managed stack; that is how the tool's state and the branches diverge.
+
+**Stack state lives in `.git/gh-stack`, which is per-clone and untracked.** A
+fresh agent worktree therefore does not inherit it: the branch is stacked on
+GitHub and looks unstacked locally, with nothing on disk explaining why.
+`gh stack checkout <pr#|branch>` re-attaches. Run `gh stack view` before
+concluding anything about a stack's shape.
+
+## 4. A read is only true at the instant it is taken
+
+Two agents working one stack — one merging, one pushing — will routinely send
+each other state that is already stale. On #799 three consecutive "this PR is at
+N files" reports were overtaken by a push before they arrived. Nobody was wrong;
+the reads were accurate when taken.
+
+Two habits that make this cheap:
+
+- **Verify before acting** on someone else's state line. Re-query, then act.
+- **Say what you want, not what you see** — "cascade #817 when #816 lands" keeps
+  its meaning; "#817 is at 11 files" expires.
+
+Related: when reporting merge status, say *who* merged. "None merged" meaning "I
+have merged nothing" reads as "nothing has merged" to someone who is merging
+underneath you.

--- a/packages/component-lib/src/components/chrome/__tests__/chrome.test.tsx
+++ b/packages/component-lib/src/components/chrome/__tests__/chrome.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { Badge } from '../Badge'
 import { Button } from '../Button'
 import { ConditionChip, Conditions } from '../Conditions'
+import { capsLabel } from '../capsLabel'
 import { EmptyState } from '../EmptyState'
 import { Field, Input, Select, Textarea } from '../Field'
 import { Glyph } from '../glyphs'
@@ -221,7 +222,12 @@ describe('StepButton / Button xs', () => {
 
   test('Button size="mini" renders the compact uppercase action (former MiniBtn)', () => {
     render(<Button size="mini">⇄ Swap</Button>)
-    expect(screen.getByRole('button', { name: '⇄ Swap' }).className).toContain('uppercase')
+    // The condensed-caps treatment is the `capsLabel` recipe, which emits
+    // `.su-*` names since #799. Asked of the recipe rather than spelled, so a
+    // rename moves this for free.
+    expect(screen.getByRole('button', { name: '⇄ Swap' }).className).toContain(
+      capsLabel({ weight: 'inherit', tracking: 'inherit' })
+    )
   })
 })
 
@@ -231,8 +237,13 @@ describe('Stamp', () => {
     const stamp = screen.getByText('Mule')
     expect(stamp.className).toContain('bg-ink')
     expect(stamp.className).toContain('text-paper')
-    expect(stamp.className).toContain('uppercase')
-    expect(stamp.className).toContain('tracking-caps-tight')
+    // One assertion, on the recipe's own output for the rungs a stamp uses,
+    // where there were two on Tailwind spellings (`uppercase`, then
+    // `tracking-caps-tight`). Both were describing the same fact — that a stamp
+    // is the condensed-caps label at its default tracking — and the recipe is
+    // the thing that decides it, so asking the recipe is both shorter and
+    // rename-proof.
+    expect(stamp.className).toContain(capsLabel({ size: undefined }))
   })
 
   test('inverse surface flips to paper-on-ink; seam rides the border', () => {

--- a/packages/component-lib/src/components/chrome/capsLabel.ts
+++ b/packages/component-lib/src/components/chrome/capsLabel.ts
@@ -6,81 +6,95 @@ import { cva } from 'class-variance-authority'
  *
  * `font-cond` + `uppercase` + a size + a weight + a tracking is the single most
  * repeated class shape in this repo: ~188 hand-spelled occurrences across ~98
- * files, and until now there was no primitive for it. `Text` deliberately has
- * no stamp/label variant (that role is `Badge shape="stamp"`), so every caps
- * label in a rail, a section header, a gauge cap or a key/value row re-derived
- * the same five decisions from scratch — which is exactly how four sites ended
- * up on Tailwind's built-in `tracking-wide` while their siblings sat on a
- * semantic rung.
+ * files, and until this existed there was no primitive for it. `Text`
+ * deliberately has no stamp/label variant (that role is `Badge shape="stamp"`),
+ * so every caps label in a rail, a section header, a gauge cap or a key/value
+ * row re-derived the same five decisions from scratch — which is exactly how
+ * four sites ended up on Tailwind's built-in `tracking-wide` while their
+ * siblings sat on a semantic rung.
+ *
+ * ## Emits `.su-*` class names now, not Tailwind classes (#799, epic #802)
+ *
+ * The recipe's SHAPE is unchanged — same axes, same values, same defaults, same
+ * `(opts) => string` signature — so **no call site moves**. Only the class names
+ * it returns changed, and the rules behind them live in `src/styles/index.css`.
+ *
+ * It stays a class-string emitter rather than becoming a `CSSProperties` object,
+ * even though every property it sets is static and the split rule would
+ * otherwise put all of it inline. The reason is `buttonVariants`: that is a
+ * public class-string export which composes this recipe into its own output,
+ * and both apps put that output on `<a>` elements. A recipe feeding a class
+ * string has to BE a class string. See the class-string exemption in this
+ * package's CLAUDE.md — this is the "anything built on them inherits the same
+ * constraint" clause. Worth revisiting once Button migrates.
  *
  * ## What this recipe does and does NOT standardise
  *
- * It locks the two invariants (`font-cond`, `uppercase`) into the base and
+ * It locks the two invariants (condensed face, uppercase) into the base and
  * makes the three genuinely-varying decisions NAMED axes. It does **not**
  * collapse the tracking ladder onto one rung: `docs/design-system/ruleset.md`
- * §4.2 (lines 235-256) considered that consolidation and **declined** it —
- * "the wide rungs are in deliberate, active use. Ratified as-is rather than
- * re-lettering every label in the app." So `tracking` is an axis with
- * `caps-tight` as its DEFAULT (the ruleset's stated default for a label:
- * "reach up the ladder only deliberately"), not a constant.
+ * §4.2 considered that consolidation and **declined** it — "the wide rungs are
+ * in deliberate, active use. Ratified as-is rather than re-lettering every label
+ * in the app." So `tracking` is an axis with `tight` as its DEFAULT (the
+ * ruleset's stated default for a label: "reach up the ladder only
+ * deliberately"), not a constant.
  *
- * The `size` axis carries only rungs of the **semantic** type ladder
- * (`--text-*` in `theme.css`). Sites currently on Tailwind's default scale
- * (`text-xs`, `text-sm`, `text-lg`, `text-3xl`) are deliberately NOT expressible
- * here — moving `text-sm` (14px) to `text-caption` (13px) is a per-site design
- * call, not a rename, so those sites keep their own class until someone rules
- * on each one. `size` has no default for the same reason a `Badge` chip supplies
- * its own: omit it and the recipe emits no size at all.
+ * The `size` axis carries only rungs of the **semantic** type ladder. Sites
+ * currently on Tailwind's default scale (`text-xs`, `text-sm`, `text-lg`,
+ * `text-3xl`) are deliberately NOT expressible here — moving `text-sm` (14px) to
+ * `text-caption` (13px) is a per-site design call, not a rename, so those sites
+ * keep their own size class until someone rules on each one. `size` has no
+ * default for the same reason a `Badge` chip supplies its own: omit it and the
+ * recipe emits no size at all.
  */
-export const capsLabel = cva('font-cond uppercase', {
+export const capsLabel = cva('su-caps', {
   variants: {
     /**
-     * Semantic type-ladder rungs only (`theme.css` §"Semantic type scale").
-     * Omit when the caller already supplies the size — a `Badge` surface, a
-     * `Button` size, or a container-driven step.
+     * Semantic type-ladder rungs only. Omit when the caller already supplies
+     * the size — a `Badge` surface, a `Button` size, or a container-driven step.
      */
     size: {
-      nano: 'text-nano',
-      micro: 'text-micro',
-      label: 'text-label',
-      'label-lg': 'text-label-lg',
-      badge: 'text-badge',
-      note: 'text-note',
-      caption: 'text-caption',
-      lede: 'text-lede',
-      readout: 'text-readout',
-      title: 'text-title',
-      display: 'text-display',
+      nano: 'su-caps--nano',
+      micro: 'su-caps--micro',
+      label: 'su-caps--label',
+      'label-lg': 'su-caps--label-lg',
+      badge: 'su-caps--badge',
+      note: 'su-caps--note',
+      caption: 'su-caps--caption',
+      lede: 'su-caps--lede',
+      readout: 'su-caps--readout',
+      title: 'su-caps--title',
+      display: 'su-caps--display',
     },
     /**
      * Caps labels run bold by default; `semibold` is the chip weight.
-     * `inherit` emits NOTHING — it is not `font-normal`. The distinction is
+     * `inherit` emits NOTHING — it is not a 400 weight. The distinction is
      * load-bearing: a label with no weight class inherits its container's
      * weight, and pinning it to 400 would silently un-bold every such label
      * that happens to sit inside a bold stamp or heading.
      */
     weight: {
       inherit: '',
-      normal: 'font-normal',
-      semibold: 'font-semibold',
-      bold: 'font-bold',
+      normal: 'su-caps--w-normal',
+      semibold: 'su-caps--w-semibold',
+      bold: 'su-caps--w-bold',
     },
     /**
      * The ratified multi-rung caps ladder (ruleset §4.2). `tight` is the
-     * default; the others exist because they are in deliberate use.
-     * `none` is Tailwind's `tracking-normal`, for the caps labels that
-     * deliberately do not letterspace (the `Button` mini chip). `inherit`
-     * emits nothing, for labels whose tracking is supplied by the surface
-     * around them (a `Badge` surface picks `caps` or `caps-snug` itself).
+     * default; the others exist because they are in deliberate use. `none` is
+     * the normal letter-spacing, for the caps labels that deliberately do not
+     * letterspace (the `Button` mini chip). `inherit` emits nothing, for labels
+     * whose tracking is supplied by the surface around them (a `Badge` surface
+     * picks `caps` or `caps-snug` itself).
      */
     tracking: {
       inherit: '',
-      none: 'tracking-normal',
-      tight: 'tracking-caps-tight',
-      snug: 'tracking-caps-snug',
-      caps: 'tracking-caps',
-      wide: 'tracking-caps-wide',
-      eyebrow: 'tracking-eyebrow',
+      none: 'su-caps--t-none',
+      tight: 'su-caps--t-tight',
+      snug: 'su-caps--t-snug',
+      caps: 'su-caps--t-caps',
+      wide: 'su-caps--t-wide',
+      eyebrow: 'su-caps--t-eyebrow',
     },
   },
   defaultVariants: {

--- a/packages/component-lib/src/styles/index.css
+++ b/packages/component-lib/src/styles/index.css
@@ -472,6 +472,101 @@ body {
     0 0 0 6px var(--su-color-ink);
 }
 
+/* ══ The condensed-caps label ═══════════════════════════════════════════════
+ *
+ * The `capsLabel` recipe (`components/chrome/capsLabel.ts`), as classes.
+ *
+ * WHY CLASSES AND NOT A STYLE OBJECT, given every property here is static and
+ * the split rule would otherwise send all of it inline: `capsLabel` is composed
+ * INTO `buttonVariants`, which is a public class-string export that both apps
+ * put on `<a>` elements. A recipe feeding a class string has to be a class
+ * string itself. That is the "anything built on them inherits the same
+ * constraint" clause of the class-string exemption in this package's CLAUDE.md,
+ * and it is the whole reason this is a CSS block rather than a `CSSProperties`
+ * object. Worth revisiting once Button migrates.
+ *
+ * The two invariants live on the base; the three genuinely-varying decisions
+ * are modifiers, exactly as the cva had them. `inherit` on weight or tracking
+ * emits NO class, which is load-bearing: a label with no weight class inherits
+ * its container's, and pinning it to 400 would silently un-bold every such
+ * label sitting inside a bold stamp or heading.
+ */
+.su-caps {
+  font-family: var(--su-font-cond);
+  text-transform: uppercase;
+}
+
+/* Semantic type-ladder rungs only. A site on an inherited Tailwind rung
+   (`text-sm`, `text-lg`, …) is deliberately NOT expressible here — moving
+   `text-sm` (14px) to `text-caption` (13px) is a per-site design call, not a
+   rename, so those keep their own size until someone rules on each one. */
+.su-caps--nano {
+  font-size: var(--su-text-nano);
+}
+.su-caps--micro {
+  font-size: var(--su-text-micro);
+}
+.su-caps--label {
+  font-size: var(--su-text-label);
+}
+.su-caps--label-lg {
+  font-size: var(--su-text-label-lg);
+}
+.su-caps--badge {
+  font-size: var(--su-text-badge);
+}
+.su-caps--note {
+  font-size: var(--su-text-note);
+}
+.su-caps--caption {
+  font-size: var(--su-text-caption);
+}
+.su-caps--lede {
+  font-size: var(--su-text-lede);
+}
+.su-caps--readout {
+  font-size: var(--su-text-readout);
+}
+.su-caps--title {
+  font-size: var(--su-text-title);
+}
+.su-caps--display {
+  font-size: var(--su-text-display);
+}
+
+/* Caps labels run bold by default; `semibold` is the chip weight. */
+.su-caps--w-normal {
+  font-weight: var(--su-weight-normal);
+}
+.su-caps--w-semibold {
+  font-weight: var(--su-weight-semibold);
+}
+.su-caps--w-bold {
+  font-weight: var(--su-weight-bold);
+}
+
+/* The ratified multi-rung caps ladder (ruleset §4.2) — `tight` is the default,
+   and the wider rungs exist because they are in deliberate use. `none` is for
+   the caps labels that deliberately do not letterspace (the Button mini chip). */
+.su-caps--t-none {
+  letter-spacing: normal;
+}
+.su-caps--t-tight {
+  letter-spacing: var(--su-tracking-caps-tight);
+}
+.su-caps--t-snug {
+  letter-spacing: var(--su-tracking-caps-snug);
+}
+.su-caps--t-caps {
+  letter-spacing: var(--su-tracking-caps);
+}
+.su-caps--t-wide {
+  letter-spacing: var(--su-tracking-caps-wide);
+}
+.su-caps--t-eyebrow {
+  letter-spacing: var(--su-tracking-eyebrow);
+}
+
 /* ══ Mobile-first touch targets ═════════════════════════════════════════════ */
 @media (pointer: coarse) {
   button,


### PR DESCRIPTION
Atoms layer, **part 2 of 3** (#799, epic #802). First PR on `gh stack`.

## What changed

`capsLabel` now emits `.su-caps` / `.su-caps--*` names instead of Tailwind classes. Same axes, same values, same defaults, same `(opts) => string` signature — so **none of its 14 call sites move**, across 10 files. Only the names it returns changed; the rules behind them live in `src/styles/index.css`.

| axis | before | after |
|---|---|---|
| base | `font-cond uppercase` | `su-caps` |
| `size` | `text-nano` … `text-display` | `su-caps--nano` … `su-caps--display` |
| `weight` | `font-normal` / `font-semibold` / `font-bold` | `su-caps--w-*` |
| `tracking` | `tracking-normal` / `tracking-caps-tight` / … | `su-caps--t-*` |

`inherit` on weight and tracking still emits **nothing**, which is load-bearing and the easiest thing to lose in a port: a label with no weight class inherits its container's, and pinning it to 400 would silently un-bold every such label sitting inside a bold stamp or heading.

## Why it stays a class-string emitter

Every property `capsLabel` sets is static, so the split rule would ordinarily send all of it into a `CSSProperties` object — and `capsLabel` is internal-only (0 app usages), so changing its return type would break no consumer outside this package.

It stays a class string anyway, and the reason is a hard constraint rather than a preference: **`buttonVariants` composes `capsLabel` into its own output**, and `buttonVariants` is a public class-string export that both apps put on `<a>` elements. A recipe feeding a class string has to *be* a class string.

That is the *"anything built on them inherits the same constraint"* clause of the class-string exemption (`packages/component-lib/CLAUDE.md`, landed in #815). Worth revisiting once Button migrates in part 3 and `buttonVariants` is the only thing holding the shape.

## Three more test assertions re-pointed from spellings to the recipe

Same species as #817's eight. These asserted `'uppercase'` and `'tracking-caps-tight'` — the Tailwind *spelling* of the treatment, not the treatment — so they broke on a change that altered nothing observable.

They now ask `capsLabel` for its own output, which is both rename-proof and closer to the actual subject. The Stamp test collapsed two assertions into one for the same reason: `'uppercase'` and `'tracking-caps-tight'` were both describing the single fact that a stamp is the condensed-caps label at its default tracking, and the recipe is what decides that.

## Verified in a browser, not from the class list

Tests can only prove the class was *applied*. This proves the rule behind it *resolves* — a rendered `Badge shape="stamp"`:

```
fontFamily:     "Barlow Semi Condensed", Barlow, system-…
textTransform:  uppercase
fontWeight:     700
letterSpacing:  0.48px     ← 0.04em at 12px, the capsTight rung
fontSize:       12px       ← Tailwind's text-xs; Badge supplies its own size,
                             and capsLabel correctly emitted no size modifier
```

That last line is the interesting one: the size still comes from Badge's own Tailwind class and wins over the (absent) recipe size, exactly as before.

## Verification

- `bun run check:all` — **exit 0**
- `bun run --filter component-lib test` — 766 pass, 0 fail (same count as baseline)
- `ladle:build` succeeds; all 21 `.su-caps*` rules confirmed in the emitted CSS
- No component API, prop, barrel export or app file touched

## Notes on the stack

This is the first PR managed by `gh stack` rather than plain branches — the switch agreed on #799 after four hand `--onto` rebases. Part 3 (`buttonVariants` + Button) stacks on top of this.

**For anyone picking this up in a fresh checkout:** stack state lives in `.git/gh-stack`, which is per-clone and untracked, so a new worktree sees a branch that is stacked on GitHub and looks unstacked locally. `gh stack checkout <pr#|branch>` re-attaches. Run `gh stack view` before assuming.

Refs #799.
