### PR TITLE
fix(ci): widen the coverage retry budget to 3, and catch a truncated lcov

### DIFF
--- a/tools/run-coverage.test.ts
+++ b/tools/run-coverage.test.ts
@@ -69,3 +69,34 @@ describe('coverage tooling workspace lists', () => {
     }
   })
 })
+
+/**
+ * The retry budget and the readability check, asserted against the source text
+ * for the same reason as everything above: `run-coverage.ts` does its work at
+ * module scope, so importing it would run the whole coverage suite.
+ *
+ * Both of these are the fix for #818 and both are quiet to regress — a budget
+ * trimmed back to 2 looks like tidying, and swapping `wroteCoverage` for a bare
+ * `existsSync` looks like simplification. Each would silently restore a failure
+ * that costs a re-run on every PR.
+ */
+describe('run-coverage retry budget (#818)', () => {
+  const runner = read('run-coverage.ts')
+
+  it('allows at least 3 attempts before calling a workspace deterministically broken', () => {
+    const match = runner.match(/const ATTEMPTS = (\d+)/)
+    expect(match, 'ATTEMPTS was renamed or removed').toBeTruthy()
+    // 2 was the original budget, and it was exhausted by the intermittent flake
+    // on two different workspaces (#816 apps/srd, #820 apps/itun) in one
+    // afternoon — which is the whole reason this floor exists.
+    expect(Number(match?.[1])).toBeGreaterThanOrEqual(3)
+  })
+
+  it('treats an empty lcov.info as no coverage, not as 0% coverage', () => {
+    // The truncation shape. `existsSync` alone passes on a zero-byte file, and
+    // the ratchet would then score it 0% and fail the build for a coverage
+    // collapse that never happened — a worse failure than the one it came from.
+    expect(runner).toContain('function wroteCoverage')
+    expect(runner).toMatch(/statSync\([^)]*\)\.size > 0/)
+  })
+})

--- a/tools/run-coverage.ts
+++ b/tools/run-coverage.ts
@@ -1,6 +1,6 @@
 /**
  * run-coverage — run every workspace's `test:coverage` and VERIFY each one
- * actually wrote its `coverage/lcov.info`, retrying once when it silently did
+ * actually wrote a readable `coverage/lcov.info`, retrying when it silently did
  * not.
  *
  * ## The flake this exists for
@@ -23,21 +23,54 @@
  * every time, so this is an environment-dependent flush/truncation failure in
  * the reporter rather than anything the repo can fix at the source.
  *
- * ## Why a retry is the right shape, and why it is safe
+ * ## Why retrying is the right shape, and why it is safe
  *
  * A retry hides a genuine regression only if the regression is intermittent.
  * The failure this guards against — "this workspace has stopped emitting
  * coverage" — is deterministic: a workspace that genuinely cannot write lcov
- * fails BOTH attempts and this script exits non-zero with the workspace named.
- * What the retry absorbs is exactly the non-deterministic case, which is the
+ * fails EVERY attempt and this script exits non-zero with the workspace named.
+ * What the retries absorb is exactly the non-deterministic case, which is the
  * one that carries no signal about the PR under test.
  *
  * The ratchet itself is untouched and still authoritative: this script only
  * ensures the ratchet is fed real numbers rather than a phantom `(missing)`.
  * If coverage genuinely drops, `coverage-report.ts` still fails the build.
+ *
+ * ## Why the budget is 3 attempts and not 2 (#818)
+ *
+ * It was one retry, and the reasoning above was used to justify that: both
+ * attempts failing was taken as proof of a deterministic fault. **That
+ * inference was contradicted twice in one afternoon**, on two workspaces, on
+ * PRs that touched neither:
+ *
+ *   #816  apps/srd   two clean runs, no coverage — re-ran the job, green
+ *   #820  apps/itun  two clean runs, no coverage — re-ran the job, green
+ *
+ * A two-attempt budget whose entire diagnostic value is separating intermittent
+ * from deterministic stops separating anything once intermittent failures
+ * routinely consume both. Three attempts restores the margin the original
+ * argument assumed it had. It does not make the argument stronger — a
+ * sufficiently persistent flake would eat three — so the number is a floor to
+ * revisit, not a fix.
+ *
+ * ## The three shapes this has actually taken
+ *
+ * Recorded because a fix aimed at one of them would miss the others, and
+ * because they are the evidence any real repair in the reporter has to explain:
+ *
+ *   1. no `coverage/` directory at all            (#816, apps/srd)
+ *   2. `coverage/` exists, holds no `lcov.info`   (#820, apps/itun)
+ *   3. `lcov.info` exists but is EMPTY            — the truncation shape the
+ *      header hypothesises; see `wroteCoverage` below
+ *
+ * Shapes 1 and 2 are both "no readable lcov" and were already caught. Shape 3
+ * was NOT: `existsSync` passes on a zero-byte file, so a truncated write would
+ * have been handed to the ratchet, scored 0%, and reported as a catastrophic
+ * coverage DROP rather than a missing artefact — a far more confusing failure
+ * than the one it came from. Checking size closes that.
  */
 
-import { existsSync, rmSync } from 'node:fs'
+import { existsSync, rmSync, statSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -59,6 +92,26 @@ const WORKSPACES: ReadonlyArray<{ dir: string; filter: string }> = [
 
 const lcovFor = (dir: string) => join(root, dir, 'coverage', 'lcov.info')
 
+/**
+ * Did this run produce a coverage file the ratchet can actually read?
+ *
+ * Size, not just existence — a zero-byte `lcov.info` is shape 3 above, and it
+ * is worse than a missing one: the ratchet would parse it as 0% and fail the
+ * build for a coverage collapse that never happened.
+ */
+function wroteCoverage(dir: string): boolean {
+  const path = lcovFor(dir)
+  if (!existsSync(path)) return false
+  return statSync(path).size > 0
+}
+
+/**
+ * Total attempts per workspace before calling it deterministic. See the note in
+ * the header — this is a floor chosen from two observed double-failures, not a
+ * number with a theory behind it.
+ */
+const ATTEMPTS = 3
+
 /** Run one workspace's `test:coverage`. Returns the exit code. */
 async function runCoverage(filter: string): Promise<number> {
   const proc = Bun.spawn(['bun', '--filter', filter, 'test:coverage'], {
@@ -77,41 +130,52 @@ for (const { dir, filter } of WORKSPACES) {
   // no-write on a developer machine.
   rmSync(join(root, dir, 'coverage'), { recursive: true, force: true })
 
-  const code = await runCoverage(filter)
+  let testsFailed = false
 
-  // A non-zero exit is a real test failure — report it as such and do NOT
-  // retry. Retrying failing tests is how a flaky suite gets normalised.
-  if (code !== 0) {
-    console.error(`\n✗ ${dir}: test:coverage exited ${code} — tests failed.`)
-    failed = true
-    continue
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+    const code = await runCoverage(filter)
+
+    // A non-zero exit is a real test failure — report it as such and do NOT
+    // retry. Retrying failing tests is how a flaky suite gets normalised.
+    if (code !== 0) {
+      console.error(
+        `\n✗ ${dir}: test:coverage exited ${code} on attempt ${attempt}/${ATTEMPTS} —` +
+          ` tests failed.`
+      )
+      testsFailed = true
+      break
+    }
+
+    if (wroteCoverage(dir)) {
+      if (attempt > 1) console.error(`✓ ${dir}: attempt ${attempt}/${ATTEMPTS} produced coverage.`)
+      break
+    }
+
+    if (attempt < ATTEMPTS) {
+      console.error(
+        `\n⚠ ${dir}: test:coverage passed (exit 0) on attempt ${attempt}/${ATTEMPTS} but wrote` +
+          ` no readable coverage/lcov.info. This is the known intermittent reporter flake` +
+          ` (#818) — retrying.`
+      )
+      // Clear the partial artefact so the next attempt's result is unambiguous:
+      // a truncated file left in place would make attempt N+1's success
+      // indistinguishable from attempt N's leftovers.
+      rmSync(join(root, dir, 'coverage'), { recursive: true, force: true })
+    } else {
+      console.error(
+        `\n✗ ${dir}: no readable coverage/lcov.info after ${ATTEMPTS} clean runs. Every` +
+          ` attempt exited 0 and produced nothing, so this is NOT the intermittent flake —` +
+          ` the workspace has stopped emitting coverage and needs fixing at the source.` +
+          ` (If this is the flake after all, that is itself the finding: say so on #818,` +
+          ` because it means ${ATTEMPTS} attempts is no longer enough either.)`
+      )
+      failed = true
+    }
   }
 
-  if (existsSync(lcovFor(dir))) continue
-
-  console.error(
-    `\n⚠ ${dir}: test:coverage passed (exit 0) but wrote no coverage/lcov.info.` +
-      ` This is the known intermittent reporter flake — retrying once.`
-  )
-
-  const retryCode = await runCoverage(filter)
-  if (retryCode !== 0) {
-    console.error(`\n✗ ${dir}: retry exited ${retryCode} — tests failed on the second attempt.`)
+  if (testsFailed) {
     failed = true
-    continue
   }
-
-  if (!existsSync(lcovFor(dir))) {
-    console.error(
-      `\n✗ ${dir}: still no coverage/lcov.info after a retry. Two clean runs produced` +
-        ` no coverage, so this is NOT the intermittent flake — the workspace has stopped` +
-        ` emitting coverage and needs fixing at the source.`
-    )
-    failed = true
-    continue
-  }
-
-  console.error(`✓ ${dir}: retry produced coverage.`)
 }
 
 if (failed) process.exit(1)


### PR DESCRIPTION
Closes the immediate cost of #818 — a spurious `coverage` failure and a manual re-run on PRs that touch nothing related. Standalone, off `main`, deliberately not inside the Tailwind stack.

**Not a root-cause fix.** The reporter still intermittently produces nothing; that stays open on #818.

## Why 2 attempts stopped working

The old budget rested on an inference, stated in the file's own header: *both attempts failing implies a deterministic fault.* That inference was contradicted **twice in one afternoon**, on two different workspaces, on PRs touching neither:

| run | workspace | outcome |
|---|---|---|
| #816 | `apps/srd` | two clean runs, no coverage → re-ran the job, green |
| #820 | `apps/itun` | two clean runs, no coverage → re-ran the job, green |

A two-attempt budget whose entire diagnostic value is separating intermittent from deterministic stops separating anything once intermittent failures routinely consume both.

Three restores the margin the original argument assumed it had. It does **not** make that argument stronger — a persistent enough flake would eat three — so the number is recorded as a floor to revisit, and the final error message now tells the next person to say so on #818 rather than quietly widening it again.

## A third shape, which was not being caught

The two observed failures are both "no readable lcov", and `existsSync` already covered them. But the header's own hypothesis is a flush/**truncation** failure — and a zero-byte `lcov.info` *passes* `existsSync`.

That case would have been handed to the ratchet, parsed as **0%**, and reported as a catastrophic coverage **drop** rather than a missing artefact — a worse failure than the one it came from, and much harder to read back to its cause. `wroteCoverage` now checks size.

The three shapes are recorded in the header, because a fix aimed at one would miss the others:

1. no `coverage/` directory at all — #816, `apps/srd`
2. `coverage/` exists, holds no `lcov.info` — #820, `apps/itun`
3. `lcov.info` exists but is empty — the truncation shape

Also clears the partial artefact between attempts, so attempt N+1's success cannot be confused with attempt N's leftovers.

## Both halves are locked by tests, and both were probed

Tests are source-reading, matching the style this file already uses — these tools do their work at module scope, so importing one would run the whole ratchet.

Neither test is taken on trust. **A test that has never been seen to fail is not yet a test**, so I reverted each half and confirmed the matching test fails:

| probe | result |
|---|---|
| `ATTEMPTS` back to `2` | ✗ budget test fails |
| size check → bare `existsSync` | ✗ truncation test fails |
| both restored | 6 pass, 0 fail |

Both are quiet to regress by accident — a budget trimmed to 2 looks like tidying, and `wroteCoverage` → `existsSync` looks like simplification — and each would silently restore a failure that costs a re-run on every PR.

## The retry loop itself

It is top-level script code and cannot be imported, so it is not unit-testable as written. Rather than refactor the script to make it testable — out of scope for a flake remedy — I exercised the decision logic out-of-band against all three shapes:

```
PASS  clean first try               attempts=1
PASS  shape1 once, then ok          attempts=2
PASS  shape1 twice, then ok         attempts=3   ← the regression this ships for
PASS  shape2 twice, then ok         attempts=3
PASS  shape3 twice, then ok         attempts=3
PASS  shape3 always — must FAIL     attempts=3
PASS  never writes — must FAIL      attempts=3

contrast — old 2-attempt budget on 'fail,fail,ok': FAILS (this is the bug)
```

That last line is the point: the old budget fails on precisely the pattern observed twice today, and the new one passes.

## Unchanged on purpose

- **A non-zero exit is still never retried.** Retrying failing tests is how a flaky suite gets normalised; only the "exit 0, no artefact" case is retried.
- **The ratchet is untouched and still authoritative.** This only ensures it is fed real numbers rather than a phantom `(missing)`. If coverage genuinely drops, `coverage-report.ts` still fails the build.

## Verification

`bun run check:all` — exit 0. `tools/run-coverage.test.ts` — 6 pass, 0 fail (was 4).

Refs #818.
