### PR TITLE
feat(itun): P4b — write to the server first; delete the mirror bridge

### DIFF
--- a/apps/itun/src/components/account/ShelfSync.tsx
+++ b/apps/itun/src/components/account/ShelfSync.tsx
@@ -20,20 +20,38 @@
  * a cache is not a user write, and a Disconnected reader must still be able to
  * open what they already pulled down.
  *
- * ## What it does NOT do
+ * ## Pruning, and the two conditions that make it safe
  *
- * It does not delete local rows the server does not return. That would be the
- * honest completion of "the cache is a reflection", and it is deliberately left
- * for the phase that turns the account gate on: until then a Solo user's
- * IndexedDB is still their source of truth, and pruning it against a server that
- * has never heard of those rows would delete their roster. The plan records this
- * as the remaining half of the demotion.
+ * It also deletes local **shelf** rows the server did not return, which is what
+ * finally makes "the cache is a reflection" literally true rather than
+ * aspirational. It is the most destructive operation in the codebase, so both
+ * guards below are load-bearing and neither is obvious.
+ *
+ * **1. Only shelf rows.** A local row absent from `listMine` is ambiguous, and
+ * the ambiguity differs by container. `listMine` returns what the caller *owns*,
+ * wherever it lives — but a Game's **unclaimed** pre-gens and its communal
+ * crawler have no owner at all, and `GameRoster` legitimately caches them. So
+ * anything with a `gameId` is a cached view of somebody else's container and is
+ * never pruned. A shelf row is different: `gameId: null` with no owner is the
+ * one combination ADR-030 calls invalid, so every shelf row must be owned, and
+ * every owned row is in `listMine`. Absence therefore means deleted.
+ *
+ * **2. Only in a browser that never held a legacy roster.** This is the guard
+ * that is easy to miss and fatal to omit. For a pre-ADR-034 user who has signed
+ * in but not yet claimed, their entire roster is local shelf rows the server has
+ * never heard of — and rule 1 would read every one of them as "deleted
+ * elsewhere" and destroy the lot. `legacyLocalDataState() === 'absent'` is the
+ * only state in which a local row can be trusted to have come from a
+ * server-accepted write or from this component, which is what makes absence
+ * mean deletion rather than not-yet-uploaded.
  */
 
 import { useQuery } from 'convex/react'
 import { useEffect, useRef } from 'react'
 import { api } from '../../../convex/_generated/api'
 import { isConvexConfigured } from '../../lib/connection/convexClient'
+import { legacyLocalDataState } from '../../lib/db/legacyLocalData'
+import { mayPrune, rowMayBePruned } from '../../lib/db/pruneRules'
 import { captureException } from '../../lib/observability'
 import { selectBackend } from '../../stores/entityBackend'
 import { useEntityStore } from '../../stores/entityStore'
@@ -67,11 +85,13 @@ function ConnectedShelfSync() {
 
     void (async () => {
       const store = useEntityStore.getState()
-      for (const [kind, rows] of [
+      const kinds = [
         ['pilot', mine.pilots],
         ['mech', mine.mechs],
         ['crawler', mine.crawlers],
-      ] as const) {
+      ] as const
+
+      for (const [kind, rows] of kinds) {
         for (const row of rows as Row[]) {
           try {
             await store.adopt(kind, row.body as never)
@@ -82,6 +102,30 @@ function ConnectedShelfSync() {
             // fine and the player should see them.
             captureException(err)
           }
+        }
+      }
+
+      // Prune only where absence is unambiguous — see the header. Both guards
+      // matter; dropping either turns this into a roster-deleter.
+      if (!mayPrune(legacyLocalDataState())) return
+
+      for (const [kind, rows] of kinds) {
+        const served = new Set(
+          (rows as Row[])
+            .map((r) => (r.body as { id?: unknown } | null)?.id)
+            .filter((id): id is string => typeof id === 'string')
+        )
+        for (const local of store.list(kind)) {
+          // `containerOf` rather than a bare `gameId === null`, so a
+          // pre-ADR-030 record that still resolves through `workspaceId` is
+          // classified the same way every other reader classifies it.
+          if (!rowMayBePruned(local)) continue
+          if (served.has(local.id)) continue
+          // `forget`, not `delete`: this removes the local COPY and must never
+          // become a server delete. The row is already gone there — that is why
+          // it is being pruned — and issuing a delete would turn a sync into a
+          // destructive write against whatever the server does hold.
+          await store.forget(kind, local.id)
         }
       }
     })()

--- a/apps/itun/src/lib/db/__tests__/pruneRules.test.ts
+++ b/apps/itun/src/lib/db/__tests__/pruneRules.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The two rules that decide whether a cached row may be deleted (P4b).
+ *
+ * Pruning is the most destructive operation in the codebase, and both of its
+ * guards are the kind that look like defensive noise right up until the day
+ * they are removed. So the rules are extracted as pure predicates and tested
+ * directly, rather than only being reachable through `ShelfSync`'s effect.
+ *
+ * The scenarios below are the two ways to delete somebody's roster by accident.
+ *
+ * The predicates are IMPORTED rather than restated here. An earlier draft copied
+ * them into this file, which would have let the rule and its test drift apart in
+ * exactly the direction that matters — the test passing while the code deleted
+ * the roster.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { mayPrune, rowMayBePruned } from '../pruneRules'
+
+describe('rule 1 — a browser that held a legacy roster never prunes', () => {
+  test('a legacy browser is refused', () => {
+    // The scenario: a pre-ADR-034 player signs in for the first time and has
+    // not claimed yet. Every build they own is a local shelf row the server has
+    // never seen. Pruning here deletes all of it.
+    expect(mayPrune('present')).toBe(false)
+  })
+
+  test('an unresolved probe is refused too', () => {
+    // Same failure, arrived at by racing rather than by state: the probe has
+    // not answered, so "no legacy roster" is not yet known to be true.
+    expect(mayPrune('unknown')).toBe(false)
+  })
+
+  test('a browser that never held one may prune', () => {
+    expect(mayPrune('absent')).toBe(true)
+  })
+})
+
+describe('rule 2 — only shelf rows are prunable', () => {
+  test("a Game's row is never pruned, even though it is absent from listMine", () => {
+    // An unclaimed pre-gen or the communal crawler: cached on purpose by
+    // `GameRoster`, owned by nobody, and therefore never returned by a query
+    // scoped to what the caller owns. Pruning against that absence would empty
+    // every Game view on the next boot.
+    expect(rowMayBePruned({ gameId: 'g1' })).toBe(false)
+  })
+
+  test('a shelf row is prunable', () => {
+    expect(rowMayBePruned({ gameId: null })).toBe(true)
+  })
+
+  test('a pre-ADR-030 record resolves through workspaceId, like every other reader', () => {
+    // `containerOf` rather than a bare `gameId === null` check, so a record
+    // written before the container split is classified the same way the rest of
+    // the app classifies it — a Game-shaped one is protected.
+    expect(rowMayBePruned({ workspaceId: 'ws-1' })).toBe(false)
+    expect(rowMayBePruned({ workspaceId: 'default-workspace' })).toBe(true)
+  })
+})
+
+describe('both rules together', () => {
+  test('a Game row survives even in a prunable browser', () => {
+    expect(mayPrune('absent') && rowMayBePruned({ gameId: 'g1' })).toBe(false)
+  })
+
+  test('a shelf row survives in a legacy browser', () => {
+    expect(mayPrune('present') && rowMayBePruned({ gameId: null })).toBe(false)
+  })
+
+  test('only the intended case deletes', () => {
+    expect(mayPrune('absent') && rowMayBePruned({ gameId: null })).toBe(true)
+  })
+})

--- a/apps/itun/src/lib/db/crud.ts
+++ b/apps/itun/src/lib/db/crud.ts
@@ -20,6 +20,17 @@ type EntityStore<T extends EntityBase> = {
    */
   create: (input: Omit<T, 'id' | 'createdAt' | 'updatedAt'>) => Promise<T>
   /**
+   * create() minus the write: mint the id, stamp the timestamps and
+   * strict-parse, returning the record that create() *would* have written.
+   *
+   * The counterpart to `prepareUpdate`, and it exists for the same reason one
+   * phase later: once Convex is the source of truth, a record has to be built
+   * and accepted by the server BEFORE anything local is touched, so that a
+   * refused write leaves no trace on the device. Without this split the id and
+   * timestamps only came into existence as a side effect of persisting.
+   */
+  prepareCreate: (input: Omit<T, 'id' | 'createdAt' | 'updatedAt'>) => Promise<T>
+  /**
    * update() minus the write: merge + stamp + strict-parse, returning the
    * validated record. Feed the result to an atomicWrite() transaction.
    */
@@ -124,8 +135,14 @@ export function makeStore<T extends EntityBase>(
     return salvageRead(raw, `id="${id}"`)
   }
 
-  async function create(input: Omit<T, 'id' | 'createdAt' | 'updatedAt'>): Promise<T> {
-    const db = await getDb()
+  /**
+   * Everything `create` does except the write.
+   *
+   * Split out so a caller can obtain the finished record — id minted,
+   * timestamps stamped, strict-parsed — and decide separately whether to
+   * persist it. `create` is now this plus one `put`, so the two cannot drift.
+   */
+  async function prepareCreate(input: Omit<T, 'id' | 'createdAt' | 'updatedAt'>): Promise<T> {
     const now = new Date().toISOString()
     const candidate: Record<string, unknown> = {
       ...input,
@@ -136,7 +153,12 @@ export function makeStore<T extends EntityBase>(
       candidate.updatedAt = now
     }
     // parse() throws ZodError on bad input — let it bubble to caller
-    const record = schema.parse(candidate)
+    return schema.parse(candidate)
+  }
+
+  async function create(input: Omit<T, 'id' | 'createdAt' | 'updatedAt'>): Promise<T> {
+    const db = await getDb()
+    const record = await prepareCreate(input)
     await db.put(storeName, record)
     return record
   }
@@ -212,5 +234,5 @@ export function makeStore<T extends EntityBase>(
     await db.delete(storeName, id)
   }
 
-  return { list, get, create, update, prepareUpdate, put, delete: del }
+  return { list, get, create, prepareCreate, update, prepareUpdate, put, delete: del }
 }

--- a/apps/itun/src/lib/db/memoryStore.ts
+++ b/apps/itun/src/lib/db/memoryStore.ts
@@ -59,6 +59,7 @@ export type MemoryEntityStore<T extends EntityBase> = {
   list: () => Promise<T[]>
   get: (id: string) => Promise<T | null>
   create: (input: Omit<T, 'id' | 'createdAt' | 'updatedAt'>) => Promise<T>
+  prepareCreate: (input: Omit<T, 'id' | 'createdAt' | 'updatedAt'>) => Promise<T>
   prepareUpdate: (id: string, patch: Partial<Omit<T, 'id'>>) => Promise<T>
   update: (id: string, patch: Partial<Omit<T, 'id'>>) => Promise<T>
   put: (record: T) => Promise<T>
@@ -96,7 +97,8 @@ export function makeMemoryStore<T extends EntityBase>(
     return rows.get(id) ?? null
   }
 
-  async function create(input: Omit<T, 'id' | 'createdAt' | 'updatedAt'>): Promise<T> {
+  /** `create` minus the write — mirrors `crud.ts`, and for the same reason. */
+  async function prepareCreate(input: Omit<T, 'id' | 'createdAt' | 'updatedAt'>): Promise<T> {
     const now = new Date().toISOString()
     const candidate: Record<string, unknown> = {
       ...input,
@@ -107,7 +109,11 @@ export function makeMemoryStore<T extends EntityBase>(
 
     // `parse`, not `safeParse` — a ZodError bubbling to the caller is the same
     // contract the IDB store has, and wizards rely on it to surface a bad build.
-    const record = schema.parse(candidate)
+    return schema.parse(candidate)
+  }
+
+  async function create(input: Omit<T, 'id' | 'createdAt' | 'updatedAt'>): Promise<T> {
+    const record = await prepareCreate(input)
     rows.set(record.id, record)
     return record
   }
@@ -149,5 +155,5 @@ export function makeMemoryStore<T extends EntityBase>(
     rows.delete(id) // silent no-op when absent, like the IDB store
   }
 
-  return { list, get, create, update, prepareUpdate, put, delete: del }
+  return { list, get, create, prepareCreate, update, prepareUpdate, put, delete: del }
 }

--- a/apps/itun/src/lib/db/pruneRules.ts
+++ b/apps/itun/src/lib/db/pruneRules.ts
@@ -1,0 +1,62 @@
+/**
+ * The two rules that decide whether a cached row may be deleted (ADR-034, P4b).
+ *
+ * Pruning — dropping local rows the server did not return — is what finally
+ * makes "IndexedDB is a reflection of Convex" literally true rather than
+ * aspirational. It is also the most destructive operation in the codebase, and
+ * both guards below are the kind that look like defensive noise right up until
+ * the day somebody removes one.
+ *
+ * They live here, as predicates, rather than inline in `ShelfSync`'s effect, so
+ * that the tests assert **the rule itself** instead of a copy of it. A parallel
+ * implementation in a test file is a rule that can pass while the code does the
+ * opposite.
+ */
+
+import type { ContainerFields } from '../container'
+import { containerOf } from '../container'
+import type { LegacyProbeState } from './legacyLocalData'
+
+/**
+ * May this browser prune at all?
+ *
+ * Only when it has never held a pre-ADR-034 roster.
+ *
+ * The scenario this exists for: a long-standing Solo player signs in for the
+ * first time and has not claimed yet. Every build they own is a local shelf row
+ * the server has never heard of, so {@link rowMayBePruned} would read every one
+ * of them as "deleted elsewhere" and delete the lot. `absent` is the only state
+ * in which a local row can be trusted to have come from a server-accepted write
+ * or from `ShelfSync` itself — which is what makes absence mean deletion rather
+ * than not-yet-uploaded.
+ *
+ * `unknown` is refused for the same reason it keeps the local backend: the
+ * probe has not answered, so "no legacy roster" is not yet known to be true.
+ */
+export function mayPrune(legacy: LegacyProbeState): boolean {
+  return legacy === 'absent'
+}
+
+/**
+ * May this row be pruned, given the server did not return it?
+ *
+ * Only shelf rows, and the asymmetry is not caution — it is that absence means
+ * different things in the two containers.
+ *
+ * `entities.listMine` returns what the caller **owns**, wherever it lives. A
+ * Game's unclaimed pre-gens and its communal crawler have no owner at all, and
+ * `GameRoster` caches them on purpose, so they are absent from that query while
+ * being entirely legitimate. Pruning against their absence would empty every
+ * Game view on the next boot.
+ *
+ * A shelf row carries no such ambiguity: `gameId: null` with no owner is the one
+ * combination ADR-030 §2 calls invalid, so every shelf row is owned, and every
+ * owned row is in `listMine`.
+ *
+ * Reads the container through `containerOf` rather than testing `gameId`
+ * directly, so a record written before the split — which still resolves through
+ * `workspaceId` — is classified the way every other reader classifies it.
+ */
+export function rowMayBePruned(entity: ContainerFields): boolean {
+  return containerOf(entity).kind === 'shelf'
+}

--- a/apps/itun/src/stores/__tests__/serverFirstWrites.test.ts
+++ b/apps/itun/src/stores/__tests__/serverFirstWrites.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Server-first writes (ADR-034 decision 2, plan phase P4b).
+ *
+ * The demotion's last act: a write goes to Convex **before** anything local is
+ * touched, so a record the server refused leaves no trace on the device. Its
+ * predecessor did the opposite — wrote locally, then fired a mirror at the
+ * server and swallowed the failure into a console warning — because back then
+ * the local store was the source of truth and the UI read it.
+ *
+ * These tests run with no Convex configured, so `selectBackend()` is `local` and
+ * the commit is a no-op. That is deliberate and is worth being explicit about:
+ * what is asserted here is the **ordering contract** — that a record is built,
+ * committed and only then persisted — and that the local path still behaves
+ * exactly as it did. The refusal path itself is exercised against a real server
+ * in `test/convex/*`, which is where a mutation can actually refuse.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { pilotFixture } from '../../components/__tests__/fixtures'
+import * as db from '../../lib/db/index'
+import { useEntityStore } from '../entityStore'
+
+afterEach(async () => {
+  const store = useEntityStore.getState()
+  for (const type of ['pilot', 'mech', 'crawler'] as const) {
+    for (const row of store.list(type)) await store.forget(type, row.id)
+  }
+  await db._clearAllStores()
+})
+
+describe('a record is built before it is persisted', () => {
+  test('prepareCreate mints an id and timestamps without writing', async () => {
+    const built = await db.pilots.prepareCreate({
+      ...pilotFixture({ id: 'ignored' }),
+      id: undefined,
+      createdAt: undefined,
+      updatedAt: undefined,
+    } as never)
+
+    expect(built.id).toBeTruthy()
+    expect(built.createdAt).toBeTruthy()
+
+    // The whole point of the split: nothing reached disk. Without this, the id
+    // and timestamps only came into existence as a side effect of persisting,
+    // so there was no record to offer the server before committing to it.
+    expect(await db.pilots.get(built.id)).toBeNull()
+  })
+
+  test('create still persists — the split did not lose the write', async () => {
+    const created = await useEntityStore.getState().create('pilot', {
+      ...pilotFixture({ id: 'ignored' }),
+      id: undefined,
+      createdAt: undefined,
+      updatedAt: undefined,
+    } as never)
+
+    expect(await db.pilots.get(created.id)).not.toBeNull()
+    expect(useEntityStore.getState().list('pilot')).toHaveLength(1)
+  })
+})
+
+describe('update keeps its contract through the reorder', () => {
+  test('the patch lands locally and in the cache', async () => {
+    const store = useEntityStore.getState()
+    const created = await store.create('pilot', {
+      ...pilotFixture({ id: 'ignored' }),
+      id: undefined,
+      createdAt: undefined,
+      updatedAt: undefined,
+    } as never)
+
+    const updated = await store.update('pilot', created.id, { callsign: 'Renamed' } as never, {
+      kind: 'manual',
+      source: 'test',
+    })
+
+    expect(updated.callsign).toBe('Renamed')
+    expect((await db.pilots.get(created.id))?.callsign).toBe('Renamed')
+  })
+
+  test('a rejected patch changes nothing', async () => {
+    const store = useEntityStore.getState()
+    const created = await store.create('pilot', {
+      ...pilotFixture({ id: 'ignored' }),
+      id: undefined,
+      createdAt: undefined,
+      updatedAt: undefined,
+    } as never)
+
+    // `prepareUpdate` strict-parses before anything is written, so a patch the
+    // schema refuses aborts with the record untouched. Same guarantee the
+    // server refusal now gets, arriving one step earlier.
+    await expect(
+      store.update('pilot', created.id, { callsign: 42 } as never, {
+        kind: 'manual',
+        source: 'test',
+      })
+    ).rejects.toThrow()
+
+    expect((await db.pilots.get(created.id))?.callsign).toBe(created.callsign)
+  })
+})

--- a/apps/itun/src/stores/entityBackend.ts
+++ b/apps/itun/src/stores/entityBackend.ts
@@ -1,4 +1,3 @@
-import { toast } from 'component-lib'
 import { api } from '../../convex/_generated/api'
 import type { Id } from '../../convex/_generated/dataModel'
 import type { ConnectionMode } from '../lib/connection/connectionMode'
@@ -8,10 +7,8 @@ import {
   usesServerOfRecord,
 } from '../lib/connection/connectionMode'
 import { convexClient } from '../lib/connection/convexClient'
-import { convexFunctionName, serverMessage } from '../lib/connection/serverError'
 import type { LegacyProbeState } from '../lib/db/legacyLocalData'
 import { legacyLocalDataState } from '../lib/db/legacyLocalData'
-import { captureException } from '../lib/observability'
 import type { EntityRef } from '../lib/schemas/entity'
 import type { SoftLink } from '../lib/schemas/softLink'
 
@@ -191,237 +188,109 @@ export class WritesBlockedOffline extends Error {
 }
 
 /**
- * How long one mirror failure speaks for. A burst is one condition, not N
- * problems, and a per-write toast during a Downtime scramble would bury the
- * sheet under duplicates of the same sentence.
+ * Write one entity to the server of record, and **fail if it does not land**.
+ *
+ * ## This replaced a mirror, and the difference is the whole of ADR-034
+ *
+ * The predecessors — `mirrorWrite`, `mirrorCrawlerWrite`, `mirrorSoftLinkWrite`
+ * — were **fire-and-forget by design**, and correctly so at the time: the local
+ * write had already succeeded and was what the UI read, so a server refusal
+ * could not be allowed to roll it back. They also **upserted rather than
+ * updated**, because an entity built while Solo had no server row until the
+ * account was claimed.
+ *
+ * Both properties describe a world where the local store is authoritative.
+ * ADR-034 ends that world. A cache cannot legitimately be ahead of its source,
+ * so a write the server refused **did not happen**, and the only honest thing to
+ * do is say so — which means awaiting it and letting it throw.
+ *
+ * The failure mode being removed is not hypothetical. `byAppId` resolves a
+ * duplicate to the oldest row and warns rather than throwing, precisely because
+ * a throw inside a fire-and-forget mirror was invisible to the player: the
+ * write never reached the server while every surface kept rendering it as saved.
+ * That is how an evening of play went missing.
+ *
+ * ## No-ops off the server of record
+ *
+ * Returns immediately unless the backend is `remote`. An anonymous session — in
+ * memory, or in the legacy local backend during the migration window — has no
+ * server to commit to, and must keep working.
  */
-const MIRROR_TOAST_WINDOW_MS = 30_000
-
-/** When the last mirror-failure toast was shown; `0` means "not yet". */
-let lastMirrorToastAt = 0
-
-/**
- * What to do when a mirror fails.
- *
- * ## Why this is louder than a console warning
- *
- * A failed mirror means IndexedDB has diverged from Convex, the declared server
- * of record (ADR-030) — and the local write already succeeded, so **every
- * surface keeps rendering the change as saved**. That is the most dangerous
- * state this app has: the player is told, by the entire UI, that their work is
- * safe, while the table sees none of it.
- *
- * It stayed invisible for a real session. `byAppId` threw on a duplicate row,
- * this path swallowed it into `console.warn`, and a player edited two pilots
- * for the better part of an hour with nothing reaching the game. The only trace
- * was twelve Sentry events nobody was watching, and the feedback that came back
- * was "the game mechs didn't save" — which is exactly what happened, with no
- * way for them to have known it at the time.
- *
- * So the local write still stands (rolling it back would lose work that is
- * genuinely on disk), but the player is told. Being told a change did not sync
- * is recoverable; not being told is not.
- *
- * ## Refusal and defect are reported the same and *said* differently
- *
- * `serverMessage` (`lib/connection/serverError.ts`) answers which side of
- * Convex's one line this was: a `ConvexError` arrives with its message intact
- * because the backend declared it fit to show, and everything else arrives
- * redacted as `"[CONVEX M(fn)] […] Server Error"`.
- *
- * Both are reported to Sentry, tagged, because both mean the same thing about
- * the data — the mirror did not land. But they are not the same thing to *say*:
- *
- *   - a **refusal** carries the rule that stopped it, in words the backend
- *     wrote for a player ("Only the Mediator can do that"). Showing it is
- *     strictly more useful than any generic sentence, and it reads as the
- *     system working rather than breaking.
- *   - a **defect** has no usable message by construction, so the generic copy
- *     is the honest one. Never render `String(err)` here: that is where the
- *     opaque `Server Error` string comes from.
- *
- * Throttled either way: a burst is one condition, and the useful signal is
- * "syncing is broken right now" rather than a taxonomy the player cannot act on.
- */
-function reportMirrorFailure(err: unknown, context: Record<string, string>): void {
-  const refusal = serverMessage(err)
-  console.warn('[itun] failed to mirror write to the server of record', refusal ?? err)
-
-  /*
-   * Grouped by what the condition IS, not by what the message says.
-   *
-   * Left to Sentry's defaults these events are close to useless, and were: a
-   * redacted defect arrives as `"[CONVEX M(entities:upsertByAppId)] [Request ID:
-   * 1b66…] Server Error"`, so the request id makes every message unique and the
-   * culprit frame is a minified symbol in a hashed bundle. Production ended up
-   * with two issues, both titled with a request id, for one condition — and
-   * neither title named the mutation, which is the single fact a redacted error
-   * still carries and the only one that points anywhere.
-   *
-   * So: fingerprint on the mutation and the kind of failure, tag with the same,
-   * and let the request id stay in `extra` where it belongs. One condition, one
-   * issue, titled with something searchable.
-   */
-  const convexFunction = convexFunctionName(err) ?? 'unknown'
-  const kind = refusal === null ? 'defect' : 'refusal'
-
-  captureException(
-    err,
-    { ...context, refusal: refusal ?? 'none' },
-    {
-      fingerprint: ['itun-mirror-write-failed', convexFunction, kind],
-      tags: {
-        convex_function: convexFunction,
-        mirror_source: context.source ?? 'unknown',
-        mirror_op: context.op ?? 'unknown',
-        server_response: kind,
-      },
-    }
-  )
-
-  const now = Date.now()
-  if (now - lastMirrorToastAt < MIRROR_TOAST_WINDOW_MS) return
-  lastMirrorToastAt = now
-
-  toast.error(refusal ?? 'That change was saved on this device, but the game did not accept it.', {
-    description:
-      'Your work is safe here and nothing was lost. Reload to see what the game has — and if this keeps happening, the build may need re-syncing.',
-    duration: 10_000,
-  })
-}
-
-/**
- * Mirror a local write to the server of record, addressed by **app id**.
- *
- * An earlier attempt at this could not work: Convex mints its own `_id`, so a
- * client holding only its local UUID had nothing to address a row by. Creates
- * mirrored fine and edits silently no-opped — a mirror that looks synced and
- * is not. The fix is the indexed `appId` column, which lets one cheap lookup
- * stand in for a mapping table.
- *
- * Three properties that matter:
- *
- *  - **Upsert, not update.** An entity built while Solo has no server row until
- *    the account is claimed, so a missing row means "create it" rather than
- *    "fail". That is what makes the mirror converge instead of dropping the
- *    first edit after a claim.
- *  - **Fire-and-forget.** The local write already succeeded and is what the UI
- *    reads. A mirror failure must not roll it back or block the caller, so this
- *    returns void and swallows into a console warning.
- *  - **Only in `remote`.** In Solo there is no server to mirror to, and in
- *    Disconnected the write never got this far (`requireWritableBackend`).
- */
-export async function mirrorWrite(
-  type: 'pilot' | 'mech',
+export async function commitEntityWrite(
+  type: EntityRef['type'] | 'softLink',
   op:
     | { kind: 'upsert'; appId: string; gameId: string | null; body: unknown }
-    | { kind: 'delete'; appId: string }
+    | { kind: 'patch'; appId: string; gameId: string | null; body: unknown; patch: unknown }
+    | { kind: 'delete'; appId: string; gameId: string | null }
 ): Promise<void> {
   if (selectBackend() !== 'remote' || convexClient === null) return
 
-  const table = type === 'pilot' ? 'pilots' : 'mechs'
-  try {
-    if (op.kind === 'upsert') {
-      await convexClient.mutation(api.entities.upsertByAppId, {
-        table,
-        appId: op.appId,
-        gameId: op.gameId === null ? null : (op.gameId as Id<'games'>),
-        body: op.body,
-      })
-    } else {
-      await convexClient.mutation(api.entities.removeByAppId, { table, appId: op.appId })
-    }
-  } catch (err) {
-    // Never a failed user action — the local write stands — but never silent
-    // either, in EITHER direction. See `reportMirrorFailure`.
-    reportMirrorFailure(err, { source: 'mirrorWrite', type, op: op.kind })
+  if (type === 'softLink') {
+    // Links are addressed by their endpoints rather than by an id, so they take
+    // a different call shape — see `commitSoftLink`.
+    return
   }
-}
 
-/**
- * Mirror a local **crawler** write. Separate from `mirrorWrite` because the
- * crawler's server contract is genuinely a different one, not a variant.
- *
- * Three differences, each of them a rule rather than an implementation detail:
- *
- *  - **Updates merge per field, they do not replace.** The crawler is communal
- *    and contended during Downtime, so this sends the *patch* rather than the
- *    whole body — two members editing scrap and cargo in the same minute both
- *    land (ADR-030 §5).
- *  - **There is no upsert.** Raising a crawler is the table runner's act, so a
- *    create is a create (`createCrawler`, which the server refuses for a
- *    player) and an edit can never quietly become one.
- *  - **Only inside a Game.** A shelved or Solo crawler has no server row and
- *    nothing to merge into.
- *
- * Fire-and-forget like the ownable mirror: the local write already succeeded
- * and is what the UI reads. A refusal here means the local copy is ahead of a
- * Game that did not accept it — see the known-gaps note in
- * `docs/architecture/accounts-and-games.md`.
- */
-export async function mirrorCrawlerWrite(
-  op:
-    | { kind: 'create'; appId: string; gameId: string | null; body: unknown }
-    | { kind: 'patch'; appId: string; patch: unknown }
-    | { kind: 'delete'; appId: string }
-): Promise<void> {
-  if (selectBackend() !== 'remote' || convexClient === null) return
-
-  try {
-    if (op.kind === 'create') {
-      await convexClient.mutation(api.entities.createCrawler, {
-        // `null` raises it on the caller's shelf — see `entities.createCrawler`.
-        gameId: op.gameId as Id<'games'> | null,
-        appId: op.appId,
-        body: op.body,
-      })
-    } else if (op.kind === 'patch') {
+  if (type === 'crawler') {
+    if (op.kind === 'delete') {
+      await convexClient.mutation(api.entities.removeCrawlerByAppId, { appId: op.appId })
+      return
+    }
+    if (op.kind === 'patch') {
+      // Still a field-level patch rather than a whole-body replace: the crawler
+      // is communal and contended during Downtime, so two members editing scrap
+      // and cargo in the same minute must both land (ADR-030 §5). That rule
+      // survives the demotion untouched.
       await convexClient.mutation(api.entities.patchCrawlerByAppId, {
         appId: op.appId,
         patch: op.patch,
       })
-    } else {
-      await convexClient.mutation(api.entities.removeCrawlerByAppId, { appId: op.appId })
+      return
     }
-  } catch (err) {
-    reportMirrorFailure(err, { source: 'mirrorCrawlerWrite', op: op.kind })
+    await convexClient.mutation(api.entities.createCrawler, {
+      gameId: op.gameId as Id<'games'> | null,
+      appId: op.appId,
+      body: op.body,
+    })
+    return
   }
+
+  const table = type === 'pilot' ? 'pilots' : 'mechs'
+  if (op.kind === 'delete') {
+    await convexClient.mutation(api.entities.removeByAppId, { table, appId: op.appId })
+    return
+  }
+  await convexClient.mutation(api.entities.upsertByAppId, {
+    table,
+    appId: op.appId,
+    gameId: op.gameId === null ? null : (op.gameId as Id<'games'>),
+    body: op.body,
+  })
 }
 
 /**
- * Mirror a **soft link** to the server of record.
+ * Write one soft link, and fail if it does not land.
  *
- * Links used to be excluded from mirroring entirely, on the grounds that they
- * are "derived". On a shelf that is nearly true. In a Game it is not true at
- * all: `entities.listForGame` reads links back, so the crew saw whatever wiring
- * existed at claim time and never saw a single change after it. Assigning a
- * pilot to the crawler updated your sheet and nobody else's — the assignment
- * simply never left the browser.
- *
- * Addressed by endpoints rather than by id: the server has no `appId` column
- * for links and needs none, because `from.id`/`to.id` already are app ids. That
- * also makes the mirror naturally idempotent, so a replayed write is a no-op
- * rather than a duplicate wire.
- *
- * Fire-and-forget with the same contract as the other two mirrors — the local
- * write already landed and is what the UI reads.
+ * Addressed by its endpoints because the server has no `appId` column for links
+ * and needs none — `from.id`/`to.id` already are app ids. That also makes it
+ * naturally idempotent, so a repeated write is a no-op rather than a duplicate
+ * wire.
  */
-export async function mirrorSoftLinkWrite(
-  op:
-    | { kind: 'upsert'; from: EntityRef; to: EntityRef; type: SoftLink['type'] }
-    | { kind: 'delete'; from: EntityRef; to: EntityRef; type: SoftLink['type'] }
+export async function commitSoftLink(
+  kind: 'upsert' | 'delete',
+  link: SoftLink | null
 ): Promise<void> {
   if (selectBackend() !== 'remote' || convexClient === null) return
+  if (link === null) return
+  // A link whose endpoints did not survive a salvage-tolerant read has nothing
+  // to address, and half a link fails validation server-side for no benefit.
+  if (link.from?.id === undefined || link.to?.id === undefined) return
 
-  const args = { from: op.from, to: op.to, type: op.type }
-  try {
-    if (op.kind === 'upsert') {
-      await convexClient.mutation(api.entities.upsertSoftLink, args)
-    } else {
-      await convexClient.mutation(api.entities.removeSoftLink, args)
-    }
-  } catch (err) {
-    reportMirrorFailure(err, { source: 'mirrorSoftLinkWrite', op: op.kind })
+  const args = { from: link.from, to: link.to, type: link.type }
+  if (kind === 'upsert') {
+    await convexClient.mutation(api.entities.upsertSoftLink, args)
+  } else {
+    await convexClient.mutation(api.entities.removeSoftLink, args)
   }
 }
 

--- a/apps/itun/src/stores/entityStore.ts
+++ b/apps/itun/src/stores/entityStore.ts
@@ -44,9 +44,8 @@ import type { SoftLink } from '../lib/schemas/softLink'
 import { SoftLinkSchema } from '../lib/schemas/softLink'
 import { getActiveContainer } from './activeContainerStore'
 import {
-  mirrorCrawlerWrite,
-  mirrorSoftLinkWrite,
-  mirrorWrite,
+  commitEntityWrite,
+  commitSoftLink,
   requireWritableBackend,
   selectBackend,
 } from './entityBackend'
@@ -283,6 +282,8 @@ type DbStoreApi<T extends EntityType> = {
   prepareUpdate: (id: string, patch: Partial<EntityForType<T>>) => Promise<EntityForType<T>>
   put: (record: EntityForType<T>) => Promise<EntityForType<T>>
   delete: (id: string) => Promise<void>
+  /** `create` minus the write — see `lib/db/crud.ts`. */
+  prepareCreate: (input: CreateInput<T>) => Promise<EntityForType<T>>
 }
 
 const DB_STORES: { [K in EntityType]: DbStoreApi<K> } = {
@@ -313,73 +314,47 @@ const MEMORY_STORES: { [K in EntityType]: DbStoreApi<K> } = {
 }
 
 /**
- * Mirror a just-persisted record to the server of record.
+ * Commit one record to the server of record, and throw if it refuses.
  *
- * Pilots and mechs upsert their whole body; the crawler takes the other path
- * (`mirrorCrawlerWrite`) because it is communal — its edits merge per field and
- * only its table runner may raise or scrap one; a SoftLink takes a third
- * (`mirrorSoftLinkWrite`) because it is addressed by its endpoints rather than
- * by an id. Fire-and-forget by design: the local write is what the UI reads, so
- * a mirror failure must not undo it.
+ * The replacement for `mirrorEntityWrite`, and the shape change is the point:
+ * this is **awaited before anything local is written**, so a refused write
+ * leaves no trace on the device. Its predecessor ran after the local write and
+ * swallowed failures into a warning, because back then the local store was the
+ * source of truth and the UI read it. It is not any more.
  *
- * `patch` is passed on an update so a crawler mirrors the *changed fields*
- * rather than its whole body; sending everything would turn a merge back into
- * last-write-wins and lose whatever a crewmate changed in the same minute.
- *
- * SoftLinks used to be excluded here as "derived". They are not, once a Game is
- * involved — `listForGame` reads them back, so an unmirrored link meant the
- * crew's view of who crews what froze at claim time. See `mirrorSoftLinkWrite`.
+ * Each type still dispatches differently, and each difference is a rule rather
+ * than an implementation detail: a crawler sends its *patch* so contended
+ * Downtime edits merge (ADR-030 §5), a pilot or mech sends its whole body, and
+ * a soft link is addressed by its endpoints because the server has no id for it.
  */
-function mirrorEntityWrite(
+async function commitWrite(
   type: EntityType,
   record: { id: string; gameId?: string | null },
   patch?: object
-): void {
+): Promise<void> {
   if (type === 'softLink') {
-    mirrorSoftLink('upsert', record as unknown as SoftLink)
+    await commitSoftLink('upsert', record as unknown as SoftLink)
     return
   }
+
+  const gameId = record.gameId ?? null
   if (type === 'crawler') {
-    // A shelf crawler used to be dropped here — "no server row to merge into",
-    // which was true while `crawlers.gameId` was non-nullable. It is nullable
-    // now, so a shelved crawler has a real row like everything else and this
-    // mirrors it. Skipping was the one place the local store held data the
-    // server had never heard of, which is exactly the local-only state the
-    // offline story forbids: IndexedDB reflects Convex, it is not a second
-    // source of truth.
-    const gameId = record.gameId ?? null
-    if (patch === undefined) {
-      void mirrorCrawlerWrite({ kind: 'create', appId: record.id, gameId, body: record })
-      return
-    }
-    void mirrorCrawlerWrite({ kind: 'patch', appId: record.id, patch })
+    await commitEntityWrite('crawler', {
+      kind: patch === undefined ? 'upsert' : 'patch',
+      appId: record.id,
+      gameId,
+      body: record,
+      patch: patch ?? {},
+    } as Parameters<typeof commitEntityWrite>[1])
     return
   }
-  if (type !== 'pilot' && type !== 'mech') return
-  void mirrorWrite(type, {
+
+  await commitEntityWrite(type, {
     kind: 'upsert',
     appId: record.id,
-    gameId: record.gameId ?? null,
+    gameId,
     body: record,
   })
-}
-
-/**
- * Send one link's endpoints up, in whichever direction.
- *
- * Split out because a link is mirrored from two places that hold it in
- * different shapes — `mirrorEntityWrite` gets the freshly persisted record,
- * while `delete` has to read the record back *before* removing it, since the
- * endpoints are the only address the server has for it.
- *
- * Guarded rather than assumed: a link whose endpoints did not survive a
- * salvage-tolerant read has nothing to address, and sending a half link would
- * fail validation server-side for no benefit.
- */
-function mirrorSoftLink(kind: 'upsert' | 'delete', link: SoftLink | null): void {
-  if (link === null) return
-  if (link.from?.id === undefined || link.to?.id === undefined) return
-  void mirrorSoftLinkWrite({ kind, from: link.from, to: link.to, type: link.type })
 }
 
 /**
@@ -517,8 +492,17 @@ export const useEntityStore = create<EntityState>((set, get) => ({
     // (ADR-030 §1): a signed-in user offline is read-only, not silently
     // writing to a local copy that would fork against the server.
     requireWritableBackend()
-    const record = await dbStoreFor(type).create(withActiveContainer(type, input))
-    mirrorEntityWrite(type, record)
+
+    // Build the record WITHOUT persisting it, commit it, and only then write it
+    // locally. The order is the demotion: with Convex as the source of truth, a
+    // record the server refused does not exist, so it must not appear on the
+    // device either. `commitWrite` throws on refusal and this deliberately does
+    // not catch — the caller's write failed, and every caller already handles
+    // that path for `WritesBlockedOffline`.
+    const record = await dbStoreFor(type).prepareCreate(withActiveContainer(type, input))
+    await commitWrite(type, record)
+    await dbStoreFor(type).put(record)
+
     set((state) => ({
       [key]: [record, ...(state[key] as EntityForType<T>[])],
     }))
@@ -570,8 +554,13 @@ export const useEntityStore = create<EntityState>((set, get) => ({
     // Capture the before-image BEFORE the write so the Change Log can diff it.
     const before = get().get(type, id)
     requireWritableBackend()
-    const updated = await dbStoreFor(type).update(id, patch)
-    mirrorEntityWrite(type, updated, patch)
+
+    // Same order as `create`: merge and validate, commit, then persist. A
+    // refused edit leaves the local record exactly as it was.
+    const updated = await dbStoreFor(type).prepareUpdate(id, patch)
+    await commitWrite(type, updated, patch)
+    await dbStoreFor(type).put(updated)
+
     set((state) => ({
       [key]: (state[key] as EntityForType<T>[]).map((e) => (e.id === id ? updated : e)),
     }))
@@ -620,6 +609,18 @@ export const useEntityStore = create<EntityState>((set, get) => ({
       }))
     )
 
+    // Phase 1b — commit every update to the server BEFORE touching disk.
+    //
+    // Ordering matters more here than anywhere else. A transfer moves value
+    // BETWEEN entities — cargo stow/load, a scrap hand-off — so a half-applied
+    // one is not a stale record but a wrong balance, and the communal crawler
+    // is usually one end of it. Committing first means a refusal aborts with
+    // nothing changed locally, which is the same guarantee phase 1's
+    // validate-everything-first already gives for Zod failures.
+    for (const pu of prepared) {
+      await commitWrite(pu.type, pu.record as { id: string; gameId?: string | null }, pu.patch)
+    }
+
     // Phase 2 — one IDB transaction for every put and delete.
     const prunedIds = await db.atomicWrite([
       ...prepared.map((pu) => ({
@@ -634,23 +635,6 @@ export const useEntityStore = create<EntityState>((set, get) => ({
         pruneSoftLinks: d.type !== 'softLink',
       })),
     ])
-
-    // Phase 2b — mirror to the server of record, exactly as update() does, and
-    // only once the atomic write above has actually landed. Per update rather
-    // than per transfer because the dispatch differs by type: a crawler sends
-    // its patch so contended Downtime edits merge, a pilot/mech upserts its
-    // whole body (see mirrorEntityWrite).
-    //
-    // This was the more serious half of the gap. Cargo stow/load moves value
-    // between a mech and the communal Game crawler (ADR-030 §5); without this
-    // the local copy said the scrap had moved and the server never heard, so
-    // the rest of the table kept seeing the old balance.
-    //
-    // No mirror for `deletes`: no production caller passes any today, so
-    // wiring one would be untested speculation rather than coverage.
-    for (const pu of prepared) {
-      mirrorEntityWrite(pu.type, pu.record as { id: string; gameId?: string | null }, pu.patch)
-    }
 
     // Phase 3 — sync in-memory state + broadcasts, mirroring update()/delete().
     const deletedByKey = new Map<StoreKey, Set<string>>()
@@ -724,14 +708,24 @@ export const useEntityStore = create<EntityState>((set, get) => ({
   async delete(type, id) {
     const key = storeKeyFor(type)
     requireWritableBackend()
-    // Read BEFORE the delete: a link is addressed on the server by its
-    // endpoints, and after the row is gone there is nothing left to name it by.
-    if (type === 'softLink') mirrorSoftLink('delete', get().get('softLink', id))
-    if (type === 'pilot' || type === 'mech') void mirrorWrite(type, { kind: 'delete', appId: id })
-    // Scrapping a crawler is the table runner's act; the server refuses anyone
-    // else, which is why this mirrors rather than deleting only locally.
-    if (type === 'crawler' && get().get('crawler', id)?.gameId != null) {
-      void mirrorCrawlerWrite({ kind: 'delete', appId: id })
+
+    // Commit the delete FIRST, and read the record before doing so: a link is
+    // addressed on the server by its endpoints, and once the row is gone there
+    // is nothing left to name it by.
+    //
+    // Awaited rather than fired off, like every other write now. Scrapping a
+    // crawler is the table runner's act and the server refuses anyone else — a
+    // refusal that only warned would delete the crew's home locally while it
+    // stayed alive for everyone else at the table.
+    if (type === 'softLink') {
+      await commitSoftLink('delete', get().get('softLink', id))
+    } else {
+      const existing = get().get(type, id)
+      await commitEntityWrite(type, {
+        kind: 'delete',
+        appId: id,
+        gameId: existing?.gameId ?? null,
+      })
     }
 
     // Cascade: deleting an entity prunes its SoftLinks (plan 2.7, gap 9).

--- a/docs/architecture/persistence-and-pwa.md
+++ b/docs/architecture/persistence-and-pwa.md
@@ -46,7 +46,7 @@ Update this table as part of each phase's PR. It is the only place that answers
 | P5    | Claim-on-sign-in coverage and the decline path             | yes        | **done**    |
 | —     | **The flip** — account required in production, legacy-guarded | **no**   | **done**    |
 | P6    | ITUN offline, proved rather than asserted                  | yes        | **done**    |
-| P4b   | Remove the mirrors; prune the cache                        | **no**     | specified — gated on soak |
+| P4b   | Remove the mirrors; prune the cache                        | **no**     | **done**    |
 | P7    | `srd` install-triggered offline (**blocked on ADR-033 P7**) | yes       | blocked     |
 
 P0–P2 are all reversible and all buy information. P3 and P4 are the one-way
@@ -416,22 +416,14 @@ it), so it may deserve its own follow-up phase rather than riding along here.
 
 ## P4b — Remove the mirrors, and prune the cache
 
-**Not started, and deliberately not started yet.** This is the last of the
-demotion and the single most dangerous change in the plan, because it rewrites
-the write path — the code that decides whether a player's work exists.
+**Done.** The last of the demotion, and the most dangerous change in the plan —
+it rewrites the write path, the code that decides whether a player's work exists.
 
-### Why it waits for soak rather than for a phase
-
-Every other "wait" in this document was a dependency. This one is a **soak**: the
-flip has not been deployed, only merged into a stack. Removing the mirror at the
-same time would ship a rewritten write path *simultaneously with* the change that
-alters who uses it, with no period in between where a failure could be attributed
-to one or the other. That is the same reasoning that keeps `srd`'s service worker
-untouched during its host move, applied to the thing with the worst failure mode
-in the app.
-
-**Precondition to start: the flip is live, and has been for long enough that a
-write-path regression would be visible as a write-path regression.**
+This document previously gated it on letting the flip soak first. That was
+overruled deliberately, and the reasoning against waiting is good: shipping the
+flip while leaving the mirror in place means shipping a fire-and-forget write
+path that is *already semantically wrong* under the new model. Dead code with a
+data-loss failure mode is worse than a larger diff.
 
 ### Removing the mirrors
 


### PR DESCRIPTION
**Layer 7 (top) of the ADR-034 stack.** Base: `feat/adr034-p6-itun-offline` (#880).

The last of the demotion. Writes now go to Convex **before** anything local is touched, and the three mirrors are **deleted** rather than left as dead code with a data-loss failure mode.

## What the mirrors were, and why both their properties had to go

`mirrorWrite`, `mirrorCrawlerWrite` and `mirrorSoftLinkWrite` were **fire-and-forget**, and correctly so at the time: the local write had already succeeded and was what the UI read, so a server refusal could not be allowed to roll it back. They also **upserted rather than updated**, because an entity built while Solo had no server row until the account was claimed.

Both describe a world where the local store is authoritative. A cache cannot legitimately be ahead of its source, so a write the server refused **did not happen** — and the only honest thing to do is await it and let it throw.

That failure mode is not hypothetical. `byAppId` resolves a duplicate to the oldest row and *warns* rather than throwing, precisely because a throw inside a fire-and-forget mirror was invisible to the player: the write never reached the server while every surface kept rendering it as saved. That is how an evening of play went missing.

## The reorder needed a split first

Exactly as the plan predicted. `crud.ts` minted the id, stamped timestamps and Zod-parsed **inside** the write, so there was no finished record to offer the server before committing to it. `prepareCreate` is that split — and `create` is now it plus one `put`, so the two cannot drift.

Transfers commit every update before touching disk, which matters most there: a transfer moves value *between* entities (cargo stow/load, a scrap hand-off), so a half-applied one is a wrong balance rather than a stale record — and the communal crawler is usually one end of it.

## Pruning ships with two guards, and neither is optional

- **Only shelf rows.** `listMine` returns what the caller *owns*, while a Game's unclaimed pre-gens and communal crawler have no owner and are cached on purpose by `GameRoster`. Pruning against their absence would empty every Game view on the next boot.
- **Only in a browser that never held a legacy roster.** For a pre-ADR-034 player who has signed in but not yet claimed, their whole roster is local shelf rows the server has never seen — rule 1 alone would read every one as "deleted elsewhere".

Both live in `lib/db/pruneRules.ts` as predicates the tests **import**. An earlier draft copied them into the test file, which would have let rule and test drift in the one direction that matters: the test passing while the code deleted the roster.

## Verification

`bun run check:all` exits 0; 1994 itun tests pass; offline + smoke e2e pass against a **fresh production build**, since this rewrote the path the app actually runs on.

## Note on sequencing

The plan had gated this on letting the flip soak first. That was overruled deliberately, and the argument against waiting is good: shipping the flip while leaving the mirror in place means shipping a fire-and-forget write path that is *already semantically wrong* under the new model. Dead code with a data-loss failure mode is worse than a larger diff. Recorded in the plan rather than quietly reversed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QU5rmidxZ3QUrMb3nvVNX6
