### PR TITLE
ci(srd): run the printed-examples gate, which ran nowhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,6 +573,21 @@ jobs:
       - name: Build srd
         run: bun --filter srd build
 
+      # Every example the site prints must resolve against what it emitted.
+      #
+      # This ran in NO automated check before. `gate` chains it between the
+      # build and the snapshot, and its own header says so — but CI runs
+      # `build` and `snapshot` as separate steps and never `gate`, so the one
+      # place the chain was documented to hold was the one place it did not.
+      # A fabricated example on /api or /discord merged green.
+      #
+      # A step rather than `gate` because `gate` re-runs the build, and this
+      # job deliberately builds once: the Playwright tier below serves that
+      # same dist. Separate steps also keep failure attribution, which is why
+      # the snapshot below is its own step too.
+      - name: Check printed examples against the built site
+        run: bun --filter srd check:examples
+
       # The output gate (ssg/snapshot.ts). Runs HERE rather than as its own job
       # because it needs the dist this step just produced, and rebuilding it in
       # a second job would double the slowest thing in the workflow.

--- a/apps/srd/ssg/checkPageExamples.ts
+++ b/apps/srd/ssg/checkPageExamples.ts
@@ -22,8 +22,11 @@
  * a `bun test` file it could only fail there or — worse — skip, and a check
  * that skips when the build is missing reads as a pass while asserting nothing.
  *
- * Running inside `gate` puts it immediately after the build that produces its
- * input, in the same job as the snapshot comparison, where `dist` is guaranteed.
+ * `gate` chains it immediately after the build that produces its input. CI does
+ * not run `gate` — it runs `build`, then this via `check:examples`, then
+ * `snapshot`, as three steps of `build-srd` so each failure stays separately
+ * attributable and the build happens once. Either way it runs where `dist` is
+ * guaranteed.
  */
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs'


### PR DESCRIPTION
**Layer 3 of 8** — audit remediation stack #921. Base: `fix/gates-that-cannot-fire` (#914).

`ssg/checkPageExamples.ts` asserts that every example the site prints resolves
against what the site actually emitted. It exists because `/api` and `/discord`
once shipped a worked example fabricated three ways at once — a chassis in no
data file, a UUID shown as a slug, and two fields that have never existed — so a
developer following the page got a 404.

**It ran in no automated check.**

`apps/srd`'s `gate` script chains it between the build and the snapshot, and the
tool's own header cites that chain as its justification. But CI's `build-srd` job
runs `bun --filter srd build` and `bun --filter srd snapshot` as separate steps
and never `gate`. The only place the chain was documented to hold was the one
place it did not, so a fabricated example merged green. Nothing in `lefthook.yml`
ran it either; the sole caller was `check:srd-output`, which only `bun run check`
invokes.

### Why a step rather than switching the job to `gate`

Two reasons the surrounding comments already give:

- `gate` re-runs the build, and this job deliberately builds **once** — the
  Playwright tier below serves that same `dist`.
- Separate steps keep failure attribution, which is why the snapshot is its own
  step too.

`apps/srd` already had the `check:examples` script; this only wires it up. The
tool header's claim about where it runs is corrected in the same commit.

### Verification

Run against a real build — this turns on a gate that is **green**, not one that
needs a fix first:

```
page-examples OK — 6 documented URL(s) resolve, 9 cited name(s) exist among 786 emitted.
SNAPSHOT OK — 1039 pages, zero unexpected differences.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfA5r8HyHvay1kd2wH8b5b
