### PR TITLE
docs: record the Cloudflare hosting decision and its executable plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Start here for navigation:** [`docs/README.md`](docs/README.md) maps user intent → relevant doc (architecture, ADRs, per-package CLAUDE.md).
 
-- [`docs/adrs/`](docs/adrs/) — architecture decision records, **32 of them** (ADR-001 through ADR-032). Consult the matching ADR before revisiting a prior decision, and **read its `## Status` header first** — several are superseded and the supersession is only recorded there (ADR-001 → ADR-030; ADR-012 → ADR-031; ADR-023 → ADR-027 → ADR-028). The three that govern:
+- [`docs/adrs/`](docs/adrs/) — architecture decision records, **33 of them** (ADR-001 through ADR-033). Consult the matching ADR before revisiting a prior decision, and **read its `## Status` header first** — several are superseded and the supersession is only recorded there (ADR-001 → ADR-030; ADR-012 → ADR-031; ADR-023 → ADR-027 → ADR-028). The three that govern:
   - [ADR-030](docs/adrs/ADR-030-accounts-games-server-of-record.md) — accounts, Games, and Convex as the server of record for identity/ownership/sharing. **Supersedes ADR-001** (local-first, no backend, no auth) and amends ADR-022. Decision accepted; delivery is phased — see [`docs/architecture/accounts-and-games.md`](docs/architecture/accounts-and-games.md) for what has actually landed.
   - [ADR-021](docs/adrs/ADR-021-itun-surface-taxonomy.md) — the surface/mode taxonomy for **where a rule is enforced**. ADR-030 adds an ownership axis to it without changing its enforcement modes.
   - [ADR-007](docs/adrs/ADR-007-automation-boundary.md) — the automation boundary. Read before building rules-driven features.
 
   ADR-015–020 cover the Dashboard play surface, built at `apps/itun/src/components/dashboard/`.
+
+- **Hosting is migrating to Cloudflare** ([ADR-033](docs/adrs/ADR-033-cloudflare-hosting.md)) — Netlify and Render are being retired in a **hard cutover with no rollback**. Everything below still describes the *current* Netlify/Render reality and stays accurate until the phase that changes it lands. Before touching hosting, deploy config, the snapshot backend or the Discord bot's transport, read the ADR and then [`docs/architecture/cloudflare-cutover.md`](docs/architecture/cloudflare-cutover.md), which carries the phase order, the per-phase gates and a progress table. Two things bind immediately: **a failed gate halts the phase and is never worked around**, and **snapshots go to R2 rather than into Convex**, which keeps a future Convex→D1 move open. Do not execute from issue #830 — the ADR supersedes it.
 
 - [`docs/architecture/`](docs/architecture/) — cross-cutting architecture (display system, data flow, package contracts, rules-engine boundary, combat loop, SEO/a11y).
 - **Rules text** — there is no curated digest. To answer "what does the book actually say", run `bun run rules:extract` (local only; the copyright-bearing PDFs in `rules/` are gitignored and absent in CI) and grep `rules/extracted/*.txt`, which carries `<!-- page N -->` markers so you can cite exact pages.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,8 @@ conventions, then the relevant architecture doc below.
 
 **I need a site id, service id, org slug, deployment name, or dashboard URL — or an MCP server isn't connecting** → [architecture/agent-tooling.md](architecture/agent-tooling.md) (**the service registry** — read it instead of listing every project on an account)
 
+**I'm working on the move to Cloudflare** → [adrs/ADR-033-cloudflare-hosting.md](adrs/ADR-033-cloudflare-hosting.md) (**the decisions** — read before revisiting any of them, especially R2-over-KV) + [architecture/cloudflare-cutover.md](architecture/cloudflare-cutover.md) (**the executable plan** — phase order, per-phase gates, progress table). Hard cutover, no rollback: **a failed gate halts the phase and is never worked around.** Do not execute from issue #830, which the ADR supersedes.
+
 **I'm touching how the SRD site is built, routed, or rendered** → [`apps/srd/ssg/DESIGN.md`](../apps/srd/ssg/DESIGN.md) (**the contract** — srd is built by an in-house SSG, **not Astro**) + [`apps/srd/CLAUDE.md`](../apps/srd/CLAUDE.md). Verify with `bun --filter srd gate` — `ssg/snapshot.ts` diffs the built output against a committed snapshot and is the acceptance gate, not your reading of the diff. If the change is intentional, `bun --filter srd snapshot:update` and commit the snapshot alongside it.
 
 ## Directory Map
@@ -53,6 +55,7 @@ conventions, then the relevant architecture doc below.
 | [seo-accessibility.md](architecture/seo-accessibility.md)             | SEO strategy (srd) + WCAG 2.1 AA patterns                                                              |
 | [accounts-and-games.md](architecture/accounts-and-games.md)           | ADR-030 delivery phases + the Convex/Netlify/Discord operational reference                             |
 | [agent-tooling.md](architecture/agent-tooling.md)                     | **Service registry** — MCP servers + auth models, and every Netlify/Render/Sentry/Convex identifier    |
+| [cloudflare-cutover.md](architecture/cloudflare-cutover.md)           | **Executable plan** for ADR-033 — phase order, per-phase gates, progress table, cutover runbook        |
 | [discord-bot-game-client.md](architecture/discord-bot-game-client.md) | **Plan** — the bot as an authenticated Game client: credential model, command surface, embed rendering |
 
 ### Rules text — extract and grep, no digest
@@ -142,6 +145,7 @@ Read the matching ADR before proposing alternatives.
 | [ADR-029](adrs/ADR-029-contribution-model-and-stat-provenance.md)    | **Proposed** — one contribution model for caps/traits/damage + stat provenance; amends ADR-022's overrides                                                                            |
 | [ADR-030](adrs/ADR-030-accounts-games-server-of-record.md)           | **Governing** — accounts, Games, ownership, and Convex as server of record; supersedes ADR-001, amends ADR-022                                                                        |
 | [ADR-031](adrs/ADR-031-srd-vite-ssg.md)                              | `srd` builds on an in-house Vite SSG (`apps/srd/ssg`); supersedes ADR-012 — same decision, different machine                                                                          |
+| [ADR-033](adrs/ADR-033-cloudflare-hosting.md)                        | Hosting moves to Cloudflare; Netlify + Render retired, hard cutover, snapshots on R2 not KV; amends ADR-004, Convex unchanged                                                          |
 
 > ADR-021 is the governing decision for rules enforcement and takes precedence
 > over prior ADRs where they conflict on _how hard a rule is enforced on which

--- a/docs/adrs/ADR-033-cloudflare-hosting.md
+++ b/docs/adrs/ADR-033-cloudflare-hosting.md
@@ -1,0 +1,173 @@
+# ADR-033: Hosting Moves to Cloudflare
+
+## Status
+
+**Accepted. Delivery is phased — see
+[architecture/cloudflare-cutover.md](../architecture/cloudflare-cutover.md) for
+the executable plan, its per-phase gates and current progress.**
+
+Amends [ADR-004](ADR-004-snapshot-netlify-functions.md): snapshots keep the
+endpoint shape, the ID scheme, the payload cap and the unauthenticated contract
+that ADR-004 decided, and change only the platform underneath them — Netlify
+Functions + Blobs become a Cloudflare Worker + R2.
+
+Re-affirms [ADR-031](ADR-031-srd-vite-ssg.md) and
+[ADR-030](ADR-030-accounts-games-server-of-record.md) without changing either.
+`srd` remains a statically pre-rendered no-backend site; Convex remains the
+server of record for identity, ownership and sharing. **Only the host changes.**
+
+Supersedes nothing.
+
+## Context
+
+Hosting is currently split three ways: Netlify serves `apps/srd`, `apps/itun`
+(SPA + three Functions + two Blobs stores) and `apps/su-assets`; Render runs
+`apps/discord-bot` as a gateway worker; Convex runs the accounts backend.
+
+Issue #830 proposed consolidating the first two onto Cloudflare. An audit
+against `1366cfdf` found the proposal sound in outline and wrong in four
+premises, and unexecutable in five respects — no acceptance criteria, no data
+migration procedure, no credential story, an unmeasured cost claim, and a
+storage choice that breaks a documented client invariant.
+
+The financial case is thin on its own: Render's worker is the only line item at
+$7/mo, and Workers Static Assets requests are free at this traffic. The reasons
+that survive scrutiny are consolidation onto one platform and the elimination of
+an entire class of Discord gateway failure.
+
+Three facts shaped the decision more than cost did.
+
+**`lp-assets` has no second copy.** The Leyline Press artwork behind
+`assets.salvageunion.io` exists only in Netlify Blobs, cannot enter this
+repository, and serves both production domains. The tool that uploaded it,
+`tools/upload-lp-assets.ts`, was deleted in #725 as dead code — so the store had
+no backup, no export path and no ingest path. That is a standing risk
+independent of this decision, and acting on it is the first phase of the plan.
+
+**The bot's data layer fits Workers Free, measured rather than assumed.** A
+probe carrying the reference corpus and the portable Discord dependencies
+deployed at 549.6 KiB compressed (18% of the 3 MB Free ceiling) with a Cloudflare-
+reported startup of 141 ms (14% of the 1 s budget). Cloudflare's deploy-time
+startup enforcement accepted it.
+
+**The bot already has a transport seam.** `apps/discord-bot/src/commands/interactions.ts`
+defines three narrow structural types that `discord.js` satisfies without
+adapters, and every runtime `discord.js` import outside `index.ts` and
+`events/ready.ts` has a portable equivalent in `@discordjs/builders`,
+`@discordjs/collection`, `@discordjs/rest` or `discord-api-types`.
+
+## Decision
+
+**1. Hosting consolidates onto Cloudflare. Netlify and Render are retired.**
+`srd` and the `itun` SPA move to Workers Static Assets; the `itun` snapshot API
+and `su-assets` become Workers; both Blobs stores become R2 buckets; the Discord
+bot moves from a Render gateway worker to Workers HTTP interactions.
+
+**2. This is a hard cutover with no rollback.** Deliberate. The consequence is
+that per-phase verification is the only safety mechanism, which is why every
+phase in the plan carries a gate written so that it can fail.
+
+**3. Snapshots use R2, not KV.** This reverses #830's proposal and is the single
+most consequential decision here, because the naive reading favours KV — payloads
+cap at 256 KB against a 25 MB value limit and access is by short ID.
+
+The disqualifying property is consistency, not shape. Cloudflare documents that
+KV writes take **up to 60 seconds to propagate globally** and that **negative
+lookups are cached**. The publish flow reads a key twice before creating it —
+once in `generateUniqueId`, once in `put`'s `onlyIfNew` check — so it primes a
+negative-cache entry for exactly the key it is about to write, and the client
+then immediately requests that key, because publish-then-share *is* the feature.
+
+`apps/itun/src/lib/snapshot/client.ts` makes this concrete. Its retry policy
+(#791) is `TRANSIENT_STATUSES = new Set([502, 504])`, and it excludes 404 with a
+written justification: *"not a blip, so retrying 400ms later just asks a store
+that has already said no."* That reasoning is true for Netlify Blobs and false
+for KV. **Choosing KV would silently invalidate a documented invariant in the
+client**, and the failure would reach users as a hard not-found with the retry
+deliberately disabled.
+
+**Do not revisit this without re-reading that comment.**
+
+**4. Builds run in GitHub Actions; deploys use `wrangler`.** Workers Builds is
+not adopted. `srd` forces this — its build provisions Chromium to render
+per-entity OG images — and applying it to all three surfaces keeps one build
+path, one place for path filtering, and the existing CI gates in front of every
+deploy.
+
+**5. Convex stays, and nothing here may foreclose moving it.** Replacing Convex
+with D1 is a separate decision requiring its own ADR. It is materially harder
+than this migration — 15 application tables plus `@convex-dev/auth`'s own,
+18 function modules across 4,589 lines, Discord OAuth, and 27 `useQuery` call
+sites consuming a reactive model that D1 has no equivalent for.
+
+Two constraints follow and are binding on this migration: **snapshots go to R2
+and not into Convex**, and the Worker↔Convex boundary stays plain HTTP with a
+bearer token. Both keep the option open at no cost today.
+
+**6. Salvage Union gets a dedicated Cloudflare account.** Cloudflare's isolation
+boundary is the account; members and roles scope who may act, not which resources
+belong to which project, so there is no in-account "team" that separates this
+work from unrelated personal projects. A dedicated account isolates the
+per-account Workers Free quota, yields a project-appropriate `workers.dev`
+subdomain, and — most usefully — lets the CI token be scoped so it cannot reach
+anything else.
+
+This binds before the zones are created, not after, because moving a zone
+between accounts later is a real migration.
+
+**7. A failed gate halts the phase.** No gate is worked around, relaxed, or
+retried with different parameters to obtain a pass, and no later phase begins
+while an earlier gate is red. With no rollback, an agent or engineer who treats
+a red gate as an obstacle converts a caught problem into an unrecoverable one.
+This rule exists to be cited.
+
+## Consequences
+
+**The Discord bot will display as permanently offline** in every server. Presence
+requires an identified gateway session, which an HTTP-interactions app never has.
+It works when invoked. `setPresence` and the `client.guilds.cache.size` liveness
+signal both go away; the latter needs rethinking rather than deleting.
+
+**The bot cutover is atomic across every server.** Gateway and HTTP interactions
+are mutually exclusive — Discord: *"you can only receive Interactions one of the
+two ways"* — and the Interactions Endpoint URL is application-level, not
+per-guild. There is no canary and no test guild. Verification is therefore a
+signed offline replay harness, not a staged rollout.
+
+**Three CI guards must be ported before the config they read is deleted.**
+`tools/check-observability.ts`, `tools/check-bun-version.ts` and
+`tools/check-convex-parity.ts` all read `netlify.toml`, and each exists because
+of a documented silent-production incident. A fourth,
+`tools/check-ci-aggregator.ts`, will correctly fire as jobs are added and removed.
+
+`check-observability.ts`'s `FUNCTION_DIRS` check is a **retirement rather than a
+port**: a Worker declares one entry point, so the "every file in a functions
+directory is a public endpoint" failure class ceases to exist.
+
+**Module scope on Workers forbids timers, async I/O and randomness.**
+`new REST()` throws outright — its constructor registers sweeper timers — and the
+failure occurs at startup, not at build. This also applies to any module-scope
+observability initialisation.
+
+**Zod's `jitless` configuration becomes load-bearing for the runtime, not only
+for CSP.** Zod v4's JIT parser compiles validators with `new Function`, which
+workerd bans. `packages/salvageunion-reference/lib/zod.ts` already disables it;
+that must not be reverted as an optimisation.
+
+**Removing `@netlify/blobs` retires two standing security suppressions.**
+`check:audit` currently ignores `GHSA-w3rx-r6r6-pgpr` and `GHSA-5p2g-fcmc-qvqq`,
+both reachable only via `@netlify/blobs → @netlify/dev-utils → image-size`. Once
+that dependency is gone, both `--ignore` flags come out and the CLAUDE.md section
+documenting them is deleted.
+
+**Netlify deploy previews disappear** when the sites do. The Workers preview-URL
+equivalent must be working beforehand.
+
+**DNS is two zones, not one.** `salvageunion.io` and `intheunionnow.com` are both
+on Netlify DNS. Neither carries MX, TXT, DMARC or a DNSSEC DS record, so the two
+classic nameserver-migration hazards do not apply here — but both zones move.
+
+**Snapshots published during DNS propagation would otherwise be lost.** This is
+not a rollback concern; both origins answer for the length of the TTL regardless.
+The plan freezes snapshot writes at a known instant and reconciles a final delta
+before the flip.

--- a/docs/architecture/cloudflare-cutover.md
+++ b/docs/architecture/cloudflare-cutover.md
@@ -1,0 +1,482 @@
+# Cloudflare Cutover
+
+The executable plan for [ADR-033](../adrs/ADR-033-cloudflare-hosting.md) —
+retiring Netlify and Render in favour of Cloudflare Workers, R2 and Workers
+Static Assets. Hard cutover, no rollback. Convex stays.
+
+**ADR-033 holds the decisions and their reasoning. This document holds the
+sequence, the gates and the progress.** Supersedes issue #830, which remains open
+for discussion history and should not be executed from.
+
+Drafted against `1366cfdf` on 2026-08-18. Cloudflare and Discord platform limits
+verified against vendor documentation on that date; repository claims read from
+source.
+
+---
+
+## The rule that governs everything else
+
+> **A failed gate halts the phase.**
+>
+> No gate is worked around, relaxed, or retried with different parameters to
+> obtain a pass. No later phase begins while an earlier gate is red. Report the
+> failure and stop.
+
+There is no rollback. Every gate below is written so that it can fail, and a gate
+that cannot fail is not a gate. If a gate looks wrong, change it in a PR and say
+why — do not route around it in the moment.
+
+---
+
+## Progress
+
+Update this table as part of each phase's PR. It is the only place that answers
+"which phase are we on".
+
+| Phase | What                                     | Reversible | Status                    |
+| ----- | ---------------------------------------- | ---------- | ------------------------- |
+| P0    | Port the CI guards                       | yes        | not started               |
+| P1    | Export `lp-assets`, restore ingest tool  | blocking   | not started               |
+| P2    | Measure the bot on real workerd          | throwaway  | **passed** — see Appendix |
+| P3    | R2 `SnapshotStorage`                     | yes        | not started               |
+| P4    | Three web surfaces on `workers.dev`      | yes        | not started               |
+| P5    | Bot on HTTP interactions                 | until flip | not started               |
+| P6    | Data sync and write freeze               | **no**     | not started               |
+| P7    | Cutover                                  | **no**     | not started               |
+| P8    | Decommission and tooling cleanup         | **no**     | not started               |
+
+**Blocked on a human decision:** the dedicated Cloudflare account (D5 below)
+blocks P4, because the `workers.dev` subdomain is account-scoped and effectively
+permanent.
+
+---
+
+## Measured facts
+
+Do not re-derive these; do re-verify them if more than a release cycle has
+passed. The probe that produced them is in the Appendix.
+
+| Quantity                             | Measured                | Free limit | Used   |
+| ------------------------------------ | ----------------------- | ---------- | ------ |
+| Worker size, compressed              | 549.6 KiB               | 3 MB       | 18%    |
+| Worker size, uncompressed            | 3,061 KiB               | 64 MB      | 5%     |
+| Startup, reported by Cloudflare      | **141 ms**              | 1,000 ms   | 14%    |
+| Startup, local workerd               | 28–32 ms (4 cold starts)| —          | —      |
+| Warm request CPU                     | below timer resolution  | 10 ms      | —      |
+| `preload('all')` under Bun           | 81.6 ms                 | —          | —      |
+| All 27 data JSON files, gzipped      | 268 KB                  | —          | —      |
+| Workers Free requests / subrequests  | —                       | 100k/day · 50 | —   |
+| KV global propagation                | up to 60 s              | —          | —      |
+
+Cloudflare's 3 MB Worker limit is measured **after compression**; the
+uncompressed ceiling is 64 MB and is not a constraint here.
+
+Workers freeze `Date.now()` between I/O as a Spectre mitigation, so per-request
+CPU cannot be timed from inside a Worker. The authoritative reading is
+`cpuTime` from `wrangler tail` against a deployed Worker.
+
+---
+
+## Phases
+
+### P0 — Port the CI guards · reversible · ½ day
+
+Three tools read `netlify.toml`, and each exists because of a documented
+silent-production incident. A hard cutover deletes that file, so they are ported
+**first**, not during.
+
+- `tools/check-observability.ts` — CSP `connect-src` per browser app. It also
+  carries a `netlifyBundled` flag per surface and a hardcoded `FUNCTION_DIRS`.
+- `tools/check-bun-version.ts` — the `BUN_VERSION` pin.
+- `tools/check-convex-parity.ts` — asserts the build command refuses to ship
+  without `CONVEX_DEPLOY_KEY`. That command moves into Actions, making this the
+  sharpest of the three.
+
+`FUNCTION_DIRS` is a **retirement, not a port** — a Worker declares one entry
+point, so the failure class it guards ceases to exist. Delete it deliberately,
+with the reason recorded in the diff.
+
+`tools/check-ci-aggregator.ts` (#812) fails when a job is missing from the
+`quality-checks` aggregate's `needs:`. It will fire as jobs change. That is
+correct; do not suppress it.
+
+**Gate**
+
+- [ ] `bun run check:all` green with both a `netlify.toml` and a `wrangler.jsonc`
+      present.
+- [ ] Each ported guard is demonstrated to **fail** when its asserted property is
+      removed. Test the guard, not just the run.
+- [ ] The `FUNCTION_DIRS` deletion carries a comment explaining why the class is
+      gone.
+
+### P1 — Export `lp-assets` and restore its ingest tool · blocking · 1 day
+
+Do this whether or not the migration proceeds. It depends on no other decision.
+
+Once Netlify is gone, R2 becomes the only copy of licensed artwork that cannot
+enter this repository. An export gives a second.
+
+- Restore `tools/upload-lp-assets.ts` from `8b678bbd` — it is the restore path.
+- Write `tools/export-lp-assets.ts` as its mirror.
+  `tools/convert-lp-assets-to-webp.ts` already has the scaffold:
+  `netlify blobs:list lp-assets --json` → keys → `blobs:get`.
+- Store the export encrypted, off Netlify, outside this repository.
+
+**Gate**
+
+- [ ] Export object count equals the `blobs:list` manifest count.
+- [ ] Every key's SHA-256 matches a fresh re-download. Not a spot check.
+- [ ] A restore has been rehearsed into a throwaway store and verified by the
+      same hash comparison.
+- [ ] The export lives somewhere durable and access-controlled that is neither
+      Netlify nor this repository.
+
+### P2 — Measure the bot on real workerd · throwaway · **passed**
+
+Ran 2026-08-18. See Measured facts and the Appendix. Cloudflare's deploy-time
+startup enforcement accepted the probe at 141 ms; the probe was deleted
+afterwards.
+
+Four constraints surfaced that Phase 5 must honour:
+
+1. **Module scope forbids timers, async I/O and randomness.** `new REST()` throws
+   with *"Disallowed operation called within global scope"* — its constructor
+   registers sweeper timers. Construct it lazily inside the handler. This also
+   applies to module-scope `initObservability()`.
+2. **`ButtonStyle` is exported by `discord-api-types`, not `@discordjs/builders`.**
+   The import rewrite is not a pure name-for-name swap.
+3. **Zod's `jitless` config is load-bearing for Workers**, not only for CSP.
+4. **Top-level `await` works at module scope**, which is what allows the preload
+   to be charged against the 1 s startup budget instead of the 10 ms request
+   budget.
+
+**Residual, deferred to P5:** per-request `cpuTime` read from `wrangler tail`
+against a deployed Worker carrying the real command handlers.
+
+### P3 — R2 `SnapshotStorage` · reversible · ½ day
+
+`SnapshotStorage` is three methods with two existing implementations, so this is
+a drop-in third. Run the **existing**
+`apps/itun/netlify/functions/__tests__/snapshot.test.ts` against it by swapping
+the injected storage — the suite becomes a conformance suite at no cost.
+
+Then add the test that justifies ADR-033 §3: publish, immediately retrieve, from
+a different colo. Run it against both R2 and KV.
+
+Revisit the rate limiter here. It is a module-scope `RateLimiter{10/min}` keyed
+on `x-nf-client-connection-ip`, already approximate, behind an enforced 256 KB
+payload cap. It is decorative. Either drop it and rely on the cap, or use
+Cloudflare's Rate Limiting binding. **Do not port the in-process version** — it
+would look like a control without being one.
+
+**Gate**
+
+- [ ] The existing snapshot suite passes **unmodified** against the R2
+      implementation.
+- [ ] Publish → immediate retrieve returns 200 from a different colo, 20
+      consecutive runs.
+- [ ] The same test against KV is observed to fail, or ADR-033 §3 is revisited on
+      the evidence.
+- [ ] A decision on the rate limiter is recorded either way.
+
+### P4 — Three web surfaces on `workers.dev` · reversible · 2 days
+
+**Blocked on D5** (the dedicated Cloudflare account) — the `workers.dev`
+subdomain is account-scoped and effectively permanent.
+
+Everything except DNS runs in parallel with production, at zero customer
+exposure. This is the acceptance gate for the whole migration.
+
+Two enabling changes first, each worth landing on its own:
+
+- `ASSET_BASE_URL` (`packages/salvageunion-reference/lib/assets.ts`) is a
+  compile-time constant. Make it env-overridable, or the artwork path cannot be
+  exercised end-to-end on `workers.dev`.
+- `apps/srd/playwright.config.ts` hardcodes `localhost:4321`. Give it the
+  `E2E_BASE_URL` support `apps/itun` already has.
+
+The routing table must be ported **in order**. Order is load-bearing at four
+points, each with an incident behind it:
+
+1. Retired-URL 301 — `/sheet/:kind/:id/share` → the sheet (#797).
+2. The four method-conditioned `/api/snapshots` rules, which become `req.method`
+   switching inside the Worker.
+3. `/assets/*` → **404**, never 200.
+4. SPA fallback.
+
+> `not_found_handling: "single-page-application"` answers **200** for a missing
+> hashed chunk, silently reintroducing the #759 cache-poisoning bug. `/assets/*`
+> must be handled Worker-first, and the curl assertion below is the only thing
+> that proves it.
+
+**Gate**
+
+- [ ] `bun --filter srd gate` clean against Cloudflare-served output — 1,039
+      pages and 899 endpoints compared byte-for-byte.
+- [ ] Both Playwright suites green against `workers.dev` via `E2E_BASE_URL`.
+- [ ] curl: a real hashed chunk returns 200 `application/javascript`; a missing
+      one returns **404, not 200**; `/`, `/s/<id>` and `/p/pilot/<id>` return 200
+      HTML.
+- [ ] All **three** header sets served correctly, including `su-assets`' (#778) —
+      verified by response, not by reading config.
+- [ ] The four redirect rules resolve in the documented order.
+
+### P5 — Bot on HTTP interactions · reversible until flip · 3 days
+
+Write one adapter satisfying the three types in `commands/interactions.ts` over
+`@discordjs/builders` + `@discordjs/rest`. The gateway half of `discord.js` does
+not run on workerd; the rest is portable. `index.ts` and `events/ready.ts` are
+the only genuinely gateway-bound modules.
+
+Port items:
+
+- `interaction.client.user?.displayAvatarURL()` (`buttons.ts`, `itunReply.ts`)
+  reads the bot's own user from the gateway cache. Hardcode or fetch once.
+- `EmbedBuilder` instances passed as `embeds: [embed]` need `.toJSON()`.
+- Every deferred command (`game.ts`, `itunReply.ts`) needs `ctx.waitUntil()`.
+- `getClientIp()`'s `x-nf-client-connection-ip` becomes `CF-Connecting-IP`.
+- Everything in P2's constraint list.
+
+> The cutover is **atomic across every server**. Gateway and HTTP interactions are
+> mutually exclusive and the Interactions Endpoint URL is application-level, not
+> per-guild. There is no canary, no percentage rollout and no test guild.
+
+**Gate**
+
+- [ ] A signed replay harness passes for every command shape in a corpus
+      harvested from the live bot. Ed25519 keypair generated locally; no second
+      Discord application.
+- [ ] Deferred commands acknowledge inside Discord's 3-second window and complete
+      via `waitUntil`.
+- [ ] Embed payloads diff clean against the JSON the gateway bot produces for the
+      same input.
+- [ ] `cpuTime` from `wrangler tail` is under 10 ms for every command shape.
+- [ ] Server admins have been told the bot will display permanently offline.
+
+### P6 — Data sync and write freeze · **irreversible** · ½ day
+
+Two stores move, and writes landing on Netlify after the final sync are lost.
+
+- Seed R2 artwork from the P1 export. Reconcile by count and per-key SHA-256.
+- Copy the `snapshots` store to R2. Reconcile by count and payload hash.
+- Ship a Netlify build where `POST` and `DELETE /api/snapshots` return 503, so
+  writes stop at a known instant while reads keep working from both origins.
+- Run a final delta sync.
+
+**Gate**
+
+- [ ] R2 artwork object count and every per-key hash match the manifest.
+- [ ] Snapshot count matches and payload hashes match.
+- [ ] `POST /api/snapshots` observed returning 503 in production.
+- [ ] The final delta sync reconciles to **zero** objects, verified after the
+      freeze rather than before.
+
+### P7 — Cutover · **irreversible** · 1 hour + propagation
+
+DNS propagation is not a rollback window, it is a physics window. Both origins
+answer for the length of the TTL, so the Netlify sites must keep serving until
+propagation completes — deleting them at the moment of the flip is strictly
+worse, because resolvers holding old records get errors rather than a
+stale-but-working site.
+
+| When   | Step                                                                                                                       |
+| ------ | -------------------------------------------------------------------------------------------------------------------------- |
+| −48 h  | Reduce TTLs on both zones to 300 s. Confirm the reduction has propagated.                                                   |
+| −2 h   | Transcribe every record in both zones into Cloudflare, grey-cloud. Diff against `dig` by hand — the auto-scan misses CNAMEs. |
+| −1 h   | Execute P6.                                                                                                                 |
+| 0      | Flip nameservers on `salvageunion.io`. This moves `srd` and `assets.salvageunion.io` together, because `ASSET_BASE_URL` is compile-time. |
+| +15 m  | Verify from multiple resolvers. Re-run the P4 curl assertions against real hostnames, including the missing-chunk 404.       |
+| +30 m  | Flip nameservers on `intheunionnow.com`. Re-run the itun Playwright suite against production.                               |
+| +1 h   | Lift the snapshot write freeze once both origins resolve to Cloudflare.                                                     |
+| +2 h   | Set the Discord Interactions Endpoint URL. Verify PING/PONG, then one command of each shape in a real server.               |
+| +24 h  | Proxy (orange-cloud) once verified. Raise TTLs back.                                                                        |
+
+**Gate**
+
+- [ ] Every gate P0–P6 green, recorded and dated in the Progress table.
+- [ ] TTLs reduced at least 48 h prior and observed in effect.
+- [ ] Every record in both zones transcribed by hand and diffed against `dig`.
+- [ ] All open decisions below are closed.
+
+### P8 — Decommission and tooling cleanup · **irreversible**
+
+Only after P7 has been stable for 24 h.
+
+- Delete the three Netlify sites and the Render service.
+- `.mcp.json`: remove `netlify` and `render`; add
+  `https://bindings.mcp.cloudflare.com/mcp` and
+  `https://observability.mcp.cloudflare.com/mcp`. Both authenticate by OAuth on
+  first connect, so **`.mcp.json` stays secret-free** — #291 removed `${VAR}`
+  placeholders deliberately; do not reintroduce them. Keep `convex`.
+- Add one project skill, `/cloudflare-deploy-verify`, the sibling of
+  `/convex-deploy-verify`. **One, not a suite** — the repository's bar is that a
+  skill encodes a decision procedure or a silent failure mode, never frontmatter
+  around a command, and six wrapper skills were deleted for failing that test.
+  The four qualifying failure modes are P4's 200-vs-404 trap, P2's module-scope
+  restriction, ADR-033 §3's KV consistency trap, and redirect ordering.
+- Port or delete `tools/convert-lp-assets-to-webp.ts` and
+  `tools/upload-lp-assets.ts`. **Not before P1's export is verified.**
+- Remove `@netlify/blobs`, then delete both `--ignore` flags from `check:audit`
+  and the CLAUDE.md section documenting them.
+- Update CLAUDE.md, `docs/README.md` and
+  [`agent-tooling.md`](agent-tooling.md) to describe Cloudflare.
+
+**Gate**
+
+- [ ] `bun run check:all` green with no `netlify.toml` anywhere in the tree.
+- [ ] `claude mcp list` shows the Cloudflare servers connected — zero tool calls
+      means "broken or unused" and the two are indistinguishable from usage data
+      alone.
+- [ ] `bun audit --audit-level=high` passes with **no** `--ignore` flags.
+- [ ] No document still describes Netlify or Render as a host.
+
+**30 days after P7:** audit skills by counted invocation — `"skill": "<name>:` in
+the session transcripts — not by intuition; a skill's own prompt injection makes
+it look ubiquitous. Anything at zero goes.
+
+---
+
+## Credentials
+
+Today Netlify holds its own build credentials and this repository holds **no
+deploy credentials at all**. Building in Actions means CI holds a token that can
+deploy production, alongside an agent PAT with `workflow` scope, no required human
+review, and pre-authorized `gh pr merge`.
+
+Minimum bar before P4 ships to any real hostname:
+
+- A Cloudflare API token scoped to *Workers Scripts: Edit* and the specific R2
+  buckets **in the dedicated account** — never an account-global token, and never
+  a token on the personal account.
+- Stored as an Actions secret. Never in `wrangler.jsonc`, never in a `.env` git
+  can see.
+- Deploy steps gated on the `quality-checks` aggregate, so a red gate cannot
+  deploy.
+- D3 below decides whether production deploys additionally require an environment
+  approval.
+
+---
+
+## Open decisions
+
+| #   | Decision                                                                          | Blocks    | Default if unanswered          |
+| --- | --------------------------------------------------------------------------------- | --------- | ------------------------------ |
+| D1  | Netlify account plan type — credit-based plans fail hard rather than billing over | nothing   | closeable with an account read |
+| D2  | Snapshot write freeze, or accept losing links published during propagation?       | P6        | freeze — it costs minutes      |
+| D3  | Do production deploys require environment approval, or does a green gate suffice? | P4        | green gate suffices            |
+| D4  | Announce the bot's permanent-offline display before the flip, or after?           | P5 gate   | before                         |
+| D5  | Dedicated Cloudflare account — name and owning email                              | **P4**    | none; must be answered         |
+
+**Closed by audit.** `lp-assets` has no backup and its ingest tool was deleted, so
+P1 grows rather than shrinks. The snapshot rate limit is decorative. The bot is
+independent of the web surfaces and P2 settled it on measured evidence.
+
+**On D5:** Cloudflare cannot create a second account on the same email from the
+dashboard. A dedicated account is registered under a different address, then
+`alxjrvs@gmail.com` is invited as Super Administrator and it appears in the
+normal account switcher.
+
+---
+
+## Accepted risks
+
+- **No rollback**, chosen deliberately. Every gate is load-bearing.
+- **The bot displays permanently offline** in every server.
+- **Netlify deploy previews disappear** when the sites do.
+- **Sentry liveness telemetry changes shape** — `client.guilds.cache.size` does
+  not exist under HTTP interactions.
+- **This document will drift.** #830's premises drifted twice — once at
+  authoring, once within a day of the audit. Re-verify against `main` before
+  executing any phase.
+
+---
+
+## Follow-up: Convex → D1
+
+Out of scope, with its own future ADR. Sized here only because the constraint it
+places on this migration is binding today.
+
+| Surface                                 | Size                              |
+| --------------------------------------- | --------------------------------- |
+| Application tables                      | 15                                |
+| Auth tables from `@convex-dev/auth`     | 6 (approx.)                       |
+| Function modules / total LOC            | 18 · 4,589                        |
+| Client reactive call sites              | 27 `useQuery` · 27 `useMutation`  |
+| Files importing `convex/react`          | 20                                |
+
+Schema translation to SQLite is the easy part. Three things are not:
+
+1. **Reactivity.** D1 has no subscriptions. ADR-030 identifies the reactive model
+   as the actual product feature and 27 call sites consume it. Cloudflare's answer
+   is Durable Objects with hibernating WebSockets, or polling — the first is a
+   real design exercise, the second is a product downgrade.
+2. **Auth.** Discord OAuth terminates on Convex via `@convex-dev/auth`. Replacing
+   it means owning the OAuth flow, session issuance and refresh, plus the
+   `authAccounts` lookup the Discord bot uses to resolve a snowflake to a user.
+3. **Transactions.** Convex mutations are serializable by default; invariants the
+   platform currently guarantees would have to become explicit.
+
+**Binding on this migration** (ADR-033 §5): snapshots go to R2 and not into
+Convex, and the Worker↔Convex boundary stays plain HTTP with a bearer token.
+
+---
+
+## Appendix — the P2 probe
+
+Deliberately **not** committed as a tool. It is a throwaway that answered a
+question, and keeping it as a permanent `tools/` entry would create maintenance
+surface — typecheck, knip and lint would all want to own a file whose runtime is
+workerd rather than Bun. Recorded here so it is reproducible instead.
+
+`wrangler.jsonc`:
+
+```jsonc
+{
+  "name": "su-p2-throwaway-probe",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-07-13"
+}
+```
+
+`src/index.ts` — imports the reference corpus and the portable Discord
+dependencies the command layer actually uses, preloads at module scope, and
+returns a lookup:
+
+```ts
+import { EmbedBuilder, SlashCommandBuilder, ActionRowBuilder, ButtonBuilder } from '@discordjs/builders'
+import { Collection } from '@discordjs/collection'
+import { REST } from '@discordjs/rest'
+import { MessageFlags, InteractionResponseType, ButtonStyle } from 'discord-api-types/v10'
+import { SalvageUnionReference } from '<abs path>/packages/salvageunion-reference/lib/index.ts'
+
+const t0 = Date.now()
+await SalvageUnionReference.preload('all')
+const startupPreloadMs = Date.now() - t0
+
+// REST must NOT be constructed at module scope — its constructor registers
+// sweeper timers, which workerd forbids in global scope.
+let rest: REST | null = null
+const getRest = () => (rest ??= new REST({ version: '10' }))
+
+export default {
+  async fetch(): Promise<Response> {
+    const chassis = SalvageUnionReference.Chassis.all()
+    const embed = new EmbedBuilder().setTitle(chassis[0]?.name ?? 'none')
+    return Response.json({ startupPreloadMs, chassisCount: chassis.length })
+  },
+}
+```
+
+Run:
+
+```bash
+bunx wrangler deploy --dry-run --outdir=dist   # bundle size, no account needed
+bunx wrangler dev --port 8799                  # real workerd, locally
+bunx wrangler deploy                           # prints "Worker Startup Time: N ms"
+bunx wrangler delete --name su-p2-throwaway-probe --force
+```
+
+`wrangler deploy` is the authoritative startup measurement: Cloudflare enforces
+the startup budget at deploy time and reports the figure on success. Do not
+register a `workers.dev` subdomain to route a probe — that name is account-scoped
+and effectively permanent (see D5).


### PR DESCRIPTION
Supersedes the *execution* of #830 (which stays open for discussion history).

Adds two documents and wires them into navigation so the work can be picked up cold:

- **[ADR-033](docs/adrs/ADR-033-cloudflare-hosting.md)** — the decisions and their reasoning.
- **[docs/architecture/cloudflare-cutover.md](docs/architecture/cloudflare-cutover.md)** — the sequence, per-phase gates, progress table and cutover runbook.

## Why #830 wasn't executable

It's an accurate audit and a credible proposal. Against `1366cfdf` it had four wrong premises and five structural gaps: no acceptance criteria, no data-migration procedure, no credential story, an unmeasured cost claim, and a storage choice that breaks a documented client invariant.

Corrected premises: `tools/upload-lp-assets.ts` no longer exists (deleted in #725, so `lp-assets` had no backup *and* no ingest path); DNS is **two** zones, not one; the bot already has a transport seam in `commands/interactions.ts`; and Sentry became one port rather than three when #781 landed `packages/observability`.

## Three decisions where the naive reading differs

**Snapshots use R2, not KV.** KV caches negative lookups and takes up to 60s to propagate. The publish flow reads a key twice before creating it, and `apps/itun/src/lib/snapshot/client.ts` deliberately excludes 404 from its retry set, justified in a comment by *"a store that has already said no"* — true for Blobs, false for KV. Choosing KV would silently invalidate that invariant and surface as a hard not-found. This reverses #830.

**Convex stays**, and two constraints keep a future D1 move open at no cost today: snapshots go to R2 rather than into Convex, and the Worker↔Convex boundary stays plain HTTP.

**A failed gate halts the phase.** There is no rollback, so per-phase verification is the only safety mechanism. A gate worked around converts a caught problem into an unrecoverable one.

## P2 is already measured and passed

| Gate | Measured | Free limit | Used |
| --- | --- | --- | --- |
| Worker size, compressed | 549.6 KiB | 3 MB | 18% |
| Startup (Cloudflare-reported) | **141 ms** | 1,000 ms | 14% |
| Warm request CPU | below timer resolution | 10 ms | — |

A real `wrangler deploy` passed Cloudflare's deploy-time startup enforcement; the probe was deleted immediately after. It surfaced four constraints Phase 5 must honour — most notably that `new REST()` throws at module scope, because workerd forbids timers in global scope.

The probe is an **appendix rather than a committed tool**: it's a throwaway, and a permanent `tools/` entry whose runtime is workerd would fight typecheck, knip and lint for no benefit.

## Open decision that blocks P4

**D5 — a dedicated Cloudflare account.** Cloudflare's isolation boundary is the account; members and roles scope who may act, not which resources belong to which project, so there's no in-account "team". This binds before the zones are created, because the `workers.dev` subdomain is account-scoped and effectively permanent.

## Verification

`bun run check:all` — exit 0. Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAMnTadKdR8YoQRbBfzHa9