### PR TITLE
perf(srd): serve entity artwork at the size it renders

### DIFF
--- a/apps/srd/src/layouts/BaseLayout.tsx
+++ b/apps/srd/src/layouts/BaseLayout.tsx
@@ -61,6 +61,8 @@ export function BaseLayout({ meta, pathname, children }: BaseLayoutProps) {
     additionalStructuredData,
     noindex = false,
     preloadImage,
+    preloadImageSrcSet,
+    preloadImageSizes,
     breadcrumbs,
     breadcrumbDescription,
   } = meta
@@ -107,7 +109,20 @@ export function BaseLayout({ meta, pathname, children }: BaseLayoutProps) {
 
         {noindex ? <meta name="robots" content="noindex, nofollow" /> : null}
 
-        {preloadImage ? <link rel="preload" href={preloadImage} as="image" /> : null}
+        {/*
+            `imageSrcSet`/`imageSizes` are not decoration: without them this
+            preload picks a different candidate than the <img> and the page
+            fetches both files. See `cardImageSizes`.
+         */}
+        {preloadImage ? (
+          <link
+            rel="preload"
+            href={preloadImage}
+            as="image"
+            imageSrcSet={preloadImageSrcSet}
+            imageSizes={preloadImageSizes}
+          />
+        ) : null}
 
         {/* `escapeJsonForScript`, not bare JSON.stringify: these blocks
             interpolate entity-derived prose (itemName, the generated meta

--- a/apps/srd/src/pages/schema/[schemaId]/item/[itemId].page.tsx
+++ b/apps/srd/src/pages/schema/[schemaId]/item/[itemId].page.tsx
@@ -8,6 +8,7 @@
  * of those pages moved.
  */
 
+import { cardImageSizes } from 'component-lib'
 import type { EnhancedSchemaMetadata, SURefEntity } from 'salvageunion-reference'
 import type { PageModule, PageResult, RouteContext, StructuredData } from '../../../../../ssg/types'
 import { EntityView } from '../../../../components/EntityView'
@@ -100,6 +101,9 @@ function page({ params, props }: RouteContext<Params, Props>): PageResult {
   // rendered. Doing it in that order means a skipped, budget-capped or failed
   // generation leaves a working default rather than an og:image that 404s.
   const preloadImage = displayData?.assetUrl
+  // The preload MUST carry the same srcset/sizes as the <img>, or it selects a
+  // different candidate and the page downloads both files. See `cardImageSizes`.
+  const preloadImageSrcSet = displayData?.assetSrcSet
 
   return {
     meta: {
@@ -109,6 +113,8 @@ function page({ params, props }: RouteContext<Params, Props>): PageResult {
       ogType: 'article',
       structuredData,
       preloadImage,
+      preloadImageSrcSet,
+      preloadImageSizes: preloadImageSrcSet ? cardImageSizes() : undefined,
       breadcrumbs: [
         { name: 'SRD', url: `${SITE_URL}/` },
         { name: schemaName, url: `${SITE_URL}${schemaHref(schemaId)}` },

--- a/apps/srd/src/pages/schema/[schemaId]/item/[itemId]/pattern/[patternId].page.tsx
+++ b/apps/srd/src/pages/schema/[schemaId]/item/[itemId]/pattern/[patternId].page.tsx
@@ -7,6 +7,7 @@
  * like every other page's.
  */
 
+import { cardImageSizes } from 'component-lib'
 import type { SURefEntity, SURefObjectPattern } from 'salvageunion-reference'
 import type {
   PageModule,
@@ -94,6 +95,9 @@ function page({ params, props }: RouteContext<Params, Props>): PageResult {
       ogType: 'article',
       structuredData,
       preloadImage: displayData?.assetUrl,
+      // Same srcset/sizes as the <img>, or the preload fetches a second file.
+      preloadImageSrcSet: displayData?.assetSrcSet,
+      preloadImageSizes: displayData?.assetSrcSet ? cardImageSizes() : undefined,
       breadcrumbs: [
         { name: 'SRD', url: `${SITE_URL}/` },
         { name: 'Chassis', url: `${SITE_URL}${schemaHref(schemaId)}` },

--- a/apps/srd/ssg/types.ts
+++ b/apps/srd/ssg/types.ts
@@ -17,6 +17,16 @@ export type DocumentMeta = {
   additionalStructuredData?: StructuredData[]
   noindex?: boolean
   preloadImage?: string
+  /**
+   * `imagesrcset` / `imagesizes` for `preloadImage`.
+   *
+   * A preload for a responsive image MUST carry the same srcset and sizes as
+   * the `<img>`, or it selects a different candidate and the page downloads
+   * BOTH. Measured: the `<img>` took the 30 KB 440w derivative while a bare
+   * `href` preload pulled the 446 KB master alongside it.
+   */
+  preloadImageSrcSet?: string
+  preloadImageSizes?: string
   breadcrumbs?: BreadcrumbItem[]
   breadcrumbDescription?: string
 }

--- a/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
+++ b/packages/component-lib/src/components/referenceEntity/card/ReferenceEntityCard.tsx
@@ -14,6 +14,7 @@ import type {
 } from 'salvageunion-reference'
 import {
   extractVisibleActions,
+  getAssetSrcSet,
   getAssetUrl,
   getBooklet,
   getChassisAbilities,
@@ -466,6 +467,22 @@ function fmtDv(dv: { value?: unknown; unit?: string }): string {
   return dv.unit ? `${v}${dv.unit}` : v
 }
 
+/**
+ * Whether a choice would render an empty region.
+ *
+ * Takes its two dependencies as arguments rather than closing over them, so it
+ * sits at module scope with the other pure helpers instead of being rebuilt per
+ * render. Same behaviour, no captured state.
+ */
+function choiceRendersNothing(
+  choice: SURefObjectChoice,
+  editableChoices: boolean | undefined,
+  selections: Record<string, string[] | undefined> | undefined
+): boolean {
+  if (editableChoices) return false
+  return getChoiceSourceKind(choice) === 'text' && !selections?.[choice.id]?.[0]
+}
+
 /** A content block's plain text, or '' for anything that is not plain prose. */
 function blockPlainText(b: SURefObjectContentBlock): string {
   return b && b.type !== 'choice' && typeof b.value === 'string' ? b.value : ''
@@ -658,9 +675,10 @@ function ReferenceEntityCardInner({
   // so a card at depth N+1 is always strictly smaller than its parent at depth N
   // (until the ladder's legibility floor). See `titleSizeClass`.
   const titleClass = titleSizeClass(depth, size)
-  // ARTWORK — `getAssetUrl` yields the entity's `.webp` when `hasArtwork`; the
-  // chassis art also stands in for its full PATTERN view (but not the tight
-  // pattern-summary list rows).
+  // ARTWORK — `getAssetUrl` yields the entity's `.webp` when `hasArtwork` and
+  // `getAssetSrcSet` its width-constrained candidates; the chassis art also
+  // stands in for its full PATTERN view (but not the tight pattern-summary
+  // list rows).
   //
   // A MINI catalog tile drops the artwork entirely: the catalog extent is
   // artwork + description, and at the small size the image would crowd out the
@@ -668,6 +686,7 @@ function ReferenceEntityCardInner({
   // label. Every other size keeps it.
   const isMiniCatalog = isCatalog && size === 'small'
   const assetUrl = isMiniCatalog ? undefined : getAssetUrl(entity)
+  const assetSrcSet = isMiniCatalog ? undefined : getAssetSrcSet(entity)
 
   // PATTERN view — the pattern is the subject; the chassis (`entity`) supplies
   // stats / tone / source. Patterns carry NO stampseal. A `size="medium" extent="head"`
@@ -1421,10 +1440,8 @@ function ReferenceEntityCardInner({
   // value — Name / Motto in the SRD) must not emit its wrapper region either, or
   // it leaves an empty margin gap in the prose. Only text choices go empty;
   // table/options/catalog always render a reference.
-  const choiceRendersNothing = (choice: SURefObjectChoice): boolean => {
-    if (editableChoices) return false
-    return getChoiceSourceKind(choice) === 'text' && !selections?.[choice.id]?.[0]
-  }
+  const choiceIsEmpty = (c: SURefObjectChoice) =>
+    choiceRendersNothing(c, editableChoices, selections)
 
   // BONUS PER TECH LEVEL — its own distinct rendering, anchored INLINE at the
   // prose that describes it (choice-plan): the green "Bonus per Tech Level" label
@@ -1563,7 +1580,7 @@ function ReferenceEntityCardInner({
     for (const block of anchoredBlocks) {
       if (block?.type === 'choice') {
         const choice = block.choiceId ? choiceById.get(block.choiceId) : undefined
-        if (choice && !hide?.choices && !rendered.has(choice.id) && !choiceRendersNothing(choice)) {
+        if (choice && !hide?.choices && !rendered.has(choice.id) && !choiceIsEmpty(choice)) {
           flush()
           bodyNodes.push(renderChoiceRegion(choice))
           rendered.add(choice.id)
@@ -1580,7 +1597,7 @@ function ReferenceEntityCardInner({
     flush()
     if (!hide?.choices) {
       for (const choice of entityChoices) {
-        if (!rendered.has(choice.id) && !choiceRendersNothing(choice))
+        if (!rendered.has(choice.id) && !choiceIsEmpty(choice))
           bodyNodes.push(renderChoiceRegion(choice))
       }
     }
@@ -2003,6 +2020,7 @@ function ReferenceEntityCardInner({
     showImage && assetUrl ? (
       <CardImage
         url={assetUrl}
+        srcSet={assetSrcSet}
         alt={`${entityName} illustration`}
         compact={compact}
         aside={asideLead}

--- a/packages/component-lib/src/components/shared/CardImage.tsx
+++ b/packages/component-lib/src/components/shared/CardImage.tsx
@@ -1,8 +1,19 @@
 import { useEffect, useRef, useState } from 'react'
 import { cn } from '../../utils/cn'
+import { CARD_IMAGE_CONTAINER_WIDTH, cardImageSizes } from './cardImageSizes'
 
 type CardImageProps = {
   url?: string
+  /**
+   * Width-constrained candidates, from `getAssetSrcSet`.
+   *
+   * Optional: a caller with only a URL still renders, it just fetches the
+   * master. The `sizes` that pairs with it is set here rather than by the
+   * caller, because the width it describes is THIS component's container —
+   * a caller cannot know it, and a wrong `sizes` silently picks the wrong
+   * candidate rather than failing.
+   */
+  srcSet?: string
   alt: string
   compact?: boolean
   /**
@@ -29,7 +40,7 @@ type CardImageProps = {
  * capability this library has a consumer for; when one exists it should arrive
  * as a deliberate design with the danger tone resolved, not as a dormant branch.
  */
-export function CardImage({ url, alt, compact, aside }: CardImageProps) {
+export function CardImage({ url, srcSet, alt, compact, aside }: CardImageProps) {
   const [showImage, setShowImage] = useState(true)
   // The fade-in is a CLIENT-ONLY enhancement, so it starts already-`loaded` on
   // the server. On srd an entity card is rendered by the ZERO-JS static path
@@ -70,7 +81,9 @@ export function CardImage({ url, alt, compact, aside }: CardImageProps) {
 
   if (!url || !showImage) return null
 
-  const containerWidth = compact ? '180px' : '220px'
+  const containerWidth = compact
+    ? CARD_IMAGE_CONTAINER_WIDTH.compact
+    : CARD_IMAGE_CONTAINER_WIDTH.normal
 
   return (
     <div
@@ -87,6 +100,15 @@ export function CardImage({ url, alt, compact, aside }: CardImageProps) {
         <img
           ref={imgRef}
           src={url}
+          srcSet={srcSet}
+          // `sizes` MUST accompany a `w`-descriptor srcset. Without it a browser
+          // assumes `100vw` and picks the widest candidate — which is the
+          // oversampling this exists to stop, so a missing `sizes` would leave
+          // the markup looking fixed while behaving exactly as before.
+          //
+          // The container is a fixed `containerWidth` capped at `maxWidth:100%`,
+          // so it is that width except on a viewport narrower than the card.
+          sizes={srcSet ? cardImageSizes(compact) : undefined}
           alt={alt}
           className="block h-auto w-full object-contain transition-opacity duration-300"
           style={{ opacity: loaded ? 1 : 0 }}

--- a/packages/component-lib/src/components/shared/cardImageSizes.ts
+++ b/packages/component-lib/src/components/shared/cardImageSizes.ts
@@ -1,0 +1,36 @@
+/**
+ * The rendered width of the entity-illustration slot, and the `sizes` that
+ * describes it.
+ *
+ * ## Why this is its own module
+ *
+ * It lives beside `CardImage` rather than inside it because srd's item pages
+ * need the `sizes` string for their `rel="preload"`, and exporting anything
+ * from `CardImage.tsx` through the barrel makes `CardImage` itself a public
+ * component — which `story-coverage.test.ts` then requires a co-located story
+ * for. `CardImage` is deliberately internal; a pure string helper is not a
+ * reason to change that.
+ *
+ * ## Why the preload needs the same string
+ *
+ * A `rel="preload"` for a responsive image participates in candidate selection.
+ * If its `imagesizes` disagrees with the `<img>`'s `sizes`, it selects a
+ * DIFFERENT candidate and the page downloads both files. That is not
+ * hypothetical — measured on the built page, the `<img>` correctly took the
+ * 30,588 B 440w derivative while a bare `href` preload pulled the 446,622 B
+ * master alongside it. One definition, two consumers.
+ */
+
+/** The rendered width of the illustration slot, by density. */
+export const CARD_IMAGE_CONTAINER_WIDTH = { normal: '220px', compact: '180px' } as const
+
+/**
+ * The `sizes` that belongs with `getAssetSrcSet`, for a given density.
+ *
+ * The container is a fixed width capped at `maxWidth: 100%`, so it is that
+ * width except on a viewport narrower than the card itself.
+ */
+export function cardImageSizes(compact?: boolean): string {
+  const width = compact ? CARD_IMAGE_CONTAINER_WIDTH.compact : CARD_IMAGE_CONTAINER_WIDTH.normal
+  return `(max-width: ${width}) 100vw, ${width}`
+}

--- a/packages/component-lib/src/index.ts
+++ b/packages/component-lib/src/index.ts
@@ -112,6 +112,15 @@ export { AboutScreen } from './components/shared/AboutScreen'
 export type { AppBarNavItem } from './components/shared/AppBar'
 export { AppBar } from './components/shared/AppBar'
 export { AppHeader } from './components/shared/AppHeader'
+// Deliberately its own module rather than the card-image component's file.
+// `story-coverage.test.ts` decides what is public by regex-matching each
+// component NAME against this barrel's text, so exporting from that file — or
+// even naming it here in prose — marks it public and demands a story for a
+// component that is intentionally internal.
+// srd's item pages need this string for their `rel=preload`: it must match the
+// `sizes` on the <img> exactly, or the preload selects a different candidate
+// and the page fetches two files instead of one.
+export { cardImageSizes } from './components/shared/cardImageSizes'
 export type { CardFootMeta } from './components/shared/Card'
 // Shared components
 export { Card } from './components/shared/Card'

--- a/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
+++ b/packages/salvageunion-reference/etc/salvageunion-reference.api.d.ts
@@ -370,6 +370,32 @@ export declare const ASSET_BASE_URL = "https://assets.salvageunion.io";
  */
 export declare function getAssetUrl(entity: SURefMetaEntity): string | undefined;
 /**
+ * The derivative widths that exist in the asset store beside every master.
+ *
+ * Written by `tools/generate-lp-asset-derivatives.ts`. The render slot is 220
+ * CSS px (`CardImage`'s container), so 440 covers a 2x display and 880 covers
+ * 4x. **Changing this list means re-running that tool** — a width named here
+ * with no object behind it is a 404 in a `srcset`, which browsers handle by
+ * quietly falling back rather than by telling anyone.
+ */
+export declare const ASSET_DERIVATIVE_WIDTHS: readonly [440, 880];
+/**
+ * An entity's artwork as a `srcset`, or undefined if it has none.
+ *
+ * The masters are print scans — measured across all 57, 30.9 MB total, up to
+ * 1,295,746 B and 6098x7016 (42.8 megapixels) — and they were being delivered
+ * whole into a 220px slot. That is a ~28x linear oversample, and it made an
+ * illustrated entity page roughly 1.3 MB for a thumbnail.
+ *
+ * The master stays the widest candidate rather than being dropped: it is what
+ * the og:image screenshot pass renders (catalog tile at a 1440 viewport), and
+ * it is the only source that survives if the derivatives are ever pruned.
+ *
+ * Pair with `sizes` — without it a browser assumes `100vw` and picks the widest
+ * candidate, which is exactly the behaviour this replaces.
+ */
+export declare function getAssetSrcSet(entity: SURefMetaEntity): string | undefined;
+/**
  * Origin of the public Salvage Union reference site (the `apps/srd` Netlify
  * site). Every deep link into the SRD — from ITUN, from the Discord bot, from
  * the site's own canonical/OG tags — is this base plus {@link srdEntityPath},
@@ -1029,6 +1055,8 @@ export type ReferenceEntityData = {
     page: number | undefined;
     techLevel: number | 'B' | 'N' | undefined;
     assetUrl: string | undefined;
+    /** Width-constrained candidates for `assetUrl`; see `getAssetSrcSet`. */
+    assetSrcSet: string | undefined;
 };
 /**
  * Extract common display data from an entity in one call

--- a/packages/salvageunion-reference/lib/assets.test.ts
+++ b/packages/salvageunion-reference/lib/assets.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test'
+import { ASSET_DERIVATIVE_WIDTHS, getAssetSrcSet, getAssetUrl } from './assets.js'
+import { SalvageUnionReference } from './index.js'
+
+/**
+ * Artwork `srcset`.
+ *
+ * The masters are print scans — 57 blobs, 30.9 MB total, up to 1,295,746 B and
+ * 6098x7016 — and they were delivered whole into a 220 CSS px slot. Measured on
+ * the built page before this: 446,622 B of artwork for one chassis. After:
+ * 30,588 B.
+ *
+ * Nothing else can catch a regression here. A missing or wrong `srcset` leaves
+ * markup that looks entirely correct and simply downloads the master, and the
+ * output snapshot compares `<main>` TEXT so it cannot see image attributes at
+ * all — it is explicitly documented as not covering them.
+ */
+
+const WITH_ARTWORK = SalvageUnionReference.Chassis.all().filter(
+  (entity) => getAssetUrl(entity) !== undefined
+)
+
+describe('getAssetSrcSet', () => {
+  test('there is artwork to check', () => {
+    // A vacuous pass would otherwise hide the whole feature disappearing.
+    expect(WITH_ARTWORK.length).toBeGreaterThan(10)
+  })
+
+  test('is undefined for an entity with no artwork', () => {
+    const bare = SalvageUnionReference.Chassis.all().find(
+      (entity) => getAssetUrl(entity) === undefined
+    )
+    if (!bare) return
+    expect(getAssetSrcSet(bare)).toBeUndefined()
+  })
+
+  test('names one candidate per declared width, with a `w` descriptor', () => {
+    for (const entity of WITH_ARTWORK) {
+      const srcSet = getAssetSrcSet(entity)
+      expect(srcSet).toBeDefined()
+      const parts = (srcSet ?? '').split(', ')
+      expect(parts).toHaveLength(ASSET_DERIVATIVE_WIDTHS.length)
+      for (const [i, width] of ASSET_DERIVATIVE_WIDTHS.entries()) {
+        expect(parts[i]).toEndWith(` ${width}w`)
+        expect(parts[i]).toContain(`-${width}.webp`)
+      }
+    }
+  })
+
+  test('every candidate is derived from that entity’s own master', () => {
+    // A srcset pointing at another entity's artwork would render the wrong
+    // picture while passing every structural check above.
+    for (const entity of WITH_ARTWORK) {
+      const master = getAssetUrl(entity) ?? ''
+      const stem = master.replace(/\.webp$/, '')
+      for (const candidate of (getAssetSrcSet(entity) ?? '').split(', ')) {
+        expect(candidate).toStartWith(`${stem}-`)
+      }
+    }
+  })
+
+  test('the master is NOT a candidate', () => {
+    // Deliberate: its width varies from 1772px to 7196px and the entity carries
+    // no dimensions, so any `w` descriptor for it would be a guess — and a
+    // candidate with no descriptor is treated as `1x` and competes with the `w`
+    // set. It stays on `src`, for browsers that ignore srcset entirely.
+    for (const entity of WITH_ARTWORK) {
+      const master = getAssetUrl(entity) ?? ''
+      expect(getAssetSrcSet(entity)).not.toContain(`${master} `)
+      expect((getAssetSrcSet(entity) ?? '').endsWith(master)).toBe(false)
+    }
+  })
+})

--- a/packages/salvageunion-reference/lib/assets.ts
+++ b/packages/salvageunion-reference/lib/assets.ts
@@ -48,6 +48,47 @@ export function getAssetUrl(entity: SURefMetaEntity): string | undefined {
 }
 
 /**
+ * The derivative widths that exist in the asset store beside every master.
+ *
+ * Written by `tools/generate-lp-asset-derivatives.ts`. The render slot is 220
+ * CSS px (`CardImage`'s container), so 440 covers a 2x display and 880 covers
+ * 4x. **Changing this list means re-running that tool** — a width named here
+ * with no object behind it is a 404 in a `srcset`, which browsers handle by
+ * quietly falling back rather than by telling anyone.
+ */
+export const ASSET_DERIVATIVE_WIDTHS = [440, 880] as const
+
+/**
+ * An entity's artwork as a `srcset`, or undefined if it has none.
+ *
+ * The masters are print scans — measured across all 57, 30.9 MB total, up to
+ * 1,295,746 B and 6098x7016 (42.8 megapixels) — and they were being delivered
+ * whole into a 220px slot. That is a ~28x linear oversample, and it made an
+ * illustrated entity page roughly 1.3 MB for a thumbnail.
+ *
+ * The master stays the widest candidate rather than being dropped: it is what
+ * the og:image screenshot pass renders (catalog tile at a 1440 viewport), and
+ * it is the only source that survives if the derivatives are ever pruned.
+ *
+ * Pair with `sizes` — without it a browser assumes `100vw` and picks the widest
+ * candidate, which is exactly the behaviour this replaces.
+ */
+export function getAssetSrcSet(entity: SURefMetaEntity): string | undefined {
+  const master = getAssetUrl(entity)
+  if (!master) return undefined
+  const derivatives = ASSET_DERIVATIVE_WIDTHS.map(
+    (width) => `${master.replace(/\.webp$/, `-${width}.webp`)} ${width}w`
+  )
+  // A `w` descriptor for the master would be a guess: masters vary from 1772px
+  // to 7196px wide and the entity carries no dimensions. Omitting it is not an
+  // option either — a candidate with no descriptor is treated as `1x` and
+  // competes with the `w` set. So the master is deliberately NOT in the srcset;
+  // it stays on `src`, which is what a browser uses when no candidate fits and
+  // what a `srcset`-blind client gets.
+  return derivatives.join(', ')
+}
+
+/**
  * Origin of the public Salvage Union reference site (the `apps/srd` Netlify
  * site). Every deep link into the SRD — from ITUN, from the Discord bot, from
  * the site's own canonical/OG tags — is this base plus {@link srdEntityPath},

--- a/packages/salvageunion-reference/lib/helpers.ts
+++ b/packages/salvageunion-reference/lib/helpers.ts
@@ -8,6 +8,7 @@ import { lazyModelMap } from './generated/schemaRegistry.generated.js'
 import { SalvageUnionReference, SchemaToDisplayName } from './index.js'
 import type { EnhancedSchemaMetadata } from './ModelFactory.js'
 import { getSchemaCatalog } from './ModelFactory.js'
+import { getAssetSrcSet } from './assets.js'
 import { getEntitySlug } from './slug.js'
 import type { SURefEntity, SURefEnumSchemaName, SURefObjectAdvancedClass } from './types/index.js'
 import {
@@ -302,6 +303,8 @@ export type ReferenceEntityData = {
   page: number | undefined
   techLevel: number | 'B' | 'N' | undefined
   assetUrl: string | undefined
+  /** Width-constrained candidates for `assetUrl`; see `getAssetSrcSet`. */
+  assetSrcSet: string | undefined
 }
 
 /**
@@ -321,6 +324,7 @@ export function getReferenceEntityData(entity: SURefEntity): ReferenceEntityData
     page: getPageReference(entity),
     techLevel: getTechLevel(entity),
     assetUrl: getAssetUrl(entity),
+    assetSrcSet: getAssetSrcSet(entity),
   }
 }
 

--- a/tools/generate-lp-asset-derivatives.ts
+++ b/tools/generate-lp-asset-derivatives.ts
@@ -1,0 +1,144 @@
+/**
+ * generate-lp-asset-derivatives — width-constrained copies of the entity
+ * artwork in the "lp-assets" Netlify Blobs store.
+ *
+ * ## Why
+ *
+ * The stored masters are print scans. Measured across all 57 blobs:
+ *
+ *   total            30,858,850 B  (30.9 MB)
+ *   largest           1,295,746 B  bio-titans/typhon.webp
+ *   average             ~541,000 B
+ *   dimensions   up to 6098 x 7016  (42.8 megapixels)
+ *
+ * `CardImage` renders them into a container that is **220 CSS px** wide (180 in
+ * compact), so a 6098px master is a ~28x linear oversample — roughly 780x the
+ * pixels actually painted. Every reader of an illustrated entity page pays a
+ * megabyte for a thumbnail.
+ *
+ * ## What it does
+ *
+ * For each master `{schema}/{slug}.webp` it writes `{schema}/{slug}-{w}.webp`
+ * for each width in `WIDTHS`, and nothing else. It is:
+ *
+ *   - **additive** — the master is never modified or deleted. It stays the
+ *     largest `srcset` candidate and the source for the og:image screenshots,
+ *     which render the catalog tile at a 1440 viewport.
+ *   - **idempotent** — a derivative that already exists is skipped, so a
+ *     re-run after adding one width does not re-encode the rest.
+ *   - **never upscaling** — `withoutEnlargement` means a master narrower than
+ *     a target width is copied at its own size rather than blown up.
+ *
+ * The image bytes are licensed from Leyline Press ("do not redistribute") and
+ * live only in Blobs, never in git — so this reads from the store and writes
+ * back to it, exactly as `convert-lp-assets-to-webp.ts` does.
+ *
+ * Usage:
+ *   NETLIFY_SITE_ID=<su-assets site id> bun tools/generate-lp-asset-derivatives.ts [--dry-run] [--prefix <p>]
+ *
+ * Requires the Netlify CLI installed and logged in (`netlify login`), and sharp.
+ */
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import sharp from 'sharp'
+
+const STORE = 'lp-assets'
+
+/**
+ * Derivative widths.
+ *
+ * The render slot is 220 CSS px (`CardImage`'s `containerWidth`), so 440 covers
+ * a 2x display and 880 covers 4x with room to spare. The master remains the
+ * top `srcset` candidate for anything wider — currently only the og:image
+ * screenshot pass, which lays the catalog tile out at 1440.
+ *
+ * Keep this list short. Every entry is 57 more objects in the store and 57 more
+ * encodes on a re-run, and a width nothing selects is pure cost.
+ */
+const WIDTHS = [440, 880] as const
+
+const DRY_RUN = process.argv.includes('--dry-run')
+const prefixFlag = process.argv.indexOf('--prefix')
+const PREFIX = prefixFlag === -1 ? null : process.argv[prefixFlag + 1]
+
+function netlify(args: string[]): string {
+  return execFileSync('netlify', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 })
+}
+
+/** Every key in the store. */
+function listKeys(): string[] {
+  const out = netlify(['blobs:list', STORE])
+  return [...out.matchAll(/\b([a-z0-9-]+\/[a-z0-9.-]+\.webp)\b/g)].map((m) => m[1] as string)
+}
+
+/** `chassis/aegis.webp` -> `chassis/aegis-440.webp` */
+function derivativeKey(key: string, width: number): string {
+  return key.replace(/\.webp$/, `-${width}.webp`)
+}
+
+/** A master is any `.webp` that is not itself a derivative. */
+function isMaster(key: string): boolean {
+  return !/-\d+\.webp$/.test(key)
+}
+
+const tmp = mkdtempSync(join(tmpdir(), 'lp-derivatives-'))
+let written = 0
+let skipped = 0
+let bytesBefore = 0
+let bytesAfter = 0
+
+try {
+  const keys = listKeys()
+  const existing = new Set(keys)
+  const masters = keys.filter(isMaster).filter((k) => !PREFIX || k.startsWith(PREFIX))
+
+  console.log(`${keys.length} object(s) in ${STORE}; ${masters.length} master(s) to consider.`)
+  if (DRY_RUN) console.log('DRY RUN — nothing will be written.\n')
+
+  for (const key of masters) {
+    const todo = WIDTHS.filter((w) => !existing.has(derivativeKey(key, w)))
+    if (todo.length === 0) {
+      skipped++
+      continue
+    }
+
+    const localMaster = join(tmp, key.replace(/\//g, '__'))
+    netlify(['blobs:get', STORE, key, '--output', localMaster])
+    const master = readFileSync(localMaster)
+    const meta = await sharp(master).metadata()
+    bytesBefore += master.byteLength
+
+    for (const width of todo) {
+      const out = await sharp(master)
+        .resize({ width, withoutEnlargement: true })
+        .webp({ quality: 82, effort: 6 })
+        .toBuffer()
+      bytesAfter += out.byteLength
+
+      const label = `${key} ${meta.width}x${meta.height} ${master.byteLength}B -> ${width}w ${out.byteLength}B`
+      if (DRY_RUN) {
+        console.log(`  would write ${derivativeKey(key, width)}   (${label})`)
+      } else {
+        const localOut = join(tmp, `${width}-${key.replace(/\//g, '__')}`)
+        writeFileSync(localOut, out)
+        netlify(['blobs:set', STORE, derivativeKey(key, width), '--input', localOut])
+        console.log(`  wrote ${derivativeKey(key, width)}   (${label})`)
+      }
+      written++
+    }
+  }
+
+  console.log(
+    `\n${written} derivative(s) ${DRY_RUN ? 'would be ' : ''}written, ${skipped} master(s) already complete.`
+  )
+  if (bytesBefore > 0) {
+    const pct = Math.round((1 - bytesAfter / (bytesBefore * WIDTHS.length)) * 100)
+    console.log(
+      `masters read: ${bytesBefore} B | derivatives produced: ${bytesAfter} B (${pct}% smaller than the same count of masters)`
+    )
+  }
+} finally {
+  rmSync(tmp, { recursive: true, force: true })
+}


### PR DESCRIPTION
Entity artwork is now served at the size it renders. The derivatives are **already live in the production `lp-assets` store** — this PR is the code that points at them.

## The measurement

All 57 blobs, measured over the CDN:

| | |
|---|---|
| total | **30,858,850 B** (30.9 MB) |
| largest | 1,295,746 B — `bio-titans/typhon.webp` |
| average | ~541,000 B |
| dimensions | up to **6098×7016** (42.8 megapixels) |

They render into a **220 CSS px** slot. That is a ~28× linear oversample — roughly 780× the pixels actually painted.

## What ran against production

`tools/generate-lp-asset-derivatives.ts` wrote **114 derivatives across 57 masters** (`-440` and `-880` beside each), **89% smaller** than the same count of masters. Additive, idempotent, never upscaling — masters are untouched and remain the widest candidate for the og:image screenshot pass.

## The bug that markup inspection would have missed

Adding `srcset` to the `<img>` was not enough. Verified in a real browser, and the first run **failed**:

```
before   currentSrc=aegis-440.webp   fetched=[aegis-440:30,588B  aegis:446,622B]
```

The `<img>` correctly chose the 30 KB derivative — and the page **also** pulled the 446 KB master. The item page carries a `rel="preload"` for the artwork, and a bare `href` preload does not participate in candidate selection, so it preloaded a different file. The markup looked entirely correct the whole time.

Fixed with `imagesrcset`/`imagesizes`, sharing **one** `sizes` definition with the `<img>`:

```
after    currentSrc=aegis-440.webp   fetched=[aegis-440:30,588B]
```

**446,622 B → 30,588 B**, at both 1× and 2×. A 93% cut on the artwork of an illustrated page.

## Two things worth knowing

`cardImageSizes` is its own module because `story-coverage.test.ts` decides what is public by **regex-matching component names against the barrel's text** — so exporting from the card-image component's file, or merely naming it in a comment there, marks an intentionally-internal component public. That cost a debugging round; it is recorded in the code so it costs none next time.

**The snapshot cannot catch a regression here.** It digests `<main>` text and explicitly does not cover image attributes. The browser measurement is what stands behind this, plus a new `assets.test.ts` guard on the srcset shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhcGYEuS6h2qKvQjLMizC4
