### PR TITLE
fix(tools): three gates that reported success without checking anything

### DIFF
--- a/tools/check-action-pinning.ts
+++ b/tools/check-action-pinning.ts
@@ -143,23 +143,49 @@ function locallyResolvedTools(root: string): Set<string> {
   return names
 }
 
-function bunxCalls(contents: string): { line: number; tool: string }[] {
-  const found: { line: number; tool: string }[] = []
+/**
+ * Every one-off package runner invocation in a workflow.
+ *
+ * `npx` and `bun x` are scanned alongside `bunx` because they do the same
+ * thing — fetch and execute a package that is not in the lockfile. Neither
+ * appears in these workflows today, so widening this is a latent guard, not a
+ * live fix; the point is that adding one later cannot slip past a gate whose
+ * whole subject is unreviewed fetches in a credentialed job.
+ *
+ * `docker run` remains out of scope: it takes an image reference rather than a
+ * package, and the one call site is digest-pinned by hand.
+ */
+function runnerCalls(contents: string): { line: number; runner: string; tool: string }[] {
+  const found: { line: number; runner: string; tool: string }[] = []
   contents.split('\n').forEach((raw, i) => {
     const line = raw.trim()
     if (line.startsWith('#')) return
-    for (const m of line.matchAll(/\bbunx\s+(?:--[\w-]+\s+)*([@\w./-]+)/g)) {
-      const tool = m[1]
-      if (tool !== undefined) found.push({ line: i + 1, tool })
+    for (const m of line.matchAll(/\b(bunx|npx|bun\s+x)\s+(?:--[\w-]+\s+)*([@\w./-]+)/g)) {
+      const runner = m[1]
+      const tool = m[2]
+      if (runner !== undefined && tool !== undefined)
+        found.push({ line: i + 1, runner: runner.replace(/\s+/, ' '), tool })
     }
   })
   return found
 }
 
-/** `wrangler@4.108.0` is pinned; `wrangler` is not. A scoped name keeps its leading @. */
+/**
+ * `wrangler@4.108.0` is pinned; `wrangler`, `wrangler@latest` and `wrangler@4`
+ * are not. A scoped name keeps its leading `@`, hence `lastIndexOf`.
+ *
+ * This tested only that SOME `@` followed position 0, so every mutable tag
+ * passed — `@latest`, `@next`, `@beta`, a bare major. The message this gate
+ * prints on failure already says "Write it as `bunx tool@X.Y.Z`"; nothing
+ * checked that shape. That mattered here more than it looks: the calls this
+ * gate guards run in the deploy job, which holds CLOUDFLARE_API_TOKEN,
+ * CONVEX_DEPLOY_KEY and SENTRY_AUTH_TOKEN, so an unreviewed `@latest` fetch is
+ * exactly the thing the whole check exists to prevent.
+ */
 function bunxIsPinned(tool: string): boolean {
   const at = tool.lastIndexOf('@')
-  return at > 0
+  if (at <= 0) return false
+  return /^\d+\.\d+\.\d+/.test(tool.slice(at + 1))
 }
 
 function bunxBaseName(tool: string): string {
@@ -218,10 +244,10 @@ function main(): void {
       thirdPartyCount += 1
       if (!SHA_PIN.test(refPin(ref))) unpinned.push({ file, line, ref })
     }
-    for (const { line, tool } of bunxCalls(contents)) {
+    for (const { line, runner, tool } of runnerCalls(contents)) {
       if (locallyResolved.has(bunxBaseName(tool))) continue
       bunxCount += 1
-      if (!bunxIsPinned(tool)) unpinnedTools.push({ file, line, ref: `bunx ${tool}` })
+      if (!bunxIsPinned(tool)) unpinnedTools.push({ file, line, ref: `${runner} ${tool}` })
     }
   }
 
@@ -242,13 +268,16 @@ function main(): void {
   }
 
   if (unpinnedTools.length > 0) {
-    console.error('\n✗ a `bunx` tool with no local manifest entry must carry an exact version:\n')
+    console.error(
+      '\n✗ a `bunx`/`npx` tool with no local manifest entry must carry an exact version:\n'
+    )
     for (const { file, line, ref } of unpinnedTools) {
       console.error(`  ${file}:${line}  ${ref}`)
     }
     console.error(
       `\n  Unpinned, this resolves whatever npm published most recently — in a job\n` +
-        `  that holds this repo's deploy credentials. Write it as \`bunx tool@X.Y.Z\`,\n` +
+        `  that holds this repo's deploy credentials. Write it as \`bunx tool@X.Y.Z\`\n` +
+        `  — an exact version, not \`@latest\` or a bare major —\n` +
         `  or add the tool to the manifest so bunx resolves it from the lockfile.\n`
     )
     process.exit(1)
@@ -271,7 +300,7 @@ function main(): void {
 
   console.log(
     `✓ supply-chain pinning: ${thirdPartyCount} third-party action reference(s) SHA-pinned ` +
-      `and ${bunxCount} bunx tool invocation(s) version-pinned across ${scanned} workflow file(s).`
+      `and ${bunxCount} one-off runner invocation(s) version-pinned across ${scanned} workflow file(s).`
   )
 }
 

--- a/tools/check-doc-drift.ts
+++ b/tools/check-doc-drift.ts
@@ -72,14 +72,28 @@ function read(root: string, relPath: string): string {
   return readFileSync(join(root, relPath), 'utf-8')
 }
 
-/** Repo-relative paths of the `.md` files directly inside `dir`, sorted. */
+/**
+ * Repo-relative paths of the `.md` files at or below `dir`, sorted.
+ *
+ * Recursive, and that is load-bearing rather than tidy: this walked one level
+ * only, while a Claude Code skill lives at `.claude/skills/<name>/SKILL.md`.
+ * `.claude/skills` is listed in `LIVE_INSTRUCTION_DOC_DIRS` precisely because a
+ * stale skill is worse than a stale doc — it hands an agent a wrong command to
+ * RUN — and it contributed exactly zero files. All four project skills were
+ * scanned by no check here.
+ *
+ * `.claude/skills` is the only listed directory that has subdirectories at all,
+ * so this widens the corpus by those four files and by nothing else.
+ */
 function markdownIn(root: string, dir: string): string[] {
   const full = join(root, dir)
   if (!existsSync(full)) return []
-  return readdirSync(full)
-    .filter((name) => name.endsWith('.md'))
-    .sort()
-    .map((name) => `${dir}/${name}`)
+  const found: string[] = []
+  for (const entry of readdirSync(full, { withFileTypes: true })) {
+    if (entry.isDirectory()) found.push(...markdownIn(root, `${dir}/${entry.name}`))
+    else if (entry.name.endsWith('.md')) found.push(`${dir}/${entry.name}`)
+  }
+  return found.sort()
 }
 
 /**
@@ -1044,7 +1058,21 @@ if (import.meta.main) {
   // `tools/lib/scanFloor.ts` was not applied to when its four siblings were
   // fixed. Floor set well below the real count: a catastrophe detector, not a
   // coverage target.
-  assertScanFloor('doc-drift (live-instruction docs)', liveInstructionDocs(repoRoot).length, 6)
+  //
+  // The floor was 6 against a real corpus of 40, which made it inert against
+  // the very catastrophe the paragraph above describes: if all four
+  // `LIVE_INSTRUCTION_DOC_DIRS` were renamed, the 3 root files and the 10
+  // per-workspace ones still survive — 13, comfortably over 6 — so the gate
+  // passed on exactly the collapse it was written to detect. 26 is ~65% of the
+  // corpus, the calibration `scanFloor.ts` prescribes and the one its four
+  // siblings use, and it sits clear of that 13-file residue.
+  const liveDocs = liveInstructionDocs(repoRoot)
+  assertScanFloor('doc-drift (live-instruction docs)', liveDocs.length, 26)
+  // Printed because this gate reported counts of FINDINGS and never of corpus,
+  // so a collapsed scan and a healthy one read identically. Printed is not
+  // asserted — the floor above is the assertion — but it is the tell that was
+  // missing when this was diagnosed.
+  console.log(`  (${liveDocs.length} live-instruction docs scanned)`)
 
   const { failures, passed } = runChecks(repoRoot)
   for (const message of passed) console.log(`✓ ${message}`)

--- a/tools/check-printed-names.ts
+++ b/tools/check-printed-names.ts
@@ -60,6 +60,22 @@ import { SalvageUnionReference } from '../packages/salvageunion-reference/lib/in
 import { DEVIATIONS } from '../packages/salvageunion-reference/lib/printedNameDeviations'
 
 const EXTRACT_DIR = 'rules/extracted'
+
+/**
+ * Which extract is the Core Book.
+ *
+ * `extract-rules.ts` names every output for its source PDF
+ * (`${basename(pdf, '.pdf')}.txt`), so the Core Book arrives as
+ * "Salvage Union Digital Edition <version>.txt". This probe previously tested
+ * for `/core book/i`, which no filename the extractor can produce will ever
+ * match — so the check exited 0 with "nothing to check against" on a fully
+ * populated directory, every time it was run.
+ *
+ * Anchored at the start deliberately: the expansions share the "Digital
+ * Edition" suffix (False Flag, Rainmaker, We Were Here First), and an
+ * unanchored pattern would pick whichever the filesystem listed first.
+ */
+const CORE_BOOK_EXTRACT = /^salvage union digital/i
 /** Entities carrying this `source` are printed in the Core Book. */
 const CORE_SOURCE = 'Salvage Union Workshop Manual'
 
@@ -219,9 +235,25 @@ async function main() {
     )
     return
   }
-  const coreFile = readdirSync(EXTRACT_DIR).find((f) => /core book/i.test(f))
+  const extracts = readdirSync(EXTRACT_DIR).filter((f) => f.endsWith('.txt'))
+  if (extracts.length === 0) {
+    console.log(
+      `No extracts in ${EXTRACT_DIR}/ — run \`bun tools/extract-rules.ts\` first (needs the PDFs in rules/).`
+    )
+    return
+  }
+
+  const coreFile = extracts.find((f) => CORE_BOOK_EXTRACT.test(f))
   if (!coreFile) {
-    console.log(`No Core Book extract in ${EXTRACT_DIR}/ — nothing to check against.`)
+    // Loud, not a notice. An ABSENT extract directory is the ordinary local
+    // case and returns above; extracts that exist while none is the Core Book
+    // means this check cannot do its job, and saying so quietly is how it
+    // spent its whole life reporting success having compared nothing.
+    console.error(
+      `${extracts.length} extract(s) in ${EXTRACT_DIR}/ but none matches ${CORE_BOOK_EXTRACT} — ` +
+        `cannot check against the Core Book index.\n  found: ${extracts.join(', ')}`
+    )
+    process.exitCode = 1
     return
   }
 


### PR DESCRIPTION
**Layer 2 of 8** — audit remediation stack #921. Base: `fix/nightly-signin-notifier` (#913).

Three gates that passed on every run of their life. None of them could fail.

### `check-printed-names` could never find its input

It located the corpus with `/core book/i`, but `extract-rules.ts` names every
output for its source PDF, so the Core Book arrives as
`Salvage Union Digital Edition 1.2.txt`. No filename the extractor can produce
will ever match those two words.

Proved by running it: on a fully populated `rules/extracted/` it printed
*"No Core Book extract — nothing to check against"* and exited 0.

The two cases it had conflated are now split. An **absent** extract directory
stays a notice and exit 0 — the ordinary local case, since the PDFs are
gitignored and the check is deliberately outside CI. Extracts that **exist**
while none is the Core Book is a misconfiguration and exits 1, naming what it
found.

**With the probe fixed the check runs for the first time**, and the data is
clean: 944 index entries parsed, 220 entities checked, **0 page mismatches**.
It reports 6 index-suspects (the book's own index disagrees with a page that
does print the name) and 1 name deviation.

### `check-doc-drift`'s scan floor was set below the collapse it detects

The floor was 6 against a corpus of 40. The comment above it describes the
catastrophe — rename a scanned directory and the gate keeps printing ✓ — but if
all four `LIVE_INSTRUCTION_DOC_DIRS` vanished, the 3 root docs and 10
per-workspace docs still survive. **13 clears 6**, so the floor passed on exactly
the failure it was written for.

Raised to 26 (~65% of corpus), the calibration `scanFloor.ts` prescribes and its
four siblings use. Verified: renaming all four directories now fails with
*"scanned 13 files, expected at least 26"* — 13 being precisely the predicted
residue.

### `check-doc-drift` walked one level deep, so it scanned no skills at all

A skill lives at `.claude/skills/<name>/SKILL.md`. `.claude/skills` is in the
scanned list *because* a stale skill is worse than a stale doc — it hands an
agent a wrong command to **run** — and it contributed **zero** files.

`markdownIn` is now recursive. `.claude/skills` is the only listed directory with
subdirectories, so this adds those four files and nothing else. Documented script
references checked rose **189 → 200** as a result.

Corpus size is now printed, because this gate reported counts of *findings* and
never of corpus — which is why a collapsed scan and a healthy one read
identically.

### `check-action-pinning` accepted every mutable tag

`bunxIsPinned` tested only that some `@` followed position 0, so
`wrangler@latest`, `@next` and a bare major all passed — in the job holding
`CLOUDFLARE_API_TOKEN`, `CONVEX_DEPLOY_KEY` and `SENTRY_AUTH_TOKEN`. Its own
failure message already said *"Write it as `bunx tool@X.Y.Z`"*; nothing checked
that shape. Now requires exact semver.

The scan also saw `bunx` only. Widened to `npx` and `bun x` — neither appears in
these workflows today, so that half is a latent guard rather than a live fix —
and the runner is now named accurately instead of every finding being labelled
"bunx". `docker run` stays out of scope: it takes an image reference, not a
package, and its one call site is digest-pinned.

Verified: `@latest` and an injected `npx some-tool` each fail; the real tree
still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfA5r8HyHvay1kd2wH8b5b
