### PR TITLE
fix(itun): adopt patterns on sync, and commit transfer deletes

### DIFF
--- a/apps/itun/src/components/account/ShelfSync.tsx
+++ b/apps/itun/src/components/account/ShelfSync.tsx
@@ -62,8 +62,10 @@ import { isConvexConfigured } from '../../lib/connection/convexClient'
 import { legacyLocalDataState } from '../../lib/db/legacyLocalData'
 import { mayPrune, rowMayBePruned } from '../../lib/db/pruneRules'
 import { captureException } from '../../lib/observability'
+import type { MechPattern } from '../../lib/schemas/pattern'
 import { selectBackend } from '../../stores/entityBackend'
 import { useEntityStore } from '../../stores/entityStore'
+import { usePatternStore } from '../../stores/patternStore'
 
 type Row = { appId?: string | null; body: unknown }
 
@@ -122,6 +124,34 @@ function ConnectedShelfSync() {
           }
         }
       }
+
+      // Patterns live in their own store, and until now were fetched and then
+      // thrown away: `entities.listMine` returns `mechPatterns`, the stamp
+      // above already keys on them — so this effect re-runs when they change —
+      // and the `kinds` table above simply had no entry for them. A signed-in
+      // player on a second device got their pilots, mechs and crawlers and an
+      // empty pattern library, which is the exact gap ADR-034 P4b exists to
+      // close. The fetch half had landed; the adopt half had not.
+      //
+      // Pattern rows carry only `{ body }` — no `appId` — because a pattern is
+      // addressed by the id inside its body, which is likely why they were
+      // skipped when the `{ appId, body }` kinds were written.
+      const patterns = usePatternStore.getState()
+      for (const row of mine.mechPatterns as { body: unknown }[]) {
+        try {
+          await patterns.adopt(row.body as MechPattern)
+        } catch (err) {
+          // Same rule as the roster loop above: one unreadable pattern must not
+          // stop the rest of the library arriving.
+          captureException(err)
+        }
+      }
+
+      // Patterns are deliberately NOT pruned below. The prune answers "the
+      // server did not return this, so it was deleted elsewhere", and that
+      // inference is only sound for rows this sync is authoritative over.
+      // Adopting them is what the bug was; deleting them is a separate decision
+      // with a much worse failure mode, and nothing has asked for it.
 
       // Prune only where absence is unambiguous — see the header. Every guard
       // matters; dropping any one turns this into a roster-deleter.

--- a/apps/itun/src/stores/__tests__/entityStore-transfer-commit.test.ts
+++ b/apps/itun/src/stores/__tests__/entityStore-transfer-commit.test.ts
@@ -1,0 +1,149 @@
+/**
+ * `transfer()` commits its DELETES to the server, not just its updates.
+ *
+ * Phase 1b already committed every update before touching disk, and its comment
+ * states the guarantee plainly — "a refusal aborts with nothing changed
+ * locally". That only ever held for the updates. The `deletes` array went
+ * straight into the phase-2 IndexedDB transaction with no commit at all, so a
+ * transfer that consumed a stack of cargo deleted it locally and left it alive
+ * on the server. `ShelfSync` then restored it on the next sync.
+ *
+ * The end state is worse than a half-applied transfer: it is BOTH ends. The
+ * value arrives at the target and the source keeps it too.
+ *
+ * These tests spy on the backend rather than running against a real server,
+ * because with no Convex configured `selectBackend()` is `local` and the commit
+ * is a no-op — the same reason `serverFirstWrites.test.ts` gives. What is
+ * asserted is that the delete reaches the commit seam at all, which is exactly
+ * what was missing.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { _clearAllStores, _resetDbSingleton } from '../../lib/db/index'
+
+// The namespace is captured with a SPREAD, before any mocking. A module
+// namespace is a live view, so holding the object itself would read as the mock
+// by the time `afterAll` restored it — this repo has been bitten by that.
+const realBackend = { ...(await import('../entityBackend')) }
+
+type EntityCommit = { kind: string; appId: string }
+const entityCommits: EntityCommit[] = []
+const softLinkCommits: string[] = []
+
+// Every export is re-provided, not only the two under test. A partial mock
+// breaks importers nobody was thinking about — `requireWritableBackend` and
+// `WritesBlockedOffline` are both reached from `entityStore` on this path.
+mock.module('../entityBackend', () => ({
+  ...realBackend,
+  commitEntityWrite: async (_type: string, write: EntityCommit) => {
+    entityCommits.push(write)
+  },
+  commitSoftLink: async (kind: string) => {
+    softLinkCommits.push(kind)
+  },
+}))
+
+afterAll(() => {
+  mock.module('../entityBackend', () => realBackend)
+})
+
+const { useEntityStore } = await import('../entityStore')
+const { LIVE_SHEET_MANUAL } = await import('../surfaceProvenance')
+
+beforeEach(async () => {
+  _resetDbSingleton()
+  await _clearAllStores()
+  useEntityStore.setState({
+    pilots: [],
+    mechs: [],
+    crawlers: [],
+    softLinks: [],
+    hydrated: { pilots: false, mechs: false, crawlers: false, softLinks: false },
+  })
+  entityCommits.length = 0
+  softLinkCommits.length = 0
+})
+
+async function seedMech(name: string) {
+  return await useEntityStore.getState().create('mech', {
+    schemaVersion: 1 as const,
+    name,
+    chassisRef: 'mule',
+    systems: [],
+    modules: [],
+    cargoLots: [],
+    conditions: [],
+  })
+}
+
+describe('transfer() commits deletes', () => {
+  test('a deleted entity reaches the commit seam', async () => {
+    const doomed = await seedMech('Doomed')
+    const keeper = await seedMech('Keeper')
+    entityCommits.length = 0
+
+    await useEntityStore.getState().transfer(
+      {
+        updates: [{ type: 'mech', id: keeper.id, patch: { name: 'Keeper Renamed' } }],
+        deletes: [{ type: 'mech', id: doomed.id }],
+      },
+      LIVE_SHEET_MANUAL
+    )
+
+    const deletes = entityCommits.filter((c) => c.kind === 'delete')
+    expect(deletes).toHaveLength(1)
+    expect(deletes[0]?.appId).toBe(doomed.id)
+  })
+
+  test('the update is still committed alongside it', async () => {
+    // Guards against a fix that swapped one loop for the other rather than
+    // adding to it.
+    const doomed = await seedMech('Doomed')
+    const keeper = await seedMech('Keeper')
+    entityCommits.length = 0
+
+    await useEntityStore.getState().transfer(
+      {
+        updates: [{ type: 'mech', id: keeper.id, patch: { name: 'Keeper Renamed' } }],
+        deletes: [{ type: 'mech', id: doomed.id }],
+      },
+      LIVE_SHEET_MANUAL
+    )
+
+    expect(entityCommits.some((c) => c.kind === 'delete')).toBe(true)
+    expect(entityCommits.some((c) => c.kind !== 'delete')).toBe(true)
+  })
+
+  test('the row is still gone locally', async () => {
+    // The fix must not have traded a server write for a local one.
+    const doomed = await seedMech('Doomed')
+    const keeper = await seedMech('Keeper')
+
+    await useEntityStore.getState().transfer(
+      {
+        updates: [{ type: 'mech', id: keeper.id, patch: { name: 'Keeper Renamed' } }],
+        deletes: [{ type: 'mech', id: doomed.id }],
+      },
+      LIVE_SHEET_MANUAL
+    )
+
+    expect(useEntityStore.getState().get('mech', doomed.id)).toBeNull()
+  })
+
+  test('a transfer with no deletes commits none', async () => {
+    // Control: the new loop must be driven by the deletes array, not fire
+    // unconditionally.
+    const keeper = await seedMech('Keeper')
+    entityCommits.length = 0
+
+    await useEntityStore.getState().transfer(
+      {
+        updates: [{ type: 'mech', id: keeper.id, patch: { name: 'Renamed' } }],
+        deletes: [],
+      },
+      LIVE_SHEET_MANUAL
+    )
+
+    expect(entityCommits.filter((c) => c.kind === 'delete')).toHaveLength(0)
+  })
+})

--- a/apps/itun/src/stores/__tests__/patternStore-adopt.test.ts
+++ b/apps/itun/src/stores/__tests__/patternStore-adopt.test.ts
@@ -1,0 +1,132 @@
+/**
+ * `adopt` on a hydrated collection — the cache-fill path `ShelfSync` uses.
+ *
+ * These exist because a commit message claimed four of them and none had been
+ * written. The write path they cover shipped with zero coverage while its own
+ * description asserted otherwise, which is the exact defect class the branch
+ * they belong to was opened to remove.
+ *
+ * What `adopt` is for: `entities.listMine` returns the account's saved patterns,
+ * and before this they were fetched and discarded — a signed-in player on a
+ * second device got their roster and an empty pattern library. It places a
+ * server record into the cache WITHOUT that placement being mistaken for a user
+ * write and mirrored back up.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { BACKUP_NUDGE_WRITE_THRESHOLD, getBackupNudgeState } from '../../lib/backupNudge'
+import { _clearAllStores, _resetDbSingleton } from '../../lib/db/index'
+import type { MechPattern } from '../../lib/schemas/pattern'
+import { usePatternStore } from '../patternStore'
+
+function pattern(id: string, name = 'Mule Pattern'): MechPattern {
+  return {
+    id,
+    schemaVersion: 1,
+    name,
+    chassisRef: 'mule',
+    systems: [],
+    modules: [],
+    cargoLots: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+  }
+}
+
+beforeEach(async () => {
+  _resetDbSingleton()
+  await _clearAllStores()
+  usePatternStore.setState({ mechPatterns: [], hydrated: false })
+})
+
+afterEach(async () => {
+  await _clearAllStores()
+})
+
+describe('adopt', () => {
+  test('places a server record into the cache', async () => {
+    await usePatternStore.getState().adopt(pattern('p1'))
+    expect(
+      usePatternStore
+        .getState()
+        .list()
+        .map((r) => r.id)
+    ).toEqual(['p1'])
+  })
+
+  test('is idempotent — re-adopting does not duplicate', async () => {
+    // `ShelfSync` re-runs whenever the server emission changes, and a pattern
+    // present in two consecutive emissions must not become two rows.
+    await usePatternStore.getState().adopt(pattern('p1'))
+    await usePatternStore.getState().adopt(pattern('p1'))
+    expect(usePatternStore.getState().list()).toHaveLength(1)
+  })
+
+  test('adopting an existing id replaces it in place', async () => {
+    // Server wins: the row that comes down is adopted over whatever the cache
+    // held. No merge — with one source of truth there is no second writer.
+    await usePatternStore.getState().adopt(pattern('p1', 'Old Name'))
+    await usePatternStore.getState().adopt(pattern('p1', 'New Name'))
+    const rows = usePatternStore.getState().list()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.name).toBe('New Name')
+  })
+
+  test('survives to disk, so a reload keeps the library', async () => {
+    // The whole point of the fix: the pattern library must still be there on
+    // the next boot, not just in this tab's memory.
+    await usePatternStore.getState().adopt(pattern('p1'))
+    usePatternStore.setState({ mechPatterns: [], hydrated: false })
+    await usePatternStore.getState().rehydrate()
+    expect(
+      usePatternStore
+        .getState()
+        .list()
+        .map((r) => r.id)
+    ).toEqual(['p1'])
+  })
+
+  test('a malformed body throws rather than writing a bad row', async () => {
+    // `ShelfSync` catches per row so one bad pattern cannot stop the rest of
+    // the library arriving; that only works if `adopt` actually rejects.
+    await expect(
+      usePatternStore.getState().adopt({ id: 'bad' } as unknown as MechPattern)
+    ).rejects.toBeDefined()
+    expect(usePatternStore.getState().list()).toHaveLength(0)
+  })
+})
+
+describe('adopt does not count as a user write', () => {
+  test('a sync of many patterns never triggers the backup nudge', async () => {
+    // The one place `adopt` deliberately diverges from the slice's other
+    // writers. `afterWrite()` calls `recordDataWrite()`, which drives the
+    // backup nudge at BACKUP_NUDGE_WRITE_THRESHOLD (25) against a
+    // localStorage-persistent counter.
+    //
+    // Routing adoption through it meant a signed-in player with 25+ saved
+    // patterns was told to "back up your data" after a sync in which they had
+    // written nothing — and again on every later sync. `entityStore.adopt` and
+    // `forget` both publish without recording, for exactly this reason.
+    const before = getBackupNudgeState().dirtyWrites
+
+    for (let i = 0; i < BACKUP_NUDGE_WRITE_THRESHOLD + 5; i += 1) {
+      await usePatternStore.getState().adopt(pattern(`sync-${i}`))
+    }
+
+    expect(getBackupNudgeState().dirtyWrites).toBe(before)
+  })
+
+  test('an ordinary create still counts', async () => {
+    // Control: the nudge must still work. If `adopt` were fixed by disabling
+    // the counter outright, this would fail.
+    const before = getBackupNudgeState().dirtyWrites
+    await usePatternStore.getState().create({
+      schemaVersion: 1,
+      name: 'Hand-saved',
+      chassisRef: 'mule',
+      systems: [],
+      modules: [],
+      cargoLots: [],
+    } as never)
+    expect(getBackupNudgeState().dirtyWrites).toBeGreaterThan(before)
+  })
+})

--- a/apps/itun/src/stores/entityStore.ts
+++ b/apps/itun/src/stores/entityStore.ts
@@ -621,6 +621,33 @@ export const useEntityStore = create<EntityState>((set, get) => ({
       await commitWrite(pu.type, pu.record as { id: string; gameId?: string | null }, pu.patch)
     }
 
+    // Phase 1c — commit the DELETES too, and for the same reason.
+    //
+    // This loop was missing, and its absence was worse than a stale row. Phase
+    // 1b's comment already states the guarantee — "a refusal aborts with
+    // nothing changed locally" — but that only ever held for the updates; the
+    // deletes went straight to disk in phase 2. So a transfer that consumed a
+    // stack of cargo deleted it locally and left it alive on the server, and
+    // `ShelfSync` then restored it on the next sync. The end state is not a
+    // half-applied transfer, it is BOTH ends: the value arrives at the target
+    // and the source keeps it too.
+    //
+    // Reads each record before committing, exactly as `delete()` does: a link
+    // is addressed on the server by its endpoints, and after phase 2 there is
+    // nothing left to name it by.
+    for (const d of deletes) {
+      if (d.type === 'softLink') {
+        await commitSoftLink('delete', get().get('softLink', d.id))
+      } else {
+        const existing = get().get(d.type, d.id)
+        await commitEntityWrite(d.type, {
+          kind: 'delete',
+          appId: d.id,
+          gameId: existing?.gameId ?? null,
+        })
+      }
+    }
+
     // Phase 2 — one IDB transaction for every put and delete.
     const prunedIds = await db.atomicWrite([
       ...prepared.map((pu) => ({

--- a/apps/itun/src/stores/makeHydratedCollection.ts
+++ b/apps/itun/src/stores/makeHydratedCollection.ts
@@ -171,7 +171,15 @@ export function makeHydratedCollectionSlice<
               : [cached, ...list]
           })(),
         })
-        afterWrite()
+        // `publish`, NOT `afterWrite()`. This is the one place the two differ,
+        // and the difference matters: `afterWrite` also calls
+        // `recordDataWrite()`, which drives the backup nudge. A cache fill is
+        // not a user write — `entityStore.adopt` and `forget` both publish
+        // alone for exactly this reason. Routing adoption through `afterWrite`
+        // meant a signed-in player with 25+ saved patterns was told to back up
+        // their data after a sync in which they had written nothing, and it
+        // accrued again on every sync (the counter is localStorage-persistent).
+        if (shouldBroadcast === undefined || shouldBroadcast()) publishStoreChange(storeName)
         return cached
       },
 

--- a/apps/itun/src/stores/makeHydratedCollection.ts
+++ b/apps/itun/src/stores/makeHydratedCollection.ts
@@ -30,6 +30,8 @@ type DbCollection<T, CreateInput> = {
   create: (input: CreateInput) => Promise<T>
   update: (id: string, patch: Partial<T>) => Promise<T>
   delete: (id: string) => Promise<void>
+  /** Writes a server-provided record verbatim. Used by {@link HydratedCollectionActions.adopt}. */
+  put: (record: T) => Promise<T>
 }
 
 /** The CRUD + hydration surface every collection store shares. */
@@ -52,6 +54,19 @@ export type HydratedCollectionActions<T, CreateInput> = {
   update: (id: string, patch: Partial<T>) => Promise<T>
   /** Deletes from db and removes from in-memory state. */
   delete: (id: string) => Promise<void>
+  /**
+   * Fills the cache from the server of record, without writing back.
+   *
+   * The counterpart to `entityStore.adopt`, and it exists for the same reason:
+   * `ShelfSync` pulls the account's rows down and must place them locally
+   * WITHOUT that placement being mistaken for a user write and mirrored back up.
+   *
+   * Deliberately no `requireWritableBackend()`, matching `entityStore.adopt`:
+   * filling the cache is not a user write, and refusing it while Disconnected
+   * would make going offline lose access to a record rather than merely making
+   * it read-only.
+   */
+  adopt: (record: T) => Promise<T>
 }
 
 type SliceConfig<K extends string, T, CreateInput> = {
@@ -139,6 +154,25 @@ export function makeHydratedCollectionSlice<
           void get().hydrate()
         }
         return records().find((r) => r.id === id) ?? null
+      },
+
+      async adopt(record) {
+        const cached = await db().put(record)
+        set({
+          [key]: (() => {
+            const list = records()
+            const exists = list.some(
+              (r) => (r as { id: string }).id === (cached as { id: string }).id
+            )
+            return exists
+              ? list.map((r) =>
+                  (r as { id: string }).id === (cached as { id: string }).id ? cached : r
+                )
+              : [cached, ...list]
+          })(),
+        })
+        afterWrite()
+        return cached
       },
 
       async create(input) {


### PR DESCRIPTION
Two independent ways the client and server drifted apart, both silent.

## 1. Patterns were fetched and thrown away

`entities.listMine` **returns** `mechPatterns`, and `ShelfSync`'s change stamp already keys on them — so the effect re-runs when they change — but the adoption table was `['pilot','mech','crawler']` and had no entry for them.

A signed-in player on a second device got their roster and an **empty pattern library**. That is the exact gap ADR-034 P4b exists to close: the fetch half had landed, the adopt half had not. Pattern rows carry only `{ body }` where the other three carry `{ appId, body }`, which is the likely reason they were skipped.

`makeHydratedCollectionSlice` gains `adopt`, mirroring `entityStore.adopt` — including its deliberate omission of `requireWritableBackend()`: filling the cache is not a user write, and refusing it while Disconnected would make going offline *lose access* to a record rather than merely making it read-only.

**Patterns are deliberately NOT added to the prune.** The prune asserts "the server did not return this, so it was deleted elsewhere". Adopting them was the bug; deleting them is a separate decision with a much worse failure mode, and nothing has asked for it.

## 2. Transfer deletes never reached the server

Phase 1b commits every update before touching disk, and its comment states the guarantee — *"a refusal aborts with nothing changed locally"*. That only held for **updates**. The `deletes` array went straight into the phase-2 IndexedDB transaction with no commit, so a transfer that consumed a stack of cargo deleted it locally and left it alive on the server — and `ShelfSync` restored it on the next sync.

The result is worse than a half-applied transfer: **it is both ends.** The value arrives at the target and the source keeps it too — a wrong balance, on the communal crawler, which is usually one end of these.

Phase 1c mirrors `delete()` exactly, reading each record before committing because a soft link is addressed on the server by its endpoints and after phase 2 there is nothing left to name it by.

## Verification

Four tests for `adopt` (placement, idempotence on re-adoption, in-place update, survival to disk so a reload keeps the library) and four for the transfer commit — including a **control** that a transfer with no deletes commits none, so a loop firing unconditionally would fail.

The transfer tests spy via `mock.module` with a spread-captured namespace and an `afterAll` restore. Full itun suite re-run at **2025 pass / 0 fail** confirms no leak into later files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fDGFcvPRW5QKxCBgPW61k