### PR TITLE
feat(tools): port the three deploy guards off netlify.toml (P0)

### DIFF
--- a/docs/architecture/cloudflare-cutover.md
+++ b/docs/architecture/cloudflare-cutover.md
@@ -35,7 +35,7 @@ Update this table as part of each phase's PR. It is the only place that answers
 
 | Phase | What                                     | Reversible | Status                    |
 | ----- | ---------------------------------------- | ---------- | ------------------------- |
-| P0    | Port the CI guards                       | yes        | not started               |
+| P0    | Port the CI guards                       | yes        | **done** — 19 guard tests |
 | P1    | Export `lp-assets`, restore ingest tool  | blocking   | not started               |
 | P2    | Measure the bot on real workerd          | throwaway  | **passed** — see Appendix |
 | P3    | R2 `SnapshotStorage`                     | yes        | not started               |
@@ -110,14 +110,36 @@ with the reason recorded in the diff.
 `quality-checks` aggregate's `needs:`. It will fire as jobs change. That is
 correct; do not suppress it.
 
-**Gate**
+**Gate — met 2026-08-18**
 
-- [ ] `bun run check:all` green with both a `netlify.toml` and a `wrangler.jsonc`
-      present.
-- [ ] Each ported guard is demonstrated to **fail** when its asserted property is
-      removed. Test the guard, not just the run.
-- [ ] The `FUNCTION_DIRS` deletion carries a comment explaining why the class is
-      gone.
+- [x] `bun run check:all` green. *Gate wording amended:* it asked for a
+      `wrangler.jsonc` to be present, which was the wrong test — the guards do not
+      read one. Each guard instead resolves its property from whichever source
+      exists, and the tests below drive it from the Cloudflare source with the
+      Netlify one deleted, which is the stronger assertion.
+- [x] Each ported guard demonstrated to **fail** when its property is removed —
+      19 tests across three files, all mutating the real tree and restoring it.
+- [x] The `FUNCTION_DIRS` retirement carries its reasoning in the diff.
+
+The rule each guard now follows, and the distinction the whole phase turns on:
+
+| State                                    | Verdict                     |
+| ---------------------------------------- | --------------------------- |
+| Config file absent                       | surface retired → skip      |
+| Config file present, property missing    | **fail** — misconfiguration |
+| No source anywhere carries the property  | **fail** — unguarded        |
+
+Two findings while porting, both recorded in the tests:
+
+- `apps/srd/public/_headers` **already exists**, carrying CORS for the JSON
+  endpoints and no CSP. So "a `_headers` file exists" must not imply "it declares
+  the policy" — the rule is *at least one source declares a CSP, and every source
+  that declares one must permit the Sentry origin*. A first attempt conflated
+  those and failed on the committed tree.
+- `check-convex-parity.ts` now names `.github/workflows/deploy-cloudflare.yml`
+  **before that workflow exists**, so P4 has to satisfy the guard rather than the
+  guard being retrofitted afterwards. The "neither source present" case fails
+  loudly, which is what closes the window where nothing asserts it.
 
 ### P1 — Export `lp-assets` and restore its ingest tool · blocking · 1 day
 

--- a/tools/__tests__/check-bun-version.test.ts
+++ b/tools/__tests__/check-bun-version.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Behaviour tests for `tools/check-bun-version.ts`.
+ *
+ * These exist because ADR-033 deletes this guard's inputs one deploy target at
+ * a time, and the guard had to learn the difference between "that target is
+ * retired" and "that target is misconfigured". Without a test, the cheap way to
+ * make a red guard green during the cutover is to widen the skip — which is
+ * precisely the failure this guard was written to prevent (su-assets shipped
+ * with no BUN_VERSION at all and nothing noticed).
+ *
+ * So both halves are asserted: a MISSING FILE must be tolerated, and a PRESENT
+ * FILE WITHOUT A PIN must still fail. A change that makes the second case pass
+ * has broken the guard, not fixed it.
+ *
+ * Each case mutates the real tree and restores it, for the same reason
+ * check-catalog.test.ts does: the tool's job is to read *these* files, and a
+ * fixture copy would not prove it is pointed at them.
+ */
+
+const ROOT = join(import.meta.dir, '..', '..')
+const TOOL = join(ROOT, 'tools', 'check-bun-version.ts')
+
+async function runCheck() {
+  const proc = Bun.spawn(['bun', TOOL], { cwd: ROOT, stdout: 'pipe', stderr: 'pipe' })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { stdout, stderr, exitCode }
+}
+
+/** Run `fn` with `relPath` temporarily rewritten, then restore it verbatim. */
+async function withFileContents(
+  relPath: string,
+  mutate: (s: string) => string,
+  fn: () => Promise<void>
+) {
+  const abs = join(ROOT, relPath)
+  const original = readFileSync(abs, 'utf-8')
+  try {
+    writeFileSync(abs, mutate(original))
+    await fn()
+  } finally {
+    writeFileSync(abs, original)
+  }
+}
+
+/** Run `fn` with `relPath` temporarily moved aside, then restore it. */
+async function withFileAbsent(relPath: string, fn: () => Promise<void>) {
+  const abs = join(ROOT, relPath)
+  const stash = `${abs}.check-bun-version-test-stash`
+  renameSync(abs, stash)
+  try {
+    await fn()
+  } finally {
+    if (existsSync(stash)) renameSync(stash, abs)
+  }
+}
+
+describe('check-bun-version', () => {
+  test('passes on the tree as committed', async () => {
+    const { exitCode, stdout } = await runCheck()
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('pinned consistently')
+  })
+
+  test('fails when a deploy config exists but carries no pin', async () => {
+    await withFileContents(
+      'apps/srd/netlify.toml',
+      (s) => s.replace(/BUN_VERSION\s*=\s*"[^"]+"/, 'NOT_THE_PIN = "x"'),
+      async () => {
+        const { exitCode, stderr } = await runCheck()
+        expect(exitCode).toBe(1)
+        expect(stderr).toContain('apps/srd/netlify.toml BUN_VERSION = (missing)')
+      }
+    )
+  })
+
+  test('fails when a deploy config pins a different version', async () => {
+    await withFileContents(
+      'render.yaml',
+      (s) => s.replace(/(-\s*key:\s*BUN_VERSION\s*\n\s*value:\s*)["']?[^"'\s]+["']?/, '$10.0.1'),
+      async () => {
+        const { exitCode, stderr } = await runCheck()
+        expect(exitCode).toBe(1)
+        expect(stderr).toContain('render.yaml BUN_VERSION = 0.0.1')
+      }
+    )
+  })
+
+  test('tolerates a retired deploy target — the file being gone', async () => {
+    await withFileAbsent('render.yaml', async () => {
+      const { exitCode, stdout } = await runCheck()
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain('1 deploy surface(s) retired')
+    })
+  })
+
+  test('still reports the surviving Netlify sites after one is retired', async () => {
+    await withFileAbsent('apps/su-assets/netlify.toml', async () => {
+      const { exitCode, stdout } = await runCheck()
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain('2 Netlify site(s)')
+    })
+  })
+})

--- a/tools/__tests__/check-convex-parity-static.test.ts
+++ b/tools/__tests__/check-convex-parity-static.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Behaviour tests for the STATIC half of `tools/check-convex-parity.ts` — the
+ * assertion that a production deploy cannot ship an ITUN client against a
+ * backend nobody pushed.
+ *
+ * That is not hypothetical: production ran that way from 2026-08-06 to
+ * 2026-08-10. The site served the current commit, the backend was four days
+ * stale, every soft-link write failed, and the UI rendered all of it as saved.
+ * Nothing was red.
+ *
+ * ADR-033 moves the build from `netlify.toml` into GitHub Actions, so the guard
+ * now accepts either source. The hazard in that change is a window where
+ * NEITHER carries the assertion and the check passes anyway — which is exactly
+ * what the third test below forbids.
+ *
+ * The `--live` half is not exercised here; it needs a real deployment and a
+ * CONVEX_DEPLOY_KEY, and runs nightly.
+ */
+
+const ROOT = join(import.meta.dir, '..', '..')
+const TOOL = join(ROOT, 'tools', 'check-convex-parity.ts')
+const WORKFLOW = '.github/workflows/deploy-cloudflare.yml'
+
+/** A workflow carrying all three properties the guard asks for. */
+const GOOD_WORKFLOW = `name: Deploy (Cloudflare)
+on:
+  push:
+    branches: [main]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse to ship without a Convex deploy key
+        env:
+          CONVEX_DEPLOY_KEY: \${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: |
+          if [ -z "$CONVEX_DEPLOY_KEY" ]; then
+            echo "FATAL: production deploy with no CONVEX_DEPLOY_KEY." >&2
+            exit 1
+          fi
+      - name: Push the backend and build the client
+        run: bunx convex deploy --cmd "bun run build"
+`
+
+async function runCheck() {
+  const proc = Bun.spawn(['bun', TOOL], { cwd: ROOT, stdout: 'pipe', stderr: 'pipe' })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { stdout, stderr, exitCode }
+}
+
+async function withFileContents(
+  relPath: string,
+  mutate: (s: string) => string,
+  fn: () => Promise<void>
+) {
+  const abs = join(ROOT, relPath)
+  const original = readFileSync(abs, 'utf-8')
+  try {
+    writeFileSync(abs, mutate(original))
+    await fn()
+  } finally {
+    writeFileSync(abs, original)
+  }
+}
+
+async function withNewFile(relPath: string, contents: string, fn: () => Promise<void>) {
+  const abs = join(ROOT, relPath)
+  if (existsSync(abs)) throw new Error(`${relPath} already exists — test would clobber it`)
+  try {
+    writeFileSync(abs, contents)
+    await fn()
+  } finally {
+    rmSync(abs, { force: true })
+  }
+}
+
+async function withFileAbsent(relPath: string, fn: () => Promise<void>) {
+  const abs = join(ROOT, relPath)
+  const stash = `${abs}.check-convex-parity-test-stash`
+  renameSync(abs, stash)
+  try {
+    await fn()
+  } finally {
+    if (existsSync(stash)) renameSync(stash, abs)
+  }
+}
+
+describe('check-convex-parity static guard', () => {
+  test('passes on the tree as committed', async () => {
+    const { exitCode, stdout } = await runCheck()
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('[netlify.toml]')
+  })
+
+  test('fails when netlify.toml stops making an absent key fatal', async () => {
+    await withFileContents(
+      'apps/itun/netlify.toml',
+      (s) => s.replace('-z "$CONVEX_DEPLOY_KEY"', '-n "$CONVEX_DEPLOY_KEY"'),
+      async () => {
+        const { exitCode, stderr } = await runCheck()
+        expect(exitCode).toBe(1)
+        expect(stderr).toContain('no longer fails a production build')
+      }
+    )
+  })
+
+  test('fails when NEITHER a netlify.toml nor a deploy workflow carries the guard', async () => {
+    await withFileAbsent('apps/itun/netlify.toml', async () => {
+      const { exitCode, stderr } = await runCheck()
+      expect(exitCode).toBe(1)
+      expect(stderr).toContain('no build definition carries the Convex deploy guard')
+    })
+  })
+
+  test('accepts the Actions workflow as the guard once netlify.toml is gone', async () => {
+    await withFileAbsent('apps/itun/netlify.toml', async () => {
+      await withNewFile(WORKFLOW, GOOD_WORKFLOW, async () => {
+        const { exitCode, stdout } = await runCheck()
+        expect(exitCode).toBe(0)
+        expect(stdout).toContain('[deploy-cloudflare.yml]')
+      })
+    })
+  })
+
+  test('a workflow that never runs `convex deploy` still fails', async () => {
+    await withFileAbsent('apps/itun/netlify.toml', async () => {
+      await withNewFile(
+        WORKFLOW,
+        GOOD_WORKFLOW.replace('bunx convex deploy', 'bun run build'),
+        async () => {
+          const { exitCode, stderr } = await runCheck()
+          expect(exitCode).toBe(1)
+          expect(stderr).toContain('no longer runs `convex deploy`')
+        }
+      )
+    })
+  })
+
+  test('a workflow that cannot fail on an absent key still fails', async () => {
+    await withFileAbsent('apps/itun/netlify.toml', async () => {
+      await withNewFile(WORKFLOW, GOOD_WORKFLOW.replace('            exit 1\n', ''), async () => {
+        const { exitCode, stderr } = await runCheck()
+        expect(exitCode).toBe(1)
+        expect(stderr).toContain('no longer fails a production deploy')
+      })
+    })
+  })
+})

--- a/tools/__tests__/check-observability-csp.test.ts
+++ b/tools/__tests__/check-observability-csp.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Behaviour tests for the CSP half of `tools/check-observability.ts`.
+ *
+ * This is the check whose absence let a fully-built Sentry stack sit dark in
+ * production: a `connect-src` missing the ingest origin blocks every event in
+ * the browser while the app looks completely healthy. ADR-033 moves that header
+ * out of `netlify.toml` and into a `_headers` file, so the check now reads
+ * either dialect — and the risk of that change is that "reads either" quietly
+ * becomes "requires neither".
+ *
+ * These assert the two rules separately, because conflating them is the actual
+ * bug this test caught during the port:
+ *
+ *   - AT LEAST ONE source must declare a CSP connect-src.
+ *   - EVERY source that declares one must permit the Sentry origin.
+ *
+ * The second rule is what stops a correct `_headers` file papering over a stale
+ * `netlify.toml` while both are live during the cutover. A source that declares
+ * no CSP at all is fine — srd's `_headers` legitimately carries only CORS.
+ */
+
+const ROOT = join(import.meta.dir, '..', '..')
+const TOOL = join(ROOT, 'tools', 'check-observability.ts')
+const SENTRY_HOST = 'https://*.ingest.de.sentry.io'
+
+async function runCheck() {
+  const proc = Bun.spawn(['bun', TOOL], { cwd: ROOT, stdout: 'pipe', stderr: 'pipe' })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { stdout, stderr, exitCode }
+}
+
+async function withFileContents(
+  relPath: string,
+  mutate: (s: string) => string,
+  fn: () => Promise<void>
+) {
+  const abs = join(ROOT, relPath)
+  const original = readFileSync(abs, 'utf-8')
+  try {
+    writeFileSync(abs, mutate(original))
+    await fn()
+  } finally {
+    writeFileSync(abs, original)
+  }
+}
+
+/** Create a file that does not exist, run, then remove it again. */
+async function withNewFile(relPath: string, contents: string, fn: () => Promise<void>) {
+  const abs = join(ROOT, relPath)
+  if (existsSync(abs)) throw new Error(`${relPath} already exists — test would clobber it`)
+  try {
+    writeFileSync(abs, contents)
+    await fn()
+  } finally {
+    rmSync(abs, { force: true })
+  }
+}
+
+async function withFileAbsent(relPath: string, fn: () => Promise<void>) {
+  const abs = join(ROOT, relPath)
+  const stash = `${abs}.check-observability-test-stash`
+  renameSync(abs, stash)
+  try {
+    await fn()
+  } finally {
+    if (existsSync(stash)) renameSync(stash, abs)
+  }
+}
+
+describe('check-observability CSP source resolution', () => {
+  test('passes on the tree as committed', async () => {
+    const { exitCode } = await runCheck()
+    expect(exitCode).toBe(0)
+  })
+
+  test('fails when the netlify.toml CSP drops the Sentry ingest origin', async () => {
+    await withFileContents(
+      'apps/itun/netlify.toml',
+      (s) => s.replace(SENTRY_HOST, 'https://example.invalid'),
+      async () => {
+        const { exitCode, stderr } = await runCheck()
+        expect(exitCode).toBe(1)
+        expect(stderr).toContain('CSP connect-src does not allow')
+      }
+    )
+  })
+
+  test('fails when NO source declares a CSP at all', async () => {
+    await withFileContents(
+      'apps/itun/netlify.toml',
+      (s) => s.replace(/Content-Security-Policy/g, 'X-Retired-Policy'),
+      async () => {
+        const { exitCode, stderr } = await runCheck()
+        expect(exitCode).toBe(1)
+        expect(stderr).toContain('declares a Content-Security-Policy')
+      }
+    )
+  })
+
+  test('accepts a _headers file as the CSP source once netlify.toml is gone', async () => {
+    await withFileAbsent('apps/itun/netlify.toml', async () => {
+      await withNewFile(
+        'apps/itun/public/_headers',
+        `/*\n  Content-Security-Policy: default-src 'self'; connect-src 'self' ${SENTRY_HOST};\n`,
+        async () => {
+          const { exitCode } = await runCheck()
+          expect(exitCode).toBe(0)
+        }
+      )
+    })
+  })
+
+  test('a _headers CSP that omits Sentry still fails — the dialect is not an escape hatch', async () => {
+    await withFileAbsent('apps/itun/netlify.toml', async () => {
+      await withNewFile(
+        'apps/itun/public/_headers',
+        `/*\n  Content-Security-Policy: default-src 'self'; connect-src 'self';\n`,
+        async () => {
+          const { exitCode, stderr } = await runCheck()
+          expect(exitCode).toBe(1)
+          expect(stderr).toContain('CSP connect-src does not allow')
+        }
+      )
+    })
+  })
+
+  test('a present _headers file with no CSP is not itself a failure', async () => {
+    // srd ships exactly this today: CORS for the JSON endpoints, no policy.
+    const headers = readFileSync(join(ROOT, 'apps/srd/public/_headers'), 'utf-8')
+    expect(headers).not.toContain('Content-Security-Policy')
+    const { exitCode } = await runCheck()
+    expect(exitCode).toBe(0)
+  })
+})
+
+describe('check-observability functions-directory retirement', () => {
+  test('a retired functions directory is tolerated, not failed', async () => {
+    await withFileAbsent('apps/su-assets/netlify/functions', async () => {
+      const { exitCode } = await runCheck()
+      expect(exitCode).toBe(0)
+    })
+  })
+
+  test('a file in a SURVIVING functions directory still must export a handler', async () => {
+    await withNewFile(
+      'apps/itun/netlify/functions/_probe-not-a-handler.ts',
+      'export const notAHandler = 1\n',
+      async () => {
+        const { exitCode, stderr } = await runCheck()
+        expect(exitCode).toBe(1)
+        expect(stderr).toContain('exports no handler')
+      }
+    )
+  })
+})

--- a/tools/check-bun-version.ts
+++ b/tools/check-bun-version.ts
@@ -15,9 +15,29 @@
  * production sites, so a Bun it was never tested against is a live risk, not a
  * hygiene point. A site with no pin now fails as `(missing)` rather than being
  * absent from the list.
+ *
+ * ## Surfaces are OPTIONAL BY FILE, mandatory by content (ADR-033)
+ *
+ * The Cloudflare cutover deletes these files one deploy target at a time, and
+ * this guard has to keep working across that — before, during and after —
+ * without ever being switched off. So each surface is resolved by two distinct
+ * questions, and conflating them is what would break it:
+ *
+ *   - **The file does not exist** → that deploy target is retired. Skip it.
+ *   - **The file exists but carries no pin** → misconfiguration. Fail as
+ *     `(missing)`, exactly as before.
+ *
+ * The second rule is the one with an incident behind it (su-assets, above), and
+ * it is untouched. Only the first is new. A retired surface is reported in the
+ * summary rather than silently dropped, so "0 Netlify sites" has to be read and
+ * agreed with rather than passing unnoticed.
+ *
+ * After the cutover, builds run in GitHub Actions, which reads `.bun-version`
+ * directly via setup-bun — so CI cannot drift from it by construction, and
+ * `bun-types` becomes the only surface that can.
  */
 
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -26,44 +46,59 @@ const expected = readFileSync(join(root, '.bun-version'), 'utf-8').trim()
 
 type Surface = { label: string; actual: string | undefined }
 
-function netlifyBunVersion(tomlPath: string): string | undefined {
-  const toml = readFileSync(join(root, tomlPath), 'utf-8')
-  return toml.match(/BUN_VERSION\s*=\s*"([^"]+)"/)?.[1]
+/**
+ * A surface backed by a deploy-config file that the cutover may delete.
+ *
+ * Returns `null` when the file is gone (target retired), and a Surface with
+ * `actual: undefined` when the file is present but unpinned (misconfigured) —
+ * the distinction this guard now turns on.
+ */
+function fileSurface(
+  label: string,
+  relPath: string,
+  extract: (contents: string) => string | undefined
+): Surface | null {
+  const abs = join(root, relPath)
+  if (!existsSync(abs)) return null
+  return { label, actual: extract(readFileSync(abs, 'utf-8')) }
+}
+
+function netlifyBunVersion(contents: string): string | undefined {
+  return contents.match(/BUN_VERSION\s*=\s*"([^"]+)"/)?.[1]
 }
 
 /** render.yaml's `- key: BUN_VERSION` / `value:` pair (YAML, so no quotes). */
-function renderBunVersion(): string | undefined {
-  const yaml = readFileSync(join(root, 'render.yaml'), 'utf-8')
-  return yaml.match(/-\s*key:\s*BUN_VERSION\s*\n\s*value:\s*["']?([^"'\s]+)["']?/)?.[1]
+function renderBunVersion(contents: string): string | undefined {
+  return contents.match(/-\s*key:\s*BUN_VERSION\s*\n\s*value:\s*["']?([^"'\s]+)["']?/)?.[1]
 }
 
 const rootPkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8')) as {
   devDependencies?: Record<string, string>
 }
 
+const retirable: Array<Surface | null> = [
+  fileSurface('apps/srd/netlify.toml BUN_VERSION', 'apps/srd/netlify.toml', netlifyBunVersion),
+  fileSurface('apps/itun/netlify.toml BUN_VERSION', 'apps/itun/netlify.toml', netlifyBunVersion),
+  fileSurface(
+    'apps/su-assets/netlify.toml BUN_VERSION',
+    'apps/su-assets/netlify.toml',
+    netlifyBunVersion
+  ),
+  // Render builds the Discord bot's shipped bundle with `bun build`, so it is
+  // the one deploy target whose Bun version affects an ARTIFACT rather than
+  // just a static build — and it was the only one this check did not cover.
+  // Same failure mode the su-assets note above describes: unpinned means
+  // "whatever the image ships", silently.
+  fileSurface('render.yaml BUN_VERSION', 'render.yaml', renderBunVersion),
+]
+
+const retiredCount = retirable.filter((s) => s === null).length
+
 const surfaces: Surface[] = [
+  ...retirable.filter((s): s is Surface => s !== null),
   {
-    label: 'apps/srd/netlify.toml BUN_VERSION',
-    actual: netlifyBunVersion('apps/srd/netlify.toml'),
-  },
-  {
-    label: 'apps/itun/netlify.toml BUN_VERSION',
-    actual: netlifyBunVersion('apps/itun/netlify.toml'),
-  },
-  {
-    label: 'apps/su-assets/netlify.toml BUN_VERSION',
-    actual: netlifyBunVersion('apps/su-assets/netlify.toml'),
-  },
-  {
-    // Render builds the Discord bot's shipped bundle with `bun build`, so it is
-    // the one deploy target whose Bun version affects an ARTIFACT rather than
-    // just a static build — and it was the only one this check did not cover.
-    // Same failure mode the su-assets note above describes: unpinned means
-    // "whatever the image ships", silently.
-    label: 'render.yaml BUN_VERSION',
-    actual: renderBunVersion(),
-  },
-  {
+    // Not retirable: this repository always has a root manifest, so `bun-types`
+    // is the one surface that survives the cutover and can still drift.
     label: 'root package.json devDependencies.bun-types',
     actual: rootPkg.devDependencies?.['bun-types'],
   },
@@ -83,6 +118,8 @@ if (drifted.length > 0) {
 // Netlify-site count from `surfaces.length`, which broke the moment a
 // non-Netlify surface joined the list).
 const netlifySites = surfaces.filter((s) => s.label.includes('netlify.toml')).length
+const retired = retiredCount > 0 ? ` (${retiredCount} deploy surface(s) retired)` : ''
 console.log(
-  `✓ Bun ${expected} pinned consistently across CI, all ${netlifySites} Netlify sites, Render, and bun-types.`
+  `✓ Bun ${expected} pinned consistently across CI, ${netlifySites} Netlify site(s), ` +
+    `${surfaces.length} surface(s) total${retired}.`
 )

--- a/tools/check-convex-parity.ts
+++ b/tools/check-convex-parity.ts
@@ -59,6 +59,15 @@ const CONVEX_DIR = join(REPO_ROOT, 'apps/itun/convex')
 const NETLIFY_TOML = join(REPO_ROOT, 'apps/itun/netlify.toml')
 
 /**
+ * Where the same guard lives once the build moves into GitHub Actions
+ * (ADR-033 §4). Named here BEFORE that workflow exists, deliberately: the
+ * property this tool protects must not have a window in which nothing asserts
+ * it, so the path is fixed in advance and the workflow has to satisfy it rather
+ * than this check being retrofitted afterwards.
+ */
+const CF_DEPLOY_WORKFLOW = join(REPO_ROOT, '.github/workflows/deploy-cloudflare.yml')
+
+/**
  * The deployment whose staleness costs something. Overridable because this is
  * the only environment-specific string in the tool, and pinning it in a repo
  * that documents its deployments elsewhere would be a second place to update.
@@ -85,11 +94,59 @@ function fail(message: string): void {
  * it is in, and an absent key in production is fatal.
  */
 function checkStatic(): void {
-  if (!existsSync(NETLIFY_TOML)) {
-    fail(`apps/itun/netlify.toml is missing — the production deploy guard lives there`)
+  const hasNetlify = existsSync(NETLIFY_TOML)
+  const hasWorkflow = existsSync(CF_DEPLOY_WORKFLOW)
+
+  // Neither source present is the one state that must never pass. During the
+  // cutover BOTH may be present, and each is checked on its own terms; after
+  // it, only the workflow remains. "Nothing asserts the guard" is the hole.
+  if (!hasNetlify && !hasWorkflow) {
+    fail(
+      `no build definition carries the Convex deploy guard — expected either\n` +
+        `      apps/itun/netlify.toml or .github/workflows/deploy-cloudflare.yml.\n` +
+        `      Without one, a production deploy can ship a client against a backend\n` +
+        `      nobody pushed, exactly as it did from 2026-08-06 to 2026-08-10.`
+    )
     return
   }
 
+  if (hasNetlify) checkNetlifyBuildGuard()
+  if (hasWorkflow) checkWorkflowBuildGuard()
+}
+
+/**
+ * The GitHub Actions form of the same three properties.
+ *
+ * Asserted on properties rather than an exact step, for the reason the Netlify
+ * version documents at length: a workflow will be edited again, and a brittle
+ * equality trains people to update the expectation without reading it.
+ */
+function checkWorkflowBuildGuard(): void {
+  const yaml = readFileSync(CF_DEPLOY_WORKFLOW, 'utf8')
+
+  if (!yaml.includes('convex deploy')) {
+    fail(
+      `.github/workflows/deploy-cloudflare.yml no longer runs \`convex deploy\`, so\n` +
+        `      the backend would never be pushed by a deploy at all`
+    )
+  }
+
+  const namesTheKey = yaml.includes('CONVEX_DEPLOY_KEY')
+  const canFail = yaml.includes('exit 1')
+
+  if (!namesTheKey || !canFail) {
+    fail(
+      `.github/workflows/deploy-cloudflare.yml no longer fails a production deploy\n` +
+        `      that has no CONVEX_DEPLOY_KEY. Without that guard an absent key ships a\n` +
+        `      current client against a stale backend and nothing goes red.`
+    )
+    return
+  }
+
+  console.log('  [deploy-cloudflare.yml] production deploy fails when CONVEX_DEPLOY_KEY is absent')
+}
+
+function checkNetlifyBuildGuard(): void {
   const toml = readFileSync(NETLIFY_TOML, 'utf8')
   const commandLine = toml.split('\n').find((line) => line.trimStart().startsWith('command ='))
 

--- a/tools/check-observability.ts
+++ b/tools/check-observability.ts
@@ -75,8 +75,16 @@ type BrowserApp = {
   modulePath: string
   /** Entry that must CALL the init. */
   entryPath: string
-  /** netlify.toml carrying the CSP. */
-  netlifyTomlPath: string
+  /**
+   * Candidate files that may carry the CSP, in preference order.
+   *
+   * Two entries, because ADR-033 moves the header from `netlify.toml` to a
+   * `_headers` file served by Workers Static Assets, and the CSP must never be
+   * unasserted in between. The rule is *at least one must exist and carry a
+   * `connect-src`* — every file that DOES exist is checked, so a stale copy
+   * cannot go wrong quietly while a good one carries the pass.
+   */
+  cspSources: string[]
   /** Production origin, for --live. */
   productionUrl: string
 }
@@ -90,7 +98,7 @@ const BROWSER_APPS: BrowserApp[] = [
     // inline module script. With Astro gone there is a single client entry, so
     // the init lives there — one place instead of one per layout.
     entryPath: 'apps/srd/src/runtime/islands.client.ts',
-    netlifyTomlPath: 'apps/srd/netlify.toml',
+    cspSources: ['apps/srd/netlify.toml', 'apps/srd/public/_headers'],
     productionUrl: 'https://salvageunion.io',
   },
   {
@@ -98,7 +106,7 @@ const BROWSER_APPS: BrowserApp[] = [
     dsnEnvVar: 'VITE_SENTRY_DSN',
     modulePath: 'apps/itun/src/lib/observability.ts',
     entryPath: 'apps/itun/src/main.tsx',
-    netlifyTomlPath: 'apps/itun/netlify.toml',
+    cspSources: ['apps/itun/netlify.toml', 'apps/itun/public/_headers'],
     productionUrl: 'https://intheunionnow.com',
   },
 ]
@@ -124,8 +132,20 @@ function connectSrcOfPolicy(policy: string): string | null {
   return directive ? directive.trim() : null
 }
 
-function connectSrcOf(toml: string): string | null {
-  const policy = toml.match(/Content-Security-Policy\s*=\s*"([^"]*)"/)?.[1]
+/**
+ * Extract `connect-src` from either config dialect.
+ *
+ * `netlify.toml` writes the header as TOML — `Content-Security-Policy = "…"` —
+ * while a Cloudflare/Netlify `_headers` file writes it as an actual header line,
+ * `Content-Security-Policy: …`, indented under a path pattern. Same directive,
+ * two spellings, and during the cutover both files exist at once.
+ *
+ * Matching on `=` or `:` in one expression rather than sniffing the filename
+ * keeps this honest about what it read: a `_headers` file that someone pasted
+ * TOML into still parses, and a rename cannot silently change the answer.
+ */
+function connectSrcOf(contents: string): string | null {
+  const policy = contents.match(/Content-Security-Policy\s*[=:]\s*"?([^"\n]*)"?/)?.[1]
   return policy === undefined ? null : connectSrcOfPolicy(policy)
 }
 
@@ -165,20 +185,47 @@ function checkStatic(app: BrowserApp): void {
 
   // The CSP half — the one that would have made a provisioned DSN look
   // healthy while silently dropping every event.
-  const toml = read(app.netlifyTomlPath)
-  if (!toml) {
-    fail(app.name, `netlify.toml missing at ${app.netlifyTomlPath}`)
-    return
-  }
-  const connectSrc = connectSrcOf(toml)
-  if (connectSrc === null) {
-    fail(app.name, `${app.netlifyTomlPath} declares no Content-Security-Policy connect-src`)
-  } else if (!connectSrc.includes(SENTRY_INGEST_HOST)) {
+  const present = app.cspSources.filter((path) => read(path) !== null)
+
+  if (present.length === 0) {
     fail(
       app.name,
-      `CSP connect-src does not allow ${SENTRY_INGEST_HOST} — Sentry events ` +
-        `would be blocked in the browser.\n      got: ${connectSrc}`
+      `no CSP source found — looked for ${app.cspSources.join(' and ')}. One of ` +
+        `them must carry the Content-Security-Policy, or the beacon is unguarded.`
     )
+    return
+  }
+
+  // Two separate rules, and conflating them was wrong: a `_headers` file may
+  // exist for reasons that have nothing to do with the CSP (srd's carries CORS
+  // for the JSON endpoints and nothing else), so "present" does not mean "must
+  // declare a policy".
+  //
+  //   - AT LEAST ONE source must declare a CSP `connect-src`.
+  //   - EVERY source that declares one must permit the Sentry origin — so a
+  //     correct file cannot paper over a stale sibling whose CSP has drifted,
+  //     whichever one the live site actually serves.
+  const declaring = present
+    .map((path) => ({ path, connectSrc: connectSrcOf(read(path) ?? '') }))
+    .filter((s): s is { path: string; connectSrc: string } => s.connectSrc !== null)
+
+  if (declaring.length === 0) {
+    fail(
+      app.name,
+      `none of ${present.join(', ')} declares a Content-Security-Policy ` +
+        `connect-src — the Sentry beacon is unguarded`
+    )
+    return
+  }
+
+  for (const { path, connectSrc } of declaring) {
+    if (!connectSrc.includes(SENTRY_INGEST_HOST)) {
+      fail(
+        app.name,
+        `${path}: CSP connect-src does not allow ${SENTRY_INGEST_HOST} — Sentry ` +
+          `events would be blocked in the browser.\n      got: ${connectSrc}`
+      )
+    }
   }
 }
 
@@ -552,10 +599,14 @@ const EXPORTS_A_HANDLER =
 function checkFunctionDirs(): void {
   for (const dir of FUNCTION_DIRS) {
     const full = join(process.cwd(), dir)
-    if (!existsSync(full)) {
-      failures.push(`  [functions] missing directory ${dir}`)
-      continue
-    }
+    // A directory that is GONE means that surface became a Worker (ADR-033).
+    // The whole failure class this check exists for — "every top-level file is
+    // implicitly a public endpoint" — is a property of Netlify's positional
+    // functions directory, and a Worker declares exactly one entry point in its
+    // wrangler config instead. So there is nothing left here to guard, and the
+    // check retires per-surface rather than being switched off wholesale: any
+    // directory that still EXISTS keeps the strict rule below, unchanged.
+    if (!existsSync(full)) continue
     for (const entry of readdirSync(full, { withFileTypes: true })) {
       if (!entry.isFile() || !/\.(ts|js|mjs)$/.test(entry.name)) continue
       const source = read(join(dir, entry.name))


### PR DESCRIPTION
Closes #832. Phase P0 of [ADR-033](docs/adrs/ADR-033-cloudflare-hosting.md) / [the cutover plan](docs/architecture/cloudflare-cutover.md).

ADR-033 deletes `netlify.toml` one deploy target at a time. Three guards read it, and each exists because of a documented silent-production incident — so they're ported **before** the config moves. Ported during, they either break loudly mid-cutover or, worse, keep passing while asserting things about a file nothing deploys.

## One rule, three guards

| State | Verdict |
| --- | --- |
| Config file absent | that deploy target is retired → skip |
| File present, property missing | **fail** — misconfiguration |
| No source carries it anywhere | **fail** — unguarded |

The middle row is the one with incidents behind it and is **unchanged**. Only the first is new.

- **`check-bun-version`** — Netlify/Render surfaces become retirable by file. The summary reports how many retired, so "0 Netlify sites" has to be read and agreed with rather than passing unnoticed.
- **`check-convex-parity`** — accepts `.github/workflows/deploy-cloudflare.yml` as an alternative home for the guard, asserting the same three properties. That path is named **before the workflow exists**, deliberately: P4 must satisfy the guard rather than the guard being retrofitted after. "Neither source present" fails loudly, closing the window where nothing asserts it.
- **`check-observability`** — reads the CSP from `netlify.toml` or a `_headers` file, matching `=` or `:` in one expression rather than sniffing the filename. `FUNCTION_DIRS` retires **per directory**: a Worker declares one entry point, so the "every top-level file is implicitly a public endpoint" class ceases to exist — but any directory that still exists keeps the strict rule.

## Two findings while porting

**`apps/srd/public/_headers` already exists**, carrying CORS for the JSON endpoints and no CSP. My first attempt required every present source to declare a policy, and it **failed on the committed tree**. The correct rule is: *at least one source declares a CSP, and every source that declares one must permit the Sentry origin* — so a good file cannot paper over a stale sibling while both are live during the cutover.

**The P0 gate is amended, not quietly satisfied.** It asked for `check:all` green "with a `wrangler.jsonc` present", which was the wrong test — no guard reads one. The tests instead drive each guard from the Cloudflare source with the Netlify one deleted, which is the stronger assertion. The amendment and its reasoning are recorded in the plan.

## Tests

19 across three files, each mutating the real tree and restoring it — a fixture copy would not prove the tools are pointed at *these* files. Every guard has at least one test proving it still **fails** when its property is removed, and one proving it accepts the Cloudflare source.

## Verification

`bun run check:all` — exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAMnTadKdR8YoQRbBfzHa9