### PR TITLE
fix(itun): serve security headers on Cloudflare, and gate their absence

### DIFF
--- a/apps/itun/public/_headers
+++ b/apps/itun/public/_headers
@@ -13,11 +13,17 @@
 # every policy below still lived in a `netlify.toml` for a host that had stopped
 # answering.
 #
+# This is a port of `apps/itun/netlify.toml`'s header block, with two stated
+# exceptions: the `/*.html` rule below is an ADDITION (the toml has no
+# counterpart), and srd's `immutable` image rules are deliberately NOT copied
+# here. Everything in the toml's `/*` and `/assets/*` blocks is present
+# unchanged, CSP included.
+#
 # `tools/check-observability.ts` reads whichever sources exist and holds every
 # one that declares a policy to the same rule. Note what that did NOT catch: an
 # *absent* source is not a declaring source, so itun passed on the strength of
 # the toml alone. The checker now also requires this file to exist whenever the
-# app's `wrangler.jsonc` declares `assets` — see the `assetSurfaces` rule there.
+# app's `wrangler.jsonc` declares `assets` — see `declaresStaticAssets` there.
 
 /*
   X-Frame-Options: DENY
@@ -57,18 +63,17 @@
 /assets/*
   Cache-Control: public, max-age=31536000, immutable
 
-# Icons and artwork are content-addressed by name and never mutated in place.
-/*.png
-  Cache-Control: public, max-age=31536000, immutable
-
-/*.webp
-  Cache-Control: public, max-age=31536000, immutable
-
-/*.svg
-  Cache-Control: public, max-age=31536000, immutable
-
+# NOT immutable, and this is the one place this file deliberately differs from
+# srd's. srd's icons and artwork really are content-addressed, so it marks
+# `/*.png` etc. immutable for a year. itun's `public/` holds `favicon.svg`,
+# `icon-192.png`, `icon-512.png` and `logos/` — FIXED names that are mutated in
+# place on redesign. A year of `immutable` on those means a changed icon that no
+# amount of reloading can dislodge, so no such rule is written here.
+#
 # HTML must never be cached: a deploy rotates the hashed chunk names, and a
-# stale document names chunks that no longer exist. This is the SPA shell, so
-# a stale copy breaks every route rather than one page.
+# stale document names chunks that no longer exist. This is the SPA shell, so a
+# stale copy breaks every route rather than one page. It is the one rule in this
+# file with no `netlify.toml` counterpart — an addition rather than a port, kept
+# because Cloudflare's asset serving would otherwise be free to cache the shell.
 /*.html
   Cache-Control: public, max-age=0, must-revalidate

--- a/apps/itun/public/_headers
+++ b/apps/itun/public/_headers
@@ -1,0 +1,74 @@
+# Response headers for intheunionnow.com.
+#
+# Copied verbatim into `dist/` by Vite's publicDir, and read by Workers Static
+# Assets (ADR-033). Netlify reads the same file format, so during the cutover
+# BOTH hosts serve these — which is what makes the parallel phase meaningful
+# rather than a comparison of two different configurations.
+#
+# This file exists because it did not. srd got a `_headers` when its CSP moved
+# out of `netlify.toml`; itun did not, and `apps/itun/wrangler.jsonc` binds
+# intheunionnow.com as a custom domain. So between the Cloudflare flip and this
+# commit the production SPA served no CSP, no HSTS, no X-Frame-Options and no
+# nosniff at all: `src/worker/index.ts` forwards asset responses untouched, and
+# every policy below still lived in a `netlify.toml` for a host that had stopped
+# answering.
+#
+# `tools/check-observability.ts` reads whichever sources exist and holds every
+# one that declares a policy to the same rule. Note what that did NOT catch: an
+# *absent* source is not a declaring source, so itun passed on the strength of
+# the toml alone. The checker now also requires this file to exist whenever the
+# app's `wrangler.jsonc` declares `assets` — see the `assetSurfaces` rule there.
+
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: geolocation=(), microphone=(), camera=()
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  X-DNS-Prefetch-Control: on
+  # connect-src MUST list Sentry's ingest origin or the browser blocks every
+  # event before it leaves the page — a DSN alone is not enough, and that
+  # failure is silent AND looks healthy (zero errors reported).
+  #
+  # `de`, not `us`: this org is in Sentry's EU data region. A DSN issued in one
+  # region under a CSP written for the other is blocked in the browser and the
+  # project reports nothing — indistinguishable, from outside, from "no errors".
+  #
+  # Kept in lockstep with SENTRY_INGEST_HOST in tools/check-observability.ts,
+  # which fails CI if this drifts. Wildcarded subdomain because the host encodes
+  # the Sentry org id.
+  #
+  # The Convex entries are load-bearing for the same reason and fail the same
+  # silent way. The accounts client (ADR-030) opens a WebSocket to the
+  # deployment for its reactive queries and POSTs mutations over HTTPS, and
+  # `@convex-dev/auth` exchanges tokens against the deployment's `.site` origin.
+  # Omit these and every one of those is blocked before it leaves the page:
+  # VITE_CONVEX_URL is set, the client constructs happily, the app reports
+  # itself Connected — and nothing ever reaches the server. Sign-in simply
+  # never completes, with no error surface.
+  #
+  # Wildcarded per deployment name, like the Sentry host, because the deployment
+  # differs by context: production is `exuberant-porpoise-183`, while a branch
+  # deploy or a local `convex dev` points elsewhere. Both schemes are required —
+  # `wss:` does NOT inherit from `https:`.
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://storage.ko-fi.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://ingesteer.services-prod.nsvcs.net https://*.ingest.de.sentry.io https://*.convex.cloud wss://*.convex.cloud https://*.convex.site;
+
+# Content-hashed bundle output from Vite's default assetsDir.
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Icons and artwork are content-addressed by name and never mutated in place.
+/*.png
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.webp
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.svg
+  Cache-Control: public, max-age=31536000, immutable
+
+# HTML must never be cached: a deploy rotates the hashed chunk names, and a
+# stale document names chunks that no longer exist. This is the SPA shell, so
+# a stale copy breaks every route rather than one page.
+/*.html
+  Cache-Control: public, max-age=0, must-revalidate

--- a/tools/__tests__/check-observability-csp.test.ts
+++ b/tools/__tests__/check-observability-csp.test.ts
@@ -94,42 +94,49 @@ describe('check-observability CSP source resolution', () => {
   })
 
   test('fails when NO source declares a CSP at all', async () => {
+    // BOTH itun sources have to be neutralised now. When this test was written
+    // itun had no `public/_headers`, so retiring the toml's header was enough to
+    // reach "nothing declares a policy". itun has one since the Cloudflare flip,
+    // and leaving it out here would have made this assertion vacuous — the run
+    // would pass on the `_headers` CSP and the test would be proving nothing.
     await withFileContents(
       'apps/itun/netlify.toml',
       (s) => s.replace(/Content-Security-Policy/g, 'X-Retired-Policy'),
       async () => {
-        const { exitCode, stderr } = await runCheck()
-        expect(exitCode).toBe(1)
-        expect(stderr).toContain('declares a Content-Security-Policy')
+        await withFileContents(
+          'apps/itun/public/_headers',
+          (s) => s.replace(/Content-Security-Policy/g, 'X-Retired-Policy'),
+          async () => {
+            const { exitCode, stderr } = await runCheck()
+            expect(exitCode).toBe(1)
+            expect(stderr).toContain('declares a Content-Security-Policy')
+          }
+        )
       }
     )
   })
 
-  test('accepts a _headers file as the CSP source once netlify.toml is gone', async () => {
+  test('accepts the _headers file as the CSP source once netlify.toml is gone', async () => {
+    // This used to invent the `_headers` file, because itun had none. It is now
+    // committed, so the test asserts the real thing: delete the toml — as P8
+    // will — and the committed `_headers` must carry the pass on its own. That
+    // makes this a live check on the actual policy rather than on a fixture.
     await withFileAbsent('apps/itun/netlify.toml', async () => {
-      await withNewFile(
-        'apps/itun/public/_headers',
-        `/*\n  Content-Security-Policy: default-src 'self'; connect-src 'self' ${SENTRY_HOST};\n`,
-        async () => {
-          const { exitCode } = await runCheck()
-          expect(exitCode).toBe(0)
-        }
-      )
+      const { exitCode } = await runCheck()
+      expect(exitCode).toBe(0)
     })
   })
 
   test('a _headers CSP that omits Sentry still fails — the dialect is not an escape hatch', async () => {
-    await withFileAbsent('apps/itun/netlify.toml', async () => {
-      await withNewFile(
-        'apps/itun/public/_headers',
-        `/*\n  Content-Security-Policy: default-src 'self'; connect-src 'self';\n`,
-        async () => {
-          const { exitCode, stderr } = await runCheck()
-          expect(exitCode).toBe(1)
-          expect(stderr).toContain('CSP connect-src does not allow')
-        }
-      )
-    })
+    await withFileContents(
+      'apps/itun/public/_headers',
+      (s) => s.replace(SENTRY_HOST, 'https://example.invalid'),
+      async () => {
+        const { exitCode, stderr } = await runCheck()
+        expect(exitCode).toBe(1)
+        expect(stderr).toContain('CSP connect-src does not allow')
+      }
+    )
   })
 
   test('a present source with no CSP is not itself a failure', async () => {
@@ -171,6 +178,78 @@ describe('check-observability functions-directory retirement', () => {
         const { exitCode, stderr } = await runCheck()
         expect(exitCode).toBe(1)
         expect(stderr).toContain('exports no handler')
+      }
+    )
+  })
+})
+
+/**
+ * The rule that would have caught the real outage.
+ *
+ * itun went live on Cloudflare with no `apps/itun/public/_headers` at all, and
+ * this checker stayed green: the CSP rule above judges only sources that EXIST,
+ * so an absent policy was filtered out before it could fail anything, and the
+ * pass came from a `netlify.toml` describing a host that had stopped answering.
+ * The site served no CSP, no HSTS and no X-Frame-Options for a day.
+ *
+ * The fix is a different KIND of rule — "config present, property missing →
+ * fail" — keyed on the deploy target rather than on the file set: if
+ * `wrangler.jsonc` declares `assets`, Cloudflare serves this app from static
+ * assets, and `_headers` is the only thing there that can carry a policy.
+ */
+describe('check-observability Workers static-assets headers', () => {
+  test('fails when an app whose wrangler declares assets has no _headers', async () => {
+    await withFileAbsent('apps/itun/public/_headers', async () => {
+      const { exitCode, stderr } = await runCheck()
+      expect(exitCode).toBe(1)
+      expect(stderr).toContain('apps/itun/public/_headers does not exist')
+    })
+  })
+
+  test('the same absence fails for srd — the rule is not itun-specific', async () => {
+    await withFileAbsent('apps/srd/public/_headers', async () => {
+      const { exitCode, stderr } = await runCheck()
+      expect(exitCode).toBe(1)
+      expect(stderr).toContain('apps/srd/public/_headers does not exist')
+    })
+  })
+
+  /**
+   * Control: the requirement must be TIED to the `assets` declaration, not
+   * unconditional. Without this, a rule that simply always demanded `_headers`
+   * would pass both tests above while being wrong about what it enforces — and
+   * it would fire on a Worker-only surface that legitimately has no static
+   * assets to attach headers to.
+   */
+  test('an app whose wrangler does NOT declare assets is exempt', async () => {
+    await withFileContents(
+      'apps/itun/wrangler.jsonc',
+      (s) => s.replace(/"assets"\s*:/, '"assetsDisabledForTest":'),
+      async () => {
+        await withFileAbsent('apps/itun/public/_headers', async () => {
+          const { exitCode, stderr } = await runCheck()
+          expect(stderr).not.toContain('apps/itun/public/_headers does not exist')
+          expect(exitCode).toBe(0)
+        })
+      }
+    )
+  })
+
+  /**
+   * The `assets` match must survive the prose. These configs mention `/assets/*`
+   * repeatedly in comments before declaring anything, so a substring match on
+   * "assets" would keep passing after the real binding was deleted — the exact
+   * trap `check-convex-parity.ts` fell into with `convex deploy`.
+   */
+  test('a commented-out assets binding does not satisfy the rule', async () => {
+    await withFileContents(
+      'apps/itun/wrangler.jsonc',
+      (s) => s.replace(/^(\s*)"assets"\s*:/m, '$1// "assets":'),
+      async () => {
+        await withFileAbsent('apps/itun/public/_headers', async () => {
+          const { stderr } = await runCheck()
+          expect(stderr).not.toContain('apps/itun/public/_headers does not exist')
+        })
       }
     )
   })

--- a/tools/check-observability.ts
+++ b/tools/check-observability.ts
@@ -85,6 +85,26 @@ type BrowserApp = {
    * cannot go wrong quietly while a good one carries the pass.
    */
   cspSources: string[]
+  /**
+   * The app's Workers config, and the `_headers` its Cloudflare deploy serves.
+   *
+   * These exist because `cspSources` alone could not catch a real outage. The
+   * rule above is "at least one PRESENT source declares a policy", and a source
+   * that does not exist on disk is filtered out before it is judged — so when
+   * itun went live on Cloudflare with no `public/_headers` at all, this checker
+   * stayed green on the strength of a `netlify.toml` describing a host that had
+   * stopped answering. An absent policy was indistinguishable from a policy
+   * carried elsewhere.
+   *
+   * So the file-level rule is not enough on its own: it validates files, while
+   * the thing that can break is a *host*. When `wrangler.jsonc` declares
+   * `assets`, Cloudflare is serving this app from static assets and `_headers`
+   * is the ONLY way it gets a policy — nothing else in the Worker path adds
+   * one. That makes the file mandatory rather than merely one candidate.
+   */
+  wranglerPath: string
+  /** The `_headers` a Workers Static Assets deploy reads. Must be in `cspSources`. */
+  workersHeadersPath: string
   /** Production origin, for --live. */
   productionUrl: string
 }
@@ -99,6 +119,8 @@ const BROWSER_APPS: BrowserApp[] = [
     // the init lives there — one place instead of one per layout.
     entryPath: 'apps/srd/src/runtime/islands.client.ts',
     cspSources: ['apps/srd/netlify.toml', 'apps/srd/public/_headers'],
+    wranglerPath: 'apps/srd/wrangler.jsonc',
+    workersHeadersPath: 'apps/srd/public/_headers',
     productionUrl: 'https://salvageunion.io',
   },
   {
@@ -107,6 +129,8 @@ const BROWSER_APPS: BrowserApp[] = [
     modulePath: 'apps/itun/src/lib/observability.ts',
     entryPath: 'apps/itun/src/main.tsx',
     cspSources: ['apps/itun/netlify.toml', 'apps/itun/public/_headers'],
+    wranglerPath: 'apps/itun/wrangler.jsonc',
+    workersHeadersPath: 'apps/itun/public/_headers',
     productionUrl: 'https://intheunionnow.com',
   },
 ]
@@ -127,6 +151,25 @@ function read(path: string): string | null {
  * Returns null when the file declares no CSP at all (which is itself a finding
  * for an app that ships one).
  */
+/**
+ * Does this `wrangler.jsonc` declare a static-assets binding?
+ *
+ * Comment lines are stripped FIRST, and that is the whole difficulty. These
+ * files are heavily commented and the word `assets` appears throughout the
+ * prose — `apps/itun/wrangler.jsonc` alone mentions `/assets/*` five times in
+ * explanation before it ever declares the binding. A naive `includes('assets')`
+ * would be satisfied by the commentary and would keep passing after someone
+ * deleted the real declaration, which is precisely the failure this rule exists
+ * to prevent. `check-convex-parity.ts` learned the same lesson the same way.
+ */
+function declaresStaticAssets(wranglerJsonc: string): boolean {
+  const withoutComments = wranglerJsonc
+    .split('\n')
+    .filter((line) => !line.trim().startsWith('//'))
+    .join('\n')
+  return /"assets"\s*:/.test(withoutComments)
+}
+
 function connectSrcOfPolicy(policy: string): string | null {
   const directive = policy.split(';').find((d) => d.trim().startsWith('connect-src'))
   return directive ? directive.trim() : null
@@ -181,6 +224,29 @@ function checkStatic(app: BrowserApp): void {
     fail(app.name, `entry missing at ${app.entryPath}`)
   } else if (!entry.includes('initBrowserObservability')) {
     fail(app.name, `${app.entryPath} never calls initBrowserObservability()`)
+  }
+
+  // Before the file-level rule: if Cloudflare serves this app from static
+  // assets, `_headers` is the only thing that can carry a policy there, so it
+  // is mandatory rather than one candidate among several.
+  //
+  // This is deliberately a "config present, property missing → fail" rule, the
+  // same shape the other ADR-033 guards already use. It is what the `present`
+  // filter below structurally cannot express: that filter drops a non-existent
+  // source before judging it, so "no file" reads as "not my business" instead
+  // of as the outage it was.
+  const wrangler = read(app.wranglerPath)
+  if (wrangler !== null && declaresStaticAssets(wrangler)) {
+    if (read(app.workersHeadersPath) === null) {
+      fail(
+        app.name,
+        `${app.wranglerPath} declares "assets", so Cloudflare serves this app from ` +
+          `static assets — but ${app.workersHeadersPath} does not exist. The Worker ` +
+          `adds no headers of its own, so the deployed site would ship no CSP, no ` +
+          `HSTS and no X-Frame-Options, however complete netlify.toml looks.`
+      )
+      return
+    }
   }
 
   // The CSP half — the one that would have made a provisioned DSN look


### PR DESCRIPTION
## What

`apps/itun/wrangler.jsonc` binds intheunionnow.com as a custom domain, but apps/itun had **no `public/_headers`**. srd got one when its CSP moved out of `netlify.toml`; itun did not. `src/worker/index.ts` forwards asset responses untouched, so since the Cloudflare flip the production SPA has served **no CSP, no HSTS, no X-Frame-Options, no nosniff and no Referrer-Policy**. All of it still lived in a `netlify.toml` for a host that had stopped answering.

## Why the checker didn't catch it

`check-observability.ts` judges only CSP sources that **exist** — a missing file is filtered out before it is assessed — so an absent policy was indistinguishable from one carried elsewhere, and itun passed on the strength of the dead toml.

This adds a different *kind* of rule, keyed on the deploy target rather than the file set: when `wrangler.jsonc` declares `assets`, Cloudflare serves the app from static assets and `_headers` is the only thing that can carry a policy there.

## Notes for review

- The Convex origins are load-bearing: `@convex-dev/auth` exchanges tokens against the deployment's `.site` origin and the reactive client opens a WebSocket. Omitting them blocks sign-in *before any request leaves the page*, with the app still reporting itself Connected. `wss:` does not inherit from `https:`, so both schemes are listed.
- The `assets` match strips comments first — these configs mention `/assets/*` repeatedly in prose, so a substring match would keep passing after the real binding was deleted.
- **Three existing tests were re-targeted, not deleted.** They were written when itun had no `_headers`, and two of them *created* the file to simulate this future. The "no source declares a CSP" case now neutralises both itun sources — left as it was, it would have passed on the new file and asserted nothing.

## Verification

Negative control: with the new file moved aside the checker exits 1 naming the exact production state from this morning; restoring it returns to 0. Four new regression tests cover both apps, plus a control proving the rule is tied to the `assets` declaration rather than firing unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fDGFcvPRW5QKxCBgPW61k