### PR TITLE
chore(audit): drop two suppressions whose cause no longer exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,9 +377,10 @@ jobs:
       #   brace-expansion ^5.0.9 -> top level unchanged at 5.0.9 (minimatch@10 asks ^5.0.5)
       #   nanoid       ^3.3.18 -> NOT ONE LOCKFILE LINE CHANGED; a pure no-op
       #   @vitejs/plugin-react-swc ^4.3.3 -> adds a nested @ladle/react copy at 3.11.0
-      # Post-removal `bun run check:audit` is EMPTY, and full `bun audit` reports
-      # only the two suppressed image-size ids below — i.e. no new advisory at any
-      # severity. `check:all`, `bun --filter component-lib ladle:build`,
+      # Post-removal `bun run check:audit` was EMPTY, and full `bun audit`
+      # reported only the two image-size ids that were suppressed at the time
+      # (since gone from the lockfile entirely — see below) — i.e. no new
+      # advisory at any severity. `check:all`, `bun --filter component-lib ladle:build`,
       # `bun run build:bot` and `bun install --frozen-lockfile` were all green.
       #
       # KNOW WHAT THIS TRADED AWAY, because it is a real cost and not zero.
@@ -425,13 +426,17 @@ jobs:
       #     Removing it costs one duplicate copy (a nested @ladle/react 3.11.0)
       #     and no advisory — install weight only, in a dev-only tool.
       #
-      # TWO ADVISORIES ARE SUPPRESSED. `check:audit` passes
-      # `--ignore=GHSA-w3rx-r6r6-pgpr --ignore=GHSA-5p2g-fcmc-qvqq`, both
-      # `image-size <=2.0.2` via `@netlify/blobs -> @netlify/dev-utils`. There is
-      # no fixed version to float a floor to — 2.0.2 IS latest — so the usual
-      # `bun update` / raise-the-floor remedy below cannot apply. Full reasoning
-      # and the removal condition are in CLAUDE.md, "Audit gate". The ignores are
-      # scoped to those two ids, so everything else still gates.
+      # NOTHING IS SUPPRESSED. `check:audit` is a bare
+      # `bun audit --audit-level=high` with no `--ignore` flags, and a full
+      # `bun audit` is clean at every severity.
+      #
+      # Two ids used to be suppressed here — `GHSA-w3rx-r6r6-pgpr` and
+      # `GHSA-5p2g-fcmc-qvqq`, both `image-size <=2.0.2` reached via
+      # `@netlify/blobs -> @netlify/dev-utils`. They were not fixed and no floor
+      # was floated: the transitive edge simply went away. `@netlify/blobs` is
+      # still here (10.7.13) and `bun why image-size` now reports the package is
+      # not in the lockfile at all, so the justification became counterfactual
+      # rather than merely satisfied. Flags and prose were removed together.
       #
       # TWO DEAD DEDUPE FLOORS, kept as lessons rather than as config:
       #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,40 +41,36 @@ This is a TypeScript monorepo with shared packages (component-lib, etc.). After 
 - **`playwright`** — Used by `tools/a11y-scan.ts` for WCAG accessibility audits. Not dead code. It is a _root_ dependency because that scanner lives in `tools/`, outside any workspace; the apps depend on `@playwright/test` separately for their e2e suites. This replaced `puppeteer-core`, which shipped no browser and had to borrow Playwright's Chromium — one browser stack now, not two.
 - **`sharp`** — Used by `tools/convert-lp-assets-to-webp.ts` to transcode the `lp-assets` Netlify Blobs artwork to WebP (`bun run assets:webp`). Not dead code.
 
-### Audit gate (`check:audit`) — two suppressed advisories
+### Audit gate (`check:audit`)
 
 `bun audit --audit-level=high` gates merges via the `static-checks` job, and
 `package.json` cannot carry comments, so the reasoning lives here.
 
-**Suppressed: `GHSA-w3rx-r6r6-pgpr` and `GHSA-5p2g-fcmc-qvqq`** — both
-`image-size <=2.0.2`, infinite loops in its ICNS / JXL / HEIF parsers (DoS).
+**There are no suppressed advisories.** `check:audit` carries no `--ignore`
+flags, and a bare `bun audit` reports nothing across 1,073 packages. It used to
+suppress two — `GHSA-w3rx-r6r6-pgpr` and `GHSA-5p2g-fcmc-qvqq`, both
+`image-size <=2.0.2` — behind a page of justification about which code paths
+could reach the parser. That justification is now moot rather than merely
+satisfied: `bun why image-size` reports the package is not in the lockfile at
+all. `@netlify/blobs` is still here (10.7.13, catalogued, used by `itun` and
+`su-assets`); it simply stopped pulling `image-size`. The flags and their
+rationale were removed together, on this section's own former instruction that
+a suppression outliving its cause is how a real advisory gets hidden.
 
-- **There is no fixed version.** `2.0.2` IS the latest release (published
-  2025-04-02) and the advisory covers `<=2.0.2`, so no `overrides` pin can
-  resolve it — `bun install` fails outright with "No version matching ^2.0.3".
-- **Nothing here can reach the vulnerable code.** The chain is
-  `@netlify/blobs → @netlify/dev-utils → image-size`, and dev-utils imports it
-  from **`src/test/image.ts`**, a test helper that generates images. This repo's
-  only use of that package is `getStore` in
-  `apps/su-assets/netlify/functions/asset.ts`; nothing in `apps/`, `packages/`
-  or `tools/` imports `image-size` or calls `imageSize()`. Exploiting it needs
-  attacker-controlled bytes fed to that parser, and no path does that.
-
-**Re-check when `@netlify/blobs` updates**: drop both `--ignore` flags and run
-`bun run check:audit`. If it passes, delete this section — a suppression that
-outlives its cause is how a real advisory gets hidden.
+**If you add an `--ignore` back, write down what would remove it.** A
+suppression with no stated exit condition is the failure mode above; the pair
+that lived here survived their cause by an unknown number of dependency bumps
+because nothing re-derived the chain.
 
 **Re-derive the chain, don't trust this prose.** `bun why <pkg>` prints the real
-path from the lockfile, so a suppression's justification can be checked in one
-command instead of read:
+path from the lockfile, so any claim about how a package got here can be
+checked in one command instead of read:
 
 ```
-$ bun why image-size
-image-size@2.0.2
-  └─ @netlify/dev-utils@4.4.7 (requires ^2.0.2)
-     └─ @netlify/blobs@10.7.12 (requires 4.4.7)
-        ├─ itun@workspace (requires ^10.7.11)
-        └─ su-assets@workspace (requires ^10.7.11)
+$ bun why @netlify/blobs
+@netlify/blobs@10.7.13
+  ├─ itun@workspace (requires catalog:)
+  └─ su-assets@workspace (requires catalog:)
 ```
 
 Use it before editing an `overrides` entry too — the CI comment in
@@ -97,7 +93,7 @@ clean" is necessary but *not sufficient* — `@opentelemetry/core` is the worked
 example of a removal that audits clean and still degrades behaviour.
 
 `nanoid` was among the six: it is no longer pinned anywhere, and `3.3.18` holds
-only because `postcss`'s `^3.3.16` caret happens to resolve there. That is a
+only because `postcss`'s `^3.3.17` caret happens to resolve there. That is a
 caret, not a guarantee — **`bunfig.toml`'s `minimumReleaseAge` makes a caret
 resolve silently *down*** to the newest version old enough (see "Install
 cooldown"), where a floor would have errored. So if `bun audit` ever reports

--- a/docs/adrs/ADR-033-cloudflare-hosting.md
+++ b/docs/adrs/ADR-033-cloudflare-hosting.md
@@ -180,11 +180,15 @@ for CSP.** Zod v4's JIT parser compiles validators with `new Function`, which
 workerd bans. `packages/salvageunion-reference/lib/zod.ts` already disables it;
 that must not be reverted as an optimisation.
 
-**Removing `@netlify/blobs` retires two standing security suppressions.**
-`check:audit` currently ignores `GHSA-w3rx-r6r6-pgpr` and `GHSA-5p2g-fcmc-qvqq`,
-both reachable only via `@netlify/blobs → @netlify/dev-utils → image-size`. Once
-that dependency is gone, both `--ignore` flags come out and the CLAUDE.md section
-documenting them is deleted.
+**Two standing security suppressions are already retired — but not by this
+migration.** `check:audit` used to ignore `GHSA-w3rx-r6r6-pgpr` and
+`GHSA-5p2g-fcmc-qvqq`, both reachable only via
+`@netlify/blobs → @netlify/dev-utils → image-size`. This ADR predicted they
+would come out when `@netlify/blobs` did. What actually happened is that
+`@netlify/dev-utils` stopped depending on `image-size`, so the package left the
+lockfile while `@netlify/blobs` stayed (10.7.13, still used by `itun` and
+`su-assets`). Both `--ignore` flags and the CLAUDE.md section are gone; this
+is no longer a benefit P8 has left to deliver.
 
 **The CI token's blast radius is the whole personal account** (§6), and that now
 includes **two live RANDSUM Workers**. Cloudflare API tokens scope by permission

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "knip": "knip",
     "check": "bun run check:schemas && concurrently -g 'bun run lint' 'bun run format:check' && bun run typecheck && concurrently -g 'bun run test' 'bun run validate:all' 'bun run knip' 'bun run check:audit' 'bun run check:tokens' 'bun run check:styling' 'bun run check:ci-aggregator' 'bun run check:srd-output'",
     "check:schemas": "bun run build:package && git diff --exit-code -- packages/salvageunion-reference/schemas packages/salvageunion-reference/docs packages/salvageunion-reference/lib/generated packages/salvageunion-reference/lib/index.ts packages/salvageunion-reference/etc .vscode/settings.json",
-    "check:audit": "bun audit --audit-level=high --ignore=GHSA-w3rx-r6r6-pgpr --ignore=GHSA-5p2g-fcmc-qvqq",
+    "check:audit": "bun audit --audit-level=high",
     "check:tokens": "bun tools/check-design-tokens.ts",
     "check:styling": "bun tools/check-styling-ownership.ts",
     "check:action-pinning": "bun tools/check-action-pinning.ts",


### PR DESCRIPTION
**Layer 4 of 8** — audit remediation stack #921. Base: `ci/run-srd-gate` (#915).

`check:audit` carried `--ignore=GHSA-w3rx-r6r6-pgpr --ignore=GHSA-5p2g-fcmc-qvqq`,
and three separate places explained why: 44 lines of `CLAUDE.md`, a paragraph in
`ci.yml`, and a forward-looking note in ADR-033. All of it described a dependency
chain that no longer exists.

```
$ bun why image-size
error: No packages matching 'image-size' found in lockfile

$ bun audit          # both --ignore flags removed
No vulnerabilities found (checked 1073 packages)
```

So the suppressions were not merely satisfied, they were **counterfactual**: the
prose asserted a live risk being managed, and there was no package.

### What did NOT happen

ADR-033 predicted these would come out when `@netlify/blobs` did, and that
prediction is the sort of thing a later reader takes as settled.
`@netlify/blobs` was **not** removed — it is still here at 10.7.13, catalogued,
used by `itun` and `su-assets`. `@netlify/dev-utils` stopped pulling
`image-size` on its own. The ADR is corrected to record that rather than left
implying P8 has this benefit still to deliver.

### Why CLAUDE.md's section is cut back, not deleted

The header promised "two suppressed advisories", but the section also carries the
`overrides` reasoning, the post-#787 watch list, and the note that the list is
manual below `high` — all still true and none of it about suppressions. What goes
is the suppression itself. What stays gains a line saying any future `--ignore`
must be written down with its exit condition, since these two outlived their
cause by an unknown number of dependency bumps precisely because nothing
re-derived the chain.

The `bun why` worked example is retargeted from `image-size`, which now errors,
to `@netlify/blobs`, which resolves — an example that no longer runs teaches the
opposite of the lesson that section exists to teach.

Also corrected while in the file: `postcss` asks `nanoid@^3.3.17`, not `^3.3.16`.

### Verification

`bun run check:audit` and a bare `bun audit` both clean; `validate:all`
(including doc-drift over `CLAUDE.md` and the ADR) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfA5r8HyHvay1kd2wH8b5b
