### PR TITLE
docs: close D5 — the cutover runs on the existing Cloudflare account

### DIFF
--- a/docs/adrs/ADR-033-cloudflare-hosting.md
+++ b/docs/adrs/ADR-033-cloudflare-hosting.md
@@ -104,16 +104,24 @@ Two constraints follow and are binding on this migration: **snapshots go to R2
 and not into Convex**, and the Worker↔Convex boundary stays plain HTTP with a
 bearer token. Both keep the option open at no cost today.
 
-**6. Salvage Union gets a dedicated Cloudflare account.** Cloudflare's isolation
-boundary is the account; members and roles scope who may act, not which resources
-belong to which project, so there is no in-account "team" that separates this
-work from unrelated personal projects. A dedicated account isolates the
-per-account Workers Free quota, yields a project-appropriate `workers.dev`
-subdomain, and — most usefully — lets the CI token be scoped so it cannot reach
-anything else.
+**6. Everything runs on the existing `alxjrvs@gmail.com` account.** A dedicated
+account was considered and declined.
 
-This binds before the zones are created, not after, because moving a zone
-between accounts later is a real migration.
+Cloudflare's isolation boundary is the account — members and roles scope who may
+act, not which resources belong to which project, so there is no in-account
+"team". A separate account would therefore have been the only way to isolate the
+Workers Free quota and to scope the CI token so it could not reach anything else.
+Cloudflare also cannot create a second account on the same email, so it would
+have meant a second address and an invitation back.
+
+The cost of not doing it is small **today** and should be re-examined if that
+changes. The account currently holds no Workers, no KV namespaces, no D1
+databases and no `workers.dev` subdomain, so the per-account Free quota
+(100k requests/day, 10 ms CPU) is shared with nothing. The real residue is
+credential blast radius, recorded under Consequences.
+
+**R2 is not yet enabled on the account** and must be activated in the dashboard
+before P1, P3 or P6 can run. KV and D1 are already available.
 
 **7. A failed gate halts the phase.** No gate is worked around, relaxed, or
 retried with different parameters to obtain a pass, and no later phase begins
@@ -159,6 +167,19 @@ that must not be reverted as an optimisation.
 both reachable only via `@netlify/blobs → @netlify/dev-utils → image-size`. Once
 that dependency is gone, both `--ignore` flags come out and the CLAUDE.md section
 documenting them is deleted.
+
+**The CI token's blast radius is the whole personal account** (§6). Cloudflare
+API tokens scope by permission group and account, so *Workers Scripts: Edit* on
+this account authorises editing **any** Worker on it, present or future. R2
+permissions can still be narrowed to named buckets, and that narrowing should be
+applied. The residue is accepted, not solved, and it compounds with an agent PAT
+carrying `workflow` scope, no required human review, and pre-authorized
+`gh pr merge` — the path from "merge a PR" to "deploy production" closes with no
+human in it. Revisit if anything unrelated is ever added to this account.
+
+**The `workers.dev` subdomain is account-scoped and effectively permanent.** It
+must be registered before P4 names anything, and the name it gets is the name it
+keeps.
 
 **Netlify deploy previews disappear** when the sites do. The Workers preview-URL
 equivalent must be working beforehand.

--- a/docs/architecture/cloudflare-cutover.md
+++ b/docs/architecture/cloudflare-cutover.md
@@ -45,9 +45,19 @@ Update this table as part of each phase's PR. It is the only place that answers
 | P7    | Cutover                                  | **no**     | not started               |
 | P8    | Decommission and tooling cleanup         | **no**     | not started               |
 
-**Blocked on a human decision:** the dedicated Cloudflare account (D5 below)
-blocks P4, because the `workers.dev` subdomain is account-scoped and effectively
-permanent.
+**Account:** everything runs on the existing `alxjrvs@gmail.com` account
+(ADR-033 §6). A dedicated account was considered and declined; the residue is a
+CI token whose blast radius is that whole account.
+
+**One human prerequisite remains, and it blocks P1, P3 and P6:**
+**R2 is not enabled** on the account and must be activated in the Cloudflare
+dashboard. KV and D1 are already available. Nothing else exists on the account —
+no Workers, no KV namespaces, no D1 databases, no `workers.dev` subdomain — so
+the per-account Free quota is shared with nothing today.
+
+The `workers.dev` subdomain still has to be registered before P4 names anything.
+It is account-scoped and effectively permanent, so choose the name deliberately;
+it is no longer a blocker, just a one-way door.
 
 ---
 
@@ -113,6 +123,9 @@ correct; do not suppress it.
 
 Do this whether or not the migration proceeds. It depends on no other decision.
 
+> The **export** half needs nothing from Cloudflare and can start immediately.
+> Seeding R2 happens in P6 and needs R2 enabled on the account first.
+
 Once Netlify is gone, R2 becomes the only copy of licensed artwork that cannot
 enter this repository. An export gives a second.
 
@@ -155,6 +168,10 @@ against a deployed Worker carrying the real command handlers.
 
 ### P3 — R2 `SnapshotStorage` · reversible · ½ day
 
+> **Prerequisite: R2 must be enabled** on the Cloudflare account
+> (`wrangler r2 bucket list` currently returns *"Please enable R2 through the
+> Cloudflare Dashboard"*, code 10042). KV and D1 are already available.
+
 `SnapshotStorage` is three methods with two existing implementations, so this is
 a drop-in third. Run the **existing**
 `apps/itun/netlify/functions/__tests__/snapshot.test.ts` against it by swapping
@@ -181,11 +198,12 @@ would look like a control without being one.
 
 ### P4 — Three web surfaces on `workers.dev` · reversible · 2 days
 
-**Blocked on D5** (the dedicated Cloudflare account) — the `workers.dev`
-subdomain is account-scoped and effectively permanent.
-
 Everything except DNS runs in parallel with production, at zero customer
 exposure. This is the acceptance gate for the whole migration.
+
+Register the `workers.dev` subdomain on the account first. It is account-scoped
+and effectively permanent — a one-way door rather than a blocker, so choose the
+name deliberately.
 
 Two enabling changes first, each worth landing on its own:
 
@@ -345,9 +363,12 @@ review, and pre-authorized `gh pr merge`.
 
 Minimum bar before P4 ships to any real hostname:
 
-- A Cloudflare API token scoped to *Workers Scripts: Edit* and the specific R2
-  buckets **in the dedicated account** — never an account-global token, and never
-  a token on the personal account.
+- A Cloudflare API token scoped to *Workers Scripts: Edit* and, for R2,
+  **narrowed to the named buckets** rather than account-wide. Cloudflare supports
+  per-bucket R2 scoping and does not support per-Worker scoping, so the Workers
+  half authorises editing any Worker on the account. With D5 closed in favour of
+  the personal account (ADR-033 §6) that is the accepted residue — narrow the
+  half that can be narrowed, and do not pretend the other half is contained.
 - Stored as an Actions secret. Never in `wrangler.jsonc`, never in a `.env` git
   can see.
 - Deploy steps gated on the `quality-checks` aggregate, so a red gate cannot
@@ -365,22 +386,30 @@ Minimum bar before P4 ships to any real hostname:
 | D2  | Snapshot write freeze, or accept losing links published during propagation?       | P6        | freeze — it costs minutes      |
 | D3  | Do production deploys require environment approval, or does a green gate suffice? | P4        | green gate suffices            |
 | D4  | Announce the bot's permanent-offline display before the flip, or after?           | P5 gate   | before                         |
-| D5  | Dedicated Cloudflare account — name and owning email                              | **P4**    | none; must be answered         |
+| ~~D5~~ | ~~Dedicated Cloudflare account~~                                                | —         | **Closed** — see below         |
 
 **Closed by audit.** `lp-assets` has no backup and its ingest tool was deleted, so
 P1 grows rather than shrinks. The snapshot rate limit is decorative. The bot is
 independent of the web surfaces and P2 settled it on measured evidence.
 
-**On D5:** Cloudflare cannot create a second account on the same email from the
-dashboard. A dedicated account is registered under a different address, then
-`alxjrvs@gmail.com` is invited as Super Administrator and it appears in the
-normal account switcher.
+**D5 — closed 2026-08-18: everything runs on `alxjrvs@gmail.com`.** A dedicated
+account was considered and declined (ADR-033 §6). It would have been the only way
+to isolate the Workers Free quota and to scope the CI token, since Cloudflare's
+isolation boundary is the account and there is no in-account "team" — but nothing
+else lives on the account, so the quota is shared with nothing today. The accepted
+residue is credential blast radius: *Workers Scripts: Edit* on this account
+authorises editing any Worker on it. **Narrow the R2 half to named buckets, which
+Cloudflare does support.** Revisit if anything unrelated is added to the account.
 
 ---
 
 ## Accepted risks
 
 - **No rollback**, chosen deliberately. Every gate is load-bearing.
+- **The CI token can reach the whole `alxjrvs@gmail.com` account** (D5). Cloudflare
+  scopes tokens by permission group and account, and supports per-bucket R2
+  scoping but not per-Worker scoping. Nothing unrelated lives on the account
+  today, which is what makes this acceptable; adding something would change that.
 - **The bot displays permanently offline** in every server.
 - **Netlify deploy previews disappear** when the sites do.
 - **Sentry liveness telemetry changes shape** — `client.guilds.cache.size` does
@@ -479,4 +508,4 @@ bunx wrangler delete --name su-p2-throwaway-probe --force
 `wrangler deploy` is the authoritative startup measurement: Cloudflare enforces
 the startup budget at deploy time and reports the figure on success. Do not
 register a `workers.dev` subdomain to route a probe — that name is account-scoped
-and effectively permanent (see D5).
+and effectively permanent, so it should be chosen deliberately in P4.


### PR DESCRIPTION
Closes #840. Follows #831.

A dedicated Salvage Union Cloudflare account was proposed and **declined**. This records the decision and, more usefully, what it costs — so the tradeoff is legible later rather than looking like an oversight.

## What a separate account would have bought

Cloudflare's isolation boundary **is** the account. Members and roles scope who may act, not which resources belong to which project, so there is no in-account "team" — a separate account was the only mechanism for isolating the Workers Free quota and for scoping the CI token so it could not reach anything else. Cloudflare also cannot create a second account on the same email, so it would have meant a second address and an invitation back.

## Why declining is fine today

Checked against the account rather than assumed. It holds **nothing else**: no Workers, no KV namespaces, no D1 databases, no `workers.dev` subdomain. The per-account Free quota (100k req/day, 10 ms CPU) is shared with nothing.

## The residue that doesn't go away

Cloudflare scopes API tokens by permission group and account. It supports **per-bucket R2 scoping** and does **not** support per-Worker scoping — so *Workers Scripts: Edit* authorises editing any Worker on the account. Narrow the half that can be narrowed; don't pretend the other half is contained.

It compounds with an agent PAT carrying `workflow` scope, no required human review, and pre-authorized `gh pr merge` — the path from "merge a PR" to "deploy production" closes with no human in it. Now an accepted risk with an explicit revisit condition, not a solved problem.

## New prerequisite found while checking

**R2 is not enabled on the account.**

```
$ bunx wrangler r2 bucket list
✘ Please enable R2 through the Cloudflare Dashboard. [code: 10042]
```

R2 is load-bearing for both stores, and ADR-033 §3 chose it over KV deliberately. KV (`[]`) and D1 (empty) both already work. Tracked as #841, blocking P3 (#834) and P6 (#837). P1's *export* half needs nothing from Cloudflare and can start now.

## Effect on the plan

- **#835 (P4) unblocked.** Registering the `workers.dev` subdomain becomes a one-way door inside that phase rather than a prerequisite outside it — still account-scoped and permanent, so choose the name deliberately.
- ADR-033 §6 rewritten; two Consequences added (token blast radius, subdomain permanence).
- Plan: D5 row struck through and closed, R2 prerequisite recorded at the top and in P3, credentials section corrected, accepted-risks updated.

## Verification

`bun run check:all` — exit 0. `bun run test` — exit 0, 0 failures.

> An earlier push attempt failed in the pre-push hook with `beforeEach/afterEach hook timed out` flakes. That was load-induced — `wrangler dev` and concurrent `check:all` runs were competing for the machine. Re-run clean on an idle machine: green.

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAMnTadKdR8YoQRbBfzHa9