### PR TITLE
feat(itun): the flip — account required in production, guarded for people already here

### DIFF
--- a/apps/itun/.env.production
+++ b/apps/itun/.env.production
@@ -1,0 +1,16 @@
+# Production-only build variables for ITUN.
+#
+# Vite loads this file for `mode=production` builds and for nothing else — not
+# `bun test`, not `bun run dev`, not a fresh checkout. That is exactly why the
+# account gate is turned on here rather than by defaulting the code to "on when
+# unset": a flag whose safe value depends on somebody remembering to set it is
+# the wrong way round, and defaulting it on flipped CI and the test runner too.
+#
+# It lives in one file rather than in each host's build command so the two
+# deploy paths cannot drift apart on it.
+#
+# See docs/adrs/ADR-034-account-required-persistence.md.
+
+# Persistence requires an account (ADR-034 decision 1). Anonymous visitors build
+# in memory; saving asks them to sign in, or to download what they have made.
+VITE_REQUIRE_ACCOUNT=true

--- a/apps/itun/src/lib/connection/ConnectionProvider.tsx
+++ b/apps/itun/src/lib/connection/ConnectionProvider.tsx
@@ -2,6 +2,7 @@ import { useConvexAuth } from 'convex/react'
 import type { ReactNode } from 'react'
 import { useEffect, useMemo, useState } from 'react'
 import { setEntityBackendAuthState } from '../../stores/entityBackend'
+import { probeLegacyLocalData } from '../db/legacyLocalData'
 import type { ConnectionState } from './connectionContext'
 import { ConnectionContext } from './connectionContext'
 import {
@@ -62,6 +63,25 @@ function useConnectionState(signedIn: boolean, authSettled: boolean): Connection
   useEffect(() => {
     setEntityBackendAuthState({ signedIn, online, authSettled })
   }, [signedIn, online, authSettled])
+
+  /**
+   * Ask once, at boot, whether this browser already holds a roster.
+   *
+   * The answer decides whether an anonymous visitor gets the in-memory backend
+   * or keeps reading their existing IndexedDB — see `lib/db/legacyLocalData.ts`.
+   * It lives here because this is already the one place that pushes session
+   * facts down to the stores, and `[]` because the probe caches its own result
+   * and must not re-run per render.
+   *
+   * `setProbed` exists to force the re-render that makes the new answer visible:
+   * `selectBackend()` reads the probe synchronously, so without a render nothing
+   * would notice it had resolved until some unrelated state change happened to
+   * repaint.
+   */
+  const [, setProbed] = useState(false)
+  useEffect(() => {
+    void probeLegacyLocalData().then(() => setProbed(true))
+  }, [])
 
   return useMemo(() => {
     const mode = resolveConnectionMode({

--- a/apps/itun/src/lib/db/__tests__/legacyLocalData.test.ts
+++ b/apps/itun/src/lib/db/__tests__/legacyLocalData.test.ts
@@ -1,0 +1,75 @@
+/**
+ * The legacy-roster probe — the guard that makes the account-required flip safe
+ * for people who were already here.
+ *
+ * Runs against `fake-indexeddb` (preloaded via `bunfig.toml`), so these are real
+ * IndexedDB reads rather than a stubbed answer.
+ */
+
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test'
+import { crawlerFixture, pilotFixture } from '../../../components/__tests__/fixtures'
+import * as db from '../index'
+import { _resetLegacyProbe, legacyLocalDataState, probeLegacyLocalData } from '../legacyLocalData'
+
+beforeEach(async () => {
+  await db._clearAllStores()
+  _resetLegacyProbe()
+})
+
+/**
+ * **Reset on the way out, not only on the way in.**
+ *
+ * The probe caches its answer in a module-level variable, and Bun runs a
+ * workspace's test files in ONE process — so a resolved `absent` here becomes
+ * `absent` for every file that runs afterwards. That is not theoretical: leaving
+ * it set sent every later wizard, chooser and starter-set test to the in-memory
+ * backend, and roughly a dozen of them failed asserting on rows that had been
+ * written to a Map instead of IndexedDB.
+ *
+ * Same discipline as `mock.module` in `.claude/rules/testing-patterns.md`:
+ * process-global state is the caller's to put back.
+ */
+afterAll(() => {
+  _resetLegacyProbe()
+})
+
+describe('an empty browser', () => {
+  test('reports absent, which is what lets a new visitor work in memory', async () => {
+    expect(await probeLegacyLocalData()).toBe('absent')
+  })
+})
+
+describe('a browser with a roster', () => {
+  test('one pilot is enough to report present', async () => {
+    await db.pilots.put(pilotFixture({ id: 'legacy-1' }))
+    expect(await probeLegacyLocalData()).toBe('present')
+  })
+
+  test('a crawler alone counts too — it is not just the pilots store', async () => {
+    // The probe has to look past `pilots`: somebody whose only local build is a
+    // crawler has just as much to lose, and checking one store would strand them
+    // while cheerfully reporting 'absent'.
+    await db.crawlers.put(crawlerFixture({ id: 'legacy-crawler' }))
+    expect(await probeLegacyLocalData()).toBe('present')
+  })
+})
+
+describe('the state it exposes', () => {
+  test('is unknown until the probe runs', () => {
+    // This is the value `backendForMode` sees at boot, and the reason it must
+    // resolve toward `local` rather than `memory`.
+    expect(legacyLocalDataState()).toBe('unknown')
+  })
+
+  test('is remembered, so the answer is stable across calls', async () => {
+    await db.pilots.put(pilotFixture({ id: 'legacy-2' }))
+    await probeLegacyLocalData()
+    expect(legacyLocalDataState()).toBe('present')
+
+    // Clearing the store afterwards must NOT flip the answer back: a browser
+    // that had a roster this session keeps the local backend, and re-probing
+    // into `absent` mid-session would move the write target out from under it.
+    await db._clearAllStores()
+    expect(await probeLegacyLocalData()).toBe('present')
+  })
+})

--- a/apps/itun/src/lib/db/legacyLocalData.ts
+++ b/apps/itun/src/lib/db/legacyLocalData.ts
@@ -1,0 +1,103 @@
+/**
+ * Does this browser already hold a roster from before accounts were required?
+ *
+ * ## Why the flip needs this
+ *
+ * ADR-034 sends an anonymous visitor to the in-memory backend. For somebody
+ * arriving fresh that is exactly right. For the years of **existing Solo users**
+ * it is a disaster: their pilots are in IndexedDB, the memory store is empty, and
+ * the app would stop reading the one place their work lives. They would open ITUN
+ * and find nothing — not deleted, but unreachable, which from where they sit is
+ * the same thing.
+ *
+ * P5's claim path does not save them either, because the claim card reads the
+ * entity store, and in memory mode the entity store is empty. There would be
+ * nothing to offer and no way to know there was anything to ask for.
+ *
+ * So the flip is conditional: **anonymous goes to memory only in a browser that
+ * has no legacy roster.** A browser that has one keeps reading it, and keeps
+ * being offered the claim, until the user takes it or exports. That is the
+ * migration window, and it closes per browser rather than on a date.
+ *
+ * ## Fails to the safe side, deliberately
+ *
+ * The probe is asynchronous and `selectBackend()` is not, so there is a window at
+ * boot where the answer is not yet known. During it the state is `unknown`, and
+ * `unknown` is treated as "there might be a roster" — the backend stays `local`.
+ *
+ * That direction is not arbitrary. Guessing `absent` wrongly sends an existing
+ * user's writes to a Map that is thrown away when the tab closes; guessing
+ * `present` wrongly gives a brand-new visitor a durable local write they were
+ * going to be asked to claim anyway. One of those loses work and the other does
+ * not, so the window resolves toward the one that does not.
+ */
+
+import { openItunDatabase } from './index'
+import { STORE_NAMES } from './stores'
+
+export type LegacyProbeState = 'unknown' | 'present' | 'absent'
+
+let state: LegacyProbeState = 'unknown'
+
+/** What the probe has concluded so far. `unknown` until it resolves. */
+export function legacyLocalDataState(): LegacyProbeState {
+  return state
+}
+
+/**
+ * The stores whose contents mean "this browser has a roster".
+ *
+ * Only the ones a *person* built. `workspaces` is the retired container and
+ * `changeLog` is provenance about entities rather than an entity, so neither
+ * would justify holding a fresh visitor in the local backend on its own — and a
+ * stray log row from a since-deleted pilot is exactly the kind of leftover that
+ * would.
+ */
+const ROSTER_STORES = [
+  STORE_NAMES.pilots,
+  STORE_NAMES.mechs,
+  STORE_NAMES.crawlers,
+  STORE_NAMES.mechPatterns,
+] as const
+
+/**
+ * Look once, at boot, and remember.
+ *
+ * Idempotent: after the first resolution this returns the cached answer without
+ * touching IndexedDB again. The answer is allowed to go stale in one direction
+ * only — a browser that gains a roster during the session got it through the
+ * local backend, which is the branch `present` already selects.
+ */
+export async function probeLegacyLocalData(): Promise<LegacyProbeState> {
+  if (state !== 'unknown') return state
+
+  try {
+    const db = await openItunDatabase()
+    for (const store of ROSTER_STORES) {
+      // `count` rather than `getAll`: the question is "is there anything", and
+      // reading a whole roster to answer it would parse every record at boot
+      // for no reason.
+      const n = await db.count(store)
+      if (n > 0) {
+        state = 'present'
+        return state
+      }
+    }
+    state = 'absent'
+  } catch (err) {
+    // A browser that refuses IndexedDB — private mode, a locked-down profile,
+    // a blocked upgrade — cannot be holding a legacy roster this app can read.
+    // `absent` is both true and the useful answer: it lets an anonymous visitor
+    // work in memory rather than stranding them against a store that will not
+    // open.
+    console.warn('[itun] could not probe for legacy local data; assuming none', err)
+    state = 'absent'
+  }
+
+  return state
+}
+
+/** Test-only: forget what the probe concluded. */
+export function _resetLegacyProbe(): void {
+  state = 'unknown'
+}

--- a/apps/itun/src/stores/__tests__/entityBackend.test.ts
+++ b/apps/itun/src/stores/__tests__/entityBackend.test.ts
@@ -106,25 +106,59 @@ describe('WritesBlockedOffline', () => {
  * beside `useConnection`.
  */
 describe('a build that requires an account gives an anonymous visitor nothing durable', () => {
-  test('solo becomes memory when the flag is on', () => {
-    expect(backendForMode('solo', true)).toBe('memory')
+  test('solo becomes memory when the flag is on and the browser is empty', () => {
+    expect(backendForMode('solo', true, 'absent')).toBe('memory')
   })
 
-  test("solo stays local when the flag is off — today's behaviour, unchanged", () => {
-    // The flag ships OFF (P2 is reversible; flipping it is P3). If this ever
-    // reads 'memory', the one-way door has been opened by accident.
-    expect(backendForMode('solo', false)).toBe('local')
-    expect(selectBackend()).toBe('local')
+  test('solo stays local when the flag is off', () => {
+    // `VITE_REQUIRE_ACCOUNT=false` is the escape hatch a deploy would need if
+    // the flip turned out to be wrong in a way the tests did not catch.
+    expect(backendForMode('solo', false, 'absent')).toBe('local')
   })
 
   test('the flag changes nothing for a signed-in user', () => {
     // Requiring an account has no opinion about somebody who has one. If these
-    // diverged, turning the gate on would change where signed-in writes go —
-    // which is P4's job and must not ride along with P3.
+    // diverged, turning the gate on would change where signed-in writes go,
+    // which belongs to the demotion and must not ride along with the flip.
     for (const flag of [true, false]) {
-      expect(backendForMode('connected', flag)).toBe('remote')
-      expect(backendForMode('disconnected', flag)).toBe('blocked')
-      expect(backendForMode('connecting', flag)).toBe('blocked')
+      for (const legacy of ['unknown', 'present', 'absent'] as const) {
+        expect(backendForMode('connected', flag, legacy)).toBe('remote')
+        expect(backendForMode('disconnected', flag, legacy)).toBe('blocked')
+        expect(backendForMode('connecting', flag, legacy)).toBe('blocked')
+      }
     }
+  })
+})
+
+describe('the legacy-roster guard on the flip', () => {
+  test('an existing roster keeps the local backend, flag or no flag', () => {
+    // The whole point of the guard. Sending an existing Solo user to the memory
+    // backend makes their pilots UNREACHABLE — not deleted, but from where they
+    // sit that is the same thing. P5's claim card cannot rescue them either: it
+    // reads the entity store, which in memory mode is empty, so there would be
+    // nothing to offer and no way to know there was anything to ask for.
+    expect(backendForMode('solo', true, 'present')).toBe('local')
+  })
+
+  test('an UNRESOLVED probe keeps the local backend — the safe side', () => {
+    // The probe is async and `selectBackend()` is not, so there is a window at
+    // boot where the answer is unknown. Guessing 'absent' wrongly sends an
+    // existing user's writes to a Map that dies with the tab; guessing 'present'
+    // wrongly gives a new visitor a durable write they were going to be asked to
+    // claim anyway. Only one of those loses work, so the window resolves toward
+    // the other one.
+    expect(backendForMode('solo', true, 'unknown')).toBe('local')
+  })
+
+  test('omitting the probe argument never picks memory', () => {
+    // A caller that forgets the third argument must not accidentally opt into
+    // the destructive branch, so it defaults to 'unknown' rather than 'absent'.
+    expect(backendForMode('solo', true)).toBe('local')
+  })
+
+  test('selectBackend agrees — the probe has not run in this test process', () => {
+    // End to end through the real wiring rather than the pure function: with no
+    // probe performed, the live selector must also refuse the memory branch.
+    expect(selectBackend()).toBe('local')
   })
 })

--- a/apps/itun/src/stores/entityBackend.ts
+++ b/apps/itun/src/stores/entityBackend.ts
@@ -9,6 +9,8 @@ import {
 } from '../lib/connection/connectionMode'
 import { convexClient } from '../lib/connection/convexClient'
 import { convexFunctionName, serverMessage } from '../lib/connection/serverError'
+import type { LegacyProbeState } from '../lib/db/legacyLocalData'
+import { legacyLocalDataState } from '../lib/db/legacyLocalData'
 import { captureException } from '../lib/observability'
 import type { EntityRef } from '../lib/schemas/entity'
 import type { SoftLink } from '../lib/schemas/softLink'
@@ -79,12 +81,25 @@ export type BackendKind = 'local' | 'remote' | 'blocked' | 'memory'
  * ([ADR-034](../../../../docs/adrs/ADR-034-account-required-persistence.md)
  * decision 1).
  *
- * **Off by default, and that is the whole point of shipping it this way.** The
- * memory backend and the account gate are separate phases (P2 and P3 in
- * `docs/architecture/persistence-and-pwa.md`): this phase builds the backend and
- * makes it selectable so it can be tested against a real app, while Solo remains
- * what an anonymous visitor actually gets. Flipping this on is the one-way door,
- * and it is P3's job together with the UI that explains it.
+ * **The code default stays OFF; production opts in.** `apps/itun/.env.production`
+ * sets this to `true`, and Vite loads that file only for a production build — so
+ * the shipped app requires an account while tests, dev and a fresh checkout do
+ * not.
+ *
+ * That split is deliberate and was arrived at the hard way. Defaulting to ON
+ * when the variable is *unset* flips every environment that never sets it —
+ * CI, the test runner, a contributor's first `bun run dev`. Measured: twelve
+ * wizard, chooser and starter-set tests failed, all of them correctly, because
+ * they assert Solo durability and the flip removes it. A flag whose safe value
+ * depends on remembering to set it is the wrong way round; the deploy is the
+ * thing that should have to say so out loud.
+ *
+ * To exercise the gate locally: `VITE_REQUIRE_ACCOUNT=true bun run dev:itun`.
+ *
+ * **It is not the only condition.** `backendForMode` also asks whether this
+ * browser holds a legacy roster, because sending an existing Solo user to the
+ * memory backend would make their pilots unreachable — see
+ * `lib/db/legacyLocalData.ts` for why that guard exists and which way it fails.
  *
  * Read once at module scope like every other `import.meta.env` flag here. A
  * build-time switch rather than a runtime one is deliberate: "does this build
@@ -118,11 +133,22 @@ function currentMode(): ConnectionMode {
  * `import.meta.env` read that a test cannot vary. The wrapper below supplies the
  * real inputs; this is what the tests drive.
  */
-export function backendForMode(mode: ConnectionMode, requireAccount: boolean): BackendKind {
-  // Anonymous, in a build that requires an account: nothing durable. Checked
-  // BEFORE the Solo branch, because Solo is exactly the state this replaces —
-  // testing it after would make the flag dead code.
-  if (mode === 'solo' && requireAccount) return 'memory'
+export function backendForMode(
+  mode: ConnectionMode,
+  requireAccount: boolean,
+  legacy: LegacyProbeState = 'unknown'
+): BackendKind {
+  // Anonymous, in a build that requires an account, in a browser with no roster
+  // of its own: nothing durable. Checked BEFORE the Solo branch, because Solo is
+  // exactly the state this replaces — testing it after would make the flag dead
+  // code.
+  //
+  // `legacy === 'absent'` rather than `!== 'present'` is the load-bearing part.
+  // While the probe is still running the answer is `unknown`, and an unknown
+  // must not send an existing user's writes to a Map that dies with the tab.
+  // The stricter test resolves that window toward the branch that cannot lose
+  // work; `legacyLocalData.ts` explains why that asymmetry is the right one.
+  if (mode === 'solo' && requireAccount && legacy === 'absent') return 'memory'
   if (mode === 'solo') return 'local'
   if (usesServerOfRecord(mode)) return 'remote'
   // `connecting` lands here alongside `disconnected`, and deliberately: writing
@@ -132,7 +158,7 @@ export function backendForMode(mode: ConnectionMode, requireAccount: boolean): B
 }
 
 export function selectBackend(): BackendKind {
-  return backendForMode(currentMode(), accountRequired)
+  return backendForMode(currentMode(), accountRequired, legacyLocalDataState())
 }
 
 /**

--- a/docs/architecture/persistence-and-pwa.md
+++ b/docs/architecture/persistence-and-pwa.md
@@ -44,6 +44,7 @@ Update this table as part of each phase's PR. It is the only place that answers
 | P3    | Gate persistence on an account (mechanism; flip deferred)  | yes        | **done**    |
 | P4    | Demote IndexedDB to a cache (**read path done**; prune + mirror removal await the flip) | **no** | part done |
 | P5    | Claim-on-sign-in coverage and the decline path             | yes        | **done**    |
+| —     | **The flip** — account required in production, legacy-guarded | **no**   | **done**    |
 | P6    | ITUN install-triggered offline                             | yes        | not started |
 | P7    | `srd` install-triggered offline (**blocked on ADR-033 P7**) | yes       | blocked     |
 


### PR DESCRIPTION
**Layer 5 of the ADR-034 stack.** Base: `feat/adr034-p5-claim-coverage` (#878).

Turns the account gate on, and does the two things that make that safe.

## The legacy guard

Sending an anonymous visitor to the memory backend is right for someone arriving fresh and a **disaster for the existing Solo users**: their pilots are in IndexedDB, the memory store is empty, and the app would stop reading the one place their work lives. Not deleted, but unreachable — which from where they sit is the same thing.

P5's claim card cannot rescue them either: it reads the entity store, which in memory mode is empty. Nothing to offer, and no way to know there was anything to ask for.

So the memory backend is now conditional on a boot probe of IndexedDB. A browser with a roster keeps reading it and keeps being offered the claim; **the window closes per browser rather than on a date.**

The probe is async and `selectBackend()` is not, so `unknown` is treated as *"there might be a roster"*. That asymmetry is the point: guessing `absent` wrongly sends an existing user's writes to a Map that dies with the tab; guessing `present` wrongly gives a new visitor a durable write they were going to be asked to claim anyway. **Only one of those loses work.**

## The flag default stays OFF; production opts in

Via a committed `apps/itun/.env.production`, which Vite loads for production builds and nothing else.

My first attempt defaulted it **on when unset**, which flipped CI, the test runner and a fresh checkout too — twelve wizard, chooser and starter-set tests failed, all of them *correctly*, because they assert Solo durability and the flip removes it. A flag whose safe value depends on somebody remembering to set it is the wrong way round.

One file rather than two build commands, so the Netlify and Cloudflare paths cannot drift apart on it.

**Verified rather than assumed:** rebuilding with the value inverted changes the `entityStore` chunk hash, which is what proves Vite reads the file and the flag reaches the bundle.

## One test-hygiene fix on the way

The probe caches in a module-level variable, and Bun runs a workspace's tests in one process — so resolving it in one file changed backend selection for **every file after it**. Reset in `afterAll`, the same discipline `.claude/rules/testing-patterns.md` sets for `mock.module`.

## Verification

`bun run check:all` exits 0; 1994 itun tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QU5rmidxZ3QUrMb3nvVNX6
