### PR TITLE
feat: snapshot write freeze, the five custom domains, and a P7 runbook built on measured DNS

### DIFF
--- a/apps/itun/netlify/functions/__tests__/writeFreeze.test.ts
+++ b/apps/itun/netlify/functions/__tests__/writeFreeze.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { FREEZE_ENV, writeFreezeResponse } from '../../lib/writeFreeze'
+
+/**
+ * The ADR-033 P6 snapshot write freeze.
+ *
+ * The freeze exists so that the delta sync's "reconciled to zero" is a proof
+ * rather than a coincidence, so these tests are about the two properties that
+ * make it trustworthy: it is OFF unless deliberately turned on, and it can be
+ * turned back OFF without a code change.
+ */
+
+const original = process.env[FREEZE_ENV]
+
+afterEach(() => {
+  // Restored rather than deleted-and-forgotten: `process.env` is process-global
+  // and Bun runs a workspace's test files in one process, so leaving this set
+  // would hand a frozen backend to every file that runs afterwards.
+  if (original === undefined) delete process.env[FREEZE_ENV]
+  else process.env[FREEZE_ENV] = original
+})
+
+describe('writeFreezeResponse', () => {
+  test('is off when the variable is absent — the freeze is opt-in', () => {
+    delete process.env[FREEZE_ENV]
+    expect(writeFreezeResponse()).toBeNull()
+  })
+
+  for (const value of ['1', 'true', 'TRUE', '  true  ']) {
+    test(`freezes on ${JSON.stringify(value)}`, () => {
+      process.env[FREEZE_ENV] = value
+      expect(writeFreezeResponse()?.status).toBe(503)
+    })
+  }
+
+  for (const value of ['', '0', 'false', 'no', 'yes']) {
+    // Anything that is not an explicit yes is a no. `yes` is in this list on
+    // purpose: an allowlist that quietly grew synonyms would make the OFF state
+    // depend on guessing which spellings were remembered.
+    test(`does not freeze on ${JSON.stringify(value)}`, () => {
+      process.env[FREEZE_ENV] = value
+      expect(writeFreezeResponse()).toBeNull()
+    })
+  }
+
+  test('the variable is read per call, so the freeze can be lifted', () => {
+    // The structural guard. A module-scope `process.env` read would capture the
+    // value once at import — which passes every test above and still makes the
+    // freeze impossible to lift on a warm serverless instance. This is the only
+    // test that would fail if someone hoisted the read.
+    delete process.env[FREEZE_ENV]
+    expect(writeFreezeResponse()).toBeNull()
+
+    process.env[FREEZE_ENV] = '1'
+    expect(writeFreezeResponse()?.status).toBe(503)
+
+    delete process.env[FREEZE_ENV]
+    expect(writeFreezeResponse()).toBeNull()
+  })
+})
+
+describe('the frozen response', () => {
+  test('says temporary, in both a status code and a header', () => {
+    process.env[FREEZE_ENV] = '1'
+    const res = writeFreezeResponse()
+
+    // 503 rather than 403/410: the other two tell clients and crawlers the
+    // endpoint is permanently gone, which is the opposite of what is true.
+    expect(res?.status).toBe(503)
+    expect(res?.headers.get('retry-after')).toBe('3600')
+  })
+
+  test('is never cached — a cached 503 would outlive the freeze', () => {
+    process.env[FREEZE_ENV] = '1'
+    expect(writeFreezeResponse()?.headers.get('cache-control')).toBe('no-store')
+  })
+
+  test('explains that existing share links still work', async () => {
+    process.env[FREEZE_ENV] = '1'
+    const body = (await writeFreezeResponse()?.json()) as { error: string; message: string }
+
+    expect(body.error).toBe('snapshot_writes_frozen')
+    // Reads are not frozen, and the message must say so — otherwise the natural
+    // reading of "sharing is unavailable" is that published links have broken.
+    expect(body.message).toContain('Existing share links keep working')
+  })
+
+  test('reads as unavailable to probeSnapshotService, which hides the share UI', () => {
+    process.env[FREEZE_ENV] = '1'
+    const status = writeFreezeResponse()?.status
+
+    // `probeSnapshotService` treats ONLY 405 and 204 as a reachable backend.
+    // Pinning that here is what ties the freeze to the client behaviour it is
+    // relying on: the affordance disappears rather than failing when pressed.
+    expect(status).not.toBe(405)
+    expect(status).not.toBe(204)
+  })
+})

--- a/apps/itun/netlify/functions/snapshot-delete.ts
+++ b/apps/itun/netlify/functions/snapshot-delete.ts
@@ -12,11 +12,18 @@ import { makeDeleteHandler } from '../../src/lib/snapshot/handlers'
 import { setSnapshotReporter } from '../../src/lib/snapshot/report'
 import { createNetlifyBlobsStorage } from '../../src/lib/snapshot/storageNetlify'
 import { captureException, initObservability } from '../lib/observability'
+import { writeFreezeResponse } from '../lib/writeFreeze'
 
 export { makeDeleteHandler }
 
 /** @public Netlify Functions handler — invoked by the platform, not imported. */
 export default async function (req: Request): Promise<Response> {
+  // Frozen for the same reason as publish, and with more at stake: a revoke
+  // that lands here after the final delta sync deletes the Blobs copy while
+  // leaving the R2 copy readable, resurrecting a snapshot its owner revoked.
+  const frozen = writeFreezeResponse()
+  if (frozen) return frozen
+
   initObservability()
   setSnapshotReporter(captureException)
   try {

--- a/apps/itun/netlify/functions/snapshot-publish.ts
+++ b/apps/itun/netlify/functions/snapshot-publish.ts
@@ -15,11 +15,19 @@ import { makePublishHandler } from '../../src/lib/snapshot/handlers'
 import { setSnapshotReporter } from '../../src/lib/snapshot/report'
 import { createNetlifyBlobsStorage } from '../../src/lib/snapshot/storageNetlify'
 import { captureException, initObservability } from '../lib/observability'
+import { writeFreezeResponse } from '../lib/writeFreeze'
 
 export { makePublishHandler }
 
 /** @public Netlify Functions handler — invoked by the platform, not imported. */
 export default async function (req: Request): Promise<Response> {
+  // Checked before anything else, including Sentry init and storage: during the
+  // ADR-033 P6 freeze this function must not touch the Blobs store at all, and
+  // it must answer every method — `probeSnapshotService` reads HEAD, and a 503
+  // there is what hides the share affordance instead of letting it fail on use.
+  const frozen = writeFreezeResponse()
+  if (frozen) return frozen
+
   initObservability()
   // The shared handlers report through a transport-neutral seam so they can
   // also run on workerd, where @sentry/node does not bundle. Netlify installs

--- a/apps/itun/netlify/lib/writeFreeze.ts
+++ b/apps/itun/netlify/lib/writeFreeze.ts
@@ -1,0 +1,88 @@
+/**
+ * The snapshot write freeze (ADR-033 P6).
+ *
+ * ## Why a freeze exists at all
+ *
+ * The migration copies the `snapshots` Blobs store into R2 while writes are
+ * still live, then runs a delta pass that must reconcile to **zero**. That
+ * second pass can only mean anything if nothing is still writing to Netlify —
+ * so the freeze is what makes "zero" a proof rather than a coincidence.
+ *
+ * Both write verbs are frozen, and the DELETE case is the one that matters
+ * most:
+ *
+ * - a **publish** that lands on Netlify after the final sync never reaches R2,
+ *   so its share link 404s from the moment the flip completes;
+ * - a **revoke** that lands on Netlify after the final sync removes the object
+ *   from Blobs but leaves the copy in R2 — so a snapshot the owner deliberately
+ *   revoked stays readable at its original URL.
+ *
+ * The second is a privacy failure and is strictly worse than the first, which
+ * is why freezing DELETE is not an afterthought.
+ *
+ * ## Why it freezes every method, not just POST and DELETE
+ *
+ * `probeSnapshotService` in `src/lib/snapshot/client.ts` feature-detects the
+ * backend with `HEAD /api/snapshots` and treats **only** 405 or 204 as
+ * available. Freezing HEAD too therefore makes the client hide the share
+ * affordance entirely, which is a better outcome than leaving a button that
+ * fails once pressed: the user never acts on a control that cannot work.
+ *
+ * Reads are deliberately untouched — `snapshot-retrieve` is a separate function
+ * and is never frozen, so every existing share link keeps resolving throughout
+ * the window. The freeze stops the store from *changing*, not from serving.
+ *
+ * ## Lifetime
+ *
+ * Temporary by construction: this lives in the Netlify adapter layer rather
+ * than in the shared handlers, so P8 deletes this file and two one-line calls
+ * and nothing else. The Workers side has no freeze — it is the destination.
+ */
+
+/** Set to `1` / `true` on the Netlify site to freeze snapshot writes. */
+export const FREEZE_ENV = 'SNAPSHOT_WRITES_FROZEN'
+
+/**
+ * Read per-call rather than at module scope.
+ *
+ * `apps/discord-bot/src/config.ts` is the cautionary example this repo already
+ * carries: a module-scope `process.env` read is captured once at import, which
+ * makes the value impossible to vary per test and, on a warm serverless
+ * instance, pins it for the life of the container. The freeze must be able to
+ * be lifted by changing the variable and redeploying, so it is read on every
+ * request.
+ */
+function frozen(): boolean {
+  const raw = process.env[FREEZE_ENV]?.trim().toLowerCase()
+  return raw === '1' || raw === 'true'
+}
+
+/**
+ * The 503 served while writes are frozen, or `null` when they are not.
+ *
+ * 503 rather than 403 or 410: this is explicitly temporary, and the other two
+ * would tell a client — and a crawler — that the endpoint is permanently gone.
+ * `Retry-After` carries the same message in a form software reads.
+ *
+ * `Cache-Control: no-store` is load-bearing, not hygiene. A cached 503 outlives
+ * the freeze it describes, and the whole point of the window is that it ends;
+ * a CDN or browser holding this response would keep sharing broken after
+ * writes resumed, with nothing left to point at as the cause.
+ */
+export function writeFreezeResponse(): Response | null {
+  if (!frozen()) return null
+  return Response.json(
+    {
+      error: 'snapshot_writes_frozen',
+      message:
+        'Sharing is briefly paused while snapshots move to their new home. Existing share links keep working.',
+    },
+    {
+      status: 503,
+      headers: {
+        'retry-after': '3600',
+        'cache-control': 'no-store',
+      },
+    }
+  )
+}

--- a/apps/itun/wrangler.jsonc
+++ b/apps/itun/wrangler.jsonc
@@ -5,6 +5,15 @@
   // routing, which Cloudflare cannot express declaratively, and `/assets/*`
   // needs a decision that no static-asset mode makes correctly (see below).
   "name": "su-itun",
+
+  // Custom domains. `www` is attached for the same reason as srd's: a hostname
+  // must be proxied before a zone-level Redirect Rule can act on it, and the
+  // rule runs ahead of Workers so this script never sees a www request. See
+  // srd/wrangler.jsonc for why the redirect cannot live in `_redirects`.
+  "routes": [
+    { "pattern": "intheunionnow.com", "custom_domain": true },
+    { "pattern": "www.intheunionnow.com", "custom_domain": true }
+  ],
   "main": "src/worker/index.ts",
   "compatibility_date": "2026-07-13",
 

--- a/apps/srd/wrangler.jsonc
+++ b/apps/srd/wrangler.jsonc
@@ -13,6 +13,32 @@
   "name": "su-srd",
   "compatibility_date": "2026-07-13",
 
+  // Custom domains. Wrangler creates the proxied DNS record for each on deploy,
+  // which is why nothing in this repo writes A records by hand — and why the
+  // addresses Cloudflare's onboarding scan captured were left as inert
+  // DNS-only placeholders rather than transcribed (they are load-balancer
+  // replies synthesized per query, not configuration; see ADR-033 P7).
+  //
+  // `www` is attached even though it must REDIRECT rather than serve, because
+  // a hostname has to be proxied through Cloudflare before a Redirect Rule can
+  // act on it. The rule runs in the Rules phase, ahead of Workers and ahead of
+  // asset serving, so the redirect wins and this Worker never sees the request.
+  //
+  // The redirect itself is NOT in this repo and cannot be: `_redirects` does
+  // not support domain-level rules — Cloudflare's own docs list them as
+  // unsupported and say malformed definitions are ignored, so a www rule there
+  // would silently do nothing. It is a zone-level Redirect Rule instead,
+  // recorded in docs/architecture/cloudflare-cutover.md §P7 so it is not
+  // invisible config.
+  //
+  // Attaching www is deliberately the fail-safe half of that split: if the
+  // Redirect Rule is ever missing, www serves the site with its correct
+  // per-page canonicals rather than erroring.
+  "routes": [
+    { "pattern": "salvageunion.io", "custom_domain": true },
+    { "pattern": "www.salvageunion.io", "custom_domain": true }
+  ],
+
   "assets": {
     "directory": "./dist",
 

--- a/apps/su-assets/wrangler.jsonc
+++ b/apps/su-assets/wrangler.jsonc
@@ -11,6 +11,12 @@
   // robots is served from the Worker rather than smuggled in as a second
   // mechanism — one place decides what this origin returns.
   "name": "su-assets",
+
+  // One hostname, and it moves with srd rather than separately: `ASSET_BASE_URL`
+  // in salvageunion-reference is compile-time, so every artwork URL baked into
+  // both apps already points at this name. Flipping salvageunion.io moves the
+  // reference site and its artwork host together — they cannot be staged apart.
+  "routes": [{ "pattern": "assets.salvageunion.io", "custom_domain": true }],
   "main": "src/worker.ts",
 
   // Pinned to what this repo's wrangler (4.108) bundles as workerd, so

--- a/docs/architecture/cloudflare-cutover.md
+++ b/docs/architecture/cloudflare-cutover.md
@@ -567,31 +567,93 @@ Two stores move, and writes landing on Netlify after the final sync are lost.
 - [ ] The final delta sync reconciles to **zero** objects, verified after the
       freeze rather than before.
 
-### P7 — Cutover · **irreversible** · 1 hour + propagation
+### P7 — Cutover · **irreversible** · ~1 hour
 
-DNS propagation is not a rollback window, it is a physics window. Both origins
-answer for the length of the TTL, so the Netlify sites must keep serving until
-propagation completes — deleting them at the moment of the flip is strictly
-worse, because resolvers holding old records get errors rather than a
-stale-but-working site.
+Both zones are **staged and answering** on their assigned nameservers while the
+live delegation still points at Netlify, so everything below has already been
+rehearsed against the real Cloudflare zones at zero customer risk.
 
-| When   | Step                                                                                                                       |
-| ------ | -------------------------------------------------------------------------------------------------------------------------- |
-| −48 h  | Reduce TTLs on both zones to 300 s. Confirm the reduction has propagated.                                                   |
-| −2 h   | Transcribe every record in both zones into Cloudflare, grey-cloud. Diff against `dig` by hand — the auto-scan misses CNAMEs. |
-| −1 h   | Execute P6.                                                                                                                 |
-| 0      | Flip nameservers on `salvageunion.io`. This moves `srd` and `assets.salvageunion.io` together, because `ASSET_BASE_URL` is compile-time. |
-| +15 m  | Verify from multiple resolvers. Re-run the P4 curl assertions against real hostnames, including the missing-chunk 404.       |
-| +30 m  | Flip nameservers on `intheunionnow.com`. Re-run the itun Playwright suite against production.                               |
-| +1 h   | Lift the snapshot write freeze once both origins resolve to Cloudflare.                                                     |
-| +2 h   | Set the Discord Interactions Endpoint URL. Verify PING/PONG, then one command of each shape in a real server.               |
-| +24 h  | Proxy (orange-cloud) once verified. Raise TTLs back.                                                                        |
+| Zone                | Cloudflare NS                                            | Live NS today             | Flip it at |
+| ------------------- | -------------------------------------------------------- | ------------------------- | ---------- |
+| `salvageunion.io`   | `davina.ns.cloudflare.com` / `rajeev.ns.cloudflare.com`   | `dns{1..4}.p08.nsone.net` | Name.com   |
+| `intheunionnow.com` | `davina.ns.cloudflare.com` / `rajeev.ns.cloudflare.com`   | `dns{1..4}.p02.nsone.net` | Tucows     |
+
+Both zones drew the **same** nameserver pair, so the two flips are the same edit
+made in two different control panels.
+
+**The current nameservers are Netlify's own** (`nsone.net` is NS1, which Netlify
+DNS runs on). Netlify is therefore not just the origin here, it is the DNS
+provider — which fixes the order of P7 and P8 rather than leaving it to
+preference: **the flip must precede decommissioning**, because deleting the
+Netlify sites while they still answer for the domain would take DNS down along
+with the origin.
+
+#### The record set, measured — not scanned
+
+Enumerated from Netlify's own API (`getDnsZones`), which is authoritative
+because Netlify DNS *is* the current provider. **Five hostnames, and nothing
+else** — no MX, TXT, CAA, DMARC, or other subdomain in either zone:
+
+| Hostname                 | Type      | Target                         |
+| ------------------------ | --------- | ------------------------------ |
+| `salvageunion.io`        | `NETLIFY` | `suindex.netlify.app`          |
+| `www.salvageunion.io`    | `NETLIFY` | `suindex.netlify.app`          |
+| `assets.salvageunion.io` | `NETLIFY` | `su-assets.netlify.app`        |
+| `intheunionnow.com`      | `NETLIFY` | `in-the-union-now.netlify.app` |
+| `www.intheunionnow.com`  | `NETLIFY` | `in-the-union-now.netlify.app` |
+
+**There are no A records to transcribe, and this corrects two steps that were
+previously in this runbook.** Every record is Netlify's `NETLIFY` ALIAS type,
+resolved to a load-balancer address *at query time*. The A records Cloudflare's
+onboarding scan captured are therefore a snapshot of a synthesized answer, not
+configuration — demonstrated twice while staging the zones:
+
+- the `salvageunion.io` scan returned `13.52.188.95` / `52.52.192.191` (us-west)
+  while production resolved `98.84.224.111` / `18.208.88.157` (us-east);
+- the `intheunionnow.com` scan returned **us-east for the apex and us-west for
+  `www`** — two hostnames with identical configuration, different answers, one
+  scan.
+
+Copying either pair would pin production to one region for no benefit. The
+scanned records are left in place, **DNS-only**, purely as inert placeholders;
+the Worker custom domains replace them.
+
+#### Propagation is ~1 hour, not 24–48
+
+The binding constraint is the **NS delegation TTL at the parent registry**,
+measured at **3600 s** via `dig +trace` — not the zone's own record TTLs. That
+is why the old "−48 h: reduce TTLs to 300 s" step is gone: lowering a record TTL
+inside the zone does not touch the delegation, and the synthesized A answers
+already carry a 120 s TTL, which is *below* the 300 s that step aimed for. It
+would have bought nothing and cost two days.
+
+#### Runbook
+
+| When  | Step                                                                                                                                                                         |
+| ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| −1 h  | Execute P6 (write freeze, then the delta sync that must reconcile to **zero**).                                                                                                |
+| −30 m | Attach Worker custom domains for all five hostnames. Cloudflare creates the proxied records itself. Verify each against the assigned NS with `dig @davina.ns.cloudflare.com`.   |
+| 0     | Flip nameservers on `salvageunion.io`. This moves `srd` and `assets.salvageunion.io` **together**, because `ASSET_BASE_URL` is compile-time.                                    |
+| +15 m | Verify from multiple resolvers. Re-run the P4 curl assertions against real hostnames, including the rotated-chunk 404.                                                          |
+| +30 m | Flip nameservers on `intheunionnow.com`. Re-run the itun Playwright suite against production.                                                                                   |
+| +1 h  | Lift the snapshot write freeze once both origins resolve to Cloudflare.                                                                                                        |
+| +2 h  | Set the Discord Interactions Endpoint URL. Verify PING/PONG, then one command of each shape in a real server.                                                                   |
+
+**Leave the Netlify sites serving until propagation completes.** DNS propagation
+is not a rollback window, it is a physics window: both origins answer for the
+length of the TTL, and deleting the old one at the moment of the flip is
+strictly worse than leaving it — resolvers still holding the old delegation get
+errors rather than a stale-but-working site. Decommissioning is P8, 24 h later.
+
+There is **no grey-cloud → orange-cloud step.** A Worker custom domain is
+proxied by definition; the record Cloudflare writes for it is already orange,
+and the DNS-only placeholders it replaces are never in the serving path.
 
 **Gate**
 
 - [ ] Every gate P0–P6 green, recorded and dated in the Progress table.
-- [ ] TTLs reduced at least 48 h prior and observed in effect.
-- [ ] Every record in both zones transcribed by hand and diffed against `dig`.
+- [ ] All five Worker custom domains attached and each verified against the
+      assigned nameservers *before* either flip.
 - [ ] All open decisions below are closed.
 
 ### P8 — Decommission and tooling cleanup · **irreversible**

--- a/docs/architecture/cloudflare-cutover.md
+++ b/docs/architecture/cloudflare-cutover.md
@@ -627,14 +627,55 @@ inside the zone does not touch the delegation, and the synthesized A answers
 already carry a 120 s TTL, which is *below* the 300 s that step aimed for. It
 would have bought nothing and cost two days.
 
+#### `www` must redirect, and `_redirects` cannot do it
+
+Both `www` hostnames **301 to their apex today** — Netlify's primary-domain
+behaviour, measured, not assumed:
+
+```
+https://www.salvageunion.io/    301 -> https://salvageunion.io/
+https://www.intheunionnow.com/  301 -> https://intheunionnow.com/
+```
+
+Workers Static Assets does not do this for you. Attaching `www` and stopping
+there would serve a full duplicate of each site — worst on `srd`, whose entire
+purpose is being indexed.
+
+`_redirects` is not the fix, and this was checked rather than attempted:
+Cloudflare's documentation lists **domain-level redirects as unsupported**, the
+`source` field is a file path only, and *"malformed definitions are ignored"* —
+so a `www` rule there would silently do nothing and look fine in review. (The
+file itself does work on Workers Static Assets; the existing
+`/sitemap.xml → /sitemap-index.xml` rule was verified live on the deployed
+Worker. It is host matching specifically that is missing.)
+
+The mechanism is a zone-level **Redirect Rule**, one per zone, created in the
+dashboard. Redirect Rules execute in the Rules phase, *ahead of* Workers and
+asset serving, so the rule wins and the Worker never sees a `www` request.
+
+| Zone                | When incoming host equals | Then                                     |
+| ------------------- | ------------------------- | ---------------------------------------- |
+| `salvageunion.io`   | `www.salvageunion.io`     | 301 → `https://salvageunion.io` + path + query |
+| `intheunionnow.com` | `www.intheunionnow.com`   | 301 → `https://intheunionnow.com` + path + query |
+
+`www` is still attached as a Worker custom domain in both `wrangler.jsonc`
+files, for two reasons: a hostname must be proxied through Cloudflare before a
+Redirect Rule can act on it at all, and it makes the failure mode safe — if a
+rule is ever missing or deleted, `www` serves the site with its correct per-page
+canonical tags rather than erroring.
+
+**This is the only piece of cutover configuration that does not live in the
+repo**, which is why it is written down here.
+
 #### Runbook
 
 | When  | Step                                                                                                                                                                         |
 | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | −1 h  | Execute P6 (write freeze, then the delta sync that must reconcile to **zero**).                                                                                                |
-| −30 m | Attach Worker custom domains for all five hostnames. Cloudflare creates the proxied records itself. Verify each against the assigned NS with `dig @davina.ns.cloudflare.com`.   |
+| −30 m | Attach Worker custom domains for all five hostnames (declared in the three `wrangler.jsonc` files; wrangler creates the proxied records on deploy). Verify each against the assigned NS with `dig @davina.ns.cloudflare.com`. |
+| −20 m | Create the two `www` → apex Redirect Rules. These cannot be verified before the flip — no certificate is issued while a zone is still pending — so verifying them is a **post-flip** step, never a pre-flip gate. |
 | 0     | Flip nameservers on `salvageunion.io`. This moves `srd` and `assets.salvageunion.io` **together**, because `ASSET_BASE_URL` is compile-time.                                    |
-| +15 m | Verify from multiple resolvers. Re-run the P4 curl assertions against real hostnames, including the rotated-chunk 404.                                                          |
+| +15 m | Verify from multiple resolvers. Re-run the P4 curl assertions against real hostnames, including the rotated-chunk 404. **Confirm `www.salvageunion.io` 301s to the apex** — if it serves a 200, the Redirect Rule did not take. |
 | +30 m | Flip nameservers on `intheunionnow.com`. Re-run the itun Playwright suite against production.                                                                                   |
 | +1 h  | Lift the snapshot write freeze once both origins resolve to Cloudflare.                                                                                                        |
 | +2 h  | Set the Discord Interactions Endpoint URL. Verify PING/PONG, then one command of each shape in a real server.                                                                   |


### PR DESCRIPTION
Two pieces of ADR-033 P6/P7, both of which changed shape once I measured instead of assumed.

## 1. The snapshot write freeze

`SNAPSHOT_WRITES_FROZEN` on the Netlify site makes both write endpoints answer 503. It is what turns the delta sync's "reconciled to zero" into a proof rather than a coincidence.

**Both write verbs freeze, and DELETE is the one that matters most:**

- a **publish** landing after the final sync never reaches R2 — its share link 404s from the moment the flip completes;
- a **revoke** landing after the final sync removes the Blobs copy but leaves the R2 copy readable — so a snapshot its owner deliberately revoked stays live at its original URL.

The second is a privacy failure and strictly worse than the first.

**It freezes every method, including HEAD.** `probeSnapshotService` feature-detects the backend with `HEAD /api/snapshots` and treats only 405/204 as available, so a 503 there makes the client hide the share affordance entirely — better than a button that fails once pressed, and it needs no client change. A test pins that coupling so the two halves can't drift apart silently.

**Reads are untouched.** `snapshot-retrieve` is a separate function and never freezes, so every existing share link keeps resolving through the window. The response body says so explicitly — "sharing is unavailable" otherwise reads as "your published links have broken".

503 + `Retry-After` rather than 403/410, which would tell clients and crawlers the endpoint is permanently gone. `Cache-Control: no-store` is load-bearing, not hygiene: a cached 503 outlives the freeze it describes.

The env var is read **per call**. A module-scope read passes every obvious test and still pins the value for the life of a warm container, making the freeze impossible to lift — this repo already carries that scar in the bot's `config.ts`. I verified the guard has teeth rather than assuming it: hoisting the read fails **8 of the 15 tests**, including the one written for exactly that.

It lives in the Netlify adapter layer, not the shared handlers, so P8 deletes one file and two call sites. The Workers side has no freeze — it is the destination.

## 2. The five custom domains, and the one redirect that can't live here

`routes` added to all three web `wrangler.jsonc` files, so wrangler creates the proxied DNS records on deploy rather than anyone hand-writing an A record. All three validated with `wrangler deploy --dry-run`.

**`www` nearly went wrong.** Both www hostnames 301 to their apex *today* — Netlify's primary-domain behaviour, measured:

```
https://www.salvageunion.io/    301 -> https://salvageunion.io/
https://www.intheunionnow.com/  301 -> https://intheunionnow.com/
```

Workers Static Assets does not do this for you; attaching www and stopping there would serve a full duplicate of each site, worst on `srd`, whose entire purpose is being indexed.

The obvious fix doesn't work, and checking beat attempting: Cloudflare's docs list domain-level redirects in `_redirects` as **unsupported**, the source field is a file path only, and *"malformed definitions are ignored"* — a www rule there would have done nothing while looking perfectly reasonable in review. (`_redirects` itself is fine here — I verified the existing `/sitemap.xml → /sitemap-index.xml` rule live on the deployed Worker first. It's host matching specifically that's absent.)

So it's a zone-level **Redirect Rule**, which runs in the Rules phase ahead of Workers. www is still attached as a custom domain for two reasons: a hostname must be proxied before a Redirect Rule can act on it, and it makes the failure safe — a missing rule leaves www serving the site with correct per-page canonicals rather than erroring. It's the only piece of cutover config that can't live in this repo, so it's written into the P7 section instead of left in a dashboard to be rediscovered.

## 3. P7 runbook, rewritten against measurement

Staging the two Cloudflare zones falsified three of my own steps:

- **"Transcribe every record, grey-cloud"** — there are no A records to transcribe. Enumerated from Netlify's API (authoritative, since Netlify DNS *is* the current provider): five hostnames, no MX/TXT/CAA anywhere, every record a `NETLIFY` ALIAS. The scanned addresses are synthesized per query, which the scans proved twice — salvageunion.io scanned us-west while production served us-east, and intheunionnow.com scanned **us-east for the apex and us-west for www in the same scan**.
- **"−48h: reduce TTLs to 300s"** — buys nothing. The binding constraint is the NS delegation TTL at the parent registry (3600s, via `dig +trace`), which a zone-record TTL doesn't touch, and the synthesized A answers already carry 120s. Two days of waiting for a number already below the target.
- **"+24h: orange-cloud once verified"** — a Worker custom domain is proxied by definition. There was never a grey→orange step.

Also recorded because it fixes the **order** of P7 and P8: the current nameservers are `nsone.net`, which is Netlify's own DNS. Netlify isn't just the origin, it's the DNS provider — so decommissioning before the flip would take DNS down along with it.

## Status

Both zones are staged and answering on their assigned nameservers (`davina`/`rajeev` — the same pair for both) while live delegation still points at Netlify. **Nothing customer-facing has moved.** Activating the freeze is a P7 step, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAMnTadKdR8YoQRbBfzHa9
