### PR TITLE
fix(ci): stop re-running the srd snapshot gate where it cannot pass; record P6/P7 status

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -146,35 +146,48 @@ jobs:
       - name: Install Chromium for the srd OG pass
         run: bun --filter srd og:install-browser
 
-      # Build and OG pass are SEPARATE steps with the gate between them, and the
-      # order is load-bearing. `og:generate` chains both, and running it before
-      # the gate emitted 2,011 `.og.png` files into `dist` that the committed
-      # snapshot has never contained — the snapshot asserts the emitted file set
-      # in both directions, so the gate failed with 2,011 "NEW, not in the
-      # snapshot" paths on a build whose HTML was byte-identical.
-      #
-      # Blessing them in would be the wrong repair: `apps/srd/CLAUDE.md` excludes
-      # binary assets from the snapshot deliberately, because their names are
-      # content-addressed and digesting them would make the gate churn until
-      # somebody switched it off.
-      #
-      # Splitting also puts each half where it belongs. The gate now verifies the
-      # deterministic build — the thing it was blessed against — and the OG pass,
-      # which is explicitly allowed to degrade to the default banner and "never
-      # fails the build", can no longer fail this gate either.
+      # Build and OG pass are separate steps rather than one `og:generate`, so
+      # each carries only its own environment: the build takes the commit ref and
+      # the Sentry DSN, the screenshot pass takes its budget. It also keeps the
+      # best-effort half independently skippable from the half that must succeed.
       - name: Build srd
         env:
           PUBLIC_COMMIT_REF: ${{ github.event.workflow_run.head_sha || github.sha }}
           PUBLIC_SENTRY_DSN: ${{ vars.PUBLIC_SENTRY_DSN }}
         run: bun --filter srd build
 
-      # The output gate, against the artifact about to ship rather than against
-      # a build made earlier for a different purpose.
-      - name: Verify srd output against the committed snapshot
-        working-directory: apps/srd
-        run: bun ssg/snapshot.ts
+      # The srd output snapshot is deliberately NOT re-run here, and the reason
+      # is that it cannot pass in this job — not that it is inconvenient.
+      #
+      # The snapshot is blessed against a build with NO Sentry DSN, which is what
+      # `bun run gate` produces locally and what CI's `build-srd` job runs on
+      # every PR. This job builds WITH `PUBLIC_SENTRY_DSN`, because production
+      # must ship Sentry. Measured — the DSN changes the emitted chunk set:
+      #
+      #   with a DSN:     assets/prod-[hash].js, assets/rolldown-runtime-[hash].js
+      #   without a DSN:  assets/preload-helper-[hash].js
+      #
+      # and the snapshot asserts the emitted file set in both directions, so it
+      # failed on exactly those three paths with the page content identical.
+      #
+      # Neither repair works. Blessing the DSN build breaks `build-srd` and every
+      # contributor's local `bun run gate`, since nobody outside Actions has the
+      # DSN. Dropping the DSN here reintroduces the silent Sentry-less production
+      # build this workflow was fixed to prevent.
+      #
+      # So the gate stays where its precondition holds — CI, on every PR — and
+      # this job verifies the DEPLOYED artifact instead, via the smoke step at
+      # the end. That is the honest division: a content gate on the reproducible
+      # build, a behaviour check on the thing actually serving.
+      #
+      # If you are tempted to re-add it, there is a second trap waiting: it must
+      # also run BEFORE the OG pass, which emits 2,011 `.og.png` files the
+      # snapshot has never contained. That one is not fixable by blessing either
+      # — `apps/srd/CLAUDE.md` excludes binary assets on purpose, because their
+      # names are content-addressed and digesting them would make the gate churn
+      # on every dependency bump until somebody switched it off.
 
-      # Additive, post-gate, and non-fatal by design: a missing browser or a
+      # Additive and non-fatal by design: a missing browser or a
       # wedged render leaves those pages on the default og:image.
       - name: Render srd OG images
         working-directory: apps/srd

--- a/docs/architecture/cloudflare-cutover.md
+++ b/docs/architecture/cloudflare-cutover.md
@@ -41,9 +41,17 @@ Update this table as part of each phase's PR. It is the only place that answers
 | P3    | R2 `SnapshotStorage`                     | yes        | **done** — 20/20 R2 RAW   |
 | P4    | Three web surfaces on `workers.dev`      | yes        | **done** — all three live |
 | P5    | Bot on HTTP interactions                 | until flip | **built** — harness green |
-| P6    | Data sync and write freeze               | **no**     | not started               |
-| P7    | Cutover                                  | **no**     | not started               |
+| P6    | Data sync and write freeze               | **no**     | **built, not activated** — bulk sync done (45/45 verified by content); freeze code merged and OFF |
+| P7    | Cutover                                  | **no**     | **staged** — both zones created and answering; custom domains declared; nameservers NOT flipped |
 | P8    | Decommission and tooling cleanup         | **no**     | not started               |
+
+**"Built" is not "activated", and for P6 the difference is the whole point.**
+The write freeze ships as code that is **off** (`SNAPSHOT_WRITES_FROZEN` unset),
+because turning it on stops sharing for real users. Activating it is a P7 step at
+−1 h, not something a merge should ever do. The same applies to P7's staging: the
+zones exist and answer on their assigned nameservers, but the live delegation
+still points at Netlify, so **nothing customer-facing has moved.** The single
+irreversible act is the nameserver flip, and it has not happened.
 
 **Account:** everything runs on the existing `alxjrvs@gmail.com` account
 (ADR-033 §6). A dedicated account was considered and declined; the residue is a


### PR DESCRIPTION
Two commits: the CI fix that unblocks the Cloudflare deploy, and a progress-table correction.

## 1. The srd snapshot gate cannot pass in the deploy job

Moving the gate ahead of the OG pass (#856) fixed the 2,011 `.og.png` differences — and then it failed again on three:

```
assets/preload-helper-[hash].js   [file-set] emitted before, MISSING now
assets/prod-[hash].js             [file-set] NEW, not in the snapshot
assets/rolldown-runtime-[hash].js [file-set] NEW, not in the snapshot
```

`rolldown-runtime` reads like a Vite bump, and that was my first guess. **It was wrong** — `bun install --frozen-lockfile` reported `no changes`, so local and CI resolve identically. The variable is `PUBLIC_SENTRY_DSN`, which this job sets and `build-srd` does not. Measured directly, same tree and lockfile, one env var:

| build | emits |
| --- | --- |
| with a DSN | `assets/prod-*.js`, `assets/rolldown-runtime-*.js` |
| without a DSN | `assets/preload-helper-*.js` |

The snapshot asserts the emitted file set in **both** directions, so it failed on exactly those three paths while all 1,039 pages were identical.

**There is no repair that keeps the gate here:**

- blessing the DSN build breaks `build-srd` and every contributor's local `bun run gate`, because nobody outside Actions has the DSN;
- dropping the DSN from this job reintroduces the silent Sentry-less production build this workflow was fixed to prevent *one commit ago*.

So the gate stays where its precondition holds — CI, on every PR, against the DSN-less build it was blessed against — and this job verifies the **deployed** artifact through the smoke step instead.

**Worth being plain about what this costs:** the committed snapshot describes a build configuration that is not what ships, and it never did. Nothing here changes that — the previous arrangement only *appeared* to close the gap, by running a check that could not pass.

The comment records both traps, since the OG one still waits for whoever re-adds the step, and it can't be blessed away either (`apps/srd/CLAUDE.md` excludes binary assets on purpose).

## 2. Progress table

It said P6 and P7 were "not started" while the bulk sync had run, the freeze had merged, and both zones were created and answering.

> **"Built" is not "activated".** The write freeze ships **off** (`SNAPSHOT_WRITES_FROZEN` unset) — turning it on stops sharing for real users, so activation is a P7 step at −1 h, never something a merge does.

**The single irreversible act is the nameserver flip, and it has not happened.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAMnTadKdR8YoQRbBfzHa9