### PR TITLE
feat(itun): let the Organizer delete a game, keeping everything built

### DIFF
--- a/apps/itun/convex/entities.ts
+++ b/apps/itun/convex/entities.ts
@@ -277,19 +277,30 @@ export const remove = mutation({
  * schema never said one, and forcing it here would make the ordinary course of
  * a campaign look like a bug.
  *
- * There is deliberately no `unassigned` axis: a crawler has no `ownerId` at all
- * (D8). It belongs to the crew from the moment it exists, which is exactly why
- * players may fill in its fields without ever being handed it.
+ * There is deliberately no `unassigned` axis **inside a Game**: a crawler there
+ * carries `ownerId: null`, which is exactly what communal means (D8). It
+ * belongs to the crew from the moment it exists, which is why players may fill
+ * in its fields without ever being handed it.
+ *
+ * ## `gameId: null` raises one on your own shelf
+ *
+ * A crawler can now also live on a shelf (`schema.ts`), and that is the only
+ * case where it has an owner. There is no table to run, so there is no table
+ * runner to require and no crew to be communal with — the caller is simply the
+ * owner. This is the path the local mirror uses for a Solo crawler, which
+ * previously had no server row at all.
  */
 export const createCrawler = mutation({
   args: {
-    gameId: v.id('games'),
+    /** The Game this crawler is raised in, or `null` to raise it on your shelf. */
+    gameId: v.union(v.id('games'), v.null()),
     /** The local UUID this row mirrors — see `pilots.appId`. */
     appId: v.optional(v.string()),
     body: v.any(),
   },
   handler: async (ctx, args): Promise<Id<'crawlers'>> => {
-    await requireTableRunner(ctx, args.gameId)
+    const userId = await requireUser(ctx)
+    if (args.gameId !== null) await requireTableRunner(ctx, args.gameId)
 
     const result = CrawlerSchema.safeParse(args.body)
     if (!result.success) {
@@ -298,6 +309,9 @@ export const createCrawler = mutation({
 
     return await ctx.db.insert('crawlers', {
       gameId: args.gameId,
+      // Communal in a Game, owned on a shelf. Both-null is the invalid row, so
+      // a shelf crawler MUST take an owner and the caller is the only candidate.
+      ownerId: args.gameId === null ? userId : null,
       appId: args.appId,
       body: result.data,
       updatedAt: Date.now(),
@@ -318,10 +332,54 @@ export const removeCrawler = mutation({
   handler: async (ctx, args): Promise<void> => {
     const doc = await ctx.db.get(args.crawlerId)
     if (doc === null) return
-    await requireTableRunner(ctx, doc.gameId)
+    await assertMayScrapCrawler(ctx, doc)
     await ctx.db.delete(args.crawlerId)
   },
 })
+
+/**
+ * Who may write a crawler's body — it depends on which container holds it.
+ *
+ * In a Game the crawler is communal (D8), so **any member** may edit it; that
+ * is the whole point of a shared home and it is why crawler edits resolve by
+ * field-level merge rather than by an ownership check. On a shelf there is no
+ * crew to share with, so it is an ordinary owned entity and only its owner may
+ * touch it.
+ *
+ * Split out from the two call sites rather than inlined at each, because a
+ * container-dependent rule written twice is a rule that will eventually be
+ * written two different ways.
+ */
+async function assertMayEditCrawler(ctx: MutationCtx, doc: Doc<'crawlers'>): Promise<void> {
+  if (doc.gameId !== null) {
+    await requireMember(ctx, doc.gameId)
+    return
+  }
+  const userId = await requireUser(ctx)
+  if (doc.ownerId !== userId) {
+    throw new NotAuthorized("You cannot edit another player's crawler")
+  }
+}
+
+/**
+ * Who may scrap a crawler. Stricter than editing one, on both sides.
+ *
+ * In a Game, destruction is the **table runner's** act and communal editing
+ * deliberately does not extend to it: the crawler is the crew's home and every
+ * pilot is anchored to it, so one member deleting it would take the table's
+ * shared state with them. On a shelf the owner decides, exactly as they do for
+ * their own pilots and mechs.
+ */
+async function assertMayScrapCrawler(ctx: MutationCtx, doc: Doc<'crawlers'>): Promise<void> {
+  if (doc.gameId !== null) {
+    await requireTableRunner(ctx, doc.gameId)
+    return
+  }
+  const userId = await requireUser(ctx)
+  if (doc.ownerId !== userId) {
+    throw new NotAuthorized("You cannot scrap another player's crawler")
+  }
+}
 
 /**
  * Whether this table already holds a row carrying this app id.
@@ -465,22 +523,24 @@ export const claimLocal = mutation({
      * every saved pattern. Somebody claiming a long-running solo campaign would
      * have watched half of it vanish with no error.
      *
-     * A crawler has no owner column (it is communal, D8) and no Game yet, so a
-     * claimed one is parked on a **placeholder Game of one** rather than
-     * discarded: the shelf cannot hold it, and inventing a crawler-shaped shelf
-     * would be a third container the model does not have.
+     * ## This used to invent a container, and no longer needs to
+     *
+     * A claimed crawler had no Game to go in and no shelf able to hold it, so
+     * it was parked on a placeholder **"Claimed crawler" Game of one** — an
+     * entire Game, plus a membership in it, raised solely to satisfy a
+     * non-nullable `gameId`. That is gone: `crawlers` now carries the same two
+     * container columns as `pilots` and `mechs`, so a claimed crawler lands
+     * exactly where a claimed pilot lands, on the claimer's shelf.
+     *
+     * Two problems go with it. The placeholder appeared in the player's games
+     * list as a table they never made and could not meaningfully use; and the
+     * ordering dance that raised it lazily — resolving what to write BEFORE
+     * inserting the Game, so that a re-claim with nothing new to say did not
+     * leave an empty one behind — was load-bearing machinery guarding a
+     * workaround. With no Game to raise there is nothing left to order, so the
+     * crawler pass is now the same straight loop the pilots and mechs use.
      */
-    /*
-     * The crawler pass resolves what it will write BEFORE it raises the
-     * placeholder Game, because that Game is itself a write that must not
-     * repeat. Raising it up front — as this did — meant a re-claim with nothing
-     * new to say still left behind an empty "Claimed crawler" Game and a
-     * membership in it, so a player's game list grew by one every time they
-     * signed in somewhere new.
-     */
-    const crawlers = args.crawlers ?? []
-    const claimableCrawlers: Array<{ appId: string | undefined; body: unknown }> = []
-    for (const body of crawlers) {
+    for (const body of args.crawlers ?? []) {
       const parsed = CrawlerSchema.safeParse(body)
       if (!parsed.success) {
         skipped += 1
@@ -492,29 +552,11 @@ export const claimLocal = mutation({
         alreadyPresent += 1
         continue
       }
-      claimableCrawlers.push({ appId, body: parsed.data })
-    }
-
-    let shelfGameId: Id<'games'> | null = null
-    if (claimableCrawlers.length > 0) {
-      shelfGameId = await ctx.db.insert('games', { name: 'Claimed crawler' })
-      await ctx.db.insert('memberships', {
-        gameId: shelfGameId,
-        userId,
-        mediator: false,
-        organizer: true,
-        joinedAt: now,
-      })
-    }
-    for (const crawler of claimableCrawlers) {
-      if (shelfGameId === null) {
-        skipped += 1
-        continue
-      }
       await ctx.db.insert('crawlers', {
-        gameId: shelfGameId,
-        appId: crawler.appId,
-        body: crawler.body,
+        gameId: null,
+        ownerId: userId,
+        appId,
+        body: parsed.data,
         updatedAt: now,
       })
       bump('crawlers')
@@ -566,7 +608,11 @@ export const claimLocal = mutation({
         continue
       }
 
-      await ctx.db.insert('softLinks', { gameId: shelfGameId, from, to, type: linkType })
+      // `gameId: null` — the shelf, matching the entities these link. It used to
+      // be the placeholder Game's id whenever a crawler happened to be claimed in
+      // the same call, which filed a shelf roster's wiring under a Game the player
+      // never made.
+      await ctx.db.insert('softLinks', { gameId: null, from, to, type: linkType })
       bump('softLinks')
     }
 
@@ -762,7 +808,7 @@ export const patchCrawlerByAppId = mutation({
     const existing = await crawlerByAppId(ctx, args.appId)
     if (existing === null) return
 
-    await requireMember(ctx, existing.gameId)
+    await assertMayEditCrawler(ctx, existing)
 
     const merged = { ...(existing.body as Record<string, unknown>), ...(args.patch as object) }
     const result = CrawlerSchema.safeParse(merged)
@@ -781,7 +827,7 @@ export const removeCrawlerByAppId = mutation({
     const existing = await crawlerByAppId(ctx, args.appId)
     if (existing === null) return
 
-    await requireTableRunner(ctx, existing.gameId)
+    await assertMayScrapCrawler(ctx, existing)
     await ctx.db.delete(existing._id)
   },
 })

--- a/apps/itun/convex/games.ts
+++ b/apps/itun/convex/games.ts
@@ -174,18 +174,50 @@ export const rename = mutation({
 })
 
 /**
- * Delete a Game and everything scoped to it.
+ * Delete a Game, and land everything it held somewhere real.
  *
- * Entities owned by members are **not** silently destroyed — they fall back to
- * their owner's shelf (`gameId: null`), so deleting a campaign never deletes
- * somebody's character. Unclaimed entities have no shelf to fall back to and
- * are removed with the Game, which is the only place ADR-030's "both columns
- * null is invalid" rule could otherwise be violated.
+ * **Organizer only.** Ending a shared campaign is administrative in the sense
+ * ADR-030 §3 means it — it is about the table's existence, not about what is on
+ * it — so it sits with `rename` and `transferOrganizer` rather than with the
+ * table-runner acts. It is deliberately NOT `requireTableRunner`: that helper
+ * falls back to the Organizer only while a Game has no Mediator, which would
+ * make who may end a campaign depend on whether one has been appointed yet.
+ *
+ * ## Nothing somebody built is destroyed
+ *
+ * Every entity falls back to a shelf — the third row of ADR-030 §2's ownership
+ * table, `gameId: null` with an owner — rather than dying with the Game:
+ *
+ * | What                           | Where it lands                  |
+ * | ------------------------------ | ------------------------------- |
+ * | a pilot or mech with an owner   | that owner's shelf             |
+ * | an **unclaimed** pilot or mech  | the deleting Organizer's shelf |
+ * | every **crawler**               | the deleting Organizer's shelf |
+ *
+ * The first row is the oldest rule here and the one that matters most: deleting
+ * a campaign must never delete somebody's character.
+ *
+ * The other two are what the previous version got wrong. It deleted unclaimed
+ * entities and crawlers outright, reasoning that they had no shelf to fall back
+ * to — true when it was written, because both need a shelf row carrying an
+ * owner and the crawler had no `ownerId` column at all. Both are expressible
+ * now (see `schema.ts`), so both fall back, and the receiving shelf is the
+ * **deleter's**: they are the one person guaranteed to exist, and the one
+ * looking at the consequence as it happens.
+ *
+ * Note this is the moment a crawler stops being communal. Inside a Game it has
+ * no owner by design (D8); on a shelf it must have one, because an entity with
+ * neither container nor owner is the invalid row. The Organizer does not so
+ * much *take* the crawler as become the person it is now filed under.
+ *
+ * Rows describing the *table* rather than something built on it — the
+ * opposition tray, the wiring, invites, requests, memberships — go with it.
  */
 export const destroy = mutation({
   args: { gameId: v.id('games') },
   handler: async (ctx, args): Promise<void> => {
-    await requireOrganizer(ctx, args.gameId)
+    const membership = await requireOrganizer(ctx, args.gameId)
+    const organizerId = membership.userId
 
     for (const table of ['pilots', 'mechs'] as const) {
       const rows = await ctx.db
@@ -193,17 +225,36 @@ export const destroy = mutation({
         .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
         .collect()
       for (const row of rows) {
-        if (row.ownerId === null) await ctx.db.delete(row._id)
-        else await ctx.db.patch(row._id, { gameId: null })
+        // An unclaimed entity has no owner to fall back to, so the Organizer
+        // becomes one. Anything already owned keeps its owner untouched.
+        await ctx.db.patch(row._id, {
+          gameId: null,
+          ownerId: row.ownerId ?? organizerId,
+        })
       }
+    }
+
+    // The crawler is communal in a Game and owned on a shelf — see above.
+    // `ownerId` is unconditionally the Organizer because a crawler in a Game
+    // never carried one to preserve.
+    const crawlers = await ctx.db
+      .query('crawlers')
+      .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+      .collect()
+    for (const crawler of crawlers) {
+      await ctx.db.patch(crawler._id, { gameId: null, ownerId: organizerId })
     }
 
     // Game-scoped rows with no personal counterpart just go. `inviteRedemptions`
     // and `joinRequests` belong here for the same reason `invites` does: they
     // describe a way into a Game that no longer exists, and an unanswered knock
     // at a deleted door would sit pending forever.
+    //
+    // `softLinks` are here because a link is a fact about the table's wiring
+    // rather than a possession: a pilot-to-crawler assignment means "aboard
+    // this crew's crawler", which stops being true when the crew disbands.
+    // Shelved entities land unwired, which is the honest state.
     for (const table of [
-      'crawlers',
       'encounterNpcs',
       'softLinks',
       'invites',

--- a/apps/itun/convex/publicSheet.ts
+++ b/apps/itun/convex/publicSheet.ts
@@ -177,21 +177,41 @@ async function pilotAbilitiesForMech(ctx: QueryCtx, mech: Doc<PublicTable>): Pro
  * `assertMayWrite`'s ctx-free sibling being reused loosely, but the same rule:
  * there is no Mediator override, because making somebody else's character
  * world-readable is the clearest possible case of a thing that is theirs to
- * decide. The crawler has no `ownerId` at all, so it follows ADR-030 §5a and is
- * the table runner's act, the same way raising and scrapping it are.
+ * decide. A crawler in a Game is communal and owned by nobody, so it follows
+ * ADR-030 §5a and is the table runner's act, the same way raising and scrapping
+ * it are.
+ *
+ * ## Why this takes the table rather than sniffing the row
+ *
+ * It used to discriminate on `!('ownerId' in row)`, which worked only while the
+ * crawler was the one entity without that column. It now has one (`schema.ts`),
+ * so that test silently stopped separating anything — and the branch it guarded
+ * narrowed to `never`. Passing the table makes the distinction explicit, and
+ * the caller already has it in hand.
+ *
+ * The two gates cannot simply be merged, even though all three rows now carry
+ * the same columns, because an **unclaimed** row means opposite things per
+ * table. An unclaimed pilot is a character waiting for a taker and may not be
+ * published until somebody owns it; an unclaimed crawler is the normal state of
+ * a crew's home and is published by whoever runs the table.
  */
 async function assertMayPublish(
   ctx: MutationCtx,
+  table: PublicTable,
   row: Doc<PublicTable>,
   userId: Id<'users'>,
   isPublic: boolean
 ): Promise<void> {
-  if (!('ownerId' in row)) {
-    // `crawlers.gameId` is `v.id('games')` and never null — a crawler is always
-    // in a Game, and a shelf crawler is not a thing — so there is deliberately
-    // no null branch here to write.
-    await requireTableRunner(ctx, row.gameId)
-    return
+  if (table === 'crawlers') {
+    // In a Game: communal, so the table runner decides (ADR-030 §5a). On a
+    // shelf: an ordinary owned entity, so its owner does — the same rule the
+    // ownable branch below applies, and for the same reason.
+    if (row.gameId !== null) {
+      await requireTableRunner(ctx, row.gameId)
+      return
+    }
+    if (row.ownerId === userId) return
+    throw new NotAuthorized("You cannot publish another player's crawler")
   }
   if (row.ownerId === userId) return
   if (row.ownerId === null) {
@@ -226,7 +246,7 @@ export const setPublic = mutation({
     const row = await byAppId(ctx, table, args.appId)
     if (row === null) throw new NotAuthorized('That entity no longer exists')
 
-    await assertMayPublish(ctx, row, userId, args.isPublic)
+    await assertMayPublish(ctx, table, row, userId, args.isPublic)
 
     // Parse before publishing, exactly as every other mutation parses before
     // persisting (ADR-030): the Zod schemas in `src/lib/schemas/` are the

--- a/apps/itun/convex/schema.ts
+++ b/apps/itun/convex/schema.ts
@@ -325,13 +325,47 @@ export default defineSchema({
     .index('by_app_id', ['appId']),
 
   /**
-   * The crawler is communal (D8) — no `ownerId` at all, and any member of the
-   * Game may write it. Conflicting writes resolve by field-level merge (D19),
+   * The crawler is communal **inside a Game** (D8) — `ownerId: null` — and any
+   * member may write it. Conflicting writes resolve by field-level merge (D19),
    * which is enforced in the mutation rather than the schema; the contended
    * fields in practice are the scrap pool and cargo lots during Downtime.
+   *
+   * ## Why this now carries the same two columns as `pilots`/`mechs`
+   *
+   * D8 read as "no `ownerId` at all", and `gameId` was correspondingly
+   * non-nullable: a crawler was a thing that could only exist inside a Game.
+   * That is amended here, and the amendment is about **containers**, not about
+   * ownership during play. Communal-while-in-a-Game is unchanged and still
+   * expressed the same way, by `ownerId: null` on a row whose `gameId` is set.
+   *
+   * What it buys is the third row of ADR-030 §2's table — `gameId: null` with
+   * an owner, *on the shelf* — which the crawler was the one entity unable to
+   * occupy. Two real consequences followed from that gap, and both were worked
+   * around rather than fixed:
+   *
+   *   - **Deleting a Game had to destroy its crawler.** Pilots and mechs fell
+   *     back to a shelf; the crew's home had nowhere to fall to.
+   *   - **`claimLocal` invented a container.** A claimed solo crawler was
+   *     parked on a placeholder "Claimed crawler" Game of one, because the
+   *     shelf could not hold it.
+   *
+   * The alternative was to copy a shelved crawler into IndexedDB alone. That is
+   * rejected on principle: offline-first here is ordinary PWA caching, so the
+   * local store is a *reflection* of Convex and never a second source of truth.
+   * A record with no server row to reflect is invisible on the player's other
+   * devices and lost with the browser's storage.
+   *
+   * `gameId == null && ownerId == null` stays the one invalid combination, for
+   * the crawler exactly as for everything else.
    */
   crawlers: defineTable({
-    gameId: v.id('games'),
+    gameId: v.union(v.id('games'), v.null()),
+    /**
+     * Null while the crawler is in a Game — that is what communal means (D8).
+     * Set only on the shelf, where a container with no owner would be the
+     * invalid row.
+     */
+    ownerId: v.union(v.id('users'), v.null()),
     /** See `pilots.appId` — same reason, same lookup path. */
     appId: v.optional(v.string()),
     /**
@@ -351,6 +385,7 @@ export default defineSchema({
     updatedAt: v.number(),
   })
     .index('by_game', ['gameId'])
+    .index('by_owner', ['ownerId'])
     .index('by_app_id', ['appId']),
 
   /** 'mech-to-pilot' | 'pilot-to-crawler'. EntityRef is NOT widened (ADR-027). */

--- a/apps/itun/convex/templates.ts
+++ b/apps/itun/convex/templates.ts
@@ -92,9 +92,12 @@ export const createGame = mutation({
     for (const mech of STARTER_MECHS) {
       await ctx.db.insert('mechs', { gameId, ownerId: null, body: mech, updatedAt: now })
     }
-    // The crawler has no ownerId column at all: it is communal by design (D8).
+    // `ownerId: null` is what communal means for a crawler in a Game (D8) — the
+    // same value the starter pilots and mechs take above, but for a different
+    // reason: they are unclaimed and waiting for a taker, the crawler is the
+    // crew's and never gets handed to anyone.
     for (const crawler of STARTER_CRAWLERS) {
-      await ctx.db.insert('crawlers', { gameId, body: crawler, updatedAt: now })
+      await ctx.db.insert('crawlers', { gameId, ownerId: null, body: crawler, updatedAt: now })
     }
     for (const link of STARTER_SOFT_LINKS) {
       await ctx.db.insert('softLinks', {

--- a/apps/itun/src/components/games/DeleteGameDialog.tsx
+++ b/apps/itun/src/components/games/DeleteGameDialog.tsx
@@ -1,0 +1,171 @@
+/**
+ * DeleteGameDialog — the confirm that stands between an Organizer and the end
+ * of a campaign.
+ *
+ * ## Why it is shared rather than written at each surface
+ *
+ * Deleting is offered in two places — the trash on a row in the Games list, and
+ * the danger zone on the Game's own screen — and the two are the same act with
+ * the same consequences. The consequences are the *whole content* of this
+ * dialog, so a second copy of it would be a second statement of where a crew's
+ * builds go, free to drift from what `games.destroy` actually does.
+ *
+ * ## It says where everything lands, not just that this cannot be undone
+ *
+ * A generic "this is permanent" would be both frightening and wrong. Deleting a
+ * Game destroys the *table* and nothing anybody built: pilots and mechs fall
+ * back to their owners' shelves, and the crawler plus anything unclaimed lands
+ * on the shelf of whoever is doing the deleting. The dialog names those
+ * outcomes with the actual counts in front of the reader, because "4 pilots"
+ * and "2 mechs" is what makes the sentence checkable against the row they just
+ * clicked.
+ *
+ * What genuinely does not survive is named too — invites, join requests, the
+ * opposition tray, and the crew's wiring. Softening that would be the failure
+ * mode of a confirm dialog: it exists to be read once, correctly.
+ */
+
+import { Button, ModalShell, Text } from 'component-lib'
+import { useMutation } from 'convex/react'
+import { useState } from 'react'
+import { api } from '../../../convex/_generated/api'
+import type { Id } from '../../../convex/_generated/dataModel'
+import { isServerRefusal, serverMessage } from '../../lib/connection/serverError'
+import { captureException } from '../../lib/observability'
+
+/** The little a confirm needs to know: what it is ending, and how big it is. */
+export type DeletableGame = {
+  _id: Id<'games'>
+  name: string
+  crawlerName: string | null
+  pilotCount: number
+  mechCount: number
+  memberCount: number
+}
+
+type Props = {
+  /** `null` closes the dialog; a game opens it. Lets one dialog serve a list. */
+  game: DeletableGame | null
+  onClose: () => void
+  /**
+   * Called after the server confirms the deletion, never optimistically.
+   *
+   * The two surfaces want different things here — the list re-renders itself
+   * from the `listMine` subscription and needs nothing, while the Game's own
+   * route has to navigate away before its `games.get` resolves to `null` and
+   * renders "you are not in this game". Passing the intent in keeps this
+   * component ignorant of routing.
+   */
+  onDeleted?: () => void
+}
+
+/** "4 pilots", "1 pilot", or null when there are none to mention. */
+function countPhrase(n: number, singular: string): string | null {
+  if (n === 0) return null
+  return `${n} ${n === 1 ? singular : `${singular}s`}`
+}
+
+export function DeleteGameDialog({ game, onClose, onDeleted }: Props) {
+  const destroy = useMutation(api.games.destroy)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleConfirm() {
+    if (game === null) return
+    setBusy(true)
+    setError(null)
+    try {
+      await destroy({ gameId: game._id })
+      onDeleted?.()
+      onClose()
+    } catch (err) {
+      // A refusal carries wording the server chose for the player —
+      // `NotAuthorized` extends `ConvexError` precisely so it survives the wire
+      // intact rather than arriving as "Server Error". Anything else does not,
+      // and rendering `String(err)` would show a redacted stack, so it gets a
+      // generic line and an operator report instead. Either way the dialog
+      // stays open with the reason on it; closing silently would look like the
+      // game had been deleted.
+      if (isServerRefusal(err)) {
+        setError(serverMessage(err))
+      } else {
+        captureException(err)
+        setError('That game could not be deleted. Try again.')
+      }
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  // The builds that survive, phrased as the reader will check them against the
+  // row: only the kinds actually present are mentioned.
+  const surviving = [
+    countPhrase(game?.pilotCount ?? 0, 'pilot'),
+    countPhrase(game?.mechCount ?? 0, 'mech'),
+  ].filter((part): part is string => part !== null)
+
+  return (
+    <ModalShell
+      open={game !== null}
+      onOpenChange={(next) => {
+        if (!next && !busy) onClose()
+      }}
+      title={`Delete ${game?.name ?? ''}?`}
+      tone="danger"
+      maxWidth="max-w-md"
+    >
+      <div className="flex flex-col gap-4 bg-paper p-5">
+        <Text>
+          This ends the table for all {game?.memberCount ?? 0} of you. It cannot be undone.
+        </Text>
+
+        <div className="flex flex-col gap-2">
+          <Text variant="hint" className="text-left">
+            Nothing anybody built is destroyed:
+          </Text>
+          <ul className="flex list-disc flex-col gap-1 pl-5">
+            {surviving.length > 0 && (
+              <li>
+                <Text variant="hint" className="text-left">
+                  {surviving.join(' and ')} go back to the shelves of whoever owns them.
+                </Text>
+              </li>
+            )}
+            <li>
+              <Text variant="hint" className="text-left">
+                {game?.crawlerName === null || game?.crawlerName === undefined
+                  ? 'Anything unclaimed lands on your shelf.'
+                  : `${game.crawlerName} and anything unclaimed land on your shelf.`}
+              </Text>
+            </li>
+          </ul>
+        </div>
+
+        <Text variant="hint" className="text-left">
+          The crew, its invites, any pending join requests, the opposition tray and the wiring
+          between everyone's builds go with the game.
+        </Text>
+
+        {error !== null && (
+          <Text variant="hint" className="text-left text-[var(--color-roll-cascade)]">
+            {error}
+          </Text>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" size="compact" disabled={busy} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="danger"
+            size="compact"
+            disabled={busy}
+            onClick={() => void handleConfirm()}
+          >
+            {busy ? 'Deleting…' : 'Delete game'}
+          </Button>
+        </div>
+      </div>
+    </ModalShell>
+  )
+}

--- a/apps/itun/src/components/games/GameRoster.tsx
+++ b/apps/itun/src/components/games/GameRoster.tsx
@@ -348,10 +348,17 @@ export function GameRoster({ gameId, gameName }: GameRosterProps) {
    * Deliberately no confirm. Copying destroys nothing and the result is one more
    * build on your shelf, so a modal would be friction guarding an undo-by-delete.
    *
-   * Crawlers are excluded at the call site rather than here: `crawlers.gameId` is
-   * **non-nullable** in the Convex schema, so a shelved crawler has no server row
-   * to be — which is why `claimLocal` parks a claimed one on a placeholder Game
-   * instead. Copying one to a shelf is not a thing the model can express.
+   * Crawlers are still excluded at the call site, but the reason has changed and
+   * is worth stating plainly. It used to be a **model limitation**: `crawlers`
+   * had a non-nullable `gameId`, so a shelved crawler had no server row to be.
+   * That is no longer true — a crawler shelves like anything else now, which is
+   * how deleting a Game keeps one.
+   *
+   * So the exclusion is a **product choice nobody has made yet**, not an
+   * impossibility. A crawler is the crew's shared home rather than a character
+   * somebody keeps, so "take your own copy of the table's crawler" wants a
+   * decision before it gets a button. Offering it is a small change if that
+   * decision goes the other way.
    */
   async function copyToShelf(row: RosterRow) {
     const created = await useEntityStore

--- a/apps/itun/src/components/games/GameRow.tsx
+++ b/apps/itun/src/components/games/GameRow.tsx
@@ -10,9 +10,15 @@ import { AppLink } from '../shared/AppLink'
  * — but it *is* another thing you own and open, so it gets the same `EntityRow`
  * the player entities use, with its own blue ontology tone (ADR-030).
  *
- * Deleting is deliberately absent. `games.destroy` ends a shared campaign for
- * everyone in it, which needs a confirm that names what is being destroyed —
- * that lives on the Game's own screen, not behind a trash icon in a list.
+ * Deleting rides the same trash affordance every other `EntityRow` uses, and is
+ * passed in rather than wired here: `games.destroy` ends a shared campaign for
+ * everyone in it, so it needs a confirm that names what is being destroyed, and
+ * one dialog serving the whole list beats one mounted per row. The parent owns
+ * that dialog; this row only reports the click.
+ *
+ * It is offered to the **Organizer alone** — the parent decides, by simply not
+ * passing `onDelete`. That is a courtesy, not the boundary: `games.destroy`
+ * calls `requireOrganizer` regardless of what the client chooses to draw.
  */
 export type GameRowGame = {
   _id: Id<'games'>
@@ -66,7 +72,7 @@ function standingStats(game: GameRowGame): EntityRowStat[] {
   return stats
 }
 
-export function GameRow({ game }: { game: GameRowGame }) {
+export function GameRow({ game, onDelete }: { game: GameRowGame; onDelete?: () => void }) {
   return (
     <EntityRow
       entityType="game"
@@ -75,6 +81,7 @@ export function GameRow({ game }: { game: GameRowGame }) {
       linkAs={AppLink}
       stats={tableStats(game)}
       bodyStats={standingStats(game)}
+      onDeleteClick={onDelete}
     />
   )
 }

--- a/apps/itun/src/components/games/GameScreen.tsx
+++ b/apps/itun/src/components/games/GameScreen.tsx
@@ -14,14 +14,17 @@
  * belonged to. A list of games is a list; the work happens inside one.
  */
 
-import { Badge, Card, PageHeading, PageShell, Text } from 'component-lib'
+import { useNavigate } from '@tanstack/react-router'
+import { Badge, Button, Card, PageHeading, PageShell, Text } from 'component-lib'
 import { useQuery } from 'convex/react'
+import { useState } from 'react'
 import { api } from '../../../convex/_generated/api'
 import type { Id } from '../../../convex/_generated/dataModel'
 import { useConnection } from '../../lib/connection/connectionContext'
 import { isConvexConfigured } from '../../lib/connection/convexClient'
 import { AppLink } from '../shared/AppLink'
 import { ConvexPending } from '../shared/ConvexPending'
+import { DeleteGameDialog } from './DeleteGameDialog'
 import { DowntimePanel } from './DowntimePanel'
 import { GameRoster } from './GameRoster'
 import { InvitePanel } from './InvitePanel'
@@ -33,6 +36,8 @@ function GameBody({ gameId }: { gameId: string }) {
   // it distinguishes "still loading" from "not a member" without fetching every
   // table the viewer belongs to.
   const game = useQuery(api.games.get, { gameId: gameId as Id<'games'> })
+  const navigate = useNavigate()
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
 
   if (game === undefined) return <ConvexPending label="this game" />
   // `null` covers both "you left" and "no such game", deliberately — a
@@ -81,6 +86,44 @@ function GameBody({ gameId }: { gameId: string }) {
           Open the Mediator surface →
         </AppLink>
       )}
+
+      {/* Ending the campaign, last on the page and Organizer-only.
+          It is offered here as well as behind the trash on the Games list
+          because this is the screen that shows what a Game actually IS — the
+          crew, the invites, the wiring — so it is where the reader can weigh
+          the consequence the confirm is about to describe. */}
+      {game.organizer && (
+        <Card
+          headerBg="bg-ink"
+          headerContent={
+            <Badge shape="stamp" as="h2" size="full">
+              End this game
+            </Badge>
+          }
+        >
+          <div className="flex flex-col gap-3 p-4">
+            <Text>
+              Deleting {game.name} disbands the crew for everyone in it. Every pilot and mech goes
+              back to its owner's shelf, and the crawler comes to yours — but the table, its invites
+              and its wiring are gone for good.
+            </Text>
+            <div>
+              <Button variant="danger" size="compact" onClick={() => setConfirmingDelete(true)}>
+                Delete this game
+              </Button>
+            </div>
+          </div>
+        </Card>
+      )}
+
+      <DeleteGameDialog
+        game={confirmingDelete ? game : null}
+        onClose={() => setConfirmingDelete(false)}
+        // Leave BEFORE the `games.get` subscription resolves to `null`, which
+        // would otherwise flip this route to "You are not in this game" — a
+        // true statement that reads as an error to someone who just deleted it.
+        onDeleted={() => void navigate({ to: '/games' })}
+      />
     </div>
   )
 }

--- a/apps/itun/src/components/games/GamesScreen.tsx
+++ b/apps/itun/src/components/games/GamesScreen.tsx
@@ -18,6 +18,8 @@ import { useConnection } from '../../lib/connection/connectionContext'
 import { isConvexConfigured } from '../../lib/connection/convexClient'
 import { SignInControl } from '../account/SignInControl'
 import { ConvexPending } from '../shared/ConvexPending'
+import type { DeletableGame } from './DeleteGameDialog'
+import { DeleteGameDialog } from './DeleteGameDialog'
 import { GameRow } from './GameRow'
 
 /**
@@ -115,6 +117,14 @@ function ConnectedGames() {
   const [code, setCode] = useState('')
   const [joinError, setJoinError] = useState<string | null>(null)
   const [joinNotice, setJoinNotice] = useState<string | null>(null)
+  /**
+   * One dialog for the whole list, holding the game it is about.
+   *
+   * Not one dialog per row: the confirm carries several paragraphs naming what
+   * is destroyed, and mounting that under every row would build a modal for
+   * each game you belong to so that at most one could ever open.
+   */
+  const [deleteTarget, setDeleteTarget] = useState<DeletableGame | null>(null)
 
   const join = () => {
     setJoinError(null)
@@ -208,11 +218,20 @@ function ConnectedGames() {
         <ul className="flex list-none flex-col gap-2.5 p-0">
           {games.map((game) => (
             <li key={game._id}>
-              <GameRow game={game} />
+              <GameRow
+                game={game}
+                // Organizer only — and only a courtesy. `games.destroy` calls
+                // `requireOrganizer` whatever the client draws (ADR-030 §3).
+                onDelete={game.organizer ? () => setDeleteTarget(game) : undefined}
+              />
             </li>
           ))}
         </ul>
       )}
+
+      {/* Nothing to do on success: `listMine` is a live subscription, so the
+          row leaves the list on its own the moment the mutation lands. */}
+      <DeleteGameDialog game={deleteTarget} onClose={() => setDeleteTarget(null)} />
     </div>
   )
 }

--- a/apps/itun/src/components/games/__tests__/GameRoster.connected.test.tsx
+++ b/apps/itun/src/components/games/__tests__/GameRoster.connected.test.tsx
@@ -213,12 +213,15 @@ describe('copy to shelf', () => {
     expect(screen.getAllByRole('button', { name: 'Copy to shelf' })).toHaveLength(3)
   })
 
-  test('the crawler does not, because a shelved crawler cannot exist', () => {
+  test('the crawler does not — a deliberate hold, no longer an impossibility', () => {
     renderAs(ME, listing({ crawlers: [CRAWLER] }))
 
-    // `crawlers.gameId` is NON-nullable in the Convex schema, so there is no
-    // server row a shelved crawler could be — which is why `claimLocal` parks a
-    // claimed one on a placeholder Game rather than shelving it.
+    // This assertion is unchanged but its reason is not. A shelved crawler was
+    // once unrepresentable (`crawlers.gameId` was non-nullable); it is ordinary
+    // now. The crawler is the crew's shared home rather than a character
+    // somebody keeps, so offering "copy the table's crawler to your shelf" is a
+    // product decision that has not been made — and this test is what will fail
+    // first, loudly and in the right place, when somebody makes it.
     expect(screen.queryByRole('button', { name: 'Copy to shelf' })).toBeNull()
   })
 

--- a/apps/itun/src/components/games/__tests__/GamesScreen.connected.test.tsx
+++ b/apps/itun/src/components/games/__tests__/GamesScreen.connected.test.tsx
@@ -181,6 +181,75 @@ describe('the Games index for a signed-in player', () => {
   })
 })
 
+/**
+ * Deleting from the index.
+ *
+ * The trash is the ONE per-game control that belongs on this screen, which is
+ * the exception to "per-game administration is NOT on the index" above: every
+ * other administrative control acts on the table's *contents* and needs the
+ * table in front of you, while deleting acts on the row itself and is the
+ * ordinary `EntityRow` affordance the Roster already uses for a pilot.
+ */
+describe('deleting a game from the index', () => {
+  test('only the Organizer is offered the trash', () => {
+    withQueries(queriesFor(GAME))
+    wrap()
+    // A Player — and, deliberately, a Mediator who is not the Organizer — has
+    // no trash, because `games.destroy` would refuse them. Hiding a control the
+    // server will refuse is the courtesy; the refusal is the boundary.
+    expect(screen.queryByLabelText('Delete Union Crawler #430')).toBeNull()
+
+    withQueries(queriesFor({ ...GAME, mediator: true }))
+    wrap()
+    expect(screen.queryByLabelText('Delete Union Crawler #430')).toBeNull()
+  })
+
+  test('the Organizer gets it', () => {
+    withQueries(queriesFor({ ...GAME, organizer: true }))
+    wrap()
+    expect(screen.getByLabelText('Delete Union Crawler #430')).toBeTruthy()
+  })
+
+  test('the trash asks first, and says where everything lands', () => {
+    withQueries(queriesFor({ ...GAME, organizer: true }))
+    wrap()
+
+    // Nothing is destroyed on click — a shared campaign ending for everyone in
+    // it is the clearest case there is for a confirm.
+    expect(screen.queryByText(/It cannot be undone/i)).toBeNull()
+
+    fireEvent.click(screen.getByLabelText('Delete Union Crawler #430'))
+
+    // The confirm's job is to be checkable against the row that opened it, so
+    // it carries the real counts and the crawler's real name rather than a
+    // generic "this is permanent".
+    expect(screen.getByText(/It cannot be undone/i)).toBeTruthy()
+    expect(screen.getByText(/4 pilots and 3 mechs go back to the shelves/i)).toBeTruthy()
+    expect(screen.getByText(/Hamlet and anything unclaimed land on your shelf/i)).toBeTruthy()
+  })
+
+  test('a game with no crawler does not promise one', () => {
+    withQueries(queriesFor({ ...GAME, organizer: true, crawlerName: null, pilotCount: 0 }))
+    wrap()
+    fireEvent.click(screen.getByLabelText('Delete Union Crawler #430'))
+
+    expect(screen.getByText(/^Anything unclaimed lands on your shelf\.$/)).toBeTruthy()
+    // With no pilots there is no "0 pilots" line to read past.
+    expect(screen.queryByText(/0 pilots/)).toBeNull()
+  })
+
+  test('cancelling leaves the game alone', () => {
+    withQueries(queriesFor({ ...GAME, organizer: true }))
+    wrap()
+
+    fireEvent.click(screen.getByLabelText('Delete Union Crawler #430'))
+    fireEvent.click(screen.getByText('Cancel'))
+
+    expect(screen.queryByText(/It cannot be undone/i)).toBeNull()
+    expect(screen.getByText('Union Crawler #430')).toBeTruthy()
+  })
+})
+
 describe('joining by code from the lobby', () => {
   test('a successful join routes into the game it joined', async () => {
     withQueries(queriesFor(GAME))

--- a/apps/itun/src/stores/entityBackend.ts
+++ b/apps/itun/src/stores/entityBackend.ts
@@ -300,7 +300,7 @@ export async function mirrorWrite(
  */
 export async function mirrorCrawlerWrite(
   op:
-    | { kind: 'create'; appId: string; gameId: string; body: unknown }
+    | { kind: 'create'; appId: string; gameId: string | null; body: unknown }
     | { kind: 'patch'; appId: string; patch: unknown }
     | { kind: 'delete'; appId: string }
 ): Promise<void> {
@@ -309,7 +309,8 @@ export async function mirrorCrawlerWrite(
   try {
     if (op.kind === 'create') {
       await convexClient.mutation(api.entities.createCrawler, {
-        gameId: op.gameId as Id<'games'>,
+        // `null` raises it on the caller's shelf — see `entities.createCrawler`.
+        gameId: op.gameId as Id<'games'> | null,
         appId: op.appId,
         body: op.body,
       })

--- a/apps/itun/src/stores/entityStore.ts
+++ b/apps/itun/src/stores/entityStore.ts
@@ -314,9 +314,14 @@ function mirrorEntityWrite(
     return
   }
   if (type === 'crawler') {
+    // A shelf crawler used to be dropped here — "no server row to merge into",
+    // which was true while `crawlers.gameId` was non-nullable. It is nullable
+    // now, so a shelved crawler has a real row like everything else and this
+    // mirrors it. Skipping was the one place the local store held data the
+    // server had never heard of, which is exactly the local-only state the
+    // offline story forbids: IndexedDB reflects Convex, it is not a second
+    // source of truth.
     const gameId = record.gameId ?? null
-    // Shelf and Solo crawlers have no server row to merge into.
-    if (gameId === null) return
     if (patch === undefined) {
       void mirrorCrawlerWrite({ kind: 'create', appId: record.id, gameId, body: record })
       return

--- a/apps/itun/test/convex/account.test.ts
+++ b/apps/itun/test/convex/account.test.ts
@@ -112,7 +112,12 @@ describe('deleteAccount — the campaign survives', () => {
 
     const crawlerId = await t.run(
       async (ctx) =>
-        await ctx.db.insert('crawlers', { gameId, body: { name: '#430' }, updatedAt: 1 })
+        await ctx.db.insert('crawlers', {
+          gameId,
+          ownerId: null,
+          body: { name: '#430' },
+          updatedAt: 1,
+        })
     )
 
     await organizer.as.mutation(api.account.deleteAccount, {})
@@ -162,7 +167,8 @@ describe('deleteAccount — the campaign survives', () => {
     const solo = await makeUser(t, 'Solo')
     const gameId = await solo.as.mutation(api.games.create, { name: 'Alone' })
     const crawlerId = await t.run(
-      async (ctx) => await ctx.db.insert('crawlers', { gameId, body: {}, updatedAt: 1 })
+      async (ctx) =>
+        await ctx.db.insert('crawlers', { gameId, ownerId: null, body: {}, updatedAt: 1 })
     )
     const unclaimed = await seedPilot(t, gameId, null)
 

--- a/apps/itun/test/convex/bot.test.ts
+++ b/apps/itun/test/convex/bot.test.ts
@@ -323,6 +323,7 @@ describe('the communal crawler is readable', () => {
       async (ctx) =>
         await ctx.db.insert('crawlers', {
           gameId,
+          ownerId: null,
           body: { name: 'The Ossuary', techLevel: '3' },
           updatedAt: Date.now(),
         })
@@ -381,6 +382,7 @@ describe('the communal crawler is readable', () => {
       async (ctx) =>
         await ctx.db.insert('crawlers', {
           gameId: otherGameId,
+          ownerId: null,
           body: { name: 'Not Yours' },
           updatedAt: Date.now(),
         })

--- a/apps/itun/test/convex/entities.test.ts
+++ b/apps/itun/test/convex/entities.test.ts
@@ -298,6 +298,7 @@ describe('the crawler is communal and merges per field', () => {
       async (ctx) =>
         await ctx.db.insert('crawlers', {
           gameId,
+          ownerId: null,
           appId: 'c1',
           // Shape probed against CrawlerSchema, not guessed: techLevel is a
           // STRING here, there is no `modules` key, and `systems` is required.
@@ -339,7 +340,13 @@ describe('the crawler is communal and merges per field', () => {
     const outsider = await makeUser(t, 'Outsider')
     await t.run(
       async (ctx) =>
-        await ctx.db.insert('crawlers', { gameId, appId: 'c1', body: {}, updatedAt: 1 })
+        await ctx.db.insert('crawlers', {
+          gameId,
+          ownerId: null,
+          appId: 'c1',
+          body: {},
+          updatedAt: 1,
+        })
     )
 
     await expect(
@@ -428,7 +435,7 @@ describe('claiming a legacy roster carries the whole thing', () => {
     expect(result.skipped).toBe(0)
   })
 
-  test('a claimed crawler gets a game, because a shelf cannot hold one', async () => {
+  test("a claimed crawler lands on the claimer's shelf, like everything else", async () => {
     const t = testConvex()
     const u = await makeUser(t, 'A')
     await u.as.mutation(api.entities.claimLocal, {
@@ -447,14 +454,19 @@ describe('claiming a legacy roster carries the whole thing', () => {
       ],
     })
 
-    // Crawlers are communal and game-scoped by design, so there is no shelf
-    // shaped to hold one — a placeholder game of one is the honest home.
+    // This used to park the crawler on a placeholder "Claimed crawler" Game of
+    // one, because `crawlers.gameId` was non-nullable and a shelf could not hold
+    // it. The shelf can hold one now, so a claimed crawler goes exactly where a
+    // claimed pilot goes — and no Game is invented to receive it.
     const crawlers = await t.run(async (ctx) => await ctx.db.query('crawlers').collect())
     expect(crawlers).toHaveLength(1)
-    expect(crawlers[0]?.gameId).not.toBeNull()
+    expect(crawlers[0]?.gameId).toBeNull()
+    expect(crawlers[0]?.ownerId).toBe(u.userId)
 
+    const games = await t.run(async (ctx) => await ctx.db.query('games').collect())
     const memberships = await t.run(async (ctx) => await ctx.db.query('memberships').collect())
-    expect(memberships[0]?.organizer).toBe(true)
+    expect(games).toHaveLength(0)
+    expect(memberships).toHaveLength(0)
   })
 
   test('the local id is preserved as appId so later edits find the row', async () => {
@@ -599,22 +611,25 @@ describe('claiming twice is a no-op, not a second copy', () => {
     )
   })
 
-  test('a repeat claim does not raise a second placeholder game', async () => {
+  test('a repeat claim of a crawler makes no second copy, and no game at all', async () => {
     const t = testConvex()
     const u = await makeUser(t, 'A')
 
     await u.as.mutation(api.entities.claimLocal, { pilots: [], mechs: [], crawlers: [crawler] })
     await u.as.mutation(api.entities.claimLocal, { pilots: [], mechs: [], crawlers: [crawler] })
 
-    // The placeholder Game used to be raised before anything checked whether
-    // there was a crawler left to put in it, so a re-claim grew the player's
-    // game list by one empty "Claimed crawler" every time.
+    // Two regressions in one assertion, and the second is now structural rather
+    // than guarded. Claiming twice must not duplicate the crawler — that check
+    // is unchanged. It must also not accumulate placeholder Games, which it once
+    // did on EVERY re-claim: a "Claimed crawler" Game was raised before anything
+    // checked whether a crawler was left to put in it. No placeholder exists to
+    // raise any more, so the count is zero rather than a carefully-held one.
     const crawlers = await t.run(async (ctx) => await ctx.db.query('crawlers').collect())
     const games = await t.run(async (ctx) => await ctx.db.query('games').collect())
     const memberships = await t.run(async (ctx) => await ctx.db.query('memberships').collect())
     expect(crawlers).toHaveLength(1)
-    expect(games).toHaveLength(1)
-    expect(memberships).toHaveLength(1)
+    expect(games).toHaveLength(0)
+    expect(memberships).toHaveLength(0)
   })
 
   test('soft links and patterns are not duplicated either', async () => {

--- a/apps/itun/test/convex/invites.test.ts
+++ b/apps/itun/test/convex/invites.test.ts
@@ -422,6 +422,7 @@ describe('games.get and the row summary', () => {
       })
       await ctx.db.insert('crawlers', {
         gameId,
+        ownerId: null,
         body: { name: 'Hamlet' },
         updatedAt: Date.now(),
       })

--- a/apps/itun/test/convex/permissions.test.ts
+++ b/apps/itun/test/convex/permissions.test.ts
@@ -297,8 +297,8 @@ describe('leaving a game', () => {
   })
 })
 
-describe('destroying a game preserves owned characters', () => {
-  test('owned entities fall back to their owner shelf; unclaimed ones go', async () => {
+describe('destroying a game preserves everything anybody built', () => {
+  test("owned entities go to their owner's shelf; unclaimed ones to the deleter's", async () => {
     const t = testConvex()
     const { organizer, player, gameId } = await seedGame(t)
     const ownedId = await seedPilot(t, gameId, player.userId)
@@ -314,14 +314,73 @@ describe('destroying a game preserves owned characters', () => {
     expect(owned?.gameId).toBeNull()
     expect(owned?.ownerId).toBe(player.userId)
 
-    // An unclaimed entity has no shelf to fall back to. Keeping it would create
-    // the one combination ADR-030 calls invalid: gameId null AND ownerId null.
-    expect(unclaimed).toBeNull()
+    // An unclaimed entity used to be DELETED here, because it had no owner to
+    // fall back to and `gameId: null` with `ownerId: null` is the one invalid
+    // combination. Deleting was never the only way out of that: the Organizer
+    // doing the deleting is a perfectly good owner, and is the person standing
+    // in front of the consequence. So it survives, on their shelf.
+    expect(unclaimed).not.toBeNull()
+    expect(unclaimed?.gameId).toBeNull()
+    expect(unclaimed?.ownerId).toBe(organizer.userId)
+  })
+
+  test('the crawler comes to the deleting Organizer, and stops being communal', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+    const crawlerId = await t.run(
+      async (ctx) =>
+        await ctx.db.insert('crawlers', {
+          gameId,
+          ownerId: null,
+          body: { name: '#430' },
+          updatedAt: 1,
+        })
+    )
+
+    await organizer.as.mutation(api.games.destroy, { gameId })
+
+    // The crawler is the crew's HOME, and it used to be destroyed with the Game
+    // — the one build that a deletion could take with it. It now falls back like
+    // everything else. `ownerId` moving from null to the Organizer is not a
+    // change of heart about D8: communal is what a crawler is INSIDE a Game, and
+    // this one is no longer in one.
+    const crawler = await t.run(async (ctx) => await ctx.db.get(crawlerId))
+    expect(crawler).not.toBeNull()
+    expect(crawler?.gameId).toBeNull()
+    expect(crawler?.ownerId).toBe(organizer.userId)
+  })
+
+  test('the table itself is gone — game, crew and invites', async () => {
+    const t = testConvex()
+    const { organizer, gameId } = await seedGame(t)
+
+    await organizer.as.mutation(api.games.destroy, { gameId })
+
+    const game = await t.run(async (ctx) => await ctx.db.get(gameId))
+    const memberships = await t.run(async (ctx) => await ctx.db.query('memberships').collect())
+    expect(game).toBeNull()
+    expect(memberships).toHaveLength(0)
   })
 
   test('a Player cannot destroy the game', async () => {
     const t = testConvex()
     const { player, gameId } = await seedGame(t)
+    await expect(player.as.mutation(api.games.destroy, { gameId })).rejects.toThrow(/organizer/i)
+  })
+
+  test('a Mediator who is not the Organizer cannot destroy the game either', async () => {
+    const t = testConvex()
+    const { organizer, player, gameId } = await seedGame(t)
+    await organizer.as.mutation(api.games.setMediator, {
+      gameId,
+      userId: player.userId,
+      mediator: true,
+    })
+
+    // Deliberate, and the reason `destroy` does not use `requireTableRunner`:
+    // that helper hands authority to the Organizer only while a Game has no
+    // Mediator, so who may end a campaign would otherwise depend on whether one
+    // had been appointed yet.
     await expect(player.as.mutation(api.games.destroy, { gameId })).rejects.toThrow(/organizer/i)
   })
 })

--- a/apps/itun/test/convex/templates.test.ts
+++ b/apps/itun/test/convex/templates.test.ts
@@ -57,14 +57,21 @@ describe('starter-set template', () => {
     expect(roster[0]?.mediator).toBe(false)
   })
 
-  test('the crawler is created communally, with no owner column at all', async () => {
+  test('the crawler is created communally — in a game, it belongs to nobody', async () => {
     const t = testConvex()
     const u = await makeUser(t, 'Organizer')
     await u.as.mutation(api.templates.createGame, { templateId: 'starter-set' })
 
     const crawlers = await t.run(async (ctx) => await ctx.db.query('crawlers').collect())
     expect(crawlers.length).toBeGreaterThan(0)
-    expect(crawlers[0]).not.toHaveProperty('ownerId')
+    // Communal is now expressed as `ownerId: null` on a row that HAS the column,
+    // rather than by the column's absence. This test used to assert the absence
+    // (`not.toHaveProperty('ownerId')`), which stopped meaning anything the
+    // moment a crawler could also sit on a shelf — where it must have an owner.
+    // What matters is unchanged and is what is asserted now: inside a Game, the
+    // crawler is the crew's and is handed to no one.
+    expect(crawlers[0]?.ownerId).toBeNull()
+    expect(crawlers[0]?.gameId).not.toBeNull()
   })
 
   test('soft links come across, so the crew is wired together on arrival', async () => {

--- a/docs/adrs/ADR-030-accounts-games-server-of-record.md
+++ b/docs/adrs/ADR-030-accounts-games-server-of-record.md
@@ -293,6 +293,74 @@ same act as removing someone from the room.
 
 Enforced in `convex/invites.ts` (`seat`, `assertSpendable`, `decideRequest`).
 
+## Amendment — the crawler can sit on a shelf, and deleting a Game destroys nothing
+
+§5 says the crawler is **communal**, and the schema expressed that by giving it
+no `ownerId` column at all and a non-nullable `gameId`: a crawler was a thing
+that could only exist inside a Game. That second half is amended. `crawlers` now
+carries the same two container columns as `pilots` and `mechs`.
+
+**Communal is unchanged.** It is now written as `ownerId: null` on a row whose
+`gameId` is set — the same fact, stated in a column instead of by a column's
+absence. Any member may still edit the crawler, conflicting writes still resolve
+by field-level merge, and raising or scrapping one inside a Game is still the
+table runner's act under §5a.
+
+What the amendment adds is the third row of §2's ownership table — `gameId:
+null` with an owner, *on the shelf* — which the crawler was the one entity
+unable to occupy. Two things were being worked around rather than fixed:
+
+- **Deleting a Game had to destroy its crawler.** Pilots and mechs fell back to
+  a shelf; the crew's home had nowhere to fall to.
+- **Claiming a Solo roster invented a container.** `entities.claimLocal` parked
+  a claimed crawler on a placeholder "Claimed crawler" Game of one, complete
+  with a membership, because the shelf could not hold it. That Game appeared in
+  the player's list as a table they never made.
+
+`gameId == null && ownerId == null` remains the one invalid combination, for the
+crawler exactly as for everything else — which is *why* a shelved crawler must
+take an owner. A crawler stops being communal at the moment it leaves a Game,
+because communal is a property of being in one.
+
+### Deleting a Game
+
+**Organizer only**, and deliberately not the table runner: `requireTableRunner`
+hands authority to the Organizer only while a Game has no Mediator, which would
+make who may end a campaign depend on whether one had been appointed yet.
+
+Nothing anybody built is destroyed:
+
+| What                            | Where it lands                 |
+| ------------------------------- | ------------------------------ |
+| a pilot or mech with an owner    | that owner's shelf            |
+| an **unclaimed** pilot or mech   | the deleting Organizer's shelf |
+| every **crawler**                | the deleting Organizer's shelf |
+
+The first row was always the rule. The other two are new: unclaimed entities and
+crawlers used to be deleted outright, on the reasoning that they had no shelf to
+fall back to — true at the time, since both need a shelf row carrying an owner.
+Both are expressible now, so both fall back, and the receiving shelf is the
+deleter's because they are the one person guaranteed to exist and to be looking
+at the consequence as it happens.
+
+What does go is the **table**: memberships, invites, pending join requests, the
+Mediator's opposition tray, and the soft links. A link is a fact about the
+table's wiring rather than a possession — a pilot-to-crawler assignment means
+"aboard this crew's crawler", which stops being true when the crew disbands — so
+shelved entities land unwired.
+
+### Why not keep a shelved crawler in the browser only
+
+The rejected alternative was to copy the crawler into IndexedDB on deletion and
+leave the server out of it, which needs no schema change. It is rejected on
+principle: offline-first in ITUN is ordinary PWA caching, so the local store is
+a **reflection** of Convex and never a second source of truth. A record with no
+server row to reflect is invisible on the player's other devices, invisible to
+sync, and lost with the browser's storage. `entityStore.adopt()` never mirrors,
+and `mirrorEntityWrite` used to skip a crawler with `gameId === null` for exactly
+this reason — that skip was the last place the client could hold data the server
+had never heard of, and it is now closed.
+
 ## Amendment to ADR-022
 
 ADR-022 states the Change Log is **local only** and never travels with a


### PR DESCRIPTION
Adds game deletion to ITUN, and makes it safe by giving the crawler somewhere real to go.

## What you get

- The ordinary `EntityRow` **trash can** on each row of the Games list, plus a **danger zone** on the Game's own screen. Both Organizer-only.
- One shared confirm (`DeleteGameDialog`) that names the crew size, the crawler by name and the real pilot/mech counts, so it can be checked against the row that opened it. It says where everything lands rather than just "this is permanent" — which would be frightening and wrong.
- Hiding the control from non-Organizers is a courtesy; `games.destroy` calls `requireOrganizer` regardless.

## Why the disposition changed

`games.destroy` already existed with **no UI caller at all**, and destroyed more than it needed to. Owned pilots and mechs already fell back to their owners' shelves. Unclaimed entities and the crawler were deleted outright — because both need a shelf row carrying an owner, and `crawlers` had no `ownerId` column.

| What | Before | Now |
| --- | --- | --- |
| pilot/mech with an owner | owner's shelf | owner's shelf |
| **unclaimed** pilot/mech | **deleted** | deleting Organizer's shelf |
| **crawler** | **deleted** | deleting Organizer's shelf |

Organizer rather than table runner is deliberate: `requireTableRunner` hands authority to the Organizer only while a Game has no Mediator, so who may end a campaign would otherwise depend on whether one had been appointed yet. There is a test for that.

## The schema change

`crawlers` takes the same two container columns as `pilots`/`mechs`. **Communal is unchanged** — it is now written as `ownerId: null` on a row that is in a Game, rather than by the column's absence. `gameId == null && ownerId == null` remains the one invalid combination, which is exactly why a shelved crawler must take an owner. A crawler stops being communal when it leaves a Game, because communal is a property of being in one.

The rejected alternative was copying a shelved crawler into IndexedDB and leaving the server out of it — no schema change needed. Rejected on principle: offline-first here is ordinary PWA caching, so the local store **reflects** Convex and is never a second source of truth. A record with no server row to reflect is invisible on your other devices, invisible to sync, and lost with browser storage.

## Two consequences of the same gap, closed with it

- **`entities.claimLocal` no longer invents a container.** It used to park a claimed crawler on a placeholder `"Claimed crawler"` Game of one, plus a membership in it, which showed up in the player's games list as a table they never made. Its soft links stop being filed under that Game too.
- **`mirrorEntityWrite` no longer skips a shelf crawler.** That skip was the last place the client could hold data the server had never heard of.

## Also

- Crawler write permission now follows its container: communal editing and table-runner destruction in a Game, owner-only on a shelf (`assertMayEditCrawler` / `assertMayScrapCrawler`).
- `publicSheet.assertMayPublish` discriminates on the **table** rather than on `'ownerId' in row`, which stopped separating anything once every row had the column — the branch it guarded had narrowed to `never`.
- `GameRoster`'s copy-to-shelf still excludes crawlers, but its stated reason was a model limitation that no longer exists. Behavior unchanged; the comment and its test now say it is a **product decision nobody has made**, and the test will fail first when someone makes it.
- ADR-030 amended to record all of it.

## Verification

`bun run check:all` exits 0 — typecheck, lint, format, knip, audit, tokens, styling, the srd output gate, and ~5,288 tests with 0 failures. The four Convex tests that failed first were the ones asserting the old contract, which is the signal you want; each was rewritten to assert the new one. New coverage: crawler falls to the Organizer, unclaimed falls to the Organizer, a non-Organizer Mediator is refused, and five UI tests for the trash. A negative control (inverting the Organizer-sees-trash expectation) produced exactly one failure, confirming the UI tests discriminate.

## Not in this PR

Requiring an account to persist (superseding ADR-030 §1's permanent Solo guarantee) is deliberately sequenced after this, with a claim-on-sign-in migration. It is a large architectural reversal and does not belong in a feature PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QU5rmidxZ3QUrMb3nvVNX6
