### PR TITLE
fix(itun): the two gates from #919/#920 were vacuous — close them

### DIFF
--- a/apps/itun/src/lib/db/__tests__/memoryStore.test.ts
+++ b/apps/itun/src/lib/db/__tests__/memoryStore.test.ts
@@ -130,6 +130,28 @@ describe('the memory twin must agree with its schema about updatedAt', () => {
     expect(saved).not.toHaveProperty('updatedAt')
   })
 
+  test('patternStore actually builds its memory store without the flag', async () => {
+    // The two behavioural tests either side of this one build their OWN store,
+    // so neither observes `patternStore.ts` — restore `hasUpdatedAt: true`
+    // there and both stay green while every anonymous save throws again. They
+    // prove the flag is fatal; only this proves the shipped file does not set
+    // it, and that pairing is what makes the fix regression-proof.
+    //
+    // A source assertion rather than a behavioural one because selecting the
+    // memory backend needs `selectBackend()` to return 'memory', which is
+    // driven by module-scope connection state; `mock.module` is process-global
+    // here (see `.claude/rules/testing-patterns.md`) and mocking it for one
+    // test would leak into every later file in the workspace.
+    const source = await Bun.file(
+      new URL('../../../stores/patternStore.ts', import.meta.url).pathname
+    ).text()
+
+    const call = source.match(/makeMemoryStore\([\s\S]*?\)\n/)?.[0]
+    expect(call).toBeDefined()
+    expect(call).toContain('MechPatternSchema')
+    expect(call).not.toContain('hasUpdatedAt')
+  })
+
   test('turning the flag back on breaks it — the bug, pinned', async () => {
     // The control for the test above, and the whole reason it exists. With
     // `hasUpdatedAt` the store stamps a field the strict schema rejects, so

--- a/apps/itun/test/convex/containerParity.test.ts
+++ b/apps/itun/test/convex/containerParity.test.ts
@@ -127,27 +127,50 @@ describe('container parity — every local store can reach the server', () => {
       )
     }
 
-    // Importing it is not using it, and NEITHER IS MENTIONING IT IN A COMMENT.
-    //
-    // Both exclusions were found by controlling this test rather than by
-    // reasoning about it. The first draft filtered only import lines, so
-    // commenting out `commit: commitPatternWrite` — the precise edit that
-    // silently stops patterns reaching the server — left the identifier
-    // sitting on a `//` line and the test went on passing. A gate for "prose
-    // asserts what code does not" that a comment can satisfy is the very bug
-    // it is meant to catch.
-    const isCode = (line: string) => {
-      const t = line.trimStart()
-      return (
-        !t.startsWith('import') && !t.startsWith('//') && !t.startsWith('*') && !t.startsWith('/*')
-      )
-    }
+    /**
+     * Strip everything that can carry the name without using it.
+     *
+     * This started as a per-LINE filter that skipped lines beginning `import`,
+     * `//`, `*` or `/*`, and it was vacuous for five of the seven stores.
+     * Biome formats a multi-name import one name per line, so
+     * `entityStore.ts`'s import block contributes lines that read exactly
+     * `  commitEntityWrite,` — which begins with none of those prefixes and was
+     * therefore counted as a use. Deleting all ten real call sites in
+     * `entityStore.ts` left `pilots`, `mechs`, `crawlers`, `softLinks` and
+     * `changeLog` passing on the strength of the import block alone.
+     *
+     * That is the same "the name exists somewhere" substitution this test was
+     * written to remove, one level down: table → declaration → mention.
+     *
+     * So the scan is now source-level rather than line-level. Comments go
+     * first (a trailing `// was commitPatternWrite` on a disabled line is what
+     * switching a mirror off actually looks like), then import and re-export
+     * statements, which name a function without invoking it.
+     */
+    const strip = (source: string) =>
+      source
+        .replace(/\/\*[\s\S]*?\*\//g, ' ')
+        .replace(/\/\/[^\n]*/g, ' ')
+        .replace(/\bimport\s+(?:type\s+)?[\s\S]*?\bfrom\s*['"][^'"]*['"]/g, ' ')
+        .replace(/\bexport\s*\{[\s\S]*?\}\s*from\s*['"][^'"]*['"]/g, ' ')
+
+    /**
+     * A use is a CALL or a wiring, not a mention.
+     *
+     * `fn(` covers the direct calls in `entityStore.ts`; `commit: fn` covers
+     * the slice wiring in `patternStore.ts` and `encounterStore.ts`, which is
+     * the single line whose removal silently stops those mirrors.
+     *
+     * Known residual, stated rather than papered over: a call inside dead code
+     * (`if (false) await commitPatternWrite(op)`) still reads as a use.
+     * Distinguishing that needs reachability analysis, not a regex, and it is
+     * a much less likely edit than the two this now catches.
+     */
+    const uses = (source: string, fn: string) =>
+      new RegExp(`\\b${fn}\\s*\\(|commit:\\s*${fn}\\b`).test(strip(source))
 
     const uncalled = Object.entries(WRITERS)
-      .filter(([, { fn, consumer }]) => {
-        const source = sources.get(consumer) ?? ''
-        return !source.split('\n').some((line) => line.includes(fn) && isCode(line))
-      })
+      .filter(([, { fn, consumer }]) => !uses(sources.get(consumer) ?? '', fn))
       .map(([store, { fn, consumer }]) => `${store} -> ${consumer} never calls ${fn}`)
 
     expect([...undeclared, ...uncalled]).toEqual([])


### PR DESCRIPTION
Follow-up to stack #921. **Adversarial review found both new guards in #919 and
#920 asserting less than their commit messages claimed** — the defect class that
stack exists to remove, committed by the stack itself. The two production fixes
in those PRs are correct and unaffected; this repairs the tests that were
supposed to hold them.

Found after merge. That is on me: I merged while a review I had commissioned was
still outstanding.

## #920's parity check was vacuous for five of seven stores

The per-line filter skipped lines beginning `import`, `//`, `*` or `/*`. Biome
formats a multi-name import **one name per line**, so `entityStore.ts`'s import
block contributes lines reading exactly `  commitEntityWrite,` — which begins
with none of those prefixes and was counted as a use.

Demonstrated rather than argued. Deleting all **ten** real call sites in
`entityStore.ts`, import block left intact:

```
before this PR:  8 pass, 0 fail        <- mirror completely dead, gate green
after  this PR:  7 pass, 1 fail
  + "pilots -> entityStore.ts never calls commitEntityWrite"
  + "mechs -> entityStore.ts never calls commitEntityWrite"
  + "crawlers -> entityStore.ts never calls commitEntityWrite"
  + "softLinks -> entityStore.ts never calls commitSoftLink"
  + "changeLog -> entityStore.ts never calls commitChangeLog"
```

Only `mechPatterns` and `encounterNpcs` were genuinely covered — their stores
import on a single line, which is the only reason my own control (commenting out
`commit: commitPatternWrite`) appeared to work. The check had moved the
substitution down one level rather than removing it: **table → declaration →
mention**.

The scan is now source-level: comments stripped first, then import and re-export
statements, and a use must be a **call** (`fn(`) or a **wiring** (`commit: fn`).

Verified against ten candidates — correctly rejected: import continuation, a
trailing `// was commitPatternWrite` on a disabled line, block-comment interior,
re-export, string literal, type-only reference, JSDoc `{@link}`. Correctly
accepted: the real wiring and the real call.

**Stated residual**, in the comment rather than papered over: a call inside dead
code (`if (false) await commitPatternWrite(op)`) still reads as a use.
Distinguishing that needs reachability analysis, not a regex.

## #919's tests never observed the file #919 fixed

Both new tests construct their own `makeMemoryStore`, so restoring
`hasUpdatedAt: true` to `patternStore.ts` left **both green** while every
anonymous "Save pattern" threw again. They proved the flag is fatal; nothing
proved the shipped file does not set it.

Adds the missing half — an assertion on `patternStore.ts`'s own
`makeMemoryStore(...)` call. A source assertion rather than a behavioural one
because selecting the memory backend needs `selectBackend()` to return
`'memory'`, and `mock.module` is process-global in this repo
(`.claude/rules/testing-patterns.md`) — mocking it for one test leaks into every
later file in the workspace.

Controlled: reintroducing `hasUpdatedAt: true` now fails.

## Verification

Full itun suite green: **2106 pass, 0 fail**. Lint and typecheck clean. Both
gates negative-controlled by reintroducing the exact regression each exists to
catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AfA5r8HyHvay1kd2wH8b5b
