### PR TITLE
feat(itun): P4 — fill the cache from the server; the read path was missing

### DIFF
--- a/apps/itun/convex/entities.ts
+++ b/apps/itun/convex/entities.ts
@@ -193,6 +193,75 @@ export const listForGame = query({
  * entity is an offer to the crew, and a player making one would be dropping
  * their own character into the pool rather than offering anything.
  */
+/**
+ * Everything this account owns, for filling the local cache.
+ *
+ * ## Why this did not exist, and why that was a bug
+ *
+ * Writes have mirrored **up** since ADR-030, but nothing ever read back **down**
+ * outside a Game (`listForGame`). The consequence is not subtle: a signed-in
+ * player opening ITUN on a second device saw an **empty roster**. Their builds
+ * were in Convex the whole time; there was simply no query that would return
+ * them. The only path down was `claimLocal`, which is for pushing a local roster
+ * up, and `GameRoster`, which is scoped to one Game.
+ *
+ * That is the gap that makes "IndexedDB is a cache" untrue as a description: a
+ * cache is something that can be *filled*, and until this there was nothing to
+ * fill it from ([ADR-034](../../../docs/adrs/ADR-034-account-required-persistence.md)
+ * decision 2).
+ *
+ * ## Owned, not shelved
+ *
+ * Deliberately every row the caller **owns**, whether it is on their shelf or
+ * in a Game, rather than the shelf alone. A Game entity you own is still yours
+ * and still belongs on your roster; scoping this to `gameId === null` would make
+ * a build vanish from the local cache the moment it was taken into a campaign,
+ * and reappear when the campaign ended.
+ *
+ * Unclaimed rows are excluded by construction — they have no `ownerId`, so the
+ * index cannot return them. That is right: an unclaimed pre-gen sitting in a
+ * Game belongs to the Game's view (`listForGame`), not to anybody's roster.
+ *
+ * The crawler is included on the same rule, which is only expressible at all
+ * because #871 gave it an owner.
+ */
+export const listMine = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await requireUser(ctx)
+
+    const [pilots, mechs, crawlers, patterns] = await Promise.all([
+      ctx.db
+        .query('pilots')
+        .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+        .collect(),
+      ctx.db
+        .query('mechs')
+        .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+        .collect(),
+      ctx.db
+        .query('crawlers')
+        .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+        .collect(),
+      ctx.db
+        .query('mechPatterns')
+        .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+        .collect(),
+    ])
+
+    // Bodies only. The caller is filling a local store whose records are keyed
+    // by the app-level id inside the body, so a Convex `_id` would be noise —
+    // and `appId` rides along separately for the rows that carry one, because
+    // that is what the mirror addresses by.
+    return {
+      pilots: pilots.map((r) => ({ appId: r.appId ?? null, body: r.body })),
+      mechs: mechs.map((r) => ({ appId: r.appId ?? null, body: r.body })),
+      crawlers: crawlers.map((r) => ({ appId: r.appId ?? null, body: r.body })),
+      mechPatterns: patterns.map((r) => ({ body: r.body })),
+    }
+  },
+})
+
 export const create = mutation({
   args: {
     table: OWNABLE,

--- a/apps/itun/src/components/account/ShelfSync.tsx
+++ b/apps/itun/src/components/account/ShelfSync.tsx
@@ -1,0 +1,102 @@
+/**
+ * ShelfSync — fills the local cache from the server of record.
+ *
+ * This is the half of ADR-034 decision 2 that was missing. Writes have mirrored
+ * **up** since ADR-030, but nothing outside a Game ever read back **down**, so a
+ * signed-in player opening ITUN on a second device saw an empty roster while
+ * their builds sat in Convex the whole time. "IndexedDB is a cache" was a
+ * description of intent rather than of behaviour: a cache is something that can
+ * be filled, and there was nothing to fill it from.
+ *
+ * ## Server wins, and that is the point
+ *
+ * Every row that comes down is adopted over whatever the cache held. There is no
+ * merge and no conflict resolution, because with one source of truth there is no
+ * second writer to conflict with — that is the whole benefit ADR-034 buys, and
+ * reintroducing a merge here would spend it.
+ *
+ * `adopt` keeps each record's own id, so the local copy **is** the entity rather
+ * than a fork of it, and it deliberately skips `requireWritableBackend`: filling
+ * a cache is not a user write, and a Disconnected reader must still be able to
+ * open what they already pulled down.
+ *
+ * ## What it does NOT do
+ *
+ * It does not delete local rows the server does not return. That would be the
+ * honest completion of "the cache is a reflection", and it is deliberately left
+ * for the phase that turns the account gate on: until then a Solo user's
+ * IndexedDB is still their source of truth, and pruning it against a server that
+ * has never heard of those rows would delete their roster. The plan records this
+ * as the remaining half of the demotion.
+ */
+
+import { useQuery } from 'convex/react'
+import { useEffect, useRef } from 'react'
+import { api } from '../../../convex/_generated/api'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+import { captureException } from '../../lib/observability'
+import { selectBackend } from '../../stores/entityBackend'
+import { useEntityStore } from '../../stores/entityStore'
+
+type Row = { appId?: string | null; body: unknown }
+
+function ConnectedShelfSync() {
+  // `undefined` while in flight — the Convex convention, not a loading flag.
+  const mine = useQuery(api.entities.listMine, {})
+  /**
+   * Which payload has already been adopted.
+   *
+   * `listMine` is a live subscription, so it re-emits on every server change —
+   * including the ones this component's own adoptions do not cause but a
+   * mirrored write does. Without this guard each emission would re-adopt the
+   * whole roster, which is a write storm rather than a sync.
+   */
+  const lastAdopted = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (mine === undefined) return
+
+    const stamp = JSON.stringify([
+      mine.pilots.length,
+      mine.mechs.length,
+      mine.crawlers.length,
+      mine.mechPatterns.length,
+    ])
+    if (lastAdopted.current === stamp) return
+    lastAdopted.current = stamp
+
+    void (async () => {
+      const store = useEntityStore.getState()
+      for (const [kind, rows] of [
+        ['pilot', mine.pilots],
+        ['mech', mine.mechs],
+        ['crawler', mine.crawlers],
+      ] as const) {
+        for (const row of rows as Row[]) {
+          try {
+            await store.adopt(kind, row.body as never)
+          } catch (err) {
+            // One unreadable row must not stop the rest of the roster arriving.
+            // A body the server accepted that this build cannot parse is a real
+            // schema disagreement worth reporting, but the other builds are
+            // fine and the player should see them.
+            captureException(err)
+          }
+        }
+      }
+    })()
+  }, [mine])
+
+  return null
+}
+
+export function ShelfSync() {
+  // Never call a Convex hook unconditionally: a build with no `VITE_CONVEX_URL`
+  // mounts no provider at all. Gating the whole subtree is the established
+  // pattern here (`AccountStrip`, `SignInControl`).
+  if (!isConvexConfigured) return null
+  // Only when the server of record is actually in play. `remote` rather than
+  // "signed in" so a Disconnected session does not fire a query it cannot serve.
+  if (selectBackend() !== 'remote') return null
+  return <ConnectedShelfSync />
+}

--- a/apps/itun/src/routes/__root.tsx
+++ b/apps/itun/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import { createRootRoute, Outlet } from '@tanstack/react-router'
 import { AppHeader, EntityHrefProvider, RecoveryPanel, Toaster } from 'component-lib'
 import { useState } from 'react'
 import { AccountStrip } from '../components/account/AccountStrip'
+import { ShelfSync } from '../components/account/ShelfSync'
 import { AnonymousWorkPromoter, UnsavedWorkBanner } from '../components/account/UnsavedWorkBanner'
 import { AppConvexProvider } from '../components/shared/AppConvexProvider'
 import { AppLink } from '../components/shared/AppLink'
@@ -92,6 +93,10 @@ function RootComponent() {
               promotion needs to run. */}
           <UnsavedWorkBanner />
           <AnonymousWorkPromoter />
+          {/* Fills the local cache from the server of record. Renders nothing;
+              mounted here because a roster is needed on every route, not only
+              the one that happens to list it. */}
+          <ShelfSync />
           <AppHeader
             onSearchClick={() => setSearchOpen(true)}
             LinkComponent={AppLink}

--- a/apps/itun/test/convex/listMine.test.ts
+++ b/apps/itun/test/convex/listMine.test.ts
@@ -1,0 +1,121 @@
+/**
+ * `entities.listMine` — the read that makes "IndexedDB is a cache" true.
+ *
+ * Until this existed, writes mirrored up and nothing outside a Game read back
+ * down, so a signed-in player on a second device saw an empty roster while
+ * their builds sat in Convex. These tests pin the two things that were easy to
+ * get wrong: it returns what you own **wherever it lives**, and it returns
+ * nothing that is not yours.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { api } from '../../convex/_generated/api'
+import { testConvex } from './harness'
+
+async function makeUser(t: ReturnType<typeof testConvex>, name: string) {
+  const userId = await t.run(async (ctx) => await ctx.db.insert('users', { name }))
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+describe('listMine returns what the caller owns', () => {
+  test('a shelved pilot comes back', async () => {
+    const t = testConvex()
+    const me = await makeUser(t, 'Me')
+    await t.run(
+      async (ctx) =>
+        await ctx.db.insert('pilots', {
+          gameId: null,
+          ownerId: me.userId,
+          body: { callsign: 'Roach-Boy' },
+          updatedAt: 1,
+        })
+    )
+
+    const mine = await me.as.query(api.entities.listMine, {})
+    expect(mine.pilots).toHaveLength(1)
+  })
+
+  test('a pilot you own INSIDE a game comes back too', async () => {
+    const t = testConvex()
+    const me = await makeUser(t, 'Me')
+    const gameId = await t.run(async (ctx) => await ctx.db.insert('games', { name: 'Table' }))
+    await t.run(
+      async (ctx) =>
+        await ctx.db.insert('pilots', {
+          gameId,
+          ownerId: me.userId,
+          body: { callsign: 'In play' },
+          updatedAt: 1,
+        })
+    )
+
+    // Scoping this to the shelf would make a build vanish from the local cache
+    // the moment it was taken into a campaign, and reappear when the campaign
+    // ended. It is still yours either way.
+    const mine = await me.as.query(api.entities.listMine, {})
+    expect(mine.pilots).toHaveLength(1)
+  })
+
+  test('the crawler comes back — only possible since #871 gave it an owner', async () => {
+    const t = testConvex()
+    const me = await makeUser(t, 'Me')
+    await t.run(
+      async (ctx) =>
+        await ctx.db.insert('crawlers', {
+          gameId: null,
+          ownerId: me.userId,
+          body: { name: '#430' },
+          updatedAt: 1,
+        })
+    )
+
+    const mine = await me.as.query(api.entities.listMine, {})
+    expect(mine.crawlers).toHaveLength(1)
+  })
+})
+
+describe("listMine returns nothing that is not the caller's", () => {
+  test("another player's pilot is not returned", async () => {
+    const t = testConvex()
+    const me = await makeUser(t, 'Me')
+    const them = await makeUser(t, 'Them')
+    await t.run(
+      async (ctx) =>
+        await ctx.db.insert('pilots', {
+          gameId: null,
+          ownerId: them.userId,
+          body: { callsign: 'Not yours' },
+          updatedAt: 1,
+        })
+    )
+
+    const mine = await me.as.query(api.entities.listMine, {})
+    expect(mine.pilots).toEqual([])
+  })
+
+  test('an UNCLAIMED pilot in a game is not returned', async () => {
+    const t = testConvex()
+    const me = await makeUser(t, 'Me')
+    const gameId = await t.run(async (ctx) => await ctx.db.insert('games', { name: 'Table' }))
+    await t.run(
+      async (ctx) =>
+        await ctx.db.insert('pilots', {
+          gameId,
+          ownerId: null,
+          body: { callsign: 'Pre-gen' },
+          updatedAt: 1,
+        })
+    )
+
+    // Excluded by construction — no `ownerId` means the index cannot return it
+    // — and that is the right answer rather than a lucky one: an unclaimed
+    // pre-gen belongs to the Game's view, not to anybody's roster.
+    const mine = await me.as.query(api.entities.listMine, {})
+    expect(mine.pilots).toEqual([])
+  })
+
+  test('it refuses a caller with no account at all', async () => {
+    const t = testConvex()
+    await expect(t.query(api.entities.listMine, {})).rejects.toThrow(/signed in/i)
+  })
+})

--- a/docs/architecture/persistence-and-pwa.md
+++ b/docs/architecture/persistence-and-pwa.md
@@ -42,7 +42,7 @@ Update this table as part of each phase's PR. It is the only place that answers
 | P1    | Test and e2e path that does not depend on Solo             | yes        | **provider done** — fixture with P3 |
 | P2    | In-memory anonymous mode (backend built, flag OFF)         | yes        | **done**    |
 | P3    | Gate persistence on an account (mechanism; flip deferred)  | yes        | **done**    |
-| P4    | Demote IndexedDB to a cache; wire all six stores, no mirrors | **no**    | not started |
+| P4    | Demote IndexedDB to a cache (**read path done**; prune + mirror removal await the flip) | **no** | part done |
 | P5    | Claim-on-sign-in coverage and the decline path             | yes        | not started |
 | P6    | ITUN install-triggered offline                             | yes        | not started |
 | P7    | `srd` install-triggered offline (**blocked on ADR-033 P7**) | yes       | blocked     |
@@ -359,9 +359,27 @@ visit.
 
 ## P4 — Demote IndexedDB to a cache
 
-**One-way door.**
+**One-way door — and it splits, because half of it cannot precede the flip.**
 
-**Work.** Make the demotion true in code rather than in prose: the local store is
+**Done now (the read path).** A cache is something that can be *filled*, and
+until this there was nothing to fill it from: writes have mirrored **up** since
+ADR-030 but nothing outside a Game ever read back **down**, so a signed-in player
+opening ITUN on a second device saw an **empty roster** while their builds sat in
+Convex. `entities.listMine` + `ShelfSync` close that, server-wins, with no merge
+— there is no second writer to conflict with, which is the benefit ADR-034 buys.
+
+**Waiting for the flip.** Two pieces cannot land while Solo still exists, and
+attempting them early is how a roster gets deleted:
+
+- **Pruning local rows the server does not return.** That is the honest
+  completion of "the cache is a reflection", and today it would delete a Solo
+  user's entire IndexedDB, which the server has never heard of.
+- **Removing the mirrors.** `mirrorWrite` upserts *because* a Solo entity has no
+  server row yet, and is fire-and-forget *because* the local write is the one the
+  UI reads. Both premises are still true until the flip; removing them first
+  would break the mode that is still shipping.
+
+**Work still outstanding.** Make the demotion true in code rather than in prose: the local store is
 populated from Convex and read for speed, and nothing treats it as authoritative.
 `writesAllowed()`'s Solo branch goes; `resolveConnectionMode`'s two `'solo'`
 returns collapse. Reconciliation is a plain rule — the server wins — because


### PR DESCRIPTION
**Layer 3 of the ADR-034 stack.** Base: `feat/adr034-p3-account-gate` (#875).

## The bug this fixes is not subtle

"IndexedDB is a cache" was a description of *intent*, not of behaviour. A cache is something that can be **filled**, and there was nothing to fill it from: writes have mirrored **up** since ADR-030, but nothing outside a Game ever read back **down**.

So a signed-in player opening ITUN on a **second device saw an empty roster** — their builds were in Convex the whole time, and no query would return them. The only paths down were `claimLocal`, which pushes a local roster *up*, and `GameRoster`, scoped to one Game.

## What lands

`entities.listMine` returns every row the caller owns; `ShelfSync` adopts them over whatever the cache held. **Server wins, no merge** — with one source of truth there is no second writer to conflict with, and reintroducing a merge here would spend the exact benefit ADR-034 buys.

**Owned, not shelved**, deliberately. Scoping to `gameId === null` would make a build vanish from the local cache the moment it was taken into a campaign and reappear when the campaign ended. It is still yours either way.

**Unclaimed rows are excluded by construction** — no `ownerId` means the index cannot return them — and that is the right answer rather than a lucky one: an unclaimed pre-gen belongs to the Game's view, not to anybody's roster. The crawler is included on the same rule, which is only expressible because #871 gave it an owner.

`ShelfSync` guards against re-adopting on every emission: `listMine` is a live subscription that re-fires on any server change, so an unguarded effect is a write storm rather than a sync. One unreadable row is reported and skipped rather than stopping the rest of the roster arriving.

## P4 splits, and I want this called out in review

Two pieces of the demotion **cannot precede the flip**, and attempting them early is how a roster gets deleted:

- **Pruning local rows the server does not return.** The honest completion of "the cache is a reflection" — and today it would delete a Solo user's entire IndexedDB, which the server has never heard of.
- **Removing the mirrors.** `mirrorWrite` upserts *because* a Solo entity has no server row yet, and is fire-and-forget *because* the local write is what the UI reads. Both premises hold until Solo goes.

Both are recorded in the plan against the flip. This layer is the half that is safe today and is independently a bug fix.

## Verification

`bun run check:all` exits 0. Six new server tests cover owned-on-shelf, owned-in-game, the crawler, another player's row, an unclaimed row, and an unauthenticated caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QU5rmidxZ3QUrMb3nvVNX6
