### PR TITLE
fix(convex): appendChangeLog must check membership, and must not write alerts

### DIFF
--- a/apps/itun/convex/entities.ts
+++ b/apps/itun/convex/entities.ts
@@ -15,6 +15,7 @@ import {
   isTableRunner,
   NotAuthorized,
   requireMember,
+  requireMemberAs,
   requireTableRunner,
   requireUser,
 } from './model/permissions'
@@ -1070,6 +1071,35 @@ export const appendChangeLog = mutation({
   },
   handler: async (ctx, args): Promise<void> => {
     const userId = await requireUser(ctx)
+
+    // `alert` is the Mediator's broadcast channel, not a field a client may
+    // append. `proposals.broadcast` writes those rows behind `requireMediator`,
+    // and `proposals.alerts` returns every one of them to every member of the
+    // game — so without this line any signed-in user could post a message into
+    // the whole crew's alert feed, carrying a real `actorId`, by calling this
+    // mutation instead. The gate on the intended path is only a gate if the
+    // unintended one is closed too.
+    const alert = args.entries.find((e) => e.field === 'alert')
+    if (alert !== undefined) {
+      throw new NotAuthorized('Alerts are written by the Mediator, not by a client append')
+    }
+
+    // Membership is checked per distinct game, not per entry.
+    //
+    // Every field of an entry is client-supplied, `gameId` included, and
+    // nothing here derived it from a record the caller can be shown to own. A
+    // user who has left a game — or who holds its id from an unredeemed invite
+    // link — could therefore write rows into that game's log indefinitely, and
+    // `proposals.alerts`/the Change Log drawer would render them as genuine
+    // provenance attributed to them.
+    //
+    // Distinct rather than per-entry because the batch is usually one edit
+    // touching several fields of ONE entity: deduplicating keeps this at one
+    // membership read for the common case rather than one per row, which
+    // preserves the round-trip argument the comment below makes.
+    const gameIds = [...new Set(args.entries.flatMap((e) => (e.gameId === null ? [] : [e.gameId])))]
+    await Promise.all(gameIds.map((gameId) => requireMemberAs(ctx, gameId, userId)))
+
     // `Promise.all` rather than a serial loop: these are independent inserts and
     // this runs on every sheet edit, so the round trips are the cost.
     await Promise.all(

--- a/apps/itun/test/convex/changeLogAuthz.test.ts
+++ b/apps/itun/test/convex/changeLogAuthz.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from 'bun:test'
+import { api } from '../../convex/_generated/api'
+import { testConvex } from './harness'
+
+/**
+ * Who may write into a game's Change Log.
+ *
+ * `entities.appendChangeLog` is the client's mirror of a local append: a record
+ * of something that ALREADY happened on the user's own device. It called
+ * `requireUser` and then inserted every entry verbatim — and every field of an
+ * entry is client-supplied, `gameId` included. Nothing derived that id from a
+ * record the caller could be shown to own.
+ *
+ * Two consequences, and the second is the sharp one:
+ *
+ *  - a signed-in user could write provenance rows into ANY game, including one
+ *    they had left, or one whose id they held from an unredeemed invite link;
+ *  - `proposals.alerts` returns every `field === 'alert'` row to every member of
+ *    a game, and `proposals.broadcast` writes those rows behind
+ *    `requireMediator`. So this mutation was an unguarded second door onto the
+ *    Mediator's broadcast channel — a message to the whole crew, carrying a
+ *    real `actorId`.
+ *
+ * Each test below fails against the pre-fix handler; the two happy-path cases
+ * are the controls that say the fix did not simply close the door on everyone.
+ */
+
+type Ctx = ReturnType<typeof testConvex>
+
+async function makeUser(t: Ctx, name: string) {
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name, displayName: name })
+  )
+  return { userId, as: t.withIdentity({ subject: userId }) }
+}
+
+function entry(gameId: string | null, over: Record<string, unknown> = {}) {
+  return {
+    gameId: gameId as never,
+    entityType: 'pilot' as const,
+    entityId: 'p1',
+    ts: 1,
+    kind: 'manual' as const,
+    field: 'name',
+    before: 'a',
+    after: 'b',
+    source: 'test',
+    ...over,
+  }
+}
+
+describe('appendChangeLog authorization', () => {
+  test('a member may append to their own game', async () => {
+    const t = testConvex()
+    const gm = await makeUser(t, 'Mediator')
+    const gameId = await gm.as.mutation(api.games.create, { name: 'Tenacity' })
+
+    await gm.as.mutation(api.entities.appendChangeLog, { entries: [entry(gameId)] })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('changeLog').collect())
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.actorId).toBe(gm.userId)
+  })
+
+  test('an append with no game is unaffected — this is the Solo path', async () => {
+    const t = testConvex()
+    const user = await makeUser(t, 'Solo')
+
+    await user.as.mutation(api.entities.appendChangeLog, { entries: [entry(null)] })
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('changeLog').collect())
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.gameId).toBeNull()
+  })
+
+  test('a non-member cannot append to a game they were never in', async () => {
+    const t = testConvex()
+    const gm = await makeUser(t, 'Mediator')
+    const outsider = await makeUser(t, 'Outsider')
+    const gameId = await gm.as.mutation(api.games.create, { name: 'Tenacity' })
+
+    await expect(
+      outsider.as.mutation(api.entities.appendChangeLog, { entries: [entry(gameId)] })
+    ).rejects.toThrow(/Not a member of this game/)
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('changeLog').collect())
+    expect(rows).toHaveLength(0)
+  })
+
+  test('the whole batch is refused when any one entry names a foreign game', async () => {
+    const t = testConvex()
+    const gm = await makeUser(t, 'Mediator')
+    const player = await makeUser(t, 'Player')
+    const theirs = await gm.as.mutation(api.games.create, { name: 'Theirs' })
+    const mine = await player.as.mutation(api.games.create, { name: 'Mine' })
+
+    // A batch that is mostly legitimate. Checking only the first entry, or
+    // stopping at the first success, would let the smuggled row through.
+    await expect(
+      player.as.mutation(api.entities.appendChangeLog, {
+        entries: [entry(mine), entry(theirs), entry(null)],
+      })
+    ).rejects.toThrow(/Not a member of this game/)
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('changeLog').collect())
+    expect(rows).toHaveLength(0)
+  })
+
+  test('a member who left can no longer append', async () => {
+    const t = testConvex()
+    const gm = await makeUser(t, 'Mediator')
+    const player = await makeUser(t, 'Player')
+    const gameId = await gm.as.mutation(api.games.create, { name: 'Tenacity' })
+    const code = await gm.as.mutation(api.invites.create, { gameId })
+    await player.as.mutation(api.invites.redeem, { code })
+
+    // While a member: allowed.
+    await player.as.mutation(api.entities.appendChangeLog, { entries: [entry(gameId)] })
+
+    await player.as.mutation(api.ownership.leaveGame, { gameId })
+
+    await expect(
+      player.as.mutation(api.entities.appendChangeLog, { entries: [entry(gameId)] })
+    ).rejects.toThrow(/Not a member of this game/)
+
+    const rows = await t.run(async (ctx) => await ctx.db.query('changeLog').collect())
+    expect(rows).toHaveLength(1)
+  })
+
+  test('alerts cannot be written through a client append, even by the Mediator', async () => {
+    const t = testConvex()
+    const gm = await makeUser(t, 'Mediator')
+    const gameId = await gm.as.mutation(api.games.create, { name: 'Tenacity' })
+    await gm.as.mutation(api.games.setMediator, { gameId, userId: gm.userId, mediator: true })
+
+    await expect(
+      gm.as.mutation(api.entities.appendChangeLog, {
+        entries: [
+          entry(gameId, {
+            field: 'alert',
+            entityType: 'game',
+            after: 'Mediator: everyone gets 20 scrap',
+          }),
+        ],
+      })
+    ).rejects.toThrow(/Alerts are written by the Mediator/)
+
+    // The point of the rule is the feed, so assert on the feed and not only on
+    // the throw: nothing reached the surface a player actually reads.
+    const alerts = await gm.as.query(api.proposals.alerts, { gameId })
+    expect(alerts).toHaveLength(0)
+  })
+
+  test('a member cannot smuggle an alert into the crew feed', async () => {
+    const t = testConvex()
+    const gm = await makeUser(t, 'Mediator')
+    const player = await makeUser(t, 'Player')
+    const gameId = await gm.as.mutation(api.games.create, { name: 'Tenacity' })
+    await gm.as.mutation(api.games.setMediator, { gameId, userId: gm.userId, mediator: true })
+    const code = await gm.as.mutation(api.invites.create, { gameId })
+    await player.as.mutation(api.invites.redeem, { code })
+
+    await expect(
+      player.as.mutation(api.entities.appendChangeLog, {
+        entries: [entry(gameId, { field: 'alert', entityType: 'game', after: 'free scrap' })],
+      })
+    ).rejects.toThrow(/Alerts are written by the Mediator/)
+
+    const alerts = await player.as.query(api.proposals.alerts, { gameId })
+    expect(alerts).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
**Layer 6 of 8** — audit remediation stack #921. Base: `docs/correct-claude-md-drift` (#917).

> Security fix. This is the layer worth reviewing closely.

`entities.appendChangeLog` called `requireUser` and then inserted every entry
verbatim. Every field of an entry is client-supplied — `gameId` included — and
nothing derived that id from a record the caller could be shown to own. The only
thing being asserted was that **somebody** was signed in.

### Two holes

**Any signed-in user could write into any game's log.** A user who had left a
game, or who held its id from an unredeemed invite link, could append provenance
rows to it indefinitely. Those rows carry a real `actorId` and are rendered by
the Change Log drawer as genuine history.

**It was an unguarded second door onto the Mediator's broadcast channel.**
`proposals.alerts` returns every `field === 'alert'` row in a game to every
member. `proposals.broadcast` writes those rows behind `requireMediator`. This
mutation wrote them behind nothing — so a player could put a message in front of
the whole crew, attributed to themselves, by calling this instead.

A gate on the intended path is only a gate if the unintended one is closed too.

### The fix

Two rules. `field === 'alert'` is refused outright here, Mediator or not, because
the sanctioned writer is `proposals.broadcast`. And membership is required for
every **distinct** non-null `gameId` in the batch.

Per distinct game deliberately: a batch is normally one edit touching several
fields of one entity, so deduplicating keeps this at a single membership read in
the common case and preserves the round-trip argument the existing comment makes
about batching. `requireMemberAs` takes the already-resolved `userId` rather than
re-deriving it per entry.

**Solo is untouched** — `gameId: null` entries need no membership and still
write, which is the anonymous/no-game path `commitChangeLog` sends.

### Verification — negative-controlled, not merely written

Seven tests in a new `changeLogAuthz.test.ts`. With the handler reverted to its
previous form, **5 of the 7 fail and exactly the 2 happy-path controls still
pass**.

- One test sends a mostly-legitimate batch with one foreign `gameId` among three
  entries, because checking only the first entry would let the smuggled row
  through.
- Two assert on `proposals.alerts` returning nothing rather than only on the
  throw — the rule exists to protect that feed, so the feed is what the test
  reads.

Full itun suite green: **2103 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfA5r8HyHvay1kd2wH8b5b
