### PR TITLE
feat(component-lib): add the eight alpha rungs the Containers group needs

### DIFF
--- a/packages/component-lib/src/design/tokens.ts
+++ b/packages/component-lib/src/design/tokens.ts
@@ -265,14 +265,22 @@ const base = {
    *  should actually own is a design call and not a port. */
   ink85: 'rgb(40 32 25 / 0.85)',
   ink75: 'rgb(40 32 25 / 0.75)',
+  /** ModalShell's scrim edge. */
+  ink60: 'rgb(40 32 25 / 0.6)',
+  /** The CrawlerEcon meta label inside `Inset`. */
+  ink55: 'rgb(40 32 25 / 0.55)',
   ink50: 'rgb(40 32 25 / 0.5)',
   ink40: 'rgb(40 32 25 / 0.4)',
+  /** SheetSectionSlab's rule. */
+  ink35: 'rgb(40 32 25 / 0.35)',
   ink30: 'rgb(40 32 25 / 0.3)',
   ink20: 'rgb(40 32 25 / 0.2)',
   ink15: 'rgb(40 32 25 / 0.15)',
   ink12: 'rgb(40 32 25 / 0.12)',
   ink10: 'rgb(40 32 25 / 0.1)',
   ink8: 'rgb(40 32 25 / 0.08)',
+  /** The faintest rung on the ramp — RosterSkeleton's resting shimmer. */
+  ink5: 'rgb(40 32 25 / 0.05)',
 
   /** The ONE light surface (ruleset §4.1) — a near-white warm paper. Pure
    *  white is retired from the UI; the only survivor is the print sheet. */
@@ -285,6 +293,12 @@ const base = {
    *  Atoms layer of #799 for `Stat`'s `inverse` skin (`text-paper/70`). */
   paper70: 'rgb(251 250 247 / 0.7)',
   paper30: 'rgb(251 250 247 / 0.3)',
+  /** FilterRow's sticky backing — near-opaque paper over scrolling content. */
+  paper85: 'rgb(251 250 247 / 0.85)',
+  /** ModalShell's panel over the scrim. */
+  paper80: 'rgb(251 250 247 / 0.8)',
+  /** MobileSearchDialog's hairline on a tone. */
+  paper15: 'rgb(251 250 247 / 0.15)',
 
   /** THE single action colour. */
   rust: 'rgb(168, 82, 34)',
@@ -314,6 +328,8 @@ const base = {
 
   // — Attention fills that are neither an ontology hue nor a status overlay —
   caution: 'rgb(215, 195, 125)',
+  /** Banner's caution wash — the advisory fill behind its caution border. */
+  caution25: 'rgb(215 195 125 / 0.25)',
   inert: 'rgb(192, 192, 192)',
 
   // — Cargo (storage) accent triplet —

--- a/packages/component-lib/src/styles/index.css
+++ b/packages/component-lib/src/styles/index.css
@@ -175,14 +175,18 @@
      `border-ink/10`, which had no rung to land on; see the note in tokens.ts. */
   --su-color-ink-85: rgb(40 32 25 / 0.85);
   --su-color-ink-75: rgb(40 32 25 / 0.75);
+  --su-color-ink-60: rgb(40 32 25 / 0.6);
+  --su-color-ink-55: rgb(40 32 25 / 0.55);
   --su-color-ink-50: rgb(40 32 25 / 0.5);
   --su-color-ink-40: rgb(40 32 25 / 0.4);
+  --su-color-ink-35: rgb(40 32 25 / 0.35);
   --su-color-ink-30: rgb(40 32 25 / 0.3);
   --su-color-ink-20: rgb(40 32 25 / 0.2);
   --su-color-ink-15: rgb(40 32 25 / 0.15);
   --su-color-ink-12: rgb(40 32 25 / 0.12);
   --su-color-ink-10: rgb(40 32 25 / 0.1);
   --su-color-ink-8: rgb(40 32 25 / 0.08);
+  --su-color-ink-5: rgb(40 32 25 / 0.05);
 
   /* The ONE light surface (ruleset §4.1). Paper as a background is always flat. */
   --su-color-paper: rgb(251, 250, 247);
@@ -191,6 +195,9 @@
   /* The de-emphasised rung ON a tone — `wk-muted`'s inverse counterpart. */
   --su-color-paper-70: rgb(251 250 247 / 0.7);
   --su-color-paper-30: rgb(251 250 247 / 0.3);
+  --su-color-paper-85: rgb(251 250 247 / 0.85);
+  --su-color-paper-80: rgb(251 250 247 / 0.8);
+  --su-color-paper-15: rgb(251 250 247 / 0.15);
 
   /* THE single action colour. */
   --su-color-rust: rgb(168, 82, 34);
@@ -212,6 +219,7 @@
 
   /* ── Attention fills ── */
   --su-color-caution: rgb(215, 195, 125);
+  --su-color-caution-25: rgb(215 195 125 / 0.25);
   --su-color-inert: rgb(192, 192, 192);
 
   /* ── Cargo (storage) accent triplet ── */


### PR DESCRIPTION
Opens the **Containers** layer of #799 (epic #802) the way #815 opened Atoms — rungs first, so the component ports that follow have an exact landing spot and never round.

## The eight rungs, each with a named consumer

| rung | justifying usage |
|---|---|
| `ink60` | ModalShell's scrim edge |
| `ink55` | the CrawlerEcon meta label inside `Inset` |
| `ink35` | SheetSectionSlab's rule |
| `ink5` | RosterSkeleton's resting shimmer |
| `paper85` | FilterRow's sticky backing |
| `paper80` | ModalShell's panel over the scrim |
| `paper15` | MobileSearchDialog's hairline on a tone |
| `caution25` | Banner's advisory wash |

**The rendered palette does not change.** Tailwind computes all eight from opacity modifiers today, so those pixels already ship. Only the *named* palette grows — by eight — which is the migration's job. `tokens.parity.test.ts` covers each.

## No speculative completeness

Six further rungs are already visible in the scan and are **deliberately not added here** — `paper/10`, `paper/40`, `paper/55`, `paper/95`, `wk-faint/80`, `ink/70`. They belong to Compositions (RollTable, WizShell, NavDrawer, CatalogChoiceListing) and arrive with the components that justify them.

## The attribution was re-measured, not reused

Two earlier scans of mine were wrong in different ways, so this one is worth describing rather than trusting:

1. **The first counted comment prose** — it reported `ink/55` and `ink/70` as needed by VitalGauge, when the only occurrences were a doc comment recording that both had been *removed* for failing WCAG AA. That is how I over-reported Atoms' needs as five rungs when it was three.
2. **The second keyed group membership by directory** — and `components/chrome/` holds both Atoms stories (Badge, Button) and Containers stories (Banner, Callout, EmptyState, PageShell), so last-write-wins attributed Banner to Atoms.

This pass strips comments and maps each component to **its own co-located story's meta title**. Where a component has no story of its own, it is attributed by its consumer: `ink/55` is Containers because CrawlerEcon is imported by `Inset`, not because of where its file sits.

## Verification

- `bun run check:all` — **exit 0**
- `tokens.parity.test.ts` — 3 pass; the TS literals and the `--su-*` custom properties agree on all eight
- No component, prop, barrel export or app file touched — tokens and the stylesheet only

## Next in Containers

With the rungs in place, the component ports follow — and this is where the `bg-*`-as-data ruling gets exercised for the first time, since ModalShell and MobileSearchDialog are among the 52 sites. Tone strings resolve to tokens at point of use; no prop renames, no narrowed value sets.

Refs #799.
