### PR TITLE
docs: how to rotate the auth credentials, learned by having to

### DIFF
--- a/docs/architecture/accounts-and-games.md
+++ b/docs/architecture/accounts-and-games.md
@@ -528,3 +528,72 @@ bunx convex env get AUTH_DISCORD_SECRET | tr -d '[:space:]' | wc -c
 
 Exit code is **not** a presence check: `convex env get` exits 0 for a variable
 that does not exist.
+
+**`convex env list` prints EVERY value in the clear.** Not the names — the
+values. It will dump `JWT_PRIVATE_KEY` and `AUTH_DISCORD_SECRET` in full, and
+this has already happened once: run unredirected while checking whether the bot
+credential was set, it put both into a transcript and forced a rotation of both.
+The names alone are worth having, so ask for only those:
+
+```bash
+bunx convex env list --deployment-name <name> | cut -d= -f1
+```
+
+Read the **dashboard** instead when you want to confirm a variable exists — it
+masks values by default.
+
+### Rotating `JWT_PRIVATE_KEY` / `JWKS`
+
+Rotating the signing keypair **signs every user out**. That is inherent, not a
+bug — old sessions were signed by the key you just replaced.
+
+The two must be generated as a pair and written together, in the format
+`@convex-dev/auth` expects, or sign-in breaks in the quiet way this document
+already warns about:
+
+| Variable          | Format                                            |
+| ----------------- | ------------------------------------------------- |
+| `JWT_PRIVATE_KEY` | PKCS8 PEM, newlines replaced by **spaces**, trimmed |
+| `JWKS`            | `{"keys":[{"use":"sig", …public JWK}]}`            |
+
+**Pipe the value in on stdin; never pass it as an argument.** Two separate
+failures make this non-negotiable, both observed:
+
+- the PEM begins `-----BEGIN`, which the CLI parses as **flags** — the command
+  simply fails;
+- Node's `execFileSync` embeds the whole command line in its **error** message,
+  so a failure prints the private key even when stdout and stderr are
+  suppressed. Suppressing output is not enough; keep the secret out of `argv`.
+
+```bash
+printf '%s' "$PEM" | bunx convex env set JWT_PRIVATE_KEY --deployment-name <name>
+```
+
+**Verify against the public endpoint, which needs no secret.** Convex serves the
+public half, so the modulus must visibly change:
+
+```bash
+curl -s https://<deployment>.convex.site/.well-known/jwks.json
+```
+
+Compare `n` before and after. Unchanged means the write did not land and the old
+key is still live — which looks identical to success from the CLI's side.
+
+### Rotating `AUTH_DISCORD_SECRET`
+
+Resetting it in the Discord portal invalidates the old value **immediately**, so
+Discord sign-in is broken from that moment until Convex is updated. Have the
+update command ready first, then reset, copy, and run it back to back.
+
+Clipboard → stdin keeps it out of `argv`, shell history and transcripts:
+
+```bash
+pbpaste | tr -d '\n' | bunx convex env set AUTH_DISCORD_SECRET --deployment-name <name>
+```
+
+Guard on **length 32** before writing. A Discord client secret is 32 characters;
+if the copy silently failed, refusing beats writing garbage into production auth
+and rediscovering it later as an unexplained login failure.
+
+Only a real sign-in proves it. Nothing server-side can compare the stored secret
+against the one Discord now holds.


### PR DESCRIPTION
Written after rotating `JWT_PRIVATE_KEY` on production. Everything here is a mistake that was actually made, not a precaution imagined in advance.

## `convex env list` prints every value

Not the names — the **values**. Run unredirected while checking whether the bot credential was set, it dumped `JWT_PRIVATE_KEY` and `AUTH_DISCORD_SECRET` in full into a transcript and forced the rotation this commit documents.

The doc already warned about `convex env get` and said nothing about `list`, which is the one that hurts more. Now recorded with a names-only invocation and a pointer to the dashboard, which masks by default.

## Pipe secrets on stdin, never `argv`

Two separate failures make this non-negotiable, both observed within minutes:

1. the PEM begins `-----BEGIN`, which the CLI parses as **flags** — the command just fails;
2. Node's `execFileSync` embeds the whole command line in its **error** message, so the failure printed the private key *even though stdout and stderr were both suppressed*.

The second is the subtle one, and the reason the guidance isn't merely "redirect output": suppressing output doesn't help when the leak is in the exception. Convex documents `pbpaste | convex env set NAME` for exactly this, which is now the shape both procedures use.

## Verify against the public endpoint

Convex serves the public half at `/.well-known/jwks.json`, so the modulus must visibly change. That needs no secret, and it's the only check that distinguishes a successful write from one that silently didn't land — which look identical from the CLI's side.

## Two more things worth saying out loud

**Rotating the keypair signs every user out.** Inherent, not a bug — old sessions were signed by the key being replaced — but better said in advance than discovered as an incident.

**`AUTH_DISCORD_SECRET`: the portal reset invalidates the old value immediately**, so sign-in is broken from that moment until Convex is updated. Stage the command first, then reset → copy → run, back to back. Guard on length 32 before writing: if the copy silently failed, refusing beats writing garbage into production auth and meeting it later as an unexplained login failure. Only a real sign-in proves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAMnTadKdR8YoQRbBfzHa9