### PR TITLE
fix(ci): a failing sign-in e2e now opens the issue instead of closing it

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -513,6 +513,7 @@ jobs:
     if: >-
       always() && !cancelled() &&
       (needs.e2e-itun.result != 'success' || needs.e2e-srd.result != 'success' ||
+       needs.e2e-itun-signin.result != 'success' ||
        needs.observability-probe.result == 'failure' ||
        needs.observability-probe.result == 'cancelled' ||
        needs.convex-parity.result == 'failure' ||
@@ -533,6 +534,7 @@ jobs:
         env:
           ITUN_RESULT: ${{ needs.e2e-itun.result }}
           SRD_RESULT: ${{ needs.e2e-srd.result }}
+          SIGNIN_RESULT: ${{ needs.e2e-itun-signin.result }}
           PROBE_RESULT: ${{ needs.observability-probe.result }}
           PARITY_RESULT: ${{ needs.convex-parity.result }}
           A11Y_RESULT: ${{ needs.a11y-srd.result }}
@@ -563,6 +565,14 @@ jobs:
             const results = [
               ['e2e-itun', process.env.ITUN_RESULT],
               ['e2e-srd', process.env.SRD_RESULT],
+              // e2e-itun-signin carries no `if:` of its own, so it always runs
+              // and is never 'skipped' — which puts it in the same class as the
+              // two above rather than in `optional()`. It shipped in `needs:`
+              // and in neither notifier's `if:`, the same defect convex-parity
+              // had, with one extra consequence: notify-recovery's condition
+              // was SATISFIED while this job was failing, so a red run CLOSED
+              // the tracking issue instead of opening one.
+              ['e2e-itun-signin', process.env.SIGNIN_RESULT],
               ...optional('observability-probe', process.env.PROBE_RESULT),
               ...optional('convex-parity', process.env.PARITY_RESULT),
               // a11y-srd follows the same rule as the two above: it can open
@@ -626,6 +636,7 @@ jobs:
     if: >-
       always() && !cancelled() &&
       needs.e2e-itun.result == 'success' && needs.e2e-srd.result == 'success' &&
+      needs.e2e-itun-signin.result == 'success' &&
       needs.observability-probe.result != 'failure' &&
       needs.observability-probe.result != 'cancelled' &&
       needs.convex-parity.result != 'failure' &&


### PR DESCRIPTION
**Layer 1 of 8** — audit remediation stack #921. Base: `main`.

`e2e-itun-signin` appeared in exactly three places in `e2e-nightly.yml`: its own
definition and the two `needs:` lists. It was in neither notifier's `if:`,
neither `env:` block, nor the reported results array.

The consequence is inverted, not merely missing:

- `notify-failure`'s condition names only the other five jobs, so it evaluated
  false and skipped — filing nothing.
- `notify-recovery`'s condition was therefore **satisfied** on that same run, so
  a run containing a failing job **closed** the open tracking issue.

This is the defect `convex-parity` shipped with, which the comment block in this
file already describes, plus that extra half-turn. The rule that block states —
*"Anything in that `if:` MUST appear in this list"* — is what this applies.

### Why `!= 'success'` and not `optional()`

The job carries no `if:` of its own, so it always runs and is never `'skipped'`.
That puts it in the same class as `e2e-itun` and `e2e-srd` rather than in
`optional()`, which exists for jobs that can legitimately not run. `!= 'success'`
also covers the `cancelled` that a `timeout-minutes` produces — the case this
file has been bitten by before.

### Verification

Both conditions were evaluated against a truth table before and after.

| scenario | before | after |
|---|---|---|
| signin fails, all else green | failure=false, **recovery=true** | failure=true, recovery=false |
| signin times out (`cancelled`) | failure=false, **recovery=true** | failure=true, recovery=false |
| all green (control) | failure=false, recovery=true | unchanged |
| `e2e-itun` fails (control) | failure=true, recovery=false | unchanged |

Exactly one notifier fires in every scenario after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfA5r8HyHvay1kd2wH8b5b
