### PR TITLE
fix(ci): stop four gates passing while checking nothing

### DIFF
--- a/apps/itun/e2e/offline.e2e.ts
+++ b/apps/itun/e2e/offline.e2e.ts
@@ -113,6 +113,13 @@ test('the app opens and reads with the network cut', async ({ page, context }) =
     !controlled && !process.env.CI,
     'No service worker controls the page — this is a dev-server run, where vite-plugin-pwa emits none. Runs for real against the CI preview build.'
   )
+  // In CI the skip above does not fire, so say WHY the rest is about to fail.
+  // Without this the first thing to break is `page.reload()` under
+  // `setOffline(true)`, which throws `net::ERR_INTERNET_DISCONNECTED` — that
+  // reads as a network or proxy fault, and nothing in the output mentions the
+  // service worker at all. The point of running this in CI is to learn that the
+  // worker stopped controlling the page; the failure has to say so.
+  expect(controlled, 'no service worker took control of the page').toBe(true)
 
   // Cut the network at the browser, not the app: `setOffline` fails real
   // requests, which is what a service worker either answers from cache or does
@@ -138,8 +145,10 @@ test('an unvisited route also resolves offline — the shell is not one page', a
   await waitForReady(page)
 
   const controlled = await ensureServiceWorkerControls(page)
-  // See the note on the first test: the skip is a local convenience only.
+  // See the note on the first test: the skip is a local convenience only, and
+  // the assertion is what makes a CI failure legible.
   test.skip(!controlled && !process.env.CI, 'No service worker controls the page — dev-server run.')
+  expect(controlled, 'no service worker took control of the page').toBe(true)
 
   await context.setOffline(true)
 

--- a/apps/itun/e2e/offline.e2e.ts
+++ b/apps/itun/e2e/offline.e2e.ts
@@ -104,8 +104,13 @@ test('the app opens and reads with the network cut', async ({ page, context }) =
   await waitForReady(page)
 
   const controlled = await ensureServiceWorkerControls(page)
+  // NOT skippable in CI. The convenience of skipping on a dev-server run, where
+  // vite-plugin-pwa emits no worker, is worth keeping — but unconditional it
+  // meant this spec went silent exactly when the thing it proves broke. If the
+  // worker stops registering or activating, `controlled` is false, both tests
+  // here skip, and nightly is green with the offline guarantee unverified.
   test.skip(
-    !controlled,
+    !controlled && !process.env.CI,
     'No service worker controls the page — this is a dev-server run, where vite-plugin-pwa emits none. Runs for real against the CI preview build.'
   )
 
@@ -133,7 +138,8 @@ test('an unvisited route also resolves offline — the shell is not one page', a
   await waitForReady(page)
 
   const controlled = await ensureServiceWorkerControls(page)
-  test.skip(!controlled, 'No service worker controls the page — dev-server run.')
+  // See the note on the first test: the skip is a local convenience only.
+  test.skip(!controlled && !process.env.CI, 'No service worker controls the page — dev-server run.')
 
   await context.setOffline(true)
 

--- a/apps/itun/e2e/signin-save.e2e.ts
+++ b/apps/itun/e2e/signin-save.e2e.ts
@@ -47,6 +47,26 @@ test('work built anonymously survives signing in to save it', async ({ page }) =
   await waitForReady(page)
 
   const ready = await seamIsPresent(page)
+
+  // Two different situations, and collapsing them is how this spec could go
+  // silent. Absence of the seam is EXPECTED in an ordinary build (no
+  // VITE_TEST_AUTH / VITE_CONVEX_URL / ITUN_TEST_AUTH) and is not a failure.
+  // But once a run has deliberately provisioned the seam, absence means the
+  // seam BROKE, and skipping there would hide exactly the regression this spec
+  // exists to catch.
+  //
+  // `ITUN_E2E_EXPECT_AUTH_SEAM` is that distinction. Note the honest state of
+  // things: no workflow sets the three variables today, so this spec currently
+  // skips in every environment including nightly. It is written and correct and
+  // has never actually executed in CI — set the variables plus this flag to
+  // change that.
+  if (!ready && process.env.ITUN_E2E_EXPECT_AUTH_SEAM) {
+    throw new Error(
+      'ITUN_E2E_EXPECT_AUTH_SEAM is set, but no `__itunTestSignIn` seam is present. ' +
+        'The build was expected to expose it (VITE_TEST_AUTH + VITE_CONVEX_URL + ' +
+        'ITUN_TEST_AUTH); either the seam regressed or the build lost a variable.'
+    )
+  }
   test.skip(
     !ready,
     'No test sign-in seam in this build — needs VITE_TEST_AUTH, VITE_CONVEX_URL and ITUN_TEST_AUTH. See this file header.'

--- a/knip.json
+++ b/knip.json
@@ -89,8 +89,17 @@
       ]
     },
     "apps/su-assets": {
-      "entry": ["netlify/functions/**/*.ts"],
-      "project": ["netlify/**/*.ts"],
+      // `src/worker.ts` is a framework entry in the same sense the Netlify
+      // handler is: workerd loads the module and calls its default export, so
+      // nothing in this repo imports it.
+      //
+      // It was missed when the itun and discord-bot Workers were added above.
+      // The consequence is worse than an un-analyzed file: `project` did not
+      // cover `src/**` either, so the whole Worker and its 217-line test sat
+      // OUTSIDE knip's scope rather than being exempted from one rule inside
+      // it — the gate passed by not looking.
+      "entry": ["netlify/functions/**/*.ts", "src/worker.ts"],
+      "project": ["netlify/**/*.ts", "src/**/*.ts"],
       "includeEntryExports": false
     },
     "apps/discord-bot": {

--- a/tools/check-doc-drift.ts
+++ b/tools/check-doc-drift.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 /**
- * Doc-drift guard (mechanical, narrow — 6 checks, not a general doc-linter).
+ * Doc-drift guard (mechanical, narrow — 7 checks, not a general doc-linter).
  *
  * A prior campaign PR had to hand-fix docs/architecture/package-contracts.md
  * after its "Entry Points" JSON block silently fell out of sync with
@@ -52,6 +52,7 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { basename, dirname, extname, join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { assertScanFloor } from './lib/scanFloor'
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
 
@@ -1026,6 +1027,25 @@ export function runChecks(root: string): { failures: string[]; passed: string[] 
 }
 
 if (import.meta.main) {
+  // Prove the corpus was actually found before believing anything about it.
+  //
+  // Three of the checks below are "for every live-instruction doc, assert X",
+  // and both directory walkers return `[]` when their directory is missing —
+  // which is correct for the fixture trees the tests build, and catastrophic
+  // here. Rename a directory in `LIVE_INSTRUCTION_DOC_DIRS` and the corpus
+  // silently collapses to the three root files while this still prints
+  // `✓ No live-instruction doc cites any of the 4 superseded ADR(s)…`.
+  //
+  // The tell was missing too: `check-architecture` prints "(588 files checked)"
+  // whereas this printed counts of FINDINGS — 4 ADRs, 181 references — never of
+  // corpus, so a collapsed scan looked identical to a healthy one.
+  //
+  // This gate walks the largest tree of any in `validate:all` and was the one
+  // `tools/lib/scanFloor.ts` was not applied to when its four siblings were
+  // fixed. Floor set well below the real count: a catastrophe detector, not a
+  // coverage target.
+  assertScanFloor('doc-drift (live-instruction docs)', liveInstructionDocs(repoRoot).length, 6)
+
   const { failures, passed } = runChecks(repoRoot)
   for (const message of passed) console.log(`✓ ${message}`)
   for (const message of failures) console.error(`✗ ${message}`)


### PR DESCRIPTION
Four instances of the same failure: a check that reports success loudest when
it is most broken.

**The offline e2e specs disarmed themselves.** Both call
`test.skip(!controlled, …)` on the absence of a service worker, and neither
consulted `process.env.CI`. So if the worker stopped registering or activating,
`controlled` went false, both tests skipped, and nightly stayed green with the
offline guarantee unverified. The spec's own header claims "**In CI it does not
skip**, which is where it counts" — nothing enforced that until now. The skip
stays as a local convenience for dev-server runs, where vite-plugin-pwa emits no
worker; it is no longer available in CI.

**`signin-save.e2e.ts` needed the opposite treatment, and turned up a finding.**
Its seam requires VITE_TEST_AUTH, VITE_CONVEX_URL and ITUN_TEST_AUTH — and no
workflow sets any of them, so that spec currently skips in every environment
including nightly. It is written, correct, and has never executed in CI.
Forcing it with `!process.env.CI` would have broken the build permanently, so
the guard distinguishes the two cases instead: absence is expected in an
ordinary build, but once `ITUN_E2E_EXPECT_AUTH_SEAM` says the seam was
provisioned, absence means it BROKE and now throws. Wiring up those variables is
a separate decision and is left to the owner; the honest state is written down
in the file.

**`check-doc-drift.ts` had no scan floor.** Both directory walkers return `[]`
on a missing directory — correct for the fixture trees its tests build,
catastrophic for the real run — and three of its checks are "for every
live-instruction doc, assert X". Rename a directory in
`LIVE_INSTRUCTION_DOC_DIRS` and the corpus silently collapses to three root
files while it still prints its ✓. There was no tell either: sibling gates print
"(588 files checked)" whereas this printed counts of FINDINGS, so a collapsed
scan looked identical to a healthy one. It walks the largest tree in
`validate:all` and was the gate `tools/lib/scanFloor.ts` was not applied to when
its four siblings were fixed. Verified by forcing the count to zero: the floor
fires.

**su-assets' Worker was outside knip entirely.** `entry` and `project` both
covered only `netlify/**`, so `src/worker.ts` and its 217-line test were not
exempted from a rule — they were invisible to the gate, which passed by not
looking. The itun and discord-bot Workers each got an entry with a written
justification when they landed; this one was missed.

One prediction checked and NOT confirmed: widening the scope was expected to
flag `AssetFailureReporter` as dead. It is not — it is used as a parameter type
within each file. It is declared twice, once per su-assets implementation, which
is duplication rather than dead code and is left for the consolidation that
should own it.

Also corrects this file's own header, which said "6 checks" while `CHECKS`
registers seven.

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_018fDGFcvPRW5QKxCBgPW61k

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>