### PR TITLE
fix(itun): anonymous "Save pattern" threw on every attempt

### DIFF
--- a/apps/itun/src/lib/db/__tests__/memoryStore.test.ts
+++ b/apps/itun/src/lib/db/__tests__/memoryStore.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, expect, test } from 'bun:test'
 import { z } from 'salvageunion-reference/zod'
+import { MechPatternSchema } from '../../schemas/pattern'
 import { makeMemoryStore } from '../memoryStore'
 
 const ThingSchema = z
@@ -106,5 +107,46 @@ describe('what makes it the ANONYMOUS store', () => {
     expect(source).not.toContain('indexedDB')
     expect(source).not.toContain('localStorage')
     expect(source).not.toContain('sessionStorage')
+  })
+})
+
+describe('the memory twin must agree with its schema about updatedAt', () => {
+  test('a pattern saves anonymously', async () => {
+    // The real pairing from `patternStore.ts`, not a stand-in. `MechPatternSchema`
+    // is `.strict()` and defines `createdAt` only — patterns are immutable after
+    // creation — so this store must NOT be given `hasUpdatedAt`.
+    const store = makeMemoryStore(MechPatternSchema, 'mechPatterns')
+
+    const saved = await store.create({
+      schemaVersion: 1,
+      name: 'Mule Pattern',
+      chassisRef: 'mule',
+      systems: [],
+      modules: [],
+      cargoLots: [],
+    } as never)
+
+    expect(saved.name).toBe('Mule Pattern')
+    expect(saved).not.toHaveProperty('updatedAt')
+  })
+
+  test('turning the flag back on breaks it — the bug, pinned', async () => {
+    // The control for the test above, and the whole reason it exists. With
+    // `hasUpdatedAt` the store stamps a field the strict schema rejects, so
+    // `prepareCreate` throws on the record it has just built and every
+    // anonymous "Save pattern" fails. `db.mechPatterns` never set the flag,
+    // which is why signed-in saves worked and the divergence went unseen.
+    const store = makeMemoryStore(MechPatternSchema, 'mechPatterns', { hasUpdatedAt: true })
+
+    await expect(
+      store.create({
+        schemaVersion: 1,
+        name: 'Mule Pattern',
+        chassisRef: 'mule',
+        systems: [],
+        modules: [],
+        cargoLots: [],
+      } as never)
+    ).rejects.toThrow(/updatedAt/)
   })
 })

--- a/apps/itun/src/stores/patternStore.ts
+++ b/apps/itun/src/stores/patternStore.ts
@@ -34,9 +34,21 @@ type PatternState = HydratedCollectionSlice<'mechPatterns', MechPattern> &
  * Built at module scope so it HOLDS the rows: a store created per call would
  * hand every read an empty Map. Mirrors `entityStore`'s `MEMORY_STORES`.
  */
-const memoryPatterns = makeMemoryStore(MechPatternSchema, STORE_NAMES.mechPatterns, {
-  hasUpdatedAt: true,
-})
+/*
+ * `hasUpdatedAt` is deliberately ABSENT, matching `db.mechPatterns`.
+ *
+ * `MechPatternSchema` is `.strict()` and defines `createdAt` only — patterns
+ * are immutable after creation, so there is nothing for an `updatedAt` to
+ * mean. With the flag on, `prepareCreate` stamped the field and the strict
+ * parse then rejected the record it had just built, so every anonymous "Save
+ * pattern" threw `Unrecognized key: "updatedAt"` before it could write.
+ *
+ * The IndexedDB store never set it, which is why signed-in saves worked and
+ * the divergence went unseen — exactly the mismatch `entityStore`'s
+ * `MEMORY_STORES` comment warns about, where an anonymous session stamps
+ * different fields from a signed-in one.
+ */
+const memoryPatterns = makeMemoryStore(MechPatternSchema, STORE_NAMES.mechPatterns)
 
 const slice = makeHydratedCollectionSlice<'mechPatterns', MechPattern, MechPatternCreateInput>({
   key: 'mechPatterns',


### PR DESCRIPTION
**Layer 7 of 8** — audit remediation stack #921. Base: `fix/changelog-membership-check` (#918).

`patternStore`'s memory twin was built with `hasUpdatedAt: true`.
`MechPatternSchema` is `.strict()` and defines `createdAt` only — patterns are
immutable after creation, so there is nothing for an `updatedAt` to mean.

So `prepareCreate` stamped the field and the strict parse then rejected the
record it had just built:

```
ZodError: Unrecognized key: "updatedAt"
```

**Every anonymous "Save pattern" failed, every time**, before it could write.

### Why nobody saw it

`db.mechPatterns` — the IndexedDB store for the same schema — never passed the
flag. That asymmetry is the whole story: signed-in saving worked, and only
visitors who had not signed in hit it. In production `VITE_REQUIRE_ACCOUNT=true`,
so the memory backend is exactly what an anonymous visitor gets, which makes this
the path a **first-time user** is on.

It is also precisely the divergence `entityStore`'s `MEMORY_STORES` comment warns
about — *"if those diverge, an anonymous session stamps different fields from a
signed-in one"* — landing in the one store that comment does not cover.

### Verification

Two tests in `memoryStore.test.ts`, which already owns this backend. The first
saves a pattern through the real schema and asserts no `updatedAt` is stamped.
The second is its control and pins the bug directly: constructing the store
**with** the flag must reject with a message naming `updatedAt`.

A fix without that second test would leave nothing to stop the flag being added
back for symmetry with the other stores, which is presumably how it arrived.

Full itun suite green: **2105 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfA5r8HyHvay1kd2wH8b5b
