### PR TITLE
feat(itun): P1 — a test-only sign-in door, gated so production has one

### DIFF
--- a/apps/itun/convex/auth.ts
+++ b/apps/itun/convex/auth.ts
@@ -1,5 +1,6 @@
 import Discord from '@auth/core/providers/discord'
 import type { User } from '@auth/core/types'
+import { Password } from '@convex-dev/auth/providers/Password'
 import { convexAuth } from '@convex-dev/auth/server'
 
 /**
@@ -14,8 +15,12 @@ import { convexAuth } from '@convex-dev/auth/server'
  *   bunx convex env set AUTH_DISCORD_ID <client-id>
  *   bunx convex env set AUTH_DISCORD_SECRET <client-secret>
  *
- * Signing in is an *upgrade*, never a gate (D10) — anonymous solo play stays
- * first-class and needs none of this.
+ * Signing in used to be an *upgrade*, never a gate (D10). That is being
+ * withdrawn by
+ * [ADR-034](../../../docs/adrs/ADR-034-account-required-persistence.md):
+ * anonymous play stays first-class for *building*, but keeping what you build
+ * will require an account. Discord remains the only door for real users — see
+ * `testOnlyProviders` below for the one exception and why it is not one.
  */
 /**
  * No `afterUserCreatedOrUpdated` callback stamps the Discord snowflake here,
@@ -44,12 +49,22 @@ const discord = Discord({})
  * means a library change that dropped it fails loudly at deploy, instead of
  * silently reinstating the `null` email this module exists to strip.
  */
-const { profile: discordProfile } = discord
-if (!discordProfile) {
+const { profile: rawDiscordProfile } = discord
+if (!rawDiscordProfile) {
   throw new Error(
     '@auth/core Discord provider no longer defines profile(); the null-field guard has nothing to wrap'
   )
 }
+
+/**
+ * The same function, bound after the guard so its *type* carries the proof.
+ *
+ * `providersFor` is a hoisted function declaration, so TypeScript will not
+ * assume the guard above has run by the time its body executes, and drops the
+ * narrowing at the call inside it. Re-binding here is what makes the proof
+ * survive into that closure.
+ */
+const discordProfile: NonNullable<typeof discord.profile> = rawDiscordProfile
 
 /**
  * Strips `null` values out of an OAuth profile before it becomes a `users` row.
@@ -77,11 +92,67 @@ function withoutNullFields(profile: User): User {
   return Object.fromEntries(Object.entries(profile).filter(([, value]) => value !== null)) as User
 }
 
+/**
+ * A password provider that exists **only so end-to-end tests can sign in**.
+ *
+ * ## Why this has to exist at all
+ *
+ * ADR-034 gates persistence on an account, and the step most likely to lose
+ * somebody's work is the hand-off: build anonymously, be asked to sign in, sign
+ * in, and find the work still there and now saved. That is a browser-level
+ * behaviour, so proving it needs a browser-level test — and with Discord OAuth
+ * as the only provider there is no credential a Playwright fixture could ever
+ * present. No e2e in this repo has ever authenticated, because until now nothing
+ * needed to.
+ *
+ * The alternative was to accept that the hand-off has no end-to-end cover. That
+ * was rejected: the whole point of a phased plan is not to walk through a
+ * one-way door untested.
+ *
+ * ## Why it is not a second door into real accounts
+ *
+ * It is included **only** when `ITUN_TEST_AUTH` is exactly `'true'` on the
+ * deployment. Production never sets it, and `test/convex/authProviders.test.ts`
+ * asserts that a deployment without it exposes Discord and nothing else — an
+ * assertion, not a comment, because a comment cannot fail.
+ *
+ * Three properties make the blast radius small even if the flag were set by
+ * mistake:
+ *
+ *  - It grants no authority of its own. A password account is an ordinary user
+ *    with an ordinary empty shelf; every capability in this app comes from
+ *    membership of a Game (`model/permissions.ts`), which such an account has
+ *    none of.
+ *  - It cannot reach an existing Discord account. Convex Auth links accounts by
+ *    provider, so signing in with a password mints a *separate* user; there is
+ *    no email-matching path that would let it land inside somebody's roster.
+ *  - It is env-gated at module scope, so a deployment either has it or does not
+ *    — there is no request-time input that could flip it.
+ *
+ * **Read as a rule rather than a description: never make this conditional on
+ * anything a request can influence, and never set `ITUN_TEST_AUTH` on the
+ * production deployment.**
+ */
+const testAuthEnabled = process.env.ITUN_TEST_AUTH === 'true'
+
+/**
+ * Exported for the test that asserts production exposes Discord alone. Callers
+ * outside that test have no reason to read it, and `providersFor` is the thing
+ * that actually decides.
+ */
+export function providersFor(testAuth: boolean) {
+  type DiscordProfileFn = typeof discordProfile
+
+  const discordProvider = {
+    ...discord,
+    profile: async (
+      raw: Parameters<DiscordProfileFn>[0],
+      tokens: Parameters<DiscordProfileFn>[1]
+    ) => withoutNullFields(await discordProfile(raw, tokens)),
+  }
+  return testAuth ? [discordProvider, Password()] : [discordProvider]
+}
+
 export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
-  providers: [
-    {
-      ...discord,
-      profile: async (raw, tokens) => withoutNullFields(await discordProfile(raw, tokens)),
-    },
-  ],
+  providers: providersFor(testAuthEnabled),
 })

--- a/apps/itun/test/convex/authProviders.test.ts
+++ b/apps/itun/test/convex/authProviders.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The gate on the test-only password provider.
+ *
+ * ADR-034 keeps **Discord as the only door** for real users. A password
+ * provider exists solely so a Playwright fixture can sign in — without it the
+ * anonymous-build → sign-in → save hand-off, which is the step most likely to
+ * lose somebody's work, has no end-to-end cover at all.
+ *
+ * That makes this file the price of admission. A second way into an account is
+ * only acceptable if it demonstrably cannot be reached in production, and
+ * "demonstrably" means an assertion that can fail — not a comment saying the
+ * env var is not set. Comments do not fail.
+ *
+ * **If these tests are ever deleted or weakened, delete the provider too.** The
+ * provider and this file are one change; keeping one without the other is
+ * exactly the ungated second door the plan refused to ship.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { providersFor } from '../../convex/auth'
+
+/** Auth.js/Convex providers expose a stable string `id`. */
+function idsOf(providers: ReturnType<typeof providersFor>): string[] {
+  return providers.map((p) => (p as { id?: string }).id ?? '<unnamed>')
+}
+
+describe('a deployment without ITUN_TEST_AUTH has exactly one door', () => {
+  test('production exposes Discord and nothing else', () => {
+    const ids = idsOf(providersFor(false))
+
+    // Length AND contents. Asserting only "contains discord" would pass with a
+    // password provider sitting quietly beside it, which is the whole failure
+    // this test exists to catch.
+    expect(ids).toEqual(['discord'])
+  })
+
+  test('the password provider is genuinely absent, not merely last', () => {
+    const ids = idsOf(providersFor(false))
+    // `'credentials'`, not `'password'`: `Password()` is built on
+    // ConvexCredentials and inherits that id. Worth pinning by its real id —
+    // asserting the absence of a name nothing ever had would pass forever.
+    expect(ids).not.toContain('credentials')
+  })
+})
+
+describe('a test deployment gets the extra provider', () => {
+  test('Discord is still there — the bypass ADDS, it never replaces', () => {
+    // If enabling test auth removed Discord, a test deployment would stop
+    // exercising the real sign-in path and the fixture would be testing
+    // something no user ever does.
+    expect(idsOf(providersFor(true))).toContain('discord')
+  })
+
+  test('password is available when the flag is on', () => {
+    expect(idsOf(providersFor(true))).toContain('credentials')
+  })
+
+  test('exactly one provider is added, and it is the password one', () => {
+    // A negative control on the control: this is what proves the two branches
+    // actually differ, so the production assertion above is not passing
+    // vacuously against a function that ignores its argument.
+    const prod = idsOf(providersFor(false))
+    const testing = idsOf(providersFor(true))
+
+    expect(testing.length).toBe(prod.length + 1)
+    expect(testing.filter((id) => !prod.includes(id))).toEqual(['credentials'])
+  })
+})
+
+describe('the flag is exact-match, not truthy', () => {
+  test("only the string 'true' enables it", () => {
+    // `providersFor` takes a boolean, so this pins the *reading* of the env var
+    // rather than the branch: `ITUN_TEST_AUTH === 'true'` and nothing looser.
+    // A truthy check would turn `ITUN_TEST_AUTH=false` — a plausible thing for
+    // somebody to set while trying to disable it — into an enabled bypass.
+    const source = Bun.file(new URL('../../convex/auth.ts', import.meta.url).pathname)
+    const text = source.text()
+    return text.then((t) => {
+      expect(t).toContain("process.env.ITUN_TEST_AUTH === 'true'")
+      // Neither a bare truthiness check nor a not-equals inversion.
+      expect(t).not.toContain('process.env.ITUN_TEST_AUTH !==')
+      expect(t).not.toMatch(/if\s*\(\s*process\.env\.ITUN_TEST_AUTH\s*\)/)
+    })
+  })
+})

--- a/docs/architecture/persistence-and-pwa.md
+++ b/docs/architecture/persistence-and-pwa.md
@@ -39,7 +39,7 @@ Update this table as part of each phase's PR. It is the only place that answers
 | Phase | What                                                      | Reversible | Status      |
 | ----- | --------------------------------------------------------- | ---------- | ----------- |
 | P0    | Make every container model expressible (schema only)       | yes        | **done**    |
-| P1    | Test and e2e path that does not depend on Solo             | yes        | route chosen — not started |
+| P1    | Test and e2e path that does not depend on Solo             | yes        | **provider done** — fixture with P3 |
 | P2    | In-memory anonymous mode (backend built, flag OFF)         | yes        | **done**    |
 | P3    | Gate persistence on an account                             | **no**     | not started |
 | P4    | Demote IndexedDB to a cache; wire all six stores, no mirrors | **no**    | not started |
@@ -233,6 +233,11 @@ The alternatives, kept because the reasoning matters if this is ever revisited:
 
 Option 3 is the status quo made explicit and is defensible; option 1 is the one
 that actually covers P3's risk, and is what was chosen.
+
+**Status.** The provider and its production gate are built (#874). The Playwright
+fixture that *uses* it lands with P3, because until the account gate exists there
+is no sign-in flow for a fixture to drive — a fixture that signed in and did
+nothing would assert nothing.
 
 **Gate.** Depends on which option above is chosen. Under 1 or 2:
 


### PR DESCRIPTION
**Layer 1 of the ADR-034 stack.** Base: `main` (ADR + P0 + P2 landed in #873).

ADR-034 gates persistence on an account, and the step most likely to lose somebody's work is the hand-off: build anonymously → get asked to sign in → sign in → find the work still there and now saved. That is browser-level behaviour, so proving it needs a browser-level test.

**It could not be written.** Discord OAuth is the only provider, so there is no credential a Playwright fixture can present — and no e2e in this repo authenticates today, because until now nothing needed to. That is a consequence of keeping Discord as the only door, not a gap in the plan.

## What this adds

Convex Auth's `Password` provider, included **only** when `ITUN_TEST_AUTH === 'true'` on the deployment. Production never sets it.

## The gate is the price of admission

A second way into an account is only acceptable if it demonstrably cannot be reached in production, and *demonstrably* means an assertion that can fail. `authProviders.test.ts` pins:

- A deployment without the flag exposes `['discord']` **exactly** — length and contents, so a password provider sitting quietly beside Discord fails the test.
- Enabling it **adds** rather than replaces, so a test deployment still exercises the real sign-in path.
- Exactly one provider appears, and it is the credentials one. This is the control on the control: it proves the two branches actually differ, so the production assertion is not passing vacuously against a function that ignores its argument.
- The env read is an exact `=== 'true'`. A truthy check would turn `ITUN_TEST_AUTH=false` — a plausible thing to set while trying to disable it — into an enabled bypass.

**If these tests are ever deleted or weakened, delete the provider too.** They are one change.

## Blast radius, if the flag were ever set by mistake

- A password account is an ordinary user with an empty shelf. Every capability in this app comes from Game membership (`model/permissions.ts`), which it has none of.
- It cannot reach an existing Discord account — Convex Auth links by provider, so it mints a separate user. There is no email-matching path into somebody's roster.
- It is env-gated at module scope: a deployment either has it or does not. No request-time input can flip it.

## Two things that corrected me

`providersFor` is a hoisted function declaration, so TypeScript drops the module-scope narrowing on `discord.profile` inside its body — the value is now re-bound after the guard so the proof survives into the closure.

And the provider's id is **`credentials`**, not `password` — `Password()` is built on ConvexCredentials. My first test asserted the absence of a name nothing ever had, which would have passed forever. The test caught it.

## Verification

`bun run check:all` exits 0.

## Not in this layer

Wiring the Playwright fixture to actually use it, which lands with P3 where there is a sign-in flow to drive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QU5rmidxZ3QUrMb3nvVNX6
