### PR TITLE
docs: correct where gh-stack state lives, and record what sync does

### DIFF
--- a/.claude/rules/stacked-prs.md
+++ b/.claude/rules/stacked-prs.md
@@ -73,11 +73,59 @@ more reviewable layers; below that the ceremony is not worth it.
 - `gh stack sync` after **every** merge beneath you. Do not hand-rebase inside a
   gh-managed stack; that is how the tool's state and the branches diverge.
 
-**Stack state lives in `.git/gh-stack`, which is per-clone and untracked.** A
-fresh agent worktree therefore does not inherit it: the branch is stacked on
-GitHub and looks unstacked locally, with nothing on disk explaining why.
+### Where the state actually lives — per WORKTREE, not per clone
+
+**In a linked worktree the state is `.git/worktrees/<name>/gh-stack`, not
+`.git/gh-stack`.** Verified by reading it, after this file first said otherwise.
+
+That is narrower than "per clone", and the difference matters here because
+almost all agent work happens in linked worktrees: two worktrees of the same
+repo share **no** stack state at all. A branch that is stacked on GitHub looks
+unstacked from any other worktree, with nothing on disk explaining why.
 `gh stack checkout <pr#|branch>` re-attaches. Run `gh stack view` before
 concluding anything about a stack's shape.
+
+### `gh stack init` anchors the trunk to your LOCAL `main`
+
+Not `origin/main`. In this repo nobody checks out `main` — every branch is cut
+from `origin/main` in a worktree — so the local ref sits wherever it was last
+left, and on the run that produced this file it was **~40 commits stale**:
+
+```
+stack trunk recorded: 1a99ef7b   ← local main, months old
+origin/main:          af60dbd3
+branch's actual base: af60dbd3   ← correct
+```
+
+The PR was unaffected: GitHub compares against the real base, and `gh stack sync`
+reported the true trunk (`Stacked on origin/main (9be883f)`) regardless. But the
+persisted `trunk.head` stayed stale even after a sync, so **do not read that
+field as truth** — it is not what the tool acts on. `git fetch origin && git
+checkout main && git pull` before `gh stack init` avoids the confusion entirely.
+
+### What `sync` does when a layer merges beneath you
+
+Measured, since this was the open question the whole experiment existed to
+answer. After the bottom PR squash-merged:
+
+```
+✓ Skipping feat/tw-atoms-capslabel (PR #820 merged)
+Skipping 1 merged branch
+Merged: #820
+✓ Branches synced
+  Stacked on origin/main (9be883f)
+```
+
+Exit 0, no conflict, no `--onto` needed, and `gh stack view` then files the
+branch under a `merged` heading. **The tool handles the squash artefact that
+section 1 describes** — which is the reason to prefer it once a change has three
+or more layers.
+
+An ordinary `gh pr merge --squash` on the bottom layer is what produced that, and
+sync reconciled it cleanly, so a merging reviewer does not have to learn a new
+verb for a one-layer stack. `gh stack merge` remains the path for landing several
+layers at once: it is all-or-nothing up to a chosen PR, and it cannot bypass
+merge requirements.
 
 ## 4. A read is only true at the instant it is taken
 

--- a/.claude/rules/stacked-prs.md
+++ b/.claude/rules/stacked-prs.md
@@ -127,6 +127,32 @@ verb for a one-layer stack. `gh stack merge` remains the path for landing severa
 layers at once: it is all-or-nothing up to a chosen PR, and it cannot bypass
 merge requirements.
 
+### `sync` cannot update local `main` here, and says so — this is benign
+
+On a second run it emitted a warning the first run did not:
+
+```
+⚠ Could not update local main: failed to run git: fatal: cannot force update
+  the branch 'main' used by worktree at '/Users/jarvis/Code/SU-SRD'
+
+  Rebasing the stack onto origin/main instead; local main is unchanged.
+```
+
+**Nothing is wrong.** `sync` tries to fast-forward the local `main` ref as a
+convenience, and git refuses because `main` is checked out in the primary
+worktree — which it always is here, since that checkout is never moved off it.
+The tool degrades to `origin/main`, which is the ref that was wanted anyway, and
+exits 0.
+
+This is also the *mechanism* behind the stale trunk noted above: `sync` cannot
+advance local `main`, and `gh stack init` anchored the trunk to local `main`, so
+the recorded trunk can never catch up on its own. Two symptoms, one cause.
+
+Worth recognising rather than debugging: it is a scary-looking `fatal:` inside a
+warning on an otherwise successful command, and the natural reaction — deleting
+the worktree, or forcing the local ref — would trade a cosmetic message for a
+real problem.
+
 ## 4. A read is only true at the instant it is taken
 
 Two agents working one stack — one merging, one pushing — will routinely send


### PR DESCRIPTION
Three corrections and additions to `.claude/rules/stacked-prs.md` (landed in #820), all **measured rather than recalled** — the first because I got it wrong the first time.

## 1. The state path was wrong

I wrote `.git/gh-stack` (per clone), taken from the house notes without checking. In a linked worktree it is actually:

```
.git/worktrees/<name>/gh-stack
```

**Per worktree**, which is narrower than per clone and matters more here: almost all agent work happens in linked worktrees, and two worktrees of the same repo share *no* stack state at all.

This is the same error class the file's own section 4 warns about — writing from memory what could be read from the source — committed in the file that warns about it. Corrected by reading the actual path.

## 2. `gh stack init` anchors the trunk to your local `main`

Not `origin/main`. Nobody checks out `main` in this repo — every branch is cut from `origin/main` in a worktree — so the local ref sits wherever it was last left. On the run that produced these notes it was **~40 commits stale**:

```
stack trunk recorded: 1a99ef7b   ← local main, months old
origin/main:          af60dbd3
branch's actual base: af60dbd3   ← correct
```

Harmless in effect: GitHub compares against the real base, and `gh stack sync` reported the true trunk (`Stacked on origin/main (9be883f)`) regardless. But the persisted `trunk.head` stayed stale *even after* a sync — so that field is not what the tool acts on, and should not be read as truth. A `git checkout main && git pull` before `gh stack init` avoids the confusion.

## 3. What `sync` does when a layer merges beneath you

This was the open question the `gh stack` experiment existed to answer, so it is now recorded rather than left to the next person. After the bottom PR (#820) squash-merged:

```
✓ Skipping feat/tw-atoms-capslabel (PR #820 merged)
Skipping 1 merged branch
Merged: #820
✓ Branches synced
  Stacked on origin/main (9be883f)
```

Exit 0, no conflict, **no `--onto` needed**, and `gh stack view` then files the branch under a `merged` heading. The tool handles the squash artefact that section 1 of the notes opens with, which is the concrete reason to prefer it once a change has three or more layers.

Worth noting for reviewers: an ordinary `gh pr merge --squash` on the bottom layer is what produced that, and sync reconciled it cleanly — so a merging reviewer does **not** need a new verb for a one-layer stack. `gh stack merge` stays the path for landing several layers at once (all-or-nothing up to a chosen PR, and it cannot bypass merge requirements).

## Verification

`bun run check:all` — exit 0. Docs only, one file.

Refs #799.