### PR TITLE
docs: ADR-034 — persistence requires an account, local store is a cache

### DIFF
--- a/.claude/rules/tanstack-query-hooks.md
+++ b/.claude/rules/tanstack-query-hooks.md
@@ -99,6 +99,23 @@ Do not reach for it just because it is mounted.
 - Do **not** build a local-only duplicate of something Convex already owns
   (membership, ownership, invites, proposals, crew vitals). Check
   `apps/itun/convex/` first.
+- Do **not** add a store, field or flow that persists **only on a device**, even
+  where the current code would let you.
+  [ADR-034](../../docs/adrs/ADR-034-account-required-persistence.md) makes Convex
+  the only source of truth for every persisted record; IndexedDB is a cache of
+  it. A row with no Convex counterpart is invisible on the user's other devices,
+  invisible to sync, and lost when browser storage clears.
+  - This is a rule about **new** code. Solo mode still runs today and the phases
+    that remove it have not landed — see
+    [persistence-and-pwa.md](../../docs/architecture/persistence-and-pwa.md).
+  - Three stores already violate it and are being repaired in P0: `mechPatterns`
+    and `encounterNpcs` write locally with no mirror, and client Change Log
+    appends never leave the device. **Do not copy their shape**; copy
+    `entityStore`'s `mirrorWrite`.
+  - If the schema cannot express where a record needs to live, **the schema
+    moves**. #871 is the worked example: `crawlers` gained `ownerId` and a
+    nullable `gameId` so a crawler leaving a deleted Game lands in Convex rather
+    than in a browser.
 - Do **not** reintroduce `fetchEntity`/`updateEntity`, hosted-DB `Tables<...>`
   types, or `isLocalId` checks — those are from the removed Postgres era and
   have nothing to do with Convex.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Start here for navigation:** [`docs/README.md`](docs/README.md) maps user intent → relevant doc (architecture, ADRs, per-package CLAUDE.md).
 
-- [`docs/adrs/`](docs/adrs/) — architecture decision records, **33 of them** (ADR-001 through ADR-033). Consult the matching ADR before revisiting a prior decision, and **read its `## Status` header first** — several are superseded and the supersession is only recorded there (ADR-001 → ADR-030; ADR-012 → ADR-031; ADR-023 → ADR-027 → ADR-028). The three that govern:
+- [`docs/adrs/`](docs/adrs/) — architecture decision records, **34 of them** (ADR-001 through ADR-034). Consult the matching ADR before revisiting a prior decision, and **read its `## Status` header first** — several are superseded and the supersession is only recorded there (ADR-001 → ADR-030; ADR-012 → ADR-031; ADR-023 → ADR-027 → ADR-028; ADR-030 §1 → ADR-034). The three that govern:
   - [ADR-030](docs/adrs/ADR-030-accounts-games-server-of-record.md) — accounts, Games, and Convex as the server of record for identity/ownership/sharing. **Supersedes ADR-001** (local-first, no backend, no auth) and amends ADR-022. Decision accepted; delivery is phased — see [`docs/architecture/accounts-and-games.md`](docs/architecture/accounts-and-games.md) for what has actually landed.
   - [ADR-021](docs/adrs/ADR-021-itun-surface-taxonomy.md) — the surface/mode taxonomy for **where a rule is enforced**. ADR-030 adds an ownership axis to it without changing its enforcement modes.
   - [ADR-007](docs/adrs/ADR-007-automation-boundary.md) — the automation boundary. Read before building rules-driven features.

--- a/apps/itun/CLAUDE.md
+++ b/apps/itun/CLAUDE.md
@@ -7,8 +7,18 @@ React app for building and running Salvage Union pilots, mechs, and crawlers.
 supersedes ADR-001):
 
 - **Solo** — not signed in. IndexedDB is the source of truth and nothing is
-  gated. This is still the default and must keep working forever; a build with
-  no `VITE_CONVEX_URL` (CI, a fresh checkout) is permanently Solo.
+  gated. This is the default today, and a build with no `VITE_CONVEX_URL` (CI, a
+  fresh checkout) is permanently Solo — which is why every Playwright e2e
+  currently runs Solo.
+  - **"Forever" no longer holds.**
+    [ADR-034](../../docs/adrs/ADR-034-account-required-persistence.md) withdraws
+    that guarantee: persistence will require an account, anonymous users get
+    in-memory sheets, and IndexedDB becomes a cache. **Accepted, nothing built**
+    — the description above is still accurate for the code as it stands, so keep
+    Solo working until the phase that removes it lands. What changes *now* is
+    what you may add: **never introduce a store, field or flow that persists only
+    on a device.** Plan and phases:
+    [persistence-and-pwa.md](../../docs/architecture/persistence-and-pwa.md).
 - **Connected / Disconnected** — signed in. Convex is the source of truth and
   IndexedDB becomes a cache. Offline means **read-only**, not a write queue.
 

--- a/apps/itun/convex/games.ts
+++ b/apps/itun/convex/games.ts
@@ -193,6 +193,7 @@ export const rename = mutation({
  * | a pilot or mech with an owner   | that owner's shelf             |
  * | an **unclaimed** pilot or mech  | the deleting Organizer's shelf |
  * | every **crawler**               | the deleting Organizer's shelf |
+ * | every **encounter NPC**         | the deleting Organizer's shelf |
  *
  * The first row is the oldest rule here and the one that matters most: deleting
  * a campaign must never delete somebody's character.
@@ -245,7 +246,27 @@ export const destroy = mutation({
       await ctx.db.patch(crawler._id, { gameId: null, ownerId: organizerId })
     }
 
-    // Game-scoped rows with no personal counterpart just go. `inviteRedemptions`
+    // The Mediator's prepared opposition falls back for the same reason the
+    // crawler does, and it became able to only in the same way: `encounterNpcs`
+    // gained a nullable `gameId` and an `ownerId` (ADR-034 decision 2), so a
+    // tray is no longer something only a Game can hold. It used to be deleted
+    // here — which threw away prep work somebody had genuinely built, the one
+    // remaining case of exactly what the rule above forbids.
+    //
+    // It goes to the Organizer rather than to whoever mediated: a Game may have
+    // several Mediators or none, while the deleter is by construction exactly
+    // one person who exists.
+    const npcs = await ctx.db
+      .query('encounterNpcs')
+      .withIndex('by_game', (q) => q.eq('gameId', args.gameId))
+      .collect()
+    for (const npc of npcs) {
+      await ctx.db.patch(npc._id, { gameId: null, ownerId: organizerId })
+    }
+
+    // What is left has no personal counterpart, so it just goes. Note this list
+    // is now only the *table's own* apparatus — nothing on it is a thing a
+    // person built. `inviteRedemptions`
     // and `joinRequests` belong here for the same reason `invites` does: they
     // describe a way into a Game that no longer exists, and an unanswered knock
     // at a deleted door would sit pending forever.
@@ -255,7 +276,6 @@ export const destroy = mutation({
     // this crew's crawler", which stops being true when the crew disbands.
     // Shelved entities land unwired, which is the honest state.
     for (const table of [
-      'encounterNpcs',
       'softLinks',
       'invites',
       'inviteRedemptions',

--- a/apps/itun/convex/mediator.ts
+++ b/apps/itun/convex/mediator.ts
@@ -1,8 +1,9 @@
 import { v } from 'convex/values'
-import type { Id } from './_generated/dataModel'
+import type { Doc, Id } from './_generated/dataModel'
+import type { MutationCtx } from './_generated/server'
 import { mutation, query } from './_generated/server'
 import { parseBody } from './model/entities'
-import { requireMediator, requireUser } from './model/permissions'
+import { NotAuthorized, requireMediator, requireUser } from './model/permissions'
 
 /**
  * The Mediator surface's server layer (ADR-030 §6, Phase 3).
@@ -60,7 +61,15 @@ export const addNpc = mutation({
   handler: async (ctx, args): Promise<Id<'encounterNpcs'>> => {
     await requireMediator(ctx, args.gameId)
     const body = parseBody('encounterNpcs', args.body)
-    return await ctx.db.insert('encounterNpcs', { gameId: args.gameId, body })
+    // `ownerId: null` is what in-a-Game means for a tray NPC — the opposition
+    // belongs to the table, and the Mediator reaches it through their role.
+    // These mutations are all Game-scoped; the shelf half of the container model
+    // has no writer yet and gains one when the client tray is wired (P4).
+    return await ctx.db.insert('encounterNpcs', {
+      gameId: args.gameId,
+      ownerId: null,
+      body,
+    })
   },
 })
 
@@ -69,7 +78,7 @@ export const updateNpc = mutation({
   handler: async (ctx, args): Promise<void> => {
     const doc = await ctx.db.get(args.npcId)
     if (doc === null) return
-    await requireMediator(ctx, doc.gameId)
+    await requireNpcWriter(ctx, doc)
     const body = parseBody('encounterNpcs', args.body)
     await ctx.db.patch(args.npcId, { body })
   },
@@ -80,10 +89,33 @@ export const removeNpc = mutation({
   handler: async (ctx, args): Promise<void> => {
     const doc = await ctx.db.get(args.npcId)
     if (doc === null) return
-    await requireMediator(ctx, doc.gameId)
+    await requireNpcWriter(ctx, doc)
     await ctx.db.delete(args.npcId)
   },
 })
+
+/**
+ * Who may write an NPC — it depends on which container holds it.
+ *
+ * In a Game, the Mediator and nobody else: the tray is the one thing §5 keeps
+ * hidden from the crew, so the read rule and the write rule are the same rule.
+ * On a shelf it is an ordinary owned record and only its owner may touch it.
+ *
+ * Split out rather than inlined at both call sites, because a
+ * container-dependent rule written twice is a rule that will eventually be
+ * written two different ways — the same reason `entities.ts` has
+ * `assertMayEditCrawler`.
+ */
+async function requireNpcWriter(ctx: MutationCtx, doc: Doc<'encounterNpcs'>): Promise<void> {
+  if (doc.gameId !== null) {
+    await requireMediator(ctx, doc.gameId)
+    return
+  }
+  const userId = await requireUser(ctx)
+  if (doc.ownerId !== userId) {
+    throw new NotAuthorized("You cannot edit another player's NPC")
+  }
+}
 
 /**
  * Whether the caller mediates this Game.

--- a/apps/itun/convex/schema.ts
+++ b/apps/itun/convex/schema.ts
@@ -400,10 +400,41 @@ export default defineSchema({
     .index('by_to', ['to.id']),
 
   /** Mediator-owned and Mediator-visible. The one thing that must stay hidden. */
+  /**
+   * An NPC, in exactly one of the two containers everything else uses
+   * ([ADR-034](../../../docs/adrs/ADR-034-account-required-persistence.md)
+   * decision 2).
+   *
+   * In a Game (`gameId` set, `ownerId: null`) it is the **Mediator's prepared
+   * opposition** — the one table members cannot read. On a shelf (`gameId:
+   * null`, `ownerId` set) it is somebody's own tray, where they prep before a
+   * Game exists or after one ends.
+   *
+   * ## Why this grew two columns
+   *
+   * It was `gameId: v.id('games')` with no `ownerId` — *precisely* the shape
+   * `crawlers` had before #871, and it produced the same two problems. An NPC
+   * could not exist outside a Game, so deleting a Game destroyed the Mediator's
+   * prep; and the client kept a local-only tray of its own under the same name,
+   * holding a different set of rows that no server table could receive. One
+   * name, two disjoint meanings, and a container model that could express only
+   * one of them.
+   *
+   * `gameId == null && ownerId == null` stays the invalid row here as
+   * everywhere else.
+   */
   encounterNpcs: defineTable({
-    gameId: v.id('games'),
+    gameId: v.union(v.id('games'), v.null()),
+    /**
+     * Null inside a Game — the tray belongs to the table, not to a member, and
+     * the Mediator reaches it through their role rather than through ownership.
+     * Set on a shelf, where a container with no owner would be the invalid row.
+     */
+    ownerId: v.union(v.id('users'), v.null()),
     body: v.any(),
-  }).index('by_game', ['gameId']),
+  })
+    .index('by_game', ['gameId'])
+    .index('by_owner', ['ownerId']),
 
   /**
    * A saved mech pattern. Personal — there is no sharing.

--- a/apps/itun/src/lib/db/__tests__/memoryStore.test.ts
+++ b/apps/itun/src/lib/db/__tests__/memoryStore.test.ts
@@ -1,0 +1,110 @@
+/**
+ * The anonymous backend (ADR-034 decision 1, plan phase P2).
+ *
+ * The property under test is an **absence** — nothing reaches durable storage —
+ * so most of this file asserts what did *not* happen. That is deliberate: a
+ * suite that only checked "the wizard still works" would pass just as happily
+ * against the IndexedDB store, which is precisely the bug worth catching.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { z } from 'salvageunion-reference/zod'
+import { makeMemoryStore } from '../memoryStore'
+
+const ThingSchema = z
+  .object({
+    id: z.string(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+    name: z.string(),
+  })
+  .strict()
+
+type Thing = z.infer<typeof ThingSchema>
+
+const makeStore = () => makeMemoryStore<Thing>(ThingSchema, 'things', { hasUpdatedAt: true })
+
+describe('the anonymous store behaves like the durable one', () => {
+  test('create mints an id and timestamps, and the record reads back', async () => {
+    const store = makeStore()
+    const made = await store.create({ name: 'Roach-Boy' } as Omit<
+      Thing,
+      'id' | 'createdAt' | 'updatedAt'
+    >)
+
+    expect(made.id).toBeTruthy()
+    expect(made.createdAt).toBeTruthy()
+    expect(made.updatedAt).toBeTruthy()
+    expect(await store.get(made.id)).toEqual(made)
+  })
+
+  test('update merges, bumps updatedAt, and refuses to move the id', async () => {
+    const store = makeStore()
+    const made = await store.create({ name: 'Roach-Boy' } as never)
+
+    const updated = await store.update(made.id, { name: 'Roach-Girl', id: 'hijack' } as never)
+
+    expect(updated.name).toBe('Roach-Girl')
+    // `id` is immutable in the IDB store and must be here too — a backend that
+    // let a patch move an id would produce a second record on the next write.
+    expect(updated.id).toBe(made.id)
+  })
+
+  test('update on a missing id throws rather than creating', async () => {
+    const store = makeStore()
+    // The IDB store throws here, and a silent create would look like success
+    // while orphaning whatever the caller thought it was editing.
+    await expect(store.update('nope', { name: 'x' } as never)).rejects.toThrow(/not found/)
+  })
+
+  test('delete is a silent no-op for an unknown id', async () => {
+    const store = makeStore()
+    await store.delete('nope')
+    expect(await store.list()).toEqual([])
+  })
+
+  test('list is newest-first', async () => {
+    const store = makeStore()
+    const older = await store.create({ name: 'older' } as never)
+    // Stamp the second one later explicitly rather than sleeping: two creates in
+    // the same millisecond would otherwise make this assert on tie-break luck.
+    await store.put({ ...older, id: 'newer', createdAt: '2099-01-01T00:00:00.000Z' })
+
+    const listed = await store.list()
+    expect(listed[0]?.id).toBe('newer')
+  })
+
+  test('a write that does not satisfy the schema throws', async () => {
+    const store = makeStore()
+    // Same contract as the IDB store: `parse`, not `safeParse`, so a wizard
+    // surfaces a bad build instead of persisting one.
+    await expect(store.create({ name: 42 } as never)).rejects.toThrow()
+  })
+})
+
+describe('what makes it the ANONYMOUS store', () => {
+  test('two stores share nothing', async () => {
+    // Each store closes over its own Map. This is what makes two tabs of an
+    // anonymous session two sessions rather than one — the reason the entity
+    // store also suppresses cross-tab broadcast for this backend.
+    const a = makeStore()
+    const b = makeStore()
+    await a.create({ name: 'only in a' } as never)
+
+    expect(await b.list()).toEqual([])
+  })
+
+  test('the module imports nothing that can persist', async () => {
+    // The load-bearing assertion of this whole phase, and the reason the
+    // backend is a separate module rather than a flag inside `crud.ts`: a
+    // conditional would leave every `db.put` one wrong branch away from
+    // writing. This checks the source rather than the behaviour, because
+    // behaviour can be right today and one refactor away from wrong.
+    const source = await Bun.file(new URL('../memoryStore.ts', import.meta.url).pathname).text()
+
+    expect(source).not.toContain("from 'idb'")
+    expect(source).not.toContain('indexedDB')
+    expect(source).not.toContain('localStorage')
+    expect(source).not.toContain('sessionStorage')
+  })
+})

--- a/apps/itun/src/lib/db/memoryStore.ts
+++ b/apps/itun/src/lib/db/memoryStore.ts
@@ -1,0 +1,153 @@
+/**
+ * memoryStore — the same CRUD contract as `crud.ts`, backed by a Map that never
+ * touches disk.
+ *
+ * This is what an **anonymous** visitor builds against under
+ * [ADR-034](../../../../../docs/adrs/ADR-034-account-required-persistence.md)
+ * decision 1: you can work through a wizard, roll, and see a finished sheet
+ * without an account, and nothing you do is written to durable storage of any
+ * kind — not Convex, and not IndexedDB. Saving is where an account is required,
+ * and it is the only place.
+ *
+ * ## Why a second implementation rather than a flag inside `crud.ts`
+ *
+ * The point of this store is what it *cannot* do. A conditional inside the IDB
+ * store would leave every `db.put` one wrong branch away from writing, and the
+ * property being claimed here — "nothing is written" — is exactly the sort that
+ * dies quietly to a missed branch. A separate object with no `idb` import at all
+ * cannot regress that way: there is nothing in this file to write with.
+ *
+ * ## Deliberately identical where it matters, and only there
+ *
+ * Everything a caller can observe is the same as the IDB store: a fresh UUID and
+ * `createdAt` on `create`, `updatedAt` when the schema has one, strict Zod
+ * validation on every write, `list()` sorted newest-first, `update` throwing on
+ * a missing id, `delete` a silent no-op. `entityStore` is written against that
+ * contract and must not learn which backend it has.
+ *
+ * Two things are deliberately *not* carried over:
+ *
+ *  - **No salvage-tolerant reads.** Salvage exists because a record persisted by
+ *    an older or newer build can drift from the current schema. Nothing here
+ *    outlives the tab, so every record in the Map was written by this exact
+ *    build, and a parse failure would be a real bug rather than version skew —
+ *    it should throw where it happens, not be repaired into a warning.
+ *  - **No cross-tab broadcast.** Two tabs of an anonymous session are two
+ *    sessions: there is nothing durable tying them together, and syncing them
+ *    would invent precisely the device-local shared state ADR-034 forbids. The
+ *    caller is responsible for not broadcasting — see `entityStore`.
+ */
+
+import type { z } from 'salvageunion-reference/zod'
+
+/** The minimum every record managed here must have. Mirrors `crud.ts`. */
+type EntityBase = {
+  id: string
+  createdAt: string
+}
+
+/**
+ * The CRUD surface, structurally identical to `crud.ts`'s `EntityStore<T>`.
+ *
+ * Declared here rather than imported because `crud.ts` does not export it, and
+ * exporting it purely to share it with this file would widen that module's
+ * public surface for no other consumer. The two are kept in step by
+ * `dbStoreFor` accepting both — a drift between them is a type error at that
+ * call site, which is the check that matters.
+ */
+export type MemoryEntityStore<T extends EntityBase> = {
+  list: () => Promise<T[]>
+  get: (id: string) => Promise<T | null>
+  create: (input: Omit<T, 'id' | 'createdAt' | 'updatedAt'>) => Promise<T>
+  prepareUpdate: (id: string, patch: Partial<Omit<T, 'id'>>) => Promise<T>
+  update: (id: string, patch: Partial<Omit<T, 'id'>>) => Promise<T>
+  put: (record: T) => Promise<T>
+  delete: (id: string) => Promise<void>
+}
+
+type MakeMemoryStoreOptions = {
+  /** Set when T carries `updatedAt`. Mirrors `makeStore`'s option of the same name. */
+  hasUpdatedAt?: boolean
+}
+
+/**
+ * Build an in-memory store for one entity type.
+ *
+ * The `Map` is closed over rather than module-global, so each store owns its own
+ * rows and a test can build a fresh one without a reset hook.
+ */
+export function makeMemoryStore<T extends EntityBase>(
+  schema: z.ZodType<T>,
+  storeName: string,
+  options: MakeMemoryStoreOptions = {}
+): MemoryEntityStore<T> {
+  const { hasUpdatedAt = false } = options
+  const rows = new Map<string, T>()
+
+  async function list(): Promise<T[]> {
+    // Sorted newest-first, like the IDB store — surfaces read this order and a
+    // difference here would show up as a roster that reorders on sign-out.
+    return [...rows.values()].sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    )
+  }
+
+  async function get(id: string): Promise<T | null> {
+    return rows.get(id) ?? null
+  }
+
+  async function create(input: Omit<T, 'id' | 'createdAt' | 'updatedAt'>): Promise<T> {
+    const now = new Date().toISOString()
+    const candidate: Record<string, unknown> = {
+      ...input,
+      id: crypto.randomUUID(),
+      createdAt: now,
+    }
+    if (hasUpdatedAt) candidate.updatedAt = now
+
+    // `parse`, not `safeParse` — a ZodError bubbling to the caller is the same
+    // contract the IDB store has, and wizards rely on it to surface a bad build.
+    const record = schema.parse(candidate)
+    rows.set(record.id, record)
+    return record
+  }
+
+  async function prepareUpdate(id: string, patch: Partial<Omit<T, 'id'>>): Promise<T> {
+    const existing = rows.get(id)
+    if (existing === undefined) {
+      throw new Error(`[itun-memory] Cannot update: record id="${id}" not found in "${storeName}"`)
+    }
+    const candidate: Record<string, unknown> = {
+      ...existing,
+      ...patch,
+      id, // immutable, exactly as in the IDB store
+    }
+    if (hasUpdatedAt) candidate.updatedAt = new Date().toISOString()
+    return schema.parse(candidate)
+  }
+
+  async function update(id: string, patch: Partial<Omit<T, 'id'>>): Promise<T> {
+    const record = await prepareUpdate(id, patch)
+    rows.set(id, record)
+    return record
+  }
+
+  /**
+   * Keep a record that arrived with its own id.
+   *
+   * Reachable here mainly through `entityStore.adopt`. It stays strict rather
+   * than salvage-tolerant for the reason in the header: nothing in this Map
+   * outlived a build, so there is no version skew for salvage to absorb.
+   */
+  async function put(record: T): Promise<T> {
+    const parsed = schema.parse(record)
+    rows.set(parsed.id, parsed)
+    return parsed
+  }
+
+  async function del(id: string): Promise<void> {
+    rows.delete(id) // silent no-op when absent, like the IDB store
+  }
+
+  return { list, get, create, update, prepareUpdate, put, delete: del }
+}

--- a/apps/itun/src/stores/__tests__/entityBackend.test.ts
+++ b/apps/itun/src/stores/__tests__/entityBackend.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from 'bun:test'
 import {
+  backendForMode,
   requireWritableBackend,
   selectBackend,
   setEntityBackendAuthState,
@@ -93,5 +94,37 @@ describe('WritesBlockedOffline', () => {
     expect(settling.reason).toBe('settling')
     expect(settling.message).toMatch(/still signing in/i)
     expect(new WritesBlockedOffline().reason).toBe('offline')
+  })
+})
+
+/**
+ * The anonymous backend (ADR-034 decision 1, plan phase P2).
+ *
+ * Driven through `backendForMode` rather than `selectBackend`, because the
+ * account-required switch is a build-time `import.meta.env` read that a test
+ * cannot vary — the same reason `resolveConnectionMode` is a pure function
+ * beside `useConnection`.
+ */
+describe('a build that requires an account gives an anonymous visitor nothing durable', () => {
+  test('solo becomes memory when the flag is on', () => {
+    expect(backendForMode('solo', true)).toBe('memory')
+  })
+
+  test("solo stays local when the flag is off — today's behaviour, unchanged", () => {
+    // The flag ships OFF (P2 is reversible; flipping it is P3). If this ever
+    // reads 'memory', the one-way door has been opened by accident.
+    expect(backendForMode('solo', false)).toBe('local')
+    expect(selectBackend()).toBe('local')
+  })
+
+  test('the flag changes nothing for a signed-in user', () => {
+    // Requiring an account has no opinion about somebody who has one. If these
+    // diverged, turning the gate on would change where signed-in writes go —
+    // which is P4's job and must not ride along with P3.
+    for (const flag of [true, false]) {
+      expect(backendForMode('connected', flag)).toBe('remote')
+      expect(backendForMode('disconnected', flag)).toBe('blocked')
+      expect(backendForMode('connecting', flag)).toBe('blocked')
+    }
   })
 })

--- a/apps/itun/src/stores/entityBackend.ts
+++ b/apps/itun/src/stores/entityBackend.ts
@@ -72,7 +72,26 @@ export function setEntityBackendAuthState(next: AuthState): void {
   authState = next
 }
 
-export type BackendKind = 'local' | 'remote' | 'blocked'
+export type BackendKind = 'local' | 'remote' | 'blocked' | 'memory'
+
+/**
+ * Whether this build requires an account to persist anything
+ * ([ADR-034](../../../../docs/adrs/ADR-034-account-required-persistence.md)
+ * decision 1).
+ *
+ * **Off by default, and that is the whole point of shipping it this way.** The
+ * memory backend and the account gate are separate phases (P2 and P3 in
+ * `docs/architecture/persistence-and-pwa.md`): this phase builds the backend and
+ * makes it selectable so it can be tested against a real app, while Solo remains
+ * what an anonymous visitor actually gets. Flipping this on is the one-way door,
+ * and it is P3's job together with the UI that explains it.
+ *
+ * Read once at module scope like every other `import.meta.env` flag here. A
+ * build-time switch rather than a runtime one is deliberate: "does this build
+ * require an account" must not be able to change under a running session, which
+ * would strand work in a store the app had stopped reading.
+ */
+export const accountRequired = import.meta.env.VITE_REQUIRE_ACCOUNT === 'true'
 
 /**
  * Which backend a write should use right now.
@@ -90,14 +109,30 @@ function currentMode(): ConnectionMode {
   })
 }
 
-export function selectBackend(): BackendKind {
-  const mode = currentMode()
+/**
+ * The backend rule, as a pure function of its inputs.
+ *
+ * Split out from `selectBackend` for the same reason `resolveConnectionMode` is
+ * a pure function beside `useConnection`: the rule is the part worth testing,
+ * and it is otherwise reachable only through a module-scope
+ * `import.meta.env` read that a test cannot vary. The wrapper below supplies the
+ * real inputs; this is what the tests drive.
+ */
+export function backendForMode(mode: ConnectionMode, requireAccount: boolean): BackendKind {
+  // Anonymous, in a build that requires an account: nothing durable. Checked
+  // BEFORE the Solo branch, because Solo is exactly the state this replaces —
+  // testing it after would make the flag dead code.
+  if (mode === 'solo' && requireAccount) return 'memory'
   if (mode === 'solo') return 'local'
   if (usesServerOfRecord(mode)) return 'remote'
   // `connecting` lands here alongside `disconnected`, and deliberately: writing
   // locally before the handshake resolves is exactly the silent fork this
   // module exists to prevent.
   return 'blocked'
+}
+
+export function selectBackend(): BackendKind {
+  return backendForMode(currentMode(), accountRequired)
 }
 
 /**
@@ -370,6 +405,11 @@ export async function mirrorSoftLinkWrite(
  * Called by the store before it touches persistence. Returns the backend to
  * use; throws rather than silently degrading when the answer is "you cannot
  * write right now".
+ *
+ * `memory` passes: an anonymous build is a legitimate write, it just does not
+ * outlive the tab. Refusing here would make the app read-only for a visitor,
+ * which is the opposite of what ADR-034 decision 1 asks for — the account is
+ * required to *keep* work, never to do it.
  */
 export function requireWritableBackend(): Exclude<BackendKind, 'blocked'> {
   const backend = selectBackend()

--- a/apps/itun/src/stores/entityStore.ts
+++ b/apps/itun/src/stores/entityStore.ts
@@ -30,19 +30,25 @@ import { recordDataWrite } from '../lib/backupNudge'
 import { moveTo } from '../lib/container'
 import { publishStoreChange, subscribeStoreChanges } from '../lib/db/broadcast'
 import * as db from '../lib/db/index'
+import { makeMemoryStore } from '../lib/db/memoryStore'
 import type { StoreName } from '../lib/db/stores'
 import { STORE_NAMES } from '../lib/db/stores'
 import type { ChangeLogKind } from '../lib/schemas/changeLog'
 import type { Crawler } from '../lib/schemas/crawler'
+import { CrawlerSchema } from '../lib/schemas/crawler'
 import type { Mech } from '../lib/schemas/mech'
+import { MechSchema } from '../lib/schemas/mech'
 import type { Pilot } from '../lib/schemas/pilot'
+import { PilotSchema } from '../lib/schemas/pilot'
 import type { SoftLink } from '../lib/schemas/softLink'
+import { SoftLinkSchema } from '../lib/schemas/softLink'
 import { getActiveContainer } from './activeContainerStore'
 import {
   mirrorCrawlerWrite,
   mirrorSoftLinkWrite,
   mirrorWrite,
   requireWritableBackend,
+  selectBackend,
 } from './entityBackend'
 import type { CreateInput, EntityForType, EntityType } from './types'
 
@@ -287,6 +293,26 @@ const DB_STORES: { [K in EntityType]: DbStoreApi<K> } = {
 }
 
 /**
+ * The same four stores, backed by a Map that never touches disk — what an
+ * anonymous visitor builds against under ADR-034 decision 1.
+ *
+ * Built once at module scope rather than per call, because these hold the rows:
+ * a fresh store per `dbStoreFor()` would hand every read an empty Map and the
+ * app would look like it was losing every write instantly.
+ *
+ * `hasUpdatedAt` mirrors `src/lib/db/index.ts`'s options for the same four
+ * stores. If those diverge, an anonymous session stamps different fields from a
+ * signed-in one, which is the kind of difference that only shows up much later
+ * as a failed strict parse on import.
+ */
+const MEMORY_STORES: { [K in EntityType]: DbStoreApi<K> } = {
+  pilot: makeMemoryStore(PilotSchema, STORE_NAMES.pilots, { hasUpdatedAt: true }),
+  mech: makeMemoryStore(MechSchema, STORE_NAMES.mechs, { hasUpdatedAt: true }),
+  crawler: makeMemoryStore(CrawlerSchema, STORE_NAMES.crawlers, { hasUpdatedAt: true }),
+  softLink: makeMemoryStore(SoftLinkSchema, STORE_NAMES.softLinks, { hasUpdatedAt: false }),
+}
+
+/**
  * Mirror a just-persisted record to the server of record.
  *
  * Pilots and mechs upsert their whole body; the crawler takes the other path
@@ -356,11 +382,49 @@ function mirrorSoftLink(kind: 'upsert' | 'delete', link: SoftLink | null): void 
   void mirrorSoftLinkWrite({ kind, from: link.from, to: link.to, type: link.type })
 }
 
+/**
+ * Which persistence this write or read should use.
+ *
+ * The one indirection the whole store reaches persistence through, which is why
+ * adding the anonymous backend needed no change to `create`, `update`,
+ * `delete`, hydration, the in-memory cache, or any component.
+ *
+ * Resolved per call rather than captured once: `selectBackend()` reads live auth
+ * state, and a module-level snapshot would pin an anonymous visitor to the
+ * memory store for the rest of the session — including after they sign in.
+ */
 function dbStoreFor<T extends EntityType>(type: T): DbStoreApi<T> {
+  const stores = selectBackend() === 'memory' ? MEMORY_STORES : DB_STORES
   // Single correlated-union assertion: TS cannot carry the runtime
   // discriminant↔record-type invariant through the map lookup for a
   // generic T (microsoft/TypeScript#30581).
-  return DB_STORES[type] as DbStoreApi<T>
+  return stores[type] as DbStoreApi<T>
+}
+
+/**
+ * Whether a write should be announced to other tabs.
+ *
+ * False for the anonymous backend: two tabs of an anonymous session are two
+ * sessions, holding two unrelated Maps. Broadcasting between them would tell tab
+ * B to re-read a store that never received tab A's write, so B would blank its
+ * own cache and lose the work it was holding — inventing exactly the
+ * device-local shared state ADR-034 exists to remove, and losing data doing it.
+ */
+function shouldBroadcast(): boolean {
+  return selectBackend() !== 'memory'
+}
+
+/**
+ * Announce a store change to other tabs, unless the backend is anonymous.
+ *
+ * Every broadcast in this module goes through here rather than calling
+ * `publishStoreChange` directly, so the anonymous case is decided once. Six
+ * guarded call sites would be five chances to forget, and forgetting would not
+ * fail a test — it would quietly blank another tab.
+ */
+function publish(name: StoreName): void {
+  if (!shouldBroadcast()) return
+  publishStoreChange(name)
 }
 
 /** Object-store name for broadcast messages. */
@@ -378,7 +442,7 @@ function broadcastNameFor(type: EntityType): StoreName {
 }
 
 function afterWrite(type: EntityType): void {
-  publishStoreChange(broadcastNameFor(type))
+  publish(broadcastNameFor(type))
   recordDataWrite()
 }
 
@@ -476,7 +540,7 @@ export const useEntityStore = create<EntityState>((set, get) => ({
         [key]: exists ? list.map((e) => (e.id === cached.id ? cached : e)) : [cached, ...list],
       }
     })
-    publishStoreChange(broadcastNameFor(type))
+    publish(broadcastNameFor(type))
     return cached
   },
 
@@ -488,12 +552,12 @@ export const useEntityStore = create<EntityState>((set, get) => ({
     if (prunedIds.length > 0) {
       const pruned = new Set(prunedIds)
       set((state) => ({ softLinks: state.softLinks.filter((l) => !pruned.has(l.id)) }))
-      publishStoreChange(STORE_NAMES.softLinks)
+      publish(STORE_NAMES.softLinks)
     }
     set((state) => ({
       [key]: (state[key] as { id: string }[]).filter((e) => e.id !== id),
     }))
-    publishStoreChange(broadcastNameFor(type))
+    publish(broadcastNameFor(type))
   },
 
   async update<T extends EntityType>(
@@ -618,7 +682,7 @@ export const useEntityStore = create<EntityState>((set, get) => ({
     ])
     for (const type of touched) afterWrite(type)
     if (pruned.size > 0 && !touched.has('softLink')) {
-      publishStoreChange(STORE_NAMES.softLinks)
+      publish(STORE_NAMES.softLinks)
     }
 
     // Phase 4 — provenance (ADR-022), mirroring update()'s awaited emit. One
@@ -681,7 +745,7 @@ export const useEntityStore = create<EntityState>((set, get) => ({
         set((state) => ({
           softLinks: state.softLinks.filter((l) => !pruned.has(l.id)),
         }))
-        publishStoreChange(STORE_NAMES.softLinks)
+        publish(STORE_NAMES.softLinks)
       }
       set((state) => ({
         [key]: (state[key] as { id: string }[]).filter((e) => e.id !== id),

--- a/apps/itun/test/convex/bot.test.ts
+++ b/apps/itun/test/convex/bot.test.ts
@@ -267,7 +267,8 @@ describe('the Mediator’s prepared opposition stays hidden', () => {
     const t = testConvex()
     const { gameId } = await seedBoundGame(t)
     const npcId = await t.run(
-      async (ctx) => await ctx.db.insert('encounterNpcs', { gameId, body: { name: 'Ambush' } })
+      async (ctx) =>
+        await ctx.db.insert('encounterNpcs', { gameId, ownerId: null, body: { name: 'Ambush' } })
     )
 
     // ADR-030 §5: the Mediator's prepared opposition is the ONE thing a player
@@ -302,7 +303,8 @@ describe('the Mediator’s prepared opposition stays hidden', () => {
     const t = testConvex()
     const { gameId } = await seedBoundGame(t)
     const npcId = await t.run(
-      async (ctx) => await ctx.db.insert('encounterNpcs', { gameId, body: { name: 'Ambush' } })
+      async (ctx) =>
+        await ctx.db.insert('encounterNpcs', { gameId, ownerId: null, body: { name: 'Ambush' } })
     )
 
     const result = await t.query(internal.botClient.sheet, {

--- a/apps/itun/test/convex/containerParity.test.ts
+++ b/apps/itun/test/convex/containerParity.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The standing gate for ADR-034 decision 2: **every local store has somewhere
+ * on the server to live.**
+ *
+ * ## Why this test exists rather than a code review habit
+ *
+ * Three stores drifted into holding records the server had never heard of —
+ * `mechPatterns`, `encounterNpcs` and the Change Log — and none of them was a
+ * decision anybody made. Each was a store added locally where wiring it up was
+ * a separate step that never happened, and nothing anywhere failed as a result.
+ * A rule that only lives in prose gets followed until the day somebody is busy.
+ *
+ * So this asserts the *shape* rather than the wiring: for every IndexedDB object
+ * store there is a Convex table that could receive it. It deliberately does NOT
+ * assert that writes are mirrored — that is P4's job and would fail today by
+ * design (see `docs/architecture/persistence-and-pwa.md`). What it catches is
+ * the cheaper and more common mistake: adding store number nine and forgetting
+ * the server entirely.
+ *
+ * ## Reading a failure
+ *
+ * If this fails you have added a local store with no server counterpart. The fix
+ * is a Convex table, not an entry in the exemption list. The exemption list has
+ * exactly one member and adding a second one needs a very good reason written
+ * down beside it.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import schema from '../../convex/schema'
+import { STORE_NAMES } from '../../src/lib/db/stores'
+
+/**
+ * The little of a Convex column validator this test reads.
+ *
+ * Deliberately structural rather than imported: the concrete `VUnion`/`VId`
+ * generics are an implementation detail whose type parameters change with the
+ * schema, and naming them here would make this file need editing every time a
+ * table gains a column.
+ */
+type ContainerColumn = { kind?: string; members?: readonly { kind?: string }[] }
+
+/**
+ * Local stores that legitimately have no Convex counterpart.
+ *
+ * `workspaces` is the retired pre-ADR-030 container. The object store survives
+ * only so migrations v10 and v13 still run against databases that predate the
+ * split; nothing writes it and nothing reads it as live data, so there is
+ * nothing for a server table to hold.
+ */
+const NO_SERVER_COUNTERPART = new Set<string>(['workspaces'])
+
+/** The tables the Convex schema actually declares. */
+function convexTables(): Set<string> {
+  return new Set(Object.keys(schema.tables))
+}
+
+describe('container parity — every local store can reach the server', () => {
+  test('every IndexedDB store has a Convex table, except the retired one', () => {
+    const tables = convexTables()
+    const orphans = Object.values(STORE_NAMES).filter(
+      (name) => !tables.has(name) && !NO_SERVER_COUNTERPART.has(name)
+    )
+
+    expect(orphans).toEqual([])
+  })
+
+  test('the exemption list has not quietly grown', () => {
+    // Named separately from the check above so that *widening the exemption*
+    // fails on its own line rather than hiding inside a passing parity test.
+    // Adding a store here is the exact move this file exists to make expensive.
+    expect([...NO_SERVER_COUNTERPART]).toEqual(['workspaces'])
+  })
+
+  test('the exemption is still real — `workspaces` has no Convex table', () => {
+    // A negative control. If `workspaces` ever gains a server table the
+    // exemption is obsolete and should be deleted, not carried forward.
+    expect(convexTables().has('workspaces')).toBe(false)
+  })
+
+  /**
+   * The two containers, asserted structurally.
+   *
+   * ADR-030 §2 allows `gameId` set (in a Game) or null (on a shelf), and
+   * ADR-034 decision 2 extends that to every entity-shaped table — which is
+   * what let a crawler survive a deleted Game (#871) and, in this change, an
+   * encounter NPC too. A table that can only be in a Game cannot express the
+   * shelf half, and that is precisely the gap both of those had.
+   */
+  test('every entity-shaped table can express BOTH containers', () => {
+    const ENTITY_TABLES = ['pilots', 'mechs', 'crawlers', 'encounterNpcs', 'mechPatterns'] as const
+
+    for (const name of ENTITY_TABLES) {
+      const table = schema.tables[name]
+      expect(table).toBeDefined()
+
+      // `validator.fields` is the public, typed column map — one validator per
+      // column, each carrying a `kind` and, for a union, its `members`. Read
+      // through this rather than the runtime-only `.json`, which is not on the
+      // public type and would need a cast to reach.
+      const columns: Record<string, ContainerColumn> = table.validator.fields
+
+      expect(Object.keys(columns)).toContain('gameId')
+      expect(Object.keys(columns)).toContain('ownerId')
+
+      // A shelf is `gameId: null`, so the column must be a union admitting
+      // null — a bare `v.id('games')` is the shape that could not hold a shelf,
+      // and is what both `crawlers` and `encounterNpcs` had to be changed from.
+      const gameId = columns.gameId
+      expect(gameId?.kind).toBe('union')
+      expect(gameId?.members?.map((m) => m.kind)).toContain('null')
+    }
+  })
+})

--- a/apps/itun/test/convex/crew.test.ts
+++ b/apps/itun/test/convex/crew.test.ts
@@ -241,7 +241,8 @@ describe('readEntity', () => {
     const t = testConvex()
     const { organizer, gameId } = await seedGame(t)
     const npcId = await t.run(
-      async (ctx) => await ctx.db.insert('encounterNpcs', { gameId, body: { name: 'Ambush' } })
+      async (ctx) =>
+        await ctx.db.insert('encounterNpcs', { gameId, ownerId: null, body: { name: 'Ambush' } })
     )
 
     // ADR-030 §5: the Mediator's prepared opposition is the ONE thing a member

--- a/apps/itun/test/convex/publicSheet.test.ts
+++ b/apps/itun/test/convex/publicSheet.test.ts
@@ -193,7 +193,7 @@ describe('the surface cannot be pointed at the Mediator’s tray', () => {
     const t = testConvex()
     await t.run(async (ctx) =>
       ctx.db.insert('games', { name: 'Tenacity' }).then(async (gameId) => {
-        await ctx.db.insert('encounterNpcs', { gameId, body: { name: 'Ambush' } })
+        await ctx.db.insert('encounterNpcs', { gameId, ownerId: null, body: { name: 'Ambush' } })
       })
     )
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,8 @@ conventions, then the relevant architecture doc below.
 
 **I'm working on the move to Cloudflare** → [adrs/ADR-033-cloudflare-hosting.md](adrs/ADR-033-cloudflare-hosting.md) (**the decisions** — read before revisiting any of them, especially R2-over-KV) + [architecture/cloudflare-cutover.md](architecture/cloudflare-cutover.md) (**the executable plan** — phase order, per-phase gates, progress table). Hard cutover, no rollback: **a failed gate halts the phase and is never worked around.** Do not execute from issue #830, which the ADR supersedes.
 
+**I'm changing where player data lives, or anything offline/PWA** → [adrs/ADR-034-account-required-persistence.md](adrs/ADR-034-account-required-persistence.md) (**the decisions** — persistence requires an account, Convex is the only source of truth, IndexedDB is a cache) + [architecture/persistence-and-pwa.md](architecture/persistence-and-pwa.md) (**the executable plan** — phase order, gates, progress, and the inventory of what is not DB-backed yet). Accepted, **nothing built**: Solo mode still works today and P3/P4 are the one-way doors. Never add a store that exists only on a device.
+
 **I'm touching how the SRD site is built, routed, or rendered** → [`apps/srd/ssg/DESIGN.md`](../apps/srd/ssg/DESIGN.md) (**the contract** — srd is built by an in-house SSG, **not Astro**) + [`apps/srd/CLAUDE.md`](../apps/srd/CLAUDE.md). Verify with `bun --filter srd gate` — `ssg/snapshot.ts` diffs the built output against a committed snapshot and is the acceptance gate, not your reading of the diff. If the change is intentional, `bun --filter srd snapshot:update` and commit the snapshot alongside it.
 
 ## Directory Map
@@ -57,6 +59,7 @@ conventions, then the relevant architecture doc below.
 | [agent-tooling.md](architecture/agent-tooling.md)                     | **Service registry** — MCP servers + auth models, and every Netlify/Render/Sentry/Convex identifier    |
 | [cloudflare-cutover.md](architecture/cloudflare-cutover.md)           | **Executable plan** for ADR-033 — phase order, per-phase gates, progress table, cutover runbook        |
 | [discord-bot-game-client.md](architecture/discord-bot-game-client.md) | **Plan** — the bot as an authenticated Game client: credential model, command surface, embed rendering |
+| [persistence-and-pwa.md](architecture/persistence-and-pwa.md)         | **Executable plan** for ADR-034 — phases, gates, progress, and what is not DB-backed yet               |
 
 ### Rules text — extract and grep, no digest
 
@@ -146,6 +149,7 @@ Read the matching ADR before proposing alternatives.
 | [ADR-030](adrs/ADR-030-accounts-games-server-of-record.md)           | **Governing** — accounts, Games, ownership, and Convex as server of record; supersedes ADR-001, amends ADR-022                                                                        |
 | [ADR-031](adrs/ADR-031-srd-vite-ssg.md)                              | `srd` builds on an in-house Vite SSG (`apps/srd/ssg`); supersedes ADR-012 — same decision, different machine                                                                          |
 | [ADR-033](adrs/ADR-033-cloudflare-hosting.md)                        | Hosting moves to Cloudflare; Netlify + Render retired, hard cutover, snapshots on R2 not KV; amends ADR-004, Convex unchanged                                                          |
+| [ADR-034](adrs/ADR-034-account-required-persistence.md)              | Persistence requires an account; Convex is the only source of truth and IndexedDB is a cache; both apps are ordinary installable PWAs. **Supersedes ADR-030 §1's Solo guarantee**; amends ADR-002 and ADR-022 |
 
 > ADR-021 is the governing decision for rules enforcement and takes precedence
 > over prior ADRs where they conflict on _how hard a rule is enforced on which

--- a/docs/adrs/ADR-030-accounts-games-server-of-record.md
+++ b/docs/adrs/ADR-030-accounts-games-server-of-record.md
@@ -3,6 +3,20 @@
 ## Status
 
 **Accepted — governing ADR for identity, ownership, and sharing.**
+
+**This ADR still governs.**
+[ADR-034](ADR-034-account-required-persistence.md) **partially supersedes it**,
+and the partial is the important word: §1 promises Solo mode — not signed in,
+IndexedDB as the source of truth — "must keep working forever", and **that one
+guarantee is withdrawn**. Persistence will require an account and IndexedDB
+becomes a cache of Convex. Everything else here — Games, memberships, roles,
+ownership, the two containers, Convex as server of record — is untouched, so
+citing this ADR remains correct for all of it.
+
+**Nothing is built yet**, so §1 still describes the app as it runs today. The
+phases and the one-way doors are in
+[architecture/persistence-and-pwa.md](../architecture/persistence-and-pwa.md).
+
 **Supersedes [ADR-001](ADR-001-local-first-no-backend.md)** (local-first, no
 backend, no auth). **Amends [ADR-022](ADR-022-provenance-log-and-overrides.md)**
 (the Change Log is no longer local-only). Extends

--- a/docs/adrs/ADR-034-account-required-persistence.md
+++ b/docs/adrs/ADR-034-account-required-persistence.md
@@ -256,13 +256,28 @@ belongs in Convex, not a reason to widen the exemption.
   bug from the day this ships. It needs a gate asserting it covers every kind,
   and that gate has to be extended whenever a kind is added.
 
-- **The Change Log is not in the bundle, and that needs a ruling.**
+- **The Change Log is deliberately not in the export bundle.**
   `buildExportBundle` covers pilots, mechs, crawlers, soft links, patterns and
-  encounter NPCs — **not `changeLog`**. That was harmless while export was a
-  backup; it is not harmless now that export is the way out. The provenance log
-  is arguably not the user's *build* and losing it may be acceptable, but that is
-  a decision to make out loud rather than a gap to leave. Named as the one open
-  question in the plan.
+  encounter NPCs, and stops there. That was an accident while export was a
+  backup; it is a **decision** now that export is the way out, so it is recorded
+  rather than left to be rediscovered.
+
+  The reasoning is what export is *for*. Somebody downloading a bundle because
+  they will not make an account wants their pilots, not an audit trail of how
+  each stat reached its current value. The log is provenance **about** the
+  builds rather than the builds themselves, and ADR-022 already treats it as a
+  separate kind of thing — a published snapshot is "frozen, historyless and
+  bare" and nobody has ever asked for that to change.
+
+  There is also a mechanical reason not to reverse this casually: `mergeImport`
+  mints a **fresh UUID per row** on import, so log entries carried across would
+  address entities that no longer exist under those ids. Including the log would
+  mean either a remap pass or entries pointing at nothing — real work, in service
+  of something no user has asked for.
+
+  **What this costs, stated plainly:** a user who leaves via export loses their
+  Change Log. That is accepted. If it is ever reversed, export-only (carry it in
+  the bundle, never re-import it) is the shape that avoids the id problem.
 
 - **Declining the claim is a terminal choice, by design.** A user who declines is
   pushed to export and then not asked again. This is the least-nagging option and

--- a/docs/adrs/ADR-034-account-required-persistence.md
+++ b/docs/adrs/ADR-034-account-required-persistence.md
@@ -90,6 +90,26 @@ than in front of a product they have not tried.
 Reading is unaffected. A public sheet (ADR-032) and the whole of `srd` remain
 open to anyone with no account at all.
 
+**Discord remains the only door.** ADR-030 §D3 chose it deliberately — the
+audience already lives there, the project ships a Discord bot, and one identity
+is what makes that bot usable — and gating persistence does not change any of
+that reasoning. The consequence must be stated rather than discovered: **a person
+with no Discord account cannot save anything, ever.** That is accepted, and it is
+accepted *because* of the escape hatch below. Without the hatch this decision
+would be indefensible.
+
+**Export to file is the escape hatch, and it is now load-bearing.** An anonymous
+user can download their in-memory work as a JSON bundle and import it after
+signing in. This is not a new mechanism — `ExportAllButton`, `buildExportBundle`
+and `mergeImport` already exist and already do it — but its *status* changes.
+Export stops being a backup convenience and becomes **the guarantee that hitting
+the account gate is never a data-loss event**. A file is not a source of truth
+and never syncs, so it is fully compatible with decision 2; what it is, is a way
+out.
+
+Treat any incompleteness in the export bundle as a defect against this ADR, not
+as a missing nice-to-have. See *The Change Log is not in the bundle* below.
+
 ### 2. Every record is DB-backed; the local store is a cache
 
 **Convex is the source of truth for every persisted record, without exception.**
@@ -105,6 +125,24 @@ not acceptable, the schema is wrong and the schema moves.
 This closes the three gaps named in Context. `mechPatterns`, `encounterNpcs` and
 the Change Log all become mirrored like pilots, mechs, crawlers and soft links
 already are.
+
+**`encounterNpcs` is one table with two containers, not two concepts.** An NPC
+lives either in a Game — the Mediator's prepared opposition, `gameId` set — or on
+somebody's shelf, their own tray to prep in before a Game exists. That is the
+ownership table from ADR-030 §2 applied unchanged, and it is the *same move*
+#871 made for the crawler: `encounterNpcs.gameId` is `v.id('games')` with no
+`ownerId` today, which is precisely the shape `crawlers` had before it. Give it a
+nullable `gameId`, an `ownerId`, a `by_owner` index and an `appId` to address
+mirrored writes, and the collision resolves into the model everything else
+already uses.
+
+Rejected: renaming the local one to a "scratch tray". It would stop the collision
+without removing the second concept, leaving a contributor two NPC ideas to keep
+straight forever in exchange for a smaller diff now.
+
+`mechPatterns` needs less: it already carries `ownerId` and a nullable `gameId`.
+What it lacks is an `appId` — which is why `claimLocal` has to match patterns by
+reading an id out of the opaque body — and a mirror.
 
 ### 3. Both apps are ordinary, installable PWAs — and install is what buys offline
 
@@ -187,6 +225,28 @@ belongs in Convex, not a reason to widen the exemption.
 - **Every feature is designed once.** The "what does this do in Solo?" question
   disappears from every future change, which is the compounding benefit and the
   main reason this is worth the cost above.
+
+- **Export becomes a tested guarantee rather than a convenience**, because two
+  separate decisions now rest on it: the anonymous escape hatch, and what happens
+  when somebody declines the claim. A silently incomplete bundle is a data-loss
+  bug from the day this ships. It needs a gate asserting it covers every kind,
+  and that gate has to be extended whenever a kind is added.
+
+- **The Change Log is not in the bundle, and that needs a ruling.**
+  `buildExportBundle` covers pilots, mechs, crawlers, soft links, patterns and
+  encounter NPCs — **not `changeLog`**. That was harmless while export was a
+  backup; it is not harmless now that export is the way out. The provenance log
+  is arguably not the user's *build* and losing it may be acceptable, but that is
+  a decision to make out loud rather than a gap to leave. Named as the one open
+  question in the plan.
+
+- **Declining the claim is a terminal choice, by design.** A user who declines is
+  pushed to export and then not asked again. This is the least-nagging option and
+  it has a real edge: somebody who declines, does not export, and later clears
+  their browser storage has genuinely lost that roster. The mitigation is that
+  the export must be *taken* rather than merely offered — see the plan's P5 gate,
+  which does not let the app stop asking until a bundle has actually been
+  produced or the user has explicitly refused that too.
 
 - **Storage and bandwidth on install become a real budget.** Deciding that an
   installed app works fully offline means someone must own what "fully" costs —

--- a/docs/adrs/ADR-034-account-required-persistence.md
+++ b/docs/adrs/ADR-034-account-required-persistence.md
@@ -1,0 +1,234 @@
+# ADR-034: Persistence Requires an Account, and the Local Store Is Only a Cache
+
+## Status
+
+**Accepted. Nothing is built yet — delivery is phased, and the executable plan
+with its per-phase gates and progress table is
+[architecture/persistence-and-pwa.md](../architecture/persistence-and-pwa.md).**
+
+**Partially supersedes [ADR-030](ADR-030-accounts-games-server-of-record.md)** —
+its §1 guarantee that Solo mode ("not signed in, IndexedDB is the source of
+truth") "must keep working forever", and nothing else. **ADR-030 remains the
+governing ADR** for Games, memberships, the role model, ownership, the two
+containers, and Convex as the server of record; it is not superseded, and it
+stays the right thing to cite for all of that.
+
+**Amends [ADR-002](ADR-002-indexeddb-idb-zod.md)** (IndexedDB + Zod). The
+storage technology and the Zod-parses-at-the-edge discipline are unchanged; what
+changes is IndexedDB's *status* — it stops being anywhere's source of truth and
+becomes a cache of Convex.
+
+**Amends [ADR-022](ADR-022-provenance-log-and-overrides.md)** for the second
+time. ADR-030 already claimed the Change Log is "now synchronized"; that claim
+was never delivered on the client side, and this ADR makes it a requirement with
+a phase behind it rather than a statement.
+
+**Interacts with [ADR-033](ADR-033-cloudflare-hosting.md)**, which is mid-flight
+at P7. See *Sequencing against the Cloudflare cutover* below — this work does
+not start on `srd` until that ADR's P7 completes.
+
+Re-affirms [ADR-032](ADR-032-public-read-only-sheets.md) without changing it: a
+public sheet stays an unauthenticated **read** of a row that an account owns.
+Reading has never required an account and still does not.
+
+## Context
+
+ADR-030 replaced ADR-001's no-backend stance with Convex as a server of record,
+but it kept a promise: an anonymous user would always have a fully working app
+whose data lived in IndexedDB, and that mode would be supported forever. The
+promise was load-bearing at the time. ITUN had years of local-first users, no
+accounts existed yet, and a migration that could strand somebody's roster was
+the worst outcome available.
+
+That promise has since produced a **second source of truth**, and the cost is no
+longer hypothetical. Three separate observations converge on the same defect.
+
+**The app holds records the server has never heard of.** Signed in, a saved mech
+pattern is written to IndexedDB and mirrored nowhere: `patternStore` writes
+straight through to `db.mechPatterns`, and the only thing that ever inserts into
+the Convex `mechPatterns` table is the one-time `entities.claimLocal`. The same
+is true of the client's encounter NPCs, whose Convex table of the same name is
+written only by `mediator.ts` and is a different set of rows entirely. And local
+Change Log entries never leave the device, while the Convex `changeLog` carries
+only server-originated entries from `ownership.ts`, `proposals.ts` and
+`botClient.ts`. Three stores, one shape of bug: a signed-in player's work is
+partly on a device and partly on a server, with nothing reconciling them.
+
+**Deleting a Game exposed the same gap in the schema.** Until #871 a crawler
+could not exist outside a Game — `crawlers.gameId` was non-nullable and there
+was no `ownerId` — so deleting a campaign had to destroy the crew's home. The
+cheap fix was to copy the crawler into IndexedDB and leave the server out of it.
+That fix was rejected and the schema moved instead, because a record with no
+server row to reflect is invisible on the player's other devices, invisible to
+sync, and lost when browser storage clears. #871 is the worked example of the
+rule this ADR now states in general.
+
+**"Local-first" was doing work as an identity, not as an engineering choice.**
+The offline story here is what any competent Progressive Web App does: cache
+what you have so the app opens without a network. It never needed a bespoke
+architecture, and having one meant every feature had to be designed twice — once
+for an account and once without — with the second design silently accumulating
+the records above.
+
+## Decision
+
+Three decisions. They are stated separately because they are separately
+falsifiable, but they are one change: each is unenforceable without the others.
+
+### 1. Persistence requires an account
+
+An anonymous visitor may **build**, and what they build is **in-memory only**.
+They can open the app, work through a wizard, roll, read, and see a finished
+sheet. Nothing they do is written to durable storage of any kind — not Convex,
+and not IndexedDB.
+
+**Saving is the moment an account is required**, and it is the *only* moment.
+This is deliberately not a paywall shape or a signup wall: the ask arrives when
+the user has something worth keeping and can see what keeping it means, rather
+than in front of a product they have not tried.
+
+Reading is unaffected. A public sheet (ADR-032) and the whole of `srd` remain
+open to anyone with no account at all.
+
+### 2. Every record is DB-backed; the local store is a cache
+
+**Convex is the source of truth for every persisted record, without exception.**
+IndexedDB holds a reflection of it, and holds nothing else. There is no record,
+of any kind, that exists only on a device.
+
+The practical test, and the one to apply when reviewing any future change: *if
+this row is not in Convex, is it lost when the user opens the app on their
+phone?* If the answer is yes and that is acceptable, it is not data — it is a
+device preference (see *What is not data* below). If the answer is yes and it is
+not acceptable, the schema is wrong and the schema moves.
+
+This closes the three gaps named in Context. `mechPatterns`, `encounterNpcs` and
+the Change Log all become mirrored like pilots, mechs, crawlers and soft links
+already are.
+
+### 3. Both apps are ordinary, installable PWAs — and install is what buys offline
+
+`itun` and `srd` are both **full PWAs**: installable, with a web app manifest,
+icons, and a service worker. Both already are; this decision is mostly about
+closing gaps and about what offline *means*.
+
+**Offline is table stakes, not a feature.** There is to be no local capability
+in either app that you would not find in any competent PWA. This is the same
+rule as decision 2 seen from the other side: the reason the local store may only
+be a cache is that caching is all a PWA's local storage is for.
+
+**Install is the trigger for full offline availability, and visiting is not.**
+
+- A user in a browser tab gets the ordinary thing: the app shell, and whatever
+  they have actually visited, cached at runtime. **An online visitor does not
+  pre-download the site.** `srd` deliberately does not precache its 1,039 HTML
+  pages today, and that stays true for browser visitors — a multi-megabyte
+  install is not a courtesy to somebody who came to read one page.
+- An **installed** app is expected to work offline in full. Installation is a
+  user saying "I want this on my device", and it is the honest point at which to
+  spend their bandwidth and storage.
+
+**"No distinct difference" does not mean one shared implementation.** The two
+apps keep the update strategy each one's failure history justifies. `itun` stays
+on `registerType: 'prompt'` — `autoUpdate` there activated a new worker under a
+live page, ran `cleanupOutdatedCaches()`, and deleted the precache that page was
+still resolving chunks against, which is why share links needed four or five
+refreshes. Forcing a single strategy across both apps in the name of uniformity
+would re-open that outage or change `srd` for no reason. Uniformity is in the
+*posture* — installable, cache-only, no bespoke local behaviour — not in the
+config.
+
+### What is not data
+
+Device preferences are exempt from decision 2, and the exemption is narrow. A
+preference qualifies only when losing it costs the user nothing but a moment's
+re-adjustment: which container is active, dashboard display preferences, the
+"you have unexported changes" nudge, the one-time claim marker, ephemeral mount
+state. These may stay in `localStorage`.
+
+**A preference that is expensive to lose is data.** If the list ever grows to
+include something a user would be annoyed to re-create, that is the signal it
+belongs in Convex, not a reason to widen the exemption.
+
+## Consequences
+
+- **Anonymous users lose durable local storage, and this is the real cost.**
+  Somebody who does not want an account can no longer keep a roster on their own
+  machine. That is a genuine loss of a genuine capability and should be stated
+  plainly rather than presented as a cleanup. It is accepted because the
+  alternative — two sources of truth forever — has already produced silent data
+  divergence in three stores, and because in-memory building keeps the app
+  usable without an account for everything except keeping the result.
+
+- **Existing local data is never destroyed.** Every current Solo user's
+  IndexedDB stays readable, and signing in **prompts them to claim it** into the
+  account. `ClaimLocalData` and `entities.claimLocal` already implement exactly
+  this, already offered rather than automatic, and already idempotent. No new
+  migration mechanism is invented; the phase is about coverage and about what
+  happens to somebody who declines.
+
+- **A build with no `VITE_CONVEX_URL` is no longer a working app**, and this is
+  the largest hidden consequence. CI, every Playwright e2e run, and a fresh
+  checkout are all permanently Solo today, and 15 of the 16 e2e specs build a
+  pilot, a mech or a crawler and expect it to persist (`bundle-budget.e2e.ts` is
+  the one that does not — it measures bundle size). Removing Solo without
+  answering this breaks nearly the whole e2e suite at once. The in-memory anonymous mode from decision 1
+  is what those tests exercise, plus a signed-in path against a test deployment
+  for anything asserting durability. This is a phase of its own and it is
+  sequenced early, because it gates the ability to verify any later phase.
+
+- **Convex becomes a hard dependency of the ITUN product**, not a feature of it.
+  A Convex outage stops new saves rather than degrading to local writes. That is
+  the same trade ADR-030 already made for Games (Disconnected is read-only, not
+  a write queue), now extended to everything; an outbox is still refused, for
+  ADR-030's original reason — it reintroduces the conflict resolution that
+  choosing a server of record exists to avoid.
+
+- **Every feature is designed once.** The "what does this do in Solo?" question
+  disappears from every future change, which is the compounding benefit and the
+  main reason this is worth the cost above.
+
+- **Storage and bandwidth on install become a real budget.** Deciding that an
+  installed app works fully offline means someone must own what "fully" costs —
+  for `srd` that is on the order of a thousand pages or the JSON endpoints
+  behind them. The plan carries a measured budget and a gate; an unmeasured
+  "download everything on install" would be a worse experience than the 404 it
+  replaces.
+
+- **`srd` gains no accounts.** It has no user data and this ADR gives it none.
+  Decision 1 does not apply to it; decisions 2 and 3 do, and for `srd` decision
+  2 is trivially satisfied because it stores nothing.
+
+## Sequencing against the Cloudflare cutover
+
+ADR-033 is at P7: `intheunionnow.com` is live on Cloudflare, `salvageunion.io`
+is still blocked on a Netlify support ticket, and P8 has not started.
+
+**No phase of this ADR touches `srd`'s service worker until ADR-033's P7 is
+complete.** Changing caching behaviour on a site whose host is mid-move would
+make any resulting failure ambiguous between two causes, and service-worker
+faults are exactly the class where that ambiguity is most expensive — a bad
+worker persists on the client after the deploy that caused it is gone.
+
+ITUN work may begin immediately: it is already live on Cloudflare, so its host
+is settled.
+
+## Alternatives considered
+
+**Keep Solo forever and mirror it too.** Rejected: mirroring a source of truth
+is not mirroring, it is synchronization, and it lands squarely back in the
+conflict-resolution problem ADR-030 chose a server of record to avoid.
+
+**Keep Solo but freeze it — read-only for anonymous users, no new writes.**
+Rejected as the worst of both: it retains all the two-sources-of-truth machinery
+and the second design of every feature, while still taking the capability away.
+Claim-on-sign-in achieves the same migration without keeping the architecture.
+
+**Local-only with an explicit opt-in "sync" toggle.** Rejected. This is the
+current state with a switch on it, and the switch does not change that a device
+can hold records the server lacks. It also makes every bug report begin with
+"which mode were you in".
+
+**A write outbox for offline writes.** Rejected, consistent with ADR-030 §1's
+existing reasoning. Deferring writes means merging them later, and the merge is
+the part that rots.

--- a/docs/adrs/ADR-034-account-required-persistence.md
+++ b/docs/adrs/ADR-034-account-required-persistence.md
@@ -122,9 +122,33 @@ phone?* If the answer is yes and that is acceptable, it is not data — it is a
 device preference (see *What is not data* below). If the answer is yes and it is
 not acceptable, the schema is wrong and the schema moves.
 
-This closes the three gaps named in Context. `mechPatterns`, `encounterNpcs` and
-the Change Log all become mirrored like pilots, mechs, crawlers and soft links
-already are.
+This closes the three gaps named in Context — but **not by adding mirrors.**
+
+**The mirror is a bridge, and this ADR is what removes the gap it bridges.**
+`entityBackend.ts` states its own three properties plainly, and every one of them
+is a consequence of the local store being able to run ahead of the server: it
+*upserts* rather than updates, because "an entity built while Solo has no server
+row until the account is claimed"; it is **fire-and-forget**, because "the local
+write already succeeded and is what the UI reads", so a failure becomes a console
+warning; and it runs only in `remote`, because "in Solo there is no server to
+mirror to".
+
+None of those premises survive decision 1. There is no pre-account entity for an
+upsert to converge, and a cache can never legitimately be ahead of its source —
+so a write that the server refuses must **fail the user's action**, not be
+swallowed. Fire-and-forget is how this repo already lost an evening of play.
+
+So the end state is not "six mirrored stores". It is **no mirrors**: the client
+writes to Convex and reads Convex's reactive result, and IndexedDB is populated
+from that. `appId` is part of the same bridge — it exists because the client
+mints ids, which it does because it used to be the source of truth — and it goes
+when the bridge does.
+
+The practical consequence for sequencing is in the plan: the *schema* work that
+makes each container model expressible is real either way and lands early, while
+the *wiring* lands once, in the final shape, at the demotion. Adding a mirror to
+`mechPatterns` and `encounterNpcs` first would mean writing a known-lossy path
+into two stores as their fix, and deleting it two phases later.
 
 **`encounterNpcs` is one table with two containers, not two concepts.** An NPC
 lives either in a Game — the Mediator's prepared opposition, `gameId` set — or on

--- a/docs/architecture/persistence-and-pwa.md
+++ b/docs/architecture/persistence-and-pwa.md
@@ -38,11 +38,11 @@ Update this table as part of each phase's PR. It is the only place that answers
 
 | Phase | What                                                      | Reversible | Status      |
 | ----- | --------------------------------------------------------- | ---------- | ----------- |
-| P0    | Close the DB-backing gaps (patterns, encounter NPCs, log)  | yes        | not started |
+| P0    | Make every container model expressible (schema only)       | yes        | **done**    |
 | P1    | Test and e2e path that does not depend on Solo             | yes        | not started |
 | P2    | In-memory anonymous mode                                   | yes        | not started |
 | P3    | Gate persistence on an account                             | **no**     | not started |
-| P4    | Demote IndexedDB to a cache                                | **no**     | not started |
+| P4    | Demote IndexedDB to a cache; wire all six stores, no mirrors | **no**    | not started |
 | P5    | Claim-on-sign-in coverage and the decline path             | yes        | not started |
 | P6    | ITUN install-triggered offline                             | yes        | not started |
 | P7    | `srd` install-triggered offline (**blocked on ADR-033 P7**) | yes       | blocked     |
@@ -91,40 +91,90 @@ moves — the record does not fall back to local-only.
 
 ---
 
-## P0 — Close the DB-backing gaps
+## P0 — Make every container model expressible (schema only)
 
-**Goal.** Every persisted record has a Convex row, before anything changes about
-who may persist. Doing this first means P3 does not have to reason about
-partially-backed data.
+**Goal.** Every store has a Convex shape that can hold what it needs to hold, so
+that later phases are wiring and nothing else.
+
+**Why this phase carries no wiring.** The obvious move is to mirror the three
+un-backed stores the way `entityStore` mirrors the other four. That is the wrong
+shape, and it is wrong for the reason ADR-034 decision 2 gives: **a mirror is a
+bridge that exists only because Solo exists.** It upserts because a Solo entity
+has no server row yet, and it is fire-and-forget because the local write has
+already succeeded and is what the UI reads. Both properties are indefensible once
+the local store is a cache — a cache cannot be ahead, so a refused write must
+fail the user's action rather than become a console warning.
+
+Building two new mirrors here would ship a known-lossy path into two stores *as
+their fix*, and then delete it at P4. The schema work below is needed under any
+sequencing and is not throwaway; the wiring waits and is written once.
 
 **Work.** Three jobs, and they are not the same size.
 
-- **`mechPatterns` — mirror only.** The table already carries `ownerId` and a
-  nullable `gameId`, so the container model is right. It lacks an `appId`, which
-  is why `claimLocal` matches a pattern by reading an id out of the opaque body.
-  Add `appId` + `by_app_id`, then mirror on the `mirrorWrite` pattern.
 - **`encounterNpcs` — the #871 move, verbatim.** The model is settled (ADR-034
-  decision 2): one table, two containers. Today it is
-  `gameId: v.id('games')` with no `ownerId` — *exactly* the shape `crawlers` had
-  before #871. Give it a nullable `gameId`, an `ownerId`, `by_owner`, and an
-  `appId`; a Game-scoped NPC keeps `ownerId: null` the way a communal crawler
-  does, and a shelf NPC takes an owner. Then fold the client's local tray onto
-  it. Read #871's diff before starting — this is the same change twice.
-- **`changeLog` — mirror the client appends**, and correct ADR-030's "now
-  synchronized" claim in the same PR. Cross-device ordering is the hard part
-  here; the log is append-only and keyed by an autoincrement `seq` locally, which
-  does not survive being merged with another device's sequence.
+  decision 2): one table, two containers. Today it is `gameId: v.id('games')`
+  with no `ownerId` — *exactly* the shape `crawlers` had before #871. Give it a
+  nullable `gameId`, an `ownerId` and a `by_owner` index; a Game-scoped NPC keeps
+  `ownerId: null` the way a communal crawler does, and a shelf NPC takes an
+  owner. Read #871's diff before starting — this is the same change twice.
+- **`mechPatterns` — nothing to do.** It already carries `ownerId` and a nullable
+  `gameId`, so its container model is already right. It has no `appId`, which is
+  why `claimLocal` matches a pattern by digging an id out of the opaque body —
+  but `appId` is part of the mirror bridge, so it is **not** added here. If the
+  wiring at P4 needs client-minted ids at all, that is the phase to decide it in.
+- **`changeLog` — decide the ordering rule, write it down, build nothing.**
+  Done, below: `seq` does not travel, `ts` does, and the append-only log
+  interleaves rather than conflicts. **No schema change proved necessary** — both
+  sides already carry `ts` and neither server row carries `seq`. Correct
+  ADR-030's "now synchronized" claim in the same PR as the wiring.
+
+### The Change Log ordering rule
+
+Written down here because it is the design question P4 would otherwise discover
+late. **No schema change is needed — the model already turned out to be right**,
+which was worth checking before proposing one.
+
+- **`seq` does not travel.** It is the IndexedDB autoincrement primary key, and
+  its doc comment calls it "the total order" — true on one device and meaningless
+  across two, since each device numbers from its own 1. It is a *storage* key,
+  not part of the record. It is never sent, never received, and is re-assigned by
+  the local store when the cache is filled.
+- **`ts` travels, and it is already on both sides.** The local entry carries
+  `ts` (epoch ms at write time) and so does the Convex row. That is when the
+  change actually happened, on the device that made it.
+- **Order for display by `ts`; paginate and reconcile by Convex's
+  `_creationTime`.** They answer different questions. `ts` is when the player did
+  it; `_creationTime` is when the server heard about it, and it is the only
+  monotonic server-assigned value, so it is the one a cursor can trust.
+- **The two disagreeing is expected, not a bug.** A device that was offline for
+  an hour lands entries whose `ts` precedes rows already stored. Because the log
+  is **append-only and every entry immutable**, that is *interleaving* — there is
+  nothing to merge, only to sort. This is the whole reason the log is the easy
+  one of the three gaps despite looking like the hard one.
+- **`ts` is unauthenticated client input and must never be trusted for anything
+  but display order.** A wrong device clock — or a hostile one — puts an entry
+  anywhere in the sequence. It must not drive authorization, cursors, or
+  supersession (`supersededBy` is an explicit pointer precisely so ordering never
+  has to imply it).
 
 **Gate.**
 
-- A signed-in user creating a pattern, an encounter NPC, and an entity edit that
-  writes a log entry, on device A, sees all three on device B after a reload.
-  Verified by doing it, not by asserting the mirror was called.
-- `bun run check:all` green.
+- Every IndexedDB store has a Convex table whose columns can express the same
+  containers. Asserted by a test over the two schemas, not by reading them.
 - No new local-only store has appeared: a test asserts the set of IndexedDB
-  stores that have no Convex counterpart is exactly `{workspaces}`.
+  stores with no Convex counterpart is exactly `{workspaces}`.
+- The `changeLog` ordering rule is written down and reviewed.
+- `bun run check:all` green.
 
-That last gate is the one worth keeping forever — it is what stops gap four.
+The second gate is the one worth keeping forever — it is what stops gap four.
+
+**Note what this phase deliberately does NOT fix.** Patterns, encounter NPCs and
+log entries still do not reach the server when it ends. That divergence is live
+today and stays live until P4. It is accepted because the alternative is two
+throwaway lossy bridges, and because the exposure is narrow: those records are on
+the user's device, they are covered by the export bundle, and nothing deletes
+them. If that judgement is wrong, the thing to change is the phase *order* — do
+the demotion sooner — not to add the mirrors back.
 
 ---
 
@@ -225,6 +275,20 @@ populated from Convex and read for speed, and nothing treats it as authoritative
 returns collapse. Reconciliation is a plain rule — the server wins — because
 there is no longer a second writer to conflict with, which is the entire benefit
 being bought.
+
+**This is where all six stores are wired, in one shape, once.** The four that
+mirror today stop mirroring; the three that do not reach the server at all are
+wired for the first time. They get the same treatment because after this phase
+they are the same kind of thing: a write goes to Convex and its failure is the
+user's failure, rather than a local success plus a swallowed warning.
+
+The bridge comes out with them. `mirrorWrite`, `mirrorCrawlerWrite` and
+`mirrorSoftLinkWrite` have no remaining premise — and `appId` is on the same
+list, since it exists only because the client mints ids as the source of truth.
+Removing it is a bigger change than the mirrors (`claimLocal`, `byAppId`,
+`upsertByAppId`, the bot's lookups and the public-sheet route all address rows by
+it), so it may deserve its own follow-up phase rather than riding along here.
+**Decide that explicitly when scoping P4 — do not let it happen by accident.**
 
 **Gate.**
 

--- a/docs/architecture/persistence-and-pwa.md
+++ b/docs/architecture/persistence-and-pwa.md
@@ -97,10 +97,23 @@ moves — the record does not fall back to local-only.
 who may persist. Doing this first means P3 does not have to reason about
 partially-backed data.
 
-**Work.** Mirror `mechPatterns` from `patternStore`, on the `mirrorWrite`
-pattern. Decide what `encounterNpcs` *is* — one set or two — and write that down
-before wiring anything. Mirror client Change Log appends, and correct ADR-030's
-"now synchronized" claim in the same change.
+**Work.** Three jobs, and they are not the same size.
+
+- **`mechPatterns` — mirror only.** The table already carries `ownerId` and a
+  nullable `gameId`, so the container model is right. It lacks an `appId`, which
+  is why `claimLocal` matches a pattern by reading an id out of the opaque body.
+  Add `appId` + `by_app_id`, then mirror on the `mirrorWrite` pattern.
+- **`encounterNpcs` — the #871 move, verbatim.** The model is settled (ADR-034
+  decision 2): one table, two containers. Today it is
+  `gameId: v.id('games')` with no `ownerId` — *exactly* the shape `crawlers` had
+  before #871. Give it a nullable `gameId`, an `ownerId`, `by_owner`, and an
+  `appId`; a Game-scoped NPC keeps `ownerId: null` the way a communal crawler
+  does, and a shelf NPC takes an owner. Then fold the client's local tray onto
+  it. Read #871's diff before starting — this is the same change twice.
+- **`changeLog` — mirror the client appends**, and correct ADR-030's "now
+  synchronized" claim in the same PR. Cross-device ordering is the hard part
+  here; the log is append-only and keyed by an autoincrement `seq` locally, which
+  does not survive being merged with another device's sequence.
 
 **Gate.**
 
@@ -178,6 +191,13 @@ survives the sign-in round trip and is written after it: a user who builds, is
 asked to sign in, and signs in must not come back to an empty screen. That
 hand-off is the whole risk of this phase.
 
+**The account gate must offer the export escape hatch at the same moment.**
+Sign-in is Discord-only and stays that way (ADR-034 decision 1), so this dialog
+is a hard wall for anybody without a Discord account. Export is what makes that
+acceptable, which means it belongs *in the gate itself* — "sign in to save, or
+download it" — not buried on another screen a blocked user has no reason to
+visit.
+
 **Gate.**
 
 - Build anonymously → save → sign in → the build is in Convex, complete, once.
@@ -185,6 +205,13 @@ hand-off is the whole risk of this phase.
   and unsaved.
 - The same flow with the network dropped mid-sign-in loses nothing.
 - No path writes an entity to IndexedDB while signed out.
+- **Export is reachable from the account gate**, and the bundle it produces
+  imports back cleanly after signing in. Verified round-trip, not just that the
+  button exists.
+- **The bundle is complete.** A test asserts `buildExportBundle` covers every
+  entity kind, and fails when a kind is added without being exported. Today it
+  covers pilots, mechs, crawlers, soft links, patterns and encounter NPCs;
+  `changeLog` is the open question below.
 
 ---
 
@@ -222,17 +249,29 @@ cover **everything** P0 made mirrorable, including patterns and the log. And
 **declining must be survivable**: today declining leaves a full local roster
 beside an empty account, which after P4 is a roster the app no longer reads.
 
-The decline path needs an explicit answer before this phase ships. The minimum
-honest one: keep the data readable and keep offering the claim, and never let a
-decline silently orphan it.
+**The decline path is settled: offer the export hard, then stop asking.** A user
+who declines the claim is pushed to download a bundle, and after that the app
+does not raise it again. This is the least-nagging option and it was chosen
+knowing its edge — somebody who declines, does not export, and later clears
+their browser storage has genuinely lost that roster.
+
+That edge is what the gate below closes. **"Offered" is not enough; the app may
+only stop asking once an export has actually been produced, or the user has
+explicitly refused the export too.** A decline dialog that quietly counts as
+"asked" and moves on is the failure mode this phase exists to prevent.
 
 **Gate.**
 
 - A pre-ADR-030 IndexedDB fixture claims completely: pilots, mechs, crawlers,
-  soft links, patterns, log entries, with counts asserted per kind.
+  soft links, patterns, encounter NPCs, log entries, with counts asserted per
+  kind.
 - Claiming twice produces no duplicates (already covered by an existing test —
   extend it to the new kinds rather than writing a second one).
-- Declining, then reloading, then accepting, still claims everything.
+- Declining, then reloading, then accepting, still claims everything — declining
+  must not be sticky against a later change of mind, only against being nagged.
+- **Declining without exporting does not silence the prompt.** The app keeps
+  asking until a bundle is produced or the export is explicitly refused.
+- The data is never deleted by any path in this phase.
 
 ---
 
@@ -288,18 +327,29 @@ than rendered HTML.
 
 ---
 
-## Open questions
+## Resolved (2026-08-19)
 
-These are not blockers for P0–P2, and each must be answered before the phase
-that needs it.
+The four questions this plan opened with are answered. Recorded here with the
+phase each one unblocks, so a reader does not have to reconstruct them from the
+ADR.
 
-1. **What does declining the claim mean, permanently?** Needed before P5.
-2. **Does an anonymous user get any escape hatch besides an account?** Export to
-   file is the obvious candidate and it is not a source of truth, so it is
-   compatible with ADR-034 — but it is a product decision, not a technical one.
-   Needed before P3.
-3. **What is the `encounterNpcs` model?** One set or two. Needed before P0
-   completes.
-4. **Which auth providers are acceptable as the only door to persistence?**
-   Gating saves on an account makes the sign-in options a product surface rather
-   than a convenience. Needed before P3.
+1. **Declining the claim → offer the export hard, then stop asking.** Unblocks
+   P5, and is why that phase's gate insists the export be *taken* rather than
+   merely offered.
+2. **Anonymous users get export to file.** Unblocks P3, and it is what makes a
+   Discord-only gate defensible rather than a wall.
+3. **`encounterNpcs` is one table with two containers** — the #871 crawler move
+   applied again. Unblocks P0.
+4. **Discord stays the only sign-in provider.** Unblocks P3. The exclusion is
+   real and accepted: no Discord account means no saving, mitigated only by (2).
+
+## Still open
+
+One, and it is new — it follows from (1) and (2) both resting on export.
+
+1. **Does the export bundle need to carry the Change Log?** `buildExportBundle`
+   covers pilots, mechs, crawlers, soft links, patterns and encounter NPCs, and
+   **not `changeLog`**. Harmless while export was a backup; not obviously
+   harmless now that it is the way out. The log is provenance rather than the
+   build itself, so dropping it may well be right — but it should be decided out
+   loud. **Needed before P3**, since that is where export becomes a promise.

--- a/docs/architecture/persistence-and-pwa.md
+++ b/docs/architecture/persistence-and-pwa.md
@@ -39,7 +39,7 @@ Update this table as part of each phase's PR. It is the only place that answers
 | Phase | What                                                      | Reversible | Status      |
 | ----- | --------------------------------------------------------- | ---------- | ----------- |
 | P0    | Make every container model expressible (schema only)       | yes        | **done**    |
-| P1    | Test and e2e path that does not depend on Solo             | yes        | **blocked — needs a decision** |
+| P1    | Test and e2e path that does not depend on Solo             | yes        | route chosen — not started |
 | P2    | In-memory anonymous mode (backend built, flag OFF)         | yes        | **done**    |
 | P3    | Gate persistence on an account                             | **no**     | not started |
 | P4    | Demote IndexedDB to a cache; wire all six stores, no mirrors | **no**    | not started |
@@ -205,12 +205,21 @@ decision rather than by effort. Sign-in is **Discord OAuth and nothing else**
 could use — and confirmed by reading the suite, **no e2e file authenticates at
 all today**. Nothing in the repo has ever needed to, because everything ran Solo.
 
-### The decision P1 needs
+### The decision P1 needed — **taken: option 1, a test-only auth provider**
 
-Pick one before P3, because P3 and P4 are the one-way doors and the halt rule
-above forbids opening them on an untested path:
+Chosen because it is the only one of the three that covers P3's actual risk: the
+anonymous-build → sign-in → save hand-off, end to end, in a browser. The two
+cheaper routes leave exactly that untested, and it is the step most likely to
+lose somebody's work.
 
-1. **A test-only auth provider.** Add Convex Auth's Password provider, enabled
+**It is an auth bypass, so it is gated like one.** The provider is live only
+under a test flag, and a test asserts a production-shaped build does not expose
+it — asserted, not commented. If that gate cannot be made to fail convincingly,
+fall back to option 3 rather than shipping an ungated second door.
+
+The alternatives, kept because the reasoning matters if this is ever revisited:
+
+1. **A test-only auth provider.** (chosen) Add Convex Auth's Password provider, enabled
    only when a test flag is set. Cheapest to write and the most conventional.
    The risk is obvious and must be gated hard: a second door into every account
    if it is ever live in production.
@@ -223,8 +232,7 @@ above forbids opening them on an untested path:
    exactly what P3 risks getting wrong, would have no end-to-end test.
 
 Option 3 is the status quo made explicit and is defensible; option 1 is the one
-that actually covers P3's risk. **This is a security-shaped choice, so it is not
-being made unilaterally.**
+that actually covers P3's risk, and is what was chosen.
 
 **Gate.** Depends on which option above is chosen. Under 1 or 2:
 
@@ -470,13 +478,14 @@ ADR.
 4. **Discord stays the only sign-in provider.** Unblocks P3. The exclusion is
    real and accepted: no Discord account means no saving, mitigated only by (2).
 
+5. **The export bundle does not carry the Change Log**, and that is now a
+   decision rather than an oversight — see ADR-034's consequences for the
+   reasoning and for the `mergeImport` id-remapping problem that makes reversing
+   it real work. Unblocks P3. The cost is stated: a user who leaves via export
+   loses their provenance history.
+
 ## Still open
 
-One, and it is new — it follows from (1) and (2) both resting on export.
-
-1. **Does the export bundle need to carry the Change Log?** `buildExportBundle`
-   covers pilots, mechs, crawlers, soft links, patterns and encounter NPCs, and
-   **not `changeLog`**. Harmless while export was a backup; not obviously
-   harmless now that it is the way out. The log is provenance rather than the
-   build itself, so dropping it may well be right — but it should be decided out
-   loud. **Needed before P3**, since that is where export becomes a promise.
+Nothing blocking. The remaining unknowns are inside phases and are named in the
+phase that owns them — most substantially, **which of P1's three routes to
+take**, which is a security-shaped choice and gates the two one-way doors.

--- a/docs/architecture/persistence-and-pwa.md
+++ b/docs/architecture/persistence-and-pwa.md
@@ -39,7 +39,7 @@ Update this table as part of each phase's PR. It is the only place that answers
 | Phase | What                                                      | Reversible | Status      |
 | ----- | --------------------------------------------------------- | ---------- | ----------- |
 | P0    | Make every container model expressible (schema only)       | yes        | **done**    |
-| P1    | Test and e2e path that does not depend on Solo             | yes        | not started |
+| P1    | Test and e2e path that does not depend on Solo             | yes        | **blocked — needs a decision** |
 | P2    | In-memory anonymous mode (backend built, flag OFF)         | yes        | **done**    |
 | P3    | Gate persistence on an account                             | **no**     | not started |
 | P4    | Demote IndexedDB to a cache; wire all six stores, no mirrors | **no**    | not started |
@@ -190,18 +190,59 @@ Solo**, and 15 of the 16 specs build an entity and expect it to persist
 without this phase does not fail a test — it fails nearly all of them at once, in
 a way that looks like the feature is broken rather than the harness.
 
-**Work.** Two paths, because the suite asks two different questions. Tests that
-only need a working app run against the in-memory mode from P2. Tests that
-assert *durability* need a signed-in session against a disposable Convex
-deployment, with a per-run teardown.
+**Work.** Two paths, because the suite asks two different questions — and they
+turn out to be in very different states.
 
-**Gate.**
+**Server-side durability is already solved and needs nothing.** The
+`test/convex/*` suite runs on `convex-test` with `t.withIdentity({ subject })`,
+so a signed-in user's mutations are exercised today with no deployment, no
+credentials and no network. Anything of the form "does this write reach Convex
+and come back" can be asserted there, and that is most of what P3 and P4 change.
+
+**Browser-level e2e with an account is blocked**, and it is blocked by a
+decision rather than by effort. Sign-in is **Discord OAuth and nothing else**
+(ADR-034 decision 1), so there is no scriptable credential a Playwright fixture
+could use — and confirmed by reading the suite, **no e2e file authenticates at
+all today**. Nothing in the repo has ever needed to, because everything ran Solo.
+
+### The decision P1 needs
+
+Pick one before P3, because P3 and P4 are the one-way doors and the halt rule
+above forbids opening them on an untested path:
+
+1. **A test-only auth provider.** Add Convex Auth's Password provider, enabled
+   only when a test flag is set. Cheapest to write and the most conventional.
+   The risk is obvious and must be gated hard: a second door into every account
+   if it is ever live in production.
+2. **A test-only session mint.** An internal mutation that issues a session for
+   a seeded user, reachable only from a test build. Narrower than a whole
+   provider, but it is still an auth bypass and wants the same care.
+3. **Accept the split.** Browser e2e covers the anonymous path only; durability
+   is asserted in `convex-test` and never in a browser. Costs nothing and adds
+   no bypass — the honest cost is that the sign-in-then-save hand-off, which is
+   exactly what P3 risks getting wrong, would have no end-to-end test.
+
+Option 3 is the status quo made explicit and is defensible; option 1 is the one
+that actually covers P3's risk. **This is a security-shaped choice, so it is not
+being made unilaterally.**
+
+**Gate.** Depends on which option above is chosen. Under 1 or 2:
 
 - The full e2e suite passes with `VITE_CONVEX_URL` set and a signed-in fixture.
 - The full e2e suite passes with it unset, exercising in-memory mode.
 - At least one e2e asserts durability across a reload — the assertion P3 is
   actually about.
 - Teardown verified: a second consecutive run is not polluted by the first.
+- **The bypass cannot reach production.** Asserted by a test, not by a comment:
+  a production-shaped build must not expose the provider or the mutation.
+
+Under option 3, the gate is smaller and honest about what it does not cover:
+
+- The full e2e suite passes with `VITE_CONVEX_URL` unset, exercising in-memory
+  mode.
+- Durability is asserted in `test/convex/*` for every store P4 rewires.
+- The sign-in-then-save hand-off is covered by unit and component tests, and the
+  plan records that it has no end-to-end coverage.
 
 ---
 

--- a/docs/architecture/persistence-and-pwa.md
+++ b/docs/architecture/persistence-and-pwa.md
@@ -1,0 +1,305 @@
+# Account-Required Persistence and the PWA Posture
+
+The executable plan for
+[ADR-034](../adrs/ADR-034-account-required-persistence.md) — making Convex the
+only source of truth for every persisted record, gating persistence on an
+account, and settling both apps as ordinary installable PWAs.
+
+**ADR-034 holds the decisions and their reasoning. This document holds the
+sequence, the gates and the progress.**
+
+Drafted against `91a45464` on 2026-08-19. Repository claims below were read from
+source, not from prose — every "today" statement names the file it came from so
+it can be re-checked rather than believed.
+
+---
+
+## The rule that governs everything else
+
+> **A failed gate halts the phase.**
+>
+> No gate is worked around or relaxed to obtain a pass. No later phase begins
+> while an earlier gate is red.
+
+One addition specific to this plan, because it is the failure mode that would
+hurt most:
+
+> **No phase may leave a user's data reachable from fewer places than before it
+> ran.** Every phase that touches storage states what happens to a roster that
+> exists only in IndexedDB when that phase ships. "It is claimed" and "it stays
+> readable" are acceptable answers. "It is gone" is not, at any phase.
+
+---
+
+## Progress
+
+Update this table as part of each phase's PR. It is the only place that answers
+"which phase are we on".
+
+| Phase | What                                                      | Reversible | Status      |
+| ----- | --------------------------------------------------------- | ---------- | ----------- |
+| P0    | Close the DB-backing gaps (patterns, encounter NPCs, log)  | yes        | not started |
+| P1    | Test and e2e path that does not depend on Solo             | yes        | not started |
+| P2    | In-memory anonymous mode                                   | yes        | not started |
+| P3    | Gate persistence on an account                             | **no**     | not started |
+| P4    | Demote IndexedDB to a cache                                | **no**     | not started |
+| P5    | Claim-on-sign-in coverage and the decline path             | yes        | not started |
+| P6    | ITUN install-triggered offline                             | yes        | not started |
+| P7    | `srd` install-triggered offline (**blocked on ADR-033 P7**) | yes       | blocked     |
+
+P0–P2 are all reversible and all buy information. P3 and P4 are the one-way
+doors and they are deliberately late.
+
+---
+
+## What is not DB-backed today
+
+This is the inventory ADR-034 decision 2 exists to close. Every row was read
+from source at `91a45464`.
+
+| Store              | Local writer                          | Convex table       | Mirrored?                                                    |
+| ------------------ | ------------------------------------- | ------------------ | ------------------------------------------------------------ |
+| `pilots`           | `entityStore`                         | `pilots`           | **yes** — `mirrorWrite`                                       |
+| `mechs`            | `entityStore`                         | `mechs`            | **yes** — `mirrorWrite`                                       |
+| `crawlers`         | `entityStore`                         | `crawlers`         | **yes** — `mirrorCrawlerWrite`, shelf included since #871     |
+| `softLinks`        | `entityStore`                         | `softLinks`        | **yes** — `mirrorSoftLinkWrite`                               |
+| `mechPatterns`     | `patternStore` → `db.mechPatterns`    | `mechPatterns`     | **NO** — server rows only ever inserted by `claimLocal`       |
+| `encounterNpcs`    | `encounterStore` → `db.encounterNpcs` | `encounterNpcs`    | **NO** — server table written only by `mediator.ts`, disjoint |
+| `changeLog`        | `db/changeLog.ts` `append`            | `changeLog`        | **NO** — server rows only from `ownership`/`proposals`/bot    |
+| `workspaces`       | retired                               | —                  | n/a — object store survives only so migrations v10/v13 run    |
+
+Three real gaps, and they are not equivalent:
+
+- **`mechPatterns` is a straightforward miss.** The table exists, the shape
+  matches, and nothing mirrors. A pattern saved while signed in is lost on any
+  other device. Lowest-risk of the three to close.
+- **`encounterNpcs` is worse than a miss — it is a name collision.** The client
+  store and the Convex table have the same name and hold different things: the
+  client's are a local GM tray, the server's are `mediator.ts`'s prepared
+  opposition, scoped to a Game. Closing this is a **modelling** job first. Do not
+  start by wiring a mirror between two things that are not the same set.
+- **`changeLog` is append-only and cross-device ordering is the hard part.**
+  ADR-030's amendment already claims the log "is now synchronized". It is not,
+  client-side, and that stale claim should be corrected in the same PR that
+  fixes it — not before.
+
+**The crawler is the worked example, and it is already done.** #871 made
+`crawlers` shelf-able specifically so that a crawler moved out of a deleted Game
+lands in Convex rather than in a browser. Use it as the pattern for the three
+above: if the schema cannot express where a record needs to live, the schema
+moves — the record does not fall back to local-only.
+
+---
+
+## P0 — Close the DB-backing gaps
+
+**Goal.** Every persisted record has a Convex row, before anything changes about
+who may persist. Doing this first means P3 does not have to reason about
+partially-backed data.
+
+**Work.** Mirror `mechPatterns` from `patternStore`, on the `mirrorWrite`
+pattern. Decide what `encounterNpcs` *is* — one set or two — and write that down
+before wiring anything. Mirror client Change Log appends, and correct ADR-030's
+"now synchronized" claim in the same change.
+
+**Gate.**
+
+- A signed-in user creating a pattern, an encounter NPC, and an entity edit that
+  writes a log entry, on device A, sees all three on device B after a reload.
+  Verified by doing it, not by asserting the mirror was called.
+- `bun run check:all` green.
+- No new local-only store has appeared: a test asserts the set of IndexedDB
+  stores that have no Convex counterpart is exactly `{workspaces}`.
+
+That last gate is the one worth keeping forever — it is what stops gap four.
+
+---
+
+## P1 — A test and e2e path that does not depend on Solo
+
+**Goal.** Be able to verify P3 before shipping P3.
+
+**Why it is this early.** CI has no `VITE_CONVEX_URL`
+(`src/lib/connection/convexClient.ts` reads it; `connectionMode.ts` returns
+`'solo'` when it is absent), so **every Playwright e2e today runs permanently
+Solo**, and 15 of the 16 specs build an entity and expect it to persist
+(`bundle-budget.e2e.ts` is the exception; it measures bundle size). Removing Solo
+without this phase does not fail a test — it fails nearly all of them at once, in
+a way that looks like the feature is broken rather than the harness.
+
+**Work.** Two paths, because the suite asks two different questions. Tests that
+only need a working app run against the in-memory mode from P2. Tests that
+assert *durability* need a signed-in session against a disposable Convex
+deployment, with a per-run teardown.
+
+**Gate.**
+
+- The full e2e suite passes with `VITE_CONVEX_URL` set and a signed-in fixture.
+- The full e2e suite passes with it unset, exercising in-memory mode.
+- At least one e2e asserts durability across a reload — the assertion P3 is
+  actually about.
+- Teardown verified: a second consecutive run is not polluted by the first.
+
+---
+
+## P2 — In-memory anonymous mode
+
+**Goal.** An anonymous visitor can build a complete pilot, mech and crawler
+without writing to any durable store.
+
+**Work.** A backend implementation behind the existing `selectBackend()` seam in
+`stores/entityBackend.ts`. That seam is the whole reason this is tractable: the
+store's public API, its lazy hydration, its in-memory cache and its broadcast
+behaviour do not change, and neither does any component. Add a memory backend;
+do not add a second store.
+
+Cross-tab broadcast is deliberately **off** for this backend — two tabs of an
+anonymous session are two sessions, because there is nothing durable tying them
+together, and pretending otherwise invents exactly the local-only semantics
+ADR-034 forbids.
+
+**Gate.**
+
+- With no account, the three wizards complete and render a finished sheet.
+- **Nothing is written.** Verified by inspecting IndexedDB after a full anonymous
+  session: the database either does not exist or holds no entity rows. This gate
+  is the point of the phase; assert absence, not behaviour.
+- A reload loses the work, and the UI said it would beforehand.
+
+---
+
+## P3 — Gate persistence on an account
+
+**One-way door.** This is the phase that withdraws ADR-030 §1's guarantee.
+
+**Work.** Save requires a session. The ask arrives at the save, naming what is
+being kept — not on load, and not in front of the wizard. Anonymous work
+survives the sign-in round trip and is written after it: a user who builds, is
+asked to sign in, and signs in must not come back to an empty screen. That
+hand-off is the whole risk of this phase.
+
+**Gate.**
+
+- Build anonymously → save → sign in → the build is in Convex, complete, once.
+- The same flow with sign-in **cancelled** returns the user to their work intact
+  and unsaved.
+- The same flow with the network dropped mid-sign-in loses nothing.
+- No path writes an entity to IndexedDB while signed out.
+
+---
+
+## P4 — Demote IndexedDB to a cache
+
+**One-way door.**
+
+**Work.** Make the demotion true in code rather than in prose: the local store is
+populated from Convex and read for speed, and nothing treats it as authoritative.
+`writesAllowed()`'s Solo branch goes; `resolveConnectionMode`'s two `'solo'`
+returns collapse. Reconciliation is a plain rule — the server wins — because
+there is no longer a second writer to conflict with, which is the entire benefit
+being bought.
+
+**Gate.**
+
+- Clearing site data and reloading, signed in, restores the full roster from
+  Convex.
+- A row present locally and absent server-side does not survive a reload. This is
+  the assertion that IndexedDB is a cache; it should feel uncomfortable and it
+  should pass.
+- `bun run check:all` green, and the `apps/itun` coverage ratchet is not
+  regressed.
+
+---
+
+## P5 — Claim-on-sign-in coverage and the decline path
+
+**Goal.** Nobody's existing local roster is stranded.
+
+**Work.** `ClaimLocalData` and `entities.claimLocal` already do the core of this,
+already offered-not-automatic, and already idempotent — `claimLocal` skips what
+it already holds, so re-claiming is a no-op. Two things are missing. It must
+cover **everything** P0 made mirrorable, including patterns and the log. And
+**declining must be survivable**: today declining leaves a full local roster
+beside an empty account, which after P4 is a roster the app no longer reads.
+
+The decline path needs an explicit answer before this phase ships. The minimum
+honest one: keep the data readable and keep offering the claim, and never let a
+decline silently orphan it.
+
+**Gate.**
+
+- A pre-ADR-030 IndexedDB fixture claims completely: pilots, mechs, crawlers,
+  soft links, patterns, log entries, with counts asserted per kind.
+- Claiming twice produces no duplicates (already covered by an existing test —
+  extend it to the new kinds rather than writing a second one).
+- Declining, then reloading, then accepting, still claims everything.
+
+---
+
+## P6 — ITUN install-triggered offline
+
+**Goal.** Deliver ADR-034 decision 3 for ITUN: installable, and installed means
+offline-capable in full.
+
+**Work.** ITUN is already installable and already precaches its shell. What is
+missing is the *account data* half: an installed app should hold the signed-in
+user's own roster for offline reading. Detection is by installed state
+(`display-mode: standalone`, `appinstalled`), not by visit count.
+
+`registerType: 'prompt'` **does not change**, for the reason ADR-034 gives.
+`chunkRecovery.ts` stays as the backstop.
+
+**Gate.**
+
+- Installed, then offline: the roster opens and reads.
+- **Browser tab, online: no bulk download.** Measured against the existing
+  bundle-budget e2e, so a regression here fails an existing gate rather than
+  needing a new one.
+- Offline is read-only, and says so — the ADR-030 rule is unchanged.
+
+---
+
+## P7 — `srd` install-triggered offline
+
+**Blocked on [ADR-033](../adrs/ADR-033-cloudflare-hosting.md) P7.**
+`salvageunion.io` is still on Netlify pending support ticket #1093312. Changing
+service-worker behaviour mid-host-move makes any failure ambiguous between two
+causes, and a bad service worker outlives the deploy that caused it.
+
+**Work.** `srd` is already installable (`site.webmanifest`, 192/512 icons,
+`ssg/pwa.ts` workbox worker). The gap is that `navigateFallback: null` and a
+`globPatterns` of js/css/woff2/svg mean an unvisited page 404s offline — correct
+for a browser visitor, wrong for an installed app.
+
+Add an install-triggered fetch of the reference set. Prefer the **899 JSON
+endpoints** over 1,039 HTML pages if measurement supports it: the endpoints
+already exist, they are what the search index reads, and they are far smaller
+than rendered HTML.
+
+**Gate.**
+
+- Measure first. The install-time payload is written into this document before
+  the code ships, with a stated ceiling. **An unmeasured "download everything"
+  does not pass**; a worse-than-404 experience is a real possible outcome.
+- Installed, then offline: an unvisited entity page renders.
+- Browser tab, online: byte-for-byte the same network profile as today.
+  `ssg/snapshot.ts` must be green, and any change to the emitted file set is
+  re-blessed deliberately with the diff read.
+
+---
+
+## Open questions
+
+These are not blockers for P0–P2, and each must be answered before the phase
+that needs it.
+
+1. **What does declining the claim mean, permanently?** Needed before P5.
+2. **Does an anonymous user get any escape hatch besides an account?** Export to
+   file is the obvious candidate and it is not a source of truth, so it is
+   compatible with ADR-034 — but it is a product decision, not a technical one.
+   Needed before P3.
+3. **What is the `encounterNpcs` model?** One set or two. Needed before P0
+   completes.
+4. **Which auth providers are acceptable as the only door to persistence?**
+   Gating saves on an account makes the sign-in options a product surface rather
+   than a convenience. Needed before P3.

--- a/docs/architecture/persistence-and-pwa.md
+++ b/docs/architecture/persistence-and-pwa.md
@@ -40,7 +40,7 @@ Update this table as part of each phase's PR. It is the only place that answers
 | ----- | --------------------------------------------------------- | ---------- | ----------- |
 | P0    | Make every container model expressible (schema only)       | yes        | **done**    |
 | P1    | Test and e2e path that does not depend on Solo             | yes        | not started |
-| P2    | In-memory anonymous mode                                   | yes        | not started |
+| P2    | In-memory anonymous mode (backend built, flag OFF)         | yes        | **done**    |
 | P3    | Gate persistence on an account                             | **no**     | not started |
 | P4    | Demote IndexedDB to a cache; wire all six stores, no mirrors | **no**    | not started |
 | P5    | Claim-on-sign-in coverage and the decline path             | yes        | not started |
@@ -221,13 +221,35 @@ anonymous session are two sessions, because there is nothing durable tying them
 together, and pretending otherwise invents exactly the local-only semantics
 ADR-034 forbids.
 
+**Ships behind `VITE_REQUIRE_ACCOUNT`, default off.** That is what keeps this
+phase reversible, as the table claims: the backend exists and is selectable, but
+an anonymous visitor still gets Solo until P3 flips it and adds the UI that
+explains what is happening. A backend nobody is routed to yet cannot strand
+anyone.
+
 **Gate.**
 
-- With no account, the three wizards complete and render a finished sheet.
-- **Nothing is written.** Verified by inspecting IndexedDB after a full anonymous
-  session: the database either does not exist or holds no entity rows. This gate
-  is the point of the phase; assert absence, not behaviour.
-- A reload loses the work, and the UI said it would beforehand.
+- The memory store satisfies the same CRUD contract as the IDB store — id and
+  timestamps minted on create, `updatedAt` bumped, id immutable through a patch,
+  update on a missing id throws, delete a silent no-op, `list()` newest-first,
+  strict Zod on every write. Asserted case by case, because `entityStore` is
+  written against that contract and must not learn which backend it has.
+- **Nothing can be written.** Asserted against the module *source*: it imports
+  no `idb`, and names neither `indexedDB` nor `localStorage` nor
+  `sessionStorage`. Behaviour can be right today and one refactor from wrong;
+  this is the assertion that does not rot.
+- Two stores share nothing — an anonymous session is per tab, which is also why
+  `entityStore` routes every broadcast through a guard that no-ops for this
+  backend.
+- **The flag is still off.** A test asserts `backendForMode('solo', false)` is
+  `'local'` and that `selectBackend()` agrees, so opening the one-way door by
+  accident fails a test.
+- The flag changes nothing for a signed-in user: `connected` stays `remote` and
+  `disconnected` stays `blocked` under both flag values.
+
+**Deferred to P3 deliberately:** the wizards-complete-anonymously and
+reload-loses-the-work checks, which need the flag on and the UI that warns
+first. Asserting them now would mean shipping the gate with no way to explain it.
 
 ---
 


### PR DESCRIPTION
The plan you asked for. **Documents only — no code changes.**

Two files: [ADR-034](docs/adrs/ADR-034-account-required-persistence.md) holds the decisions, [persistence-and-pwa.md](docs/architecture/persistence-and-pwa.md) holds the sequence, gates and progress table — the same split ADR-033 / cloudflare-cutover.md uses.

## The decisions

1. **Persistence requires an account.** Anonymous visitors build in-memory only; the ask arrives at the *save*, not on load.
2. **Every record is DB-backed.** Convex is the only source of truth; IndexedDB holds a reflection of it and nothing else.
3. **Both apps are ordinary installable PWAs, and installing is what buys offline.** A browser visitor gets the shell plus what they actually visited — **no bulk pre-download**. An installed app works offline in full.

"No distinct difference" is read as *posture*, not one shared config: ITUN keeps `registerType: 'prompt'`, because `autoUpdate` there deleted the precache under live pages and made share links need four or five refreshes. Uniformity that re-opens a documented outage isn't uniformity worth having.

**Partially supersedes ADR-030** — its §1 "Solo forever" guarantee, and nothing else. ADR-030 stays the governing ADR for Games, ownership and the server-of-record model.

## What the audit found

You asked to make sure *everything* is DB-backed. Three stores are not, all read from source rather than prose:

| Store | Convex table | Mirrored? |
| --- | --- | --- |
| `pilots` / `mechs` / `crawlers` / `softLinks` | yes | **yes** (crawler shelf included since #871) |
| `mechPatterns` | exists | **NO** — only ever inserted by the one-time `claimLocal`, so a pattern saved while signed in never leaves the device |
| `encounterNpcs` | exists | **NO** — and it's a *name collision*: the client's local GM tray and `mediator.ts`'s prepared opposition are different sets. Modelling job first, not a wiring job |
| `changeLog` | exists | **NO** — client appends stay local, while ADR-030 already claims the log "is now synchronized". It is not |

The crawler case you named is already done — #871 is the worked example the plan generalises: when the schema can't express where a record needs to live, the schema moves.

## Sequencing

P0–P2 are reversible and buy information. **P3 (gate persistence) and P4 (demote IndexedDB) are the one-way doors and are deliberately late.**

**P1 exists because of a constraint that would otherwise bite hard:** CI has no `VITE_CONVEX_URL`, so 15 of 16 e2e specs run permanently Solo and expect persistence. Removing Solo without a test path first doesn't fail *a* test — it fails nearly the whole suite at once, looking like a broken feature rather than a broken harness.

**P7 is blocked on ADR-033 P7.** No service-worker change to `srd` while `salvageunion.io` is mid-host-move — a bad worker outlives the deploy that caused it, and two possible causes make any failure ambiguous.

Migration is as you specified: existing local data stays readable and sign-in **prompts to claim it**. `ClaimLocalData` + `entities.claimLocal` already do this, already offered-not-automatic and already idempotent; P5 is coverage plus an answer for what declining means.

## Also

- Corrects the "Solo must keep working forever" claim where it's loaded into **every session** (`apps/itun/CLAUDE.md`, `.claude/rules/tanstack-query-hooks.md`) so it isn't followed as current, and adds a standing rule against new device-only storage.
- ADR count in root `CLAUDE.md` was already stale at 33; now 34.

## One thing the tooling caught

My first draft wrote "§1 is superseded by ADR-034" in ADR-030's Status. `tools/check-doc-drift.ts` parses that phrasing and marked ADR-030 **wholly** superseded — 30 failures, four in an unrelated doc. The tool was right and the wording was wrong: ADR-030 is the governing ADR. Reworded to the repo's existing "partially supersedes" vocabulary; drift is green and reports 4 superseded ADRs, correctly not including ADR-030.

## Open questions in the plan

Four, each tied to the phase that needs it: what declining the claim means permanently; whether anonymous users get an escape hatch (file export is compatible but is a product call); the `encounterNpcs` model; and which auth providers are acceptable as the only door to persistence.

## Verification

`bun run check:all` exits 0 — including `validate:doc-drift`, which is the check that actually has an opinion about these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QU5rmidxZ3QUrMb3nvVNX6
