### PR TITLE
feat(tools): export lp-assets, restore its ingest tool, correct ADR-033 §6 (P1)

### DIFF
--- a/docs/adrs/ADR-033-cloudflare-hosting.md
+++ b/docs/adrs/ADR-033-cloudflare-hosting.md
@@ -114,11 +114,29 @@ Workers Free quota and to scope the CI token so it could not reach anything else
 Cloudflare also cannot create a second account on the same email, so it would
 have meant a second address and an invitation back.
 
-The cost of not doing it is small **today** and should be re-examined if that
-changes. The account currently holds no Workers, no KV namespaces, no D1
-databases and no `workers.dev` subdomain, so the per-account Free quota
-(100k requests/day, 10 ms CPU) is shared with nothing. The real residue is
-credential blast radius, recorded under Consequences.
+**Correction, 2026-08-18.** This section first claimed the account "holds no
+Workers, no KV namespaces, no D1 databases and no `workers.dev` subdomain, so
+the per-account Free quota is shared with nothing". **Two-thirds of that was
+wrong**, and the error is worth recording because of how it was made: KV and D1
+were verified directly (`wrangler kv namespace list`, `wrangler d1 list`, both
+empty), the attempt to list Workers was blocked, and "empty" was *inferred* from
+the other two rather than checked. An inference was written down in the voice of
+a measurement.
+
+What is actually on the account:
+
+- **Two Workers**, `randsum-rdn` (`notation.randsum.dev`) and `randsum-site`
+  (`randsum.dev` + one more route) — so `RANDSUM/randsum` is already hosted here.
+- **A `workers.dev` subdomain already registered: `alxjrvs.workers.dev`.** There
+  is one per account, so this project takes preview URLs under it rather than
+  choosing its own name. Renaming it would move RANDSUM's Workers.
+- KV and D1 remain empty, as verified.
+
+So the Free quota (100k requests/day, 10 ms CPU) **is** shared, with a project
+that is already live. That does not reverse the decision — the traffic on both
+sides is far from those ceilings — but it does mean the credential blast radius
+under Consequences is a live concern rather than a theoretical one, and it
+removes the argument that a dedicated account would isolate nothing.
 
 **R2 is not yet enabled on the account** and must be activated in the dashboard
 before P1, P3 or P6 can run. KV and D1 are already available.
@@ -168,18 +186,24 @@ both reachable only via `@netlify/blobs → @netlify/dev-utils → image-size`. 
 that dependency is gone, both `--ignore` flags come out and the CLAUDE.md section
 documenting them is deleted.
 
-**The CI token's blast radius is the whole personal account** (§6). Cloudflare
-API tokens scope by permission group and account, so *Workers Scripts: Edit* on
-this account authorises editing **any** Worker on it, present or future. R2
-permissions can still be narrowed to named buckets, and that narrowing should be
-applied. The residue is accepted, not solved, and it compounds with an agent PAT
-carrying `workflow` scope, no required human review, and pre-authorized
-`gh pr merge` — the path from "merge a PR" to "deploy production" closes with no
-human in it. Revisit if anything unrelated is ever added to this account.
+**The CI token's blast radius is the whole personal account** (§6), and that now
+includes **two live RANDSUM Workers**. Cloudflare API tokens scope by permission
+group and account, so *Workers Scripts: Edit* on this account authorises editing
+`randsum-rdn` and `randsum-site` as well as anything this project deploys.
+Cloudflare supports per-bucket R2 scoping but not per-Worker scoping, so that
+half cannot be narrowed; narrow the R2 half, and do not describe the other half
+as contained.
 
-**The `workers.dev` subdomain is account-scoped and effectively permanent.** It
-must be registered before P4 names anything, and the name it gets is the name it
-keeps.
+This compounds with an agent PAT carrying `workflow` scope, no required human
+review, and pre-authorized `gh pr merge` — the path from "merge a PR" to "deploy
+production" closes with no human in it, and the production it can reach is not
+only this project's. **Accepted, not solved.** Revisit if RANDSUM's deployments
+ever become something this repository must not be able to touch.
+
+**The `workers.dev` subdomain is `alxjrvs.workers.dev`, already registered.**
+One per account, so this project takes preview URLs beneath it
+(`<worker>.alxjrvs.workers.dev`) rather than choosing its own. Renaming it would
+move RANDSUM's Workers and is out of scope.
 
 **Netlify deploy previews disappear** when the sites do. The Workers preview-URL
 equivalent must be working beforehand.

--- a/docs/architecture/cloudflare-cutover.md
+++ b/docs/architecture/cloudflare-cutover.md
@@ -36,7 +36,7 @@ Update this table as part of each phase's PR. It is the only place that answers
 | Phase | What                                     | Reversible | Status                    |
 | ----- | ---------------------------------------- | ---------- | ------------------------- |
 | P0    | Port the CI guards                       | yes        | **done** — 19 guard tests |
-| P1    | Export `lp-assets`, restore ingest tool  | blocking   | not started               |
+| P1    | Export `lp-assets`, restore ingest tool  | blocking   | **done** — 57/57 verified |
 | P2    | Measure the bot on real workerd          | throwaway  | **passed** — see Appendix |
 | P3    | R2 `SnapshotStorage`                     | yes        | not started               |
 | P4    | Three web surfaces on `workers.dev`      | yes        | not started               |
@@ -49,15 +49,30 @@ Update this table as part of each phase's PR. It is the only place that answers
 (ADR-033 §6). A dedicated account was considered and declined; the residue is a
 CI token whose blast radius is that whole account.
 
-**One human prerequisite remains, and it blocks P1, P3 and P6:**
-**R2 is not enabled** on the account and must be activated in the Cloudflare
-dashboard. KV and D1 are already available. Nothing else exists on the account —
-no Workers, no KV namespaces, no D1 databases, no `workers.dev` subdomain — so
-the per-account Free quota is shared with nothing today.
+**One human prerequisite remains, and it blocks P3 and P6: R2 is not enabled.**
+Activation is a checkout flow requiring a billing address and two consent
+checkboxes ("I agree to the Terms of Service", "I authorize Cloudflare to charge
+this card… until cancellation"). Total due today is $0.00 and a payment method is
+already on file, but entering personal or payment details and accepting terms are
+operator actions — an agent cannot do them. Page:
+`dash.cloudflare.com/<account>/r2/checkout/payment`.
 
-The `workers.dev` subdomain still has to be registered before P4 names anything.
-It is account-scoped and effectively permanent, so choose the name deliberately;
-it is no longer a blocker, just a one-way door.
+**What is actually on the account** (checked in the dashboard 2026-08-18, after
+an earlier claim of "nothing" turned out to be an inference rather than a
+measurement — see ADR-033 §6):
+
+| Resource            | State                                                     |
+| ------------------- | --------------------------------------------------------- |
+| Workers             | **two** — `randsum-rdn`, `randsum-site` (RANDSUM is live here) |
+| `workers.dev`       | **already registered — `alxjrvs.workers.dev`**             |
+| KV namespaces       | none                                                       |
+| D1 databases        | none                                                       |
+| R2                  | **not enabled**                                            |
+
+Two consequences. The Free quota is **shared with a live project**, though both
+sides are far from the ceilings. And preview URLs come from the existing
+subdomain (`<worker>.alxjrvs.workers.dev`) — there is one per account, and
+renaming it would move RANDSUM's Workers.
 
 ---
 
@@ -157,14 +172,28 @@ enter this repository. An export gives a second.
   `netlify blobs:list lp-assets --json` → keys → `blobs:get`.
 - Store the export encrypted, off Netlify, outside this repository.
 
-**Gate**
+**Gate — met 2026-08-18, one item deferred**
 
-- [ ] Export object count equals the `blobs:list` manifest count.
-- [ ] Every key's SHA-256 matches a fresh re-download. Not a spot check.
-- [ ] A restore has been rehearsed into a throwaway store and verified by the
-      same hash comparison.
-- [ ] The export lives somewhere durable and access-controlled that is neither
-      Netlify nor this repository.
+- [x] Export object count equals the `blobs:list` manifest count — **57/57**,
+      30,858,850 bytes, 57 distinct SHA-256 digests (no accidental duplicates).
+- [x] Every key's SHA-256 matches a fresh re-download. The tool re-downloads
+      **every** object and compares; it is not a spot check, because the failure
+      being guarded against is a silently truncated stream, which yields a file
+      that exists and has a plausible size and is not the artwork.
+- [ ] **Deferred: restore rehearsal.** Restoring into a throwaway Blobs store
+      would need a second Netlify site, and Netlify is being retired. The
+      equivalent rehearsal is seeding R2 from this export in P6, whose gate
+      already reconciles per-key hashes against `manifest.json`. Recorded rather
+      than silently dropped — until P6 runs, the restore path is *written and
+      unexercised*.
+- [x] The export lives outside Netlify and outside this repository. Operator
+      holds the archive; `manifest.json` travels with it so a restore verifies
+      against the list captured at export time rather than a fresh `blobs:list`
+      taken after something has already gone wrong.
+
+`tools/upload-lp-assets.ts` is restored from `8b678bbd` unchanged — it *is* the
+restore path, and #725 deleted it as dead code while it was the store's only
+ingest mechanism.
 
 ### P2 — Measure the bot on real workerd · throwaway · **passed**
 

--- a/tools/export-lp-assets.ts
+++ b/tools/export-lp-assets.ts
@@ -1,0 +1,176 @@
+#!/usr/bin/env bun
+
+/**
+ * export-lp-assets — pull every blob out of the "lp-assets" Netlify Blobs store
+ * (the bytes behind https://assets.salvageunion.io) into a local directory, and
+ * prove the copy is complete and byte-exact.
+ *
+ * ## Why this exists
+ *
+ * The artwork is licensed from Leyline Press ("used with special permission …
+ * do not redistribute"). It therefore lives ONLY in Blobs — never in this public
+ * repo — and it serves two production domains. That made it a single point of
+ * failure holding third-party licensed material, and the tool that put it there
+ * (`upload-lp-assets.ts`) was deleted as dead code in #725, so for a while the
+ * store had no backup, no export path AND no ingest path.
+ *
+ * ADR-033 retires Netlify. Restoring the ingest tool and adding this one is
+ * Phase 1 of that plan, and it is worth doing **whether or not the migration
+ * proceeds** — after the cutover R2 becomes the only copy, which is the same
+ * single-point-of-failure relocated rather than fixed. An export is the second
+ * copy.
+ *
+ * ## What "verified" means here
+ *
+ * A file count is not verification. Two things are checked, and the second is
+ * the one that matters:
+ *
+ *   1. every key in the store manifest produced a local file, and
+ *   2. re-downloading each key yields bytes whose SHA-256 matches the file on
+ *      disk — a spot check would not have caught a truncated stream.
+ *
+ * The manifest is written alongside the export as `manifest.json` so a restore
+ * can be verified against the same list rather than against a fresh `blobs:list`
+ * taken after something has already gone wrong.
+ *
+ * ## Usage
+ *
+ *   NETLIFY_SITE_ID=<su-assets site id> bun tools/export-lp-assets.ts <out-dir> [--prefix <p>]
+ *
+ * Requires the Netlify CLI installed and logged in (`netlify login`).
+ *
+ * The output directory is laid out exactly as `upload-lp-assets.ts` expects, so
+ * a restore is:
+ *
+ *   NETLIFY_SITE_ID=<id> bun tools/upload-lp-assets.ts <out-dir>
+ *
+ * @public CLI entry — invoked by an operator, not imported.
+ */
+import { execFileSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+const STORE = 'lp-assets'
+
+function netlify(args: string[]): string {
+  return execFileSync('netlify', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 })
+}
+
+function sha256(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+/**
+ * Every key under `prefix`, recursively.
+ *
+ * `blobs:list --json` returns `{ blobs: [{ key, etag }], directories: [...] }`
+ * and recurses by default (without `-d`), so `blobs` already holds every key.
+ * Same call `convert-lp-assets-to-webp.ts` makes — deliberately, so the two
+ * tools cannot disagree about what "everything in the store" means.
+ */
+function listKeys(prefix?: string): string[] {
+  const args = ['blobs:list', STORE, '--json']
+  if (prefix) args.push('--prefix', prefix)
+  const parsed = JSON.parse(netlify(args)) as { blobs?: Array<{ key: string }> }
+  return (parsed.blobs ?? []).map((b) => b.key)
+}
+
+/**
+ * Download one blob to `dest`.
+ *
+ * `blobs:get --output` writes the file itself rather than streaming through
+ * this process, which keeps binary bytes off stdout — passing image data
+ * through a shell pipe is how a "successful" export ends up subtly corrupt.
+ */
+function downloadTo(key: string, dest: string): void {
+  mkdirSync(dirname(dest), { recursive: true })
+  netlify(['blobs:get', STORE, key, '--output', dest])
+}
+
+function main(): void {
+  const args = process.argv.slice(2)
+  const outDir = args.find((a) => !a.startsWith('--'))
+  const prefixIdx = args.indexOf('--prefix')
+  const prefix = prefixIdx !== -1 ? args[prefixIdx + 1] : undefined
+
+  if (!outDir) {
+    console.error(
+      'usage: NETLIFY_SITE_ID=<id> bun tools/export-lp-assets.ts <out-dir> [--prefix <p>]'
+    )
+    process.exit(1)
+  }
+  if (!process.env.NETLIFY_SITE_ID) {
+    console.error('error: set NETLIFY_SITE_ID to the su-assets site id')
+    process.exit(1)
+  }
+
+  const keys = listKeys(prefix)
+  if (keys.length === 0) {
+    console.error(`error: store "${STORE}" reported 0 keys — refusing to write an empty export`)
+    process.exit(1)
+  }
+  console.log(`store "${STORE}" reports ${keys.length} key(s)${prefix ? ` under "${prefix}"` : ''}`)
+
+  const manifest: Array<{ key: string; bytes: number; sha256: string }> = []
+  const failed: string[] = []
+
+  for (const key of keys) {
+    const dest = join(outDir, key)
+    try {
+      downloadTo(key, dest)
+      const bytes = readFileSync(dest)
+      if (bytes.length === 0) throw new Error('wrote 0 bytes')
+      manifest.push({ key, bytes: bytes.length, sha256: sha256(bytes) })
+      console.log(`  ✓ ${key} (${bytes.length} bytes)`)
+    } catch (err) {
+      failed.push(key)
+      console.error(`  ✗ ${key}: ${(err as Error).message}`)
+    }
+  }
+
+  if (failed.length > 0) {
+    console.error(`\n✗ ${failed.length}/${keys.length} key(s) failed to export:`)
+    for (const k of failed) console.error(`    ${k}`)
+    console.error('  → the export is INCOMPLETE. Do not treat it as a backup.')
+    process.exit(1)
+  }
+
+  // Verify pass. Re-download every key and compare hashes, because the failure
+  // this is guarding against is a silently truncated stream — which produces a
+  // file that exists, has a plausible size, and is not the artwork.
+  console.log(`\nverifying ${manifest.length} object(s) by re-download…`)
+  const mismatched: string[] = []
+  const tmpRoot = join(outDir, '.verify')
+  for (const entry of manifest) {
+    const tmp = join(tmpRoot, entry.key)
+    try {
+      downloadTo(entry.key, tmp)
+      if (sha256(readFileSync(tmp)) !== entry.sha256) mismatched.push(entry.key)
+    } catch (err) {
+      mismatched.push(`${entry.key} (${(err as Error).message})`)
+    }
+  }
+
+  if (mismatched.length > 0) {
+    console.error(`\n✗ ${mismatched.length} object(s) did not match on re-download:`)
+    for (const k of mismatched) console.error(`    ${k}`)
+    process.exit(1)
+  }
+
+  const manifestPath = join(outDir, 'manifest.json')
+  writeFileSync(
+    manifestPath,
+    `${JSON.stringify({ store: STORE, exportedKeys: manifest.length, objects: manifest }, null, 2)}\n`
+  )
+
+  const totalBytes = manifest.reduce((sum, e) => sum + e.bytes, 0)
+  console.log(
+    `\n✓ exported and verified ${manifest.length} object(s), ${totalBytes} bytes total\n` +
+      `  manifest: ${manifestPath}\n` +
+      `  restore:  NETLIFY_SITE_ID=<id> bun tools/upload-lp-assets.ts ${outDir}\n` +
+      `  NOTE: ${tmpRoot} holds the verification copies — delete it before archiving.`
+  )
+}
+
+main()

--- a/tools/upload-lp-assets.ts
+++ b/tools/upload-lp-assets.ts
@@ -1,0 +1,72 @@
+/**
+ * upload-lp-assets — push Salvage Union entity artwork into the "lp-assets"
+ * Netlify Blobs store that backs https://assets.salvageunion.io (the su-assets
+ * site). This replaces the former hosted Storage bucket.
+ *
+ * The artwork is licensed from Leyline Press ("do not redistribute") so the
+ * BYTES never live in this public repo — only this tool does. Point it at a
+ * local directory of images (kept outside git) laid out as:
+ *
+ *     <dir>/<category>/<file>     e.g.  <dir>/chassis/iron-mongrel.jpg
+ *
+ * Each file is stored under the blob key "<category>/<file>" (exactly the path
+ * that appears after the host in an asset_url), so the asset function can serve
+ * it at https://assets.salvageunion.io/<category>/<file>.
+ *
+ * Usage:
+ *   NETLIFY_SITE_ID=<su-assets site id> bun tools/upload-lp-assets.ts <dir>
+ *
+ * Requires the Netlify CLI to be installed and logged in (`netlify login`).
+ * Re-runnable / idempotent — also the workflow for adding new artwork later.
+ */
+import { execFileSync } from 'node:child_process'
+import { readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+const STORE = 'lp-assets'
+
+function walk(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) out.push(...walk(full))
+    else out.push(full)
+  }
+  return out
+}
+
+function main(): void {
+  const root = process.argv[2]
+  if (!root) {
+    console.error('usage: bun tools/upload-lp-assets.ts <image-dir>')
+    process.exit(1)
+  }
+  if (!process.env.NETLIFY_SITE_ID) {
+    console.error('error: set NETLIFY_SITE_ID to the su-assets site id')
+    process.exit(1)
+  }
+
+  const files = walk(root)
+  let ok = 0
+  const failed: string[] = []
+
+  for (const file of files) {
+    const key = relative(root, file).split('\\').join('/')
+    try {
+      execFileSync('netlify', ['blobs:set', STORE, key, '--input', file], { stdio: 'ignore' })
+      ok++
+      console.log(`  ✓ ${key}`)
+    } catch {
+      failed.push(key)
+      console.error(`  ✗ ${key}`)
+    }
+  }
+
+  console.log(`\nuploaded ${ok}/${files.length} to store "${STORE}"`)
+  if (failed.length) {
+    console.error(`failed:\n${failed.map((k) => `  ${k}`).join('\n')}`)
+    process.exit(1)
+  }
+}
+
+main()


### PR DESCRIPTION
Closes #833. Phase P1 of [ADR-033](docs/adrs/ADR-033-cloudflare-hosting.md) / [the cutover plan](docs/architecture/cloudflare-cutover.md).

The Leyline-licensed artwork behind `assets.salvageunion.io` lived **only** in Netlify Blobs, cannot enter this repo, and serves two production domains. `tools/upload-lp-assets.ts` was deleted as dead code in #725 — so the store had no backup, no export path **and** no ingest path.

- **`tools/upload-lp-assets.ts`** restored verbatim from `8b678bbd`. It *is* the restore path; deleting it removed the only way to put the bytes back.
- **`tools/export-lp-assets.ts`** is its mirror: list → download → re-download and compare SHA-256 → write `manifest.json`.

Verification re-downloads **every** object rather than sampling, because the failure being guarded against is a silently truncated stream — which yields a file that exists, has a plausible size, and is not the artwork. `blobs:get --output` writes to disk instead of streaming through the process, so image bytes never cross a shell pipe.

**Run against the live store: 57/57 objects, 30,858,850 bytes, 57 distinct digests, all matching on re-download.** The archive lives off Netlify and outside this repo, with `manifest.json` alongside so a restore verifies against the list captured at export time rather than a fresh `blobs:list` taken after something has already gone wrong.

**One gate item deferred, not dropped.** Rehearsing a restore needs a second Netlify Blobs store, and Netlify is being retired. Seeding R2 in P6 is the equivalent rehearsal and its gate already reconciles per-key hashes. Until then the restore path is *written and unexercised*, and the plan says so.

---

## Correction to ADR-033 §6

Included here because a wrong fact in a merged decision record is worse than no fact.

ADR-033 §6 and the plan both claimed the Cloudflare account *"holds no Workers, no KV namespaces, no D1 databases and no `workers.dev` subdomain, so the per-account Free quota is shared with nothing"*. **Two-thirds of that was wrong.** KV and D1 were verified directly; the attempt to list Workers was blocked, and "empty" was **inferred** from the other two — then written in the voice of a measurement.

What is actually there:

| Resource | State |
| --- | --- |
| Workers | **two** — `randsum-rdn`, `randsum-site` (RANDSUM is already hosted here) |
| `workers.dev` | **already registered — `alxjrvs.workers.dev`** |
| KV / D1 | empty, as verified |
| R2 | not enabled |

This does **not** reverse D5 — both sides are far from the ceilings — but two things change:

- The CI token's blast radius is a **live** concern, not theoretical: `Workers Scripts: Edit` on this account can edit RANDSUM's deployments, and Cloudflare supports per-bucket R2 scoping but **not** per-Worker scoping.
- The `workers.dev` subdomain is fixed. One per account, so previews are `<worker>.alxjrvs.workers.dev`; renaming would move RANDSUM's Workers.

Also recorded: **enabling R2 is a checkout flow** requiring a billing address and two consent checkboxes ("I agree to the Terms of Service" / "I authorize Cloudflare to charge this card… until cancellation"). $0.00 due and a payment method is on file, but entering personal or payment details and accepting terms are operator actions — so R2 remains a human prerequisite for P3 and P6.

## Verification

`bun run check:all` — exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAMnTadKdR8YoQRbBfzHa9