### PR TITLE
fix(reference): stop the schema catalog embedding the package version

### DIFF
--- a/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
+++ b/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
@@ -229,12 +229,15 @@ export type EnhancedSchemaMetadata = {
 /**
  * Get schema catalog with enhanced metadata
  * Exposed for client use
+ *
+ * No `version` — see the note on `SchemaIndex` in tools/generateDocs.ts for why
+ * embedding the package version in this generated catalog broke every release
+ * PR, and why re-adding it would break them again.
  */
 export declare function getSchemaCatalog(): {
     $schema: string;
     title: string;
     description: string;
-    version: string;
     generated: string;
     schemas: EnhancedSchemaMetadata[];
 };

--- a/packages/salvageunion-reference/lib/ModelFactory.ts
+++ b/packages/salvageunion-reference/lib/ModelFactory.ts
@@ -216,12 +216,15 @@ export type EnhancedSchemaMetadata = {
 /**
  * Get schema catalog with enhanced metadata
  * Exposed for client use
+ *
+ * No `version` — see the note on `SchemaIndex` in tools/generateDocs.ts for why
+ * embedding the package version in this generated catalog broke every release
+ * PR, and why re-adding it would break them again.
  */
 export function getSchemaCatalog(): {
   $schema: string
   title: string
   description: string
-  version: string
   generated: string
   schemas: EnhancedSchemaMetadata[]
 } {

--- a/packages/salvageunion-reference/schemas/index.json
+++ b/packages/salvageunion-reference/schemas/index.json
@@ -2,8 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Salvage Union Data Schema Catalog",
   "description": "Catalog of all available schemas in the salvageunion-data repository",
-  "version": "2.11.0",
-  "generated": "2026-08-14T06:02:44.516Z",
+  "generated": "2026-08-16T00:32:54.595Z",
   "schemas": [
     {
       "id": "abilities",

--- a/packages/salvageunion-reference/tools/generateDocs.ts
+++ b/packages/salvageunion-reference/tools/generateDocs.ts
@@ -30,18 +30,6 @@ interface SchemaInfo {
   displayName: string
 }
 
-// Get version from package.json
-function getPackageVersion(): string {
-  try {
-    const packageJsonPath = path.join(PACKAGE_DIR, 'package.json')
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
-    return packageJson.version || '1.0.0'
-  } catch {
-    console.warn('⚠️  Could not read package.json version, using default')
-    return '1.0.0'
-  }
-}
-
 // Get all schema files
 function getSchemaFiles(): string[] {
   const schemasDir = path.join(PACKAGE_DIR, 'schemas')
@@ -166,11 +154,32 @@ function parseSchemaFile(schemaFile: string): SchemaInfo | null {
   }
 }
 
+/**
+ * NOTE: there is deliberately no `version` field here, and re-adding one will
+ * break every release.
+ *
+ * This catalog used to embed `package.json`'s version. Nothing ever read it —
+ * the package is `private: true` (never published to npm), no endpoint serves
+ * the catalog, and no caller touches `getSchemaCatalog().version`. What it did
+ * do was couple a GENERATED artifact to a version release-please bumps in
+ * `package.json` alone: every release PR therefore arrived with a stale
+ * `version` here, `check:schemas` regenerated it, saw the mismatch, and failed.
+ * Release PRs were unmergeable by construction (#786).
+ *
+ * release-please's `extra-files` is the usual fix for a file that carries a
+ * version, but it does not work here: its JSON updater re-serializes through
+ * `JSON.stringify(parsed, replacer, indent)`, which expands every
+ * `requiredFields` array onto multiple lines, and `format:check` then rejects
+ * the file Biome wants collapsed. That trades a `static-checks` failure for a
+ * `quality-checks` one.
+ *
+ * So the coupling is gone instead of maintained. Two files tracking one version
+ * stay in sync only by convention, and this one had no reader to justify it.
+ */
 interface SchemaIndex {
   $schema: string
   title: string
   description: string
-  version: string
   generated: string
   schemas: Array<{
     id: string
@@ -203,7 +212,6 @@ function generateSchemaIndex(schemas: SchemaInfo[]): void {
     $schema: 'http://json-schema.org/draft-07/schema#',
     title: 'Salvage Union Data Schema Catalog',
     description: 'Catalog of all available schemas in the salvageunion-data repository',
-    version: getPackageVersion(),
     generated: new Date().toISOString(),
     schemas: schemas.map((s) => {
       // Find existing entry to preserve meta property


### PR DESCRIPTION
## The blocker

`SU-SRD` has been unable to cut a release since 2026-08-14, and nothing surfaced it.

release-please's PR #786 (`chore: release main`) fails `static-checks` → `quality-checks` on **"Verify generated files are up to date"**:

```
packages/salvageunion-reference/schemas/index.json
-  "version": "2.11.0",
+  "version": "2.11.1",
```

`schemas/index.json` is generated by `tools/generateDocs.ts` (wired into `build:package` via the `docs` script) and embedded `package.json`'s version. release-please bumps `package.json` alone, so the committed catalog kept the old version; `check:schemas` regenerated it, saw the mismatch, and correctly failed.

**Every release PR fails by construction.** The check only trips when a version changes, and only release-please changes versions — which is why it passes on `main` and has been red for two days on the one workflow nobody watches. #786 is `behind_by=0` with a current base, so staleness is not a factor.

## Why remove the field rather than teach release-please about it

**Nothing reads it.**

- No caller touches `getSchemaCatalog().version` — the field was reachable only through that function's `...schemaIndex` spread and its declared return type.
- The package is `"private": true` with no publish workflow anywhere in `.github/`, so it is not on npm and has no external package consumers.
- No endpoint serves the catalog; the SSG's `snapshot.version` is an unrelated hardcoded format version.
- It dates to #42 and has never had a reader.

**And `extra-files` does not actually work here.** It was the safer-looking default, so it was measured rather than assumed. `release-please-action@v5` pins `release-please@^17.6.0`, whose JSON updater re-serializes through `jsonStringify` → `JSON.stringify(parsed, replacer, detectIndent(...))`. That expands every `requiredFields` array onto its own lines. Reproducing that rewrite locally and running Biome:

```
× Formatter would have printed the following content:
-      "requiredFields": [
-        "id",
...
+      "requiredFields": ["id", "name", "source", "page", "tree", "level", "actions"],
```

So `extra-files` trades a `static-checks` failure for a `quality-checks` (`format:check`) one, and would need a second change — excluding this file from Biome — to work at all. Two files tracking one version stay in sync only by convention; this one had no reader to justify the convention.

## The change

- Drop `version` from the generated catalog, from `SchemaIndex` in `tools/generateDocs.ts`, and from `getSchemaCatalog()`'s return type.
- Remove the now-dead `getPackageVersion()`.
- Commit the regenerated `schemas/index.json` and `etc/salvageunion-reference.api.d.ts` so the tree is self-consistent.
- Leave a comment on `SchemaIndex` recording why the field is absent and why re-adding it would break releases again.

## Verification

- `bun run check:all` — exit 0, working tree clean.
- **Simulated the exact failure**: bumped `packages/salvageunion-reference/package.json` to `2.11.1` and re-ran `check:schemas`. It passes, where the same bump is what #786 fails on today. Reverted before committing.
- Re-running `build:package` is idempotent — the generator's "only generated timestamp would change" guard skips the write.

**What remains unproven:** this cannot be fully verified without an actual release, and I did not cut one. The real confirmation is the next release-please PR passing `static-checks`. Once this lands, release-please will refresh #786 on its next run (push to `main`, or the 06:17 UTC schedule), and that PR going green is the verification.

## Not done, deliberately

No release cut, #786 not merged, no tags touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0134EvKDdA1167vAeBoPpuf1