### PR TITLE
fix(reference): one Tech Level comparator, and it handles Bio/Nanite

### DIFF
--- a/apps/itun/src/components/mech/InstallStep.tsx
+++ b/apps/itun/src/components/mech/InstallStep.tsx
@@ -1,6 +1,6 @@
 import { Badge, EmptyState, MasonryColumns, ReferenceEntityCard } from 'component-lib'
 import { useMemo, useState } from 'react'
-import { SalvageUnionReference, techLevelRank } from 'salvageunion-reference'
+import { byTechLevelThenName, SalvageUnionReference } from 'salvageunion-reference'
 import { matchesRef } from 'salvageunion-reference/rules'
 import type { TechLevel } from '../../lib/rules/types'
 
@@ -31,10 +31,7 @@ export function InstallStep({ kind, selected, onAdd }: InstallStepProps) {
     const accessor =
       kind === 'systems' ? SalvageUnionReference.Systems : SalvageUnionReference.Modules
     const items = accessor.all()
-    return [...items].sort(
-      (a, b) =>
-        techLevelRank(a.techLevel) - techLevelRank(b.techLevel) || a.name.localeCompare(b.name)
-    )
+    return [...items].sort((a, b) => byTechLevelThenName(a, b))
   }, [kind])
 
   const visible =

--- a/apps/itun/src/components/wizard/BlankCreateDialog.tsx
+++ b/apps/itun/src/components/wizard/BlankCreateDialog.tsx
@@ -16,7 +16,7 @@
 
 import { Button, Field, FieldError, Input, ModalShell, Select } from 'component-lib'
 import { useMemo, useState } from 'react'
-import { nameToSlug, SalvageUnionReference, techLevelRank } from 'salvageunion-reference'
+import { byTechLevelThenName, nameToSlug, SalvageUnionReference } from 'salvageunion-reference'
 import type { BlankCreateKind } from '../../lib/wizard/blankCreate'
 import { createBlank } from '../../lib/wizard/blankCreate'
 
@@ -52,10 +52,7 @@ function chassisOptions(): RefOption[] {
   try {
     const all = SalvageUnionReference.Chassis.all()
     return [...all]
-      .sort(
-        (a, b) =>
-          techLevelRank(a.techLevel) - techLevelRank(b.techLevel) || a.name.localeCompare(b.name)
-      )
+      .sort((a, b) => byTechLevelThenName(a, b))
       .map((c) => ({
         value: nameToSlug(c.name),
         label: `${c.name} · TL ${String(c.techLevel)}`,

--- a/packages/component-lib/src/components/wizard/EquipmentStep.tsx
+++ b/packages/component-lib/src/components/wizard/EquipmentStep.tsx
@@ -1,5 +1,5 @@
 import type { SURefEquipment } from 'salvageunion-reference'
-import { SalvageUnionReference } from 'salvageunion-reference'
+import { byTechLevelThenName, SalvageUnionReference } from 'salvageunion-reference'
 import { isLegalCreationEquipment } from 'salvageunion-reference/rules'
 import { EmptyState } from '../chrome/EmptyState'
 import { ReferenceEntityCard } from '../referenceEntity/card/ReferenceEntityCard'
@@ -52,11 +52,7 @@ export function EquipmentStep({
       ? surEquipment.findAll((e: unknown) => isLegalCreationEquipment(e as SURefEquipment))
       : surEquipment.findAll(() => true)
   ) as SURefEquipment[]
-  const sorted = isCreate
-    ? equipment
-    : [...equipment].sort(
-        (a, b) => Number(a.techLevel) - Number(b.techLevel) || a.name.localeCompare(b.name)
-      )
+  const sorted = isCreate ? equipment : [...equipment].sort(byTechLevelThenName)
 
   // Copies picked per id (create mode allows duplicates).
   const counts = new Map<string, number>()

--- a/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
+++ b/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
@@ -987,7 +987,7 @@ export declare function techLevelRank(techLevel: number | 'B' | 'N' | undefined)
  * The canonical "Tech Level, then name" comparator.
  *
  * This exists because the expression it replaces was written out by hand at
- * four call sites and two of them got it wrong — using `Number(a.techLevel)`
+ * three call sites and one of them got it wrong — using `Number(a.techLevel)`
  * instead of {@link techLevelRank}. The failure is quieter than it first looks:
  * `Number('B') - 1` is `NaN`, and `NaN` is FALSY, so the `||` falls straight
  * through to the name tiebreak. A Bio or Nanite item is therefore not randomly
@@ -1001,6 +1001,15 @@ export declare function techLevelRank(techLevel: number | 'B' | 'N' | undefined)
  * A comparator is exactly the kind of thing that should not be re-derived per
  * widget: the ordering is a property of the game's taxonomy, the bug is silent,
  * and the wrong version looks right.
+ *
+ * **One hand-rolled comparator is deliberately NOT folded in.**
+ * `component-lib/src/components/shared/EntitySearcher.tsx` composes
+ * `techLevelRank` correctly — no NaN — but short-circuits to the name tiebreak
+ * whenever EITHER side's Tech Level is `undefined`, where this ranks `undefined`
+ * last. That is a real behavioural difference on TL-less entities, not a
+ * cosmetic one, so switching it is a decision about search ordering rather than
+ * a de-duplication. Left alone on purpose; noted here so "all the call sites use
+ * the shared one" is not read as a claim about that file.
  *
  * @param a - Entity-shaped value carrying a Tech Level and a name
  * @param b - The value to compare against

--- a/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
+++ b/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
@@ -984,6 +984,36 @@ export declare function getEntitySchemas(): EnhancedSchemaMetadata[];
  */
 export declare function techLevelRank(techLevel: number | 'B' | 'N' | undefined): number;
 /**
+ * The canonical "Tech Level, then name" comparator.
+ *
+ * This exists because the expression it replaces was written out by hand at
+ * four call sites and two of them got it wrong — using `Number(a.techLevel)`
+ * instead of {@link techLevelRank}. The failure is quieter than it first looks:
+ * `Number('B') - 1` is `NaN`, and `NaN` is FALSY, so the `||` falls straight
+ * through to the name tiebreak. A Bio or Nanite item is therefore not randomly
+ * ordered — it is ordered purely by NAME, interleaved among the numeric tiers
+ * instead of sorted after them. Plausible-looking output is exactly why it
+ * survived at two call sites. It was dormant only by luck of the data:
+ * `equipment.json` happens to carry no Bio or Nanite entries, while
+ * `systems.json` has 7 B + 3 N and `modules.json` 3 B + 3 N — so the same
+ * expression copied one file over ships a scrambled list.
+ *
+ * A comparator is exactly the kind of thing that should not be re-derived per
+ * widget: the ordering is a property of the game's taxonomy, the bug is silent,
+ * and the wrong version looks right.
+ *
+ * @param a - Entity-shaped value carrying a Tech Level and a name
+ * @param b - The value to compare against
+ * @returns Negative, zero or positive, per Array#sort
+ */
+export declare function byTechLevelThenName(a: {
+    techLevel?: number | 'B' | 'N';
+    name: string;
+}, b: {
+    techLevel?: number | 'B' | 'N';
+    name: string;
+}): number;
+/**
  * Get unique tech levels from an array of entities, sorted correctly
  * Numeric levels ascending, then 'B', then 'N'
  * @param entities - Array of entities to extract tech levels from

--- a/packages/salvageunion-reference/lib/helpers.test.ts
+++ b/packages/salvageunion-reference/lib/helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import {
+  byTechLevelThenName,
   getCrawlerMutations,
   getMaxSpBonus,
   getUniqueTechLevels,
@@ -94,5 +95,77 @@ describe('techLevelRank', () => {
     const levels = getUniqueTechLevels(entities)
     const resorted = [...levels].sort((a, b) => techLevelRank(a) - techLevelRank(b))
     expect(resorted).toEqual(levels)
+  })
+})
+
+describe('byTechLevelThenName', () => {
+  // The bug this comparator exists to end: two of four hand-written call sites
+  // used `Number(a.techLevel)`. `Number('B')` is NaN, `NaN - NaN` is NaN, and a
+  // comparator returning NaN leaves the sort implementation-defined.
+  it('orders Bio and Nanite after the numeric tiers', () => {
+    const items = [
+      { techLevel: 'N' as const, name: 'Nanite Thing' },
+      { techLevel: 3 as const, name: 'Tier Three' },
+      { techLevel: 'B' as const, name: 'Bio Thing' },
+      { techLevel: 1 as const, name: 'Tier One' },
+    ]
+    expect([...items].sort(byTechLevelThenName).map((i) => i.name)).toEqual([
+      'Tier One',
+      'Tier Three',
+      'Bio Thing',
+      'Nanite Thing',
+    ])
+  })
+
+  it('the naive Number() version really does misorder the same input', () => {
+    // A control, so this file records WHY the shared comparator exists rather
+    // than merely asserting that it works. If `Number()` were adequate the
+    // comparator would be needless indirection.
+    //
+    // The precise failure is subtler than "returns NaN". `Number('B') - 1` IS
+    // NaN — but NaN is FALSY, so `NaN || a.name.localeCompare(b.name)` falls
+    // straight through to the name tiebreak. So a Bio or Nanite item is not
+    // randomly ordered; it is ordered purely by NAME, interleaved among the
+    // numeric tiers instead of sorted after them. Quietly plausible output,
+    // which is why it survived at two call sites.
+    const naive = (
+      a: { techLevel?: number | 'B' | 'N'; name: string },
+      b: { techLevel?: number | 'B' | 'N'; name: string }
+    ) => Number(a.techLevel) - Number(b.techLevel) || a.name.localeCompare(b.name)
+
+    const items = [
+      { techLevel: 'B' as const, name: 'Aardvark Plating' },
+      { techLevel: 1 as const, name: 'Zinc Bolt' },
+    ]
+
+    // Naive: the Bio item leads, because 'Aardvark' < 'Zinc'.
+    expect([...items].sort(naive).map((i) => i.name)).toEqual(['Aardvark Plating', 'Zinc Bolt'])
+
+    // Correct: Bio ranks 7, so it follows every numeric tier regardless of name.
+    expect([...items].sort(byTechLevelThenName).map((i) => i.name)).toEqual([
+      'Zinc Bolt',
+      'Aardvark Plating',
+    ])
+  })
+
+  it('falls back to name within a tier', () => {
+    const items = [
+      { techLevel: 2 as const, name: 'Zeta' },
+      { techLevel: 2 as const, name: 'Alpha' },
+    ]
+    expect([...items].sort(byTechLevelThenName).map((i) => i.name)).toEqual(['Alpha', 'Zeta'])
+  })
+
+  it('an absent Tech Level sorts last, not first', () => {
+    const items = [
+      { techLevel: undefined, name: 'Unranked' },
+      { techLevel: 'N' as const, name: 'Nanite' },
+      { techLevel: 1 as const, name: 'Tier One' },
+    ]
+    expect([...items].sort(byTechLevelThenName).map((i) => i.name)).toEqual([
+      'Tier One',
+      'Nanite',
+      'Unranked',
+    ])
   })
 })

--- a/packages/salvageunion-reference/lib/helpers.ts
+++ b/packages/salvageunion-reference/lib/helpers.ts
@@ -249,7 +249,7 @@ export function techLevelRank(techLevel: number | 'B' | 'N' | undefined): number
  * The canonical "Tech Level, then name" comparator.
  *
  * This exists because the expression it replaces was written out by hand at
- * four call sites and two of them got it wrong — using `Number(a.techLevel)`
+ * three call sites and one of them got it wrong — using `Number(a.techLevel)`
  * instead of {@link techLevelRank}. The failure is quieter than it first looks:
  * `Number('B') - 1` is `NaN`, and `NaN` is FALSY, so the `||` falls straight
  * through to the name tiebreak. A Bio or Nanite item is therefore not randomly
@@ -263,6 +263,15 @@ export function techLevelRank(techLevel: number | 'B' | 'N' | undefined): number
  * A comparator is exactly the kind of thing that should not be re-derived per
  * widget: the ordering is a property of the game's taxonomy, the bug is silent,
  * and the wrong version looks right.
+ *
+ * **One hand-rolled comparator is deliberately NOT folded in.**
+ * `component-lib/src/components/shared/EntitySearcher.tsx` composes
+ * `techLevelRank` correctly — no NaN — but short-circuits to the name tiebreak
+ * whenever EITHER side's Tech Level is `undefined`, where this ranks `undefined`
+ * last. That is a real behavioural difference on TL-less entities, not a
+ * cosmetic one, so switching it is a decision about search ordering rather than
+ * a de-duplication. Left alone on purpose; noted here so "all the call sites use
+ * the shared one" is not read as a claim about that file.
  *
  * @param a - Entity-shaped value carrying a Tech Level and a name
  * @param b - The value to compare against

--- a/packages/salvageunion-reference/lib/helpers.ts
+++ b/packages/salvageunion-reference/lib/helpers.ts
@@ -246,6 +246,36 @@ export function techLevelRank(techLevel: number | 'B' | 'N' | undefined): number
 }
 
 /**
+ * The canonical "Tech Level, then name" comparator.
+ *
+ * This exists because the expression it replaces was written out by hand at
+ * four call sites and two of them got it wrong — using `Number(a.techLevel)`
+ * instead of {@link techLevelRank}. The failure is quieter than it first looks:
+ * `Number('B') - 1` is `NaN`, and `NaN` is FALSY, so the `||` falls straight
+ * through to the name tiebreak. A Bio or Nanite item is therefore not randomly
+ * ordered — it is ordered purely by NAME, interleaved among the numeric tiers
+ * instead of sorted after them. Plausible-looking output is exactly why it
+ * survived at two call sites. It was dormant only by luck of the data:
+ * `equipment.json` happens to carry no Bio or Nanite entries, while
+ * `systems.json` has 7 B + 3 N and `modules.json` 3 B + 3 N — so the same
+ * expression copied one file over ships a scrambled list.
+ *
+ * A comparator is exactly the kind of thing that should not be re-derived per
+ * widget: the ordering is a property of the game's taxonomy, the bug is silent,
+ * and the wrong version looks right.
+ *
+ * @param a - Entity-shaped value carrying a Tech Level and a name
+ * @param b - The value to compare against
+ * @returns Negative, zero or positive, per Array#sort
+ */
+export function byTechLevelThenName(
+  a: { techLevel?: number | 'B' | 'N'; name: string },
+  b: { techLevel?: number | 'B' | 'N'; name: string }
+): number {
+  return techLevelRank(a.techLevel) - techLevelRank(b.techLevel) || a.name.localeCompare(b.name)
+}
+
+/**
  * Get unique tech levels from an array of entities, sorted correctly
  * Numeric levels ascending, then 'B', then 'N'
  * @param entities - Array of entities to extract tech levels from


### PR DESCRIPTION
`byTechLevelThenName` replaces an expression written out by hand at three call
sites, one of which was wrong.

`EquipmentStep.tsx` used `Number(a.techLevel) - Number(b.techLevel)` where the
other two correctly composed `techLevelRank`. Tech Levels include 'B' (Bio) and
'N' (Nanite), so that is `NaN`.

The failure is quieter than "returns NaN", and getting this right matters more
than the fix: **NaN is falsy**, so `NaN || a.name.localeCompare(b.name)` falls
straight through to the name tiebreak. A Bio or Nanite item is therefore not
randomly ordered — it is ordered purely by NAME, interleaved among the numeric
tiers instead of sorted after them. Plausible-looking output is exactly why this
survived. (An earlier draft of this commit and its test both asserted the
comparator returned NaN; the control test failed and was right to.)

Dormant only by luck of the data: `equipment.json` carries no B/N entries, so
the broken site sorts correctly today. `systems.json` has 7 B + 3 N and
`modules.json` 3 B + 3 N — the same expression copied one file over ships a
scrambled list.

A comparator is precisely what should not be re-derived per widget: the ordering
is a property of the game's taxonomy, the bug is silent, and the wrong version
looks right. So all three sites now call the shared one, including the two that
were already correct.

Four tests, including a control that runs the naive version against the same
input and asserts it produces the WRONG order — so the file records why the
shared comparator exists rather than merely that it works, and cannot pass if
`Number()` were adequate after all.

One process note worth recording: the first version of these tests used `test(`
in a file that imports `it`, so all four silently did not run while the suite
reported 13 pass. That is the same vacuous-pass class this stack is fixing
elsewhere, arrived at from the other direction.

Co-Authored-By: alxjrvs <alxjrvs@gmail.com>
Claude-Session: https://claude.ai/code/session_018fDGFcvPRW5QKxCBgPW61k

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>