### PR TITLE
docs(cloudflare): record the P7 follow-up and the nameserver ask

### DIFF
--- a/docs/architecture/cloudflare-cutover.md
+++ b/docs/architecture/cloudflare-cutover.md
@@ -42,7 +42,7 @@ Update this table as part of each phase's PR. It is the only place that answers
 | P4    | Three web surfaces on `workers.dev`      | yes        | **done** — all three live |
 | P5    | Bot on HTTP interactions                 | **reversible** | **LIVE on Cloudflare** (2026-08-19) — Discord validated the endpoint |
 | P6    | Data sync and write freeze               | **no**     | **built, not activated** — bulk sync done (45/45 verified by content); freeze code merged and OFF |
-| P7    | Cutover                                  | **no**     | **half done** — `intheunionnow.com` **LIVE on Cloudflare** (2026-08-19); `salvageunion.io` blocked on Netlify support ticket #1093312, **no agent reply as of 2026-08-21** |
+| P7    | Cutover                                  | **no**     | **half done** — `intheunionnow.com` **LIVE on Cloudflare** (2026-08-19); `salvageunion.io` blocked on Netlify support ticket #1093312, **still no agent reply as of 2026-08-28** — follow-up sent 2026-08-28 asking Netlify to set the nameservers directly, Name.com transfer kept as fallback |
 | P8    | Decommission and tooling cleanup         | **no**     | not started               |
 
 **"Built" is not "activated", and for P6 the difference is the whole point.**
@@ -751,14 +751,18 @@ support link there is pre-filled with the right subject and body.
 
    This is the long pole — a human ticket, not an API call.
 
-   **Ask for the nameserver change too, and ask for it first.** As of
-   2026-08-21 there is still no agent reply, and the ticket as written requests
-   only the larger of the two things Netlify could do. Moving the registration
-   into the Name.com account is a registrar action with ICANN process attached;
-   *setting the nameservers on their side* is a config change that **finishes the
-   migration on its own** and needs no transfer at all — step 3 is the milestone
-   either way, and it does not care which party performs it. Requesting both,
-   preferring the nameserver change, gives support a cheap way to say yes.
+   **Ask for the nameserver change too, and ask for it first. Done
+   2026-08-28** — a follow-up on #1093312 now asks for both, leading with the
+   nameserver change. The original 2026-08-19 message requested only the larger
+   of the two things Netlify could do and drew no agent reply in nine days; the
+   only response the ticket has ever had is the auto-triage bot, which offered
+   an auth code and was told why an auth code alone cannot help. Moving the
+   registration into the Name.com account is a registrar action with ICANN
+   process attached; *setting the nameservers on their side* is a config change
+   that **finishes the migration on its own** and needs no transfer at all —
+   step 3 is the milestone either way, and it does not care which party
+   performs it. Requesting both, preferring the nameserver change, gives
+   support a cheap way to say yes.
 
    Stated honestly, because the reply may be no: Netlify does **not** document
    this service. [Transfer a domain](https://docs.netlify.com/manage/domains/manage-domains/transfer-a-domain/)


### PR DESCRIPTION
## What

Updates two stale statements in `docs/architecture/cloudflare-cutover.md` about where P7 actually stands, and records the follow-up that was sent to Netlify.

## Why

Both the P7 progress-table row and step 2 of the deadlock section said **"no agent reply as of 2026-08-21."** That was a week stale. This file is loaded as navigation for the cutover, and the repo's own guidance is explicit that stale prose in a doc like this gets *followed* rather than checked.

The status has not improved — it has aged. Netlify ticket **#1093312** has still never had a human reply. The only response it has ever drawn is the auto-triage bot on 2026-08-19, which offered an authorization code; that framing is wrong for this case and was corrected in the reply, because an auth code cannot reach the nameserver gate.

## What changed underneath

Step 2 already carried the recommendation to *"ask for the nameserver change too, and ask for it first"* — the config change Netlify could make on their side that finishes the migration outright, with no registrar transfer and no ICANN process. That ask had never actually been made; the original 2026-08-19 message requested only the larger of the two things.

**A follow-up was sent 2026-08-28** that leads with the nameserver change and keeps the Name.com transfer (account code on file) as the fallback. The doc now records which of the two Netlify is sitting on.

## Verified, not asserted

Re-derived at the time of writing rather than restated from the doc:

| Signal | Value |
| --- | --- |
| `netlify api getDnsZones` → `transferred_at` | `None` |
| same → `auth_code` | none |
| same → `uses_netlify_registrar` | `true` |
| `dig +short NS salvageunion.io` | `dns1-4.p08.nsone.net` |
| Netlify API methods mentioning a nameserver | **0 of 11** DNS methods |

So nothing customer-facing has moved, and the deadlock the section describes still holds exactly as written.

## Scope

Documentation only — one file, no code, no config. `intheunionnow.com` remains live on Cloudflare; `salvageunion.io` remains on Netlify pending a human at Netlify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFoAHqfHmFcTeNBShT4Y4Y
