### PR TITLE
docs: link the Butter Stack from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ with the test that enforces them.
 
 ## Monorepo Conventions
 
+Built on **[the Butter Stack](https://alxjrvs.github.io/butter/)** — Bun · Unified workspace · TypeScript · TanStack · Edge-deployed · React.
+
 - **Bun** for all package management (not npm/yarn); single `bun.lock` at root.
 - Workspace packages reference each other via the `workspace:*` protocol.
 - Relative imports only (no `@/` path aliases); `type` over `interface`; named


### PR DESCRIPTION
Names the stack this repo is built on and points at the page that describes it: <https://alxjrvs.github.io/butter/>.

One line under **Monorepo Conventions**, where the section is already about the shape of the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YB4dTHRMqHCCHGEEVs6QBA