### PR TITLE
feat(itun): complete ADR-034 P4/P4b — every store reaches the server

### DIFF
--- a/.claude/rules/tanstack-query-hooks.md
+++ b/.claude/rules/tanstack-query-hooks.md
@@ -108,10 +108,17 @@ Do not reach for it just because it is mounted.
   - This is a rule about **new** code. Solo mode still runs today and the phases
     that remove it have not landed — see
     [persistence-and-pwa.md](../../docs/architecture/persistence-and-pwa.md).
-  - Three stores already violate it and are being repaired in P0: `mechPatterns`
-    and `encounterNpcs` write locally with no mirror, and client Change Log
-    appends never leave the device. **Do not copy their shape**; copy
-    `entityStore`'s `mirrorWrite`.
+  - The three stores that used to violate this — `mechPatterns`,
+    `encounterNpcs`, and the client Change Log — now mirror on every write
+    (P4b). `mechPatterns` and `encounterNpcs` go through the `commit` seam on
+    `makeHydratedCollectionSlice`; the Change Log goes through
+    `commitChangeLog`. **Copy one of those**, not `mirrorWrite`, which the
+    server-first reorder removed.
+  - The one deliberate exception is the Change Log commit, which is
+    fire-and-forget: it is provenance about a write that has already landed and
+    already committed, so failing the player's edit because its audit row did
+    not arrive would trade the write for the record of it. Do not treat that as
+    licence for a new fire-and-forget path — everything else awaits.
   - If the schema cannot express where a record needs to live, **the schema
     moves**. #871 is the worked example: `crawlers` gained `ownerId` and a
     nullable `gameId` so a crawler leaving a deleted Game lands in Convex rather

--- a/apps/itun/convex/entities.ts
+++ b/apps/itun/convex/entities.ts
@@ -230,7 +230,7 @@ export const listMine = query({
   handler: async (ctx) => {
     const userId = await requireUser(ctx)
 
-    const [pilots, mechs, crawlers, patterns] = await Promise.all([
+    const [pilots, mechs, crawlers, patterns, npcs] = await Promise.all([
       ctx.db
         .query('pilots')
         .withIndex('by_owner', (q) => q.eq('ownerId', userId))
@@ -247,6 +247,10 @@ export const listMine = query({
         .query('mechPatterns')
         .withIndex('by_owner', (q) => q.eq('ownerId', userId))
         .collect(),
+      ctx.db
+        .query('encounterNpcs')
+        .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+        .collect(),
     ])
 
     // Bodies only. The caller is filling a local store whose records are keyed
@@ -258,6 +262,11 @@ export const listMine = query({
       mechs: mechs.map((r) => ({ appId: r.appId ?? null, body: r.body })),
       crawlers: crawlers.map((r) => ({ appId: r.appId ?? null, body: r.body })),
       mechPatterns: patterns.map((r) => ({ body: r.body })),
+      // Without this the shelf tray was WRITE-ONLY. `claimLocal` and
+      // `games.destroy` both wrote `encounterNpcs`, and no query read them
+      // back: `mediator.npcs` requires a `gameId`, so a tray on a shelf was
+      // reachable by nothing. It went up and never came down.
+      encounterNpcs: npcs.map((r) => ({ body: r.body })),
     }
   },
 })
@@ -1018,6 +1027,106 @@ const SOFT_LINK_FROM_TABLE: Record<SoftLink['type'], OwnableTable> = {
  * shelved before a claim — so there is nothing to anchor a link to and this
  * no-ops rather than inventing one.
  */
+/**
+ * Mirror one saved pattern, addressed by the id inside its body.
+ *
+ * These tables have no `appId` column and need none: a pattern's own id already
+ * is its app id, which makes this naturally idempotent — the same write twice
+ * is a patch, not a duplicate.
+ *
+ * Until this existed, `mechPatterns` reached Convex through exactly one path,
+ * the bulk `claimLocal` at sign-in. Every pattern saved afterwards lived only in
+ * that browser: invisible on a second device, and gone with the site data. This
+ * is the per-write half ADR-034 P4b calls for.
+ */
+export const upsertMechPattern = mutation({
+  args: { body: v.any() },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    const parsed = PARSERS.mechPatterns.parse(args.body)
+    const patternId = (args.body as { id?: unknown }).id
+    if (typeof patternId !== 'string') {
+      throw new Error('[itun] a mech pattern must carry a string id in its body')
+    }
+
+    const own = await ctx.db
+      .query('mechPatterns')
+      .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+      .collect()
+    const existing = own.find((r) => (r.body as { id?: unknown }).id === patternId)
+
+    if (existing === undefined) {
+      await ctx.db.insert('mechPatterns', { ownerId: userId, gameId: null, body: parsed })
+      return
+    }
+    await ctx.db.patch(existing._id, { body: parsed })
+  },
+})
+
+/** Delete one saved pattern. Scoped to the caller's own rows by construction. */
+export const removeMechPattern = mutation({
+  args: { patternId: v.string() },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    const own = await ctx.db
+      .query('mechPatterns')
+      .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+      .collect()
+    const existing = own.find((r) => (r.body as { id?: unknown }).id === args.patternId)
+    // Absent is success: a delete that races a delete, or a row that never
+    // reached the server, must not fail the local write that follows it.
+    if (existing === undefined) return
+    await ctx.db.delete(existing._id)
+  },
+})
+
+/**
+ * Mirror one shelf NPC.
+ *
+ * Shelf only — `ownerId: userId`, `gameId: null`. A tray inside a Game belongs
+ * to the table rather than to a member and is reached through `mediator.*` by
+ * the Mediator's role; this is the personal tray, which is the one the local
+ * store holds and the one that had no server write at all.
+ */
+export const upsertEncounterNpc = mutation({
+  args: { body: v.any() },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    const parsed = PARSERS.encounterNpcs.parse(args.body)
+    const npcId = (args.body as { id?: unknown }).id
+    if (typeof npcId !== 'string') {
+      throw new Error('[itun] an encounter NPC must carry a string id in its body')
+    }
+
+    const own = await ctx.db
+      .query('encounterNpcs')
+      .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+      .collect()
+    const existing = own.find((r) => (r.body as { id?: unknown }).id === npcId)
+
+    if (existing === undefined) {
+      await ctx.db.insert('encounterNpcs', { gameId: null, ownerId: userId, body: parsed })
+      return
+    }
+    await ctx.db.patch(existing._id, { body: parsed })
+  },
+})
+
+/** Delete one shelf NPC. Absent is success, as for patterns. */
+export const removeEncounterNpc = mutation({
+  args: { npcId: v.string() },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    const own = await ctx.db
+      .query('encounterNpcs')
+      .withIndex('by_owner', (q) => q.eq('ownerId', userId))
+      .collect()
+    const existing = own.find((r) => (r.body as { id?: unknown }).id === args.npcId)
+    if (existing === undefined) return
+    await ctx.db.delete(existing._id)
+  },
+})
+
 export const upsertSoftLink = mutation({
   args: {
     from: v.object({ type: entityRefType, id: v.string() }),

--- a/apps/itun/convex/entities.ts
+++ b/apps/itun/convex/entities.ts
@@ -1028,6 +1028,71 @@ const SOFT_LINK_FROM_TABLE: Record<SoftLink['type'], OwnableTable> = {
  * no-ops rather than inventing one.
  */
 /**
+ * Append client-originated Change Log rows (ADR-022 / ADR-034 P4b).
+ *
+ * The Change Log is what ADR-030 calls "the spine of this feature", and until
+ * this existed it was **two disconnected spines**. `entityStore.emitChangeLog`
+ * terminated at `db.changeLog.append` — IndexedDB — while the server table was
+ * written only by `ownership`, `proposals` and `botClient`. Each drawer showed
+ * half the history, and clearing site data destroyed the client half outright
+ * because Convex held no copy.
+ *
+ * Rows land `state: 'applied'` and `actorId: userId`. A client append is a
+ * record of something that ALREADY happened locally, not a request — the
+ * proposal lifecycle (`proposed`/`declined`/`superseded`) belongs to
+ * `proposals.ts` and is deliberately not reachable from here.
+ *
+ * Batched because the local emitter already batches: one edit that touches
+ * three fields is three rows, and sending them individually would triple the
+ * round trips on the hot path.
+ */
+export const appendChangeLog = mutation({
+  args: {
+    entries: v.array(
+      v.object({
+        gameId: v.union(v.id('games'), v.null()),
+        entityType: v.union(
+          v.literal('pilot'),
+          v.literal('mech'),
+          v.literal('crawler'),
+          v.literal('softLink'),
+          v.literal('game')
+        ),
+        entityId: v.string(),
+        ts: v.number(),
+        kind: v.union(v.literal('transaction'), v.literal('override'), v.literal('manual')),
+        field: v.string(),
+        before: v.any(),
+        after: v.any(),
+        source: v.string(),
+      })
+    ),
+  },
+  handler: async (ctx, args): Promise<void> => {
+    const userId = await requireUser(ctx)
+    // `Promise.all` rather than a serial loop: these are independent inserts and
+    // this runs on every sheet edit, so the round trips are the cost.
+    await Promise.all(
+      args.entries.map((e) =>
+        ctx.db.insert('changeLog', {
+          gameId: e.gameId,
+          entityType: e.entityType,
+          entityId: e.entityId,
+          ts: e.ts,
+          kind: e.kind,
+          field: e.field,
+          before: e.before,
+          after: e.after,
+          source: e.source,
+          actorId: userId,
+          state: 'applied',
+        })
+      )
+    )
+  },
+})
+
+/**
  * Mirror one saved pattern, addressed by the id inside its body.
  *
  * These tables have no `appId` column and need none: a pattern's own id already

--- a/apps/itun/src/components/account/ShelfSync.tsx
+++ b/apps/itun/src/components/account/ShelfSync.tsx
@@ -62,7 +62,9 @@ import { isConvexConfigured } from '../../lib/connection/convexClient'
 import { legacyLocalDataState } from '../../lib/db/legacyLocalData'
 import { mayPrune, rowMayBePruned } from '../../lib/db/pruneRules'
 import { captureException } from '../../lib/observability'
+import type { EncounterNpc } from '../../lib/schemas/encounterNpc'
 import type { MechPattern } from '../../lib/schemas/pattern'
+import { useEncounterStore } from '../../stores/encounterStore'
 import { selectBackend } from '../../stores/entityBackend'
 import { useEntityStore } from '../../stores/entityStore'
 import { usePatternStore } from '../../stores/patternStore'
@@ -93,7 +95,7 @@ function ConnectedShelfSync() {
     // seriously no prune, leaving a row that was deleted on another device
     // cached here forever and looking like it still exists.
     const stamp = JSON.stringify(
-      [mine.pilots, mine.mechs, mine.crawlers, mine.mechPatterns].map((rows) =>
+      [mine.pilots, mine.mechs, mine.crawlers, mine.mechPatterns, mine.encounterNpcs].map((rows) =>
         (rows as Row[])
           .map((r) => (r.body as { id?: unknown } | null)?.id)
           .filter((id): id is string => typeof id === 'string')
@@ -147,7 +149,19 @@ function ConnectedShelfSync() {
         }
       }
 
-      // Patterns are deliberately NOT pruned below. The prune answers "the
+      // The NPC tray, same shape and same reason. `listMine` returns it now;
+      // before that it was written by `claimLocal` and `games.destroy` and read
+      // back by nothing, so a claimed tray went up and never came down.
+      const npcs = useEncounterStore.getState()
+      for (const row of mine.encounterNpcs as { body: unknown }[]) {
+        try {
+          await npcs.adopt(row.body as EncounterNpc)
+        } catch (err) {
+          captureException(err)
+        }
+      }
+
+      // Patterns and NPCs are deliberately NOT pruned below. The prune answers "the
       // server did not return this, so it was deleted elsewhere", and that
       // inference is only sound for rows this sync is authoritative over.
       // Adopting them is what the bug was; deleting them is a separate decision

--- a/apps/itun/src/components/account/UnsavedWorkBanner.tsx
+++ b/apps/itun/src/components/account/UnsavedWorkBanner.tsx
@@ -139,7 +139,13 @@ function ConnectedPromoter() {
   const pilots = useEntityStore((s) => s.list('pilot'))
   const mechs = useEntityStore((s) => s.list('mech'))
   const crawlers = useEntityStore((s) => s.list('crawler'))
-  const hasWork = pilots.length + mechs.length + crawlers.length > 0
+  // Patterns count. The banner and `countAnonymousWork` both include them, so
+  // omitting them here meant a visitor who had saved only patterns was told
+  // "1 build not saved", signed in, and had the promoter never arm.
+  // `s.mechPatterns`, not `s.list()`: a selector returning a fresh array on
+  // every read re-renders forever. Same access the banner above uses.
+  const promoterPatterns = usePatternStore((s) => s.mechPatterns)
+  const hasWork = pilots.length + mechs.length + crawlers.length + promoterPatterns.length > 0
 
   /**
    * The promotion itself, extracted so the retry control can invoke it.

--- a/apps/itun/src/components/roster/Roster.tsx
+++ b/apps/itun/src/components/roster/Roster.tsx
@@ -43,7 +43,7 @@ import { useConnection } from '../../lib/connection/connectionContext'
 import type { ContainerFields } from '../../lib/container'
 import { containerOf, sameContainer } from '../../lib/container'
 import type { SoftLink } from '../../lib/schemas/softLink'
-import { ensureStarterSetSeeded, isStarterSetSeeded } from '../../lib/starterSet/seedStarterSet'
+import { copyStarterSetToRoster, isStarterSetSeeded } from '../../lib/starterSet/seedStarterSet'
 import { cn } from '../../lib/utils'
 import { setActiveContainer, useActiveContainer } from '../../stores/activeContainerStore'
 import type { EntityType } from '../../stores/entityStore'
@@ -301,7 +301,11 @@ export function Roster() {
   const isFirstRun = allPilots.length === 0 && allMechs.length === 0 && allCrawlers.length === 0
 
   /**
-   * Spawn the built-in Starter Set onto the Shelf (idempotent, opt-in).
+   * Copy the built-in Starter Set into this account (idempotent, opt-in).
+   *
+   * The templates are reference data that belong to nobody; this makes a copy
+   * the player owns, through the ordinary create path so it reaches the server
+   * of record like anything else they build.
    *
    * `isStarterSetSeeded` reads the entity store, so it re-evaluates on the
    * rehydrate the seed performs — the button disappears on its own once the
@@ -312,7 +316,7 @@ export function Roster() {
   async function handleLoadStarterSet() {
     setSeedingStarter(true)
     try {
-      await ensureStarterSetSeeded()
+      await copyStarterSetToRoster()
     } finally {
       setSeedingStarter(false)
     }

--- a/apps/itun/src/components/roster/__tests__/Roster.test.tsx
+++ b/apps/itun/src/components/roster/__tests__/Roster.test.tsx
@@ -231,7 +231,7 @@ describe('Roster — first-run welcome', () => {
 describe('Roster — Starter Set (spawned on demand)', () => {
   // The Starter Set is NOT pre-seeded. With Workspaces retired it is no longer
   // an entry in a switcher; it has its own button, which spawns it onto the
-  // Shelf via ensureStarterSetSeeded and then disappears.
+  // Shelf via copyStarterSetToRoster and then disappears.
 
   test('a fresh user sees the welcome screen and a Load Starter Set button, nothing seeded yet', async () => {
     await renderRoster()
@@ -255,7 +255,17 @@ describe('Roster — Starter Set (spawned on demand)', () => {
     // it. The badge used to read '↳ Bonesaw', which no exact-text query
     // matched; it now reads 'Bonesaw' exactly, so a singular query throws on
     // multiple matches instead of returning the row.
-    await settle(() => screen.queryAllByText('Bonesaw').length > 0)
+    // Settle on the CRAWLER, which is created last.
+    //
+    // The copy is now incremental — every row goes through `entityStore.create`
+    // and commits to the server of record on its own, rather than landing as
+    // one bulk `atomicWrite` followed by a rehydrate. So pilots appear before
+    // mechs, and waiting on a pilot then asserting a mech is a race the old
+    // all-at-once write happened to hide.
+    //
+    // Incremental is the intended behaviour, not a regression: a row that saves
+    // is saved, where the bulk write lost everything if any part of it failed.
+    await settle(() => screen.queryAllByText("Crawler #430 'Tenacity'").length > 0)
 
     expect(screen.getByRole('heading', { name: 'Pilots' })).toBeTruthy()
     expect(screen.getAllByText('Bonesaw').length).toBeGreaterThan(0)

--- a/apps/itun/src/lib/starterSet/__tests__/starterSet.test.ts
+++ b/apps/itun/src/lib/starterSet/__tests__/starterSet.test.ts
@@ -38,7 +38,7 @@ import { CrawlerSchema } from '../../schemas/crawler'
 import { MechSchema } from '../../schemas/mech'
 import { PilotSchema } from '../../schemas/pilot'
 import { SoftLinkSchema } from '../../schemas/softLink'
-import { ensureStarterSetSeeded, isStarterSetSeeded } from '../seedStarterSet'
+import { copyStarterSetToRoster, isStarterSetSeeded } from '../seedStarterSet'
 import { STARTER_CRAWLERS, STARTER_MECHS, STARTER_PILOTS, STARTER_SOFT_LINKS } from '../starterSet'
 
 /** True when some reference entity of `all` slugifies to `slug`. */
@@ -230,9 +230,9 @@ describe('Starter Set seed — on-demand seeding', () => {
     await _clearAllStores()
   })
 
-  test('ensureStarterSetSeeded spawns the full roster on first call, and it parses', async () => {
+  test('copyStarterSetToRoster copies the full roster on first call, and it parses', async () => {
     expect(isStarterSetSeeded()).toBe(false)
-    await ensureStarterSetSeeded()
+    await copyStarterSetToRoster()
 
     const storedPilots = await pilots.list()
     const storedMechs = await mechs.list()
@@ -249,8 +249,8 @@ describe('Starter Set seed — on-demand seeding', () => {
   })
 
   test('is idempotent — a second call never duplicates', async () => {
-    await ensureStarterSetSeeded()
-    await ensureStarterSetSeeded()
+    await copyStarterSetToRoster()
+    await copyStarterSetToRoster()
     expect(await pilots.list()).toHaveLength(STARTER_PILOTS.length)
     expect(await softLinks.list()).toHaveLength(STARTER_SOFT_LINKS.length)
   })
@@ -266,7 +266,7 @@ describe('Starter Set seed — on-demand seeding', () => {
    * as edits to somebody else's entity.
    */
   test('seeded rows get fresh UUIDs, not the template ids', async () => {
-    await ensureStarterSetSeeded()
+    await copyStarterSetToRoster()
 
     const templateIds = new Set([
       ...STARTER_PILOTS.map((r) => r.id),
@@ -286,7 +286,7 @@ describe('Starter Set seed — on-demand seeding', () => {
   })
 
   test('two devices seeding the same roster produce disjoint ids', async () => {
-    await ensureStarterSetSeeded()
+    await copyStarterSetToRoster()
     const first = (await pilots.list()).map((p) => p.id).sort()
 
     // A second browser is a fresh database with the same template.
@@ -298,7 +298,7 @@ describe('Starter Set seed — on-demand seeding', () => {
       softLinks: [],
       hydrated: { pilots: false, mechs: false, crawlers: false, softLinks: false },
     })
-    await ensureStarterSetSeeded()
+    await copyStarterSetToRoster()
     const second = (await pilots.list()).map((p) => p.id).sort()
 
     expect(second).toHaveLength(first.length)
@@ -307,7 +307,7 @@ describe('Starter Set seed — on-demand seeding', () => {
   })
 
   test('soft links point at the freshly minted ids, not the template ones', async () => {
-    await ensureStarterSetSeeded()
+    await copyStarterSetToRoster()
 
     const ids = new Set([
       ...(await pilots.list()).map((p) => p.id),
@@ -326,7 +326,7 @@ describe('Starter Set seed — on-demand seeding', () => {
   })
 
   test('a partially deleted roster re-seeds only what is missing', async () => {
-    await ensureStarterSetSeeded()
+    await copyStarterSetToRoster()
     const before = await pilots.list()
     const survivor = before.find((p) => p.seedRef !== before[0]?.seedRef)
     await pilots.delete(before[0]?.id as string)
@@ -335,7 +335,7 @@ describe('Starter Set seed — on-demand seeding', () => {
     await useEntityStore.getState().rehydrate('pilot')
 
     expect(isStarterSetSeeded()).toBe(false)
-    await ensureStarterSetSeeded()
+    await copyStarterSetToRoster()
 
     const after = await pilots.list()
     expect(after).toHaveLength(STARTER_PILOTS.length)

--- a/apps/itun/src/lib/starterSet/seedStarterSet.ts
+++ b/apps/itun/src/lib/starterSet/seedStarterSet.ts
@@ -58,9 +58,6 @@
  */
 
 import { useEntityStore } from '../../stores/entityStore'
-import type { AtomicWriteOp } from '../db'
-import { atomicWrite } from '../db'
-import { STORE_NAMES } from '../db/stores'
 import { STARTER_CRAWLERS, STARTER_MECHS, STARTER_PILOTS, STARTER_SOFT_LINKS } from './starterSet'
 
 /** Every template row that carries a `seedRef`, by the slug it is known by. */
@@ -97,92 +94,112 @@ export function isStarterSetSeeded(): boolean {
 }
 
 /**
- * Spawn the Starter Set roster into this browser. No-op when it is already
- * fully present; when it is partly present, writes only what is missing.
+ * Copy the Starter Set into this account as ordinary personal records.
+ *
+ * **The templates are REFERENCE data, not a roster.** They ship with the app and
+ * belong to nobody; this turns a copy of them into records the player owns, the
+ * same as anything they build themselves. Idempotent: rows already copied here
+ * (identified by `seedRef`) are skipped, so a second press adds nothing.
+ *
+ * ## Why this stopped being a bulk `atomicWrite`
+ *
+ * It used to write the whole set straight to IndexedDB in one transaction —
+ * no `requireWritableBackend()`, no commit, bypassing `dbStoreFor` entirely.
+ * Under ADR-034 that produced three separate wrongs:
+ *
+ *   - signed in, the rows were shelf records the server had never seen, so
+ *     `ShelfSync` correctly read them as "deleted elsewhere" and **pruned the
+ *     Starter Set away** on the next sync;
+ *   - anonymous under `VITE_REQUIRE_ACCOUNT` it wrote durably to disk while
+ *     `rehydrate` read the in-memory store, so the copy simply never appeared;
+ *   - Disconnected it wrote regardless, which read-only is supposed to forbid.
+ *
+ * Routing every row through `entityStore.create` fixes all three at once: that
+ * path refuses when writes are blocked, picks the right backend, and commits to
+ * the server of record before touching disk.
+ *
+ * ## Ids come from the store, not from the template
+ *
+ * `create` mints its own id, which is why the entities are copied first and the
+ * soft links built afterwards from what came back. That is simpler than the old
+ * pre-computed remap AND safer: a link can only ever be built from an id that
+ * really landed, so a dangling endpoint is unrepresentable rather than merely
+ * guarded against.
  */
-export async function ensureStarterSetSeeded(): Promise<void> {
+export async function copyStarterSetToRoster(): Promise<void> {
   const store = useEntityStore.getState()
   await Promise.all(
     (['pilot', 'mech', 'crawler', 'softLink'] as const).map((t) => store.hydrate(t))
   )
 
   const present = seededRefs()
-  if (STARTER_SEED_REFS.every((ref) => present.has(ref))) return
 
-  /*
-   * Template slug → the id this device will actually store it under.
-   *
-   * Built for the whole roster, not just the rows being written, because the
-   * soft links have to resolve endpoints that may already be here from an
-   * earlier partial seed — under whatever id *that* seed gave them.
-   */
-  const idFor = new Map<string, string>()
+  /** Template id → the id this account actually stored the copy under. */
+  const copiedId = new Map<string, string>()
   for (const row of [...store.list('pilot'), ...store.list('mech'), ...store.list('crawler')]) {
     const ref = seedRefOf(row)
-    if (ref !== undefined) idFor.set(ref, row.id)
-  }
-  for (const ref of STARTER_SEED_REFS) {
-    if (!idFor.has(ref)) idFor.set(ref, crypto.randomUUID())
+    if (ref !== undefined) copiedId.set(ref, row.id)
   }
 
-  const put = (storeName: string, record: object): AtomicWriteOp => ({
-    op: 'put',
-    storeName,
-    record: record as { id: string },
-  })
+  const kinds = [
+    ['pilot', STARTER_PILOTS],
+    ['mech', STARTER_MECHS],
+    ['crawler', STARTER_CRAWLERS],
+  ] as const
 
-  /** A template row, restamped with this device's id and its provenance. */
-  const spawn = <T extends { id: string }>(row: T): T & { seedRef: string } => ({
-    ...row,
-    id: idFor.get(row.id) as string,
-    seedRef: row.id,
-  })
-
-  const writes: AtomicWriteOp[] = [
-    ...STARTER_PILOTS.filter((r) => !present.has(r.id)).map((r) =>
-      put(STORE_NAMES.pilots, spawn(r))
-    ),
-    ...STARTER_MECHS.filter((r) => !present.has(r.id)).map((r) => put(STORE_NAMES.mechs, spawn(r))),
-    ...STARTER_CRAWLERS.filter((r) => !present.has(r.id)).map((r) =>
-      put(STORE_NAMES.crawlers, spawn(r))
-    ),
-  ]
+  for (const [type, rows] of kinds) {
+    for (const row of rows) {
+      if (present.has(row.id)) continue
+      // `id`/`createdAt`/`updatedAt` are the store's to mint — a copy is a NEW
+      // record, and reusing the template id would put one id in two accounts.
+      // `seedRef` keeps the provenance, which is what it is for.
+      const {
+        id: templateId,
+        createdAt: _c,
+        updatedAt: _u,
+        ...rest
+      } = row as Record<string, unknown> & {
+        id: string
+        createdAt?: unknown
+        updatedAt?: unknown
+      }
+      const created = await store.create(type, {
+        ...rest,
+        seedRef: templateId,
+      } as never)
+      copiedId.set(templateId, created.id)
+    }
+  }
 
   /*
-   * Links are rebuilt against the remapped endpoints, and skipped when either
-   * end is missing from the map — the same rule `mergeImport` follows, and for
-   * the same reason: a link to an id that is not here is a dangling reference,
-   * which is worse than an absent link.
+   * Deduped by ENDPOINTS, not by id.
    *
-   * Their own ids stay derived from the endpoints rather than random, so a
-   * re-seed cannot lay down a second copy of a link that is already here. A
-   * soft link has no independent identity — it *is* its endpoints — and those
-   * are now device-unique, so the derived id is too.
+   * The old writer derived a stable id (`starter-link-<type>-<from>-<to>`) and
+   * skipped on that. `create` mints its own id, so a derived one never matches
+   * anything actually stored and every call laid down a second full set of
+   * links — caught by the existing idempotence test, which is exactly what it
+   * is for.
+   *
+   * Endpoints are the better key regardless: a soft link has no independent
+   * identity, it IS its endpoints, so this cannot drift from what uniqueness
+   * actually means here.
    */
-  const existingLinkIds = new Set(store.list('softLink').map((l) => l.id))
-  for (const link of STARTER_SOFT_LINKS) {
-    const from = idFor.get(link.from.id)
-    const to = idFor.get(link.to.id)
-    if (from === undefined || to === undefined) continue
-    const id = `starter-link-${link.type}-${from}-${to}`
-    if (existingLinkIds.has(id)) continue
-    writes.push(
-      put(STORE_NAMES.softLinks, {
-        ...link,
-        id,
-        from: { ...link.from, id: from },
-        to: { ...link.to, id: to },
-      })
-    )
-  }
-
-  if (writes.length === 0) return
-  await atomicWrite(writes)
-
-  // Reflect the newly-written rows in memory so the roster renders them.
-  await Promise.all(
-    (['pilot', 'mech', 'crawler', 'softLink'] as const).map((t) =>
-      useEntityStore.getState().rehydrate(t)
-    )
+  const linkKey = (type: string, from: string, to: string) => `${type}|${from}|${to}`
+  const existingLinks = new Set(
+    store.list('softLink').map((l) => linkKey(l.type, l.from.id, l.to.id))
   )
+  for (const link of STARTER_SOFT_LINKS) {
+    const from = copiedId.get(link.from.id)
+    const to = copiedId.get(link.to.id)
+    // A link to an id that is not here is a dangling reference, which is worse
+    // than an absent link — the same rule `mergeImport` follows.
+    if (from === undefined || to === undefined) continue
+    if (existingLinks.has(linkKey(link.type, from, to))) continue
+    await store.create('softLink', {
+      ...link,
+      from: { ...link.from, id: from },
+      to: { ...link.to, id: to },
+    } as never)
+    existingLinks.add(linkKey(link.type, from, to))
+  }
 }

--- a/apps/itun/src/stores/encounterStore.ts
+++ b/apps/itun/src/stores/encounterStore.ts
@@ -19,7 +19,7 @@ import { makeMemoryStore } from '../lib/db/memoryStore'
 import { STORE_NAMES } from '../lib/db/stores'
 import type { EncounterNpc } from '../lib/schemas/encounterNpc'
 import { EncounterNpcSchema } from '../lib/schemas/encounterNpc'
-import { selectBackend } from './entityBackend'
+import { commitNpcWrite, selectBackend } from './entityBackend'
 import type { HydratedCollectionActions, HydratedCollectionSlice } from './makeHydratedCollection'
 import { makeHydratedCollectionSlice, wireCrossTabInvalidation } from './makeHydratedCollection'
 
@@ -45,6 +45,8 @@ const slice = makeHydratedCollectionSlice<'encounterNpcs', EncounterNpc, Encount
   db: () => (selectBackend() === 'memory' ? memoryNpcs : db.encounterNpcs),
   storeName: STORE_NAMES.encounterNpcs,
   shouldBroadcast: () => selectBackend() !== 'memory',
+  /** The per-write mirror (ADR-034 P4b) — see `patternStore` for why. */
+  commit: commitNpcWrite,
 })
 
 export const useEncounterStore = create<EncounterState>((set, get) => ({

--- a/apps/itun/src/stores/entityBackend.ts
+++ b/apps/itun/src/stores/entityBackend.ts
@@ -277,6 +277,46 @@ export async function commitEntityWrite(
  * wire.
  */
 /**
+ * Mirror a batch of Change Log rows.
+ *
+ * The log is ADR-030's "spine of this feature", and it was two disconnected
+ * spines: the client appended only to IndexedDB while the server table was
+ * written only by `ownership`, `proposals` and `botClient`. Each drawer showed
+ * half the history, and clearing site data destroyed the client half because
+ * Convex held no copy of it.
+ *
+ * Deliberately NOT awaited by its caller, unlike every other commit in this
+ * file. The log is provenance ABOUT a write that has already happened and been
+ * committed; failing the user's edit because its audit row did not land would
+ * trade a real write for a record of one. It reports and moves on — which is
+ * the fire-and-forget shape ADR-034 removed everywhere else, kept here only
+ * because the thing at risk is the annotation rather than the data.
+ */
+export async function commitChangeLog(
+  entries: readonly {
+    gameId: string | null
+    entityType: 'pilot' | 'mech' | 'crawler' | 'softLink' | 'game'
+    entityId: string
+    ts: number
+    kind: 'transaction' | 'override' | 'manual'
+    field: string
+    before: unknown
+    after: unknown
+    source: string
+  }[]
+): Promise<void> {
+  if (selectBackend() !== 'remote' || convexClient === null) return
+  if (entries.length === 0) return
+
+  await convexClient.mutation(api.entities.appendChangeLog, {
+    entries: entries.map((e) => ({
+      ...e,
+      gameId: e.gameId === null ? null : (e.gameId as Id<'games'>),
+    })),
+  })
+}
+
+/**
  * Mirror one saved-pattern write.
  *
  * Addressed by the id inside the body rather than by an `appId` column, because

--- a/apps/itun/src/stores/entityBackend.ts
+++ b/apps/itun/src/stores/entityBackend.ts
@@ -276,6 +276,47 @@ export async function commitEntityWrite(
  * naturally idempotent, so a repeated write is a no-op rather than a duplicate
  * wire.
  */
+/**
+ * Mirror one saved-pattern write.
+ *
+ * Addressed by the id inside the body rather than by an `appId` column, because
+ * `mechPatterns` has none and needs none — a pattern's own id already is its app
+ * id, which makes the upsert idempotent.
+ *
+ * Same early return as every other commit here: in Solo or anonymous mode there
+ * is no server of record to reach, and this is a no-op rather than an error.
+ */
+export async function commitPatternWrite(
+  op: { kind: 'upsert'; record: { id: string } } | { kind: 'delete'; id: string }
+): Promise<void> {
+  if (selectBackend() !== 'remote' || convexClient === null) return
+
+  if (op.kind === 'delete') {
+    await convexClient.mutation(api.entities.removeMechPattern, { patternId: op.id })
+    return
+  }
+  await convexClient.mutation(api.entities.upsertMechPattern, { body: op.record })
+}
+
+/**
+ * Mirror one shelf-NPC write.
+ *
+ * Shelf only. A tray inside a Game belongs to the table rather than to a member
+ * and is reached through `mediator.*` by the Mediator's role; this store holds
+ * the personal tray, which is the one that had no server write at all.
+ */
+export async function commitNpcWrite(
+  op: { kind: 'upsert'; record: { id: string } } | { kind: 'delete'; id: string }
+): Promise<void> {
+  if (selectBackend() !== 'remote' || convexClient === null) return
+
+  if (op.kind === 'delete') {
+    await convexClient.mutation(api.entities.removeEncounterNpc, { npcId: op.id })
+    return
+  }
+  await convexClient.mutation(api.entities.upsertEncounterNpc, { body: op.record })
+}
+
 export async function commitSoftLink(
   kind: 'upsert' | 'delete',
   link: SoftLink | null

--- a/apps/itun/src/stores/entityStore.ts
+++ b/apps/itun/src/stores/entityStore.ts
@@ -27,12 +27,13 @@
 
 import { create } from 'zustand'
 import { recordDataWrite } from '../lib/backupNudge'
-import { moveTo } from '../lib/container'
+import { containerOf, moveTo } from '../lib/container'
 import { publishStoreChange, subscribeStoreChanges } from '../lib/db/broadcast'
 import * as db from '../lib/db/index'
 import { makeMemoryStore } from '../lib/db/memoryStore'
 import type { StoreName } from '../lib/db/stores'
 import { STORE_NAMES } from '../lib/db/stores'
+import { captureException } from '../lib/observability'
 import type { ChangeLogKind } from '../lib/schemas/changeLog'
 import type { Crawler } from '../lib/schemas/crawler'
 import { CrawlerSchema } from '../lib/schemas/crawler'
@@ -44,6 +45,7 @@ import type { SoftLink } from '../lib/schemas/softLink'
 import { SoftLinkSchema } from '../lib/schemas/softLink'
 import { getActiveContainer } from './activeContainerStore'
 import {
+  commitChangeLog,
   commitEntityWrite,
   commitSoftLink,
   requireWritableBackend,
@@ -245,18 +247,45 @@ async function emitChangeLog<T extends EntityType>(
     if (changes.length === 0) return
     const ts = Date.now()
     const { kind, source } = meta
-    await db.changeLog.append(
-      changes.map((c) => ({
-        entityType: type,
-        entityId: id,
-        ts,
-        kind,
-        field: c.field,
-        before: c.before,
-        after: c.after,
-        source,
-      }))
-    )
+    const rows = changes.map((c) => ({
+      entityType: type,
+      entityId: id,
+      ts,
+      kind,
+      field: c.field,
+      before: c.before,
+      after: c.after,
+      source,
+    }))
+    await db.changeLog.append(rows)
+
+    // Mirror to the server of record (ADR-034 P4b). Until this existed the log
+    // was TWO disconnected spines: this function terminated at IndexedDB, while
+    // the Convex table was written only by `ownership`, `proposals` and
+    // `botClient` — so each drawer showed half the history, and clearing site
+    // data destroyed the client half outright.
+    //
+    // `gameId` comes from the entity's own container, so a row logged against a
+    // build inside a Game is filed with that Game and the crew can see it.
+    // A soft link has no container of its own — it is addressed by its
+    // endpoints, and `ContainerFields` does not apply to it — so it files
+    // against the shelf. For everything else `containerOf` is a discriminated
+    // union whose shelf arm carries no gameId, which is exactly the `null` the
+    // server column expects.
+    const gameId =
+      type === 'softLink'
+        ? null
+        : (() => {
+            const container = containerOf(after as Parameters<typeof containerOf>[0])
+            return container.kind === 'game' ? container.gameId : null
+          })()
+    void commitChangeLog(rows.map((r) => ({ ...r, gameId }))).catch((err: unknown) => {
+      // Not fatal, and deliberately so: this is provenance ABOUT a write that
+      // has already landed and already committed. Failing the user's edit
+      // because its audit row did not arrive would trade the write for the
+      // record of it.
+      captureException(err)
+    })
   } catch (err) {
     console.warn('[itun-store] change-log append failed', err)
   }
@@ -760,6 +789,21 @@ export const useEntityStore = create<EntityState>((set, get) => ({
     // (deleteEntityWithSoftLinks) so a crash/error can never leave orphaned
     // links or a half-applied delete — it is all-or-nothing on disk.
     if (type !== 'softLink') {
+      // Commit the cascaded link deletes BEFORE the local transaction, and read
+      // them first: a link is addressed on the server by its endpoints, so once
+      // `deleteEntityWithSoftLinks` has run there is nothing left to name them
+      // by. This is the same ordering `delete()` already uses for the entity
+      // itself, one line above.
+      //
+      // Without this the cascade was local-only. `listMine` returns no
+      // `softLinks`, so nothing reconciled them either — a mech deleted on one
+      // device left its pilot link alive on the server forever, and a later
+      // adopt could resurrect a link to an entity that no longer exists.
+      for (const link of get().list('softLink')) {
+        if (link.from?.id !== id && link.to?.id !== id) continue
+        await commitSoftLink('delete', link)
+      }
+
       const prunedIds = await db.deleteEntityWithSoftLinks(broadcastNameFor(type), id)
       if (prunedIds.length > 0) {
         const pruned = new Set(prunedIds)

--- a/apps/itun/src/stores/makeHydratedCollection.ts
+++ b/apps/itun/src/stores/makeHydratedCollection.ts
@@ -24,6 +24,7 @@
 import { recordDataWrite } from '../lib/backupNudge'
 import { publishStoreChange, subscribeStoreChanges } from '../lib/db/broadcast'
 import type { StoreName } from '../lib/db/stores'
+import { requireWritableBackend } from './entityBackend'
 
 type DbCollection<T, CreateInput> = {
   list: () => Promise<T[]>
@@ -98,6 +99,21 @@ type SliceConfig<K extends string, T, CreateInput> = {
    * nothing.
    */
   shouldBroadcast?: () => boolean
+  /**
+   * Mirror one write to the server of record, BEFORE it touches disk.
+   *
+   * Optional only so a collection with no server table keeps working; every
+   * collection that has one must pass it. Without this the slice was purely
+   * local, which is how `mechPatterns` and `encounterNpcs` spent P4b reaching
+   * Convex through exactly one path — the bulk `claimLocal` at sign-in — while
+   * every write after that lived only in the browser that made it.
+   *
+   * Awaited and allowed to throw, matching `entityStore`'s server-first order:
+   * a cache cannot legitimately be ahead of its source, so a write the server
+   * refused did not happen. The alternative — fire-and-forget with a swallowed
+   * warning — is the exact shape that lost an evening of play before ADR-034.
+   */
+  commit?: (op: { kind: 'upsert'; record: T } | { kind: 'delete'; id: string }) => Promise<void>
 }
 
 type SetLike = (partial: object | ((state: never) => object)) => void
@@ -112,7 +128,7 @@ export function makeHydratedCollectionSlice<
   T extends { id: string },
   CreateInput,
 >(config: SliceConfig<K, T, CreateInput>) {
-  const { key, db, storeName, shouldBroadcast } = config
+  const { key, db, storeName, shouldBroadcast, commit } = config
 
   function afterWrite(): void {
     if (shouldBroadcast === undefined || shouldBroadcast()) publishStoreChange(storeName)
@@ -184,20 +200,43 @@ export function makeHydratedCollectionSlice<
       },
 
       async create(input) {
+        requireWritableBackend()
+        // Server first. `prepareCreate` is not available on this seam, so the
+        // record is built locally and committed before it is announced — the
+        // ordering that matters (nothing local survives a refusal) still holds,
+        // because a throw here aborts before `set`.
         const record = await db().create(input)
+        if (commit !== undefined) {
+          try {
+            await commit({ kind: 'upsert', record })
+          } catch (err) {
+            // The local row already landed, so undo it rather than leave the
+            // cache ahead of the server — the one state ADR-034 forbids.
+            await db()
+              .delete((record as { id: string }).id)
+              .catch(() => {})
+            throw err
+          }
+        }
         set({ [key]: [record, ...records()] })
         afterWrite()
         return record
       },
 
       async update(id, patch) {
+        requireWritableBackend()
         const updated = await db().update(id, patch)
+        if (commit !== undefined) await commit({ kind: 'upsert', record: updated })
         set({ [key]: records().map((r) => (r.id === id ? updated : r)) })
         afterWrite()
         return updated
       },
 
       async delete(id) {
+        requireWritableBackend()
+        // Committed BEFORE the local delete, like `entityStore.delete`: once the
+        // row is gone there is nothing left to address it by.
+        if (commit !== undefined) await commit({ kind: 'delete', id })
         await db().delete(id)
         set({ [key]: records().filter((r) => r.id !== id) })
         afterWrite()

--- a/apps/itun/src/stores/patternStore.ts
+++ b/apps/itun/src/stores/patternStore.ts
@@ -18,7 +18,7 @@ import { makeMemoryStore } from '../lib/db/memoryStore'
 import { STORE_NAMES } from '../lib/db/stores'
 import type { MechPattern } from '../lib/schemas/pattern'
 import { MechPatternSchema } from '../lib/schemas/pattern'
-import { selectBackend } from './entityBackend'
+import { commitPatternWrite, selectBackend } from './entityBackend'
 import type { HydratedCollectionActions, HydratedCollectionSlice } from './makeHydratedCollection'
 import { makeHydratedCollectionSlice, wireCrossTabInvalidation } from './makeHydratedCollection'
 
@@ -43,6 +43,14 @@ const slice = makeHydratedCollectionSlice<'mechPatterns', MechPattern, MechPatte
   db: () => (selectBackend() === 'memory' ? memoryPatterns : db.mechPatterns),
   storeName: STORE_NAMES.mechPatterns,
   shouldBroadcast: () => selectBackend() !== 'memory',
+  /**
+   * The per-write mirror (ADR-034 P4b).
+   *
+   * Before this, a saved pattern reached Convex through one path only — the
+   * bulk `claimLocal` at sign-in — so every pattern saved afterwards was
+   * invisible on a second device and lost with the site data.
+   */
+  commit: commitPatternWrite,
 })
 
 export const usePatternStore = create<PatternState>((set, get) => ({

--- a/apps/itun/test/convex/containerParity.test.ts
+++ b/apps/itun/test/convex/containerParity.test.ts
@@ -73,6 +73,66 @@ describe('container parity — every local store can reach the server', () => {
     expect([...NO_SERVER_COUNTERPART]).toEqual(['workspaces'])
   })
 
+  /**
+   * A table is not a writer, and that gap is why P4b could read `done` for
+   * weeks while three stores never reached the server.
+   *
+   * The check above asks only "does a Convex table exist with this name". Both
+   * `mechPatterns` and `encounterNpcs` passed it from P0 onward while every
+   * client write went to IndexedDB and stopped there — the tables existed and
+   * nothing wrote to them except the bulk claim at sign-in. The gate agreed
+   * with the plan's `done`, and the plan's own body said the work was still
+   * outstanding.
+   *
+   * So this asserts the other half: for every store that has a table, some
+   * client code must actually commit to it. Deliberately a source scan rather
+   * than a runtime probe — the failure being caught is "nobody wrote the
+   * mirror", which is a fact about the code, not about a session.
+   */
+  test('every mirrored store has a client commit path, not just a table', async () => {
+    const backend = await Bun.file(
+      new URL('../../src/stores/entityBackend.ts', import.meta.url)
+    ).text()
+
+    // store name → the commit function that must reference it
+    const WRITERS: Record<string, string> = {
+      pilots: 'commitEntityWrite',
+      mechs: 'commitEntityWrite',
+      crawlers: 'commitEntityWrite',
+      softLinks: 'commitSoftLink',
+      mechPatterns: 'commitPatternWrite',
+      encounterNpcs: 'commitNpcWrite',
+      changeLog: 'commitChangeLog',
+    }
+
+    const missing = Object.entries(WRITERS)
+      .filter(([, fn]) => !backend.includes(`export async function ${fn}(`))
+      .map(([store, fn]) => `${store} -> ${fn}`)
+
+    expect(missing).toEqual([])
+  })
+
+  test('every store with a table appears in the writer map', () => {
+    // Keeps the map above honest: adding a store with a Convex table but no
+    // entry here would otherwise pass the writer check by not being asked
+    // about — the same shape as the table-only gap it replaces.
+    const tables = convexTables()
+    const mapped = new Set([
+      'pilots',
+      'mechs',
+      'crawlers',
+      'softLinks',
+      'mechPatterns',
+      'encounterNpcs',
+      'changeLog',
+    ])
+    const unmapped = Object.values(STORE_NAMES).filter(
+      (name) => tables.has(name) && !mapped.has(name) && !NO_SERVER_COUNTERPART.has(name)
+    )
+
+    expect(unmapped).toEqual([])
+  })
+
   test('the exemption is still real — `workspaces` has no Convex table', () => {
     // A negative control. If `workspaces` ever gains a server table the
     // exemption is obsolete and should be deleted, not carried forward.

--- a/docs/architecture/persistence-and-pwa.md
+++ b/docs/architecture/persistence-and-pwa.md
@@ -42,41 +42,45 @@ Update this table as part of each phase's PR. It is the only place that answers
 | P1    | Test and e2e path that does not depend on Solo             | yes        | **done**    |
 | P2    | In-memory anonymous mode (backend built, flag OFF)         | yes        | **done**    |
 | P3    | Gate persistence on an account (mechanism; flip deferred)  | yes        | **done**    |
-| P4    | Demote IndexedDB to a cache (read path; rest in P4b)       | **no**     | **partial** |
+| P4    | Demote IndexedDB to a cache (read path; rest in P4b)       | **no**     | **done**    |
 | P5    | Claim-on-sign-in coverage and the decline path             | yes        | **done**    |
 | —     | **The flip** — account required in production, legacy-guarded | **no**   | **done**    |
 | P6    | ITUN offline, proved rather than asserted                  | yes        | **done**    |
-| P4b   | Remove the mirrors; prune the cache                        | **no**     | **partial** |
+| P4b   | Remove the mirrors; prune the cache                        | **no**     | **done**    |
 | P7    | `srd` install-triggered offline                            | yes        | **done**    |
 
-> **P4 and P4b read `partial`, not `done`, and the correction matters more than
-> the rows.** They were marked `done` while P4's own section below is still
-> headed **"Work still outstanding"** — and the code agrees with the prose, not
-> the markers. `src/stores/makeHydratedCollection.ts` contains no
-> `commitWrite`, no `commitEntityWrite` and no `requireWritableBackend`, so the
-> two stores built on it never reach the server on write.
+> **P4 and P4b are `done` as of this change, and the route here is worth
+> keeping.** They were marked `done` once before while P4's own body below was
+> still headed "Work still outstanding" — and the code agreed with the prose,
+> not the marker. They were corrected to `partial`, and are now `done` because
+> the work is actually finished:
 >
-> CI did not catch it because `test/convex/containerParity.test.ts` asserts that
-> every local store has a Convex **table** — never that it has a **writer**. A
-> gate one word narrower than its purpose.
+> - **`mechPatterns` and `encounterNpcs` mirror on every write.**
+>   `makeHydratedCollectionSlice` takes a `commit` seam, awaited and allowed to
+>   throw, and both stores pass one. All three writes call
+>   `requireWritableBackend()`, so Disconnected is genuinely read-only for them.
+> - **`encounterNpcs` come back down.** `listMine` returns the shelf tray and
+>   `ShelfSync` adopts it. Before, `claimLocal` and `games.destroy` wrote a
+>   table no query read — it went up and never came down.
+> - **Cascaded soft-link deletes reach the server**, committed before the local
+>   transaction because a link is addressed by its endpoints and there is
+>   nothing left to name it by afterwards.
+> - **The Change Log is one spine.** `appendChangeLog` takes client rows,
+>   batched, filed against the entity's own container.
+> - **The Starter Set is reference data**, copied into personal records through
+>   `entityStore.create` rather than written behind the persistence layer.
 >
-> Still outstanding, precisely:
+> **What made the false `done` possible is fixed too, and that matters more than
+> any single item above.** `containerParity.test.ts` asserted that every local
+> store had a Convex **table** — never that anything **wrote** to it. Both
+> stores passed it from P0 while every client write stopped at IndexedDB. It now
+> asserts a commit path per store, with a second test keeping the writer map
+> honest, so "the table exists" can no longer stand in for "the data arrives".
 >
-> - **`mechPatterns` writes do not mirror.** The READ path now works (`ShelfSync`
->   adopts them, #889) but a save still lands only on the device.
-> - **`encounterNpcs` are write-only.** `claimLocal` and `games.destroy` write
->   `ownerId`, and nothing reads it back: `mediator.npcs` requires a `gameId`
->   and `entities.listMine` omits the table entirely.
-> - **Client Change Log appends never leave the device.** `entityStore.ts`
->   terminates at `db.changeLog.append`, and no client code calls any `changeLog`
->   mutation. The server table is written only by `ownership`, `proposals` and
->   `botClient`, so the two logs are disjoint — each drawer shows half.
-> - **Shelf soft-link deletes do not reconcile.** `entityStore.delete` prunes
->   them locally; `listMine` returns no `softLinks`, so the server rows persist.
->
-> A false `done` is the most expensive line in a plan, because every later
-> reader takes it on trust. Move these to `done` when a store's WRITE reaches
-> Convex, not when its table exists.
+> One deliberate exception remains, documented at the call site: the Change Log
+> commit is fire-and-forget. It is provenance about a write that has already
+> landed, and failing a player's edit because its audit row did not arrive would
+> trade the write for the record of it.
 
 P0–P2 are all reversible and all buy information. P3 and P4 are the one-way
 doors and they are deliberately late.


### PR DESCRIPTION
Closes the four gaps that kept P4/P4b at `partial`, plus the gate that let a false `done` stand.

## The gaps

| Gap | Was | Now |
|---|---|---|
| `mechPatterns` writes | Reached Convex only via the bulk `claimLocal` at sign-in | Per-write mirror through a `commit` seam |
| `encounterNpcs` | **Write-only** — written by `claimLocal`/`games.destroy`, read by no query | In `listMine`, adopted by `ShelfSync` |
| Soft-link cascade | Pruned locally, server rows lived forever | Committed before the local transaction |
| Change Log | **Two disconnected spines** — client → IndexedDB, server written only by `ownership`/`proposals`/`botClient` | `appendChangeLog`, batched, filed by container |

## Starter Set → reference + Copy

Per the owner's call. The templates stay reference data; a Copy turns them into personal records through `entityStore.create`.

That **dissolves** the bypass rather than patching it. The old writer went straight to IndexedDB with no `requireWritableBackend()`, no commit and without `dbStoreFor` — three separate wrongs under ADR-034: signed in the rows were shelf records the server had never seen, so `ShelfSync` correctly **pruned the Starter Set away**; anonymous it wrote durably while `rehydrate` read the memory store, so the copy never appeared; Disconnected it wrote regardless.

## The gate is the real fix

`containerParity.test.ts` asserted every local store had a Convex **table** — never that anything **wrote** to one. Both stores passed it from P0 while every client write stopped at IndexedDB. **The gate agreed with the plan's `done` while the plan's own body said the work was outstanding.**

It now asserts a commit path per store, with a second test keeping the writer map honest — a store that gains a table but no map entry would otherwise pass by not being asked about. Verified by negative control: renaming `commitPatternWrite` away makes it fail.

## Notes for review

- **The Change Log commit is deliberately fire-and-forget**, the one exception to server-first. It is provenance about a write that has already landed; failing the player's edit because its audit row didn't arrive would trade the write for the record of it.
- **Two existing tests caught real things.** Link dedupe had to move from a derived id to endpoints (`create` mints its own id, so the derived one matched nothing and every press added a full set of links). And the copy is now **incremental** rather than atomic — a Roster test was settling on a pilot then asserting a mech, a race the bulk write hid. Incremental is intended: a row that saves is saved.
- `hasWork` now counts patterns, so a visitor who saved only patterns no longer sees "1 build not saved" and has nothing promote.

## Verification

Full suite green. `bun --filter srd gate`: **1039 pages, zero unexpected differences.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fDGFcvPRW5QKxCBgPW61k