### PR TITLE
fix: three cutover-blocking defects found by running the deploy

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -138,25 +138,50 @@ jobs:
       # srd — static, but the OG pass needs a browser.
       # ---------------------------------------------------------------------
       #
-      # `og:generate` chains the SSG build and the screenshot pass. It never
-      # fails the build: a missing browser or a wedged render logs and leaves
-      # those pages on the default og:image, capped by OG_SCREENSHOTS_BUDGET_MS.
-      # The worst case is "some previews are generic", never a failed deploy.
+      # The OG screenshot pass never fails the build: a missing browser or a
+      # wedged render logs and leaves those pages on the default og:image,
+      # capped by OG_SCREENSHOTS_BUDGET_MS. The worst case is "some previews are
+      # generic", never a failed deploy. `og:generate` (build + screenshots in
+      # one script) is deliberately NOT used here — see the steps below.
       - name: Install Chromium for the srd OG pass
         run: bun --filter srd og:install-browser
 
+      # Build and OG pass are SEPARATE steps with the gate between them, and the
+      # order is load-bearing. `og:generate` chains both, and running it before
+      # the gate emitted 2,011 `.og.png` files into `dist` that the committed
+      # snapshot has never contained — the snapshot asserts the emitted file set
+      # in both directions, so the gate failed with 2,011 "NEW, not in the
+      # snapshot" paths on a build whose HTML was byte-identical.
+      #
+      # Blessing them in would be the wrong repair: `apps/srd/CLAUDE.md` excludes
+      # binary assets from the snapshot deliberately, because their names are
+      # content-addressed and digesting them would make the gate churn until
+      # somebody switched it off.
+      #
+      # Splitting also puts each half where it belongs. The gate now verifies the
+      # deterministic build — the thing it was blessed against — and the OG pass,
+      # which is explicitly allowed to degrade to the default banner and "never
+      # fails the build", can no longer fail this gate either.
       - name: Build srd
         env:
           PUBLIC_COMMIT_REF: ${{ github.event.workflow_run.head_sha || github.sha }}
           PUBLIC_SENTRY_DSN: ${{ vars.PUBLIC_SENTRY_DSN }}
-          OG_SCREENSHOTS_BUDGET_MS: '300000'
-        run: bun --filter srd og:generate
+        run: bun --filter srd build
 
       # The output gate, against the artifact about to ship rather than against
       # a build made earlier for a different purpose.
       - name: Verify srd output against the committed snapshot
         working-directory: apps/srd
         run: bun ssg/snapshot.ts
+
+      # Additive, post-gate, and non-fatal by design: a missing browser or a
+      # wedged render leaves those pages on the default og:image.
+      - name: Render srd OG images
+        working-directory: apps/srd
+        env:
+          OG_SCREENSHOTS: '1'
+          OG_SCREENSHOTS_BUDGET_MS: '300000'
+        run: bun scripts/og-screenshots.ts
 
       - name: Deploy srd
         working-directory: apps/srd

--- a/apps/itun/wrangler.jsonc
+++ b/apps/itun/wrangler.jsonc
@@ -14,6 +14,11 @@
     { "pattern": "intheunionnow.com", "custom_domain": true },
     { "pattern": "www.intheunionnow.com", "custom_domain": true }
   ],
+
+  // See srd/wrangler.jsonc: declaring `routes` disables workers.dev unless it is
+  // asked for explicitly, and workers.dev is both the only pre-flip way to reach
+  // this Worker and what every smoke test in deploy-cloudflare.yml curls.
+  "workers_dev": true,
   "main": "src/worker/index.ts",
   "compatibility_date": "2026-07-13",
 

--- a/apps/srd/wrangler.jsonc
+++ b/apps/srd/wrangler.jsonc
@@ -39,6 +39,17 @@
     { "pattern": "www.salvageunion.io", "custom_domain": true }
   ],
 
+  // Load-bearing, and NOT a default: declaring `routes` makes wrangler disable
+  // workers.dev unless it is asked for explicitly. Measured on su-assets — the
+  // first deploy carrying a route reported "No targets deployed" and its
+  // workers.dev URL began answering Cloudflare's own 404 instead of the Worker.
+  //
+  // That URL is the only way to reach these Workers before the nameserver flip,
+  // and all five smoke tests in deploy-cloudflare.yml curl one. Losing it
+  // silently would have made the post-deploy gate pass by absence at exactly
+  // the moment it matters most.
+  "workers_dev": true,
+
   "assets": {
     "directory": "./dist",
 

--- a/apps/su-assets/wrangler.jsonc
+++ b/apps/su-assets/wrangler.jsonc
@@ -17,6 +17,18 @@
   // both apps already points at this name. Flipping salvageunion.io moves the
   // reference site and its artwork host together — they cannot be staged apart.
   "routes": [{ "pattern": "assets.salvageunion.io", "custom_domain": true }],
+
+  // Load-bearing, and NOT a default. Declaring `routes` makes wrangler disable
+  // workers.dev unless it is asked for explicitly — measured: the first deploy
+  // with a route reported "No targets deployed" and
+  // su-assets.alxjrvs.workers.dev started answering Cloudflare's own 404
+  // instead of this Worker.
+  //
+  // That URL is the only way to reach any of these Workers before the
+  // nameserver flip, and every smoke test in deploy-cloudflare.yml curls one.
+  // Losing it silently would have turned the whole post-deploy gate green-by-
+  // absence at exactly the moment it matters most.
+  "workers_dev": true,
   "main": "src/worker.ts",
 
   // Pinned to what this repo's wrangler (4.108) bundles as workerd, so

--- a/docs/architecture/cloudflare-cutover.md
+++ b/docs/architecture/cloudflare-cutover.md
@@ -614,9 +614,25 @@ configuration — demonstrated twice while staging the zones:
   `www`** — two hostnames with identical configuration, different answers, one
   scan.
 
-Copying either pair would pin production to one region for no benefit. The
-scanned records are left in place, **DNS-only**, purely as inert placeholders;
-the Worker custom domains replace them.
+Copying either pair would pin production to one region for no benefit.
+
+**The scanned records must be DELETED, not left as placeholders — and this
+corrects an earlier instruction here that said the opposite.** Leaving them
+looked harmless, since a non-authoritative zone serves nothing. It is not: a
+Worker custom domain creates its own DNS record, and Cloudflare will not write
+one over an existing record for the same name. The first deploy carrying a
+route failed with
+
+```
+PUT .../workers/scripts/su-assets/domains/records
+-- CF API RESPONSE: Conflict 409
+```
+
+which wrangler surfaces only as *"A request to the Cloudflare API … failed"*.
+Deleting the six records and redeploying attached the domain immediately, so the
+409 was the conflicting placeholder and **not** the zone being pending — a
+pending zone accepts custom domains perfectly well. Both zones now hold zero
+records; wrangler writes the real ones.
 
 #### Propagation is ~1 hour, not 24–48
 
@@ -626,6 +642,20 @@ is why the old "−48 h: reduce TTLs to 300 s" step is gone: lowering a record T
 inside the zone does not touch the delegation, and the synthesized A answers
 already carry a 120 s TTL, which is *below* the 300 s that step aimed for. It
 would have bought nothing and cost two days.
+
+#### `routes` silently disables `workers.dev` — the gate's own blind spot
+
+Declaring `routes` makes wrangler turn off the workers.dev subdomain unless
+`"workers_dev": true` is set explicitly. Measured on `su-assets`: the first
+deploy carrying a route reported **"No targets deployed"**, and
+`su-assets.alxjrvs.workers.dev` began answering Cloudflare's own 404 instead of
+the Worker.
+
+That would have been quiet and expensive. Every one of the five post-deploy
+smoke tests in `deploy-cloudflare.yml` curls a workers.dev URL, and before the
+flip there is **no other way to reach these Workers at all** — so the change
+that removes the verification surface is the same change that needs verifying.
+All three web configs now set `workers_dev: true`.
 
 #### `www` must redirect, and `_redirects` cannot do it
 


### PR DESCRIPTION
Two failures found by **running** the deploy rather than reading the config back. Either one would have broken the cutover, and both were silent in different ways.

## 1. `routes` silently disables workers.dev

Declaring `routes` makes wrangler turn off the workers.dev subdomain unless asked for explicitly. The first deploy carrying a route reported:

```
No targets deployed for su-assets
```

and `su-assets.alxjrvs.workers.dev` began answering Cloudflare's own 404 instead of the Worker.

That is the expensive kind of quiet. **All five post-deploy smoke tests in `deploy-cloudflare.yml` curl a workers.dev URL**, and before the nameserver flip there is no other way to reach any of these Workers — so the change that removes the verification surface is the same change that needed verifying. The gate would have gone green by absence at the worst possible moment.

`workers_dev: true` in all three web configs.

## 2. The custom-domain attach 409'd, and my own instruction caused it

The plan (as merged in #854) said to leave the onboarding scan's A records in the zone as inert DNS-only placeholders, reasoning that a non-authoritative zone serves nothing. The reasoning is fine; the conclusion was wrong. A Worker custom domain creates its **own** DNS record, and Cloudflare will not write one over an existing record for the same name:

```
PUT .../workers/scripts/su-assets/domains/records
-- CF API RESPONSE: Conflict 409
```

wrangler surfaces this only as *"A request to the Cloudflare API … failed"* — no status, no reason. It took `WRANGLER_LOG=debug` to see the 409, which is worth knowing because the error as printed invites hunting for a permissions problem that isn't there.

Deleting the records and redeploying attached the domain immediately:

```
https://su-assets.alxjrvs.workers.dev
assets.salvageunion.io (custom domain)
```

So **a pending zone accepts custom domains perfectly well** — the conflict was the placeholder, not the zone state. Both zones now hold zero records and wrangler writes the real ones.

## Verified after the fix

- workers.dev serves artwork `200`
- the Cloudflare zone answers `assets.salvageunion.io` with the `100::` proxied placeholder
- production still resolves to Netlify — **nothing customer-facing has moved**

Had this been left for cutover, the P6 write freeze would already have been live, sharing already paused, and the deploy would have failed on a 409 whose error message points nowhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAMnTadKdR8YoQRbBfzHa9