### PR TITLE
test(itun): parity must assert the writer is CALLED, not merely declared

### DIFF
--- a/apps/itun/test/convex/containerParity.test.ts
+++ b/apps/itun/test/convex/containerParity.test.ts
@@ -94,22 +94,63 @@ describe('container parity — every local store can reach the server', () => {
       new URL('../../src/stores/entityBackend.ts', import.meta.url)
     ).text()
 
-    // store name → the commit function that must reference it
-    const WRITERS: Record<string, string> = {
-      pilots: 'commitEntityWrite',
-      mechs: 'commitEntityWrite',
-      crawlers: 'commitEntityWrite',
-      softLinks: 'commitSoftLink',
-      mechPatterns: 'commitPatternWrite',
-      encounterNpcs: 'commitNpcWrite',
-      changeLog: 'commitChangeLog',
+    // store name → the commit function, and the store module that must CALL it.
+    //
+    // The consumer half is the point. This test asserted only that
+    // `entityBackend.ts` DECLARED each function, which is a weaker claim than
+    // it reads as: `commitPatternWrite` and `commitNpcWrite` have exactly one
+    // call site each, so deleting `commit: commitPatternWrite` from
+    // `patternStore.ts` stops patterns reaching Convex while leaving the
+    // declaration — and this test — untouched. That is the same shape as the
+    // table-only gap this test replaced: "the name exists somewhere" standing
+    // in for "the data arrives".
+    const WRITERS: Record<string, { fn: string; consumer: string }> = {
+      pilots: { fn: 'commitEntityWrite', consumer: 'entityStore.ts' },
+      mechs: { fn: 'commitEntityWrite', consumer: 'entityStore.ts' },
+      crawlers: { fn: 'commitEntityWrite', consumer: 'entityStore.ts' },
+      softLinks: { fn: 'commitSoftLink', consumer: 'entityStore.ts' },
+      mechPatterns: { fn: 'commitPatternWrite', consumer: 'patternStore.ts' },
+      encounterNpcs: { fn: 'commitNpcWrite', consumer: 'encounterStore.ts' },
+      changeLog: { fn: 'commitChangeLog', consumer: 'entityStore.ts' },
     }
 
-    const missing = Object.entries(WRITERS)
-      .filter(([, fn]) => !backend.includes(`export async function ${fn}(`))
-      .map(([store, fn]) => `${store} -> ${fn}`)
+    const undeclared = Object.entries(WRITERS)
+      .filter(([, { fn }]) => !backend.includes(`export async function ${fn}(`))
+      .map(([store, { fn }]) => `${store} -> ${fn} is not declared in entityBackend.ts`)
 
-    expect(missing).toEqual([])
+    const sources = new Map<string, string>()
+    for (const { consumer } of Object.values(WRITERS)) {
+      if (sources.has(consumer)) continue
+      sources.set(
+        consumer,
+        await Bun.file(new URL(`../../src/stores/${consumer}`, import.meta.url)).text()
+      )
+    }
+
+    // Importing it is not using it, and NEITHER IS MENTIONING IT IN A COMMENT.
+    //
+    // Both exclusions were found by controlling this test rather than by
+    // reasoning about it. The first draft filtered only import lines, so
+    // commenting out `commit: commitPatternWrite` — the precise edit that
+    // silently stops patterns reaching the server — left the identifier
+    // sitting on a `//` line and the test went on passing. A gate for "prose
+    // asserts what code does not" that a comment can satisfy is the very bug
+    // it is meant to catch.
+    const isCode = (line: string) => {
+      const t = line.trimStart()
+      return (
+        !t.startsWith('import') && !t.startsWith('//') && !t.startsWith('*') && !t.startsWith('/*')
+      )
+    }
+
+    const uncalled = Object.entries(WRITERS)
+      .filter(([, { fn, consumer }]) => {
+        const source = sources.get(consumer) ?? ''
+        return !source.split('\n').some((line) => line.includes(fn) && isCode(line))
+      })
+      .map(([store, { fn, consumer }]) => `${store} -> ${consumer} never calls ${fn}`)
+
+    expect([...undeclared, ...uncalled]).toEqual([])
   })
 
   test('every store with a table appears in the writer map', () => {


### PR DESCRIPTION
**Layer 8 of 8** — audit remediation stack #921. Base: `fix/anonymous-pattern-save` (#919).

The writer half of `containerParity` existed because *"a Convex table exists with
this name"* had passed for weeks while three stores never reached the server. It
replaced that with *"`entityBackend.ts` declares a function with this name"* — a
stronger claim, but **the same shape**, and weaker than it reads.

`commitPatternWrite` and `commitNpcWrite` have exactly one call site each. Delete
`commit: commitPatternWrite` from `patternStore.ts` and saved patterns stop
reaching Convex entirely, while the declaration in `entityBackend.ts` — and
therefore this test — is untouched. The gate would have stayed green through the
exact regression it was written to catch, one line away from the bug it was
created in response to.

Now each store maps to the module that must **call** its writer, and the test
reads that module.

### Two exclusions, and I found the second by controlling the test

Importing a function is not using it, so import lines do not count — that much
was in the first draft.

But commenting out `commit: commitPatternWrite` left the identifier sitting on a
`//` line, and **the first draft went on passing**: a gate against "prose asserts
what code does not" that a comment could satisfy. Comment lines are excluded too.

### Verification

Controlled both ways:

- with the wiring commented out, the suite fails with
  `mechPatterns -> patternStore.ts never calls commitPatternWrite`
- with it restored, 8 pass

The pre-existing declaration check is kept — it is still necessary, just not
sufficient — and its failures are reported separately so a future break says
which half gave way.

---

### Stack verification

`bun run check` on this branch (the top of the stack, so all eight layers
together) is fully green: 0 failures across every suite, `SNAPSHOT OK — 1039
pages, zero unexpected differences`, and every sub-check exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfA5r8HyHvay1kd2wH8b5b
