### PR TITLE
feat(component-lib): move Button and buttonVariants onto .su-btn class names

### DIFF
--- a/apps/itun/src/components/sheet/__tests__/Sheet-topbar-segments.test.tsx
+++ b/apps/itun/src/components/sheet/__tests__/Sheet-topbar-segments.test.tsx
@@ -15,6 +15,7 @@
 
 import { afterEach, describe, expect, test } from 'bun:test'
 import { cleanup, render, screen } from '@testing-library/react'
+import { buttonVariants } from 'component-lib'
 import type { Crawler } from '../../../lib/schemas/crawler'
 import type { Mech } from '../../../lib/schemas/mech'
 import type { Pilot } from '../../../lib/schemas/pilot'
@@ -219,10 +220,20 @@ describe('Sheet — mobile segment switch', () => {
     // mobile-only row, stitched into the sticky bar
     expect(nav.className).toContain('sm:hidden')
 
-    // Active segment = the viewed kind: rust fill, aria-current, not a link.
+    // Active segment = the viewed kind: primary (rust) fill, aria-current, not
+    // a link.
+    //
+    // Asserted via `buttonVariants` rather than the `bg-rust` spelling it used
+    // to emit. component-lib moved that recipe onto `.su-*` class names in
+    // #799, and the spelling was never this test's subject — "the active
+    // segment is the PRIMARY variant" is. Asking the recipe keeps that true
+    // through the rename and any future one.
+    const primaryClass = buttonVariants({ variant: 'primary' })
+      .split(' ')
+      .find((c) => c.startsWith('su-btn--')) as string
     const active = nav.querySelector('[aria-current="page"]')
     expect(active?.textContent).toBe('Pilot')
-    expect(active?.className).toContain('bg-rust')
+    expect(active?.className).toContain(primaryClass)
     expect(active?.tagName).not.toBe('A')
 
     // The other segments navigate to the wired counterparts' sheets.

--- a/packages/component-lib/src/components/chrome/__tests__/Btn.test.tsx
+++ b/packages/component-lib/src/components/chrome/__tests__/Btn.test.tsx
@@ -1,26 +1,56 @@
 import { describe, expect, mock, test } from 'bun:test'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { Button } from '../Button'
+import { buttonVariants } from '../buttonVariants'
 import { DISABLED } from '../interaction'
+
+/**
+ * The class the recipe emits for one variant, isolated from the rest of its
+ * output. Asserting on this rather than on a colour's spelling keeps these
+ * tests about "which variant did Button pick" — which is what they are for —
+ * and survives the rename that #799 just performed on every one of them.
+ */
+const variantClass = (variant: 'default' | 'primary' | 'ghost' | 'danger') =>
+  buttonVariants({ variant })
+    .split(' ')
+    .find((c) => c.startsWith('su-btn--')) as string
+
+type Size = 'full' | 'compact' | 'mini' | 'iconOnly'
+
+/**
+ * The same trick for the size axis, diffed against a DIFFERENT explicit size.
+ *
+ * It cannot use `size: undefined` as the baseline the way `variantClass` gets
+ * away with a single call: omitting `size` falls back to the default rung
+ * (`compact`), so the baseline would already contain the very class being
+ * looked for and the diff would come back empty. Comparing two explicit sizes
+ * leaves exactly the size rung, since the variant class is common to both.
+ */
+const sizeClass = (size: Size) => {
+  const other: Size = size === 'iconOnly' ? 'full' : 'iconOnly'
+  const baseline = new Set(buttonVariants({ size: other }).split(' '))
+  return buttonVariants({ size })
+    .split(' ')
+    .find((c) => c.startsWith('su-btn--') && !baseline.has(c)) as string
+}
 
 describe('Button', () => {
   test('defaults to a paper/ink md button of type="button"', () => {
     render(<Button>Cancel</Button>)
     const btn = screen.getByRole('button', { name: 'Cancel' })
     expect(btn.getAttribute('type')).toBe('button')
-    expect(btn.className).toContain('bg-paper')
+    expect(btn.className).toContain(variantClass('default'))
   })
 
   test('primary variant is rust with white text', () => {
     render(<Button variant="primary">Create Pilot</Button>)
     const btn = screen.getByRole('button')
-    expect(btn.className).toContain('bg-rust')
-    expect(btn.className).toContain('text-paper')
+    expect(btn.className).toContain(variantClass('primary'))
   })
 
   test('ghost variant is transparent', () => {
     render(<Button variant="ghost">Back</Button>)
-    expect(screen.getByRole('button').className).toContain('bg-transparent')
+    expect(screen.getByRole('button').className).toContain(variantClass('ghost'))
   })
 
   test('danger variant uses the status-bad fill', () => {
@@ -28,15 +58,15 @@ describe('Button', () => {
     // status-bad, not a bespoke `danger` red: --color-danger was the third red
     // in a set that should have had one, and is retired. status-bad is the
     // sanctioned state token (ruleset §3.3).
-    expect(screen.getByRole('button').className).toContain('bg-status-bad')
+    expect(screen.getByRole('button').className).toContain(variantClass('danger'))
   })
 
   test('compact and full rungs adjust padding/type scale', () => {
     render(<Button size="compact">Small</Button>)
-    expect(screen.getByRole('button').className).toContain('text-xs')
+    expect(screen.getByRole('button').className).toContain(sizeClass('compact'))
     cleanup()
     render(<Button size="full">Large</Button>)
-    expect(screen.getByRole('button').className).toContain('text-lede')
+    expect(screen.getByRole('button').className).toContain(sizeClass('full'))
   })
 
   test('disabled blocks clicks and fades', () => {

--- a/packages/component-lib/src/components/chrome/buttonVariants.ts
+++ b/packages/component-lib/src/components/chrome/buttonVariants.ts
@@ -3,23 +3,30 @@ import { capsLabel } from './capsLabel'
 import { DISABLED, FOCUS_RING } from './interaction'
 
 /**
- * The disabled treatment for FILLED variants (`primary`, `danger`).
- *
- * The shared `DISABLED` fades whatever is there to 40% opacity, which is right
- * for an outline button but wrong for a solid fill: rust at 40% is a pastel
- * salmon and red at 40% is pink, and both read as an enabled variant nobody
- * recognises rather than as an off control. A disabled control should look
- * *drained*, not *tinted*, so the fill is emptied to a flat ink wash instead.
- * `opacity-100` cancels the base fade (variant classes are emitted after the
- * base, so this wins the merge).
- */
-const DRAINED = 'disabled:opacity-100 disabled:border-ink-30 disabled:bg-ink-8 disabled:text-ink-50'
-
-/**
  * The `.btn` cva recipe (design-spec §2.4), exported for non-button elements
- * (e.g. links styled as buttons) so consumers don't re-inline the class
- * string. Lives in its own file so Button.tsx only exports components
- * (react-refresh).
+ * (e.g. links styled as buttons) so consumers don't re-inline the class string.
+ * Lives in its own file so Button.tsx only exports components (react-refresh).
+ *
+ * ## Emits `.su-btn*` class names now, not Tailwind classes (#799, epic #802)
+ *
+ * Same three axes, same values, same defaults, same `(opts) => string`
+ * signature — so **no call site moves**, including the ~30 in `apps/itun` and
+ * `apps/srd` that put the result on `<a>` elements. Only the names changed; the
+ * rules behind them live in `src/styles/index.css`.
+ *
+ * **ALL of the styling moved there, geometry and type included** — not just the
+ * stateful half the split rule would send to a stylesheet. That is not an
+ * exception to the rule, it is the rule's boundary: the split rule assumes the
+ * library owns the element being styled, and this recipe deliberately does not.
+ * A caller putting this string on an `<a>` never receives a style object, and a
+ * function returning a string cannot return one without changing a signature
+ * that is public API. See the class-string exemption in this package's
+ * CLAUDE.md.
+ *
+ * The `.su-btn*` names are public API from that same moment, for the same
+ * reason — apps compose them with `cn()`, so they end up in app-side code.
+ *
+ * ## The axes
  *
  * The `surface` axis picks the WORLD the button lives on: `paper` (default —
  * the light app chrome) or `instrument` (the dashboard HUD scope, `.pc-root`).
@@ -32,79 +39,60 @@ const DRAINED = 'disabled:opacity-100 disabled:border-ink-30 disabled:bg-ink-8 d
  * Note the instrument surface is a TYPOGRAPHY choice as much as a colour one:
  * the cockpit's chassis is cream, not dark, so its buttons are ink like the
  * rest of the app — what still separates them is condensed caps.
+ *
+ * Both `instrument` and `mini` still compose `capsLabel`, which is why that
+ * recipe must itself stay a class-string emitter (see its own note).
  */
-export const buttonVariants = cva(
-  `inline-flex cursor-pointer items-center justify-center gap-2 whitespace-nowrap rounded-card border-chrome font-body font-medium tracking-normal transition-colors duration-[120ms] ${FOCUS_RING} ${DISABLED}`,
-  {
-    variants: {
-      variant: {
-        default: 'border-ink bg-paper text-ink hover:bg-ink-8',
-        primary: `border-rust bg-rust text-paper hover:border-rust-hi hover:bg-rust-hi ${DRAINED}`,
-        ghost: 'border-ink bg-transparent text-ink hover:bg-ink-8',
-        danger: `border-status-bad bg-status-bad text-paper hover:opacity-90 ${DRAINED}`,
-      },
-      surface: {
-        // Light app chrome — the paper/ink/rust world (the existing default).
-        paper: '',
-        // Dashboard HUD — condensed-caps typography; the ghost recolour
-        // (the one variant the HUD uses) rides on the compoundVariant below.
-        // Size rides on the `size` axis below, so the recipe is role-only.
-        instrument: capsLabel(),
-      },
-      // The canonical size ladder (styles/sizing.ts) — full / compact / mini.
-      size: {
-        // The reading size for a primary CTA (formerly `lg`).
-        full: 'px-[22px] py-3 text-lede',
-        // The default workhorse scale (the former `sm`, which absorbed `md`
-        // when the four-rung axis was merged down to the ladder's three).
-        compact: 'px-[11px] py-[6px] text-xs',
-        // The former MiniBtn / `xs`: a compact uppercase action chip (badge
-        // radius, condensed caps, tight padding) for secondary controls like
-        // '⇄ Swap' / '✕ Remove'. Overrides the base radius/font/gap via twMerge.
-        mini: `gap-1 rounded-badge px-2 py-[3px] ${capsLabel({ size: 'label-lg', weight: 'semibold', tracking: 'none' })}`,
-        /**
-         * The SQUARE icon-only rung — a glyph with no label (a close ✕, a
-         * collapse chevron, a search magnifier).
-         *
-         * It is a `size` rung rather than a separate component because an icon
-         * button differs from a worded one only in its geometry: same frame,
-         * same variants, same focus ring, same disabled treatment. Before this
-         * there were five hand-rolled squares across the package — 28 / 32 / 36
-         * / 44px, three radii, four border treatments — and the one with no
-         * visible focus ring at all was the only one a keyboard user could not
-         * see.
-         *
-         * 36px (`size-9`) is the resting geometry: comfortably past the WCAG
-         * 2.5.8 24px minimum, and the size the majority of those squares
-         * already were. A call site whose button must line up with a
-         * neighbouring control of a different height overrides with a single
-         * `size-*` class (the sheet slab's chevron matches its `compact`
-         * siblings at `size-7`; a phone's bar trigger holds the 44px WCAG
-         * 2.5.5 target at `size-11`) — one class, not a whole re-spelled skin.
-         */
-        iconOnly: 'size-9 shrink-0 gap-0 p-0 text-base leading-none',
-      },
+export const buttonVariants = cva(`su-btn ${FOCUS_RING} ${DISABLED}`, {
+  variants: {
+    variant: {
+      default: 'su-btn--default',
+      primary: 'su-btn--primary',
+      ghost: 'su-btn--ghost',
+      danger: 'su-btn--danger',
     },
-    compoundVariants: [
-      // INSTRUMENT recolour: an ink hairline on the transparent chassis, going
-      // to a paper fill on hover — the ghost treatment for a button sitting on
-      // a cream instrument card (rail, band, dial).
-      //
-      // This was previously paper text on transparent, for the retired dark
-      // instrument skin. It survived the skin it was built for and only ever
-      // rendered legibly because the base `text-ink` won a class-order race
-      // against its arbitrary-value utility — i.e. white-on-white held off by
-      // luck. Now that the cockpit chassis is cream, ink is simply correct.
-      {
-        surface: 'instrument',
-        variant: 'ghost',
-        class: 'border-ink-30 bg-transparent text-ink hover:border-ink-50 hover:bg-paper',
-      },
-    ],
-    defaultVariants: {
-      variant: 'default',
-      surface: 'paper',
-      size: 'compact',
+    surface: {
+      // Light app chrome — the paper/ink/rust world (the existing default).
+      paper: '',
+      // Dashboard HUD — condensed-caps typography; the ghost recolour (the one
+      // variant the HUD uses) rides on the compoundVariant below. Size rides on
+      // the `size` axis, so the recipe is role-only.
+      instrument: `su-btn--instrument ${capsLabel()}`,
     },
-  }
-)
+    // The canonical size ladder (styles/sizing.ts) — full / compact / mini.
+    size: {
+      /** The reading size for a primary CTA (formerly `lg`). */
+      full: 'su-btn--full',
+      /** The default workhorse scale (the former `sm`, which absorbed `md`). */
+      compact: 'su-btn--compact',
+      /**
+       * The former MiniBtn / `xs`: a compact uppercase action chip for
+       * secondary controls like '⇄ Swap' / '✕ Remove'. Its geometry is
+       * `.su-btn--mini`; its condensed caps come from the recipe below, which
+       * is why the two are composed rather than duplicated.
+       */
+      mini: `su-btn--mini ${capsLabel({ size: 'label-lg', weight: 'semibold', tracking: 'none' })}`,
+      /** The SQUARE icon-only rung — a glyph with no label. */
+      iconOnly: 'su-btn--icon-only',
+    },
+  },
+  // NO `compoundVariants`, and the absence is deliberate.
+  //
+  // The instrument × ghost recolour still exists — it is the compound SELECTOR
+  // `.su-btn--instrument.su-btn--ghost` in index.css, whose two-class
+  // specificity beats plain `.su-btn--ghost` without relying on source order.
+  // Both classes are already emitted by the `surface` and `variant` axes, so a
+  // cva entry here would have to carry an empty `class` to do nothing, and dead
+  // configuration that looks load-bearing is worse than none.
+  //
+  // (That recolour was previously paper text on transparent, for the retired
+  // dark instrument skin. It survived the skin it was built for and only ever
+  // rendered legibly because the base `text-ink` won a class-order race against
+  // its arbitrary-value utility — white-on-white held off by luck. Now that the
+  // cockpit chassis is cream, ink is simply correct.)
+  defaultVariants: {
+    variant: 'default',
+    surface: 'paper',
+    size: 'compact',
+  },
+})

--- a/packages/component-lib/src/styles/index.css
+++ b/packages/component-lib/src/styles/index.css
@@ -472,6 +472,170 @@ body {
     0 0 0 6px var(--su-color-ink);
 }
 
+/* ══ Button ═════════════════════════════════════════════════════════════════
+ *
+ * The `.btn` recipe (design-spec §2.4), ported from the `buttonVariants` cva.
+ *
+ * ALL of it is here, geometry and type included — not just the stateful half.
+ * `buttonVariants` is a public class-string export that both apps put on `<a>`
+ * elements the library never renders, so there is no element for a style object
+ * to attach to. That is the class-string exemption in this package's CLAUDE.md,
+ * and it is why this block is larger than the split rule alone would predict.
+ *
+ * ORDER MATTERS TWICE in here, and both are single-class specificity, so source
+ * position is the tiebreak:
+ *   · size modifiers come after the base, so `--mini` can override the base gap
+ *     and radius;
+ *   · the whole block sits BEFORE `.su-caps`, so the caps recipe wins
+ *     `font-family` on the two rungs that compose it (`--mini`, `--instrument`).
+ */
+.su-btn {
+  align-items: center;
+  border-radius: var(--su-radius-card);
+  border-style: solid;
+  border-width: var(--su-bw-chrome);
+  cursor: pointer;
+  display: inline-flex;
+  font-family: var(--su-font-body);
+  font-weight: var(--su-weight-medium);
+  gap: var(--su-space-8);
+  justify-content: center;
+  letter-spacing: normal;
+  transition:
+    color 120ms,
+    background-color 120ms,
+    border-color 120ms;
+  white-space: nowrap;
+}
+
+/* ── Variants. Colour only, and every one of the three colour properties is
+      overridden on :hover or :disabled, so all three keep their RESTING value
+      here rather than inline — see the per-property note at the top of the
+      stateful section. ── */
+.su-btn--default {
+  background-color: var(--su-color-paper);
+  border-color: var(--su-color-ink);
+  color: var(--su-color-ink);
+}
+
+.su-btn--default:hover:not(:disabled) {
+  background-color: var(--su-color-ink-8);
+}
+
+.su-btn--ghost {
+  background-color: transparent;
+  border-color: var(--su-color-ink);
+  color: var(--su-color-ink);
+}
+
+.su-btn--ghost:hover:not(:disabled) {
+  background-color: var(--su-color-ink-8);
+}
+
+.su-btn--primary {
+  background-color: var(--su-color-rust);
+  border-color: var(--su-color-rust);
+  color: var(--su-color-paper);
+}
+
+.su-btn--primary:hover:not(:disabled) {
+  background-color: var(--su-color-rust-hi);
+  border-color: var(--su-color-rust-hi);
+}
+
+.su-btn--danger {
+  background-color: var(--su-color-status-bad);
+  border-color: var(--su-color-status-bad);
+  color: var(--su-color-paper);
+}
+
+.su-btn--danger:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+/*
+ * The DRAINED disabled treatment, for the FILLED variants only.
+ *
+ * The shared 40% fade (`.su-disabled`) is right for an outline button and wrong
+ * for a solid fill: rust at 40% is a pastel salmon and red at 40% is pink, and
+ * both read as an enabled variant nobody recognises rather than as an off
+ * control. A disabled control should look DRAINED, not tinted, so the fill is
+ * emptied to a flat ink wash. `opacity: 1` cancels the shared fade, exactly as
+ * `disabled:opacity-100` did.
+ */
+.su-btn--primary:disabled,
+.su-btn--danger:disabled {
+  background-color: var(--su-color-ink-8);
+  border-color: var(--su-color-ink-30);
+  color: var(--su-color-ink-50);
+  opacity: 1;
+}
+
+/*
+ * INSTRUMENT × ghost — an ink hairline on the cream instrument chassis, going to
+ * a paper fill on hover. The one variant the dashboard HUD uses.
+ *
+ * This was a cva `compoundVariant`, and a compound SELECTOR is the natural CSS
+ * shape for it — which also gives it the 2-class specificity it needs to beat
+ * plain `.su-btn--ghost` above without depending on source order.
+ */
+.su-btn--instrument.su-btn--ghost {
+  background-color: transparent;
+  border-color: var(--su-color-ink-30);
+  color: var(--su-color-ink);
+}
+
+.su-btn--instrument.su-btn--ghost:hover:not(:disabled) {
+  background-color: var(--su-color-paper);
+  border-color: var(--su-color-ink-50);
+}
+
+/* ── The size ladder (styles/sizing.ts). The odd numbers are the arbitrary
+      Tailwind values carried verbatim — `px-[22px]`, `py-[6px]`, `py-[3px]` —
+      because rounding them onto the space scale would resize every button. ── */
+.su-btn--full {
+  font-size: var(--su-text-lede);
+  padding: var(--su-space-12) 22px;
+}
+
+.su-btn--compact {
+  font-size: var(--su-text-xs);
+  padding: var(--su-space-6) 11px;
+}
+
+/* The compact uppercase action chip ('⇄ Swap', '✕ Remove'): badge radius,
+   tighter gap, and deliberately NO letterspacing. Its condensed caps come from
+   the `capsLabel` classes the recipe composes in, not from here. */
+.su-btn--mini {
+  border-radius: var(--su-radius-badge);
+  gap: var(--su-space-4);
+  padding: 3px var(--su-space-8);
+}
+
+/*
+ * The SQUARE icon-only rung — a glyph with no label (a close ✕, a collapse
+ * chevron, a search magnifier).
+ *
+ * A size rung rather than its own component because an icon button differs from
+ * a worded one only in geometry: same frame, variants, focus ring and disabled
+ * treatment. Before it there were five hand-rolled squares in the package —
+ * 28/32/36/44px, three radii, four border treatments — and the one with no
+ * visible focus ring was the only one a keyboard user could not see.
+ *
+ * 36px is the resting geometry, comfortably past the WCAG 2.5.8 24px minimum. A
+ * call site that must line up with a neighbouring control overrides width and
+ * height at the call site, as it previously overrode `size-*`.
+ */
+.su-btn--icon-only {
+  flex-shrink: 0;
+  font-size: var(--su-text-base);
+  gap: 0;
+  height: 36px;
+  line-height: 1;
+  padding: 0;
+  width: 36px;
+}
+
 /* ══ The condensed-caps label ═══════════════════════════════════════════════
  *
  * The `capsLabel` recipe (`components/chrome/capsLabel.ts`), as classes.


### PR DESCRIPTION
Atoms layer, **part 3 of 3** — the layer the class-string ruling on #799 was made for. **This completes Atoms.**

## What changed

`buttonVariants` emits `.su-btn*` names instead of Tailwind classes. Same three axes, same values, same defaults, same `(opts) => string` signature — so **no call site moves**, including the ~30 in `apps/itun` and `apps/srd` that put its output on `<a>` elements. `Button.tsx` is untouched.

**All of the styling moved to `index.css` — geometry and type included**, not just the stateful half. That is the rule's *boundary*, not an exception: the split rule assumes the library owns the element, and this recipe exists precisely so an app can style one the library never renders. A caller putting the string on an `<a>` never receives a style object, and a function returning a string cannot return one without changing a signature that is public API.

## Two ordering facts that are load-bearing

Both are single-class specificity, so source position is the tiebreak. Both are commented where they apply:

- **Size modifiers follow the base**, so `.su-btn--mini` can override the base `gap` and `border-radius`.
- **The whole Button block precedes `.su-caps`**, so the caps recipe wins `font-family` on the two rungs that compose it (`--mini`, `--instrument`).

The instrument × ghost recolour became the compound selector `.su-btn--instrument.su-btn--ghost`, whose two-class specificity beats plain `.su-btn--ghost` *without* depending on order. `compoundVariants` is consequently empty and **deleted** — both classes already come from their own axes, so an entry would carry an empty `class` and do nothing. Dead configuration that looks load-bearing is worse than none.

## Verified in a browser across all eight states

A class list cannot show that a rule resolved, so:

| variant | resting | disabled |
|---|---|---|
| default | paper bg · ink border/text | `opacity: 0.4` |
| primary | rust bg+border · paper text | **DRAINED** |
| ghost | transparent · ink border/text | `opacity: 0.4` |
| danger | status-bad bg+border · paper text | **DRAINED** |

**DRAINED is the subtle one, and it is correct.** The filled variants compute `opacity: 1` with an ink-8 fill, ink-30 border and ink-50 text — so they read as *drained* rather than as a pastel tint of themselves — while the outline variants keep the shared 0.4 fade. That distinction was a cva `DRAINED` string cancelling a base fade; it is now two rules, and it survived the port.

Geometry checks out too: 1.5px chrome border, 3px card radius, 6px/11px compact padding, 12px type, weight 500.

**Hover verified live**, since it is the exact case the naive reading of the split rule kills silently:

```
resting  rgb(251, 250, 247)      ← paper
hovered  rgba(40, 32, 25, 0.08)  ← ink-8
```

## One consequence worth naming: an app *test* changed

Six assertions were re-pointed from Tailwind spellings to the recipe — five in the library, **and one in `apps/itun`**.

That app test asserted `bg-rust` to mean "this segment is the active one". It now asks `buttonVariants` which class the primary variant emits. The app's **source** is untouched — no prop, no call site, no import in shipped code — but a test that reached into the library's emitted class string was always coupled to an implementation detail, and this rename is what proved it.

So the "zero app edits" claim from the ruling holds for app *source* and not for app *tests*. Flagging it rather than letting it pass as nothing: it is one file and one line, and it is still a real qualification of the promise.

## `capsLabel` is now the only holdout

It stays a class-string emitter because `buttonVariants` composes it. With Button ported, `buttonVariants` is the only thing holding that shape — so the question of whether `capsLabel` can become a style object is now live. **Deliberately not answered here**: two changes to one recipe in a single PR is how a clean port becomes unreviewable.

## Verification

- `bun run check:all` — **exit 0**
- component-lib 766 pass · srd 1113 pass · itun 1885 pass — 0 fail
- `ladle:build` succeeds; all `.su-btn*` rules confirmed in the emitted CSS
- No component API, prop, barrel export, or app source file changed

Refs #799.
