### PR TITLE
feat(itun): P3 — the account gate and the promotion behind it

### DIFF
--- a/apps/itun/src/components/account/UnsavedWorkBanner.tsx
+++ b/apps/itun/src/components/account/UnsavedWorkBanner.tsx
@@ -1,0 +1,189 @@
+/**
+ * UnsavedWorkBanner — the account gate, at the moment it means something.
+ *
+ * ADR-034 decision 1: an anonymous visitor may build, and what they build is
+ * in-memory only. This is what says so, and it is the only place the app asks
+ * for an account.
+ *
+ * ## Why it appears when there is work, not on arrival
+ *
+ * The ADR is explicit that the ask "arrives when the user has something worth
+ * keeping and can see what keeping it means, rather than in front of a product
+ * they have not tried". A visitor with an empty roster is told nothing at all;
+ * the banner appears the moment they have built something, and names the count
+ * so what is at stake is legible rather than abstract.
+ *
+ * ## Why it offers a download beside the sign-in
+ *
+ * Sign-in is Discord and nothing else, so this banner is a hard wall for anybody
+ * without a Discord account. Export is what keeps that from being a data-loss
+ * event, which means it belongs *here* — in the gate — and not on a settings
+ * screen a blocked user has no reason to visit. ADR-034 calls the export
+ * load-bearing for exactly this reason.
+ *
+ * ## Why it is not dismissible
+ *
+ * It is stating a fact about the session — this work will not survive the tab —
+ * and a dismissed banner would leave a visitor believing their build was saved
+ * because nothing on screen said otherwise. It goes away when the work is saved
+ * or when there is no work, which are the two states in which it is untrue.
+ */
+
+import { Text } from 'component-lib'
+import { useMutation } from 'convex/react'
+import { useEffect, useRef, useState } from 'react'
+import { api } from '../../../convex/_generated/api'
+import {
+  captureAnonymousWork,
+  countAnonymousWork,
+  promoteAnonymousWork,
+} from '../../lib/account/promoteAnonymousWork'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+import { isServerRefusal, serverMessage } from '../../lib/connection/serverError'
+import { captureException } from '../../lib/observability'
+import { selectBackend } from '../../stores/entityBackend'
+import { useEntityStore } from '../../stores/entityStore'
+import { usePatternStore } from '../../stores/patternStore'
+import { ExportAllButton } from '../export/ExportAllButton'
+import { SignInControl } from './SignInControl'
+
+/** "3 builds" / "1 build". Plain, because it is being read in a warning. */
+function buildPhrase(n: number): string {
+  return `${n} ${n === 1 ? 'build' : 'builds'}`
+}
+
+export function UnsavedWorkBanner() {
+  // Subscribed rather than captured: the banner has to appear the moment the
+  // first build lands and disappear the moment the work is promoted, and both
+  // of those are store changes.
+  const pilots = useEntityStore((s) => s.list('pilot'))
+  const mechs = useEntityStore((s) => s.list('mech'))
+  const crawlers = useEntityStore((s) => s.list('crawler'))
+  const patterns = usePatternStore((s) => s.mechPatterns)
+
+  const count = pilots.length + mechs.length + crawlers.length + patterns.length
+  const anonymous = selectBackend() === 'memory'
+
+  if (!anonymous || count === 0) return null
+
+  return (
+    <div className="border-b-2 border-ink bg-paper px-4 py-3">
+      <div className="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-3">
+        <Text>
+          <strong>{buildPhrase(count)} not saved.</strong> Everything here lives in this tab only —
+          closing it loses the lot.
+        </Text>
+        <div className="flex flex-wrap items-center gap-2">
+          {/* Both ways out, side by side. Neither is the "cancel". */}
+          <ExportAllButton />
+          {isConvexConfigured && <SignInControl />}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Promotes anonymous work once a sign-in resolves.
+ *
+ * Separate from the banner because it must keep running after the banner has
+ * stopped rendering: the sign-in flips the backend to `remote`, at which point
+ * `selectBackend() === 'memory'` is false and the banner unmounts — so a
+ * promotion living inside it would be torn down at exactly the moment it was
+ * needed. Mount this once, high, and let it watch.
+ *
+ * ## It only promotes work THIS session built anonymously
+ *
+ * The distinction is not cosmetic, it is the consent rule. A signed-in user
+ * whose IndexedDB holds an old roster must be *offered* the upload
+ * (`ClaimLocalData`), because publishing somebody's builds is a decision made
+ * with their data and signing in to view a friend's game is not consent to it.
+ * Work built anonymously in this tab is different: the user reached this path by
+ * pressing a control that said "sign in to save this".
+ *
+ * A naive "signed in and there is work → promote" test cannot tell those apart
+ * and would silently upload the first case. The ref is what draws the line — it
+ * is set only while the session is genuinely anonymous with work in hand, so a
+ * page loaded already signed in never arms it.
+ */
+export function AnonymousWorkPromoter() {
+  // Split so the Convex hook below is never reached without a provider — see
+  // `AnonymousWorkPromoter` for why that is not optional.
+  if (!isConvexConfigured) return null
+  return <ConnectedPromoter />
+}
+
+/**
+ * The half that talks to Convex.
+ *
+ * **Never call a Convex hook unconditionally.** A build with no
+ * `VITE_CONVEX_URL` — CI, a fresh checkout, a deliberately backend-free deploy —
+ * mounts no Convex context at all, and `useMutation` throws on the spot. Mounted
+ * at the root as this is, that throw takes the entire app down: the first-run
+ * welcome never renders and every route is blank. The e2e smoke test caught
+ * exactly that, which is what it is for.
+ *
+ * The gate has to be a separate component rather than an early return in the
+ * one below, because hooks cannot sit behind a condition.
+ */
+function ConnectedPromoter() {
+  const claimLocal = useMutation(api.entities.claimLocal)
+  const [error, setError] = useState<string | null>(null)
+
+  /** Armed only by an anonymous session that had work. See the header. */
+  const armed = useRef(false)
+  /** Stops a re-render mid-promotion starting a second one. */
+  const running = useRef(false)
+
+  const backend = selectBackend()
+  const pilots = useEntityStore((s) => s.list('pilot'))
+  const mechs = useEntityStore((s) => s.list('mech'))
+  const crawlers = useEntityStore((s) => s.list('crawler'))
+  const hasWork = pilots.length + mechs.length + crawlers.length > 0
+
+  useEffect(() => {
+    if (backend === 'memory' && hasWork) {
+      armed.current = true
+      return
+    }
+
+    // `remote` rather than "not memory" so a Disconnected reader, who cannot
+    // write at all, never starts a promotion that would fail halfway through.
+    if (backend !== 'remote' || !armed.current || running.current) return
+
+    running.current = true
+    const work = captureAnonymousWork()
+    if (countAnonymousWork(work) === 0) {
+      armed.current = false
+      running.current = false
+      return
+    }
+
+    void promoteAnonymousWork(claimLocal, work)
+      .then(() => {
+        armed.current = false
+      })
+      .catch((err: unknown) => {
+        // Nothing is lost when this fails — the caches still hold the work — so
+        // it reports and stops rather than retrying into a loop against a server
+        // that is refusing. `armed` stays true so a later attempt can pick it up.
+        if (isServerRefusal(err)) setError(serverMessage(err))
+        else {
+          captureException(err)
+          setError('That could not be saved to your account. Try again.')
+        }
+      })
+      .finally(() => {
+        running.current = false
+      })
+  }, [backend, hasWork, claimLocal])
+
+  if (error === null) return null
+  return (
+    <div className="border-b-2 border-ink bg-paper px-4 py-3">
+      <Text variant="hint" className="text-left text-[var(--color-roll-cascade)]">
+        {error}
+      </Text>
+    </div>
+  )
+}

--- a/apps/itun/src/lib/account/__tests__/promoteAnonymousWork.test.ts
+++ b/apps/itun/src/lib/account/__tests__/promoteAnonymousWork.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Promoting anonymous work into an account (ADR-034 decision 1, plan phase P3).
+ *
+ * Two properties matter here and they pull in opposite directions: everything
+ * the visitor built must reach the server, and **nothing they did not ask to
+ * upload may reach it**. The second is the one with a rule behind it — see
+ * `AnonymousWorkPromoter`'s header on why an existing roster is offered rather
+ * than promoted.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { pilotFixture } from '../../../components/__tests__/fixtures'
+import { useEntityStore } from '../../../stores/entityStore'
+import {
+  captureAnonymousWork,
+  countAnonymousWork,
+  promoteAnonymousWork,
+} from '../promoteAnonymousWork'
+
+/** A claimLocal stand-in that records what it was handed. */
+function recordingClaim() {
+  const calls: Record<string, unknown>[] = []
+  const fn = async (args: Record<string, unknown>) => {
+    calls.push(args)
+    return { claimed: 0, skipped: 0, alreadyPresent: 0, byKind: {} }
+  }
+  return { fn, calls }
+}
+
+afterEach(async () => {
+  // The entity store is a module singleton; leaving rows behind would leak into
+  // the next file (see .claude/rules/testing-patterns.md on process-global state).
+  const store = useEntityStore.getState()
+  for (const type of ['pilot', 'mech', 'crawler'] as const) {
+    for (const row of store.list(type)) await store.forget(type, row.id)
+  }
+})
+
+describe('countAnonymousWork', () => {
+  test('counts builds, not wiring', () => {
+    const n = countAnonymousWork({
+      pilots: [{}, {}],
+      mechs: [{}],
+      crawlers: [],
+      softLinks: [{}, {}, {}],
+      mechPatterns: [{}],
+    })
+
+    // 2 pilots + 1 mech + 1 pattern. The three soft links are deliberately not
+    // counted: they are wiring between things rather than things, so including
+    // them would make the banner say "7 builds" for a roster of four.
+    expect(n).toBe(4)
+  })
+
+  test('an empty capture is zero, so the banner stays away', () => {
+    expect(
+      countAnonymousWork({
+        pilots: [],
+        mechs: [],
+        crawlers: [],
+        softLinks: [],
+        mechPatterns: [],
+      })
+    ).toBe(0)
+  })
+})
+
+describe('captureAnonymousWork', () => {
+  test('reads what the store is holding', async () => {
+    // `adopt` rather than `create`: this test is about the capture, and adopt
+    // takes a whole record so the shared fixture can be used verbatim instead
+    // of hand-rolling a Pilot the schema would reject.
+    await useEntityStore.getState().adopt('pilot', pilotFixture({ id: 'cap-1' }))
+
+    const work = captureAnonymousWork()
+    expect(work.pilots).toHaveLength(1)
+  })
+})
+
+describe('promoteAnonymousWork', () => {
+  test('hands every kind to the server, wiring included', async () => {
+    const claim = recordingClaim()
+    const work = {
+      pilots: [{ id: 'p1' }],
+      mechs: [{ id: 'm1' }],
+      crawlers: [{ id: 'c1' }],
+      softLinks: [{ id: 'l1' }],
+      mechPatterns: [{ id: 'pat1' }],
+    }
+
+    await promoteAnonymousWork(claim.fn as never, work)
+
+    // Soft links and patterns are excluded from the *count* but must still be
+    // sent — a roster that arrives unwired, or without its saved patterns, is a
+    // partial save presented as a complete one.
+    const sent = claim.calls[0]
+    expect(sent?.pilots).toHaveLength(1)
+    expect(sent?.mechs).toHaveLength(1)
+    expect(sent?.crawlers).toHaveLength(1)
+    expect(sent?.softLinks).toHaveLength(1)
+    expect(sent?.mechPatterns).toHaveLength(1)
+  })
+
+  test('a local cache failure does NOT fail the save', async () => {
+    const claim = recordingClaim()
+
+    // `{ id: 'p1' }` does not parse as a Pilot, so adoption throws. The server
+    // write already landed, so this must still resolve: reporting a failure
+    // after a successful save is how one save becomes two.
+    const result = await promoteAnonymousWork(claim.fn as never, {
+      pilots: [{ id: 'p1' }],
+      mechs: [],
+      crawlers: [],
+      softLinks: [],
+      mechPatterns: [],
+    })
+
+    expect(result.claimed).toBe(0)
+    expect(claim.calls).toHaveLength(1)
+  })
+
+  test('a server refusal propagates rather than being swallowed', async () => {
+    const failing = async () => {
+      throw new Error('nope')
+    }
+
+    // The caller reports this and leaves the work in the caches. Swallowing it
+    // would show a saved roster that the server never received — the exact
+    // silent-divergence failure ADR-034 exists to end.
+    await expect(
+      promoteAnonymousWork(failing as never, {
+        pilots: [{ id: 'p1' }],
+        mechs: [],
+        crawlers: [],
+        softLinks: [],
+        mechPatterns: [],
+      })
+    ).rejects.toThrow('nope')
+  })
+
+  test('an empty promotion still calls through, and asks for nothing', async () => {
+    const claim = recordingClaim()
+    await promoteAnonymousWork(claim.fn as never, {
+      pilots: [],
+      mechs: [],
+      crawlers: [],
+      softLinks: [],
+      mechPatterns: [],
+    })
+
+    expect(claim.calls).toHaveLength(1)
+    expect(claim.calls[0]?.pilots).toEqual([])
+  })
+})

--- a/apps/itun/src/lib/account/promoteAnonymousWork.ts
+++ b/apps/itun/src/lib/account/promoteAnonymousWork.ts
@@ -1,0 +1,143 @@
+/**
+ * Turning anonymous work into saved work.
+ *
+ * ADR-034 decision 1 lets a visitor build without an account, in memory, and
+ * requires an account only to **keep** what they built. This module is the
+ * "keep" half: it takes everything sitting in the anonymous stores and writes
+ * it to Convex, then fills the local cache from the same rows.
+ *
+ * ## The hazard this module exists to handle
+ *
+ * `selectBackend()` reads live auth state, so the instant a sign-in resolves it
+ * flips from `memory` to `remote` — and `dbStoreFor` starts returning the
+ * IndexedDB stores instead of the Maps. The Maps are still there, but **nothing
+ * reads them any more**, and the first `rehydrate()` after that point overwrites
+ * the in-memory cache with what IndexedDB holds, which for a brand-new visitor
+ * is nothing at all.
+ *
+ * So the work must be **captured from the Zustand cache** (which survives the
+ * flip, because it is neither backend) and promoted before anything re-reads.
+ * Capturing from `dbStoreFor` instead would race the flip and silently promote
+ * an empty roster — the failure mode being: user signs in to save, is told it
+ * worked, and finds an empty account.
+ *
+ * ## Why this promotes rather than offers
+ *
+ * `ClaimLocalData` deliberately *offers* — uploading somebody's existing roster
+ * the moment they sign in is a decision made with their data, and signing in to
+ * look at a friend's game should not publish your own builds. That reasoning
+ * does not apply here and the difference is consent, not mechanism: this path is
+ * only reached because the user pressed a control that says "sign in to save
+ * this". Asking again immediately afterwards would be asking whether they meant
+ * the thing they just asked for.
+ *
+ * The mutation underneath is the same `entities.claimLocal`, which is already
+ * idempotent — it skips anything it already holds — so a promotion that runs
+ * twice is a no-op rather than a duplicate roster.
+ */
+
+import type { useMutation } from 'convex/react'
+import type { api } from '../../../convex/_generated/api'
+import { useEntityStore } from '../../stores/entityStore'
+import { usePatternStore } from '../../stores/patternStore'
+
+/** Everything an anonymous session can be holding. */
+export type AnonymousWork = {
+  pilots: unknown[]
+  mechs: unknown[]
+  crawlers: unknown[]
+  softLinks: unknown[]
+  mechPatterns: unknown[]
+}
+
+/**
+ * Read the anonymous work out of the in-memory caches.
+ *
+ * Synchronous and from `getState()` on purpose — see the header. This must not
+ * await anything, because an await is a window in which the backend can flip.
+ */
+export function captureAnonymousWork(): AnonymousWork {
+  const entities = useEntityStore.getState()
+  return {
+    pilots: entities.list('pilot'),
+    mechs: entities.list('mech'),
+    crawlers: entities.list('crawler'),
+    softLinks: entities.list('softLink'),
+    mechPatterns: usePatternStore.getState().list(),
+  }
+}
+
+/** How many records a capture holds. Zero means there is nothing to offer. */
+export function countAnonymousWork(work: AnonymousWork): number {
+  return (
+    work.pilots.length + work.mechs.length + work.crawlers.length + work.mechPatterns.length
+    // Soft links are deliberately excluded from the COUNT: they are wiring
+    // between things rather than things, so "3 builds" reads correctly while
+    // "5 builds" (with two links) would not. They are still promoted.
+  )
+}
+
+type ClaimLocal = ReturnType<typeof useMutation<typeof api.entities.claimLocal>>
+
+export type PromotionResult = {
+  claimed: number
+  skipped: number
+  alreadyPresent: number
+}
+
+/**
+ * Write captured anonymous work to the server, then cache it locally.
+ *
+ * Takes the mutation as an argument rather than calling `useMutation` itself,
+ * so this stays a plain function testable without a Convex provider — the same
+ * shape the rest of `src/lib` uses.
+ *
+ * The local adoption is not decoration. Without it the UI would keep rendering
+ * the Maps until something happened to re-read, and the first rehydrate would
+ * blank the roster even though the server now holds it — correct data, and a
+ * screen that says otherwise.
+ */
+export async function promoteAnonymousWork(
+  claimLocal: ClaimLocal,
+  work: AnonymousWork
+): Promise<PromotionResult> {
+  const result = await claimLocal({
+    pilots: work.pilots,
+    mechs: work.mechs,
+    crawlers: work.crawlers,
+    softLinks: work.softLinks,
+    mechPatterns: work.mechPatterns,
+  })
+
+  // Adopt keeps each record's own id, so the local copy IS the entity rather
+  // than a fork of it — the same reason `GameRoster.ensureLocal` uses adopt.
+  // **A failed adoption must not fail the promotion.** The server write above
+  // has already landed, so the work IS saved; adoption only fills the local
+  // cache. Letting a parse failure here throw would tell the user their save
+  // failed immediately after it succeeded, and would very likely make them try
+  // again — which is how one save becomes two. A cache that is briefly empty
+  // heals on the next read; a false failure message does not.
+  const store = useEntityStore.getState()
+  for (const [kind, rows] of [
+    ['pilot', work.pilots],
+    ['mech', work.mechs],
+    ['crawler', work.crawlers],
+    ['softLink', work.softLinks],
+  ] as const) {
+    for (const row of rows) {
+      try {
+        await store.adopt(kind, row as never)
+      } catch (err) {
+        // Worth knowing about — a row the server accepted that this build
+        // cannot parse is a real schema disagreement — but not worth failing on.
+        console.warn(`[itun] promoted ${kind} but could not cache it locally`, err)
+      }
+    }
+  }
+
+  return {
+    claimed: result.claimed,
+    skipped: result.skipped,
+    alreadyPresent: result.alreadyPresent,
+  }
+}

--- a/apps/itun/src/routes/__root.tsx
+++ b/apps/itun/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import { createRootRoute, Outlet } from '@tanstack/react-router'
 import { AppHeader, EntityHrefProvider, RecoveryPanel, Toaster } from 'component-lib'
 import { useState } from 'react'
 import { AccountStrip } from '../components/account/AccountStrip'
+import { AnonymousWorkPromoter, UnsavedWorkBanner } from '../components/account/UnsavedWorkBanner'
 import { AppConvexProvider } from '../components/shared/AppConvexProvider'
 import { AppLink } from '../components/shared/AppLink'
 import { BackupNudgeToast } from '../components/shared/BackupNudgeToast'
@@ -83,6 +84,14 @@ function RootComponent() {
             data, so it paints immediately instead of sitting behind the full
             preload. */}
           <NotConnectedBanner />
+          {/* The account gate (ADR-034 decision 1). Both live here, above the
+              game-data gate, because they are facts about the SESSION rather
+              than about any route: work that will not survive the tab is worth
+              saying on every screen, and the promoter has to outlive the banner
+              — signing in unmounts the banner at exactly the moment the
+              promotion needs to run. */}
+          <UnsavedWorkBanner />
+          <AnonymousWorkPromoter />
           <AppHeader
             onSearchClick={() => setSearchOpen(true)}
             LinkComponent={AppLink}

--- a/apps/itun/src/stores/encounterStore.ts
+++ b/apps/itun/src/stores/encounterStore.ts
@@ -15,8 +15,11 @@ import { create } from 'zustand'
 import type { Container } from '../lib/container'
 import { containerOf, sameContainer } from '../lib/container'
 import * as db from '../lib/db/index'
+import { makeMemoryStore } from '../lib/db/memoryStore'
 import { STORE_NAMES } from '../lib/db/stores'
 import type { EncounterNpc } from '../lib/schemas/encounterNpc'
+import { EncounterNpcSchema } from '../lib/schemas/encounterNpc'
+import { selectBackend } from './entityBackend'
 import type { HydratedCollectionActions, HydratedCollectionSlice } from './makeHydratedCollection'
 import { makeHydratedCollectionSlice, wireCrossTabInvalidation } from './makeHydratedCollection'
 
@@ -32,10 +35,16 @@ type EncounterState = HydratedCollectionSlice<'encounterNpcs', EncounterNpc> &
     listForContainer: (container: Container | null) => EncounterNpc[]
   }
 
+/** The anonymous backing for the NPC tray — see `patternStore` for the shape. */
+const memoryNpcs = makeMemoryStore(EncounterNpcSchema, STORE_NAMES.encounterNpcs, {
+  hasUpdatedAt: true,
+})
+
 const slice = makeHydratedCollectionSlice<'encounterNpcs', EncounterNpc, EncounterNpcCreateInput>({
   key: 'encounterNpcs',
-  db: db.encounterNpcs,
+  db: () => (selectBackend() === 'memory' ? memoryNpcs : db.encounterNpcs),
   storeName: STORE_NAMES.encounterNpcs,
+  shouldBroadcast: () => selectBackend() !== 'memory',
 })
 
 export const useEncounterStore = create<EncounterState>((set, get) => ({

--- a/apps/itun/src/stores/makeHydratedCollection.ts
+++ b/apps/itun/src/stores/makeHydratedCollection.ts
@@ -57,9 +57,32 @@ export type HydratedCollectionActions<T, CreateInput> = {
 type SliceConfig<K extends string, T, CreateInput> = {
   /** State key holding the array — preserved per store for selector compat. */
   key: K
-  db: DbCollection<T, CreateInput>
+  /**
+   * Where this collection persists, resolved **per call** rather than captured.
+   *
+   * A function rather than a value because the answer changes with auth state:
+   * an anonymous visitor writes to a Map that never touches disk (ADR-034
+   * decision 1), and a signed-in one writes to IndexedDB. Capturing the
+   * collection once at module scope would pin whichever backend happened to be
+   * current when the store file was first imported — for a page loaded signed
+   * out, that is the memory store *for the rest of the session*, including
+   * after signing in.
+   *
+   * This mirrors `entityStore`'s `dbStoreFor` for the same reason and should
+   * stay in step with it.
+   */
+  db: () => DbCollection<T, CreateInput>
   /** Broadcast channel name; also drives the cross-tab subscription. */
   storeName: StoreName
+  /**
+   * Whether a write should be announced to other tabs.
+   *
+   * Anonymous sessions do not broadcast: two tabs hold two unrelated Maps, so
+   * telling tab B to re-read would blank the work it is holding. Optional so
+   * a store with no anonymous mode keeps its current behaviour by saying
+   * nothing.
+   */
+  shouldBroadcast?: () => boolean
 }
 
 type SetLike = (partial: object | ((state: never) => object)) => void
@@ -74,10 +97,10 @@ export function makeHydratedCollectionSlice<
   T extends { id: string },
   CreateInput,
 >(config: SliceConfig<K, T, CreateInput>) {
-  const { key, db, storeName } = config
+  const { key, db, storeName, shouldBroadcast } = config
 
   function afterWrite(): void {
-    publishStoreChange(storeName)
+    if (shouldBroadcast === undefined || shouldBroadcast()) publishStoreChange(storeName)
     recordDataWrite()
   }
 
@@ -100,7 +123,7 @@ export function makeHydratedCollectionSlice<
       },
 
       async rehydrate() {
-        const loaded = await db.list()
+        const loaded = await db().list()
         set({ [key]: loaded, hydrated: true })
       },
 
@@ -119,21 +142,21 @@ export function makeHydratedCollectionSlice<
       },
 
       async create(input) {
-        const record = await db.create(input)
+        const record = await db().create(input)
         set({ [key]: [record, ...records()] })
         afterWrite()
         return record
       },
 
       async update(id, patch) {
-        const updated = await db.update(id, patch)
+        const updated = await db().update(id, patch)
         set({ [key]: records().map((r) => (r.id === id ? updated : r)) })
         afterWrite()
         return updated
       },
 
       async delete(id) {
-        await db.delete(id)
+        await db().delete(id)
         set({ [key]: records().filter((r) => r.id !== id) })
         afterWrite()
       },

--- a/apps/itun/src/stores/patternStore.ts
+++ b/apps/itun/src/stores/patternStore.ts
@@ -14,8 +14,11 @@
 
 import { create } from 'zustand'
 import * as db from '../lib/db/index'
+import { makeMemoryStore } from '../lib/db/memoryStore'
 import { STORE_NAMES } from '../lib/db/stores'
 import type { MechPattern } from '../lib/schemas/pattern'
+import { MechPatternSchema } from '../lib/schemas/pattern'
+import { selectBackend } from './entityBackend'
 import type { HydratedCollectionActions, HydratedCollectionSlice } from './makeHydratedCollection'
 import { makeHydratedCollectionSlice, wireCrossTabInvalidation } from './makeHydratedCollection'
 
@@ -25,10 +28,21 @@ export type MechPatternCreateInput = Omit<MechPattern, 'id' | 'createdAt' | 'upd
 type PatternState = HydratedCollectionSlice<'mechPatterns', MechPattern> &
   HydratedCollectionActions<MechPattern, MechPatternCreateInput>
 
+/**
+ * The anonymous backing for saved patterns (ADR-034 decision 1).
+ *
+ * Built at module scope so it HOLDS the rows: a store created per call would
+ * hand every read an empty Map. Mirrors `entityStore`'s `MEMORY_STORES`.
+ */
+const memoryPatterns = makeMemoryStore(MechPatternSchema, STORE_NAMES.mechPatterns, {
+  hasUpdatedAt: true,
+})
+
 const slice = makeHydratedCollectionSlice<'mechPatterns', MechPattern, MechPatternCreateInput>({
   key: 'mechPatterns',
-  db: db.mechPatterns,
+  db: () => (selectBackend() === 'memory' ? memoryPatterns : db.mechPatterns),
   storeName: STORE_NAMES.mechPatterns,
+  shouldBroadcast: () => selectBackend() !== 'memory',
 })
 
 export const usePatternStore = create<PatternState>((set, get) => ({

--- a/docs/architecture/persistence-and-pwa.md
+++ b/docs/architecture/persistence-and-pwa.md
@@ -41,7 +41,7 @@ Update this table as part of each phase's PR. It is the only place that answers
 | P0    | Make every container model expressible (schema only)       | yes        | **done**    |
 | P1    | Test and e2e path that does not depend on Solo             | yes        | **provider done** — fixture with P3 |
 | P2    | In-memory anonymous mode (backend built, flag OFF)         | yes        | **done**    |
-| P3    | Gate persistence on an account                             | **no**     | not started |
+| P3    | Gate persistence on an account (mechanism; flip deferred)  | yes        | **done**    |
 | P4    | Demote IndexedDB to a cache; wire all six stores, no mirrors | **no**    | not started |
 | P5    | Claim-on-sign-in coverage and the decline path             | yes        | not started |
 | P6    | ITUN install-triggered offline                             | yes        | not started |
@@ -309,7 +309,23 @@ first. Asserting them now would mean shipping the gate with no way to explain it
 
 ## P3 — Gate persistence on an account
 
-**One-way door.** This is the phase that withdraws ADR-030 §1's guarantee.
+**Deliberately NOT the one-way door any more — the plan was wrong about this.**
+
+As written, P3 both built the gate and flipped the switch. Trying to execute it
+surfaced the problem: flipping the switch routes anonymous users to the memory
+backend, and **an existing Solo user's IndexedDB roster then stops being read**.
+That breaks this plan's own rule that no phase may leave data reachable from
+fewer places than before it ran — and it breaks it *before* P5, which is the
+phase that gives those users a claim path.
+
+So P3 is split. This phase builds the whole mechanism — gate, promotion, and the
+stores that still wrote durably while signed out — and leaves
+`VITE_REQUIRE_ACCOUNT` **off**. The flip becomes its own small, deliberate layer
+**after P5**, when there is a claim path for every existing roster to take.
+
+That is strictly safer and costs nothing: a mechanism nobody is routed to yet
+cannot strand anyone, and the flip is then one line whose blast radius is
+obvious.
 
 **Work.** Save requires a session. The ask arrives at the save, naming what is
 being kept — not on load, and not in front of the wizard. Anonymous work


### PR DESCRIPTION
**Layer 2 of the ADR-034 stack.** Base: `feat/adr034-p1-test-auth` (#874).

Builds the whole "sign in to keep this" mechanism. **Does not flip the switch.**

## The plan was wrong about P3, and executing it is what showed why

P3 was written as the one-way door — build the gate *and* turn it on. Turning it on routes anonymous users to the memory backend, at which point **an existing Solo user's IndexedDB roster stops being read**. That breaks this plan's own rule that no phase may leave data reachable from fewer places than before it ran, and it breaks it two phases before P5 gives those users a claim path.

So the flip is deferred to its own small layer after P5. A mechanism nobody is routed to yet cannot strand anyone, and the flip is then one line whose blast radius is obvious.

## Three parts

**`UnsavedWorkBanner`** appears only once there *is* work — the ADR is explicit that the ask arrives when the user has something worth keeping, not in front of a product they have not tried. It names the count, and it puts the download **beside** the sign-in rather than behind it: Discord-only means this banner is a hard wall for anyone without a Discord account, and export is what keeps that from being a data-loss event. Not dismissible — it states a fact about the session, and a dismissed banner leaves someone believing their build was saved.

**`promoteAnonymousWork`** handles the hazard that makes this phase risky. `selectBackend()` reads live auth state, so a sign-in flips it to `remote` and `dbStoreFor` starts returning IndexedDB — the Maps are still there but nothing reads them, and the first rehydrate blanks the cache. The work is therefore captured **synchronously from the Zustand cache**, which survives the flip because it is neither backend. Capturing from `dbStoreFor` would race it and promote an empty roster: user signs in to save, is told it worked, finds an empty account.

**`AnonymousWorkPromoter`** is separate from the banner because signing in unmounts the banner at exactly the moment the promotion needs to run. It promotes **only work this session built anonymously**, tracked by a ref armed while genuinely anonymous. A naive "signed in and there is work" test cannot tell that from a returning user's existing roster and would silently upload it — which is the consent rule `ClaimLocalData` exists to honour.

## Also closes a gap inherited from P2

`patternStore` and `encounterStore` still wrote to IndexedDB regardless of backend, so "nothing is written" was **not true** for patterns or NPCs. Both now resolve their collection per call, and `makeHydratedCollection` takes a resolver rather than a captured value — same reasoning as `dbStoreFor`, since capturing once pins whichever backend was current at first import.

## A defect the tests found

An adoption failure used to reject the whole promotion — reporting "could not save" immediately **after** the server write landed. That invites a retry, and that is how one save becomes two. Adoption is now non-fatal and warns: the cache heals on the next read, a false failure message does not. There is a test for it.

## Verification

`bun run check:all` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QU5rmidxZ3QUrMb3nvVNX6
