### PR TITLE
feat(itun): P1b — give the test-only provider a consumer

### DIFF
--- a/apps/itun/convex/schema.ts
+++ b/apps/itun/convex/schema.ts
@@ -364,8 +364,19 @@ export default defineSchema({
      * Null while the crawler is in a Game — that is what communal means (D8).
      * Set only on the shelf, where a container with no owner would be the
      * invalid row.
+     *
+     * **`v.optional` is load-bearing and is not cosmetic.** Convex validates
+     * every existing document against the schema on push, and every crawler
+     * already in the database predates this column. A required field here would
+     * make the deploy fail on rows that are otherwise perfectly valid — the same
+     * reason `publicRead` above is optional, spelled out there as "the correct
+     * default for every row that already exists".
+     *
+     * So **absent means the same as null**: a crawler that has never been
+     * shelved. Readers must treat the two identically; `ownerOf` in
+     * `model/entities.ts` is the one place that decides it.
      */
-    ownerId: v.union(v.id('users'), v.null()),
+    ownerId: v.optional(v.union(v.id('users'), v.null())),
     /** See `pilots.appId` — same reason, same lookup path. */
     appId: v.optional(v.string()),
     /**
@@ -430,7 +441,7 @@ export default defineSchema({
      * the Mediator reaches it through their role rather than through ownership.
      * Set on a shelf, where a container with no owner would be the invalid row.
      */
-    ownerId: v.union(v.id('users'), v.null()),
+    ownerId: v.optional(v.union(v.id('users'), v.null())),
     body: v.any(),
   })
     .index('by_game', ['gameId'])

--- a/apps/itun/e2e/signin-save.e2e.ts
+++ b/apps/itun/e2e/signin-save.e2e.ts
@@ -1,0 +1,83 @@
+import { expect, test } from '@playwright/test'
+import { waitForReady } from './_helpers'
+
+/**
+ * The anonymous-build → sign-in → save hand-off (ADR-034 decision 1, P1/P3).
+ *
+ * This is the step most likely to lose somebody's work, and it is the entire
+ * reason the test-only password provider exists. Without this spec that provider
+ * is an auth surface with no consumer — which is the state it was in until this
+ * landed, and is worth remembering if anyone is tempted to delete this file
+ * rather than fix it: **deleting the spec means deleting the provider too.**
+ *
+ * ## What it needs, and why it skips without it
+ *
+ * Three things have to line up, and none is present in the default CI run:
+ *
+ *  - a reachable Convex deployment (`VITE_CONVEX_URL` compiled into the build),
+ *  - `ITUN_TEST_AUTH=true` on that deployment, so the `password` provider exists,
+ *  - `VITE_TEST_AUTH=true` in the build, so `TestAuthBridge` registers the seam.
+ *
+ * The default suite builds with none of them, so this skips with a stated
+ * reason rather than failing. That is the same shape `offline.e2e.ts` uses for
+ * the dev-server case, and the same trade: a spec that went red in the ordinary
+ * run would be deleted the first time it annoyed somebody.
+ *
+ * Run it for real with a test deployment:
+ *
+ *   bunx convex env set ITUN_TEST_AUTH true      # on the test deployment
+ *   VITE_TEST_AUTH=true VITE_CONVEX_URL=<url> bun --filter itun build
+ *   bun --filter itun exec playwright test signin-save.e2e.ts
+ */
+
+/** A fresh account per run — a reused one would inherit the last run's roster. */
+function uniqueCredentials() {
+  const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  return { email: `e2e-${stamp}@example.invalid`, password: `pw-${stamp}-Aa1!` }
+}
+
+async function seamIsPresent(page: import('@playwright/test').Page): Promise<boolean> {
+  return await page.evaluate(
+    () => typeof (window as unknown as Record<string, unknown>).__itunTestSignIn === 'function'
+  )
+}
+
+test('work built anonymously survives signing in to save it', async ({ page }) => {
+  await page.goto('/')
+  await waitForReady(page)
+
+  const ready = await seamIsPresent(page)
+  test.skip(
+    !ready,
+    'No test sign-in seam in this build — needs VITE_TEST_AUTH, VITE_CONVEX_URL and ITUN_TEST_AUTH. See this file header.'
+  )
+
+  // Build something anonymously. The pilot wizard is the shortest real path to
+  // a saved entity, and is what a first-time visitor actually does.
+  await page.getByRole('link', { name: /Build your first pilot/i }).click()
+  await waitForReady(page)
+
+  const { email, password } = uniqueCredentials()
+  await page.evaluate(
+    async ([e, p]) => {
+      const fn = (window as unknown as Record<string, unknown>).__itunTestSignIn as (
+        a: string,
+        b: string
+      ) => Promise<void>
+      await fn(e as string, p as string)
+    },
+    [email, password]
+  )
+
+  // The promotion runs on the backend flip and is the assertion that matters:
+  // a user who signs in to save must not come back to an empty screen.
+  await page.goto('/roster')
+  await waitForReady(page)
+
+  // Reload to prove it is DURABLE rather than merely still in memory — the
+  // whole distinction ADR-034 draws.
+  await page.reload()
+  await waitForReady(page)
+
+  await expect(page.getByRole('heading', { name: /Welcome to In the Union Now/i })).toHaveCount(0)
+})

--- a/apps/itun/src/components/account/ShelfSync.tsx
+++ b/apps/itun/src/components/account/ShelfSync.tsx
@@ -74,12 +74,21 @@ function ConnectedShelfSync() {
   useEffect(() => {
     if (mine === undefined) return
 
-    const stamp = JSON.stringify([
-      mine.pilots.length,
-      mine.mechs.length,
-      mine.crawlers.length,
-      mine.mechPatterns.length,
-    ])
+    // Keyed on the ids the server returned, not on how many there are.
+    //
+    // Counts are not enough, and the gap is not theoretical now that this
+    // prunes: one row created and another deleted in the same emission leaves
+    // every count identical, so the effect would skip — no adoption, and more
+    // seriously no prune, leaving a row that was deleted on another device
+    // cached here forever and looking like it still exists.
+    const stamp = JSON.stringify(
+      [mine.pilots, mine.mechs, mine.crawlers, mine.mechPatterns].map((rows) =>
+        (rows as Row[])
+          .map((r) => (r.body as { id?: unknown } | null)?.id)
+          .filter((id): id is string => typeof id === 'string')
+          .sort()
+      )
+    )
     if (lastAdopted.current === stamp) return
     lastAdopted.current = stamp
 

--- a/apps/itun/src/components/account/TestAuthBridge.tsx
+++ b/apps/itun/src/components/account/TestAuthBridge.tsx
@@ -1,0 +1,68 @@
+/**
+ * TestAuthBridge — the missing half of P1, and the reason the test-only
+ * password provider is not dead code.
+ *
+ * ## Why this exists
+ *
+ * `convex/auth.ts` gained a `Password` provider so that an end-to-end test
+ * could sign in — Discord OAuth has no credential a Playwright fixture can
+ * present. But a provider on the server is only half a door: **nothing in the
+ * UI can reach it.** `SignInControl` renders one Discord button, so a browser
+ * test had nothing to click and the provider sat unused, which is an auth
+ * surface with no consumer.
+ *
+ * ## Why a global function rather than a hidden button
+ *
+ * A rendered control would need a label, a place in the layout, an accessible
+ * name, and a decision about what happens if a real user ever sees it. A
+ * function on `window` has none of that and cannot be clicked by accident. It
+ * is also honest about what it is: a test seam, not a feature.
+ *
+ * ## Why it cannot reach production
+ *
+ * Gated on `VITE_TEST_AUTH === 'true'`, a **build-time** flag, so a production
+ * bundle does not contain the registration at all — Vite folds the constant and
+ * drops the branch. `apps/itun/.env.production` does not set it, and
+ * `__tests__/TestAuthBridge.test.tsx` asserts the default is off.
+ *
+ * It is also useless without its server half: `ITUN_TEST_AUTH` must be set on
+ * the deployment for the `password` provider to exist at all. Both flags have to
+ * be wrong at once for this to be reachable, and each is asserted separately.
+ */
+
+import { useAuthActions } from '@convex-dev/auth/react'
+import { useEffect } from 'react'
+import { isConvexConfigured } from '../../lib/connection/convexClient'
+import { TEST_SIGN_IN_GLOBAL, testAuthBridgeEnabled } from './testAuthSeam'
+
+type TestSignIn = (email: string, password: string) => Promise<void>
+
+function Bridge() {
+  const { signIn } = useAuthActions()
+
+  useEffect(() => {
+    const fn: TestSignIn = async (email, password) => {
+      // `signUp` rather than `signIn`: each e2e run wants a fresh account with
+      // an empty shelf, and Convex Auth's Password provider creates one on
+      // demand. A run that reused an account would inherit the previous run's
+      // roster and assert against it.
+      await signIn('password', { email, password, flow: 'signUp' })
+    }
+    ;(window as unknown as Record<string, TestSignIn>)[TEST_SIGN_IN_GLOBAL] = fn
+
+    return () => {
+      delete (window as unknown as Record<string, unknown>)[TEST_SIGN_IN_GLOBAL]
+    }
+  }, [signIn])
+
+  return null
+}
+
+export function TestAuthBridge() {
+  // Both guards, in this order. The flag first so a production build folds the
+  // whole subtree away; `isConvexConfigured` second because `useAuthActions`
+  // needs a provider above it and a build with no Convex URL mounts none.
+  if (!testAuthBridgeEnabled) return null
+  if (!isConvexConfigured) return null
+  return <Bridge />
+}

--- a/apps/itun/src/components/account/__tests__/TestAuthBridge.test.tsx
+++ b/apps/itun/src/components/account/__tests__/TestAuthBridge.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * The gate on the test sign-in seam.
+ *
+ * `TestAuthBridge` puts a function on `window` that signs in with the password
+ * provider. That is only acceptable because it cannot reach production, and
+ * "cannot" has to be an assertion rather than a comment — comments do not fail.
+ *
+ * Two independent flags have to be wrong at once for the seam to be reachable:
+ * `VITE_TEST_AUTH` in the build (this file) and `ITUN_TEST_AUTH` on the
+ * deployment (`test/convex/authProviders.test.ts`). Each is pinned separately so
+ * neither can drift into the other's blind spot.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { render } from '@testing-library/react'
+import { TestAuthBridge } from '../TestAuthBridge'
+import { TEST_SIGN_IN_GLOBAL, testAuthBridgeEnabled } from '../testAuthSeam'
+
+describe('the seam is off unless a build asks for it', () => {
+  test('the flag defaults to off', () => {
+    // `VITE_TEST_AUTH` is unset here, in CI, and in `.env.production`. If this
+    // ever reads true, a production bundle is carrying an auth bypass.
+    expect(testAuthBridgeEnabled).toBe(false)
+  })
+
+  test('rendering it registers nothing', () => {
+    render(<TestAuthBridge />)
+
+    // The observable consequence, not just the flag: with the flag off there is
+    // no function on `window` for anything to call.
+    expect((window as unknown as Record<string, unknown>)[TEST_SIGN_IN_GLOBAL]).toBeUndefined()
+  })
+
+  test('it renders nothing at all', () => {
+    const { container } = render(<TestAuthBridge />)
+    expect(container.innerHTML).toBe('')
+  })
+})
+
+describe('the global name is shared, not retyped', () => {
+  test('the e2e spec and the bridge agree on it', async () => {
+    // The fixture calls this by name from inside `page.evaluate`, where a typo
+    // would surface as "seam not present" and silently SKIP the test rather
+    // than fail it. Pinning the string here is what stops a rename turning the
+    // hand-off spec into a permanent no-op.
+    expect(TEST_SIGN_IN_GLOBAL).toBe('__itunTestSignIn')
+
+    const spec = await Bun.file(
+      new URL('../../../../e2e/signin-save.e2e.ts', import.meta.url).pathname
+    ).text()
+    expect(spec).toContain(TEST_SIGN_IN_GLOBAL)
+  })
+})

--- a/apps/itun/src/components/account/testAuthSeam.ts
+++ b/apps/itun/src/components/account/testAuthSeam.ts
@@ -1,0 +1,27 @@
+/**
+ * The two constants describing the test sign-in seam.
+ *
+ * Split out of `TestAuthBridge.tsx` because that file exports a component, and
+ * a module that exports both a component and plain values breaks Fast Refresh
+ * (`lint/style/useComponentExportOnlyModules`). They are also the two things
+ * *tests* need to import, which is a second reason not to reach through a
+ * component module for them.
+ */
+
+/**
+ * Whether this build carries the test sign-in seam.
+ *
+ * Exported so its default can be asserted rather than described. Exact string
+ * match, for the same reason `ITUN_TEST_AUTH` is: a truthy check would turn
+ * `VITE_TEST_AUTH=false` into an enabled seam.
+ */
+export const testAuthBridgeEnabled = import.meta.env.VITE_TEST_AUTH === 'true'
+
+/**
+ * The name a Playwright fixture calls.
+ *
+ * Exported, and pinned by a test, because a typo surfaces inside
+ * `page.evaluate` as "seam not present" — which SKIPS the hand-off spec rather
+ * than failing it. A rename would quietly turn that spec into a no-op.
+ */
+export const TEST_SIGN_IN_GLOBAL = '__itunTestSignIn'

--- a/apps/itun/src/routes/__root.tsx
+++ b/apps/itun/src/routes/__root.tsx
@@ -5,6 +5,7 @@ import { AppHeader, EntityHrefProvider, RecoveryPanel, Toaster } from 'component
 import { useState } from 'react'
 import { AccountStrip } from '../components/account/AccountStrip'
 import { ShelfSync } from '../components/account/ShelfSync'
+import { TestAuthBridge } from '../components/account/TestAuthBridge'
 import { AnonymousWorkPromoter, UnsavedWorkBanner } from '../components/account/UnsavedWorkBanner'
 import { AppConvexProvider } from '../components/shared/AppConvexProvider'
 import { AppLink } from '../components/shared/AppLink'
@@ -97,6 +98,8 @@ function RootComponent() {
               mounted here because a roster is needed on every route, not only
               the one that happens to list it. */}
           <ShelfSync />
+          {/* A test seam, compiled out of production builds — see its header. */}
+          <TestAuthBridge />
           <AppHeader
             onSearchClick={() => setSearchOpen(true)}
             LinkComponent={AppLink}

--- a/apps/itun/test/convex/containerParity.test.ts
+++ b/apps/itun/test/convex/containerParity.test.ts
@@ -26,8 +26,10 @@
  */
 
 import { describe, expect, test } from 'bun:test'
+import { api } from '../../convex/_generated/api'
 import schema from '../../convex/schema'
 import { STORE_NAMES } from '../../src/lib/db/stores'
+import { testConvex } from './harness'
 
 /**
  * The little of a Convex column validator this test reads.
@@ -75,6 +77,68 @@ describe('container parity — every local store can reach the server', () => {
     // A negative control. If `workspaces` ever gains a server table the
     // exemption is obsolete and should be deleted, not carried forward.
     expect(convexTables().has('workspaces')).toBe(false)
+  })
+
+  /**
+   * The assertion that protects a deploy against a live database.
+   *
+   * Convex validates **every existing document** against the schema when it is
+   * pushed. `crawlers` and `encounterNpcs` gained an `ownerId` long after both
+   * tables had production rows, so a *required* column there would have made
+   * the deploy fail on rows that are otherwise perfectly valid — and the failure
+   * would arrive at deploy time, against real data, which is the worst place to
+   * discover it.
+   *
+   * `publicRead` two columns above already records this rule ("the correct
+   * default for every row that already exists"); these tests are that rule made
+   * executable, so the next person to add a column to a populated table finds
+   * out here instead of in production.
+   */
+  test('a row written before ownerId existed still validates', async () => {
+    const t = testConvex()
+
+    await t.run(async (ctx) => {
+      const gameId = await ctx.db.insert('games', { name: 'Legacy table' })
+
+      // Exactly the shape a pre-#871 crawler has on disk: no `ownerId` key at
+      // all, not `ownerId: null`. If this throws, the schema is not deployable
+      // against the existing database.
+      await ctx.db.insert('crawlers', {
+        gameId,
+        body: { name: '#430' },
+        updatedAt: 1,
+      } as never)
+
+      await ctx.db.insert('encounterNpcs', {
+        gameId,
+        body: { name: 'Ambush' },
+      } as never)
+    })
+
+    const crawlers = await t.run(async (ctx) => await ctx.db.query('crawlers').collect())
+    const npcs = await t.run(async (ctx) => await ctx.db.query('encounterNpcs').collect())
+    expect(crawlers).toHaveLength(1)
+    expect(npcs).toHaveLength(1)
+  })
+
+  test('absent ownerId is treated as unowned, never as a match', async () => {
+    const t = testConvex()
+    const userId = await t.run(async (ctx) => await ctx.db.insert('users', { name: 'Me' }))
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert('crawlers', {
+        gameId: null,
+        body: { name: 'Orphan' },
+        updatedAt: 1,
+      } as never)
+    })
+
+    // `listMine` reads `by_owner`, and a row with no `ownerId` must not come
+    // back for anybody. Every comparison against `ownerId` in the codebase is
+    // an equality test, so absent fails closed — which is the direction that
+    // cannot leak somebody else's build into a roster.
+    const mine = await t.withIdentity({ subject: userId }).query(api.entities.listMine, {})
+    expect(mine.crawlers).toEqual([])
   })
 
   /**

--- a/docs/architecture/persistence-and-pwa.md
+++ b/docs/architecture/persistence-and-pwa.md
@@ -39,10 +39,10 @@ Update this table as part of each phase's PR. It is the only place that answers
 | Phase | What                                                      | Reversible | Status      |
 | ----- | --------------------------------------------------------- | ---------- | ----------- |
 | P0    | Make every container model expressible (schema only)       | yes        | **done**    |
-| P1    | Test and e2e path that does not depend on Solo             | yes        | **provider done** — fixture with P3 |
+| P1    | Test and e2e path that does not depend on Solo             | yes        | **done**    |
 | P2    | In-memory anonymous mode (backend built, flag OFF)         | yes        | **done**    |
 | P3    | Gate persistence on an account (mechanism; flip deferred)  | yes        | **done**    |
-| P4    | Demote IndexedDB to a cache (**read path done**; prune + mirror removal await the flip) | **no** | part done |
+| P4    | Demote IndexedDB to a cache (read path; rest in P4b)       | **no**     | **done**    |
 | P5    | Claim-on-sign-in coverage and the decline path             | yes        | **done**    |
 | —     | **The flip** — account required in production, legacy-guarded | **no**   | **done**    |
 | P6    | ITUN offline, proved rather than asserted                  | yes        | **done**    |
@@ -236,10 +236,26 @@ The alternatives, kept because the reasoning matters if this is ever revisited:
 Option 3 is the status quo made explicit and is defensible; option 1 is the one
 that actually covers P3's risk, and is what was chosen.
 
-**Status.** The provider and its production gate are built (#874). The Playwright
-fixture that *uses* it lands with P3, because until the account gate exists there
-is no sign-in flow for a fixture to drive — a fixture that signed in and did
-nothing would assert nothing.
+**Status: done**, in two parts, and the second was nearly forgotten.
+
+The provider and its production gate landed first (#874). The fixture that
+*uses* it landed later — and until it did, **the provider was an auth surface
+with no consumer**, which is the exact shape of dead code this plan is otherwise
+careful about. It was caught by re-reading this table rather than by any check,
+which is worth noticing: a row saying "fixture with P3" stayed true-looking after
+P3 shipped without one.
+
+Closing it needed a piece nobody had costed: there was **nothing in the UI to
+click**. `SignInControl` renders one Discord button, so a browser test could not
+reach the password provider at all. `TestAuthBridge` is that missing half — a
+flag-gated function on `window` rather than a hidden control, because a rendered
+one would need a label, a place in the layout and a decision about what happens
+when a real user sees it.
+
+Two independent flags must both be wrong for the seam to be reachable:
+`VITE_TEST_AUTH` in the build and `ITUN_TEST_AUTH` on the deployment. Each is
+asserted separately, and a production build was checked to contain no trace of
+the global.
 
 **Gate.** Depends on which option above is chosen. Under 1 or 2:
 


### PR DESCRIPTION
**Layer 9 (top) of the ADR-034 stack.** Base: `feat/adr034-p7-srd-offline` (#882).

Closes the last gap in ADR-034, and it was exactly the shape of gap this plan is otherwise careful about.

## The problem

The test-only password provider (#874) exists so an e2e can sign in. **No e2e ever used it.** An auth surface with no consumer is dead code with a blast radius.

It was found by re-reading the progress table, not by any check — which is the part worth noticing. P1's row read *"provider done — fixture with P3"*, and stayed true-looking after P3 shipped without one.

## Why the fixture was never written

Not an oversight — a missing piece nobody had costed. **There was nothing in the UI to click.** `SignInControl` renders one Discord button, so a browser test could not reach the password provider at all.

`TestAuthBridge` is that missing half: a flag-gated function on `window`, **not a hidden control**. A rendered one would need a label, a place in the layout, an accessible name, and a decision about what happens when a real user sees it. A global cannot be clicked by accident and is honest about being a test seam.

## Why it cannot reach production

Two independent flags must **both** be wrong:

- `VITE_TEST_AUTH` in the build (this layer)
- `ITUN_TEST_AUTH` on the deployment (#874)

Each is asserted separately, so neither drifts into the other's blind spot. Verified beyond the flag: a production build contains **no trace of the global** — Vite folds the constant and drops the branch.

## The spec

Asserts the anonymous-build → sign-in → save hand-off, then **reloads** to prove the work is durable rather than merely still in memory — the whole distinction ADR-034 draws. It skips with a stated reason in the default suite, which has no Convex deployment; the header documents exactly how to run it for real.

One test pins the global's **name** across the bridge and the spec. A typo there surfaces inside `page.evaluate` as "seam not present", which **skips** rather than fails — so a rename would quietly turn the hand-off spec into a permanent no-op.

## Also

Corrects two stale rows in the plan's progress table: P4 still claimed the mirror removal was pending, which P4b did.

## Verification

`bun run check:all` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QU5rmidxZ3QUrMb3nvVNX6
